### PR TITLE
fix(terminal): prevent safety filter false positives on quoted background-wrapper keywords (salvage #20066)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1544,9 +1544,29 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
-_SHELL_LEVEL_BACKGROUND_RE = re.compile(r"\b(?:nohup|disown|setsid)\b", re.IGNORECASE)
+_SHELL_LEVEL_BACKGROUND_RE = re.compile(
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b", re.IGNORECASE | re.MULTILINE
+)
 _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
+
+
+def _strip_quotes(command: str) -> str:
+    """Remove single- and double-quoted content so regex checks don't match inside strings.
+
+    This prevents false positives when keywords like 'nohup' or 'setsid' appear
+    in commit messages, Python -c code, echo arguments, or PR body text.
+    Also strips backtick-quoted content and heredoc-style inline text.
+    """
+    # Remove single-quoted strings (no escaping inside single quotes in shell)
+    result = re.sub(r"'[^']*'", "''", command)
+    # Remove double-quoted strings (handle escaped quotes)
+    result = re.sub(r'"(?:[^"\\]|\\.)*"', '""', result)
+    # Remove backtick-quoted strings
+    result = re.sub(r"`[^`]*`", "``", result)
+    return result
+
+
 _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|watch)\b", re.IGNORECASE),
     re.compile(r"\bdocker\s+compose\s+up\b", re.IGNORECASE),
@@ -1579,21 +1599,25 @@ def _foreground_background_guidance(command: str) -> str | None:
     if _looks_like_help_or_version_command(command):
         return None
 
-    if _SHELL_LEVEL_BACKGROUND_RE.search(command):
+    # Strip quoted content so keywords inside strings/arguments don't trigger
+    # false positives (e.g., git commit -m "... setsid ...", python3 -c "os.setsid").
+    unquoted = _strip_quotes(command)
+
+    if _SHELL_LEVEL_BACKGROUND_RE.search(unquoted):
         return (
             "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
             "Use terminal(background=true) so Hermes can track the process, then run "
             "readiness checks and tests in separate commands."
         )
 
-    if _INLINE_BACKGROUND_AMP_RE.search(command) or _TRAILING_BACKGROUND_AMP_RE.search(command):
+    if _INLINE_BACKGROUND_AMP_RE.search(unquoted) or _TRAILING_BACKGROUND_AMP_RE.search(unquoted):
         return (
             "Foreground command uses '&' backgrounding. Use terminal(background=true) for long-lived "
             "processes, then run health checks and tests in follow-up terminal calls."
         )
 
     for pattern in _LONG_LIVED_FOREGROUND_PATTERNS:
-        if pattern.search(command):
+        if pattern.search(unquoted):
             return (
                 "This foreground command appears to start a long-lived server/watch process. "
                 "Run it with background=true, verify readiness (health endpoint/log signal), "


### PR DESCRIPTION
## Summary

Salvage of #20066 onto current `main`, preserving @kshitijk4poor's original commit authorship.

This keeps the fix small and behavior-focused: the terminal safety filter should still block real background-wrapper usage, but it should stop tripping on `nohup`, `disown`, or `setsid` when those tokens appear inside quoted strings.

## Problem

`tools/terminal_tool.py::_foreground_background_guidance()` matches background-wrapper keywords too broadly, so legitimate commands like these can be blocked:

- `python3 -c "x = 'preexec_fn=os.setsid'"`
- `git commit -m "fix: replace preexec_fn=os.setsid with process_group=0"`
- `gh pr create --body "We removed os.setsid..."`
- `grep -r 'nohup' tests/`

## Root cause

The existing regex matched `nohup|disown|setsid` anywhere in the full command text, including inside quoted strings.

## Fix

- strip single-quoted, double-quoted, and backtick-quoted content before background-wrapper matching
- tighten the regex so it only matches those keywords in shell-command positions rather than any word boundary

## Solution sketch

```mermaid
flowchart TD
    A[Raw shell command] --> B[Strip quoted segments]
    B --> C[Run position-aware background-wrapper regex]
    C --> D{Real wrapper usage?}
    D -->|Yes| E[Return guidance / block]
    D -->|No| F[Allow command]
```

## Why salvage

- the original PR is small: `1` file, `+28/-4`
- collaborator comment on #20066 confirms the same root cause for #20064
- the change cherry-picked cleanly onto `main` on May 14, 2026
- original authorship is preserved in git history

## Duplicate check

I did not find a stronger competing salvage for this exact quoted-string safety-filter bug.

## Tests

Original PR reported:
- all `test_terminal_tool.py` tests passing
- all `test_terminal_compound_background.py` and `test_terminal_foreground_timeout_cap.py` tests passing

Local verification in this environment:
- `python -m py_compile tools/terminal_tool.py`
- `pytest` could not be rerun locally here because the current Windows environment does not have `pytest` installed

## Risk

Low. The diff is tightly scoped to terminal safety-filter preprocessing and match positioning.

Fixes #20064 via salvage of #20066.
