### PR TITLE
fix(gateway): restrict ppid==1 systemd detection to Linux only

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -140,7 +140,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    ctx["under_systemd"] = bool(invocation_id) or (sys.platform.startswith("linux") and ppid == 1)
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -80,6 +80,30 @@ class TestSnapshotShutdownContext:
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert ctx["under_systemd"] is False
 
+    def test_under_systemd_false_on_macos_when_ppid_is_one(self, monkeypatch):
+        """On macOS (darwin), PID 1 is launchd, not systemd — must NOT flag under_systemd."""
+        monkeypatch.setattr(sf, "sys", type("M", (), {"platform": "darwin"})())
+        monkeypatch.setattr(os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is False
+
+    def test_under_systemd_true_on_linux_when_ppid_is_one(self, monkeypatch):
+        """On Linux, PID 1 is init/systemd — ppid==1 should flag under_systemd."""
+        monkeypatch.setattr(sf, "sys", type("M", (), {"platform": "linux"})())
+        monkeypatch.setattr(os, "getppid", lambda: 1)
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is True
+
+    def test_under_systemd_invocation_id_overrides_platform(self, monkeypatch):
+        """INVOCATION_ID env var must set under_systemd=True regardless of platform."""
+        monkeypatch.setattr(sf, "sys", type("M", (), {"platform": "darwin"})())
+        monkeypatch.setattr(os, "getppid", lambda: 999)
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is True
+
     def test_completes_quickly(self):
         """Snapshot must NOT block — it runs inside the asyncio signal handler."""
         start = time.monotonic()


### PR DESCRIPTION
## Summary

Fixes #25508

When `shutdown_forensics.py` detects `ppid == 1`, it assumes the process runs under `systemd`. On macOS, PID 1 is **launchd** (Apple's service manager), not systemd. This causes the gateway to incorrectly use systemd-specific shutdown logic on macOS.

## Root Cause

In `gateway/shutdown_forensics.py` line 143:

```python
ctx["under_systemd"] = bool(invocation_id) or ppid == 1
```

The `ppid == 1` check is platform-agnostic, but PID 1 only implies systemd on Linux.

## Fix

Restrict the `ppid == 1` heuristic to Linux only:

```python
ctx["under_systemd"] = bool(invocation_id) or (sys.platform.startswith("linux") and ppid == 1)
```

The `INVOCATION_ID` environment variable check remains platform-independent (it's only set by systemd on Linux, so no false positive on macOS).

## Test Plan

- [x] 3 new tests in `tests/gateway/test_shutdown_forensics.py`:
  - `test_under_systemd_false_on_macos_when_ppid_is_one` — macOS + ppid==1 → `under_systemd=False`
  - `test_under_systemd_true_on_linux_when_ppid_is_one` — Linux + ppid==1 → `under_systemd=True`
  - `test_under_systemd_invocation_id_overrides_platform` — `INVOCATION_ID` always wins
- [x] All 33 tests in `test_shutdown_forensics.py` pass (30 existing + 3 new)
