### PR TITLE
fix: honor gateway max history depth

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,36 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
+def _positive_int_or_none(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _configured_max_history_depth(user_config: dict) -> Optional[int]:
+    try:
+        return _positive_int_or_none(
+            cfg_get(user_config or {}, "context", "max_history_depth")
+        )
+    except Exception:
+        return None
+
+
+def _limit_history_depth(
+    history: List[Dict[str, Any]],
+    max_depth: Optional[int],
+) -> List[Dict[str, Any]]:
+    if not history or not max_depth or len(history) <= max_depth:
+        return history
+
+    start = max(0, len(history) - max_depth)
+    while start > 0 and history[start].get("role") in {"tool", "function"}:
+        start -= 1
+    return history[start:]
+
+
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
     """Rewrite slash-command mentions to Telegram-valid command names.
 
@@ -14311,6 +14341,19 @@ class GatewayRunner:
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        user_config = _load_gateway_config()
+        _max_history_depth = _configured_max_history_depth(user_config)
+        _original_history_len = len(history or [])
+        history = _limit_history_depth(history or [], _max_history_depth)
+        if len(history) != _original_history_len:
+            logger.info(
+                "Gateway context: applied context.max_history_depth=%d; "
+                "passing %d of %d history messages",
+                _max_history_depth,
+                len(history),
+                _original_history_len,
+            )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
@@ -14331,8 +14374,7 @@ class GatewayRunner:
             if run_generation is None or not session_key:
                 return True
             return self._is_session_run_current(session_key, run_generation)
-        
-        user_config = _load_gateway_config()
+
         platform_key = _platform_config_key(source.platform)
 
         from hermes_cli.tools_config import _get_platform_tools

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1088,6 +1088,7 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        "max_history_depth": 0,  # 0 disables the gateway history hard cap
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -51,6 +51,67 @@ def _make_large_history_tokens(target_tokens: int) -> list:
     return _make_history(n_msgs, content_size=content_size)
 
 
+def test_configured_max_history_depth_reads_context_value():
+    gateway_run = importlib.import_module("gateway.run")
+
+    assert (
+        gateway_run._configured_max_history_depth(
+            {"context": {"max_history_depth": "5"}}
+        )
+        == 5
+    )
+
+
+def test_configured_max_history_depth_ignores_invalid_values():
+    gateway_run = importlib.import_module("gateway.run")
+
+    assert gateway_run._configured_max_history_depth({}) is None
+    assert (
+        gateway_run._configured_max_history_depth(
+            {"context": {"max_history_depth": 0}}
+        )
+        is None
+    )
+    assert (
+        gateway_run._configured_max_history_depth(
+            {"context": {"max_history_depth": "nope"}}
+        )
+        is None
+    )
+
+
+def test_limit_history_depth_keeps_recent_messages():
+    gateway_run = importlib.import_module("gateway.run")
+    history = _make_history(12, content_size=10)
+
+    assert gateway_run._limit_history_depth(history, 5) == history[-5:]
+
+
+def test_limit_history_depth_does_not_start_with_tool_result():
+    gateway_run = importlib.import_module("gateway.run")
+    history = [
+        {"role": "user", "content": "before"},
+        {"role": "assistant", "content": "older"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call-1", "type": "function"},
+                {"id": "call-2", "type": "function"},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "tool result 1"},
+        {"role": "tool", "tool_call_id": "call-2", "content": "tool result 2"},
+        {"role": "assistant", "content": "after tools"},
+        {"role": "user", "content": "latest"},
+    ]
+
+    limited = gateway_run._limit_history_depth(history, 4)
+
+    assert limited == history[2:]
+    assert limited[0]["role"] == "assistant"
+
+
 class HygieneCaptureAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -672,6 +672,7 @@ The context engine controls how conversations are managed when approaching the m
 ```yaml
 context:
   engine: "compressor"    # default — built-in lossy summarization
+  max_history_depth: 0     # optional gateway hard cap; 0 disables it
 ```
 
 To use a plugin engine (e.g., LCM for lossless context management):


### PR DESCRIPTION
﻿## Summary
- read `context.max_history_depth` for gateway turns and apply it before the local agent or proxy receives history
- keep tool-result tails attached to the assistant tool call when the cap cuts through a tool sequence
- document the disabled-by-default `max_history_depth: 0` setting

Fixes #25538.

## To verify
- `python -m py_compile gateway\run.py hermes_cli\config.py tests\gateway\test_session_hygiene.py`
- `python -m ruff check gateway\run.py hermes_cli\config.py tests\gateway\test_session_hygiene.py`
- `python -m pytest tests\gateway\test_session_hygiene.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `git diff --check`
