### PR TITLE
fix(memory): expose legacy honcho setup alias

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -18,7 +18,7 @@ Usage:
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
     hermes doctor              # Check configuration and dependencies
-    hermes honcho setup                    # Configure Honcho AI memory integration
+    hermes honcho setup                    # Legacy alias → redirects to `hermes memory setup`
     hermes honcho status                   # Show Honcho config and connection status
     hermes honcho sessions                 # List directory → session name mappings
     hermes honcho map <name>               # Map current directory to a session name
@@ -11093,7 +11093,10 @@ def _plugin_cli_discovery_needed() -> bool:
     first = _first_positional_argv()
     if first is None:
         # Bare ``hermes`` or only flags → defaults to ``chat``.
-        return False
+        # Keep plugin CLI discovery enabled for root help so legacy aliases like
+        # ``hermes honcho setup`` remain visible to users before a provider is
+        # activated.
+        return any(arg in ("-h", "--help") for arg in sys.argv[1:])
     if first in _BUILTIN_SUBCOMMANDS:
         return False
     # Unknown token — could be a plugin subcommand, OR a chat prompt

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -32,16 +32,20 @@ Honcho provides AI-native cross-session user modeling. It learns who the user is
 ### Cloud (app.honcho.dev)
 
 ```bash
-hermes honcho setup
-# select "cloud", paste API key from https://app.honcho.dev
+hermes memory setup
+# select "honcho", then choose "cloud" and paste the API key from https://app.honcho.dev
 ```
+
+Legacy alias: `hermes honcho setup`
 
 ### Self-hosted
 
 ```bash
-hermes honcho setup
-# select "local", enter base URL (e.g. http://localhost:8000)
+hermes memory setup
+# select "honcho", then choose "local" and enter the base URL (e.g. http://localhost:8000)
 ```
+
+Legacy alias: `hermes honcho setup`
 
 See: https://docs.honcho.dev/v3/guides/integrations/hermes#running-honcho-locally-with-hermes
 
@@ -389,7 +393,7 @@ This fix addresses edge cases where raw user conclusions containing markup or sp
 ## Troubleshooting
 
 ### "Honcho not configured"
-Run `hermes honcho setup`. Ensure `memory.provider: honcho` is in `~/.hermes/config.yaml`.
+Run `hermes memory setup` and select `honcho`. Legacy alias: `hermes honcho setup`.
 
 ### Memory not persisting across sessions
 Check `hermes honcho status` -- verify `saveMessages: true` and `writeFrequency` isn't `session` (which only writes on exit).
@@ -413,7 +417,8 @@ Session summary requires at least one prior turn in the current Honcho session. 
 
 | Command | Description |
 |---------|-------------|
-| `hermes honcho setup` | Interactive setup wizard (cloud/local, identity, observation, recall, sessions) |
+| `hermes memory setup` | Preferred entrypoint — choose `honcho` in the unified memory wizard |
+| `hermes honcho setup` | Legacy alias — redirects to `hermes memory setup` |
 | `hermes honcho status` | Show resolved config, connection test, peer info for active profile |
 | `hermes honcho enable` | Enable Honcho for the active profile (creates host block if needed) |
 | `hermes honcho disable` | Disable Honcho for the active profile |

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -320,22 +320,58 @@ def _get_active_memory_provider() -> Optional[str]:
         return None
 
 
+def _load_memory_cli_module(provider_name: str, plugin_dir: Path):
+    """Import and return a provider's lightweight ``cli.py`` module."""
+    cli_file = plugin_dir / "cli.py"
+    if not cli_file.exists():
+        return None
+
+    _is_bundled = _MEMORY_PLUGINS_DIR in plugin_dir.parents or plugin_dir.parent == _MEMORY_PLUGINS_DIR
+    module_name = (
+        f"plugins.memory.{provider_name}.cli"
+        if _is_bundled else f"_hermes_user_memory.{provider_name}.cli"
+    )
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, str(cli_file))
+    if not spec or not spec.loader:
+        return None
+
+    cli_mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = cli_mod
+    spec.loader.exec_module(cli_mod)
+    return cli_mod
+
+
+def _register_honcho_legacy_cli(subparser) -> None:
+    """Register a minimal legacy ``hermes honcho`` compatibility surface."""
+    subparser.add_argument(
+        "--target-profile", metavar="NAME", dest="target_profile",
+        help="Target a specific profile's Honcho config without switching",
+    )
+    subparser.description = (
+        "Legacy Honcho entrypoint. Use 'hermes memory setup' for first-time setup; "
+        "'hermes honcho setup' is kept as a compatibility alias that redirects there."
+    )
+    subs = subparser.add_subparsers(dest="honcho_command")
+    subs.add_parser(
+        "setup",
+        help="Legacy alias for 'hermes memory setup' (Honcho provider setup)",
+        description=(
+            "Legacy alias for 'hermes memory setup'. Select the Honcho provider "
+            "from the unified memory wizard."
+        ),
+    )
+
+
 def discover_plugin_cli_commands() -> List[dict]:
