### PR TITLE
fix: 移除 test/tmp/root/sudo 的 profile 保留名限制

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -190,8 +190,10 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
 })
 
 # Names that cannot be used as profile aliases
+# Only 'hermes' and 'default' are truly reserved — the rest were causing
+# inconsistency where profiles could be created but not deleted.
 _RESERVED_NAMES = frozenset({
-    "hermes", "default", "test", "tmp", "root", "sudo",
+    "hermes", "default",
 })
 
 # Hermes subcommands that cannot be used as profile names/aliases


### PR DESCRIPTION
## Summary

test/tmp/root/sudo 作为 profile 名称被不合理地禁止在 `_RESERVED_NAMES` 中。

**问题：** 创建 profile 时这个检查被绕过（或之前创建过），但删除时一定会被 `validate_profile_name` 拒绝，导致用户**创建了 profile 却无法删除**的不一致行为。

**修复：** `_RESERVED_NAMES` 只保留 `hermes` 和 `default`。其余名称（test、tmp、root、sudo）没有实际冲突理由，不应禁止。

## Test plan
- [ ] 可以创建名为 `test` 的 profile
- [ ] 可以正常删除名为 `test` 的 profile
- [ ] 仍然不能创建/删除名为 `default` 的 profile
- [ ] 仍然不能创建/删除名为 `hermes` 的 profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)