### PR TITLE
feat(slack): support per-channel toolsets

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -845,6 +845,18 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if plat == Platform.SLACK and "channel_toolsets" in platform_cfg:
+                    # Per-channel hard tool gate. Numeric YAML keys (e.g. raw
+                    # 123:) are normalized to strings so the resolver, which
+                    # compares against the string channel_id from the Slack
+                    # event, can match them.
+                    channel_toolsets = platform_cfg["channel_toolsets"]
+                    if isinstance(channel_toolsets, dict):
+                        bridged["channel_toolsets"] = {
+                            str(k): v for k, v in channel_toolsets.items()
+                        }
+                    else:
+                        bridged["channel_toolsets"] = channel_toolsets
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -804,6 +804,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -829,7 +830,28 @@ class APIServerAdapter(BasePlatformAdapter):
         model = _resolve_gateway_model()
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        base_enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if enabled_toolsets_override is not None:
+            _override_cfg = dict(user_config)
+            _existing_platform_toolsets = dict(_override_cfg.get("platform_toolsets") or {})
+            _existing_platform_toolsets["api_server"] = list(enabled_toolsets_override)
+            _override_cfg["platform_toolsets"] = _existing_platform_toolsets
+            requested_toolsets = _get_platform_tools(
+                _override_cfg,
+                "api_server",
+                include_default_mcp_servers=False,
+            )
+            explicit_request = {str(name) for name in enabled_toolsets_override}
+            explicit_request.discard("no_mcp")
+            # Request-scoped overrides are a restriction, not an escalation path:
+            # they may narrow the API server's configured/default tools but cannot
+            # enable toolsets the remote server would not otherwise expose.  Also
+            # strip resolver-added defaults so the request is a hard explicit gate.
+            enabled_toolsets = sorted(
+                requested_toolsets & set(base_enabled_toolsets) & explicit_request
+            )
+        else:
+            enabled_toolsets = base_enabled_toolsets
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -987,6 +1009,18 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = body.get("stream", False)
+        enabled_toolsets_override = body.get("enabled_toolsets")
+        if enabled_toolsets_override is not None:
+            if not isinstance(enabled_toolsets_override, list) or not all(
+                isinstance(name, str) for name in enabled_toolsets_override
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "'enabled_toolsets' must be a list of toolset names",
+                        param="enabled_toolsets",
+                    ),
+                    status=400,
+                )
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -1167,6 +1201,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=enabled_toolsets_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -1186,11 +1221,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=enabled_toolsets_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body,
+                keys=["model", "messages", "tools", "tool_choice", "stream", "enabled_toolsets"],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -2690,6 +2729,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        enabled_toolsets_override: Optional[List[str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2713,6 +2753,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
+                enabled_toolsets_override=enabled_toolsets_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -955,6 +955,13 @@ class MessageEvent:
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
+
+    # Per-channel hard toolset gate (e.g. Slack channel_toolsets). When set,
+    # overrides the platform-level ``platform_toolsets`` default for this
+    # event's agent run only. Thread replies inherit the parent channel's
+    # binding via the resolver's parent_id fallback. None preserves existing
+    # behavior — use _get_platform_tools(user_config, platform_key).
+    channel_toolsets: Optional[List[str]] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
@@ -1253,6 +1260,56 @@ def resolve_channel_skills(
                     if nm and nm not in seen:
                         seen.append(nm)
                 return seen or None
+    return None
+
+
+def resolve_channel_toolsets(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> list[str] | None:
+    """Resolve a per-channel enabled-toolset list from platform config.
+
+    Looks up ``channel_toolsets`` in the adapter's ``config.extra`` dict.
+    Used by the Slack adapter to apply a per-channel hard tool gate that
+    overrides ``platform_toolsets.slack`` for the matching channel.
+
+    Config format::
+
+        channel_toolsets:
+          "C01SAFE": [web, skills, todo]   # business-facing channel
+          "C02OPS":  [terminal, file, mcp, skills]
+          "C03ONLY": skills                # single string also accepted
+
+    Prefers an exact match on *channel_id*; falls back to *parent_id*
+    (Slack thread replies inheriting the parent channel's binding).
+
+    Returns a deduplicated, blank-filtered list of toolset names (order
+    preserved), or None when no binding applies. An explicit empty/blank
+    binding returns [] so callers can enforce a "no tools" hard gate.
+    """
+    mapping = config_extra.get("channel_toolsets") or {}
+    if not isinstance(mapping, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        value = mapping.get(str(key))
+        if value is None:
+            continue
+        if isinstance(value, str):
+            v = value.strip()
+            return [v] if v else []
+        if isinstance(value, list):
+            seen: list[str] = []
+            for name in value:
+                if not isinstance(name, str):
+                    continue
+                nm = name.strip()
+                if nm and nm not in seen:
+                    seen.append(nm)
+            return seen
     return None
 
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2189,12 +2189,21 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_ts,
         )
 
-        # Per-channel ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt, resolve_channel_skills
+        # Per-channel ephemeral prompt + auto-skill(s) + hard tool gate.
+        # Thread replies share the parent's channel_id in Slack, so they
+        # inherit the binding without needing an explicit parent lookup.
+        from gateway.platforms.base import (
+            resolve_channel_prompt,
+            resolve_channel_skills,
+            resolve_channel_toolsets,
+        )
         _channel_prompt = resolve_channel_prompt(
             self.config.extra, channel_id, None,
         )
         _auto_skill = resolve_channel_skills(
+            self.config.extra, channel_id, None,
+        )
+        _channel_toolsets = resolve_channel_toolsets(
             self.config.extra, channel_id, None,
         )
 
@@ -2226,6 +2235,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
+            channel_toolsets=_channel_toolsets,
         )
 
         # Only react when bot is directly addressed (DM or @mention).
@@ -2808,12 +2818,20 @@ class SlackAdapter(BasePlatformAdapter):
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
         )
+        from gateway.platforms.base import resolve_channel_toolsets
+
+        channel_toolsets = resolve_channel_toolsets(
+            self.config.extra,
+            channel_id,
+            None,
+        )
 
         event = MessageEvent(
             text=text,
             message_type=MessageType.COMMAND if text.startswith("/") else MessageType.TEXT,
             source=source,
             raw_message=command,
+            channel_toolsets=channel_toolsets,
         )
 
         # Stash the Slack response_url so the first reply for this

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1700,6 +1700,37 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _resolve_channel_toolsets_for_source(
+        self,
+        source: SessionSource,
+    ) -> Optional[List[str]]:
+        """Resolve event-scoped toolsets for synthetic Slack turns.
+
+        Normal Slack inbound events get ``channel_toolsets`` from the adapter.
+        Runner-created synthetic events bypass the adapter parser, so they must
+        resolve the same hard gate here before entering the normal agent path.
+        ``None`` means no binding/fallback to platform defaults; ``[]`` is an
+        explicit no-tools restriction and must be preserved.
+        """
+        if source.platform != Platform.SLACK:
+            return None
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            return None
+        try:
+            from gateway.platforms.base import resolve_channel_toolsets
+
+            adapter_cfg = getattr(adapter, "config", None)
+            extra = getattr(adapter_cfg, "extra", {}) or {}
+            return resolve_channel_toolsets(
+                extra,
+                getattr(source, "chat_id", "") or "",
+                getattr(source, "parent_chat_id", None),
+            )
+        except Exception as exc:
+            logger.debug("Failed to resolve Slack channel_toolsets: %s", exc)
+            return None
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -3213,6 +3244,7 @@ class GatewayRunner:
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
+                channel_toolsets=self._resolve_channel_toolsets_for_source(source),
             )
             task = asyncio.create_task(adapter.handle_message(event))
             self._background_tasks.add(task)
@@ -3927,6 +3959,7 @@ class GatewayRunner:
             text=synthetic_text,
             source=dest_source,
             internal=True,
+            channel_toolsets=self._resolve_channel_toolsets_for_source(dest_source),
         )
 
         logger.info(
@@ -6071,6 +6104,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_toolsets=getattr(event, "channel_toolsets", None),
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
@@ -6098,6 +6132,7 @@ class GatewayRunner:
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            channel_toolsets=getattr(event, "channel_toolsets", None),
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -6120,6 +6155,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_toolsets=getattr(event, "channel_toolsets", None),
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -7610,6 +7646,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                channel_toolsets=getattr(event, "channel_toolsets", None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -9405,6 +9442,7 @@ class GatewayRunner:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_toolsets=getattr(event, "channel_toolsets", None),
         )
         
         # Let the normal message handler process it
@@ -9526,6 +9564,7 @@ class GatewayRunner:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    channel_toolsets=getattr(event, "channel_toolsets", None),
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:
@@ -9703,6 +9742,7 @@ class GatewayRunner:
         try:
             adapter = self.adapters.get(source.platform)
             _quick_key = self._session_key_for_source(source)
+            _channel_toolsets = self._resolve_channel_toolsets_for_source(source)
             if adapter and _quick_key:
                 cont_event = MessageEvent(
                     text=prompt,
@@ -9710,6 +9750,7 @@ class GatewayRunner:
                     source=source,
                     message_id=None,
                     channel_prompt=None,
+                    channel_toolsets=_channel_toolsets,
                 )
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
@@ -13352,6 +13393,7 @@ class GatewayRunner:
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
+                channel_toolsets=self._resolve_channel_toolsets_for_source(source),
             )
             logger.info(
                 "Watch pattern notification — injecting for %s chat=%s thread=%s",
@@ -13456,6 +13498,7 @@ class GatewayRunner:
                                 message_type=MessageType.TEXT,
                                 source=source,
                                 internal=True,
+                                channel_toolsets=self._resolve_channel_toolsets_for_source(source),
                             )
                             logger.info(
                                 "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
@@ -14010,6 +14053,7 @@ class GatewayRunner:
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        channel_toolsets: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -14085,6 +14129,8 @@ class GatewayRunner:
             "messages": api_messages,
             "stream": True,
         }
