### PR TITLE
docs: add repository planning guidance

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -1,0 +1,13 @@
+# Work-in-Progress Plans
+
+This directory is for local, exploratory, or work-in-progress plans.
+
+Use `.plans/` for drafts that are not yet the agreed implementation path, including early design sketches, spike notes, and agent-generated plans that still need review.
+
+Promotion policy:
+
+- Keep rough or speculative plans here.
+- Move or copy a plan to `plans/` when it becomes shared, reviewed, or user-facing.
+- Prefer preserving useful context when promoting a plan, but remove obsolete scratch notes first.
+
+If a plan is intended for contributors or for a PR, it usually belongs in `plans/`, not `.plans/`.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,41 @@ See `hermes claw migrate --help` for all options, or use the `openclaw-migration
 
 ---
 
+## Repository Orientation
+
+For contributors and agent-driven development, the main code paths are:
+
+| Path | Purpose |
+| --- | --- |
+| `run_agent.py` | Core agent conversation loop and tool-call orchestration. Large legacy entrypoint; refactor incrementally. |
+| `cli.py` | Interactive terminal UI and in-session command handling. Large legacy entrypoint; refactor incrementally. |
+| `agent/` | Prompt building, memory, compression, model routing, credentials, and skill dispatch support. |
+| `hermes_cli/` | CLI subcommands, configuration, setup flows, slash-command registry, and command-line entrypoint code. |
+| `tools/` | Tool implementations and central registry. |
+| `gateway/` | Messaging gateway and platform adapters. |
+| `cron/` | Scheduled job model and scheduler. |
+| `plugins/` | Optional plugin integrations. |
+| `skills/` | Bundled skills available as part of the default skill set. |
+| `optional-skills/` | Official skills that ship with the repository but are not activated by default. See `optional-skills/DESCRIPTION.md`. |
+| `tests/` | Pytest suite and shared hermetic fixtures. |
+| `website/` | Docusaurus documentation site. |
+| `plans/` | Shared or reviewed implementation plans. See `plans/README.md`. |
+| `.plans/` | Local, exploratory, or work-in-progress plans. See `.plans/README.md`. |
+
+### Planning documents
+
+Use planning documents for non-trivial changes before implementation:
+
+- Put reviewed, shared, or user-facing implementation plans in `plans/`.
+- Put local drafts, experiments, and work-in-progress plans in `.plans/`.
+- Promote a `.plans/` draft to `plans/` when it becomes the agreed implementation plan.
+
+### Test harness notes
+
+The test suite is designed to be hermetic. Shared fixtures redirect `HERMES_HOME` to a per-test temporary directory, remove credential-shaped environment variables, clear behavioral `HERMES_*` variables, pin deterministic runtime settings, and reset module-level state between tests. Integration tests are excluded by default through `pyproject.toml`.
+
+---
+
 ## Contributing
 
 We welcome contributions! See the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) for development setup, code style, and PR process.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,15 @@
+# Implementation Plans
+
+This directory is for shared, reviewed, or user-facing implementation plans.
+
+Use `plans/` when a plan is meant to be read by contributors, referenced from issues or PRs, or used as the agreed implementation path for a non-trivial change.
+
+Guidelines:
+
+- Prefer one plan per feature or refactor.
+- Use descriptive kebab-case filenames, for example `refactor-root-entrypoints.md`.
+- Include the goal, architecture, files to touch, testing strategy, and verification steps.
+- Keep tasks small enough to implement and review incrementally.
+- If a plan starts as an experiment in `.plans/`, move or copy it here once it becomes the accepted plan.
+
+Local drafts and exploratory notes belong in `.plans/` until they are ready to share.


### PR DESCRIPTION
## Summary

- Add repository-orientation notes to README for contributors and agent-driven development
- Document the intended distinction between `plans/` and `.plans/`
- Add README files for shared implementation plans and work-in-progress plans

## Test Plan

- Documentation-only change
- Verified referenced local paths exist