### PR TITLE
Add regression for union schema argument coercion

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -540,7 +540,11 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         # ``None`` itself is preserved — we don't know whether the model
         # meant "omit" or "empty list", and tools with sensible defaults
         # (e.g. read_file's normalize_read_pagination) already handle it.
-        if expected == "array" and value is not None and not isinstance(value, (list, tuple)):
+        if (
+            _expected_includes_type(expected, "array")
+            and value is not None
+            and not isinstance(value, (list, tuple))
+        ):
             if isinstance(value, str):
                 coerced = _coerce_value(value, expected, schema=prop_schema)
                 if coerced is not value:
@@ -609,6 +613,12 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
+
+
+def _expected_includes_type(expected_type, schema_type: str) -> bool:
+    if isinstance(expected_type, list):
+        return schema_type in expected_type
+    return expected_type == schema_type
 
 
 def _schema_expected_type(schema: dict | None):

--- a/model_tools.py
+++ b/model_tools.py
@@ -531,7 +531,7 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         prop_schema = properties.get(key)
         if not prop_schema:
             continue
-        expected = prop_schema.get("type")
+        expected = _schema_expected_type(prop_schema)
 
         # Wrap bare non-list values when the schema declares ``array``.
         # Strings still go through _coerce_value first so JSON-encoded
@@ -609,6 +609,32 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
     if expected_type == "null" and value.strip().lower() == "null":
         return None
     return value
+
+
+def _schema_expected_type(schema: dict | None):
+    """Return the direct or union-declared JSON Schema type for coercion."""
+    if not isinstance(schema, dict):
+        return None
+
+    schema_type = schema.get("type")
+    if schema_type:
+        return schema_type
+
+    union_types = []
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            variant_type = variant.get("type")
+            if isinstance(variant_type, list):
+                union_types.extend(variant_type)
+            elif variant_type:
+                union_types.append(variant_type)
+
+    return union_types or None
 
 
 def _schema_allows_null(schema: dict | None) -> bool:

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -321,6 +321,21 @@ class TestCoerceToolArgs:
             result = coerce_tool_args("test_tool", args)
             assert result["urls"] == ["https://a.com"]
 
+    def test_bare_string_wrapped_for_union_declared_array(self):
+        """anyOf/oneOf array schemas still get scalar-to-list repair."""
+        schema = self._mock_schema({
+            "urls": {
+                "anyOf": [
+                    {"type": "array", "items": {"type": "string"}},
+                    {"type": "null"},
+                ],
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"urls": "https://a.com"}
+            result = coerce_tool_args("test_tool", args)
+            assert result["urls"] == ["https://a.com"]
+
     def test_bare_int_wrapped_as_array(self):
         """Bare non-string scalars (int, bool, float) also get wrapped."""
         schema = self._mock_schema({"ids": {"type": "array", "items": {"type": "integer"}}})

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -112,6 +112,42 @@ class TestHandleFunctionCall:
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
 
+    def test_json_string_argument_coerces_for_union_schema(self):
+        """Provider-emitted JSON strings should still coerce when a tool
+        declares array/object types through anyOf/oneOf instead of direct type.
+        """
+        schema = {
+            "name": "web_search",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "queries": {
+                        "anyOf": [
+                            {"type": "array", "items": {"type": "string"}},
+                            {"type": "null"},
+                        ]
+                    }
+                },
+            },
+        }
+        seen_args = {}
+
+        def fake_dispatch(_name, args, **_kwargs):
+            seen_args.update(args)
+            return json.dumps({"ok": True})
+
+        with (
+            patch("model_tools.registry.get_schema", return_value=schema),
+            patch("model_tools.registry.dispatch", side_effect=fake_dispatch),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+        ):
+            result = json.loads(
+                handle_function_call("web_search", {"queries": '["alpha", "beta"]'})
+            )
+
+        assert result == {"ok": True}
+        assert seen_args["queries"] == ["alpha", "beta"]
+
 
 # =========================================================================
 # Agent loop tools


### PR DESCRIPTION
## Summary
- add a regression test through handle_function_call for JSON-string tool args whose schema type is declared via anyOf/oneOf
- teach model_tools coercion to derive expected types from direct and union schema declarations

## Validation
- ./scripts/run_tests.sh tests/test_model_tools.py::TestHandleFunctionCall::test_json_string_argument_coerces_for_union_schema -q (1 passed)
- ./scripts/run_tests.sh tests/test_model_tools.py -q (25 passed)
- git diff --check (passed)

## Note
- ./scripts/check.sh was requested by the work pack but is not present in this checkout; running it exits 127 with: No such file or directory.