### PR TITLE
fix(tui): rebase async paste edits

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -81,4 +81,18 @@ describe('rebaseAsyncPasteResult', () => {
       })
     ).toBeNull()
   })
+
+  it('drops stale async paste results when the suffix mutated after the original cursor', () => {
+    // Prefix is intact but the original suffix was edited in flight: the
+    // captured anchor no longer exists, so the async paste must be dropped
+    // rather than inserted at a stale position.
+    expect(
+      rebaseAsyncPasteResult({
+        currentValue: 'prefix changed',
+        result: { cursor: 18, value: 'prefix [[paste]] suffix' },
+        startCursor: 'prefix '.length,
+        startValue: 'prefix suffix'
+      })
+    ).toBeNull()
+  })
 })

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldPassThroughToGlobalHandler } from '../components/textInput.js'
+import { rebaseAsyncPasteResult, shouldPassThroughToGlobalHandler } from '../components/textInput.js'
 import { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } from '../lib/platform.js'
 
 const key = (overrides: Record<string, unknown> = {}) =>
@@ -39,5 +39,46 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
+  })
+})
+
+describe('rebaseAsyncPasteResult', () => {
+  it('keeps an async paste at its original position when typing continues', () => {
+    expect(
+      rebaseAsyncPasteResult({
+        currentValue: 'typed after paste',
+        result: { cursor: 5, value: 'PATH-' },
+        startCursor: 0,
+        startValue: ''
+      })
+    ).toEqual({
+      cursor: 5,
+      value: 'PATH-typed after paste'
+    })
+  })
+
+  it('rebases transformed paste text before edits made at the same cursor', () => {
+    expect(
+      rebaseAsyncPasteResult({
+        currentValue: 'prefix user suffix',
+        result: { cursor: 18, value: 'prefix [[paste]] suffix' },
+        startCursor: 'prefix '.length,
+        startValue: 'prefix suffix'
+      })
+    ).toEqual({
+      cursor: 'prefix [[paste]] '.length,
+      value: 'prefix [[paste]] user suffix'
+    })
+  })
+
+  it('drops stale async paste results when the original anchor changed', () => {
+    expect(
+      rebaseAsyncPasteResult({
+        currentValue: 'changed suffix',
+        result: { cursor: 18, value: 'prefix [[paste]] suffix' },
+        startCursor: 'prefix '.length,
+        startValue: 'prefix suffix'
+      })
+    ).toBeNull()
   })
 })

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -269,7 +269,11 @@ export function rebaseAsyncPasteResult({
 
   if (currentValue.startsWith(startValue)) {
     insertAt = cursor
-  } else if (currentValue.startsWith(prefix)) {
+  } else if (currentValue.startsWith(prefix) && (!suffix || currentValue.endsWith(suffix))) {
+    // Same-cursor rebase: prefix is intact, but also require the original
+    // suffix to remain present when non-empty. Otherwise a user edit after the
+    // original cursor (suffix mutation) would still receive a stale paste at
+    // an anchor that no longer exists.
     insertAt = prefix.length
   }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -238,6 +238,51 @@ const isPasteResultPromise = (
   value: PasteResult | Promise<PasteResult> | null | undefined
 ): value is Promise<PasteResult> => !!value && typeof (value as PromiseLike<PasteResult>).then === 'function'
 
+export function rebaseAsyncPasteResult({
+  currentValue,
+  result,
+  startCursor,
+  startValue
+}: {
+  currentValue: string
+  result: Exclude<PasteResult, null>
+  startCursor: number
+  startValue: string
+}): { cursor: number; value: string } | null {
+  const cursor = Math.max(0, Math.min(startCursor, startValue.length))
+  const prefix = startValue.slice(0, cursor)
+  const suffix = startValue.slice(cursor)
+
+  if (!result.value.startsWith(prefix) || (suffix && !result.value.endsWith(suffix))) {
+    return null
+  }
+
+  const inserted = suffix
+    ? result.value.slice(prefix.length, result.value.length - suffix.length)
+    : result.value.slice(prefix.length)
+
+  if (!inserted) {
+    return null
+  }
+
+  let insertAt: number | null = null
+
+  if (currentValue.startsWith(startValue)) {
+    insertAt = cursor
+  } else if (currentValue.startsWith(prefix)) {
+    insertAt = prefix.length
+  }
+
+  if (insertAt === null) {
+    return null
+  }
+
+  return {
+    cursor: insertAt + inserted.length,
+    value: currentValue.slice(0, insertAt) + inserted + currentValue.slice(insertAt)
+  }
+}
+
 export function TextInput({
   columns = 80,
   value,
@@ -529,21 +574,29 @@ export function TextInput({
 
   const emitPaste = (e: PasteEvent) => {
     const startVersion = editVersionRef.current
+    const startCursor = e.cursor
+    const startValue = e.value
     const h = cbPaste.current?.(e)
 
     if (isPasteResultPromise(h)) {
-      const fallbackText = e.text
-
       void h
         .then(result => {
           if (result && editVersionRef.current === startVersion) {
             commit(result.value, result.cursor)
-          } else if (result && fallbackText && PRINTABLE.test(fallbackText)) {
-            // User typed while async paste was in-flight — fall back to raw text insert
-            // so the pasted content is not silently lost.
-            const cur = curRef.current
-            const v = vRef.current
-            commit(v.slice(0, cur) + fallbackText + v.slice(cur), cur + fallbackText.length)
+          } else if (result) {
+            // User typed while async paste handling was in-flight. Preserve the
+            // paste at the position where it originally happened instead of
+            // appending stale text at the user's current cursor.
+            const rebased = rebaseAsyncPasteResult({
+              currentValue: vRef.current,
+              result,
+              startCursor,
+              startValue
+            })
+
+            if (rebased) {
+              commit(rebased.value, rebased.cursor)
+            }
           }
         })
         .catch(() => {})


### PR DESCRIPTION
Fixes #25607

## Summary
- rebase async paste results back to the cursor position where the paste started
- avoid inserting stale paste text at the user's current cursor after they keep typing
- add regression coverage for async paste rebasing and stale-anchor drops

## Tests
- npm test
- npm run type-check
- npm run build

Note: full npm run lint still reports pre-existing unrelated lint errors in other files; touched files have no eslint errors.