### PR TITLE
docs: add Claude Code subagent orchestration guidance

### DIFF
--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: claude-code
 description: "Delegate coding to Claude Code CLI (features, PRs)."
-version: 2.2.0
+version: 2.3.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation]
-    related_skills: [codex, hermes-agent, opencode]
+    tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation, Subagents]
+    related_skills: [codex, hermes-agent, opencode, github-pr-workflow]
 ---
 
 # Claude Code — Hermes Orchestration Guide
@@ -583,6 +583,25 @@ terminal(command="claude --agents '{\"reviewer\": {\"description\": \"Reviews co
 
 Claude can orchestrate multiple agents: "Use @db-expert to optimize queries, then @security to audit the changes."
 
+### Hermes parent orchestration contract
+
+When Hermes launches Claude Code to do subagent-style implementation, the Claude child is **not** the final authority. The parent Hermes agent must supervise the run, then independently review the git tree before committing, pushing, or opening a PR. Load `references/subagent-orchestration.md` for the full checklist whenever a task says Claude Code should use subagents, work autonomously in the background, or produce a PR.
+
+Minimum parent loop after Claude finishes:
+
+1. Wait for the Claude process/session to exit; capture `session_id`, stop reason, stderr, and cost if JSON output is available.
+2. Inspect `git status --short --branch`, `git diff --stat`, `git diff --check`, and recent commits directly. Do not trust the child summary alone.
+3. Review scope, secrets, local-machine paths, portability, and validation output. Fix or relaunch for gaps before committing.
+4. Commit coherent reviewed changes on a feature branch unless direct `main` work was explicitly authorized.
+5. Check for an existing PR for the branch; update it if present, otherwise push and create one with `gh pr create --body-file`.
+6. Notify the user with the branch/PR URL, commit SHA, local validation, and CI status if a messaging/final-response path is available.
+
+Short prompt clause to include in Claude Code launch prompts:
+
+```markdown
+You may use Claude Code subagents if useful. Leave the worktree reviewable. Final response must list files changed, validation run, skipped checks, and follow-up work. The parent Hermes agent will independently review, commit, open/update the PR, and notify the user.
+```
+
 ## Hooks — Automation on Events
 
 Configure in `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
@@ -741,5 +760,6 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 6. **Look for the `❯` prompt** — indicates Claude is waiting for input (done or asking a question)
 7. **Clean up tmux sessions** — kill them when done to avoid resource leaks
 8. **Report results to user** — after completion, summarize what Claude did and what changed
-9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
-10. **Use `--allowedTools`** — restrict capabilities to what the task actually needs
+9. **For subagent orchestration, parent owns review/commit/PR** — after Claude finishes, inspect git state, run validation, commit coherent changes, open/update the PR if needed, and notify the user. See `references/subagent-orchestration.md`.
+10. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
+11. **Use `--allowedTools`** — restrict capabilities to what the task actually needs

--- a/skills/autonomous-ai-agents/claude-code/references/subagent-orchestration.md
+++ b/skills/autonomous-ai-agents/claude-code/references/subagent-orchestration.md
@@ -1,0 +1,140 @@
+# Claude Code Subagent Orchestration
+
+Use this reference when Hermes launches Claude Code to coordinate subagents, agent teams, or a long autonomous implementation where Claude may spawn specialized agents internally.
+
+## Parent/child responsibility split
+
+- **Claude Code child**: implement the requested change, use Claude-native subagents when useful, run targeted validation, and report exactly what changed.
+- **Hermes parent**: supervise lifecycle, inspect the resulting git tree, perform an independent review, commit coherent changes, open or update the PR, and notify the user.
+
+Do not let the child agent's final message be the only proof. The parent must verify the filesystem and git state directly.
+
+## Launch prompt requirements
+
+When starting Claude Code for subagent-style implementation, put these requirements in the prompt file or inline prompt:
+
+```markdown
+You may use Claude Code subagents for implementation/review if useful.
+
+Completion contract:
+1. Keep changes limited to the requested scope.
+2. Run the repo's documented validation commands, or explain why they cannot run.
+3. Leave the worktree in a reviewable state.
+4. Commit only if explicitly asked; otherwise leave changes uncommitted for the parent Hermes agent to review.
+5. Final response must include:
+   - files changed
+   - tests/validation run with results
+   - any skipped checks and why
+   - any follow-up work
+```
+
+Prefer parent-owned commits and PRs unless the user explicitly asked Claude Code to commit. Parent-owned commits keep the review gate outside the child worker.
+
+## Supervision loop
+
+1. Start Claude Code in print mode for bounded jobs, ideally with JSON output:
+   ```bash
+   claude -p "$(< /tmp/prompt.md)" \
+     --output-format json \
+     --max-turns 20 \
+     --max-budget-usd 5 \
+     --allowedTools "Read,Edit,Write,Bash"
+   ```
+2. If running in the background, wait or poll until the process exits. Do not stop at "started" unless the user explicitly requested a background launch only.
+3. Parse the result for `subtype`, `terminal_reason`, `session_id`, cost, and permission/tool errors.
+4. Inspect git state directly:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   git log --oneline --decorate --max-count=5
+   ```
+5. If Claude reports success but git shows no relevant changes, treat it as incomplete and investigate before reporting success.
+
+## Independent parent review
+
+Before committing or opening a PR, the Hermes parent must review the result:
+
+- Scope: changed files match the user's request and no unrelated cleanup snuck in.
+- Safety: no secrets, token-bearing remotes, credentials, or private paths in committed files.
+- Portability: no hardcoded `/Users/...`, venv interpreters, local temp paths, or machine-specific assumptions unless intentionally documented.
+- Tests: run the repo's expected local verification, or at minimum the targeted tests plus syntax/compile checks for touched languages.
+- Docs: if behavior changed, user-facing docs or skill docs were updated where appropriate.
+
+Useful commands:
+
+```bash
+git diff --stat origin/main...HEAD 2>/dev/null || git diff --stat
+git diff --check
+# project-specific validation goes here, e.g. scripts/run_tests.sh or pytest
+```
+
+If the child made partial or broken changes, fix them in the parent or relaunch Claude Code with the exact gaps. Do not commit a branch solely because Claude said it was done.
+
+## Commit protocol
+
+After review and validation:
+
+1. Ensure the branch is not `main` unless the user explicitly authorized direct mainline commits.
+2. Stage only intended files:
+   ```bash
+   git add <intended files>
+   git status --short
+   ```
+3. Commit with a conventional commit message:
+   ```bash
+   git commit -m "docs: add Claude Code subagent orchestration guidance"
+   ```
+4. Re-check cleanliness:
+   ```bash
+   git status --short --branch
+   ```
+
+If Claude already created commits, inspect them with `git show --stat --oneline HEAD` and amend/follow up only if needed. Avoid rewriting a pushed PR branch unless necessary; use `--force-with-lease` if you do.
+
+## PR protocol
+
+After committing, check whether a PR already exists for the current branch before creating one:
+
+```bash
+BRANCH=$(git branch --show-current)
+gh pr view --json number,title,url,headRefName,baseRefName,state 2>/dev/null || \
+  gh pr list --head "$BRANCH" --json number,title,url,headRefName,baseRefName,state
+```
+
+- If a PR exists: push the branch, update the PR body or add a comment with validation results when useful.
+- If no PR exists and the branch is not `main`: push and create one using a temp body file:
+  ```bash
+  git push -u origin HEAD
+  cat > /tmp/pr-body.md <<'EOF'
+  ## Summary
+  - ...
+
+  ## Test Plan
+  - [x] ...
+  EOF
+  gh pr create --title "..." --body-file /tmp/pr-body.md
+  ```
+- If the work landed directly on `main`, provide the commit URL instead of pretending there is a PR.
+
+## User notification
+
+Notify the user when the child work has actually reached a durable state:
+
+- Local-only completion: final response with summary, changed files, validation, and any blockers.
+- PR opened/updated: include PR URL, branch, commit SHA, and local/CI status separately.
+- Background or out-of-band run: if a messaging tool is available and the user asked for notification, send a short message via the current/home channel after commit/PR creation. Keep the notification factual, not chatty.
+
+Example notification:
+
+```text
+Claude Code subagent run finished. Reviewed and committed changes on docs/claude-code-subagent-orchestration, opened PR #123, local validation passed; CI pending: <url>
+```
+
+## Pitfalls
+
+1. **Trusting child summaries.** Always inspect git state and files directly.
+2. **Opening duplicate PRs.** `gh pr list --head` can miss some cases; if `gh pr create` says a PR already exists, treat that URL as authoritative and view it.
+3. **Letting background runs disappear.** Capture stdout/stderr paths, session IDs, and process IDs before waiting or reporting.
+4. **Committing local machine details.** Subagents often copy exact paths from prompts or logs; search/skim before committing.
+5. **Reporting CI as green from local tests.** Say local validation passed and CI is pending/missing/failing separately.

--- a/skills/software-development/idea-to-execution-lifecycle/SKILL.md
+++ b/skills/software-development/idea-to-execution-lifecycle/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: idea-to-execution-lifecycle
+description: "Use when turning Tanner's product ideas into specs, technical debt, execution plans, implementation PRs, and archived/validated lifecycle records."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [planning, specs, technical-debt, execution-plans, pull-requests, lifecycle]
+    related_skills: [writing-plans, subagent-driven-development, github-pr-workflow, claude-code]
+---
+
+# Idea → Spec → Debt/Plan → PR Lifecycle
+
+## Overview
+
+Use this skill to keep Tanner's ideas moving through a durable product-development lifecycle instead of becoming loose chat context. The goal is a clean chain of custody:
+
+```text
+idea / observation
+  → durable spec update or new spec
+  → technical debt item or immediate execution plan
+  → active execution plan
+  → implementation PR
+  → PR merged / closed
+  → debt archived, specs validated/refined, plans archived
+```
+
+Specs are durable behavior contracts. Technical debt tracks known gaps between current and target behavior. Execution plans are tactical, time-bounded work instructions. PRs prove and land the work. Archive notes preserve what actually happened.
+
+## When to Use
+
+Use when Tanner says things like:
+
+- "turn this idea into specs/plans"
+- "add this to technical debt"
+- "make exec plans from this gap analysis"
+- "execute the next plan"
+- "close out the debt after the PR merged"
+- "validate/refine the specs after implementation"
+- "organize this repo like specs + debt + exec plans"
+
+Also use when a conversation produces a durable product decision, missing capability, discovered issue, or next implementation slice.
+
+Do not use for tiny one-off edits that do not affect product direction, specs, debt, or plan lifecycle.
+
+## Canonical Repository Shape
+
+Prefer an existing repo convention over inventing a new one. If no convention exists, use this shape:
+
+```text
+specs/
+  README.md                         # index of durable subsystem contracts
+  <subsystem>.md                    # behavior-first spec files
+
+docs/
+  TECHNICAL_DEBT.md                 # stable debt register with IDs and links
+  exec-plans/
+    README.md                       # plan lifecycle/current ordering if repo wants it
+    active/                         # exactly one or very few current plans
+    backlog/                        # not-yet-selected dated plans
+    archive/                        # completed/superseded plans with status notes
+```
+
+Keep these layers distinct:
+
+- **Idea capture**: raw user intent, sources, hypotheses, alternatives.
+- **Spec**: target behavior and invariants; should remain useful after implementation.
+- **Technical debt**: explicit current-vs-target gap with stable ID, severity, owner/scope, and links.
+- **Execution plan**: exact files, steps, tests, validation, and PR proof for one implementation slice.
+- **PR**: concrete branch that changes code/docs and records proof.
+- **Archive**: completed plan/debt notes linking to PRs and updated specs.
+
+## Intake: Classify the Idea
+
+Before writing files, inspect disk truth:
+
+```bash
+git status --short --branch
+find specs docs/exec-plans -maxdepth 2 -type f 2>/dev/null | sort
+sed -n '1,220p' docs/TECHNICAL_DEBT.md 2>/dev/null || true
+sed -n '1,220p' specs/README.md 2>/dev/null || true
+```
+
+Classify the idea into one of four paths:
+
+1. **Spec-first** — the idea changes desired behavior, system contracts, lifecycle semantics, or product philosophy.
+2. **Debt-first** — the idea identifies a gap, missing capability, broken invariant, or known compromise.
+3. **Plan-first** — the idea is already scoped and ready to execute without broader spec/debt work.
+4. **Spike-first** — the idea is plausible but uncertain; create a short research/spike plan before specs or implementation.
+
+Default to **spec-first** when the idea affects durable behavior. Default to **debt-first** when current behavior is known to fall short. Go straight to an execution plan only when target behavior and acceptance criteria are already clear.
+
+## Spec Writing / Refinement
+
+A spec should answer "what must be true?" not "what task do we do today?"
+
+Each spec should include:
+
+- Purpose / subsystem boundary
+- Current behavior if relevant
+- Target behavior
+- Invariants and non-goals
+- Lifecycle/state transitions where relevant
+- Validation signals or acceptance criteria
+- Links to debt IDs and execution plans
+- Open questions only if they materially affect implementation
+
+When refining after implementation:
+
+1. Read the merged PR diff and tests, not just the PR summary.
+2. Update the spec to match verified behavior, not wishful behavior.
+3. If implementation intentionally diverged from old target behavior, either update the target or create a debt item for the remaining gap.
+4. Remove stale open questions that were answered by the PR.
+
+## Technical Debt Register
+
+A good debt item is stable and actionable. Use IDs like `TD-001` if the repo already does, otherwise follow the repo's convention.
+
+Debt item template:
+
+```markdown
+### TD-XXX — Short title
+
+**Status:** open | active | blocked | resolved | archived  
+**Severity:** low | medium | high  
+**Area:** subsystem / files / feature area  
+**Specs:** [`specs/<subsystem>.md`](../specs/<subsystem>.md)  
+**Plans:** [`docs/exec-plans/backlog/YYYY-MM-DD-slice.md`](exec-plans/backlog/YYYY-MM-DD-slice.md)
+
+**Current state:** What exists today.
+
+**Target state:** What should be true.
+
+**Why it matters:** User/product/operator impact.
+
+**Candidate implementation:** Likely implementation path; keep this high level.
+
+**Resolution notes:** Fill when archived/resolved with PR links and validation.
+```
+
+Debt rules:
+
+- Link every debt item to at least one spec or explicitly say why no spec exists yet.
+- Link execution plans when they are created.
+- Do not delete resolved debt casually; mark resolved/archive with PR and date when the repo wants historical traceability.
+- If a PR only partially resolves debt, split the remaining work into a new debt item or update the existing item with remaining scope.
+
+## Execution Plan Lifecycle
+
+Execution plans are tactical. They should be concrete enough for a fresh agent to execute.
+
+Plan states:
+
+- **backlog**: valid future work, not selected now.
+- **active**: selected current implementation slice.
+- **archive**: completed, superseded, or deliberately abandoned.
+
+When promoting a plan:
+
+1. Sync the branch/base first.
+2. Move exactly one plan from `backlog/` to `active/` unless parallel work is intentional.
+3. Change the plan status line to `active`.
+4. Update `docs/exec-plans/README.md` if present.
+5. Commit the lifecycle move separately or include it in the implementation PR if that is the repo convention.
+
+Execution plan minimum contents:
+
+```markdown
+# <Feature/Slice> Execution Plan
+
+**Status:** backlog | active | archived
+**Date:** YYYY-MM-DD
+**Specs:** links
+**Debt:** links
+**Target PR:** optional branch/PR once known
+
+## Goal
+
+## Non-goals
+
+## Context
+
+## Tasks
+- [ ] Task 1: exact files, expected behavior, validation
+- [ ] Task 2: exact files, expected behavior, validation
+
+## Validation
+- targeted tests
+- full/local checks
+- artifact or behavior proof
+
+## Completion / Archive Notes
+```
+
+Prefer several narrow plans over one giant plan. Each plan should map to one coherent PR when possible.
+
+## Executing Plans and Closing PRs
+
+When Tanner asks to execute a plan:
+
+1. Load `writing-plans`, `subagent-driven-development`, and `github-pr-workflow` as relevant.
+2. Verify live branch, open PRs, plan location, and dirty state.
+3. Create a feature branch from current `main` unless continuing an existing PR branch.
+4. Execute the plan task-by-task. Use subagents or Claude Code only when they improve throughput or isolation.
+5. Run required validation and capture proof.
+6. Update the active plan with status/proof notes.
+7. Commit and push.
+8. Open or update the PR with:
+   - summary
+   - spec/debt/plan links
+   - validation commands and results
+   - screenshots/artifact excerpts when behavior or evidence output changed
+9. Watch CI if available; distinguish local validation from CI status.
+
+When a PR is merged or closed:
+
+1. Fetch/sync `main` and verify the PR state.
+2. Read the merge commit / PR diff / changed tests.
+3. Update affected specs to match landed behavior.
+4. Mark linked debt resolved, partially resolved, or still open.
+5. Move completed active plans to `archive/` with a short archive note:
+   ```markdown
+   **Archive status:** Completed by PR #123 on YYYY-MM-DD. Validation: <summary>. Remaining work: <links or none>.
+   ```
+6. If the PR was closed unmerged, mark the plan superseded/abandoned and keep or revise debt accordingly.
+7. Create the next backlog/active plan if obvious; otherwise report the next decision fork.
+
+## Spec Validation After Implementation
+
+After implementation, validate specs against reality:
+
+- Do tests exercise the key invariants named in the spec?
+- Does runtime behavior match spec terminology and state transitions?
+- Did the PR introduce a new limitation that belongs in technical debt?
+- Are old debt links now stale or resolved?
+- Does README/project map still point to the right specs, debt, and plans?
+
+If a spec claims a behavior exists but no test/proof covers it, either add validation in the implementation PR or add a debt item for missing proof.
+
+## PR Closure and Debt Archival Checklist
+
+Use this checklist before declaring a lifecycle closed:
+
+- [ ] PR is merged, or closed-unmerged status is explicit.
+- [ ] Local `main`/base branch is synced after merge.
+- [ ] Specs were read and updated/refined as needed.
+- [ ] Debt item status reflects reality: resolved, partial, still open, or superseded.
+- [ ] Active plan moved to archive with PR/date/validation note.
+- [ ] Next active/backlog plan selected or explicitly deferred.
+- [ ] README / specs index / exec-plan index links still resolve.
+- [ ] Validation commands and CI state are reported separately.
+
+## Common Pitfalls
+
+1. **Turning every idea straight into tasks.** If the behavior contract is unclear, write/refine the spec first.
+2. **Burying durable design in execution plans.** Plans expire; specs survive.
+3. **Deleting technical debt after a PR.** Prefer resolved/archive notes with PR links unless the repo explicitly wants pruning.
+4. **Letting active plans accumulate.** Keep active small; backlog is for parked work.
+5. **Calling local tests CI.** Report local validation and GitHub checks separately.
+6. **Archiving without reading the merged diff.** PR bodies can lie or drift; validate against actual landed changes.
+7. **Forgetting partial resolution.** If a PR closes 70% of a debt item, keep the remainder visible.
+
+## Minimal Commands
+
+```bash
+# Inspect lifecycle state
+git status --short --branch
+find specs docs/exec-plans -maxdepth 2 -type f 2>/dev/null | sort
+
+# Inspect PR after merge/close
+gh pr view <N> --json state,mergedAt,mergeCommit,headRefName,baseRefName,files,url
+
+# Verify docs links with a repo-local checker if present; otherwise run the repo's normal validation
+python3 -m pytest
+python3 -m compileall src tests
+```
+
+## Remember
+
+```text
+Ideas become durable when they are linked.
+Specs define target truth.
+Debt records gaps.
+Execution plans move one slice.
+PRs prove the slice.
+Archive notes close the loop.
+```


### PR DESCRIPTION
## Summary
- Adds a Claude Code subagent orchestration contract to the built-in `claude-code` skill.
- Adds a detailed `references/subagent-orchestration.md` checklist covering parent supervision, independent review, commit/PR handling, and user notification.
- Adds a new `idea-to-execution-lifecycle` skill for moving ideas through specs, technical debt, execution plans, PRs, archival, and spec validation/refinement.
- Bumps the Claude Code skill version and tags/related skills to reflect subagent + PR workflow coverage.

## Test Plan
- [x] Validated `SKILL.md` frontmatter, metadata, size, and reference-file presence with a Python check.
- [x] Ran `git diff --check`.
- [x] Ran `python3 scripts/build_skills_index.py` successfully.
- [ ] Full test suite not run; docs/skill-only change.
