### PR TITLE
feat(delegate_task): per-call model/provider override (revives #3719)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -958,6 +958,92 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
 
 
+class TestPerTaskCredentialOverride(unittest.TestCase):
+    """Tests for per-call model/provider override on delegate_task (issue #3719)."""
+
+    def setUp(self):
+        from tools.delegate_tool import _resolve_per_task_creds
+        self._resolve = _resolve_per_task_creds
+        self.parent = _make_mock_parent(depth=0)
+        self.default_creds = {
+            "model": "default-model",
+            "provider": "default-provider",
+            "base_url": "https://default.example/v1",
+            "api_key": "default-key",
+            "api_mode": "chat_completions",
+        }
+        self.cfg = {"model": "default-model", "provider": "default-provider"}
+
+    def test_no_override_returns_default_creds(self):
+        creds = self._resolve({}, None, None, self.default_creds, self.cfg, self.parent)
+        self.assertIs(creds, self.default_creds)
+
+    def test_model_only_top_level_override_swaps_model_keeps_provider(self):
+        creds = self._resolve({}, "new-model", None, self.default_creds, self.cfg, self.parent)
+        self.assertEqual(creds["model"], "new-model")
+        self.assertEqual(creds["provider"], "default-provider")
+        self.assertEqual(creds["base_url"], "https://default.example/v1")
+
+    def test_per_task_model_beats_top_level(self):
+        creds = self._resolve(
+            {"model": "per-task-model"},
+            "top-level-model", None,
+            self.default_creds, self.cfg, self.parent,
+        )
+        self.assertEqual(creds["model"], "per-task-model")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_provider_override_re_resolves_full_bundle(self, mock_resolve):
+        mock_resolve.return_value = {
+            "model": "glm-5.1",
+            "provider": "zai",
+            "base_url": "https://api.z.ai/v1",
+            "api_key": "zai-key",
+            "api_mode": "chat_completions",
+        }
+        creds = self._resolve(
+            {}, None, "zai",
+            self.default_creds, self.cfg, self.parent,
+        )
+        self.assertEqual(creds["provider"], "zai")
+        self.assertEqual(creds["base_url"], "https://api.z.ai/v1")
+        # Verify resolver was called with cleaned cfg (no stale base_url / api_key)
+        called_cfg = mock_resolve.call_args[0][0]
+        self.assertEqual(called_cfg["provider"], "zai")
+        self.assertNotIn("base_url", called_cfg)
+        self.assertNotIn("api_key", called_cfg)
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_provider_beats_top_level(self, mock_resolve):
+        mock_resolve.return_value = {
+            "model": "task-model",
+            "provider": "minimax",
+            "base_url": "https://minimax/v1",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }
+        creds = self._resolve(
+            {"provider": "minimax", "model": "task-model"},
+            None, "openrouter",
+            self.default_creds, self.cfg, self.parent,
+        )
+        called_cfg = mock_resolve.call_args[0][0]
+        self.assertEqual(called_cfg["provider"], "minimax")
+        self.assertEqual(called_cfg["model"], "task-model")
+        self.assertEqual(creds["provider"], "minimax")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_provider_resolution_failure_falls_back_to_default(self, mock_resolve):
+        mock_resolve.side_effect = ValueError("OPENROUTER_API_KEY not set")
+        creds = self._resolve(
+            {}, "new-model", "openrouter",
+            self.default_creds, self.cfg, self.parent,
+        )
+        # Falls back to default creds with model swap (since eff_model was provided)
+        self.assertEqual(creds["model"], "new-model")
+        self.assertEqual(creds["provider"], "default-provider")
+
+
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1906,6 +1906,57 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_per_task_creds(
+    task_dict: Dict[str, Any],
+    top_level_model: Optional[str],
+    top_level_provider: Optional[str],
+    default_creds: Dict[str, Any],
+    cfg: dict,
+    parent_agent,
+) -> Dict[str, Any]:
+    """Compute effective credentials for a single delegated task.
+
+    Precedence: per-task model/provider > top-level model/provider > config
+    (``default_creds``). When ``provider`` is overridden, the full credential
+    bundle is re-resolved through the runtime provider system so ``base_url``,
+    ``api_key``, and ``api_mode`` match the new provider. When only ``model``
+    is overridden, the surrounding credentials are preserved.
+
+    Returns ``default_creds`` (or a model-swapped copy) if any provider
+    resolution fails; the original delegation continues with the configured
+    fallback rather than aborting the whole batch.
+    """
+    eff_model = task_dict.get("model") or top_level_model
+    eff_provider = task_dict.get("provider") or top_level_provider
+
+    if not eff_provider:
+        if eff_model:
+            return {**default_creds, "model": eff_model}
+        return default_creds
+
+    override_cfg = dict(cfg)
+    override_cfg["provider"] = eff_provider
+    if eff_model:
+        override_cfg["model"] = eff_model
+    # When the operator picks a different provider, the original base_url /
+    # api_key belong to the old provider — drop them so the resolver pulls the
+    # new provider's endpoint and credentials.
+    override_cfg.pop("base_url", None)
+    override_cfg.pop("api_key", None)
+
+    try:
+        return _resolve_delegation_credentials(override_cfg, parent_agent)
+    except ValueError as exc:
+        logger.warning(
+            "delegate_task: per-call override provider=%s model=%s failed (%s); "
+            "falling back to configured delegation credentials.",
+            eff_provider, eff_model, exc,
+        )
+        if eff_model:
+            return {**default_creds, "model": eff_model}
+        return default_creds
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1915,6 +1966,8 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2049,26 +2102,37 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model/provider beats top-level beats config. When the
+            # provider is overridden, the credential bundle is re-resolved so
+            # base_url / api_key / api_mode match the new provider.
+            task_creds = _resolve_per_task_creds(
+                t,
+                top_level_model=model,
+                top_level_provider=provider,
+                default_creds=creds,
+                cfg=cfg,
+                parent_agent=parent_agent,
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2713,6 +2777,22 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'glm-5.1'). "
+                                "Overrides the top-level 'model' for this task only. "
+                                "Falls back to delegation.model from config when unset."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'zai'). When set, the "
+                                "credential bundle (base_url, api_key, api_mode) is re-resolved "
+                                "via the runtime provider system. Overrides the top-level 'provider'."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2748,6 +2828,23 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the model for every subagent in this delegation "
+                    "(e.g. 'glm-5.1'). Per-task 'model' inside the 'tasks' array "
+                    "beats this; this beats delegation.model from config."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Override the provider for every subagent in this delegation "
+                    "(e.g. 'zai'). When set, the credential bundle (base_url, api_key, "
+                    "api_mode) is re-resolved via the runtime provider system. "
+                    "Per-task 'provider' beats this; this beats delegation.provider from config."
+                ),
+            },
         },
         "required": [],
     },
