### PR TITLE
fix(gateway): mark text-capture mode when base send_clarify renders choices as text

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1800,11 +1800,23 @@ class BasePlatformAdapter(ABC):
             mark_awaiting_text(clarify_id)
         else:
             text = f"❓ {question}"
-        return await self.send(
+        result = await self.send(
             chat_id=chat_id,
             content=text,
             metadata=metadata,
         )
+        # When choices are rendered as text (this default implementation),
+        # the user will reply with a number or text.  Flip the entry into
+        # text-capture mode so the gateway intercept picks it up.  Adapters
+        # that override this method with inline buttons (Telegram, Discord)
+        # do NOT reach here — they resolve via button callbacks instead.
+        if choices:
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                mark_awaiting_text(clarify_id)
+            except Exception:
+                pass
+        return result
 
     async def send_private_notice(
         self,

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -729,3 +729,87 @@ class TestProxyKwargsForAiohttp:
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
 
+
+
+class TestSendClarifyTextFallback:
+    """The default send_clarify must flip entries to text-capture when
+    rendering choices as numbered text (issue #25567)."""
+
+    def setup_method(self):
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+            cm._notify_cbs.clear()
+
+    def test_send_clarify_choices_marks_awaiting_text(self):
+        """When the base send_clarify renders choices as text, it calls
+        mark_awaiting_text so the gateway text-intercept can find the entry."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+        from tools import clarify_gateway as cm
+        from gateway.platforms.base import SendResult
+
+        entry = cm.register("cid-base", "sk-base", "Pick one", ["A", "B"])
+        assert entry.awaiting_text is False
+        assert cm.get_pending_for_session("sk-base") is None
+
+        # Create a mock adapter with send returning a success result
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+
+        # Call the REAL send_clarify from BasePlatformAdapter
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                BasePlatformAdapter.send_clarify(
+                    adapter,
+                    chat_id="chat1",
+                    question="Pick one",
+                    choices=["A", "B"],
+                    clarify_id="cid-base",
+                    session_key="sk-base",
+                )
+            )
+        finally:
+            loop.close()
+
+        # After send_clarify, awaiting_text should be True
+        assert entry.awaiting_text is True, (
+            "send_clarify with choices should call mark_awaiting_text"
+        )
+        pending = cm.get_pending_for_session("sk-base")
+        assert pending is not None
+        assert pending.clarify_id == "cid-base"
+
+    def test_send_clarify_no_choices_no_mark(self):
+        """When send_clarify has no choices (open-ended), mark_awaiting_text
+        is NOT called — it's already True from register()."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+        from tools import clarify_gateway as cm
+        from gateway.platforms.base import SendResult
+
+        entry = cm.register("cid-open", "sk-open", "Describe?", None)
+        assert entry.awaiting_text is True
+
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m2"))
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                BasePlatformAdapter.send_clarify(
+                    adapter,
+                    chat_id="chat1",
+                    question="Describe?",
+                    choices=None,
+                    clarify_id="cid-open",
+                    session_key="sk-open",
+                )
+            )
+        finally:
+            loop.close()
+
+        # Should still be True (was True before, still True)
+        assert entry.awaiting_text is True


### PR DESCRIPTION
## What does this PR do?

When `clarify` is called with multiple choices on platforms that don't support inline buttons (Mattermost, etc.), the default `send_clarify` in `BasePlatformAdapter` renders choices as a numbered text list. The user replies with a number or text, but the gateway's text-intercept never fires because `awaiting_text` remains `False`. The agent blocks for 10 minutes and then times out.


### Root Cause

`clarify_gateway.register()` sets `awaiting_text = not bool(choices)` (line 95). When choices are provided, `awaiting_text` is `False`. `get_pending_for_session()` (line 178) only returns entries with `awaiting_text == True`, so the user's text reply is never matched.

The base `send_clarify` in `gateway/platforms/base.py` renders choices as text but never calls `mark_awaiting_text(clarify_id)` to flip the flag. Adapters with inline buttons (Telegram, Discord) override `send_clarify` and resolve via button callbacks -- they don't hit this code path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

GitNexus unavailable -- analysis skipped, grep-based fallback used.
- Verified: `get_pending_for_session` called from `gateway/run.py:5871` and `gateway/platforms/base.py:2899` -- both are text-intercept paths
- Verified: `mark_awaiting_text` called from `gateway/platforms/telegram.py:2814` (button callback) -- confirms button platforms handle it separately
- Blast radius: LOW -- only affects the default `send_clarify` path; adapters with button overrides are unaffected

Fixes Bug: clarify multiple-choice text fallback never intercepts user reply on Mattermost #25567