### PR TITLE
fix(terminal): tolerate PTY wait without timeout

### DIFF
--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -90,6 +90,41 @@ def test_kill_process_uses_cached_pgid_if_wrapper_already_exited(monkeypatch):
     assert killpg_calls == [(67890, signal.SIGTERM), (67890, 0)]
 
 
+def test_kill_process_tolerates_pty_wait_without_timeout(monkeypatch):
+    """PTY-backed process cleanup must not pass timeout through as a hard crash.
+
+    ``ptyprocess.PtyProcess.wait()`` accepts no timeout argument.  The local
+    backend's final best-effort wait runs after SIGTERM/SIGKILL cleanup, so a
+    PTY object should skip that timed wait instead of surfacing TypeError to
+    terminal_tool callers such as sudo commands.
+    """
+    env = object.__new__(LocalEnvironment)
+
+    class PtyLikeProc:
+        pid = 12345
+
+        def poll(self):
+            return None
+
+        def wait(self):
+            return 0
+
+        def kill(self):
+            pass
+
+    monotonic_values = iter([0.0, 2.0, 2.0, 5.0])
+
+    monkeypatch.setattr(os, "getpgid", lambda _pid: 67890)
+    monkeypatch.setattr(os, "killpg", lambda _pgid, _sig: None)
+    monkeypatch.setattr(
+        "tools.environments.local.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+    monkeypatch.setattr("tools.environments.local.time.sleep", lambda _seconds: None)
+
+    env._kill_process(PtyLikeProc())
+
+
 def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -556,6 +556,12 @@ class LocalEnvironment(BaseEnvironment):
                 _wait_for_group_exit(pgid, 2.0)
                 try:
                     proc.wait(timeout=0.2)
+                except TypeError:
+                    # ptyprocess.PtyProcess.wait() does not accept a timeout
+                    # argument. This final wait is only a best-effort reap
+                    # after process-group termination, so do not let PTY-backed
+                    # terminal cleanup crash sudo/interactive command paths.
+                    pass
                 except (subprocess.TimeoutExpired, OSError):
                     pass
         except (ProcessLookupError, PermissionError, OSError):


### PR DESCRIPTION
## What does this PR do?

Fixes a terminal cleanup crash when PTY-backed commands go through the local backend's process-group termination path.

`tools.environments.local.LocalEnvironment._kill_process()` performs a final best-effort `proc.wait(timeout=0.2)` after SIGTERM/SIGKILL cleanup. That works for `subprocess.Popen`, but `ptyprocess.PtyProcess.wait()` does not accept a timeout argument. When sudo or other interactive/PTY terminal paths reached that cleanup branch, Hermes could surface:

```text
TypeError: PtyProcess.wait() takes 1 positional argument but 2 were given
```

The fix treats this timed wait as optional for PTY-backed process objects: if the process object rejects the `timeout` keyword, cleanup skips the final wait instead of crashing the terminal tool call.

## Related Issue

Fixes #25212

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py`
  - Catches `TypeError` from the final best-effort `proc.wait(timeout=0.2)` in `_kill_process()`.
  - Documents why PTY-backed process handles may reject timeout-based waits.
- `tests/tools/test_local_interrupt_cleanup.py`
  - Adds a regression test using a `PtyProcess`-like object whose `wait()` accepts no timeout.
  - Confirms local cleanup no longer surfaces TypeError for that path.

## How to Test

1. Reproduced the failure before the fix with a PTY-like process object:

   ```bash
   python - <<'PY'
   import os, signal
   from types import SimpleNamespace
   from unittest.mock import patch
   from tools.environments.local import LocalEnvironment

   class PtyLikeProc:
       pid = 12345
       def poll(self):
           return None
       def wait(self):
           return 0
       def kill(self):
           pass

   proc = PtyLikeProc()
   env = object.__new__(LocalEnvironment)
   clock = iter([0, 2, 2, 5])
   with patch.object(os, 'getpgid', return_value=67890), \
        patch.object(os, 'killpg', return_value=None), \
        patch('tools.environments.local.time.monotonic', side_effect=lambda: next(clock)), \
        patch('tools.environments.local.time.sleep', return_value=None):
       try:
           env._kill_process(proc)
       except TypeError as exc:
           print(type(exc).__name__, exc)
   PY
   ```

   Result before fix:

   ```text
   TypeError PtyLikeProc.wait() got an unexpected keyword argument 'timeout'
   ```

2. Verified the same repro after the fix:

   ```bash
   python - <<'PY'
   import os
   from unittest.mock import patch
   from tools.environments.local import LocalEnvironment

   class PtyLikeProc:
       pid = 12345
       def poll(self):
           return None
       def wait(self):
           return 0
       def kill(self):
           pass

   proc = PtyLikeProc()
   env = object.__new__(LocalEnvironment)
   clock = iter([0, 2, 2, 5])
   with patch.object(os, 'getpgid', return_value=67890), \
        patch.object(os, 'killpg', return_value=None), \
        patch('tools.environments.local.time.monotonic', side_effect=lambda: next(clock)), \
        patch('tools.environments.local.time.sleep', return_value=None):
       env._kill_process(proc)
   print('no TypeError')
   PY
   ```

   Result after fix:

   ```text
   no TypeError
   ```

3. Ran syntax checks:

   ```bash
   python -m py_compile tools/environments/local.py tests/tools/test_local_interrupt_cleanup.py
   ```

   Result: passed.

4. Ran targeted regression test:

   ```bash
   /tmp/hermes-provider-refresh-venv/bin/python -m pytest -o addopts= tests/tools/test_local_interrupt_cleanup.py::test_kill_process_tolerates_pty_wait_without_timeout
   ```

   Result:

   ```text
   1 passed in 13.27s
   ```

5. Ran the related cleanup test file:

   ```bash
   /tmp/hermes-provider-refresh-venv/bin/python -m pytest -o addopts= tests/tools/test_local_interrupt_cleanup.py
   ```

   Result:

   ```text
   3 passed in 9.39s
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Relevant verification logs are included in "How to Test" above.
