### PR TITLE
fix(qqbot): notify gateway on max reconnect exhaustion instead of silent death

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -553,7 +553,12 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        self._mark_disconnected()
+                        self._set_fatal_error(
+                            "qq_max_reconnect",
+                            "Max reconnect attempts reached (rate-limited)",
+                            retryable=True,
+                        )
+                        await self._notify_fatal_error()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -607,7 +612,12 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
-                        self._mark_disconnected()
+                        self._set_fatal_error(
+                            "qq_max_reconnect",
+                            "Max reconnect attempts reached (QQCloseError)",
+                            retryable=True,
+                        )
+                        await self._notify_fatal_error()
                         return
 
             except Exception as exc:
@@ -619,7 +629,12 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
-                    self._mark_disconnected()
+                    self._set_fatal_error(
+                        "qq_max_reconnect",
+                        "Max reconnect attempts reached",
+                        retryable=True,
+                    )
+                    await self._notify_fatal_error()
                     return
 
                 if await self._reconnect(backoff_idx):


### PR DESCRIPTION
## Summary

When the QQBot adapter exhausts `MAX_RECONNECT_ATTEMPTS` (100), it previously called `_mark_disconnected()` and returned silently. The gateway was never notified, so:

1. `GatewayRunner._handle_adapter_fatal_error()` was never triggered
2. The platform was never added to `_failed_platforms`
3. `_platform_reconnect_watcher()` never retried the connection

This left QQBot **permanently offline** until a manual gateway restart.

## Changes

Replace `_mark_disconnected()` with `_set_fatal_error(retryable=True)` + `await _notify_fatal_error()` at all three max-reconnect exit paths in `_listen_loop()`:

- **Rate-limit (4008) exhaustion** — was silently returning
- **QQCloseError exhaustion** — was logging error but silently returning
- **Generic Exception exhaustion** — was logging error but silently returning

This mirrors the pattern already used by the Telegram adapter for the same scenario.

## Testing

All 144 existing QQBot tests pass (`python -m pytest tests/gateway/test_qqbot.py`).

Closes #25505