### PR TITLE
docs(cli): clarify hermes -z version boundary and one-shot timeout behavior

### DIFF
--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -19,7 +19,8 @@ Hermes also ships a modern TUI with modal overlays, mouse selection, and non-blo
 hermes
 
 # Single query mode (non-interactive)
-hermes chat -q "Hello"
+hermes chat -q "Hello"   # Portable across all versions
+hermes -z "Hello"        # One-shot mode (v0.12.0+) — prints only the final response
 
 # With a specific model
 hermes chat --model "anthropic/claude-sonnet-4"
@@ -46,6 +47,29 @@ hermes chat --verbose
 hermes -w                         # Interactive mode in worktree
 hermes -w -q "Fix issue #123"     # Single query in worktree
 ```
+
+## One-Shot / Non-Interactive Invocation
+
+For scripts, pipes, and automation there are two non-interactive entry points:
+
+| Invocation | Available since | Notes |
+|------------|-----------------|-------|
+| `hermes chat -q "prompt"` | All releases | Portable across every Hermes version. Prints the final response plus session info. |
+| `hermes -z "prompt"` | v0.12.0 (v2026.4.30) | Top-level one-shot mode. Prints **only** the final response text — no banner, spinner, tool previews, or session line. Pairs with top-level `-m/--model` and `--provider`. |
+
+`hermes -z` / `--oneshot` was added in **v0.12.0**; releases before that only ship
+`hermes chat -q`. Scripts that must run against older installs should prefer
+`hermes chat -q`, or check `hermes --version` before using `-z`.
+
+:::info Bounding run time
+Neither `hermes -z` nor `hermes chat -q` accepts a `--timeout` flag — there is no
+built-in time limit for a one-shot run. To bound execution time, wrap the call with
+your own timeout, e.g. the shell `timeout` command or a subprocess timeout:
+
+```bash
+timeout 300 hermes -z "summarize this repo"
+```
+:::
 
 ## Interface Layout
 


### PR DESCRIPTION
## What changed and why

Per the reporter's corrected findings on issue #25121 (comment on 2026-05-14), the original "`hermes -z` is rejected on some versions" claim was retracted — there was no raw evidence of the parser rejecting `-z`. The actual situation is a documentation gap:

- `hermes -z` / `--oneshot` was added in **v0.12.0 (v2026.4.30)**; earlier releases only ship `hermes chat -q`.
- `hermes chat -q` is the portable cross-version one-shot entry point.
- Neither `hermes -z` nor `hermes chat -q` accepts a `--timeout` flag (verified against `hermes_cli/_parser.py` — `--timeout` only exists on the `model`/`login`/`auth` subparsers as a network timeout).

This PR adds a **One-Shot / Non-Interactive Invocation** section to `website/docs/user-guide/cli.md` that spells out the version boundary, recommends `hermes chat -q` for scripts targeting older installs, and shows how to bound run time with an external `timeout` wrapper. The single-query example in "Running the CLI" now also shows `hermes -z` alongside `hermes chat -q`.

Adding an actual `--timeout` flag to one-shot/chat invocations is a separate feature request and is intentionally **not** in scope here.

## How to test

- Render the docs: `cd website && npm install && npm run start`, then open `/docs/user-guide/cli` and confirm the new "One-Shot / Non-Interactive Invocation" section renders, including the table and the `:::info` admonition.
- Or just review the Markdown diff in `website/docs/user-guide/cli.md`.
- Doc test suite: `pytest tests/website/ -q --timeout=60` (7 passed locally).

## What platforms tested on

macOS (Darwin 24.6.0). Change is documentation-only (a single Markdown file); no runtime code paths are touched, so it is platform-independent.

Fixes #25121

<!-- autocontrib:worker-id=issue-followup-1ab43ac6 kind=pr-open -->