### PR TITLE
fix(api_server): preserve run SSE streams on reconnect

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -24,6 +24,7 @@ Requires:
 - aiohttp (already available in the gateway)
 """
 
+import ast
 import asyncio
 import hashlib
 import hmac
@@ -127,6 +128,43 @@ def _normalize_chat_content(
         return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
     except Exception:
         return ""
+
+
+def _normalize_stream_delta(delta: Any) -> Optional[str]:
+    """Best-effort normalize streamed assistant deltas for SSE clients.
+
+    Most transports already emit plain text chunks. Some edge paths can leak
+    structured content blocks (or their stringified repr) through the
+    ``stream_delta_callback``. In that case, extract only the text parts and
+    drop pure tool metadata so the Web UI doesn't render raw JSON.
+    """
+    if delta is None:
+        return None
+
+    if not isinstance(delta, str):
+        normalized = _normalize_chat_content(delta)
+        return normalized or None
+
+    if not delta:
+        return None
+
+    probe = delta.strip()
+    if probe.startswith(("[", "{")) and "type" in probe:
+        parsed: Any = None
+        try:
+            parsed = json.loads(delta)
+        except Exception:
+            try:
+                parsed = ast.literal_eval(delta)
+            except Exception:
+                parsed = None
+        if isinstance(parsed, (list, dict)):
+            normalized = _normalize_chat_content(parsed)
+            if normalized:
+                return normalized
+            return None
+
+    return delta
 
 
 # Content part type aliases used by the OpenAI Chat Completions and Responses
@@ -2899,14 +2937,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
-            if delta is None:
+            normalized = _normalize_stream_delta(delta)
+            if normalized is None:
                 return
             try:
                 loop.call_soon_threadsafe(q.put_nowait, {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
-                    "delta": delta,
+                    "delta": normalized,
                 })
             except Exception:
                 pass
@@ -3161,8 +3200,10 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
-            self._run_streams.pop(run_id, None)
-            self._run_streams_created.pop(run_id, None)
+            status = str(self._run_statuses.get(run_id, {}).get("status", "")).lower()
+            if status in {"completed", "failed", "cancelled"}:
+                self._run_streams.pop(run_id, None)
+                self._run_streams_created.pop(run_id, None)
 
         return response
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -306,6 +306,78 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_disconnect_keeps_queue_for_running_run(self, adapter):
+        """Disconnecting one SSE client must not destroy a still-running queue."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, _ = _make_slow_agent()
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                agent_ready.wait(timeout=3.0)
+                await asyncio.sleep(0.1)
+
+                first_events = await cli.get(f"/v1/runs/{run_id}/events")
+                assert first_events.status == 200
+                await asyncio.sleep(0.05)
+                first_events.close()
+                await asyncio.sleep(0.1)
+
+                assert run_id in adapter._run_streams
+
+                second_events = await cli.get(f"/v1/runs/{run_id}/events")
+                assert second_events.status == 200
+
+                stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stop_resp.status == 200
+
+                body = await second_events.text()
+                assert "stream closed" in body or "run.cancelled" in body or "run.failed" in body
+
+    @pytest.mark.asyncio
+    async def test_events_stream_filters_stringified_content_blocks(self, adapter):
+        """SSE deltas should expose only text, not raw content-block reprs."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                captured = {}
+                mock_agent = MagicMock()
+
+                def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+                    stream_cb = captured["stream_delta_callback"]
+                    stream_cb(
+                        "[{'type': 'text', 'text': 'empty message'}, "
+                        "{'type': 'tool_use', 'id': 'call_00', 'name': 'skill_manage'}]"
+                    )
+                    return {"final_response": "done"}
+
+                def _create_agent_side_effect(*args, **kwargs):
+                    captured["stream_delta_callback"] = kwargs["stream_delta_callback"]
+                    return mock_agent
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.side_effect = _create_agent_side_effect
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                assert "message.delta" in body
+                assert "empty message" in body
+                assert "tool_use" not in body
+                assert "run.completed" in body
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep `/v1/runs/{run_id}/events` queues alive across transient SSE disconnects until the run reaches a terminal state
- normalize stringified structured content-block deltas before emitting `message.delta` so the Web UI only renders text
- add regression coverage for SSE reconnect survival and content-block filtering

Closes #25583.

## Proof
- `uv run --frozen pytest -o addopts= tests/gateway/test_api_server_runs.py -k "events_stream_returns_completed or disconnect_keeps_queue_for_running_run or stringified_content_blocks"`
- `uv run --frozen ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check`