-    """Return CLI commands for the **active** memory plugin only.
+    """Return CLI commands for the active memory plugin.
 
-    Only one memory provider can be active at a time (set via
-    ``memory.provider`` in config.yaml).  This function reads that
-    value and only loads CLI registration for the matching plugin.
-    If no provider is active, no commands are registered.
-
-    Looks for a ``register_cli(subparser)`` function in the active
-    plugin's ``cli.py``.  Returns a list of at most one dict with
-    keys: ``name``, ``help``, ``description``, ``setup_fn``,
-    ``handler_fn``.
-
-    This is a lightweight scan — it only imports ``cli.py``, not the
-    full plugin module.  Safe to call during argparse setup before
-    any provider is loaded.
+    When no memory provider is active, we still expose a minimal legacy
+    ``hermes honcho`` entrypoint so existing docs, skills, and user habits can
+    discover ``hermes honcho setup`` and get redirected into ``hermes memory
+    setup``. Provider-specific CLIs remain active-provider-gated otherwise.
     """
     results: List[dict] = []
     if not _MEMORY_PLUGINS_DIR.is_dir():
@@ -343,6 +379,26 @@ def discover_plugin_cli_commands() -> List[dict]:
 
     active_provider = _get_active_memory_provider()
     if not active_provider:
+        honcho_dir = find_provider_dir("honcho")
+        if not honcho_dir:
+            return results
+        try:
+            cli_mod = _load_memory_cli_module("honcho", honcho_dir)
+            if cli_mod is None:
+                return results
+            results.append({
+                "name": "honcho",
+                "help": "Legacy Honcho setup alias (redirects to 'hermes memory setup')",
+                "description": (
+                    "Compatibility entrypoint for Honcho memory setup. "
+                    "Use 'hermes memory setup' for normal configuration."
+                ),
+                "setup_fn": _register_honcho_legacy_cli,
+                "handler_fn": getattr(cli_mod, "honcho_command", None),
+                "plugin": "honcho",
+            })
+        except Exception as e:
+            logger.debug("Failed to scan legacy CLI for memory plugin 'honcho': %s", e)
         return results
 
     # Only look at the active provider's directory
@@ -350,25 +406,10 @@ def discover_plugin_cli_commands() -> List[dict]:
     if not plugin_dir:
         return results
 
-    cli_file = plugin_dir / "cli.py"
-    if not cli_file.exists():
-        return results
-
-    _is_bundled = _MEMORY_PLUGINS_DIR in plugin_dir.parents or plugin_dir.parent == _MEMORY_PLUGINS_DIR
-    module_name = f"plugins.memory.{active_provider}.cli" if _is_bundled else f"_hermes_user_memory.{active_provider}.cli"
     try:
-        # Import the CLI module (lightweight — no SDK needed)
-        if module_name in sys.modules:
-            cli_mod = sys.modules[module_name]
-        else:
-            spec = importlib.util.spec_from_file_location(
-                module_name, str(cli_file)
-            )
-            if not spec or not spec.loader:
-                return results
-            cli_mod = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = cli_mod
-            spec.loader.exec_module(cli_mod)
+        cli_mod = _load_memory_cli_module(active_provider, plugin_dir)
+        if cli_mod is None:
+            return results
 
         register_cli = getattr(cli_mod, "register_cli", None)
         if not callable(register_cli):

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -218,7 +218,8 @@ hermes insights [--days N]  Usage analytics
 hermes update               Update to latest version
 hermes pairing list/approve/revoke  DM authorization
 hermes plugins list/install/remove  Plugin management
-hermes honcho setup/status  Honcho memory integration (requires honcho plugin)
+hermes honcho setup         Legacy Honcho setup alias → redirects to `hermes memory setup`
+hermes honcho status        Honcho status/tools when provider is active
 hermes memory setup/status/off  Memory provider config
 hermes completion bash|zsh  Shell completions
 hermes acp                  ACP server (IDE integration)

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -109,13 +109,17 @@ class TestMemoryPluginCliDiscovery:
         assert callable(cmds[0]["setup_fn"])
         assert cmds[0]["handler_fn"].__name__ == "testplugin_command"
 
-    def test_returns_nothing_when_no_active_provider(self, tmp_path, monkeypatch):
-        """No commands when memory.provider is not set in config."""
-        plugin_dir = tmp_path / "testplugin"
+    def test_returns_legacy_honcho_setup_when_no_active_provider(self, tmp_path, monkeypatch):
+        """No active provider still exposes the legacy honcho setup alias only."""
+        plugin_dir = tmp_path / "honcho"
         plugin_dir.mkdir()
         (plugin_dir / "__init__.py").write_text("pass\n")
         (plugin_dir / "cli.py").write_text(
-            "def register_cli(subparser):\n    pass\n"
+            "def honcho_command(args):\n"
+            "    return None\n"
+            "\n"
+            "def register_cli(subparser):\n"
+            "    subparser.add_argument('--full')\n"
         )
 
         import plugins.memory as pm
@@ -124,10 +128,24 @@ class TestMemoryPluginCliDiscovery:
         monkeypatch.setattr(pm, "_get_active_memory_provider", lambda: None)
         try:
             cmds = pm.discover_plugin_cli_commands()
+            parser = argparse.ArgumentParser()
+            subparsers = parser.add_subparsers(dest="command")
+            honcho_parser = subparsers.add_parser(cmds[0]["name"])
+            cmds[0]["setup_fn"](honcho_parser)
         finally:
             monkeypatch.setattr(pm, "_MEMORY_PLUGINS_DIR", original_dir)
+            sys.modules.pop("plugins.memory.honcho.cli", None)
 
-        assert len(cmds) == 0
+        assert len(cmds) == 1
+        assert cmds[0]["name"] == "honcho"
+        assert "redirects" in cmds[0]["help"]
+        assert cmds[0]["handler_fn"].__name__ == "honcho_command"
+
+        subparsers_action = next(
+            action for action in honcho_parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        )
+        assert set(subparsers_action.choices) == {"setup"}
 
     def test_skips_plugin_without_register_cli(self, tmp_path, monkeypatch):
         """An active plugin with cli.py but no register_cli returns nothing."""
@@ -183,3 +201,19 @@ class TestProviderCollectorCliNoop:
         )
         # Should not store anything — CLI is discovered via file convention
         assert not hasattr(collector, "_cli_commands")
+
+
+class TestPluginCliDiscoveryGate:
+    def test_root_help_triggers_plugin_cli_discovery(self, monkeypatch):
+        """Root help should still include legacy plugin aliases like honcho."""
+        from hermes_cli import main as main_mod
+
+        monkeypatch.setattr(sys, "argv", ["hermes", "--help"])
+        assert main_mod._plugin_cli_discovery_needed() is True
+
+    def test_bare_cli_still_skips_plugin_cli_discovery(self, monkeypatch):
+        """Bare interactive chat should keep the fast path."""
+        from hermes_cli import main as main_mod
+
+        monkeypatch.setattr(sys, "argv", ["hermes"])
+        assert main_mod._plugin_cli_discovery_needed() is False

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -8,6 +8,7 @@ Covers:
   - Honcho register_cli() builds correct argparse tree
 """
 
