### PR TITLE
fix(cli): support Windows paste in setup secret prompts

### DIFF
--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -5,6 +5,8 @@ functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
 
+import re
+
 from hermes_cli.colors import Colors, color
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -40,6 +42,26 @@ def print_header(text: str) -> None:
 # ─── Input Prompts ────────────────────────────────────────────────────────────
 
 
+_BRACKETED_PASTE_PATTERN = re.compile(r"(?:\x1b)?\[\s*(?:200|201)~")
+
+
+def _sanitize_pasted_input(value: str) -> str:
+    """Strip leaked bracketed-paste control markers from pasted text."""
+    if not isinstance(value, str) or not value:
+        return value
+    return _BRACKETED_PASTE_PATTERN.sub("", value)
+
+
+def read_line(display: str) -> str:
+    """Read a visible line and strip leaked bracketed-paste markers."""
+    return _sanitize_pasted_input(input(display))
+
+
+def read_secret_line(display: str) -> str:
+    """Read a hidden line and strip leaked bracketed-paste markers."""
+    return _sanitize_pasted_input(masked_secret_prompt(display))
+
+
 def prompt(
     question: str,
     default: str | None = None,
@@ -58,9 +80,9 @@ def prompt(
 
     try:
         if password:
-            value = masked_secret_prompt(display)
+            value = read_secret_line(display)
         else:
-            value = input(display)
+            value = read_line(display)
         value = value.strip()
         return value if value else (default or "")
     except (KeyboardInterrupt, EOFError):

--- a/hermes_cli/secret_prompt.py
+++ b/hermes_cli/secret_prompt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import re
 import sys
 from collections.abc import Callable
 
@@ -11,6 +12,14 @@ from collections.abc import Callable
 _BACKSPACE_CHARS = {"\b", "\x7f"}
 _ENTER_CHARS = {"\r", "\n"}
 _EOF_CHARS = {"\x04", "\x1a"}
+_BRACKETED_PASTE_PATTERN = re.compile(r"(?:\x1b)?\[\s*(?:200|201)~")
+
+
+def _sanitize_pasted_input(value: str) -> str:
+    """Strip leaked bracketed-paste control markers from pasted text."""
+    if not isinstance(value, str) or not value:
+        return value
+    return _BRACKETED_PASTE_PATTERN.sub("", value)
 
 
 def _collect_masked_input(
@@ -62,23 +71,31 @@ def masked_secret_prompt(prompt: str, *, mask: str = "*") -> str:
     stdin = sys.stdin
     stdout = sys.stdout
 
-    if not _stream_is_tty(stdin) or not _stream_is_tty(stdout):
-        return getpass.getpass(prompt)
-
-    if os.name == "nt":
+    if _should_use_prompt_toolkit_secret_input(stdin, stdout):
         try:
-            return _masked_secret_prompt_windows(prompt, mask=mask)
+            return _sanitize_pasted_input(_prompt_toolkit_secret_prompt(prompt))
         except (KeyboardInterrupt, EOFError):
             raise
         except Exception:
-            return getpass.getpass(prompt)
+            pass
+
+    if not _stream_is_tty(stdin) or not _stream_is_tty(stdout):
+        return _sanitize_pasted_input(getpass.getpass(prompt))
+
+    if os.name == "nt":
+        try:
+            return _sanitize_pasted_input(_masked_secret_prompt_windows(prompt, mask=mask))
+        except (KeyboardInterrupt, EOFError):
+            raise
+        except Exception:
+            return _sanitize_pasted_input(getpass.getpass(prompt))
 
     try:
-        return _masked_secret_prompt_posix(prompt, mask=mask)
+        return _sanitize_pasted_input(_masked_secret_prompt_posix(prompt, mask=mask))
     except (KeyboardInterrupt, EOFError):
         raise
     except Exception:
-        return getpass.getpass(prompt)
+        return _sanitize_pasted_input(getpass.getpass(prompt))
 
 
 def _stream_is_tty(stream) -> bool:
@@ -86,6 +103,46 @@ def _stream_is_tty(stream) -> bool:
         return bool(stream.isatty())
     except Exception:
         return False
+
+
+def _should_use_prompt_toolkit_secret_input(stdin, stdout) -> bool:
+    """Use prompt_toolkit for interactive Windows secret prompts.
+
+    On Windows, prompt_toolkit preserves hidden input while allowing paste
+    paths that raw ``msvcrt.getwch()`` and ``getpass`` commonly miss.
+    """
+    return sys.platform == "win32" and _stream_is_tty(stdin) and _stream_is_tty(stdout)
+
+
+def _prompt_toolkit_secret_prompt(prompt: str) -> str:
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.keys import Keys
+    from prompt_toolkit.shortcuts import prompt as pt_prompt
+
+    kb = KeyBindings()
+
+    @kb.add("c-v")
+    def _paste_clipboard(event):
+        try:
+            clip = event.app.clipboard.get_data()
+        except Exception:
+            return
+        text = _sanitize_pasted_input(getattr(clip, "text", "") or "")
+        if text:
+            event.current_buffer.insert_text(text)
+
+    @kb.add(Keys.BracketedPaste, eager=True)
+    def _handle_bracketed_paste(event):
+        text = _sanitize_pasted_input(event.data or "")
+        if text:
+            event.current_buffer.insert_text(text)
+
+    return pt_prompt(
+        ANSI(prompt),
+        is_password=True,
+        key_bindings=kb,
+    )
 
 
 def _masked_secret_prompt_windows(prompt: str, *, mask: str) -> str:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -156,10 +156,11 @@ def print_header(title: str):
 from hermes_cli.cli_output import (  # noqa: E402
     print_error,
     print_info,
+    read_line,
+    read_secret_line,
     print_success,
     print_warning,
 )
-from hermes_cli.secret_prompt import masked_secret_prompt  # noqa: E402
 
 
 def is_interactive_stdin() -> bool:
@@ -201,25 +202,13 @@ def prompt(question: str, default: str = None, password: bool = False) -> str:
 
     try:
         if password:
-            value = masked_secret_prompt(color(display, Colors.YELLOW))
+            value = read_secret_line(color(display, Colors.YELLOW))
         else:
-            value = input(color(display, Colors.YELLOW))
-
-        cleaned = _sanitize_pasted_input(value)
-        return cleaned.strip() or default or ""
+            value = read_line(color(display, Colors.YELLOW))
+        return value.strip() or default or ""
     except (KeyboardInterrupt, EOFError):
         print()
         sys.exit(1)
-
-
-_BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
-
-
-def _sanitize_pasted_input(value: str) -> str:
-    """Strip terminal bracketed-paste control markers from pasted text."""
-    if not isinstance(value, str) or not value:
-        return value
-    return _BRACKETED_PASTE_PATTERN.sub("", value)
 
 
 def _curses_prompt_choice(question: str, choices: list, default: int = 0, description: str | None = None) -> int:

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -18,3 +18,22 @@ def test_empty_password_prompt_returns_default(monkeypatch):
     monkeypatch.setattr(cli_output, "masked_secret_prompt", lambda _display: "")
 
     assert cli_output.prompt("API key", default="old", password=True) == "old"
+
+
+def test_visible_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _display: "\x1b[200~ pasted value \x1b[201~",
+    )
+
+    assert cli_output.prompt("Name") == "pasted value"
+
+
+def test_secret_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        cli_output,
+        "masked_secret_prompt",
+        lambda _display: "\x1b[200~secret-token\x1b[201~",
+    )
+
+    assert cli_output.prompt("Bot token", password=True) == "secret-token"

--- a/tests/hermes_cli/test_secret_prompt.py
+++ b/tests/hermes_cli/test_secret_prompt.py
@@ -1,6 +1,17 @@
 import pytest
 
+from hermes_cli import secret_prompt
 from hermes_cli.secret_prompt import _collect_masked_input, masked_secret_prompt
+
+
+class _TTY:
+    def isatty(self):
+        return True
+
+
+class _Pipe:
+    def isatty(self):
+        return False
 
 
 def _run_collect(chars: str):
@@ -51,12 +62,40 @@ def test_collect_masked_input_raises_keyboard_interrupt():
 
 
 def test_masked_secret_prompt_falls_back_to_getpass_for_non_tty(monkeypatch):
-    class NonTty:
-        def isatty(self):
-            return False
-
-    monkeypatch.setattr("sys.stdin", NonTty())
-    monkeypatch.setattr("sys.stdout", NonTty())
+    monkeypatch.setattr("sys.stdin", _Pipe())
+    monkeypatch.setattr("sys.stdout", _Pipe())
     monkeypatch.setattr("getpass.getpass", lambda prompt: f"value from {prompt}")
 
     assert masked_secret_prompt("API key: ") == "value from API key: "
+
+
+def test_masked_secret_prompt_sanitizes_getpass_fallback(monkeypatch):
+    monkeypatch.setattr("sys.stdin", _Pipe())
+    monkeypatch.setattr("sys.stdout", _Pipe())
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda _prompt: "\x1b[200~secret-token\x1b[201~",
+    )
+
+    assert masked_secret_prompt("API key: ") == "secret-token"
+
+
+def test_masked_secret_prompt_uses_prompt_toolkit_on_windows_tty(monkeypatch):
+    captured = {}
+
+    def fake_prompt(message, is_password=False, key_bindings=None):
+        captured["message"] = message
+        captured["is_password"] = is_password
+        captured["key_bindings"] = key_bindings
+        return "\x1b[200~secret-token\x1b[201~"
+
+    monkeypatch.setattr(secret_prompt.sys, "platform", "win32", raising=False)
+    monkeypatch.setattr("sys.stdin", _TTY())
+    monkeypatch.setattr("sys.stdout", _TTY())
+    monkeypatch.setattr("prompt_toolkit.shortcuts.prompt", fake_prompt)
+
+    value = masked_secret_prompt("API key: ")
+
+    assert value == "secret-token"
+    assert captured["is_password"] is True
+    assert captured["key_bindings"] is not None

