### PR TITLE
fix: check for agent interrupt in clarify wait loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15197,7 +15197,11 @@ class GatewayRunner:
                     return "[clarify prompt could not be delivered]"
 
                 timeout = _clarify_mod.get_clarify_timeout()
-                response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
+                response = _clarify_mod.wait_for_response(
+                    clarify_id,
+                    timeout=float(timeout),
+                    on_interrupt_check=lambda: getattr(agent, '_interrupt_requested', False),
+                )
                 if response is None or response == "":
                     # Timeout or session-boundary cancellation
                     return f"[user did not respond within {int(timeout / 60)}m]"

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -177,6 +177,72 @@ class TestClarifyPrimitive:
         assert isinstance(timeout, int)
         assert timeout > 0
 
+    def test_interrupt_check_aborts_wait(self):
+        """wait_for_response returns None early when on_interrupt_check fires."""
+        from tools import clarify_gateway as cm
+
+        cm.register("id_int", "sk_int", "Q?", ["A"])
+
+        # Simulate interrupt flag flipping after a short delay.
+        interrupt_state = {"interrupted": False}
+
+        def set_interrupt():
+            time.sleep(0.1)
+            interrupt_state["interrupted"] = True
+
+        threading.Thread(target=set_interrupt).start()
+
+        result = cm.wait_for_response(
+            "id_int",
+            timeout=10.0,
+            on_interrupt_check=lambda: interrupt_state["interrupted"],
+        )
+        # Interrupt fired → returns None (no response).
+        assert result is None
+        # Should have returned well before the 10s timeout.
+        # (The test itself would hang for 10s if interrupt didn't work.)
+
+    def test_interrupt_check_false_keeps_waiting(self):
+        """wait_for_response blocks normally when interrupt check returns False."""
+        from tools import clarify_gateway as cm
+
+        cm.register("id_no_int", "sk_no_int", "Q?", ["A"])
+
+        def resolver():
+            time.sleep(0.05)
+            cm.resolve_gateway_clarify("id_no_int", "X")
+
+        threading.Thread(target=resolver).start()
+
+        result = cm.wait_for_response(
+            "id_no_int",
+            timeout=5.0,
+            on_interrupt_check=lambda: False,
+        )
+        assert result == "X"
+
+    def test_interrupt_check_exception_is_ignored(self):
+        """Exceptions in on_interrupt_check are swallowed — wait continues."""
+        from tools import clarify_gateway as cm
+
+        cm.register("id_exc", "sk_exc", "Q?", ["A"])
+
+        def resolver():
+            time.sleep(0.05)
+            cm.resolve_gateway_clarify("id_exc", "Y")
+
+        threading.Thread(target=resolver).start()
+
+        def bad_check():
+            raise RuntimeError("oops")
+
+        result = cm.wait_for_response(
+            "id_exc",
+            timeout=5.0,
+            on_interrupt_check=bad_check,
+        )
+        assert result == "Y"
+
 
 class TestGatewayTextIntercept:
     """The gateway's _handle_message intercepts text replies to pending clarifies."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -100,7 +100,11 @@ def register(
     return entry
 
 
-def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
+def wait_for_response(
+    clarify_id: str,
+    timeout: float,
+    on_interrupt_check: Optional[Callable[[], bool]] = None,
+) -> Optional[str]:
     """Block on the entry's event until resolved or timeout fires.
 
     Polls in 1-second slices so the agent's inactivity heartbeat keeps
@@ -108,7 +112,12 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     for 10 minutes with zero activity touches and the gateway's inactivity
     watchdog kills the agent while the user is still typing.
 
-    Returns the resolved response string, or ``None`` on timeout.
+    *on_interrupt_check* is an optional callback that returns ``True`` when
+    the agent thread has been interrupted (e.g. ``/stop`` command).  When
+    set, the poll loop checks it each second and aborts early so the agent
+    can unwind instead of deadlocking until the full timeout.
+
+    Returns the resolved response string, or ``None`` on timeout / interrupt.
     """
     with _lock:
         entry = _entries.get(clarify_id)
@@ -126,6 +135,16 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
+        # Check for agent interrupt before blocking on the event.
+        if on_interrupt_check is not None:
+            try:
+                if on_interrupt_check():
+                    logger.info(
+                        "Clarify %s interrupted — aborting wait", clarify_id,
+                    )
+                    break
+            except Exception:
+                pass
         if entry.event.wait(timeout=min(1.0, remaining)):
             break
         if touch_activity_if_due is not None:


### PR DESCRIPTION
## Summary

- Add optional `on_interrupt_check` callback to `wait_for_response()` in `clarify_gateway.py`
- The 1-second poll loop calls the callback each iteration; if it returns `True`, the wait aborts immediately
- Gateway's `_clarify_callback_sync` now passes `lambda: agent._interrupt_requested` so `/stop` and other interrupt signals are honored while the agent is waiting for a user clarify response
- 3 new tests cover: interrupt aborts wait, false keeps waiting, exception in callback is ignored

## Problem

When an agent was waiting for a user clarify response in Gateway mode, the `wait_for_response` loop did not check `_interrupt_requested`.  Sending `/stop` or another interrupt command while the agent was blocked on clarify would leave the agent deadlocked for the full 10-minute timeout, ignoring the interrupt entirely.

## Fix

```python
# clarify_gateway.py — new parameter
def wait_for_response(clarify_id, timeout, on_interrupt_check=None):
    ...
    while True:
        if on_interrupt_check is not None and on_interrupt_check():
            break  # abort early
        if entry.event.wait(timeout=1.0):
            break
    ...

# gateway/run.py — pass agent's interrupt flag
response = _clarify_mod.wait_for_response(
    clarify_id,
    timeout=float(timeout),
    on_interrupt_check=lambda: getattr(agent, '_interrupt_requested', False),
)
```

## Testing

```
python -m pytest tests/tools/test_clarify_gateway.py -v
# 17 passed (14 existing + 3 new)
```

Fixes #25482