### PR TITLE
fix(agent): forward custom_providers to context-length probe on fallback activation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8897,10 +8897,20 @@ class AIAgent:
             # the fallback activation drops to 128K even when config says 204800.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
+                # Re-read custom_providers from live config so per-model
+                # context_length overrides are honored for the fallback model —
+                # mirrors switch_model() (closes #15779 for the fallback path).
+                _fb_custom_providers = None
+                try:
+                    from hermes_cli.config import load_config, get_compatible_custom_providers
+                    _fb_custom_providers = get_compatible_custom_providers(load_config())
+                except Exception:
+                    _fb_custom_providers = None
                 fb_context_length = get_model_context_length(
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
                     config_context_length=getattr(self, "_config_context_length", None),
+                    custom_providers=_fb_custom_providers,
                 )
                 self.context_compressor.update_model(
                     model=self.model,

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -509,3 +509,59 @@ class TestFallbackKeyEnvResolution:
         assert captured["explicit_api_key"] is None, (
             "Unset api_key_env should yield None, not empty string"
         )
+
+
+# =============================================================================
+# custom_providers forwarding in compressor update (#25494 parity)
+# =============================================================================
+
+class TestFallbackCompressorCustomProviders:
+    """Fallback activation must forward custom_providers to get_model_context_length.
+
+    PR #25494 fixed _check_compression_model_feasibility; this covers the
+    third path (_try_activate_fallback) that was still missing the forward.
+    Without it, a custom provider with a per-model context_length entry in
+    config.yaml falls through to the 256K default when the fallback activates,
+    causing the compressor to use the wrong threshold.
+    """
+
+    def test_custom_providers_forwarded_to_context_length_probe(self):
+        """get_model_context_length must receive custom_providers when the
+        fallback model is activated and a context_compressor is present."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+
+        mock_client = _mock_resolve(
+            api_key="sk-or-key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        mock_compressor = MagicMock()
+        agent.context_compressor = mock_compressor
+
+        fake_providers = [{"name": "my-proxy", "base_url": "http://127.0.0.1:8080", "models": {}}]
+
+        captured = {}
+
+        def _fake_get_ctx(model, base_url="", api_key="", config_context_length=None,
+                          provider="", custom_providers=None):
+            captured["custom_providers"] = custom_providers
+            return 200_000
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(mock_client, "anthropic/claude-sonnet-4")),
+            patch("agent.model_metadata.get_model_context_length", side_effect=_fake_get_ctx),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.config.get_compatible_custom_providers",
+                  return_value=fake_providers),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert "custom_providers" in captured, (
+            "get_model_context_length was not called in the fallback activation path"
+        )
+        assert captured["custom_providers"] == fake_providers, (
+            "custom_providers from live config was not forwarded to get_model_context_length"
+        )


### PR DESCRIPTION
## What does this PR do?

**Root cause:** `_try_activate_fallback()` updates the context compressor when switching to the fallback model, but called `get_model_context_length()` without `custom_providers`. Users who pin `context_length` on a model via `custom_providers` in `config.yaml` (e.g. a 1M-context proxy behind a custom endpoint) saw the compressor silently fall through to the 256K default when the primary provider failed over — shifting the compression threshold to the wrong value for the remainder of the session.

**Fix:** Mirror the `switch_model()` pattern — re-read `custom_providers` from live config and forward the list to `get_model_context_length()`. This is consistent with the approach used by `_check_compression_model_feasibility()` (PR #25494) and `switch_model()` (which both correctly forward `custom_providers`). The fallback activation path was the remaining gap.

The three call sites now behave consistently:
- `switch_model()` → forwards re-read `_sm_custom_providers` ✅
- `_check_compression_model_feasibility()` → forwards `self._custom_providers` ✅ (PR #25494)
- `_try_activate_fallback()` → forwards re-read `_fb_custom_providers` ✅ (this PR)

## Related Issue

Closes #8785

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `run_agent.py`: re-read `custom_providers` from live config and forward to `get_model_context_length()` in `_try_activate_fallback()` (+10 lines)
- `tests/run_agent/test_fallback_model.py`: regression test verifying `custom_providers` is passed through when a context compressor is present (+50 lines)

## How to Test

```
pytest tests/run_agent/test_fallback_model.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single fix only | Test added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A