### PR TITLE
fix(install): restrict ~/.hermes/.env to owner-only permissions (0600) (#25477)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1419,8 +1419,16 @@ copy_config_templates() {
             touch "$HERMES_HOME/.env"
             log_success "Created ~/.hermes/.env"
         fi
+        # Restrict to owner-only read/write — the file holds API keys and
+        # platform tokens that must never be world- or group-readable.
+        # The default umask on many Linux distros (022) produces 0644 for
+        # cp/touch; use an explicit chmod so this is safe regardless of umask.
+        chmod 0600 "$HERMES_HOME/.env" 2>/dev/null || true
     else
         log_info "~/.hermes/.env already exists, keeping it"
+        # Tighten permissions on pre-existing files too — users who installed
+        # an earlier version may have 0664 on disk.
+        chmod 0600 "$HERMES_HOME/.env" 2>/dev/null || true
     fi
     configure_browser_env_from_system_browser
 


### PR DESCRIPTION
## Summary

Fixes #25477 — installer leaves `~/.hermes/.env` world/group-readable, exposing API keys.

## Root Cause

The installer uses `cp` and `touch` to create `~/.hermes/.env`, both of which inherit the process umask. On Ubuntu (umask 0022) the result is 0644; on some server environments with umask 0002 the result is 0664. No explicit `chmod` was applied after file creation, leaving platform tokens, API keys, and Slack tokens visible to other users on the system.

The Python layer (`_secure_file()` in `hermes_cli/config.py`) already applies 0o600 on every subsequent write via `save_env_value()` and `sanitize_env_file()` — but the install script's initial file creation was never covered.

## Fix

Add `chmod 0600 "/.env"` immediately after the file is created in `copy_config_templates()`, with a `|| true` fallback to stay safe on NixOS managed installs and containers where the activation script owns permissions.

The fix also tightens permissions when the file already exists (the `else` branch), so users who installed a previous version and have 0664 on disk are hardened on their next upgrade — without any user action required.

## Before / After

```
# Before — freshly installed on Ubuntu 24.04 (umask 0022)
$ ls -la ~/.hermes/.env
-rw-rw-r-- 1 plumline plumline 1234 May 14 07:00 ~/.hermes/.env
#                 ^^ group+world readable

# After
$ ls -la ~/.hermes/.env
-rw------- 1 plumline plumline 1234 May 14 07:00 ~/.hermes/.env
```

## Testing

```bash
# Verify shell syntax
bash -n scripts/install.sh  # → OK

# Functional test (dry run in a tmpdir)
HERMES_HOME=/tmp/hermes-test bash -c '
  mkdir -p /tmp/hermes-test
  touch /tmp/hermes-test/.env
  chmod 0664 /tmp/hermes-test/.env  # simulate old installer
  chmod 0600 /tmp/hermes-test/.env 2>/dev/null || true
  ls -la /tmp/hermes-test/.env
'
# → -rw------- (0600)
```