### PR TITLE
fix(ssh): warn when adjacent public key sidecar is stale

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -75,6 +75,7 @@ AUTHOR_MAP = {
     "aubrey@freeman-wisco.com": "Freeman-Consulting",
     "don.rhm@gmail.com": "rahimsais",
     "40222899+rahimsais@users.noreply.github.com": "rahimsais",
+    "wesley.simplicio.ext@siemens-energy.com": "wesleysimplicio",
     "alfred@Alfreds-Mac-mini.local": "NivOO5",
     "231191380+NivOO5@users.noreply.github.com": "NivOO5",
     "jameshuang@gmail.com": "kjames2001",

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -200,6 +200,108 @@ class TestSSHPreflight:
         assert env.host == "example.com"
         assert env.user == "alice"
 
+    def test_stale_public_key_sidecar_returns_warning(self, tmp_path, monkeypatch):
+        private_key = tmp_path / "id_ed25519"
+        private_key.write_text("private", encoding="utf-8")
+        private_key.with_name("id_ed25519.pub").write_text(
+            "ssh-ed25519 stale-key comment\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout="ssh-ed25519 derived-key comment\n", stderr=""
+            ),
+        )
+
+        warning = ssh_env._check_stale_public_key_sidecar(str(private_key))
+
+        assert warning is not None
+        assert "id_ed25519.pub" in warning
+        assert "ssh-keygen -y -f" in warning
+
+    def test_public_key_sidecar_check_closes_stdin(self, tmp_path, monkeypatch):
+        private_key = tmp_path / "id_ed25519"
+        private_key.write_text("private", encoding="utf-8")
+        private_key.with_name("id_ed25519.pub").write_text(
+            "ssh-ed25519 stale-key comment\n",
+            encoding="utf-8",
+        )
+
+        def _fake_run(*args, **kwargs):
+            assert kwargs["input"] == ""
+            assert kwargs["timeout"] <= 3
+            return subprocess.CompletedProcess(
+                args[0], 0, stdout="ssh-ed25519 derived-key comment\n", stderr=""
+            )
+
+        monkeypatch.setattr(ssh_env.subprocess, "run", _fake_run)
+
+        assert ssh_env._check_stale_public_key_sidecar(str(private_key)) is not None
+
+    def test_matching_public_key_sidecar_ignores_comment(self, tmp_path, monkeypatch):
+        private_key = tmp_path / "id_ed25519"
+        private_key.write_text("private", encoding="utf-8")
+        private_key.with_name("id_ed25519.pub").write_text(
+            "ssh-ed25519 shared-key sidecar-comment\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout="ssh-ed25519 shared-key derived-comment\n", stderr=""
+            ),
+        )
+
+        assert ssh_env._check_stale_public_key_sidecar(str(private_key)) is None
+
+    def test_missing_public_key_sidecar_skips_keygen(self, tmp_path, monkeypatch):
+        private_key = tmp_path / "id_ed25519"
+        private_key.write_text("private", encoding="utf-8")
+
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda *a, **k: pytest.fail("ssh-keygen should not run without a .pub sidecar"),
+        )
+
+        assert ssh_env._check_stale_public_key_sidecar(str(private_key)) is None
+
+    def test_invalid_public_key_sidecar_is_ignored(self, tmp_path, monkeypatch):
+        private_key = tmp_path / "id_ed25519"
+        private_key.write_text("private", encoding="utf-8")
+        private_key.with_name("id_ed25519.pub").write_bytes(b"\xff\xfe\x00")
+
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout="ssh-ed25519 derived-key comment\n", stderr=""
+            ),
+        )
+
+        assert ssh_env._check_stale_public_key_sidecar(str(private_key)) is None
+
+    def test_connection_failure_includes_stale_public_key_warning(self, monkeypatch):
+        env = object.__new__(ssh_env.SSHEnvironment)
+        env.host = "example.com"
+        env.user = "alice"
+        env._key_sidecar_warning = "SSH public key sidecar /tmp/id.pub does not match private key /tmp/id"
+
+        monkeypatch.setattr(env, "_build_ssh_command", lambda: ["ssh", "alice@example.com"])
+        monkeypatch.setattr(
+            ssh_env.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 255, stdout="", stderr="Permission denied"),
+        )
+
+        with pytest.raises(RuntimeError, match="public key sidecar"):
+            env._establish_connection()
+
 
 def _setup_ssh_env(monkeypatch, persistent: bool):
     monkeypatch.setenv("TERMINAL_ENV", "ssh")

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -33,6 +33,61 @@ def _ensure_ssh_available() -> None:
         )
 
 
