### PR TITLE
feat(tools): add image_transform tool — vision→describe→generate pipeline

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -89,6 +89,8 @@ AUTHOR_MAP = {
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
     "44045943+ayushere@users.noreply.github.com": "ayushere",
+    "ayushere@users.noreply.github.com": "ayushere",
+    "44045943+ayushere@users.noreply.github.com": "ayushere",
     "daniellsmarta@gmail.com": "DanielLSM",
     "264291321+v1b3coder@users.noreply.github.com": "v1b3coder",
     "silverchris@foxmail.com": "ming1523",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "mike@grossmann.at": "ReqX",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
+    "44045943+ayushere@users.noreply.github.com": "ayushere",
     "daniellsmarta@gmail.com": "DanielLSM",
     "264291321+v1b3coder@users.noreply.github.com": "v1b3coder",
     "silverchris@foxmail.com": "ming1523",

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1035,6 +1035,17 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     return json.dumps(result)
 
 
+def dispatch_to_provider(prompt: str, aspect_ratio: str, **extra_kwargs):
+    """Public entry point for dispatching an image generation request to a
+    plugin-registered provider.
+
+    Thin wrapper around :func:`_dispatch_to_plugin_provider` so external
+    tools (e.g. ``image_transform_tool``) can import a stable public symbol
+    instead of coupling to a private helper.
+    """
+    return _dispatch_to_plugin_provider(prompt, aspect_ratio, **extra_kwargs)
+
+
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
     if not prompt:

--- a/tools/image_transform_tool.py
+++ b/tools/image_transform_tool.py
@@ -23,7 +23,7 @@ import requests
 
 _THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
 
-from tools.registry import registry, tool_error
+from tools.registry import registry
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,8 @@ def image_transform(
         )
         logger.debug("image_transform description: %s...", description[:120])
     except Exception as exc:
-        return {"success": False, "error": f"Vision analysis failed: {exc}"}
+        logger.exception("image_transform: vision analysis failed")
+        return {"success": False, "error": "Vision analysis failed", "error_type": "vision_error"}
 
     # ── Step 2: craft generation prompt ────────────────────────────────────
     try:
@@ -122,15 +123,16 @@ def image_transform(
         gen_prompt = gen_prompt[:1480].rsplit(" ", 1)[0] + "."
 
     try:
-        from tools.image_generation_tool import _dispatch_to_plugin_provider
-        result_json = _dispatch_to_plugin_provider(gen_prompt, aspect_ratio)
+        from tools.image_generation_tool import dispatch_to_provider
+        result_json = dispatch_to_provider(gen_prompt, aspect_ratio)
         if result_json:
             result = json.loads(result_json)
             result["source_description"] = description[:300]
             result["generation_prompt"] = gen_prompt
             return result
     except Exception as exc:
-        return {"success": False, "error": f"Image generation failed: {exc}"}
+        logger.exception("image_transform: image generation failed")
+        return {"success": False, "error": "Image generation failed", "error_type": "generation_error"}
 
     return {"success": False, "error": "No image gen provider available"}
 

--- a/tools/image_transform_tool.py
+++ b/tools/image_transform_tool.py
@@ -1,0 +1,200 @@
+"""Image transform tool — vision → describe → generate pipeline using MiniMax.
+
+Three MiniMax API calls, all on the same API key:
+
+1. MiniMax LLM (vision, /v1 endpoint) — analyzes the input image and
+   produces an ultra-detailed description suitable for image generation.
+2. MiniMax LLM — takes the description + user's transformation instruction
+   and crafts an optimized generation prompt.
+3. MiniMax image-01 — generates the transformed image from the prompt.
+
+Accepts URLs or base64 data URLs (data:image/jpeg;base64,...).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict
+
+import requests
+
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_CHAT_URL = "https://api.minimax.io/v1/chat/completions"
+_VISION_MODEL = "MiniMax-M2.7"
+
+_DESCRIBE_PROMPT = (
+    "Describe this image in extreme detail for AI image generation. "
+    "Cover: every subject (appearance, pose, expression, clothing, age), "
+    "colors, textures, lighting direction and quality, atmosphere, background, "
+    "art style, composition, camera angle, depth of field, mood. "
+    "Be precise and exhaustive. Output ONLY the description, no preamble."
+)
+
+_TRANSFORM_SYSTEM = (
+    "You are an expert AI image prompt engineer. "
+    "Given a detailed image description and a transformation request, "
+    "write a single optimized image generation prompt. "
+    "Preserve every detail that should stay the same. "
+    "Apply the transformation faithfully. "
+    "Output ONLY the final prompt, nothing else."
+)
+
+
+def _llm_call(messages: list, api_key: str, max_tokens: int = 600) -> str:
+    """Single MiniMax chat completion call. Raises on failure."""
+    resp = requests.post(
+        _CHAT_URL,
+        json={"model": _VISION_MODEL, "messages": messages, "max_tokens": max_tokens},
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    content = data["choices"][0]["message"]["content"]
+    # Strip <think>...</think> reasoning blocks (MiniMax-M2.7 chain-of-thought)
+    content = _THINK_RE.sub("", content).strip()
+    return content
+
+
+def image_transform(
+    input_image: str,
+    transformation: str,
+    aspect_ratio: str = "1:1",
+) -> Dict[str, Any]:
+    """Transform an image via the MiniMax vision → describe → generate pipeline."""
+
+    api_key = os.getenv("MINIMAX_API_KEY", "").strip()
+    if not api_key:
+        return {"success": False, "error": "MINIMAX_API_KEY not set"}
+    if not input_image:
+        return {"success": False, "error": "input_image is required"}
+    if not transformation:
+        return {"success": False, "error": "transformation is required"}
+
+    # ── Step 1: describe the source image ──────────────────────────────────
+    try:
+        description = _llm_call(
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": input_image}},
+                    {"type": "text", "text": _DESCRIBE_PROMPT},
+                ],
+            }],
+            api_key=api_key,
+            max_tokens=800,
+        )
+        logger.debug("image_transform description: %s...", description[:120])
+    except Exception as exc:
+        return {"success": False, "error": f"Vision analysis failed: {exc}"}
+
+    # ── Step 2: craft generation prompt ────────────────────────────────────
+    try:
+        gen_prompt = _llm_call(
+            messages=[
+                {"role": "system", "content": _TRANSFORM_SYSTEM},
+                {"role": "user", "content": (
+                    f"Original image:\n{description}\n\n"
+                    f"Transformation: {transformation}\n\n"
+                    f"Keep the final prompt under 1400 characters."
+                )},
+            ],
+            api_key=api_key,
+            max_tokens=400,
+        )
+        logger.debug("image_transform gen_prompt: %s...", gen_prompt[:120])
+    except Exception as exc:
+        # Graceful fallback: combine directly
+        gen_prompt = f"{description}. Style/change: {transformation}."
+        logger.debug("Prompt crafting failed (%s), using fallback prompt", exc)
+
+    # ── Step 3: generate the transformed image ──────────────────────────────
+    # MiniMax image API limits prompt to 1500 chars — truncate at word boundary
+    if len(gen_prompt) > 1480:
+        gen_prompt = gen_prompt[:1480].rsplit(" ", 1)[0] + "."
+
+    try:
+        from tools.image_generation_tool import _dispatch_to_plugin_provider
+        result_json = _dispatch_to_plugin_provider(gen_prompt, aspect_ratio)
+        if result_json:
+            result = json.loads(result_json)
+            result["source_description"] = description[:300]
+            result["generation_prompt"] = gen_prompt
+            return result
+    except Exception as exc:
+        return {"success": False, "error": f"Image generation failed: {exc}"}
+
+    return {"success": False, "error": "No image gen provider available"}
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+_SCHEMA = {
+    "name": "image_transform",
+    "description": (
+        "Transform an existing image by describing what to change. "
+        "Uses MiniMax vision to analyze the source, then generates a new "
+        "image with the requested modification applied. "
+        "Accepts a URL or base64 data URL (data:image/jpeg;base64,...). "
+        "Good for: style changes ('make it cyberpunk', 'oil painting style'), "
+        "scene edits ('change background to snowy mountains', 'add rain'), "
+        "mood/lighting ('dramatic lighting', 'golden hour'). "
+        "Returns the transformed image path or URL in the `image` field."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "input_image": {
+                "type": "string",
+                "description": (
+                    "Source image to transform. Accepts a public URL "
+                    "or a base64 data URL (data:image/jpeg;base64,...)."
+                ),
+            },
+            "transformation": {
+                "type": "string",
+                "description": (
+                    "What to change. Be specific: "
+                    "'make it look like a neon cyberpunk night scene', "
+                    "'convert to watercolor painting style', "
+                    "'change the background to a snowy forest', "
+                    "'add dramatic stormy lighting'."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"],
+                "description": "Output aspect ratio. Defaults to 1:1.",
+                "default": "1:1",
+            },
+        },
+        "required": ["input_image", "transformation"],
+    },
+}
+
+
+def _handle(args, **kw):
+    result = image_transform(
+        input_image=args.get("input_image", ""),
+        transformation=args.get("transformation", ""),
+        aspect_ratio=args.get("aspect_ratio", "1:1"),
+    )
+    return json.dumps(result)
+
+
+registry.register(
+    name="image_transform",
+    toolset="image_gen",
+    schema=_SCHEMA,
+    handler=_handle,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -103,7 +103,7 @@ TOOLSETS = {
     
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "tools": ["image_generate", "image_transform"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

New `image_transform` tool that performs semantic image transformation using three chained MiniMax API calls — no additional API keys required beyond `MINIMAX_API_KEY`.

## How it works

1. **MiniMax LLM (vision, `/v1`)** — analyzes the source image and produces a detailed description covering subjects, lighting, style, composition, and atmosphere
2. **MiniMax LLM** — combines the description with the user's transformation instruction and crafts an optimized generation prompt (enforced ≤1400 chars to fit MiniMax image API limits)
3. **MiniMax image-01** — generates the transformed image from the prompt

## Usage

```
transform this image [URL] → make it look like a neon cyberpunk night scene
```

Or explicitly:
```
image_transform(input_image="https://...", transformation="oil painting style", aspect_ratio="16:9")
```

Accepts public URLs or base64 data URLs (`data:image/jpeg;base64,...`).

## Files changed

- `tools/image_transform_tool.py` — new tool; auto-discovered via `tools/*.py` scanning
- `tools/image_generation_tool.py` — expose `subject_reference` in `image_generate` schema; thread `**extra_kwargs` through `_dispatch_to_plugin_provider` so plugin providers receive additional parameters
- `toolsets.py` — add `image_transform` to the `image_gen` toolset

## Notes

- `<think>` blocks from MiniMax chain-of-thought are stripped before using the generated prompt
- Prompt is hard-truncated at 1480 chars (word boundary) as a safety net before the API call
- Falls back gracefully: if prompt crafting (step 2) fails, uses `{description}. {transformation}.` directly
- Registered on the `image_gen` toolset — only available when image gen is enabled