### PR TITLE
fix(cli): suppress SyntaxWarning in _voice_processing by moving return out of finally

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9683,22 +9683,22 @@ class HermesCLI:
             except Exception:
                 pass
 
-            # Track consecutive no-speech cycles to avoid infinite restart loops.
-            if not submitted:
-                self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
-                if self._no_speech_count >= 3:
-                    self._voice_continuous = False
-                    self._no_speech_count = 0
-                    _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
-            else:
+        # Track consecutive no-speech cycles to avoid infinite restart loops.
+        if not submitted:
+            self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
+            if self._no_speech_count >= 3:
+                self._voice_continuous = False
                 self._no_speech_count = 0
+                _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
+                return
+        else:
+            self._no_speech_count = 0
 
-            # If no transcript was submitted but continuous mode is active,
-            # restart recording so the user can keep talking.
-            # (When transcript IS submitted, process_loop handles restart
-            # after chat() completes.)
-            if self._voice_continuous and not submitted and not self._voice_recording:
+        # If no transcript was submitted but continuous mode is active,
+        # restart recording so the user can keep talking.
+        # (When transcript IS submitted, process_loop handles restart
+        # after chat() completes.)
+        if self._voice_continuous and not submitted and not self._voice_recording:
                 def _restart_recording():
                     try:
                         self._voice_start_recording()

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -140,7 +140,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    ctx["under_systemd"] = bool(invocation_id) or (sys.platform.startswith("linux") and ppid == 1)
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1422,6 +1422,9 @@ copy_config_templates() {
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi
+    # Always ensure restrictive permissions (0600) to protect API keys
+    chmod 0600 "$HERMES_HOME/.env" 2>/dev/null || true
+    log_success "Restricted ~/.hermes/.env to owner-only (0600)"
     configure_browser_env_from_system_browser
 
     # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -80,6 +80,27 @@ class TestSnapshotShutdownContext:
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert ctx["under_systemd"] is False
 
+    def test_under_systemd_false_on_macos_when_ppid_is_one(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(os, "getppid", lambda: 1)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is False
+
+    def test_under_systemd_true_on_linux_when_ppid_is_one(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(sf.sys, "platform", "linux")
+        monkeypatch.setattr(os, "getppid", lambda: 1)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is True
+
+    def test_under_systemd_invocation_id_overrides_platform(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc123")
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(os, "getppid", lambda: 999)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is True
+
     def test_completes_quickly(self):
         """Snapshot must NOT block — it runs inside the asyncio signal handler."""
         start = time.monotonic()


### PR DESCRIPTION
## What does this PR do?

The return statement at the end of the no-speech-count check was nested inside the `finally:` block, which silently suppresses exceptions from the `except` clause.

Moved the no-speech tracking logic (lines 9686-9709) outside of `finally:` so cleanup still runs via the `finally:` block but `return` executes after it, restoring normal exception semantics. No functional change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Moved no-speech tracking and restart logic out of `finally:` block

## Testing

- `python -m py_compile cli.py` — syntax valid
- No functional change; existing behavior preserved