### PR TITLE
fix(gateway): clean stale PID file before O_EXCL write

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -482,10 +482,29 @@ def write_pid_file() -> None:
     Uses atomic O_CREAT | O_EXCL creation so that concurrent --replace
     invocations race: exactly one process wins and the rest get
     FileExistsError.
+
+    Before the atomic create, stale PID files left behind by crashes or
+    SIGKILL are cleaned up so that a restart can succeed.
     """
     path = _get_pid_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     record = json.dumps(_build_pid_record())
+
+    # Pre-check: if PID file exists but the recorded process is dead,
+    # remove it first so the O_EXCL write won't fail on a stale file.
+    if path.exists():
+        existing = _read_pid_record(path)
+        if existing:
+            try:
+                pid = int(existing["pid"])
+                os.kill(pid, 0)
+            except (ProcessLookupError, PermissionError, ValueError, TypeError):
+                # Process is gone - remove stale PID file
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
     try:
         fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except FileExistsError:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -244,6 +244,40 @@ class TestGatewayPidState:
         finally:
             status.release_gateway_runtime_lock()
 
+    def test_write_pid_file_cleans_stale_pid_from_dead_process(self, tmp_path, monkeypatch):
+        """Stale PID files from dead processes should be cleaned before O_EXCL."""
+        monkeypatch.setattr("gateway.status._get_pid_path", lambda: tmp_path / "gateway.pid")
+
+        # Write a stale PID file pointing to a non-existent process
+        stale_pid = 999999998  # Very unlikely to exist
+        stale_record = json.dumps({"pid": stale_pid, "start_time": 0})
+        (tmp_path / "gateway.pid").write_text(stale_record)
+
+        # write_pid_file should succeed by cleaning the stale file first
+        from gateway.status import write_pid_file
+        write_pid_file()  # Should NOT raise FileExistsError
+
+        # Verify new PID file was written
+        from gateway.status import _read_pid_record
+        record = _read_pid_record(tmp_path / "gateway.pid")
+        assert record is not None
+        assert record["pid"] == os.getpid()
+
+    def test_write_pid_file_preserves_pid_file_for_live_process(self, tmp_path, monkeypatch):
+        """PID file for a live process should NOT be removed; FileExistsError raised."""
+        import pytest
+
+        monkeypatch.setattr("gateway.status._get_pid_path", lambda: tmp_path / "gateway.pid")
+
+        # Write a PID file pointing to the current process (which is alive)
+        import os as _os
+        live_record = json.dumps({"pid": _os.getpid(), "start_time": 0})
+        (tmp_path / "gateway.pid").write_text(live_record)
+
+        from gateway.status import write_pid_file
+        with pytest.raises(FileExistsError):
+            write_pid_file()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_json_file_uses_atomic_json_write(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #13511

After an abnormal gateway exit (SIGKILL, crash, OOM, terminal disconnect), the `gateway.pid` file remains on disk. On next gateway start, `write_pid_file()` uses `O_CREAT | O_EXCL` which raises `FileExistsError` — causing the gateway to exit with "PID file race lost to another gateway instance" even though the old process is dead.

## Root Cause

`write_pid_file()` in `gateway/status.py` does not check whether the process recorded in a pre-existing PID file is still alive before attempting the atomic `O_EXCL` create. The `FileExistsError` is unconditionally re-raised, blocking restart.

## Fix

Before the `os.open(path, O_CREAT | O_EXCL | ...)` call, add a stale PID cleanup step:
1. If the PID file exists, read the recorded PID
2. Probe the process with `os.kill(pid, 0)` 
3. If `ProcessLookupError` (process dead), remove the stale file
4. Then proceed with the normal `O_EXCL` creation

This preserves the atomic race behavior for truly concurrent starts while fixing the stale-file blocking case.

## Testing

Added 2 new tests in `tests/gateway/test_status.py`:
- `test_write_pid_file_cleans_stale_pid_from_dead_process` — stale PID file is cleaned, write succeeds
- `test_write_pid_file_preserves_pid_file_for_live_process` — live process PID file preserved, `FileExistsError` raised

All 13 `TestGatewayPidState` tests pass.
