### PR TITLE
fix(cli): handle NoConsoleScreenBufferError in _cprint on Windows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1479,7 +1479,16 @@ def _cprint(text: str):
     # direct prompt_toolkit print is safe and matches existing behavior
     # (spinner frames, streamed tokens, tool activity prefixes, …).
     if app is None or not getattr(app, "_is_running", False):
-        _pt_print(_PT_ANSI(text))
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception as _e:
+            # NoConsoleScreenBufferError on Windows when no console is attached
+            # (e.g. Kanban task runner, Scheduled Task, non-interactive context).
+            # Fall back to plain print so output is not lost (issue #25535).
+            if "NoConsoleScreenBufferError" in type(_e).__name__ or "console" in str(_e).lower():
+                print(text)
+            else:
+                raise
         return
 
     try:


### PR DESCRIPTION
## Problem

Kanban task runner on Windows crashes with `NoConsoleScreenBufferError` because prompt_toolkit tries to access a Win32 console buffer that does not exist in non-interactive contexts. Gateway log shows `crashed=1` for the kanban dispatcher.

## Fix

Catch `NoConsoleScreenBufferError` in `_cprint` and fall back to `print()` so output is not lost and execution continues.

Fixes #25535