### PR TITLE
ci: add authoritative local validation gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,7 +46,7 @@ Fixes #
 - [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
 - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
 - [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
-- [ ] I've run `pytest tests/ -q` and all tests pass
+- [ ] I've run `scripts/check.sh` and all checks pass
 - [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
 - [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
 
@@ -72,4 +72,3 @@ Fixes #
 ## Screenshots / Logs
 
 <!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
+          scripts/check.sh tests/ -q --tb=short
         env:
           # Ensure tests don't accidentally call real APIs
           OPENROUTER_API_KEY: ""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - name: Fetch validation base
+        run: git fetch --no-tags --prune --depth=1 origin main:refs/remotes/origin/main
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,12 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv .venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[all,dev]"
-scripts/run_tests.sh
+scripts/check.sh
 ```
+
+`scripts/check.sh` is the local PR handoff gate. It runs executable validators
+and focused validation smoke tests by default; pass explicit pytest paths such as
+`scripts/check.sh tests/` when you need to expand the test scope.
 
 > **RL Training (optional):** The RL/Atropos integration (`environments/`) — see [`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#development-setup) for the full setup.
 

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -338,7 +338,10 @@ def should_scan_file(path: Path) -> bool:
         if str(path).endswith(suffix):
             return False
     # Skip self and docs that intentionally mention the patterns
-    rel = path.relative_to(REPO_ROOT).as_posix()
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
     if rel in EXCLUDED_FILES:
         return False
     # Only scan text files (rough heuristic — .py, .md, .sh, .ps1, .yaml, etc.)
@@ -592,7 +595,10 @@ def main(argv: list[str]) -> int:
         files_scanned += 1
         matches = scan_file(path, FOOTGUNS)
         for lineno, line, fg in matches:
-            rel = path.relative_to(REPO_ROOT).as_posix()
+            try:
+                rel = path.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                rel = path.as_posix()
             print(f"{rel}:{lineno}: [{fg.name}]")
             print(f"    {line.strip()}")
             print(f"    — {fg.message}")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -73,7 +73,18 @@ run_step() {
   "$@"
 }
 
-run_step "git diff --check" git diff --check
+run_step "git diff --check (worktree)" git diff --check
+
+BASE_REF="${HERMES_CHECK_BASE_REF:-origin/main}"
+if git rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null; then
+  MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
+  run_step "git diff --check ($BASE_REF...HEAD)" git diff --check "$MERGE_BASE" HEAD
+else
+  echo
+  echo "error: cannot verify committed diff; base ref '$BASE_REF' was not found" >&2
+  echo "  fetch the base branch or set HERMES_CHECK_BASE_REF to a local commit/ref" >&2
+  exit 1
+fi
 
 if command -v uv >/dev/null 2>&1; then
   run_step "uv lock --check" uv lock --check

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Canonical local validation gate for PR handoff.
+#
+# This is the one command contributors and work-pack agents should run before
+# opening or handing off a PR. It mirrors the blocking checks that protect main:
+#   * git whitespace/conflict-marker validation
+#   * uv.lock / pyproject.toml consistency
+#   * blocking ruff rules
+#   * Windows cross-platform footgun scanner
+#   * hermetic pytest wrapper over the validation smoke tests
+#
+# Usage:
+#   scripts/check.sh
+#   scripts/check.sh tests/
+#   scripts/check.sh tests/agent/test_foo.py::test_bar
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+VENV=""
+PYTHON_VERSION="${HERMES_CHECK_PYTHON:-3.11}"
+
+venv_matches_python() {
+  local candidate="$1"
+  [ -f "$candidate/bin/activate" ] || return 1
+  "$candidate/bin/python" - "$PYTHON_VERSION" <<'PY'
+import sys
+
+want = tuple(int(part) for part in sys.argv[1].split("."))
+raise SystemExit(0 if sys.version_info[: len(want)] == want else 1)
+PY
+}
+
+for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+  if venv_matches_python "$candidate"; then
+    VENV="$candidate"
+    break
+  fi
+done
+
+if [ -z "$VENV" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        worktree_path="${line#worktree }"
+        for candidate in "$worktree_path/.venv" "$worktree_path/venv"; do
+          if venv_matches_python "$candidate"; then
+            VENV="$candidate"
+            break 2
+          fi
+        done
+        ;;
+    esac
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null || true)
+fi
+
+if [ -z "$VENV" ]; then
+  echo "error: no Python $PYTHON_VERSION virtualenv found in $REPO_ROOT/.venv, $REPO_ROOT/venv, or linked worktrees" >&2
+  exit 1
+fi
+
+PYTHON="$VENV/bin/python"
+
+run_step() {
+  local name="$1"
+  shift
+  echo
+  echo "==> $name"
+  "$@"
+}
+
+run_step "git diff --check" git diff --check
+
+if command -v uv >/dev/null 2>&1; then
+  run_step "uv lock --check" uv lock --check
+else
+  echo
+  echo "error: uv is required for the local validation gate" >&2
+  echo "  install: https://docs.astral.sh/uv/getting-started/installation/" >&2
+  exit 1
+fi
+
+run_step "ruff check ." "$PYTHON" -m ruff check .
+run_step "Windows footgun checker" "$PYTHON" scripts/check-windows-footguns.py --all
+
+if [ "$#" -eq 0 ]; then
+  TEST_ARGS=(tests/scripts/test_validation_gate_scripts.py -q)
+else
+  TEST_ARGS=("$@")
+fi
+
+run_step "pytest" scripts/run_tests.sh "${TEST_ARGS[@]}"
+
+echo
+echo "Local validation gate passed."

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,15 +27,44 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Prefer a .venv in the current tree, fall back to the main checkout's venv
 # (useful for worktrees where we don't always duplicate the venv).
 VENV=""
+PYTHON_VERSION="${HERMES_TEST_PYTHON:-3.11}"
+
+venv_matches_python() {
+  local candidate="$1"
+  [ -f "$candidate/bin/activate" ] || return 1
+  "$candidate/bin/python" - "$PYTHON_VERSION" <<'PY'
+import sys
+
+want = tuple(int(part) for part in sys.argv[1].split("."))
+raise SystemExit(0 if sys.version_info[: len(want)] == want else 1)
+PY
+}
+
 for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+  if venv_matches_python "$candidate"; then
     VENV="$candidate"
     break
   fi
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        worktree_path="${line#worktree }"
+        for candidate in "$worktree_path/.venv" "$worktree_path/venv"; do
+          if venv_matches_python "$candidate"; then
+            VENV="$candidate"
+            break 2
+          fi
+        done
+        ;;
+    esac
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null || true)
+fi
+
+if [ -z "$VENV" ]; then
+  echo "error: no Python $PYTHON_VERSION virtualenv found in $REPO_ROOT/.venv, $REPO_ROOT/venv, or linked worktrees" >&2
   exit 1
 fi
 
@@ -126,4 +155,4 @@ exec "$PYTHON" -m pytest \
   --ignore=tests/integration \
   --ignore=tests/e2e \
   -m "not integration" \
-  "${ARGS[@]}"
+  "${ARGS[@]+"${ARGS[@]}"}"

--- a/tests/scripts/test_validation_gate_scripts.py
+++ b/tests/scripts/test_validation_gate_scripts.py
@@ -115,3 +115,17 @@ os.execv({sys.executable!r}, [{sys.executable!r}, *sys.argv[1:]])
     assert result.returncode != 0
     assert "git diff --check" in result.stdout
     assert "trailing whitespace" in result.stdout
+
+
+def test_tests_workflow_fetches_check_sh_default_base_before_validation():
+    workflow = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+    lines = workflow.read_text(encoding="utf-8").splitlines()
+
+    fetch_line = next(
+        i
+        for i, line in enumerate(lines)
+        if "git fetch" in line and "refs/remotes/origin/main" in line
+    )
+    check_line = next(i for i, line in enumerate(lines) if "scripts/check.sh" in line)
+
+    assert fetch_line < check_line

--- a/tests/scripts/test_validation_gate_scripts.py
+++ b/tests/scripts/test_validation_gate_scripts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_windows_footguns_module():
+    module_path = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+    spec = importlib.util.spec_from_file_location("check_windows_footguns", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_windows_footgun_checker_exits_nonzero_for_bare_open(tmp_path):
+    module = _load_windows_footguns_module()
+    target = tmp_path / "bad.py"
+    target.write_text("with open('notes.txt') as f:\n    print(f.read())\n", encoding="utf-8")
+
+    assert module.main([str(target)]) == 1
+
+
+def test_windows_footgun_checker_allows_explicit_encoding(tmp_path):
+    module = _load_windows_footguns_module()
+    target = tmp_path / "good.py"
+    target.write_text(
+        "with open('notes.txt', encoding='utf-8') as f:\n    print(f.read())\n",
+        encoding="utf-8",
+    )
+
+    assert module.main([str(target)]) == 0

--- a/tests/scripts/test_validation_gate_scripts.py
+++ b/tests/scripts/test_validation_gate_scripts.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import shutil
+import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -36,3 +40,78 @@ def test_windows_footgun_checker_allows_explicit_encoding(tmp_path):
     )
 
     assert module.main([str(target)]) == 0
+
+
+def test_check_sh_rejects_whitespace_errors_in_committed_diff(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy2(REPO_ROOT / "scripts" / "check.sh", scripts_dir / "check.sh")
+    (scripts_dir / "run_tests.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    (scripts_dir / "check-windows-footguns.py").write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    for script in scripts_dir.iterdir():
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+    venv_bin = repo / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "activate").write_text("", encoding="utf-8")
+    python_wrapper = venv_bin / "python"
+    python_wrapper.write_text(
+        f"""#!/usr/bin/env python3
+import os
+import sys
+
+if sys.argv[1:3] == ["-m", "ruff"]:
+    raise SystemExit(0)
+
+os.execv({sys.executable!r}, [{sys.executable!r}, *sys.argv[1:]])
+""",
+        encoding="utf-8",
+    )
+    python_wrapper.chmod(python_wrapper.stat().st_mode | stat.S_IXUSR)
+
+    bin_dir = repo / "bin"
+    bin_dir.mkdir()
+    uv = bin_dir / "uv"
+    uv.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+
+    good_file = repo / "example.txt"
+    good_file.write_text("clean\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=repo, check=True)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    subprocess.run(["git", "checkout", "-qb", "feature"], cwd=repo, check=True)
+    good_file.write_text("bad trailing whitespace \n", encoding="utf-8")
+    subprocess.run(["git", "add", "example.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "add whitespace error"], cwd=repo, check=True)
+
+    env = {
+        **os.environ,
+        "HERMES_CHECK_BASE_REF": base,
+        "HERMES_CHECK_PYTHON": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", "scripts/check.sh"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "git diff --check" in result.stdout
+    assert "trailing whitespace" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Adds `scripts/check.sh` as the documented local PR handoff gate and wires the main test workflow to invoke it with an explicit full-suite pytest target. The gate runs executable validators: `git diff --check`, `uv lock --check`, blocking `ruff check .`, the Windows footgun scanner, and hermetic pytest.

It also fixes two validation-runner issues found while making the gate executable from a worktree:
- `scripts/run_tests.sh` now finds Python 3.11 venvs in linked worktrees and handles no pytest args under `set -u`.
- `scripts/check-windows-footguns.py` can scan explicit files outside the repo without crashing.

## How to Test

1. `./scripts/check.sh`
2. `git diff --check`

## Residual Risk

The bare local gate uses focused validation smoke tests by default so it can be a reliable handoff command. Passing explicit pytest paths still expands scope; CI now calls `scripts/check.sh tests/ -q --tb=short` for the full test job. A local full-suite run was attempted under Python 3.11 and showed broad pre-existing failures before being stopped at 35%, so this PR does not claim to make the entire suite pass on macOS locally.