### PR TITLE
fix(compression): preserve context when summary fails

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -967,7 +967,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
             self._last_summary_error = "no auxiliary LLM provider configured"
             logging.warning("Context compression: no provider available for "
-                            "summary. Middle turns will be dropped without summary "
+                            "summary. Compression will be skipped "
                             "for %d seconds.",
                             _SUMMARY_FAILURE_COOLDOWN_SECONDS)
             return None
@@ -1464,6 +1464,14 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Phase 3: Generate structured summary
         summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
+        if not summary:
+            if not self.quiet_mode:
+                logger.warning("Summary generation failed — leaving context uncompressed")
+            n_dropped = compress_end - compress_start
+            self._last_summary_dropped_count = n_dropped
+            self._last_summary_fallback_used = True
+            return messages
+
         # Phase 4: Assemble compressed message list
         compressed = []
         for i in range(compress_start):
@@ -1477,22 +1485,6 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                         "\n\n" + _compression_note if isinstance(existing, str) and existing else _compression_note,
                     )
             compressed.append(msg)
-
-        # If LLM summary failed, insert a static fallback so the model
-        # knows context was lost rather than silently dropping everything.
-        if not summary:
-            if not self.quiet_mode:
-                logger.warning("Summary generation failed — inserting static fallback context marker")
-            n_dropped = compress_end - compress_start
-            self._last_summary_dropped_count = n_dropped
-            self._last_summary_fallback_used = True
-            summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
-            )
 
         _merge_summary_into_tail = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1410,6 +1410,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
 
+        # Keep the exact caller-provided message list available. The pruning
+        # pass below is intentionally lossy, so failed summary generation must
+        # return this original object instead of the post-pruning copy.
+        original_messages = messages
+
         # Phase 1: Prune old tool results (cheap, no LLM call)
         messages, pruned_count = self._prune_old_tool_results(
             messages, protect_tail_count=self.protect_last_n,
@@ -1470,7 +1475,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             n_dropped = compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
-            return messages
+            return original_messages
 
         # Phase 4: Assemble compressed message list
         compressed = []

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -6,6 +6,13 @@ from unittest.mock import patch, MagicMock
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
 
 
+def _mock_summary_response(content="summary text"):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
 @pytest.fixture()
 def compressor():
     """Create a ContextCompressor with mocked dependencies."""
@@ -64,20 +71,19 @@ class TestCompress:
         result = compressor.compress(msgs)
         assert result == msgs
 
-    def test_truncation_fallback_no_client(self, compressor):
-        # compressor has client=None, so should use truncation fallback
+    def test_no_summary_provider_returns_unchanged(self, compressor):
         msgs = [{"role": "system", "content": "System prompt"}] + self._make_messages(10)
         result = compressor.compress(msgs)
-        assert len(result) < len(msgs)
-        # Should keep system message and last N
-        assert result[0]["role"] == "system"
-        assert compressor.compression_count == 1
+        assert result == msgs
+        assert compressor.compression_count == 0
 
     def test_compression_increments_count(self, compressor):
         msgs = self._make_messages(10)
-        compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", return_value=_mock_summary_response()):
+            compressor.compress(msgs)
         assert compressor.compression_count == 1
-        compressor.compress(msgs)
+        with patch("agent.context_compressor.call_llm", return_value=_mock_summary_response()):
+            compressor.compress(msgs)
         assert compressor.compression_count == 2
 
     def test_protects_first_and_last(self, compressor):
@@ -128,7 +134,8 @@ class TestGenerateSummaryNoneContent:
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
             for i in range(10)
         ]
-        result = c.compress(msgs)
+        with patch("agent.context_compressor.call_llm", return_value=_mock_summary_response()):
+            result = c.compress(msgs)
         assert len(result) < len(msgs)
 
 
@@ -716,11 +723,10 @@ class TestAuxModelFallbackSurfacedToCallers:
 
 
 class TestSummaryFailureTrackingForGatewayWarning:
-    """When summary generation fails, the compressor must record dropped count
-    + fallback flag so gateway hygiene & /compress can surface a visible
-    warning instead of silently dropping context."""
+    """When summary generation fails, the compressor must record the unsafe
+    condition without committing a destructive compaction."""
 
-    def test_compress_records_fallback_and_dropped_count_on_summary_failure(self):
+    def test_compress_preserves_original_messages_on_summary_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
 
