### PR TITLE
fix: read approvals.timeout from config in CLI approval callback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10064,7 +10064,7 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = 60
+            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()
 
             self._approval_state = {


### PR DESCRIPTION
## Summary

The `_approval_callback` method in `HermesCLI` (cli.py) hardcodes `timeout = 60` instead of reading the `approvals.timeout` config value. This means the config setting is silently ignored for CLI interactive approval prompts — the user sets `approvals.timeout: 86400` but the prompt still times out after 60 seconds.

## Root Cause

Two other approval paths already read the config correctly:
- `tools/approval.py:_request_approval_interactive()` → reads `_get_approval_timeout()` which calls `_get_approval_config()`
- `hermes_cli/callbacks.py:approval_callback()` → reads `CLI_CONFIG.get("approvals", {}).get("timeout", 60)`

But `cli.py:HermesCLI._approval_callback()` — the one that actually gets registered as the CLI approval callback — has the value hardcoded.

## Fix

One-line change: replace `timeout = 60` with `timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))`.

## Test Plan

- [ ] Set `approvals.timeout: 86400` in config.yaml
- [ ] Trigger a dangerous command (e.g. `rm -rf`)
- [ ] Verify the approval prompt countdown shows 24h instead of 60s