### PR TITLE
feat(auth): add minimax-cn-oauth provider + migrate to OAuth2 endpoints + dedicated client_id

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -72,11 +72,11 @@ DEFAULT_AGENT_KEY_MIN_TTL_SECONDS = 30 * 60  # 30 minutes
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
-MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
-MINIMAX_OAUTH_SCOPE = "group_id profile model.completion"
-MINIMAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:user_code"
-MINIMAX_OAUTH_GLOBAL_BASE = "https://api.minimax.io"
-MINIMAX_OAUTH_CN_BASE = "https://api.minimaxi.com"
+MINIMAX_OAUTH_CLIENT_ID = "62a38dcb-17d9-4303-a71e-aa694efa20fd"
+MINIMAX_OAUTH_SCOPE = "openid profile coding_plan"
+MINIMAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+MINIMAX_OAUTH_GLOBAL_BASE = "https://account.minimax.io"
+MINIMAX_OAUTH_CN_BASE = "https://account.minimaxi.com"
 MINIMAX_OAUTH_GLOBAL_INFERENCE = "https://api.minimax.io/anthropic"
 MINIMAX_OAUTH_CN_INFERENCE = "https://api.minimaxi.com/anthropic"
 MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
@@ -305,6 +305,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimaxi.com/anthropic",
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
+    ),
+    "minimax-cn-oauth": ProviderConfig(
+        id="minimax-cn-oauth",
+        name="MiniMax (OAuth \u00b7 minimaxi.com)",
+        auth_type="oauth_minimax",
+        portal_base_url=MINIMAX_OAUTH_CN_BASE,
+        inference_base_url=MINIMAX_OAUTH_CN_INFERENCE,
+        client_id=MINIMAX_OAUTH_CLIENT_ID,
+        scope=MINIMAX_OAUTH_SCOPE,
+        extra={"region": "cn"},
     ),
     "deepseek": ProviderConfig(
         id="deepseek",
@@ -4782,9 +4792,8 @@ def _minimax_request_user_code(
     code_challenge: str, state: str,
 ) -> Dict[str, Any]:
     response = client.post(
-        f"{portal_base_url}/oauth/code",
+        f"{portal_base_url}/oauth2/device/code",
         data={
-            "response_type": "code",
             "client_id": client_id,
             "scope": MINIMAX_OAUTH_SCOPE,
             "code_challenge": code_challenge,
@@ -4848,7 +4857,7 @@ def _minimax_poll_token(
 
     while _time.time() < deadline:
         response = client.post(
-            f"{portal_base_url}/oauth/token",
+            f"{portal_base_url}/oauth2/token",
             data={
                 "grant_type": MINIMAX_OAUTH_GRANT_TYPE,
                 "client_id": client_id,
@@ -5007,7 +5016,7 @@ def _refresh_minimax_oauth_state(
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
                       follow_redirects=True) as client:
         response = client.post(
-            f"{portal_base_url}/oauth/token",
+            f"{portal_base_url}/oauth2/token",
             data={
                 "grant_type": "refresh_token",
                 "client_id": state["client_id"],

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -33,7 +33,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth", "google-gemini-cli", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth", "google-gemini-cli", "minimax-oauth", "minimax-cn-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -170,7 +170,7 @@ def auth_add_command(args) -> None:
         if provider.startswith(CUSTOM_POOL_PREFIX):
             requested_type = AUTH_TYPE_API_KEY
         else:
-            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "nous", "openai-codex", "qwen-oauth", "google-gemini-cli", "minimax-oauth"} else AUTH_TYPE_API_KEY
+            requested_type = AUTH_TYPE_OAUTH if provider in {"anthropic", "nous", "openai-codex", "qwen-oauth", "google-gemini-cli", "minimax-oauth", "minimax-cn-oauth"} else AUTH_TYPE_API_KEY
 
     pool = load_pool(provider)
 
@@ -376,6 +376,31 @@ def auth_add_command(args) -> None:
 
     if provider == "minimax-oauth":
         creds = auth_mod._minimax_oauth_login(
+            open_browser=not getattr(args, "no_browser", False),
+            timeout_seconds=getattr(args, "timeout", None) or 15.0,
+        )
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["access_token"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:minimax_oauth",
+            access_token=creds["access_token"],
+            refresh_token=creds.get("refresh_token"),
+            base_url=creds.get("inference_base_url"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "minimax-cn-oauth":
+        creds = auth_mod._minimax_oauth_login(
+            region="cn",
             open_browser=not getattr(args, "no_browser", False),
             timeout_seconds=getattr(args, "timeout", None) or 15.0,
         )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -935,6 +935,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
     ProviderEntry("minimax-oauth",  "MiniMax (OAuth)",          "MiniMax via OAuth browser login (Coding Plan, minimax.io)"),
     ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),
+    ProviderEntry("minimax-cn-oauth", "MiniMax China (OAuth)",  "MiniMax China via OAuth browser login (Coding Plan, minimaxi.com)"),
     ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (cloud-hosted open models — ollama.com)"),
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models — direct API)"),
     ProviderEntry("gmi",            "GMI Cloud",                "GMI Cloud (multi-model direct API)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -120,6 +120,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
+    "minimax-cn-oauth": HermesOverlay(
+        transport="anthropic_messages",
+        auth_type="oauth_external",
+        base_url_override="https://api.minimaxi.com/anthropic",
+    ),
     "deepseek": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="DEEPSEEK_BASE_URL",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -250,6 +250,10 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "anthropic_messages"
         pconfig = PROVIDER_REGISTRY.get(provider)
         base_url = base_url or (pconfig.inference_base_url if pconfig else "")
+    elif provider == "minimax-cn-oauth":
+        api_mode = "anthropic_messages"
+        pconfig = PROVIDER_REGISTRY.get(provider)
+        base_url = base_url or (pconfig.inference_base_url if pconfig else "")
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -1149,6 +1153,20 @@ def resolve_runtime_provider(
                         "falling through to next provider.")
 
     if provider == "minimax-oauth":
+        pconfig = PROVIDER_REGISTRY.get(provider)
+        if pconfig and pconfig.auth_type == "oauth_minimax":
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+            creds = resolve_minimax_oauth_runtime_credentials()
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages",
+                "base_url": creds["base_url"],
+                "api_key": creds["api_key"],
+                "source": creds.get("source", "oauth"),
+                "requested_provider": requested_provider,
+            }
+
+    if provider == "minimax-cn-oauth":
         pconfig = PROVIDER_REGISTRY.get(provider)
         if pconfig and pconfig.auth_type == "oauth_minimax":
             from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials

--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -40,6 +40,20 @@ minimax_oauth = ProviderProfile(
     default_aux_model="MiniMax-M2.7-highspeed",
 )
 
+minimax_cn_oauth = ProviderProfile(
+    name="minimax-cn-oauth",
+    aliases=("minimax_cn_oauth", "minimax-oauth-cn"),
+    api_mode="anthropic_messages",
+    display_name="MiniMax China (OAuth)",
+    description="MiniMax China via OAuth browser flow — no API key required",
+    signup_url="https://api.minimaxi.com/",
+    env_vars=(),
+    base_url="https://api.minimaxi.com/anthropic",
+    auth_type="oauth_external",
+    default_aux_model="MiniMax-M2.7-highspeed",
+)
+
 register_provider(minimax)
 register_provider(minimax_cn)
 register_provider(minimax_oauth)
+register_provider(minimax_cn_oauth)

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -147,7 +147,7 @@ def test_request_user_code_happy_path():
 
     # Verify correct endpoint was called
     call_args = client.post.call_args
-    assert "/oauth/code" in call_args[0][0]
+    assert "/oauth2/device/code" in call_args[0][0]
     headers = call_args[1].get("headers", {})
     assert "x-request-id" in headers
 
@@ -538,3 +538,18 @@ def test_generic_auth_status_dispatches_minimax_oauth():
     assert status["logged_in"] is True
     assert status["provider"] == "minimax-oauth"
     assert status["region"] == "global"
+
+
+# ---------------------------------------------------------------------------
+# 16. CN OAuth provider — registered alongside global
+# ---------------------------------------------------------------------------
+
+def test_provider_registry_contains_minimax_cn_oauth():
+    assert "minimax-cn-oauth" in PROVIDER_REGISTRY
+    pconfig = PROVIDER_REGISTRY["minimax-cn-oauth"]
+    assert pconfig.auth_type == "oauth_minimax"
+    assert pconfig.client_id == MINIMAX_OAUTH_CLIENT_ID
+    # CN config points at minimaxi.com, not minimax.io
+    assert "minimaxi.com" in pconfig.portal_base_url
+    assert "minimaxi.com" in pconfig.inference_base_url
+    assert pconfig.extra.get("region") == "cn"

--- a/website/docs/guides/minimax-oauth.md
+++ b/website/docs/guides/minimax-oauth.md
@@ -56,11 +56,17 @@ hermes auth add minimax-oauth
 
 ### China region
 
-If your account is on the China platform (`minimaxi.com`), use the China-region OAuth provider id `minimax-cn` instead, or skip OAuth and configure `MINIMAX_CN_API_KEY` / `MINIMAX_CN_BASE_URL` directly. The `--region cn` flag described in older docs is **not** wired through the CLI's argument parser; use the `minimax-cn` provider instead:
+If your account is on the China platform (`minimaxi.com`), use the dedicated `minimax-cn-oauth` provider:
 
 ```bash
-hermes auth add minimax-cn --type oauth   # if OAuth is supported on your CN account
-# or simpler:
+hermes auth add minimax-cn-oauth
+```
+
+Or via `hermes model` — the picker now lists **"MiniMax China (OAuth)"** alongside the global OAuth entry. The flow is identical to the global one but the browser opens `account.minimaxi.com`. The token is saved to the same `~/.hermes/auth.json` slot as the global OAuth (region recorded inside the entry), so switching between the global and China OAuth picker entries triggers a fresh login.
+
+If you'd rather skip OAuth on China entirely, the API-key path still works:
+
+```bash
 echo 'MINIMAX_CN_API_KEY=your-key' >> ~/.hermes/.env
 ```
 


### PR DESCRIPTION
Closes #25542

## Summary

Two related changes:

1. **Add China-region OAuth as a separate picker entry** so users on the `minimaxi.com` platform can sign in via browser without copying an API key (closes the gap where docs claimed `minimax-cn` supported OAuth but the registered provider was api_key only).
2. **Migrate the MiniMax OAuth helpers from the OpenClaw-shared `api.{minimax.io,minimaxi.com}/oauth/*` endpoints to the canonical `account.{minimax.io,minimaxi.com}/oauth2/*` endpoints** — same set that mmx-cli and the opencode `minimax-coding-plan` plugin already target. The old endpoints still respond, but `account/oauth2/*` is what MiniMax platform team treats as canonical going forward.

Also switches Hermes from the OpenClaw-shared client_id to its own dedicated one (registered against the new OAuth2 backend specifically for this integration).

## Endpoint migration (verified live)

Both global + CN return HTTP 200 with valid user_code + verification_uri for the dedicated Hermes client_id:

| | Before | After |
|---|---|---|
| Global base | `https://api.minimax.io` | `https://account.minimax.io` |
| CN base     | `https://api.minimaxi.com` | `https://account.minimaxi.com` |
| Device code | `{base}/oauth/code` | `{base}/oauth2/device/code` |
| Token       | `{base}/oauth/token` | `{base}/oauth2/token` |
| Grant type  | `…:grant-type:user_code` | `…:grant-type:device_code` (RFC 8628) |
| Scope       | `group_id profile model.completion` | `openid profile coding_plan` |
| Extra param | `response_type: "code"` (sent in body) | (removed — new endpoint doesn't expect it) |

## Approach

Mirrors the existing `_minimax_oauth_login(region="cn", ...)` code path that was already in tree but never exposed as a provider. Storage and runtime resolution stay on the existing `minimax-oauth` auth.json slot (region recorded inside the entry) — no refactor of helper signatures, no new alias dispatch.

Each new branch follows the surrounding parallel-block style (separate `if provider == "..."` blocks rather than collapsing with the existing `minimax-oauth` branch) — keeps the diff easy to grep and revert.

## What changes

| File | Change |
|---|---|
| `hermes_cli/auth.py` | Endpoint migration (5 constants + 3 endpoint URL strings + 1 removed `response_type` param). New `minimax-cn-oauth` ProviderConfig in PROVIDER_REGISTRY. `MINIMAX_OAUTH_CLIENT_ID` updated to dedicated Hermes id |
| `plugins/model-providers/minimax/__init__.py` | New `minimax_cn_oauth` ProviderProfile mirroring `minimax_oauth` with CN URLs |
| `hermes_cli/auth_commands.py` | Adds `minimax-cn-oauth` to `_OAUTH_CAPABLE_PROVIDERS` set + the inline duplicate at line 173. New `if provider == "minimax-cn-oauth":` block routes to `_minimax_oauth_login(region="cn")` |
| `hermes_cli/runtime_provider.py` | Parallel `elif`/`if` blocks for the new provider in both api_mode pinning and the runtime credential resolver |
| `hermes_cli/models.py` | Picker entry: `ProviderEntry("minimax-cn-oauth", "MiniMax China (OAuth)", ...)` as the 4th MiniMax row |
| `hermes_cli/providers.py` | Overlay entry for `minimax-cn-oauth` |
| `tests/test_minimax_oauth.py` | +1 test verifying the new ProviderConfig is registered with CN URLs; updates one endpoint-path assertion to the new path |
| `website/docs/guides/minimax-oauth.md` | "China region" section rewritten to point at the new provider id |

## Trade-off

Switching between the global and China OAuth picker entries triggers a fresh login (the OAuth tokens live in the same auth.json slot — last login wins, region is recorded inside). Users who need both regions logged in concurrently would benefit from a follow-up that splits storage by region; this PR keeps the change surface minimal.

## Client ID

Switches from the previously shared OpenClaw client_id (`78257093-...`) to a dedicated Hermes one (`62a38dcb-17d9-4303-a71e-aa694efa20fd`) registered with MiniMax specifically for this integration on the new OAuth2 backend.

## How verified

- `pytest tests/test_minimax_oauth.py tests/providers/test_provider_profiles.py tests/hermes_cli/test_provider_config_validation.py` → 78/78 pass
- Live `POST account.minimax.io/oauth2/device/code` (and `account.minimaxi.com/oauth2/device/code`) with the dedicated client_id and new scope/PKCE → HTTP 200, valid user_code + verification_uri returned. Both regions confirmed registered.
- Local end-to-end OAuth login flow on the CN provider before the endpoint migration also worked, confirming the dedicated client_id + the old endpoints work too — the migration is for canonical alignment, not because the old endpoints are broken.