### PR TITLE
fix(credential_pool): parse ISO-string last_status_at during from_dict rehydration (#25516)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -128,6 +128,9 @@ class PooledCredential:
     def from_dict(cls, provider: str, payload: Dict[str, Any]) -> "PooledCredential":
         field_names = {f.name for f in fields(cls) if f.name != "provider"}
         data = {k: payload.get(k) for k in field_names if k in payload}
+        # Rehydrated last_status_at may be an ISO string from to_dict() — normalize to float epoch
+        if "last_status_at" in data and isinstance(data["last_status_at"], str):
+            data["last_status_at"] = _parse_absolute_timestamp(data["last_status_at"])
         extra = {k: payload[k] for k in _EXTRA_KEYS if k in payload and payload[k] is not None}
         data["extra"] = extra
         data.setdefault("id", uuid.uuid4().hex[:6])


### PR DESCRIPTION
## Summary

Fixes the `TypeError: can only concatenate str (not "int") to str` crash that occurs when a GPT-family provider pool entry is rehydrated from disk after a rate-limit hit.

## Root Cause

`PooledCredential.from_dict()` was directly passing the `last_status_at` value from the serialized payload into the dataclass constructor. `to_dict()` serializes `last_status_at` as-is, which means an ISO-8601 string (e.g. `"2026-05-11T08:23:20.891066+00:00"`) gets stored in JSON and later read back as a `str`. When `_exhausted_until()` runs `entry.last_status_at + _exhausted_ttl(...)`, the expression is `str + int`, which raises `TypeError`.

## Fix

After extracting `last_status_at` from the payload, if it is a `str`, normalize it through the existing `_parse_absolute_timestamp()` helper (which already handles ISO strings, epoch floats, and epoch milliseconds). This ensures the rehydrated entry has a `float` epoch value, matching the type the rest of the code expects.

## Test Plan

- `pytest tests/agent/test_credential_pool.py` — 43 passed.

## Related

Closes #25516
