### PR TITLE
fix(cli): gracefully handle Windows console failures in _cprint (kanban fix)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1525,7 +1525,13 @@ def _cprint(text: str):
     # direct prompt_toolkit print is safe and matches existing behavior
     # (spinner frames, streamed tokens, tool activity prefixes, …).
     if app is None or not getattr(app, "_is_running", False):
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            # No Windows console available (e.g. background agent subprocess
+            # with TERM=xterm-256color).  Fall back to plain print so the
+            # process doesn't crash.
+            print(text)
         return
 
     try:
@@ -1533,7 +1539,10 @@ def _cprint(text: str):
     except Exception:
         loop = None
     if loop is None:
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            print(text)
         return
 
     import asyncio as _asyncio
@@ -1549,7 +1558,10 @@ def _cprint(text: str):
         current_loop = None
     # Same thread as the app's loop → safe to print directly.
     if current_loop is loop and loop.is_running():
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            print(text)
         return
 
     # Cross-thread emission: ask the app's event loop to schedule a


### PR DESCRIPTION
## Summary

- On Windows, `prompt_toolkit`'s `_pt_print` can raise an exception when no console is attached (e.g. a background agent subprocess launched with `TERM=xterm-256color`).
- This caused the kanban board to crash outright on Windows rather than degrading gracefully.
- Wraps every `_pt_print(_PT_ANSI(text))` call inside `_cprint` with a `try/except` that falls back to `print()`, keeping the process alive and output visible even when the Windows console API is unavailable.

## Test plan

- [ ] Run the kanban board on Windows in a normal terminal — output still renders correctly via prompt_toolkit.
- [ ] Run the kanban board on Windows in a background/detached subprocess (no attached console) — no crash, plain-text output appears instead.
- [ ] Run on Linux/macOS — no behavioural change, prompt_toolkit path still taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)