### PR TITLE
fix(cli): read approvals.timeout from config in CLI approval callback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10064,7 +10064,7 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = 60
+            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()
 
             self._approval_state = {


### PR DESCRIPTION
Summary

The _approval_callback method in HermesCLI hardcodes timeout = 60 instead of reading the approvals.timeout config value. One-line change to read from CLI_CONFIG.