+        if channel_toolsets is not None:
+            body["enabled_toolsets"] = list(channel_toolsets)
 
         # Set up platform streaming if available -------------------------
         _stream_consumer = None
@@ -14298,6 +14344,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_toolsets: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -14322,6 +14369,7 @@ class GatewayRunner:
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                channel_toolsets=channel_toolsets,
             )
 
         from run_agent import AIAgent
@@ -14336,7 +14384,30 @@ class GatewayRunner:
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        # Per-channel toolsets (Slack channel_toolsets) override the platform
+        # default for this event only. We re-route the override through
+        # _get_platform_tools so subset inference, MCP allowlisting, plugin
+        # handling, and default-off rules stay consistent with the platform-
+        # level config path.
+        if channel_toolsets is not None:
+            _override_cfg = dict(user_config)
+            _existing_platform_toolsets = dict(_override_cfg.get("platform_toolsets") or {})
+            _existing_platform_toolsets[platform_key] = list(channel_toolsets)
+            _override_cfg["platform_toolsets"] = _existing_platform_toolsets
+            enabled_toolsets = sorted(
+                _get_platform_tools(
+                    _override_cfg,
+                    platform_key,
+                    include_default_mcp_servers=False,
+                )
+            )
+            _explicit_channel_toolsets = {str(name) for name in channel_toolsets}
+            _explicit_channel_toolsets.discard("no_mcp")
+            enabled_toolsets = [
+                name for name in enabled_toolsets if name in _explicit_channel_toolsets
+            ]
+        else:
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 
@@ -16157,6 +16228,7 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_channel_toolsets = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
@@ -16174,6 +16246,7 @@ class GatewayRunner:
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_channel_toolsets = getattr(pending_event, "channel_toolsets", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -16199,6 +16272,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    channel_toolsets=next_channel_toolsets,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1242,6 +1242,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_toolsets": {},        # Per-channel hard toolset overrides
     },
 
     # Discord platform settings (gateway mode)

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -127,3 +127,61 @@ class TestApiServerAdapterToolset:
             call_kwargs = mock_agent_cls.call_args
             toolsets = call_kwargs.kwargs.get("enabled_toolsets")
             assert sorted(toolsets) == ["terminal", "web"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_request_override_restricts_default_mcp_servers(self):
+        """Request-scoped tool gates must not inherit globally enabled MCP servers."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {
+                "mcp_servers": {
+                    "ops-mcp": {"command": "python", "args": ["server.py"]},
+                }
+            }
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(enabled_toolsets_override=["web"])
+
+            mock_agent_cls.assert_called_once()
+            call_kwargs = mock_agent_cls.call_args
+            toolsets = call_kwargs.kwargs.get("enabled_toolsets")
+            assert toolsets == ["web"]
+            assert "ops-mcp" not in toolsets
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_empty_request_override_stays_empty(self):
+        """An explicit empty request override must not fall back to full tools."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent(enabled_toolsets_override=[])
+
+            mock_agent_cls.assert_called_once()
+            call_kwargs = mock_agent_cls.call_args
+            assert call_kwargs.kwargs.get("enabled_toolsets") == []

--- a/tests/gateway/test_slack_channel_toolsets.py
+++ b/tests/gateway/test_slack_channel_toolsets.py
@@ -1,0 +1,725 @@
+"""Tests for Slack channel_toolsets resolution and gateway override.
+
+Mirrors the shape of test_slack_channel_skills.py / test_discord_channel_prompts.py.
+
+A Slack workspace may run domain conversations across many channels while
+needing to lock down dangerous tools (terminal, file-write, etc.) on
+business-facing channels. ``slack.channel_toolsets`` provides a per-channel
+hard gate that overrides ``platform_toolsets.slack`` for the matching channel.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Resolver-only tests (no Slack SDK required).
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(extra=None):
+    """Create a minimal SlackAdapter stub with the given ``config.extra``."""
+    from gateway.platforms.slack import SlackAdapter
+
+    adapter = object.__new__(SlackAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = extra or {}
+    return adapter
+
+
+def _resolve(adapter, channel_id, parent_id=None):
+    from gateway.platforms.base import resolve_channel_toolsets
+
+    return resolve_channel_toolsets(adapter.config.extra, channel_id, parent_id)
+
+
+class TestResolveChannelToolsets:
+    def test_no_mapping_returns_none(self):
+        adapter = _make_adapter()
+        assert _resolve(adapter, "C01SAFE") is None
+
+    def test_match_by_channel_id(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": ["web", "skills", "todo"],
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == ["web", "skills", "todo"]
+
+    def test_no_match_returns_none(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": ["web", "skills"],
+            }
+        })
+        assert _resolve(adapter, "C99OTHER") is None
+
+    def test_match_by_parent_id_for_thread(self):
+        """Thread replies inherit the parent channel's binding."""
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C0PARENT": ["web", "skills"],
+            }
+        })
+        assert _resolve(adapter, "thread-ts-123", parent_id="C0PARENT") == [
+            "web", "skills",
+        ]
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C0THREAD": ["web"],
+                "C0PARENT": ["terminal", "file"],
+            }
+        })
+        assert _resolve(adapter, "C0THREAD", parent_id="C0PARENT") == ["web"]
+
+    def test_string_value_returns_single_element_list(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": "skills",
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == ["skills"]
+
+    def test_dedup_preserves_order(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": ["web", "skills", "web", "todo", "skills"],
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == ["web", "skills", "todo"]
+
+    def test_empty_list_returns_empty_override(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": [],
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == []
+
+    def test_empty_string_returns_empty_override(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": "",
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == []
+
+    def test_blank_entries_filtered(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": ["web", "  ", "", "skills"],
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == ["web", "skills"]
+
+    def test_non_dict_mapping_returns_none(self):
+        adapter = _make_adapter({"channel_toolsets": ["not-a-dict"]})
+        assert _resolve(adapter, "C01SAFE") is None
+
+    def test_non_string_entries_skipped(self):
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C01SAFE": ["web", 42, None, "skills"],
+            }
+        })
+        assert _resolve(adapter, "C01SAFE") == ["web", "skills"]
+
+
+class TestSlackMessageEventChannelToolsets:
+    """MessageEvent carries an optional channel_toolsets override."""
+
+    def test_message_event_carries_channel_toolsets(self):
+        from gateway.platforms.base import (
+            MessageEvent,
+            MessageType,
+            Platform,
+            SessionSource,
+            resolve_channel_toolsets,
+        )
+
+        config_extra = {
+            "channel_toolsets": {
+                "C01SAFE": ["web", "skills", "todo"],
+            }
+        }
+        ts = resolve_channel_toolsets(config_extra, "C01SAFE")
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C01SAFE",
+            chat_name="biz",
+            chat_type="group",
+            user_id="U0ABC",
+            user_name="Biz",
+        )
+        event = MessageEvent(
+            text="status?",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="123.456",
+            channel_toolsets=ts,
+        )
+        assert event.channel_toolsets == ["web", "skills", "todo"]
+
+    def test_message_event_defaults_channel_toolsets_to_none(self):
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        event = MessageEvent(text="hi", message_type=MessageType.TEXT)
+        assert event.channel_toolsets is None
+
+
+# ---------------------------------------------------------------------------
+# Slack adapter integration: verify the adapter resolves and attaches.
+# ---------------------------------------------------------------------------
+
+
+class TestSlackAdapterAttachesChannelToolsets:
+    """The Slack adapter resolves channel_toolsets when building MessageEvent."""
+
+    def test_resolve_uses_config_extra(self):
+        """Adapter-level resolution mirrors the auto_skill / channel_prompt path."""
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C0OPS": ["terminal", "file", "mcp", "skills"],
+            }
+        })
+        # Adapter doesn't need a private resolver — the standalone helper is
+        # the contract; the slack handler imports and uses it directly. We
+        # assert the helper returns what the handler will attach.
+        from gateway.platforms.base import resolve_channel_toolsets
+
+        assert resolve_channel_toolsets(adapter.config.extra, "C0OPS") == [
+            "terminal", "file", "mcp", "skills",
+        ]
+        assert resolve_channel_toolsets(adapter.config.extra, "C0SAFE") is None
+
+
+    @pytest.mark.asyncio
+    async def test_slash_question_attaches_channel_toolsets(self):
+        """Legacy /hermes questions must not bypass the channel hard gate."""
+        from gateway.platforms.base import MessageType, Platform
+
+        adapter = _make_adapter({
+            "channel_toolsets": {
+                "C0SAFE": ["web", "skills"],
+            }
+        })
+        adapter.platform = Platform.SLACK
+        adapter._channel_team = {}
+        adapter._slash_command_contexts = {}
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_slash_command({
+            "command": "/hermes",
+            "text": "summarize this channel",
+            "user_id": "U123",
+            "channel_id": "C0SAFE",
+            "team_id": "T123",
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.TEXT
+        assert event.text == "summarize this channel"
+        assert event.channel_toolsets == ["web", "skills"]
+
+
+# ---------------------------------------------------------------------------
+# Gateway run wiring: verify _run_agent honors event.channel_toolsets.
+# ---------------------------------------------------------------------------
+
+
+from gateway.config import Platform  # noqa: E402
+from gateway.platforms.base import MessageEvent  # noqa: E402
+from gateway.session import SessionSource  # noqa: E402
+
+
+def _import_gateway_run(monkeypatch):
+    """Import gateway.run without leaking real API-server env into later tests.
+
+    gateway.run loads Hermes' .env at import time.  In the developer's real
+    environment that can set API_SERVER_KEY/API_SERVER_HOST, and those process
+    env vars would make unrelated gateway config tests think api_server is
+    enabled.  Keep this file's gateway-run wiring tests hermetic.
+    """
+    for name in (
+        "API_SERVER_ENABLED",
+        "API_SERVER_KEY",
+        "API_SERVER_CORS_ORIGINS",
+        "API_SERVER_PORT",
+        "API_SERVER_HOST",
+        "API_SERVER_MODEL_NAME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    import gateway.run as gateway_run
+
+    return gateway_run
+
+
+class _CapturingAgent:
+    """Captures the kwargs the gateway passed to AIAgent for assertion."""
+
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message=None,
+    ):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner(gateway_run):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C01SAFE",
+        chat_type="group",
+        user_id="U0ABC",
+    )
+
+
+def test_runner_resolves_channel_toolsets_for_synthetic_slack_events(monkeypatch):
+    """Runner-created Slack events must get the same hard gate as adapter events."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    runner = _make_runner(gateway_run)
+    runner.adapters = {
+        Platform.SLACK: SimpleNamespace(
+            config=SimpleNamespace(
+                extra={
+                    "channel_toolsets": {
+                        "C01SAFE": [],
+                        "C02OPS": ["terminal", "skills"],
+                    }
+                }
+            )
+        )
+    }
+
+    assert runner._resolve_channel_toolsets_for_source(_make_source()) == []
+    assert runner._resolve_channel_toolsets_for_source(
+        SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C02OPS",
+            chat_type="group",
+            user_id="U0ABC",
+        )
+    ) == ["terminal", "skills"]
+    assert runner._resolve_channel_toolsets_for_source(
+        SessionSource(platform=Platform.DISCORD, chat_id="C01SAFE", chat_type="group")
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_run_agent_applies_channel_toolsets_override(monkeypatch, tmp_path):
+    """When event.channel_toolsets is set, AIAgent.enabled_toolsets reflects it.
+
+    The override must replace the platform-level toolset list (sourced from
+    ``_get_platform_tools(user_config, platform_key)``) so dangerous tools
+    can be hard-gated per channel.
+    """
+    gateway_run = _import_gateway_run(monkeypatch)
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner(gateway_run)
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  system_prompt: Global prompt\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    # Fake resolver: when an override is set, echo it; otherwise return the
+    # platform default. This is the behavior _get_platform_tools delivers in
+    # production — channel_toolsets goes into platform_toolsets[platform_key]
+    # before resolution, and the resolver returns it.
+    def fake_get_platform_tools(user_config, platform_key, **_kwargs):
+        platform_toolsets = user_config.get("platform_toolsets") or {}
+        toolset_names = platform_toolsets.get(platform_key)
+        if toolset_names:
+            return set(toolset_names)
+        return {"terminal", "file", "core"}
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", fake_get_platform_tools)
+
+    _CapturingAgent.last_init = None
+    event = MessageEvent(
+        text="hi",
+        source=_make_source(),
+        message_id="m1",
+        channel_toolsets=["web", "skills", "todo"],
+    )
+
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=event.channel_toolsets,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["enabled_toolsets"] == ["skills", "todo", "web"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_channel_toolsets_exclude_default_mcp_servers(monkeypatch, tmp_path):
+    """A safe channel override must not inherit globally enabled MCP servers."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner(gateway_run)
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  system_prompt: Global prompt\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "mcp_servers": {
+                "ops-mcp": {"command": "python", "args": ["server.py"]},
+            }
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=["web", "skills"],
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["enabled_toolsets"] == ["skills", "web"]
+    assert "ops-mcp" not in _CapturingAgent.last_init["enabled_toolsets"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_empty_channel_toolsets_stays_empty(monkeypatch, tmp_path):
+    """An explicit empty channel override means no tools, not platform defaults."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner(gateway_run)
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  system_prompt: Global prompt\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=[],
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["enabled_toolsets"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_channel_toolsets_to_proxy(monkeypatch):
+    """Proxy mode must forward the hard tool gate to the remote API server."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    runner = _make_runner(gateway_run)
+    runner._get_proxy_url = lambda: "http://127.0.0.1:12345"
+    captured = {}
+
+    async def fake_proxy(**kwargs):
+        captured.update(kwargs)
+        return {"final_response": "ok", "messages": [], "api_calls": 0}
+
+    monkeypatch.setattr(runner, "_run_agent_via_proxy", fake_proxy)
+
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=["web", "skills"],
+    )
+
+    assert result["final_response"] == "ok"
+    assert captured["channel_toolsets"] == ["web", "skills"]
+
+    captured.clear()
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=[],
+    )
+    assert result["final_response"] == "ok"
+    assert captured["channel_toolsets"] == []
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_preserves_slack_channel_toolsets(monkeypatch):
+    """Automatic goal-continuation turns must keep the channel hard gate."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    runner = _make_runner(gateway_run)
+    source = _make_source()
+    adapter = SimpleNamespace(
+        _pending_messages={},
+        config=SimpleNamespace(
+            extra={"channel_toolsets": {"C01SAFE": ["web", "skills"]}}
+        ),
+    )
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._session_key_for_source = lambda _source: "goal-key"
+    runner._goal_max_turns_from_config = lambda: 5
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+
+    fake_goals = types.ModuleType("hermes_cli.goals")
+
+    class FakeGoalManager:
+        def __init__(self, session_id, default_max_turns):
+            self.session_id = session_id
+            self.default_max_turns = default_max_turns
+
+        def is_active(self):
+            return True
+
+        def evaluate_after_turn(self, final_response, user_initiated=True):
+            return {
+                "message": "continue",
+                "should_continue": True,
+                "continuation_prompt": "next step",
+            }
+
+    fake_goals.GoalManager = FakeGoalManager
+    monkeypatch.setitem(sys.modules, "hermes_cli.goals", fake_goals)
+
+    await runner._post_turn_goal_continuation(
+        session_entry=SimpleNamespace(session_id="session-1"),
+        source=source,
+        final_response="partial answer",
+    )
+
+    pending = adapter._pending_messages["goal-key"]
+    assert pending.text == "next step"
+    assert pending.channel_toolsets == ["web", "skills"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_without_channel_toolsets_uses_platform_default(
+    monkeypatch, tmp_path,
+):
+    """When no channel override is provided, the platform default is used."""
+    gateway_run = _import_gateway_run(monkeypatch)
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner(gateway_run)
+
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  system_prompt: Global prompt\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    def fake_get_platform_tools(user_config, platform_key, **_kwargs):
+        platform_toolsets = user_config.get("platform_toolsets") or {}
+        toolset_names = platform_toolsets.get(platform_key)
+        if toolset_names:
+            return set(toolset_names)
+        return {"terminal", "file", "core"}
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", fake_get_platform_tools)
+
+    _CapturingAgent.last_init = None
+
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:slack:group:C01SAFE",
+        channel_toolsets=None,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["enabled_toolsets"] == ["core", "file", "terminal"]
+
+
+# ---------------------------------------------------------------------------
+# Config bridge: ensure slack.channel_toolsets reaches PlatformConfig.extra.
+# ---------------------------------------------------------------------------
+
+
+class TestSlackChannelToolsetsConfigBridge:
+    """gateway/config.py must bridge slack.channel_toolsets into extra."""
+
+    def test_bridges_slack_channel_toolsets_from_config_yaml(self, tmp_path, monkeypatch):
+        from gateway.config import Platform, load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  channel_toolsets:\n"
+            '    "C01SAFE": [web, skills, todo]\n'
+            '    "C02OPS": [terminal, file, mcp, skills]\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["channel_toolsets"] == {
+            "C01SAFE": ["web", "skills", "todo"],
+            "C02OPS": ["terminal", "file", "mcp", "skills"],
+        }
+
+    def test_numeric_yaml_keys_normalized_to_string(self, tmp_path, monkeypatch):
+        from gateway.config import Platform, load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  channel_toolsets:\n"
+            "    123: [web]\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["channel_toolsets"] == {
+            "123": ["web"],
+        }

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -566,6 +566,27 @@ Notes:
 - The skill is loaded only at session start (new session or after auto-reset). If you change the binding, run `/new` or wait for the session to auto-reset for it to take effect.
 - Combine with `channel_prompts` for per-channel tone/constraints on top of the skill's instructions.
 
+## Per-Channel Toolsets
+
+Restrict which toolsets are exposed to the agent in specific Slack channels. This is a hard tool-schema gate for the matching channel: if a channel override is present, Hermes constructs that turn's agent with the configured toolsets instead of the platform-wide `platform_toolsets.slack` default.
+
+This is useful for shared company workspaces where everyone should benefit from the same domain context and skills, but not every channel should have the same operational permissions. For example, a business-facing channel can stay read-only/safe while an engineering or ops channel can explicitly opt into stronger tools such as `terminal` or infrastructure-facing MCP tools.
+
+```yaml
+slack:
+  channel_toolsets:
+    # Business-facing channel — no command execution tools
+    "C01BUSINESS": [web, skills, todo]
+    # Engineering/ops channel — explicitly opt into stronger tools
+    "C02OPS": [terminal, file, web, skills, todo]
+```
+
+Notes:
+- Keys are Slack channel IDs. Thread replies inherit the parent channel's binding because Slack threads share the same channel ID.
+- If a channel has no `channel_toolsets` entry, Hermes falls back to `platform_toolsets.slack` as before.
+- An explicit empty list (`"C01LOCKED": []`) is a hard "no tools" override, not a fallback.
+- `channel_prompts` can request behavior, but `channel_toolsets` controls which tool schemas are actually exposed to the model for the channel.
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## Summary
- Add `slack.channel_toolsets` as a per-channel hard tool-schema gate for Slack.
- Thread/direct Slack events, `/hermes <question>` slash-command questions, queued follow-ups, goal continuations, restart auto-resume, CLI handoff, and background-process synthetic turns preserve the channel toolset override.
- Forward Slack channel tool gates through proxy mode via `enabled_toolsets`, and make the API server treat request-scoped `enabled_toolsets` as a restriction rather than an escalation path.
- Document the new Slack config shape, including explicit `[]` as a no-tools override.

## Motivation
Closes #25483.

Shared company Slack workspaces often need common Hermes context/skills across business and engineering channels, but they should not expose the same tool schemas everywhere. A business-facing channel can use safe/read-only toolsets while an ops channel can explicitly opt into stronger tools.

## Testing
- `python -m pytest tests/gateway/test_slack_channel_toolsets.py tests/gateway/test_api_server_toolset.py -q -o 'addopts='` → 39 passed
- `python -m ruff check gateway/config.py gateway/platforms/base.py gateway/platforms/slack.py gateway/platforms/api_server.py gateway/run.py hermes_cli/config.py tests/gateway/test_slack_channel_toolsets.py tests/gateway/test_api_server_toolset.py` → passed
- `python -m pytest tests/gateway/test_slack_channel_toolsets.py tests/gateway/test_slack_channel_skills.py tests/gateway/test_discord_channel_skills.py tests/gateway/test_config.py tests/gateway/test_config_env_bridge_authority.py tests/gateway/test_api_server_toolset.py tests/hermes_cli/test_tools_config.py -q -o 'addopts='` → 171 passed

## Review
- Codex blocker-only review: APPROVED
