### PR TITLE
Consolidate OpenAI choices response validation

### DIFF
--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -13,6 +13,17 @@ from typing import Any, Dict, List, Optional
 from agent.transports.types import NormalizedResponse
 
 
+def has_non_empty_openai_choices(response: Any) -> bool:
+    """Return whether an OpenAI-compatible response has usable choices."""
+    if response is None:
+        return False
+    if not hasattr(response, "choices") or response.choices is None:
+        return False
+    if not response.choices:
+        return False
+    return True
+
+
 class ProviderTransport(ABC):
     """Base class for provider-specific format conversion and normalization."""
 

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -8,7 +8,7 @@ boto3 calls stay on AIAgent.
 
 from typing import Any, Dict, List, Optional
 
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, has_non_empty_openai_choices
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -128,7 +128,7 @@ class BedrockTransport(ProviderTransport):
             return "output" in response
         # Already-normalized SimpleNamespace
         if hasattr(response, "choices"):
-            return bool(response.choices)
+            return has_non_empty_openai_choices(response)
         return False
 
     def map_finish_reason(self, raw_reason: str) -> str:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, has_non_empty_openai_choices
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
@@ -585,13 +585,7 @@ class ChatCompletionsTransport(ProviderTransport):
 
     def validate_response(self, response: Any) -> bool:
         """Check that response has valid choices."""
-        if response is None:
-            return False
-        if not hasattr(response, "choices") or response.choices is None:
-            return False
-        if not response.choices:
-            return False
-        return True
+        return has_non_empty_openai_choices(response)
 
     def extract_cache_stats(self, response: Any) -> dict[str, int] | None:
         """Extract OpenRouter/OpenAI cache stats from prompt_tokens_details."""

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -4,7 +4,7 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from agent.transports.base import ProviderTransport
+from agent.transports.base import ProviderTransport, has_non_empty_openai_choices
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 from agent.transports import get_transport, register_transport, _REGISTRY
 
@@ -45,6 +45,19 @@ class TestProviderTransportABC:
         assert t.validate_response(None) is True  # default
         assert t.extract_cache_stats(None) is None  # default
         assert t.map_finish_reason("end_turn") == "end_turn"  # default passthrough
+
+
+class TestOpenAIChoicesValidation:
+
+    def test_rejects_missing_choices(self):
+        assert has_non_empty_openai_choices(None) is False
+        assert has_non_empty_openai_choices(SimpleNamespace()) is False
+        assert has_non_empty_openai_choices(SimpleNamespace(choices=None)) is False
+        assert has_non_empty_openai_choices(SimpleNamespace(choices=[])) is False
+
+    def test_accepts_non_empty_choices(self):
+        response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hi"))])
+        assert has_non_empty_openai_choices(response) is True
 
 
 # ── Registry tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a canonical has_non_empty_openai_choices helper for OpenAI-compatible response validation.
- Route Chat Completions and normalized Bedrock response validation through the shared helper.
- Cover the helper directly while preserving both transport call-path tests.

## Validation
- PASS: env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u GITHUB_TOKEN -u GH_TOKEN TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /Users/jwalinshah/projects/agents/hermes-agent/.venv/bin/python -m pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/agent/transports/test_transport.py tests/agent/transports/test_chat_completions.py::TestChatCompletionsValidate tests/agent/transports/test_bedrock_transport.py::TestBedrockValidate -q
- PASS: git diff --check
- BLOCKED: ./scripts/check.sh is not present in this worktree.