@@ -743,8 +749,9 @@ class TestSummaryFailureTrackingForGatewayWarning:
         assert c._last_summary_fallback_used is True
         assert c._last_summary_dropped_count > 0
         assert c._last_summary_error is not None
-        # Result must still be well-formed (fallback summary present).
-        assert any(
+        assert c.compression_count == 0
+        assert result == msgs
+        assert not any(
             isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
             for m in result
         )
@@ -1338,7 +1345,8 @@ class TestSummaryTargetRatio:
             + [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
                for i in range(8)]
         )
-        result = c.compress(msgs)
+        with patch("agent.context_compressor.call_llm", return_value=_mock_summary_response()):
+            result = c.compress(msgs)
         # System prompt (msg[0]) survives as head
         assert result[0]["role"] == "system"
         assert result[0]["content"].startswith("System prompt")

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -756,6 +756,56 @@ class TestSummaryFailureTrackingForGatewayWarning:
             for m in result
         )
 
+    def test_summary_failure_returns_exact_original_before_tool_pruning(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=2,
+                summary_target_ratio=0.10,
+            )
+        c.tail_token_budget = 1
+
+        unique_tool_output = "UNIQUE_TOOL_OUTPUT_" + ("x" * 2000)
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"cmd": "pytest"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": unique_tool_output},
+            {"role": "assistant", "content": "processed tool output"},
+            {"role": "user", "content": "middle user work"},
+            {"role": "assistant", "content": "middle assistant work"},
+            {"role": "user", "content": "recent user request"},
+            {"role": "assistant", "content": "recent assistant reply"},
+        ]
+
+        pruned_preview, pruned_count = c._prune_old_tool_results(
+            msgs,
+            protect_tail_count=c.protect_last_n,
+            protect_tail_tokens=c.tail_token_budget,
+        )
+        assert pruned_count >= 1
+        assert pruned_preview[3]["content"] != unique_tool_output
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception("summary unavailable")):
+            result = c.compress(msgs)
+
+        assert result is msgs
+        assert result[3]["content"] == unique_tool_output
+        assert c._last_summary_fallback_used is True
+        assert c.compression_count == 0
+
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -10,7 +10,7 @@ def _compressor() -> ContextCompressor:
         return ContextCompressor(
             model="test/model",
             threshold_percent=0.85,
-            protect_first_n=1,
+            protect_first_n=0,
             protect_last_n=1,
             quiet_mode=True,
         )
@@ -30,6 +30,7 @@ def _messages_with_handoff(summary_body: str):
         {"role": "user", "content": "new user turn after resume"},
         {"role": "assistant", "content": "new assistant work after resume"},
         {"role": "user", "content": "more new work after resume"},
+        {"role": "assistant", "content": "additional middle work after resume"},
         {"role": "assistant", "content": "latest tail response"},
     ]
 


### PR DESCRIPTION
## What does this PR do?

Prevents automatic context compression from discarding conversation turns when summary generation fails.

Previously, if the summary LLM/provider failed, `ContextCompressor.compress()` inserted a static "summary unavailable" marker and still dropped the middle turns. That is risky for long-running sessions because the visible transcript can remain available while the model-facing context loses recent work and keeps an old protected head.

This changes failed-summary compression to fail closed: record warning state for callers, but return the original messages unchanged.

## Related Issue

Fixes #25585

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`
  - Return the original message list when `_generate_summary()` returns no summary.
  - Keep `_last_summary_fallback_used`, `_last_summary_dropped_count`, and `_last_summary_error` available so callers can surface warnings.
  - Do not increment `compression_count` for failed compression.
  - Update no-provider warning text so it no longer claims middle turns will be dropped.
- `tests/agent/test_context_compressor.py`
  - Replace the old static-fallback truncation expectation with a regression test that failed summaries preserve the original messages.
  - Keep successful-summary compression coverage explicit by mocking `call_llm` where tests expect compression.
- `tests/agent/test_context_compressor_summary_continuity.py`
  - Keep continuity tests exercising the actual summary window instead of sitting on the minimum-message boundary.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_compress_focus.py tests/gateway/test_compress_command.py tests/gateway/test_compress_focus.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_compression_persistence.py`
2. `python3 - <<'PY'\nimport py_compile\npy_compile.compile('agent/context_compressor.py', doraise=True)\nprint('py_compile ok')\nPY`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test run:

```text
100 passed in 6.59s
```

`git diff --check` completed with no output.
