### PR TITLE
fix: sms platform adapter in `gateway/platforms/sms.py`

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
-from utils import atomic_json_write
+from ...utils import atomic_json_write
 
 if TYPE_CHECKING:
     from gateway.platforms.base import MessageEvent


### PR DESCRIPTION
## What does this PR do?

Fixes a broken relative import in `gateway/platforms/helpers.py` — `from utils import atomic_json_write` was incorrect and needed to be `from ...utils import atomic_json_write` to resolve properly from the `gateway/platforms/` package.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)