### PR TITLE
fix(kanban): persist worker session metadata on completion

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -75,6 +75,7 @@ AUTHOR_MAP = {
     "aubrey@freeman-wisco.com": "Freeman-Consulting",
     "don.rhm@gmail.com": "rahimsais",
     "40222899+rahimsais@users.noreply.github.com": "rahimsais",
+    "wesley.simplicio.ext@siemens-energy.com": "wesleysimplicio",
     "alfred@Alfreds-Mac-mini.local": "NivOO5",
     "231191380+NivOO5@users.noreply.github.com": "NivOO5",
     "jameshuang@gmail.com": "kjames2001",

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -128,6 +128,7 @@ def worker_env(monkeypatch, tmp_path):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     from pathlib import Path as _Path
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
@@ -308,6 +309,58 @@ def test_complete_metadata_round_trips_through_show(worker_env):
     assert shown["task"]["status"] == "done"
     assert shown["runs"][-1]["summary"] == "finished with structured evidence"
     assert shown["runs"][-1]["metadata"] == handoff
+
+
+def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-trusted")
+    metadata = {"files": 2, "worker_session_id": "user-spoof"}
+
+    out = kt._handle_complete({
+        "summary": "done by scoped worker",
+        "metadata": metadata,
+    })
+    assert json.loads(out)["ok"] is True
+    assert metadata["worker_session_id"] == "user-spoof"
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run.metadata == {
+            "files": 2,
+            "worker_session_id": "session-trusted",
+        }
+    finally:
+        conn.close()
+
+
+def test_complete_does_not_stamp_worker_session_id_without_scoped_task(
+    monkeypatch, worker_env
+):
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-trusted")
+
+    out = kt._handle_complete({
+        "task_id": worker_env,
+        "summary": "done outside worker scope",
+        "metadata": {"files": 2, "worker_session_id": "user-provided"},
+    })
+    assert json.loads(out)["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run.metadata == {
+            "files": 2,
+            "worker_session_id": "user-provided",
+        }
+    finally:
+        conn.close()
 
 
 def test_complete_with_result_only(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -112,6 +112,20 @@ def _worker_run_id(task_id: str) -> Optional[int]:
         return None
 
 
+def _stamp_worker_session_metadata(
+    task_id: str, metadata: Optional[dict]
+) -> Optional[dict]:
+    """Add trusted worker session id metadata for this worker's own task."""
+    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+        return metadata
+    session_id = os.environ.get("HERMES_SESSION_ID")
+    if not session_id:
+        return metadata
+    stamped = dict(metadata or {})
+    stamped["worker_session_id"] = session_id
+    return stamped
+
+
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     """Reject worker-driven destructive calls on foreign task IDs.
 
@@ -392,6 +406,7 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
+    metadata = _stamp_worker_session_metadata(tid, metadata)
     try:
         kb, conn = _connect()
         try:


### PR DESCRIPTION
﻿## Problem

Hermes Kanban task runs do not persist the worker session identifier when a worker completes a task. That makes it harder to trace which worker session executed a specific task run.

## Root cause

`kanban_complete` stored completion metadata, but it did not stamp `task_runs.metadata.worker_session_id` from the worker session context.

## Fix

- stamp `metadata.worker_session_id` from `HERMES_SESSION_ID`
- only stamp when `HERMES_KANBAN_TASK` matches the completed task id
- preserve existing metadata while ensuring the worker-scoped session id wins over caller-supplied values
- add focused regression tests for worker-scoped stamping and non-worker completions

## Solution sketch

```mermaid
flowchart TD
    A[kanban_complete task_id metadata] --> B{HERMES_KANBAN_TASK == task_id?}
    B -- no --> C[preserve metadata as-is]
    B -- yes --> D[read HERMES_SESSION_ID]
    D --> E[merge metadata]
    E --> F[set worker_session_id from env]
    C --> G[persist complete_task]
    F --> G
    G --> H[task_runs.metadata records worker session]
```

## Duplicate check

- built for issue #25380
- reviewed against #23199; that issue tracks orchestrator/task `session_id`, while this fix targets `task_runs.metadata.worker_session_id`
- no open PR found for `codex/kanban-worker-session-id`

## Tests

Local validation run:

- `python -m py_compile tools/kanban_tools.py tests/tools/test_kanban_tools.py`
- focused inline Python smoke validation against the real Kanban DB helpers
- `git diff --check -- tools/kanban_tools.py tests/tools/test_kanban_tools.py`

Environment note:

- `pytest` is not installed in this local Python environment, so I could not run `python -m pytest tests/tools/test_kanban_tools.py -q`

## Risk

Low. The change is narrowly scoped to worker completion metadata and only applies when the current worker session is explicitly associated with the completed task.
