### PR TITLE
fix: use AUTOINCREMENT id for message ordering instead of timestamp

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1597,10 +1597,10 @@ class SessionDB:
         self._execute_write(_do)
 
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
-        """Load all messages for a session, ordered by timestamp."""
+        """Load all messages for a session, ordered by insertion order."""
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
                 (session_id,),
             )
             rows = cursor.fetchall()
@@ -1700,7 +1700,7 @@ class SessionDB:
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items "
-                f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
+                f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 


### PR DESCRIPTION
## Problem

get_messages and get_messages_as_conversation both sort with
ORDER BY timestamp, id. On WSL2 (and potentially Docker on Mac/Windows),
time.time() is not strictly monotonic — NTP sync or host clock adjustments
can cause it to jump backward mid-session. When this happens during a multi-tool
flush, later-inserted rows get earlier timestamps, breaking the
tool_calls → tool_response adjacency invariant required by the OpenAI API.

Result: **HTTP 400** — *An assistant message with 'tool_calls' must be followed by
tool messages responding to each 'tool_call_id'* — on session resume, with no
recovery path.

## Root Cause (confirmed with direct SQLite inspection)

Rows inserted at higher AUTOINCREMENT ids carried timestamps ~40ms earlier than
lower-id rows in the same flush due to WSL2 clock regression:

| id   | role      | tool_call_id / tool_calls              | timestamp          |
|------|-----------|----------------------------------------|--------------------|
| 5215 | assistant | call_00_dHyxPkIstvRa4wwvNDoK5794       | 1778744108.382     |
| 5216 | tool      | call_00_dHyxPkIstvRa4wwvNDoK5794       | 1778744108.484     |
| 5221 | assistant | call_00_Mkl6CAJ8rLFNUhduTSKL5878       | **1778744108.441** ← earlier than id=5216 |
| 5222 | tool      | call_00_Mkl6CAJ8rLFNUhduTSKL5878       | **1778744108.464** ← earlier than id=5216 |

ORDER BY timestamp, id sorts id=5221 *before* id=5216, producing:



The API rejects this with HTTP 400.

## Fix



id INTEGER PRIMARY KEY AUTOINCREMENT always reflects true insertion order
regardless of system clock behavior. timestamp is preserved in the schema
for analytics/display; it must not drive message ordering.

## Impact

- **Severity**: High — silently corrupts conversation history; agent cannot continue the session
- **Platform**: Any environment where time.time() is not strictly monotonic (WSL2 confirmed; Docker on Mac/Windows may also be affected)
- **Workaround**: None (restarting the session discards in-progress work)