### PR TITLE
fix(tests): stabilize codex fallback and website policy cache (salvage #3887)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1355,6 +1355,17 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
 
+        # Some non-CLI entry points (gateway, cron, tests) can legitimately
+        # reach AIAgent with provider credentials resolved but no explicit model
+        # selected. Codex Responses requests require a non-empty model string,
+        # so normalize that here instead of relying on caller-specific CLI logic.
+        if not isinstance(self.model, str) or not self.model.strip():
+            if self.provider == "openai-codex" or (
+                self.api_mode == "codex_responses"
+                and "chatgpt.com/backend-api/codex" in self._base_url_lower
+            ):
+                self.model = "gpt-5.3-codex"
+
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -95,6 +95,7 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
 
 def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setattr(run_agent, "OpenAI", _FakeOpenAI)
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(
@@ -124,8 +125,28 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     assert _Codex401ThenSuccessAgent.last_init["api_mode"] == "codex_responses"
 
 
+def test_ai_agent_defaults_empty_codex_model(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setattr(run_agent, "OpenAI", _FakeOpenAI)
+
+    agent = run_agent.AIAgent(
+        model="",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-token",
+        skip_context_files=True,
+        skip_memory=True,
+        max_iterations=1,
+        quiet_mode=True,
+    )
+
+    assert agent.model == "gpt-5.3-codex"
+
+
 def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setattr(run_agent, "OpenAI", _FakeOpenAI)
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -240,6 +240,16 @@ def test_load_website_blocklist_wraps_shared_file_read_errors(tmp_path, monkeypa
 
 
 def test_check_website_access_uses_dynamic_hermes_home(monkeypatch, tmp_path):
+    from tools import website_policy
+
+    website_policy.invalidate_cache()
+    # Seed the cache with a disabled policy for a different HERMES_HOME to
+    # prove the default-path cache key follows runtime HERMES_HOME changes.
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(other_home))
+    assert check_website_access("https://dynamic.example/path") is None
+
     hermes_home = tmp_path / "hermes-home"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -30,6 +30,8 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
 
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
 # URL check (a web_crawl with 50 pages would otherwise mean 51 YAML parses).
+# The cache key must follow the resolved default HERMES_HOME path dynamically;
+# tests and long-lived processes may change HERMES_HOME at runtime.
 _CACHE_TTL_SECONDS = 30.0
 _cache_lock = threading.Lock()
 _cached_policy: Optional[Dict[str, Any]] = None
@@ -137,7 +139,8 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     """
     global _cached_policy, _cached_policy_path, _cached_policy_time
 
-    resolved_path = str(config_path) if config_path else "__default__"
+    default_path = _get_default_config_path()
+    resolved_path = str(config_path or default_path)
     now = time.monotonic()
 
     # Return cached policy if still fresh and same path
@@ -150,7 +153,7 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
             ):
                 return _cached_policy
 
-    config_path = config_path or _get_default_config_path()
+    config_path = config_path or default_path
     policy = _load_policy_config(config_path)
 
     raw_domains = policy.get("domains", []) or []
@@ -193,7 +196,7 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if config_path == _get_default_config_path():
         with _cache_lock:
             _cached_policy = result
-            _cached_policy_path = "__default__"
+            _cached_policy_path = str(config_path)
             _cached_policy_time = now
 
     return result
@@ -201,9 +204,11 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
 
 def invalidate_cache() -> None:
     """Force the next ``check_website_access`` call to re-read config."""
-    global _cached_policy
+    global _cached_policy, _cached_policy_path, _cached_policy_time
     with _cache_lock:
         _cached_policy = None
+        _cached_policy_path = None
+        _cached_policy_time = 0.0
 
 
 def _match_host_against_rule(host: str, pattern: str) -> bool:
@@ -242,8 +247,13 @@ def check_website_access(url: str, config_path: Optional[Path] = None) -> Option
     # Fast path: if no explicit config_path and the cached policy is disabled
     # or empty, skip all work (no YAML read, no host extraction).
     if config_path is None:
+        current_default_path = str(_get_default_config_path())
         with _cache_lock:
-            if _cached_policy is not None and not _cached_policy.get("enabled"):
+            if (
+                _cached_policy is not None
+                and _cached_policy_path == current_default_path
+                and not _cached_policy.get("enabled")
+            ):
                 return None
 
     host = _extract_host_from_urlish(url)


### PR DESCRIPTION
## Summary

Salvage of #3887 onto current `main`, preserving @kshitijk4poor's original commit authorship.

This combines two tightly related stabilizations that were already scoped together in the original PR:
- make Codex runtime paths resilient when `provider=openai-codex` resolves with an empty model string
- make website-policy cache entries follow the resolved `HERMES_HOME` config path so stale state does not leak across tests

## Problem

PR #3883 exposed unrelated suite instability in two hot areas:

1. Codex execution-path tests could fail when runtime provider resolution produced Codex credentials but no explicit model was configured.
2. Website-policy checks could reuse stale cached state after `HERMES_HOME` changed, making test behavior depend on previous cache contents.

## Root cause

- non-CLI `AIAgent` paths could enter Codex Responses mode with an empty model string
- website-policy caching keyed the default-path case too generically instead of by the resolved config path

## Fix

- default empty Codex model selection inside `AIAgent` for Codex Responses runtime paths
- key website-policy cache entries by resolved default config path and clear bookkeeping consistently on invalidation
- keep the regression tests explicit about env clearing and stale-cache setup

## Solution sketch

```mermaid
flowchart TD
    A[Runtime / test setup] --> B{Codex model empty?}
    B -->|Yes| C[Apply Codex default model]
    B -->|No| D[Use configured model]
    A --> E[Resolve HERMES_HOME config path]
    E --> F[Cache website policy by resolved path]
    F --> G[Invalidate path-specific stale state]
```

## Why salvage

- the original PR is focused: `4` files, `+57/-5`
- it cherry-picked cleanly onto `main` on May 14, 2026
- it targets two regressions already grouped in the original investigation and test plan
- original authorship is preserved in git history

## Duplicate check

I did not find a stronger current-main salvage already opened for this exact Codex fallback + website-policy cache stabilization pair.

## Tests

Original PR reported:
- `python -m pytest tests/test_codex_execution_paths.py tests/tools/test_website_policy.py -q -n auto --tb=short`
- result: `25 passed`

Local verification in this environment:
- `python -m py_compile run_agent.py tools/website_policy.py tests/cron/test_codex_execution_paths.py tests/tools/test_website_policy.py`
- `pytest` could not be rerun locally here because the current Windows environment does not have `pytest` installed

## Risk

Low to medium. The diff is still small, but it touches runtime-provider fallback behavior plus cache invalidation logic.

Salvage of #3887.
