### PR TITLE
fix(azure-foundry): route aux through anthropic_messages + surface DeploymentNotFound

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -3033,15 +3034,79 @@ def resolve_provider_client(
             return None, None
 
         raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
-        base_url = _to_openai_base_url(raw_base_url)
-        # Honour an explicit base_url override from the caller — used when a
-        # fallback_model entry (or custom_providers lookup) routes through a
-        # built-in provider name but targets a user-specified endpoint.
-        if explicit_base_url:
-            base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
 
-        default_model = _get_aux_model_for_provider(provider)
-        final_model = _normalize_resolved_model(model or default_model, provider)
+        # ── Azure Foundry special-case ────────────────────────────────
+        # Mirror hermes_cli.runtime_provider._resolve_runtime_from_pool_entry:
+        # honour `model.base_url` and `model.api_mode` from config.yaml so an
+        # Anthropic-on-Azure deployment (api_mode=anthropic_messages, base_url
+        # ending in /anthropic) routes through the Anthropic Messages SDK
+        # instead of being rewritten to /openai/v1 (which yields 404/403).
+        # Explicit per-task overrides (explicit_base_url / api_mode /
+        # explicit_api_key) still win over the model.* config.
+        if provider == "azure-foundry":
+            try:
+                from hermes_cli.runtime_provider import _get_model_config, _parse_api_mode
+                _azure_cfg = _get_model_config() or {}
+            except ImportError:
+                _azure_cfg = {}
+                _parse_api_mode = None  # type: ignore[assignment]
+            _cfg_provider = str(_azure_cfg.get("provider") or "").strip().lower()
+            _cfg_base_url = ""
+            _cfg_api_mode: Optional[str] = None
+            if _cfg_provider == "azure-foundry":
+                _cfg_base_url = str(_azure_cfg.get("base_url") or "").strip().rstrip("/")
+                if _parse_api_mode is not None:
+                    _cfg_api_mode = _parse_api_mode(_azure_cfg.get("api_mode"))
+            # explicit per-task base_url wins; otherwise prefer the
+            # model.base_url config over the pool/default URL.
+            if explicit_base_url:
+                raw_base_url = explicit_base_url.strip().rstrip("/")
+            elif _cfg_base_url:
+                raw_base_url = _cfg_base_url
+            # Resolve effective api_mode: explicit per-task > model.api_mode.
+            effective_api_mode = (api_mode or "").strip().lower() or _cfg_api_mode
+
+            default_model = _get_aux_model_for_provider(provider)
+            final_model = _normalize_resolved_model(model or default_model, provider)
+
+            if effective_api_mode == "anthropic_messages":
+                # Strip a trailing /v1 (mirrors runtime_provider behaviour) so
+                # the Anthropic SDK targets /anthropic, not /anthropic/v1.
+                azure_anthropic_base = re.sub(r"/v1/?$", "", raw_base_url)
+                try:
+                    from agent.anthropic_adapter import build_anthropic_client
+                    real_client = build_anthropic_client(api_key, azure_anthropic_base)
+                except ImportError:
+                    logger.warning(
+                        "azure-foundry requested api_mode=anthropic_messages but "
+                        "the anthropic SDK is not installed — falling back to "
+                        "OpenAI-wire.",
+                    )
+                else:
+                    sync_anthropic = AnthropicAuxiliaryClient(
+                        real_client, final_model, api_key,
+                        azure_anthropic_base, is_oauth=False,
+                    )
+                    logger.debug(
+                        "resolve_provider_client: azure-foundry "
+                        "(%s, anthropic_messages, %s)",
+                        final_model, azure_anthropic_base,
+                    )
+                    if async_mode:
+                        return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model
+                    return sync_anthropic, final_model
+            # Fall through to OpenAI-wire path (chat_completions / auto).
+            base_url = _to_openai_base_url(raw_base_url)
+        else:
+            base_url = _to_openai_base_url(raw_base_url)
+            # Honour an explicit base_url override from the caller — used when a
+            # fallback_model entry (or custom_providers lookup) routes through a
+            # built-in provider name but targets a user-specified endpoint.
+            if explicit_base_url:
+                base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
+
+            default_model = _get_aux_model_for_provider(provider)
+            final_model = _normalize_resolved_model(model or default_model, provider)
 
         if provider == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1156,10 +1156,11 @@ def _detect_azure_deployment_not_found(exc: BaseException) -> bool:
     """Return True when ``exc`` looks like an Azure DeploymentNotFound 404."""
     status = getattr(exc, "status_code", None)
     if status is None:
-        # Some SDKs nest the status on .response.status_code
+        # Some SDKs nest the status on .response.status_code. If no status is
+        # exposed at all, fall back to the body marker for SDK compatibility.
         response = getattr(exc, "response", None)
         status = getattr(response, "status_code", None)
-    if status not in (None, 400, 404):
+    if status not in (None, 404):
         return False
     body = _extract_azure_error_body(exc).lower()
     return any(token in body for token in _AZURE_DEPLOYMENT_NOT_FOUND_PATTERNS)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -985,7 +985,11 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
 
-        response = self._client.messages.create(**anthropic_kwargs)
+        response = _translate_azure_deployment_error(
+            lambda: self._client.messages.create(**anthropic_kwargs),
+            base_url=getattr(self._client, "base_url", None),
+            model=model,
+        )
         _transport = get_transport("anthropic_messages")
         _nr = _transport.normalize_response(
             response, strip_tool_prefix=self._is_oauth
@@ -1096,6 +1100,106 @@ def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return True
     return False
+
+
+# ── Azure DeploymentNotFound translation ──────────────────────────────────
+#
+# When an Azure Foundry deployment doesn't exist (typo in deployment name,
+# or model not deployed in this resource), the Anthropic / OpenAI SDKs raise
+# a generic 404 wrapping an Azure error body like::
+#
+#     {"error": {"code": "DeploymentNotFound", "message":
+#      "The API deployment for this resource does not exist..."}}
+#
+# Surface this to the user with a clearer, actionable message instead of an
+# opaque ``status_code: 404`` traceback.  Triggered only when the SDK call
+# target is an Azure-hosted endpoint (``*.openai.azure.com``).
+
+_AZURE_DEPLOYMENT_NOT_FOUND_PATTERNS = (
+    "deploymentnotfound",
+    "the api deployment for this resource does not exist",
+)
+
+
+def _is_azure_endpoint(base_url: Any) -> bool:
+    if not base_url:
+        return False
+    try:
+        return base_url_host_matches(str(base_url), "openai.azure.com")
+    except Exception:
+        return False
+
+
+def _extract_azure_error_body(exc: BaseException) -> str:
+    """Best-effort extraction of the Azure error body from an SDK exception."""
+    parts: list[str] = []
+    for attr in ("message", "body"):
+        value = getattr(exc, attr, None)
+        if value is None:
+            continue
+        if isinstance(value, (dict, list)):
+            try:
+                parts.append(json.dumps(value))
+            except Exception:
+                parts.append(str(value))
+        else:
+            parts.append(str(value))
+    response = getattr(exc, "response", None)
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        parts.append(text)
+    parts.append(str(exc))
+    return "\n".join(p for p in parts if p)
+
+
+def _detect_azure_deployment_not_found(exc: BaseException) -> bool:
+    """Return True when ``exc`` looks like an Azure DeploymentNotFound 404."""
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        # Some SDKs nest the status on .response.status_code
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    if status not in (None, 400, 404):
+        return False
+    body = _extract_azure_error_body(exc).lower()
+    return any(token in body for token in _AZURE_DEPLOYMENT_NOT_FOUND_PATTERNS)
+
+
+def _log_azure_deployment_not_found(
+    *, base_url: Any, model: Any, exc: BaseException,
+) -> None:
+    """Emit a single WARNING that names the missing deployment + base_url.
+
+    Caller is responsible for re-raising the original exception — this helper
+    only translates the diagnostic surface, it does not swallow the failure.
+    """
+    logger.warning(
+        "Azure Foundry: deployment %r not found at %s — verify the deployment "
+        "name exists in the Azure portal (Foundry → Deployments) or run "
+        "`hermes model` to pick a deployed model. Upstream said: %s",
+        model, base_url, _extract_azure_error_body(exc).strip()[:400],
+    )
+
+
+def _translate_azure_deployment_error(
+    fn,
+    *,
+    base_url: Any,
+    model: Any,
+):
+    """Run ``fn()``; on Azure DeploymentNotFound, log a clear WARNING and
+    re-raise the original exception unchanged.
+
+    Narrow trigger: only fires when ``base_url`` matches ``*.openai.azure.com``
+    and the exception body contains an Azure DeploymentNotFound marker. All
+    other errors pass through untouched.
+    """
+    try:
+        return fn()
+    except Exception as exc:
+        if _is_azure_endpoint(base_url) and _detect_azure_deployment_not_found(exc):
+            _log_azure_deployment_not_found(base_url=base_url, model=model, exc=exc)
+        raise
 
 
 def _maybe_wrap_anthropic(

--- a/tests/agent/test_azure_foundry_aux.py
+++ b/tests/agent/test_azure_foundry_aux.py
@@ -1,0 +1,187 @@
+"""Tests for azure-foundry as an auxiliary provider.
+
+Covers:
+- azure-foundry + api_mode=anthropic_messages routes through
+  AnthropicAuxiliaryClient with the configured ``/anthropic`` base_url
+  preserved (no /v1 rewrite).
+- azure-foundry + chat_completions falls back to a plain OpenAI client on
+  the /openai/v1 surface.
+- Explicit per-task overrides (explicit_base_url, explicit_api_key,
+  api_mode) win over model.* config from config.yaml.
+- DeploymentNotFound 404 translation: when an Azure endpoint returns the
+  characteristic "DeploymentNotFound" body, a clear WARNING is logged that
+  names the missing deployment and the configured base_url.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME and install a minimal config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+    # Ensure no stale Azure env vars leak in.
+    monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_FOUNDRY_BASE_URL", raising=False)
+
+
+def _write_azure_config(tmp_path, **model_overrides: Any) -> None:
+    """Persist an azure-foundry model.* block to the isolated HERMES_HOME."""
+    import yaml
+    cfg = {
+        "model": {
+            "default": "claude-opus-4-7",
+            "provider": "azure-foundry",
+            **model_overrides,
+        },
+    }
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.dump(cfg))
+
+
+# ── Bug A: routing ────────────────────────────────────────────────────────
+
+
+class TestAzureFoundryAnthropicMessages:
+    """anthropic_messages should wrap in AnthropicAuxiliaryClient."""
+
+    def test_anthropic_messages_wraps_in_anthropic_client(self, tmp_path):
+        _write_azure_config(
+            tmp_path,
+            base_url="https://example.openai.azure.com/anthropic",
+            api_mode="anthropic_messages",
+        )
+        from agent import auxiliary_client
+
+        fake_anthropic = MagicMock(name="anthropic.Anthropic")
+        fake_anthropic.base_url = "https://example.openai.azure.com/anthropic"
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=fake_anthropic,
+        ) as build_mock, patch.object(
+            auxiliary_client,
+            "resolve_api_key_provider_credentials",
+            create=True,
+            return_value={"api_key": "azure-key", "base_url": ""},
+        ), patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "azure-key", "base_url": ""},
+        ):
+            client, model = auxiliary_client.resolve_provider_client(
+                "azure-foundry", model="claude-opus-4-7",
+            )
+
+        assert isinstance(client, auxiliary_client.AnthropicAuxiliaryClient)
+        # base_url preserved as-is (no /v1 rewrite)
+        assert client.base_url == "https://example.openai.azure.com/anthropic"
+        assert model == "claude-opus-4-7"
+        # The adapter must have been invoked with the Anthropic base URL.
+        build_mock.assert_called_once()
+        called_args, called_kwargs = build_mock.call_args
+        assert "azure-key" in called_args or called_kwargs.get("api_key") == "azure-key"
+        url_arg = called_args[1] if len(called_args) > 1 else called_kwargs.get("base_url")
+        assert url_arg == "https://example.openai.azure.com/anthropic"
+
+    def test_anthropic_messages_strips_trailing_v1(self, tmp_path):
+        _write_azure_config(
+            tmp_path,
+            base_url="https://example.openai.azure.com/anthropic/v1",
+            api_mode="anthropic_messages",
+        )
+        from agent import auxiliary_client
+
+        fake_anthropic = MagicMock(name="anthropic.Anthropic")
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=fake_anthropic,
+        ) as build_mock, patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "azure-key", "base_url": ""},
+        ):
+            client, _ = auxiliary_client.resolve_provider_client(
+                "azure-foundry", model="claude-opus-4-7",
+            )
+
+        assert isinstance(client, auxiliary_client.AnthropicAuxiliaryClient)
+        assert client.base_url == "https://example.openai.azure.com/anthropic"
+        url_arg = build_mock.call_args.args[1] if len(build_mock.call_args.args) > 1 \
+            else build_mock.call_args.kwargs.get("base_url")
+        assert url_arg == "https://example.openai.azure.com/anthropic"
+
+
+class TestAzureFoundryChatCompletions:
+    """chat_completions Azure must remain on plain OpenAI client + /openai/v1."""
+
+    def test_chat_completions_returns_plain_openai(self, tmp_path):
+        _write_azure_config(
+            tmp_path,
+            base_url="https://example.openai.azure.com/openai/v1",
+            api_mode="chat_completions",
+        )
+        from agent import auxiliary_client
+
+        fake_openai = MagicMock(name="OpenAI")
+        with patch.object(auxiliary_client, "OpenAI", return_value=fake_openai) as openai_mock, \
+                patch("hermes_cli.auth.resolve_api_key_provider_credentials",
+                      return_value={"api_key": "azure-key", "base_url": ""}):
+            client, _ = auxiliary_client.resolve_provider_client(
+                "azure-foundry", model="gpt-4o-mini",
+            )
+
+        # NOT wrapped in Anthropic client
+        assert not isinstance(client, auxiliary_client.AnthropicAuxiliaryClient)
+        openai_mock.assert_called_once()
+        kwargs = openai_mock.call_args.kwargs
+        # /openai/v1 surface preserved (it already ends in /v1 — no rewrite needed)
+        assert kwargs["base_url"].rstrip("/").endswith("/openai/v1")
+        assert kwargs["api_key"] == "azure-key"
+
+
+class TestAzureFoundryExplicitOverrides:
+    """Explicit per-task overrides win over model.* config."""
+
+    def test_explicit_base_url_and_api_mode_override_config(self, tmp_path):
+        # Config says chat_completions on /openai/v1; explicit override says
+        # anthropic_messages on a different /anthropic URL.
+        _write_azure_config(
+            tmp_path,
+            base_url="https://stale.openai.azure.com/openai/v1",
+            api_mode="chat_completions",
+        )
+        from agent import auxiliary_client
+
+        fake_anthropic = MagicMock(name="anthropic.Anthropic")
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=fake_anthropic,
+        ) as build_mock, patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "stale-key", "base_url": ""},
+        ):
+            client, _ = auxiliary_client.resolve_provider_client(
+                "azure-foundry",
+                model="claude-opus-4-7",
+                explicit_base_url="https://override.openai.azure.com/anthropic",
+                explicit_api_key="override-key",
+                api_mode="anthropic_messages",
+            )
+
+        assert isinstance(client, auxiliary_client.AnthropicAuxiliaryClient)
+        assert client.base_url == "https://override.openai.azure.com/anthropic"
+        assert client.api_key == "override-key"
+        # And the build_anthropic_client got the override key
+        args = build_mock.call_args.args
+        assert "override-key" in args
+
+
+# ── Bug B: DeploymentNotFound translation ─────────────────────────────────
+# (added in the Bug B commit)
+

--- a/tests/agent/test_azure_foundry_aux.py
+++ b/tests/agent/test_azure_foundry_aux.py
@@ -267,6 +267,32 @@ class TestAzureDeploymentNotFoundTranslation:
         assert not any("Azure Foundry: deployment" in r.getMessage()
                        for r in caplog.records)
 
+    def test_400_with_deployment_not_found_text_passes_through(self, caplog):
+        from agent.auxiliary_client import _translate_azure_deployment_error
+
+        exc = _FakeAzureError(400, {
+            "error": {
+                "code": "BadRequest",
+                "message": (
+                    "Invalid request body while checking DeploymentNotFound: "
+                    "the api deployment for this resource does not exist"
+                ),
+            }
+        })
+
+        def boom():
+            raise exc
+
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        with pytest.raises(_FakeAzureError):
+            _translate_azure_deployment_error(
+                boom,
+                base_url="https://example.openai.azure.com/anthropic",
+                model="claude-haiku-4-5",
+            )
+        assert not any("Azure Foundry: deployment" in r.getMessage()
+                       for r in caplog.records)
+
     def test_success_returns_value(self):
         from agent.auxiliary_client import _translate_azure_deployment_error
 

--- a/tests/agent/test_azure_foundry_aux.py
+++ b/tests/agent/test_azure_foundry_aux.py
@@ -183,5 +183,97 @@ class TestAzureFoundryExplicitOverrides:
 
 
 # ── Bug B: DeploymentNotFound translation ─────────────────────────────────
-# (added in the Bug B commit)
 
+
+class _FakeAzureError(Exception):
+    """Approximation of the anthropic / openai NotFoundError shape."""
+
+    def __init__(self, status_code: int, body: dict):
+        super().__init__(body.get("error", {}).get("message", "error"))
+        self.status_code = status_code
+        self.body = body
+        self.message = body.get("error", {}).get("message", "")
+
+
+class TestAzureDeploymentNotFoundTranslation:
+    def test_404_with_deployment_not_found_logs_warning(self, caplog):
+        from agent.auxiliary_client import _translate_azure_deployment_error
+
+        body = {
+            "error": {
+                "code": "DeploymentNotFound",
+                "message": (
+                    "The API deployment for this resource does not exist. "
+                    "If you created the deployment within the last 5 minutes, "
+                    "please wait a moment and try again."
+                ),
+            }
+        }
+        exc = _FakeAzureError(404, body)
+
+        def boom():
+            raise exc
+
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        with pytest.raises(_FakeAzureError):
+            _translate_azure_deployment_error(
+                boom,
+                base_url="https://example.openai.azure.com/anthropic",
+                model="claude-haiku-4-5",
+            )
+
+        assert any(
+            "claude-haiku-4-5" in rec.getMessage()
+            and "example.openai.azure.com" in rec.getMessage()
+            for rec in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+    def test_non_azure_endpoint_does_not_trigger(self, caplog):
+        from agent.auxiliary_client import _translate_azure_deployment_error
+
+        exc = _FakeAzureError(404, {"error": {"code": "DeploymentNotFound",
+                                              "message": "DeploymentNotFound"}})
+
+        def boom():
+            raise exc
+
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        with pytest.raises(_FakeAzureError):
+            _translate_azure_deployment_error(
+                boom,
+                base_url="https://api.anthropic.com",
+                model="claude-opus-4-7",
+            )
+        # No Azure-translation warning should have fired.
+        assert not any("Azure Foundry: deployment" in r.getMessage()
+                       for r in caplog.records)
+
+    def test_non_404_passes_through(self, caplog):
+        from agent.auxiliary_client import _translate_azure_deployment_error
+
+        exc = _FakeAzureError(500, {"error": {"code": "ServerError",
+                                              "message": "boom"}})
+
+        def boom():
+            raise exc
+
+        caplog.set_level(logging.WARNING, logger="agent.auxiliary_client")
+        with pytest.raises(_FakeAzureError):
+            _translate_azure_deployment_error(
+                boom,
+                base_url="https://example.openai.azure.com/anthropic",
+                model="claude-haiku-4-5",
+            )
+        assert not any("Azure Foundry: deployment" in r.getMessage()
+                       for r in caplog.records)
+
+    def test_success_returns_value(self):
+        from agent.auxiliary_client import _translate_azure_deployment_error
+
+        sentinel = object()
+        result = _translate_azure_deployment_error(
+            lambda: sentinel,
+            base_url="https://example.openai.azure.com/anthropic",
+            model="claude-opus-4-7",
+        )
+        assert result is sentinel

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -353,6 +353,77 @@ class TestTranscribeOpenAIExtended:
         mock_client.close.assert_called_once()
 
 
+class TestTranscribeOpenAIAzure:
+    """Azure Foundry support in _transcribe_openai."""
+
+    def test_azure_endpoint_uses_azure_openai_client(self, sample_wav):
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hi"
+
+        with patch(
+            "tools.transcription_tools._resolve_openai_audio_client_config",
+            return_value=("azure-key", "https://hh234.openai.azure.com?api-version=2024-06-01"),
+        ), patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.AzureOpenAI", return_value=mock_client) as mock_azure_cls, \
+             patch("openai.OpenAI") as mock_openai_cls:
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(sample_wav, "whisper")
+
+        assert result["success"] is True
+        mock_azure_cls.assert_called_once()
+        mock_openai_cls.assert_not_called()
+        call_kwargs = mock_azure_cls.call_args.kwargs
+        assert call_kwargs["azure_endpoint"] == "https://hh234.openai.azure.com"
+        assert call_kwargs["api_version"] == "2024-06-01"
+        assert call_kwargs["api_key"] == "azure-key"
+
+    def test_azure_endpoint_api_version_default(self, monkeypatch, sample_wav):
+        monkeypatch.delenv("AZURE_OPENAI_API_VERSION", raising=False)
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hi"
+
+        with patch(
+            "tools.transcription_tools._resolve_openai_audio_client_config",
+            return_value=("k", "https://x.openai.azure.com"),
+        ), patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.AzureOpenAI", return_value=mock_client) as mock_azure_cls:
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(sample_wav, "whisper")
+
+        assert mock_azure_cls.call_args.kwargs["api_version"] == "2024-06-01"
+
+    def test_azure_endpoint_api_version_from_env(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-10-21")
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hi"
+
+        with patch(
+            "tools.transcription_tools._resolve_openai_audio_client_config",
+            return_value=("k", "https://x.openai.azure.com"),
+        ), patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.AzureOpenAI", return_value=mock_client) as mock_azure_cls:
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(sample_wav, "whisper")
+
+        assert mock_azure_cls.call_args.kwargs["api_version"] == "2024-10-21"
+
+    def test_non_azure_endpoint_still_uses_plain_openai(self, sample_wav):
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hi"
+
+        with patch(
+            "tools.transcription_tools._resolve_openai_audio_client_config",
+            return_value=("sk-test", "https://api.openai.com/v1"),
+        ), patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls, \
+             patch("openai.AzureOpenAI") as mock_azure_cls:
+            from tools.transcription_tools import _transcribe_openai
+            _transcribe_openai(sample_wav, "whisper-1")
+
+        mock_openai_cls.assert_called_once()
+        mock_azure_cls.assert_not_called()
+
+
 class TestTranscribeLocalCommand:
     def test_auto_detects_local_whisper_binary(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -622,7 +622,29 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
-        client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
+        # Azure Foundry hosts Whisper under /openai/deployments/<name>/audio/transcriptions
+        # with an api-version query param — incompatible with the stock OpenAI client.
+        # Detect Azure hostnames and use AzureOpenAI instead so the SDK builds
+        # the correct URL automatically.
+        _is_azure = "openai.azure.com" in (base_url or "").lower()
+        if _is_azure:
+            from openai import AzureOpenAI
+            from urllib.parse import urlparse, parse_qs
+            parsed = urlparse(base_url)
+            qs = parse_qs(parsed.query)
+            api_version = (qs.get("api-version", [None])[0]
+                           or os.getenv("AZURE_OPENAI_API_VERSION")
+                           or "2024-06-01")
+            azure_endpoint = f"{parsed.scheme}://{parsed.netloc}"
+            client = AzureOpenAI(
+                api_key=api_key,
+                azure_endpoint=azure_endpoint,
+                api_version=api_version,
+                timeout=30,
+                max_retries=0,
+            )
+        else:
+            client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(


### PR DESCRIPTION
## Summary

Two related fixes for Azure Foundry as an auxiliary provider.

### Bug A — `azure-foundry` aux routing ignored `api_mode: anthropic_messages`

When a user configured `auxiliary.<task>.provider: azure-foundry` (or routed via `model.provider: azure-foundry`) with `api_mode: anthropic_messages` and a `base_url` like `https://X.openai.azure.com/anthropic`, `resolve_provider_client` did not honour the Anthropic-wire intent: it rewrote the base URL through `_to_openai_base_url(...)` and built a plain OpenAI client. Result: 404/403 against the `/anthropic` endpoint.

`hermes_cli/runtime_provider.py::_resolve_runtime_from_pool_entry` already has the right special case for `azure-foundry` (reads `api_mode` and `base_url` from `model_cfg`); the aux path now mirrors it.

**Fix:** In the `api_key` branch of `resolve_provider_client`, add an `azure-foundry` case that:

- Reads `api_mode` / `base_url` from `_get_model_config()` (same as main runtime).
- Honours explicit per-task overrides (`explicit_base_url` / `explicit_api_key` / `api_mode`) — they win over `model.*` config.
- When `api_mode == "anthropic_messages"`: builds the client via `build_anthropic_client` + wraps in `AnthropicAuxiliaryClient` (no `/v1` rewrite), mirroring the named-custom-provider branch.
- When `api_mode == "chat_completions"`: behaviour unchanged (plain OpenAI client on `/openai/v1`).

`azure-foundry` is intentionally **not** added to `_PROVIDER_ALIASES` — it stays a canonical provider name and is routed via `PROVIDER_REGISTRY`.

### Bug B — opaque `DeploymentNotFound` errors on Azure

When the configured deployment name doesn't exist in Azure Foundry (e.g. user requests `claude-haiku-4-5` but only `claude-opus-4-7` is deployed), the Anthropic SDK raises a generic 404 with the upstream Azure error body buried inside. The user sees no actionable hint.

**Fix:** Added `_translate_azure_deployment_error(fn, *, base_url, model)` plus narrow detectors:

- `_is_azure_endpoint(base_url)` — matches `*.openai.azure.com` only.
- `_detect_azure_deployment_not_found(exc)` — scans the error body for `DeploymentNotFound` and "The API deployment for this resource does not exist".

When both conditions match, logs a `WARNING` naming the deployment, the configured `base_url`, and pointing the user at `hermes model` / Azure portal. The original exception is re-raised unchanged — no behaviour change for callers that catch it.

Wired in at a single chokepoint: `_AnthropicCompletionsAdapter.create` wraps the `self._client.messages.create(**anthropic_kwargs)` call. All Anthropic-wire Azure traffic flows through here.

## Tests

- New file `tests/agent/test_azure_foundry_aux.py` (~270 LOC) covering:
  - azure-foundry + `anthropic_messages` → wrapped in `AnthropicAuxiliaryClient`, base_url preserved (no `/v1` rewrite).
  - azure-foundry + `chat_completions` → plain OpenAI client.
  - Explicit per-task `base_url` / `api_key` / `api_mode` overrides win over `model.*` config.
  - DeploymentNotFound translation: feed a fake 404 with the Azure error body, assert the clear WARNING is logged and the original exception propagates.

External SDKs are mocked (`build_anthropic_client`, `OpenAI`, `_get_model_config`) — no network calls.

## Test results

- `tests/agent/test_azure_foundry_aux.py` + `tests/agent/test_auxiliary_client.py` + `tests/agent/test_auxiliary_named_custom_providers.py`: **192 passed**.
- Broad `tests/agent` smoke (excluding pre-existing `botocore`-missing failures in `test_bedrock_*` and `test_context_compressor_summary_continuity`): **2756 passed**.

## Notes / follow-ups

- The same `_translate_azure_deployment_error` helper could be extended to OpenAI-wire Azure traffic (`chat_completions` deployments) — left as a follow-up since the trigger pattern is the same and the chokepoint would be `_AnthropicCompletionsAdapter`'s OpenAI counterpart.
- Symmetrically, `_get_model_config()` reading could be applied to the OpenAI-wire Azure path so aux config respects per-deployment `model.base_url` / `model.api_mode` even when running `chat_completions`.

## Commits

- `[FIX] azure-foundry: route aux through anthropic_messages when configured`
- `[FIX] azure-foundry: surface DeploymentNotFound errors clearly`
