### PR TITLE
fix(docs): correct Google Chat Pub/Sub IAM principal to workspace add-ons SA

### DIFF
--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -95,8 +95,19 @@ After creation, the topic's detail page has a **Subscriptions** tab. Create one:
 
 On the **topic** (not the subscription), add an IAM principal:
 
-- Principal: `chat-api-push@system.gserviceaccount.com`
+- Principal: `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`
 - Role: `Pub/Sub Publisher`
+
+Replace `<PROJECT_NUMBER>` with your GCP project number (not the project ID).
+Find it in **GCP Console → Home** or **IAM** — it's a numeric ID like `123456789012`.
+
+:::tip Where does this email come from?
+This is the Google-managed service account that Google Chat uses to publish
+events to your Pub/Sub topic. You can also see this same email when you
+configure the Chat app in **Step 7** — if you'd rather configure the app
+first and copy the email from there, that works too. Just make sure you
+apply the IAM binding before installing the bot in a test space.
+:::
 
 Without this, Google Chat cannot publish events to your topic and your bot will
 never receive anything.
@@ -294,7 +305,7 @@ evicts only that user's cache. Users don't disrupt each other.
    and that the SA is listed as `Pub/Sub Subscriber` on the subscription.
 2. If the subscription has zero messages, Google Chat isn't publishing.
    Double-check the IAM binding on the **topic**:
-   `chat-api-push@system.gserviceaccount.com` must have `Pub/Sub Publisher`.
+   `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com` must have `Pub/Sub Publisher` (see Step 5 for instructions on finding your project number).
 3. Check `hermes gateway` logs for `[GoogleChat] Connected`. If you see
    `[GoogleChat] Config validation failed`, the error message tells you which
    env var to fix.


### PR DESCRIPTION
## Summary

The principal for the Pub/Sub topic IAM binding was documented as `chat-api-push@system.gserviceaccount.com`, which is incorrect for Google Chat apps. The actual service account is the Google-managed Workspace add-ons SA.

## Changes

- **Step 5**: Changed the IAM principal from `chat-api-push@system.gserviceaccount.com` to `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`
- **Step 5**: Added instructions for finding the GCP project number in Console → Home or IAM
- **Step 5**: Added a tip box explaining where this email comes from, with a cross-reference to Step 7 as an alternative way to discover it
- **Troubleshooting**: Updated the stale email reference to match

## Why

The old principal (`chat-api-push@system.gserviceaccount.com`) is not the correct SA for Chat apps using Pub/Sub. Google Chat publishes events through the Workspace add-ons Google-managed SA, which follows the format `service-<PROJECT_NUMBER>@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`.

Users following the old doc would set up IAM with the wrong principal, the topic would never receive events, and the bot would silently fail.