### PR TITLE
fix(backup): keep quick snapshot labels path-safe

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -20,6 +20,7 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
 
@@ -500,6 +501,28 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     return home / _QUICK_SNAPSHOTS_DIR
 
 
+def _quick_snapshot_label_slug(label: Optional[str]) -> Optional[str]:
+    """Return a filesystem-safe label component for quick snapshot IDs."""
+    if label is None:
+        return None
+    text = str(label).strip()
+    if not text:
+        return None
+    return quote(text, safe="-._")
+
+
+def _resolve_quick_snapshot_dir(root: Path, snap_id: str) -> Path:
+    """Resolve a snapshot directory and ensure it stays below ``root``."""
+    root.mkdir(parents=True, exist_ok=True)
+    root_resolved = root.resolve()
+    snap_dir = (root / snap_id).resolve()
+    try:
+        snap_dir.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(f"Unsafe quick snapshot id: {snap_id!r}") from exc
+    return snap_dir
+
+
 def create_quick_snapshot(
     label: Optional[str] = None,
     hermes_home: Optional[Path] = None,
@@ -516,8 +539,11 @@ def create_quick_snapshot(
     root = _quick_snapshot_root(home)
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    snap_id = f"{ts}-{label}" if label else ts
-    snap_dir = root / snap_id
+    label_text = str(label).strip() if label is not None else None
+    label_text = label_text or None
+    label_slug = _quick_snapshot_label_slug(label_text)
+    snap_id = f"{ts}-{label_slug}" if label_slug else ts
+    snap_dir = _resolve_quick_snapshot_dir(root, snap_id)
     snap_dir.mkdir(parents=True, exist_ok=True)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
@@ -568,7 +594,7 @@ def create_quick_snapshot(
     meta = {
         "id": snap_id,
         "timestamp": ts,
-        "label": label,
+        "label": label_text,
         "file_count": len(manifest),
         "total_size": sum(manifest.values()),
         "files": manifest,

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1098,6 +1098,28 @@ class TestQuickSnapshot:
         snap_id = create_quick_snapshot(label="before-upgrade", hermes_home=hermes_home)
         assert "before-upgrade" in snap_id
 
+    def test_label_path_components_cannot_escape_snapshot_root(self, hermes_home, tmp_path):
+        from hermes_cli.backup import create_quick_snapshot
+
+        label = "x/../../../leaked"
+        snap_id = create_quick_snapshot(label=label, hermes_home=hermes_home)
+
+        assert snap_id is not None
+        assert "/" not in snap_id
+        assert "\\" not in snap_id
+        assert "%2F" in snap_id
+
+        root = hermes_home / "state-snapshots"
+        snap_dir = root / snap_id
+        assert snap_dir.is_dir()
+        assert (snap_dir / "auth.json").exists()
+        assert not (tmp_path / "leaked").exists()
+
+        with open(snap_dir / "manifest.json", encoding="utf-8") as f:
+            meta = json.load(f)
+        assert meta["id"] == snap_id
+        assert meta["label"] == label
+
     def test_state_db_safely_copied(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(hermes_home=hermes_home)


### PR DESCRIPTION
## Summary
- percent-encode quick snapshot labels before using them in snapshot directory IDs
- verify resolved quick snapshot directories stay under `state-snapshots` before writing state files
- preserve the original label in `manifest.json` and add a regression test for traversal-style labels

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_backup.py -q`
- `python3 -m py_compile hermes_cli/backup.py`
- `git diff --check -- hermes_cli/backup.py tests/hermes_cli/test_backup.py`
- Manual reproducer for `label="x/../../../leaked"`: outside path not created, snapshot files remain under `state-snapshots`
