### PR TITLE
Add CLI smoke contract

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Cheap local validation for the CLI smoke contract.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_ROOT/.venv/bin/activate" ] \
+  || [ -f "$REPO_ROOT/venv/bin/activate" ] \
+  || [ -f "$HOME/.hermes/hermes-agent/venv/bin/activate" ]; then
+  "$REPO_ROOT/scripts/run_tests.sh" tests/hermes_cli/test_cli_smoke_contract.py -q
+else
+  cd "$REPO_ROOT"
+  python3 -m pytest -o "addopts=" tests/hermes_cli/test_cli_smoke_contract.py -q
+fi

--- a/tests/hermes_cli/test_cli_smoke_contract.py
+++ b/tests/hermes_cli/test_cli_smoke_contract.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HERMES = ROOT / "hermes"
+
+
+def _run_hermes(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+    return subprocess.run(
+        [sys.executable, str(HERMES), *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def test_cli_help_smoke_proves_launcher_imports_and_argparse():
+    result = _run_hermes("--help")
+
+    assert result.returncode == 0
+    assert "Hermes Agent - AI assistant" in result.stdout
+    assert "usage: hermes" in result.stdout
+    assert result.stderr == ""
+
+
+def test_cli_bad_input_reports_clear_nonzero_failure():
+    result = _run_hermes("--not-a-real-hermes-flag")
+
+    assert result.returncode == 2
+    assert "usage: hermes" in result.stderr
+    assert "unrecognized arguments: --not-a-real-hermes-flag" in result.stderr


### PR DESCRIPTION
## Summary
- add a no-secret CLI smoke test for the real ./hermes launcher help path
- assert bad CLI input exits nonzero with argparse's clear failure message
- add a cheap scripts/check.sh wrapper for local validation of the smoke contract

## Validation
- ./scripts/check.sh
- git diff --check