@@ -2770,6 +2867,8 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2782,15 +2782,23 @@ DELEGATE_TASK_SCHEMA = {
                             "description": (
                                 "Per-task model override (e.g. 'glm-5.1'). "
                                 "Overrides the top-level 'model' for this task only. "
-                                "Falls back to delegation.model from config when unset."
+                                "Falls back to delegation.model from config when unset. "
+                                "MODEL-ONLY: keeps the surrounding provider bundle "
+                                "(base_url / api_key / api_mode). If the model belongs "
+                                "to a different provider, also set 'provider' on this "
+                                "task or the request will hit the wrong endpoint."
                             ),
                         },
                         "provider": {
                             "type": "string",
                             "description": (
-                                "Per-task provider override (e.g. 'zai'). When set, the "
-                                "credential bundle (base_url, api_key, api_mode) is re-resolved "
-                                "via the runtime provider system. Overrides the top-level 'provider'."
+                                "Per-task provider override (e.g. 'zai'). "
+                                "Overrides the top-level 'provider'. "
+                                "PROVIDER OVERRIDE: re-resolves the full credential "
+                                "bundle (base_url, api_key, api_mode) via the runtime "
+                                "provider system, replacing the original delegation "
+                                "config's base_url / api_key so the new provider's "
+                                "endpoint is used."
                             ),
                         },
                     },
@@ -2833,16 +2841,27 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Override the model for every subagent in this delegation "
                     "(e.g. 'glm-5.1'). Per-task 'model' inside the 'tasks' array "
-                    "beats this; this beats delegation.model from config."
+                    "beats this; this beats delegation.model from config. "
+                    "MODEL-ONLY OVERRIDE: keeps the existing provider's credential "
+                    "bundle (base_url / api_key / api_mode) — the model name is "
+                    "swapped within the current provider. Use this when the new "
+                    "model is served by the same provider you already use. If the "
+                    "model belongs to a DIFFERENT provider, also set 'provider' "
+                    "below to trigger full credential re-resolution; otherwise the "
+                    "request will be routed to the wrong endpoint."
                 ),
             },
             "provider": {
                 "type": "string",
                 "description": (
                     "Override the provider for every subagent in this delegation "
-                    "(e.g. 'zai'). When set, the credential bundle (base_url, api_key, "
-                    "api_mode) is re-resolved via the runtime provider system. "
-                    "Per-task 'provider' beats this; this beats delegation.provider from config."
+                    "(e.g. 'zai'). Per-task 'provider' beats this; this beats "
+                    "delegation.provider from config. "
+                    "PROVIDER OVERRIDE: triggers full credential re-resolution via "
+                    "the runtime provider system — base_url, api_key, and api_mode "
+                    "are rebuilt for the new provider, and any base_url / api_key "
+                    "from the original delegation config are discarded so the new "
+                    "provider's endpoint and key are used."
                 ),
             },
         },