+import argparse
 import sys
 from unittest.mock import MagicMock
 

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -111,8 +111,6 @@ def test_first_positional_argv(argv, expected):
     "argv",
     [
         ["hermes"],                          # bare → chat
-        ["hermes", "--help"],                # top-level help
-        ["hermes", "-h"],
         ["hermes", "version"],               # known built-in
         ["hermes", "logs"],
         ["hermes", "gateway", "run"],
@@ -126,6 +124,12 @@ def test_first_positional_argv(argv, expected):
 def test_discovery_skipped_for_builtins(argv):
     with patch.object(sys, "argv", argv):
         assert _plugin_cli_discovery_needed() is False
+
+
+@pytest.mark.parametrize("argv", [["hermes", "--help"], ["hermes", "-h"]])
+def test_root_help_keeps_plugin_cli_discovery_enabled(argv):
+    with patch.object(sys, "argv", argv):
+        assert _plugin_cli_discovery_needed() is True
 
 
 @pytest.mark.parametrize(

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -66,7 +66,7 @@ AI-native cross-session user modeling with dialectic reasoning, session-scoped c
 hermes memory setup        # select "honcho" — runs the Honcho-specific post-setup
 ```
 
-The legacy `hermes honcho setup` command still works (it now redirects to `hermes memory setup`), but is only registered after Honcho is selected as the active memory provider.
+The legacy `hermes honcho setup` command still works (it redirects to `hermes memory setup`) so old docs and muscle memory keep working, but the rest of the Honcho CLI remains registered only when Honcho is the active memory provider.
 
 **Config:** `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.json` (global). Resolution order: `$HERMES_HOME/honcho.json` > `~/.hermes/honcho.json` > `~/.honcho/config.json`. See the [config reference](https://github.com/hermes-ai/hermes-agent/blob/main/plugins/memory/honcho/README.md) and the [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -235,7 +235,8 @@ hermes insights [--days N]  Usage analytics
 hermes update               Update to latest version
 hermes pairing list/approve/revoke  DM authorization
 hermes plugins list/install/remove  Plugin management
-hermes honcho setup/status  Honcho memory integration (requires honcho plugin)
+hermes honcho setup         Legacy Honcho setup alias → redirects to `hermes memory setup`
+hermes honcho status        Honcho status/tools when provider is active
 hermes memory setup/status/off  Memory provider config
 hermes completion bash|zsh  Shell completions
 hermes acp                  ACP server (IDE integration)

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -47,16 +47,20 @@ Honcho provides AI-native cross-session user modeling. It learns who the user is
 ### Cloud (app.honcho.dev)
 
 ```bash
-hermes honcho setup
-# select "cloud", paste API key from https://app.honcho.dev
+hermes memory setup
+# select "honcho", then choose "cloud" and paste the API key from https://app.honcho.dev
 ```
+
+Legacy alias: `hermes honcho setup`
 
 ### Self-hosted
 
 ```bash
-hermes honcho setup
-# select "local", enter base URL (e.g. http://localhost:8000)
+hermes memory setup
+# select "honcho", then choose "local" and enter the base URL (e.g. http://localhost:8000)
 ```
+
+Legacy alias: `hermes honcho setup`
 
 See: https://docs.honcho.dev/v3/guides/integrations/hermes#running-honcho-locally-with-hermes
 
@@ -404,7 +408,7 @@ This fix addresses edge cases where raw user conclusions containing markup or sp
 ## Troubleshooting
 
 ### "Honcho not configured"
-Run `hermes honcho setup`. Ensure `memory.provider: honcho` is in `~/.hermes/config.yaml`.
+Run `hermes memory setup` and select `honcho`. Legacy alias: `hermes honcho setup`.
 
 ### Memory not persisting across sessions
 Check `hermes honcho status` -- verify `saveMessages: true` and `writeFrequency` isn't `session` (which only writes on exit).
@@ -428,7 +432,8 @@ Session summary requires at least one prior turn in the current Honcho session. 
 
 | Command | Description |
 |---------|-------------|
-| `hermes honcho setup` | Interactive setup wizard (cloud/local, identity, observation, recall, sessions) |
+| `hermes memory setup` | Preferred entrypoint — choose `honcho` in the unified memory wizard |
+| `hermes honcho setup` | Legacy alias — redirects to `hermes memory setup` |
 | `hermes honcho status` | Show resolved config, connection test, peer info for active profile |
 | `hermes honcho enable` | Enable Honcho for the active profile (creates host block if needed) |
 | `hermes honcho disable` | Disable Honcho for the active profile |


### PR DESCRIPTION
## Summary
- keep a minimal `hermes honcho` compatibility entrypoint discoverable before Honcho is the active memory provider
- redirect legacy `hermes honcho setup` users into `hermes memory setup`
- align bundled docs/skills with the unified memory setup flow

## Implementation
- register a legacy-only Honcho CLI surface when no memory provider is active
- preserve provider-gated full Honcho CLI behavior once `memory.provider=honcho`
- update help text and Honcho skill/docs references to prefer `hermes memory setup`

## Testing
- `pytest -q tests/hermes_cli/test_plugin_cli_registration.py`
- `python -m hermes_cli.main --help`
- `python -m hermes_cli.main honcho --help`
- `python -m hermes_cli.main honcho setup --help`