+def _public_key_fields(key_text: str) -> tuple[str, str] | None:
+    fields = key_text.strip().split()
+    if len(fields) < 2:
+        return None
+    return fields[0], fields[1]
+
+
+def _check_stale_public_key_sidecar(key_path: str) -> str | None:
+    """Warn when an adjacent .pub file no longer matches the private key."""
+    if not key_path:
+        return None
+
+    private_key = Path(key_path).expanduser()
+    public_key = private_key.with_name(f"{private_key.name}.pub")
+    if not public_key.exists():
+        return None
+
+    try:
+        result = subprocess.run(
+            ["ssh-keygen", "-y", "-f", str(private_key)],
+            capture_output=True,
+            input="",
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("Could not derive public key from %s: %s", private_key, exc)
+        return None
+
+    if result.returncode != 0:
+        logger.debug(
+            "Could not derive public key from %s: %s",
+            private_key,
+            result.stderr.strip() or result.stdout.strip(),
+        )
+        return None
+
+    derived_fields = _public_key_fields(result.stdout)
+    try:
+        sidecar_fields = _public_key_fields(public_key.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as exc:
+        logger.debug("Could not read SSH public key sidecar %s: %s", public_key, exc)
+        return None
+
+    if not derived_fields or not sidecar_fields or derived_fields == sidecar_fields:
+        return None
+
+    return (
+        f"SSH public key sidecar {public_key} does not match private key "
+        f"{private_key}. Regenerate the sidecar public key from the private key "
+        f"(for example, with ssh-keygen -y -f {shlex.quote(str(private_key))} > "
+        f"{shlex.quote(str(public_key))})."
+    )
+
+
 class SSHEnvironment(BaseEnvironment):
     """Run commands on a remote machine over SSH.
 
@@ -65,6 +120,9 @@ class SSHEnvironment(BaseEnvironment):
         ).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()
+        self._key_sidecar_warning = _check_stale_public_key_sidecar(self.key_path)
+        if self._key_sidecar_warning:
+            logger.warning(self._key_sidecar_warning)
         self._establish_connection()
         self._remote_home = self._detect_remote_home()
 
@@ -104,6 +162,8 @@ class SSHEnvironment(BaseEnvironment):
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
             if result.returncode != 0:
                 error_msg = result.stderr.strip() or result.stdout.strip()
+                if getattr(self, "_key_sidecar_warning", None):
+                    error_msg = f"{error_msg}\n{self._key_sidecar_warning}"
                 raise RuntimeError(f"SSH connection failed: {error_msg}")
         except subprocess.TimeoutExpired:
             raise RuntimeError(f"SSH connection to {self.user}@{self.host} timed out")


### PR DESCRIPTION
## What does this PR do?

SSH users can keep an adjacent `id_key.pub` sidecar that no longer matches the private key. When that happens, the current Hermes SSH environment only surfaces the remote SSH failure, which makes the real root cause easy to miss.

## Root cause

SSH users can keep an adjacent `id_key.pub` sidecar that no longer matches the private key. When that happens, the current Hermes SSH environment only surfaces the remote SSH failure, which makes the real root cause easy to miss.

## Fix

- add a best-effort stale `.pub` preflight check using `ssh-keygen -y -f <private-key>`
- compare only key type + blob so comment drift does not trigger false positives
- keep the check non-blocking when the sidecar is missing, unreadable, malformed, or the derived key cannot be read quickly
- append the stale-sidecar warning to the SSH connection failure so the actionable cause is visible

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

SSH users can keep an adjacent `id_key.pub` sidecar that no longer matches the private key. When that happens, the current Hermes SSH environment only surfaces the remote SSH failure, which makes the real root cause easy to miss.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

SSH users can keep an adjacent `id_key.pub` sidecar that no longer matches the private key. When that happens, the current Hermes SSH environment only surfaces the remote SSH failure, which makes the real root cause easy to miss.

## Root cause

`SSHEnvironment` tried the real connection immediately and never checked whether the adjacent public-key sidecar had drifted from the private key.

## Fix

- add a best-effort stale `.pub` preflight check using `ssh-keygen -y -f <private-key>`
- compare only key type + blob so comment drift does not trigger false positives
- keep the check non-blocking when the sidecar is missing, unreadable, malformed, or the derived key cannot be read quickly
- append the stale-sidecar warning to the SSH connection failure so the actionable cause is visible

## Solution sketch

```mermaid
flowchart TD
    A[SSHEnvironment init] --> B{key_path has adjacent .pub?}
    B -- no --> C[skip preflight]
    B -- yes --> D[derive public key with ssh-keygen -y]
    D --> E{type + blob match sidecar?}
    E -- yes --> C
    E -- no --> F[store stale sidecar warning]
    C --> G[attempt SSH connection]
    F --> G
    G --> H{connection failed?}
    H -- no --> I[continue session setup]
    H -- yes --> J[append warning to error]
```

## Duplicate check

- built for issue #25391
- no open PR found for `codex/ssh-stale-pub-preflight`
- scoped to `tools/environments/ssh.py` and focused tests only

## Tests

Local validation run:

- `python -m py_compile tools/environments/ssh.py tests/tools/test_ssh_environment.py`
- focused Python smoke script covering stale sidecar, matching sidecar, invalid sidecar, and warning propagation
- `git diff --check -- tools/environments/ssh.py tests/tools/test_ssh_environment.py`

Environment note:

- `pytest` is not installed in this local Python environment, so I could not run `python -m pytest tests/tools/test_ssh_environment.py`

## Risk

Low to medium. The new check is best-effort, short-timeout, and only adds diagnostic output; it does not block normal SSH setup if the sidecar is absent or unreadable.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_