### PR DESCRIPTION
## Summary

Adds optional `model` and `provider` parameters to `delegate_task`, both at the top level and per-task inside the `tasks` array. This unblocks model-routing plugins (per-phase models for SDD-style workflows) without forcing them to monkey-patch `delegate_tool.py`.

This is a fresh take on #3719 / #3794. #3794 bundled a delegation **pool** with per-call override; that PR was closed without merge. This PR keeps only the per-call override — the smaller, lower-risk half — so it can land and unblock downstream work. The pool can land as a follow-up.

## Why

SDD-style workflows route different phases to different models for cost/quality balance: cheap models for scout/explore, mid-tier for apply, reasoning models for verify/design. `delegate_task` exposes no way to do that today — `delegation.model`/`delegation.provider` are global per-config.

The plumbing already exists: `_build_child_agent` accepts `model` / `override_provider` / `override_base_url` / `override_api_key` / `override_api_mode` natively. This PR wires the public schema → handler → `_build_child_agent` path.

## Evidence

I maintain [cobalt-agent](https://github.com/thestark77/cobalt-agent), a Hermes plugin that does this routing via a source patch (`apply_routing_patch.py` injects `_routed_*` fields into task dicts before `_build_child_agent` is called). It has been running on two production VPS instances for ~4 weeks. 12 measurement runs, last 6 at 95% routing accuracy (logs in [cobalt-agent CHANGELOG.md](https://github.com/thestark77/cobalt-agent/blob/main/CHANGELOG.md)).

The patch works, but with Hermes shipping weekly the source-level approach is fragile — that's the whole reason for the upstream request. Once this PR lands I can retire the patch in favour of the official schema.

## Diff overview

| Change | Where |
|---|---|
| `model` / `provider` params on `delegate_task()` | `tools/delegate_tool.py` (signature + handler lambda) |
| `model` / `provider` properties on `DELEGATE_TASK_SCHEMA` | top-level + `tasks[].properties` |
| `_resolve_per_task_creds()` helper | `tools/delegate_tool.py` |
| Loop uses per-task creds instead of batch creds | `tools/delegate_tool.py` |
| 6 unit tests covering precedence + fallback | `tests/tools/test_delegate.py` |

Total: +192 / -7 lines.

## API

### Top-level (whole batch uses the same model)
```json
{
  "name": "delegate_task",
  "arguments": {
    "goal": "Implement the auth middleware",
    "model": "glm-5.1",
    "provider": "zai"
  }
}
```

### Per-task (different model per task in one call)
```json
{
  "name": "delegate_task",
  "arguments": {
    "tasks": [
      {"goal": "Research competitors", "model": "glm-5",   "provider": "zai"},
      {"goal": "Write integration tests", "model": "glm-5.1"}
    ]
  }
}
```

### Precedence
```
per-task model/provider > top-level model/provider > delegation.{model,provider} from config
```

## Provider re-resolution

When `provider` is overridden, `_resolve_per_task_creds` re-runs `_resolve_delegation_credentials` with the new provider so `base_url` / `api_key` / `api_mode` match the new provider (instead of dragging the original provider's credentials). The original `base_url` / `api_key` are stripped from the override config before resolution — they belong to the old provider.

When only `model` is overridden, the surrounding credentials are preserved (model and provider often share the same endpoint).

## Failure handling

If credential resolution fails for the overridden provider (missing API key, unknown provider, etc.), the task falls back to the configured delegation credentials rather than aborting the batch. The failure is logged at WARN level.

## Backwards compatibility

The new params are optional and default to `None`. Behavior is identical to today when no overrides are supplied — only difference is the schema now advertises the two new properties.

## Tests

`TestPerTaskCredentialOverride` (6 tests):
- `test_no_override_returns_default_creds`
- `test_model_only_top_level_override_swaps_model_keeps_provider`
- `test_per_task_model_beats_top_level`
- `test_provider_override_re_resolves_full_bundle` (verifies stale `base_url`/`api_key` are stripped)
- `test_per_task_provider_beats_top_level`
- `test_provider_resolution_failure_falls_back_to_default`

Existing `TestDelegationCredentialResolution` and `TestDelegationProviderIntegration` should keep passing unchanged.

## Follow-ups (separate PRs)

- Delegation **pool** with strengths-per-model (the other half of #3794)
- `base_url` per-call override for direct endpoints