### PR TITLE
fix(clarify): set awaiting_text=True for all clarify entries including multiple-choice

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10064,7 +10064,7 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = 60
+            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()
 
             self._approval_state = {

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -91,8 +91,13 @@ def register(
         session_key=session_key,
         question=question,
         choices=list(choices) if choices else None,
-        # Open-ended (no choices) → next message IS the response, no buttons needed.
-        awaiting_text=not bool(choices),
+        # Text-fallback adapters (e.g. Mattermost) render a numbered list
+        # and intercept the user's text reply via get_pending_for_session,
+        # which only matches entries with awaiting_text=True.
+        # Button-based adapters (e.g. Telegram) resolve via
+        # resolve_gateway_clarify directly and do not check awaiting_text.
+        # So we always set awaiting_text=True so both paths work.
+        awaiting_text=True,
     )
     with _lock:
         _entries[clarify_id] = entry


### PR DESCRIPTION
Summary

On Mattermost, clarify with multiple choices renders a numbered list but the user reply is never intercepted because awaiting_text was False when choices were provided. Now awaiting_text is always True.