### PR TITLE
fix: restrict .env file permissions to 0600

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -379,6 +379,12 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
             new_lines.append(f"{key}={val}")
 
     env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    # Restrict permissions — .env holds API keys and tokens.
+    try:
+        import stat
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    except OSError:
+        pass  # Windows or read-only FS
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1422,6 +1422,10 @@ copy_config_templates() {
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi
+    # Restrict .env permissions — this file holds API keys and tokens.
+    # 0600 ensures only the file owner can read/write, matching standard
+    # practice for credential files (.netrc, .aws/credentials, .ssh/config).
+    chmod 600 "$HERMES_HOME/.env"
     configure_browser_env_from_system_browser
 
     # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)


### PR DESCRIPTION
## Summary

- Set file mode `0600` on `~/.hermes/.env` after creation in the installer (`scripts/install.sh`)
- Enforce `0600` after every write via `memory_setup._write_env_vars()` (Python-side)
- Handles both new installs and existing installations (chmod runs unconditionally)
- Gracefully handles Windows/read-only FS with `try/except OSError`

## Why

The installer previously left `.env` at the default umask (typically `0664`), making API keys and tokens group/world-readable. On any multi-user system this is a security footgun.

Standard practice for credential files (`.netrc`, `.aws/credentials`, `.ssh/config`) is `0600` — owner-only read/write.

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | `chmod 600 "$HERMES_HOME/.env"` after creating or preserving `.env` |
| `hermes_cli/memory_setup.py` | `env_path.chmod(0o600)` after `write_text()` in `_write_env_vars()` |

## Testing

- **Fresh install**: `curl ... \| bash` → `ls -la ~/.hermes/.env` shows `-rw-------`
- **Existing install**: `hermes setup memory` → `.env` permissions reset to `0600`
- **Windows**: `OSError` caught silently (no-op)

Fixes #25477