### PR TITLE
fix(install): set 0600 permissions on .env file after creation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1429,6 +1429,8 @@ copy_config_templates() {
             touch "$HERMES_HOME/.env"
             log_success "Created ~/.hermes/.env"
         fi
+        # Restrict .env to owner-only (holds API keys and secrets)
+        chmod 0600 "$HERMES_HOME/.env" 2>/dev/null || true
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -345,6 +345,8 @@ fi
 if [ ! -f ".env" ]; then
     if [ -f ".env.example" ]; then
         cp .env.example .env
+        # Restrict .env to owner-only (holds API keys and secrets)
+        chmod 0600 .env 2>/dev/null || true
         echo -e "${GREEN}✓${NC} Created .env from template"
     fi
 else

--- a/tests/test_install_sh_env_permissions.py
+++ b/tests/test_install_sh_env_permissions.py
@@ -1,0 +1,34 @@
+"""Regression tests for .env file permissions in install scripts.
+
+The .env file holds API keys and secrets.  Install scripts that create it
+must restrict permissions to owner-only (0600) to prevent other local users
+from reading the secrets.
+
+See: https://github.com/NousResearch/hermes-agent/issues/25477
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_HERMES_SH = REPO_ROOT / "setup-hermes.sh"
+
+
+def test_install_sh_sets_0600_on_new_env() -> None:
+    """install.sh must chmod 0600 the .env file after creating it."""
+    text = INSTALL_SH.read_text()
+
+    # The chmod must appear inside the "if [ ! -f ... .env ]" block
+    assert 'chmod 0600 "$HERMES_HOME/.env"' in text, (
+        "install.sh should set 0600 on newly created .env"
+    )
+
+
+def test_setup_hermes_sets_0600_on_new_env() -> None:
+    """setup-hermes.sh must chmod 0600 the .env file after creating it."""
+    text = SETUP_HERMES_SH.read_text()
+
+    assert "chmod 0600 .env" in text, (
+        "setup-hermes.sh should set 0600 on newly created .env"
+    )


### PR DESCRIPTION
## Summary

Set `chmod 0600` on `~/.hermes/.env` after creation in both `scripts/install.sh` and `setup-hermes.sh`.

## Root Cause

The install scripts create `.env` via `cp` or `touch` without restricting file permissions. The resulting file inherits the default umask (typically `0664`), leaving API keys and secrets group- and world-readable on multi-user systems.

The Python side already handles this correctly — `save_env_value()` in `hermes_cli/config.py` calls `_secure_file()` which sets `0600`. But the shell scripts run **before** the setup wizard writes any keys, so the initial `.env` file is created with overly permissive mode.

## Fix

- `scripts/install.sh`: Add `chmod 0600 "$HERMES_HOME/.env"` after creating `.env` (both `cp` and `touch` paths)
- `setup-hermes.sh`: Add `chmod 0600 .env` after creating `.env` from template
- Both use `2>/dev/null || true` to handle permission-restricted environments gracefully

## Code Intelligence

- **Analyzed**: `save_env_value` (callers: 15+ in setup.py), `_secure_file` (callers: save_env_value, save_config_value, ensure_hermes_home)
- **Blast radius**: LOW — only affects the install scripts' .env creation path; no runtime behavior change
- **Related patterns**: `_secure_file()` in `hermes_cli/config.py:360` already does `os.chmod(path, 0o600)`

## Regression Coverage

- `tests/test_install_sh_env_permissions.py`: Text-based assertions that both scripts contain the `chmod 0600` pattern
- All existing install script tests pass (17/17)

## Testing

```
python -m pytest tests/test_install_sh_env_permissions.py tests/test_install_sh_*.py tests/test_termux_all_extra_compat.py tests/cron/test_file_permissions.py -v
# 27 passed
```

## Notes

- Related: #8448 (open 32 days, covers only `install.sh`, no tests)
- The Python `_secure_file()` function intentionally skips chmod in containers and managed mode — the shell scripts should follow the same pattern in the future if container-specific install paths are added

Fixes [bug]: Installer leaves ~/.hermes/.env at file mode 0664 — group/world readable, secrets exposed #25477