--- a/tests/hermes_cli/test_setup_prompt_menus.py
+++ b/tests/hermes_cli/test_setup_prompt_menus.py
@@ -12,11 +12,11 @@ def test_prompt_strips_bracketed_paste_markers(monkeypatch):
     assert value == "sk-ant-api-key"
 
 
-def test_password_prompt_strips_bracketed_paste_markers(monkeypatch):
+def test_password_prompt_uses_secret_line_helper(monkeypatch):
     monkeypatch.setattr(
         setup_mod,
-        "masked_secret_prompt",
-        lambda _prompt="": "\x1b[200~secret-token\x1b[201~",
+        "read_secret_line",
+        lambda _prompt="": " secret-token ",
     )
 
     value = setup_mod.prompt("API key", password=True)


### PR DESCRIPTION
## Summary
Fix Windows setup/gateway secret prompts so pasted Telegram bot tokens and other hidden inputs can be entered reliably.

## Problem
hermes setup and hermes gateway setup collect secret values through getpass.getpass(). On Windows, that path does not reuse the main CLI's prompt_toolkit paste handling, so Ctrl+V appears to do nothing in hidden prompts such as the Telegram bot token field.

## Root cause
- Messaging platform setup marks Telegram bot tokens as password=True.
- The shared setup prompt path ultimately used plain getpass.getpass() for hidden input.
- Hermes already has prompt_toolkit-based paste handling in the main CLI, but setup/gateway secret prompts were not using that input layer.

## What changed
- Centralized setup input sanitization in hermes_cli.cli_output.
- Added ead_line() and ead_secret_line() helpers.
- On interactive Windows TTYs, ead_secret_line() now uses a hidden prompt_toolkit prompt with Ctrl+V and bracketed paste handling.
- Preserved getpass fallback outside that Windows/TTY path.
- Updated hermes_cli.setup to reuse the shared helpers instead of maintaining a duplicate secret-input implementation.
- Added focused tests covering the Windows prompt_toolkit path and the non-TTY fallback path.

## Scope
This PR intentionally fixes the setup/gateway secret-prompt path only. It does not refactor every other getpass call site in the CLI.

## Verification
- pytest -v tests/hermes_cli/test_setup_prompt_menus.py tests/hermes_cli/test_cli_output.py
- 7 tests passed locally.

## Why this is not a duplicate
This is not the same as the existing work that strips bracketed-paste markers after input is already read, or the Windows getpass control-character sanitization work. This change addresses the missing paste-capable hidden-input path for Windows setup prompts themselves.