### PR TITLE
fix: preserve custom provider routing metadata

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6772,8 +6772,9 @@ class HermesCLI:
         # Persistence
         if persist_global:
             save_config_value("model.default", result.new_model)
-            if result.provider_changed:
-                save_config_value("model.provider", result.target_provider)
+            save_config_value("model.provider", result.target_provider)
+            save_config_value("model.api_mode", result.api_mode or "")
+            save_config_value("model.base_url", result.base_url or "")
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")

--- a/docs/plans/2026-05-14-hermes-provider-routing-and-custom-provider-slugs.md
+++ b/docs/plans/2026-05-14-hermes-provider-routing-and-custom-provider-slugs.md
@@ -1,0 +1,129 @@
+# Hermes Provider Routing and Custom Provider Slugs — Implementation Plan
+
+> **For Hermes:** keep this PR small, fit it to the existing codebase, and do not add new abstractions unless the current ones already expect them
+
+**Goal:** fix custom provider routing so Hermes preserves the real transport/api_mode, supports stable custom-provider slugs via `provider_key`, and honors custom provider context lengths during compression feasibility checks
+
+**Architecture:**
+This PR stays inside the current Hermes provider/config pipeline. It does not introduce new provider types or new runtime features. It only makes existing custom-provider resolution more faithful to config, improves slug stability for named endpoints, and threads existing custom-provider metadata into the compression feasibility path
+
+**Tech Stack:** Python, pytest, Hermes config YAML, existing provider/model-switch runtime
+
+---
+
+## Scope
+
+### In scope
+- `hermes_cli/config.py`: allow `provider_key` and `description` in custom provider config entries
+- `hermes_cli/providers.py`: resolve custom providers with the correct transport from `api_mode` / `transport`
+- `hermes_cli/model_switch.py`: prefer `provider_key` when building custom-provider slugs
+- `run_agent.py`: pass resolved custom providers into compression context-length checks
+- `tests/*`: add or keep focused coverage for custom provider routing and compression feasibility
+
+### Out of scope
+- No new provider backends
+- No new chat features
+- No broad compression auto-sync on `/model --global`
+- No changes to unrelated gateway behavior
+- No schema migration beyond the existing config parser acceptance
+
+---
+
+## Current English audit summary
+
+The uncommitted work is mostly coherent and fits Hermes' existing architecture, but the earlier version was too broad in one place: it tried to auto-rewrite compression config when switching the global model. That is risky because it silently changes user intent. The safer PR is the smaller provider-routing fix plus compression feasibility context support
+
+### Safe pieces
+- custom provider `api_mode` / `transport` is now preserved instead of being hardcoded to `openai_chat`
+- `provider_key` gives stable identifiers for custom providers, which helps `/model` and config round-tripping
+- compression feasibility can now see custom provider context-length overrides
+
+### Risk to avoid
+- do not couple `/model --global` to compression config rewriting unless there is an explicit opt-in flag or a separate PR
+
+---
+
+## Implementation tasks
+
+### Task 1: Keep custom provider config schema compatible
+
+**Objective:** let Hermes accept `provider_key` and `description` on custom provider entries without treating them as unknown noise
+
+**Files:**
+- Modify: `hermes_cli/config.py`
+- Test: `tests/hermes_cli/test_provider_config_validation.py`
+
+**Verification:**
+- `pytest tests/hermes_cli/test_provider_config_validation.py -q`
+
+---
+
+### Task 2: Preserve real transport for custom providers
+
+**Objective:** map custom providers to the correct runtime transport instead of forcing `openai_chat`
+
+**Files:**
+- Modify: `hermes_cli/providers.py`
+- Test: `tests/hermes_cli/test_runtime_provider_resolution.py` or existing custom-provider model-switch tests
+
+**Verification:**
+- `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
+- `pytest tests/hermes_cli/test_custom_provider_model_switch.py -q`
+
+---
+
+### Task 3: Prefer explicit provider keys in model picker output
+
+**Objective:** make stable custom-provider slugs win when present, so config and runtime stay aligned
+
+**Files:**
+- Modify: `hermes_cli/model_switch.py`
+- Test: `tests/hermes_cli/test_model_switch_custom_providers.py`
+
+**Verification:**
+- `pytest tests/hermes_cli/test_model_switch_custom_providers.py -q`
+
+---
+
+### Task 4: Honor custom provider context lengths in compression checks
+
+**Objective:** let compression feasibility use the same custom-provider metadata Hermes already knows about
+
+**Files:**
+- Modify: `run_agent.py`
+- Test: `tests/run_agent/test_compression_feasibility.py`
+
+**Verification:**
+- `pytest tests/run_agent/test_compression_feasibility.py -q`
+
+---
+
+## PR checklist
+
+- [ ] Keep the diff focused on existing Hermes plumbing
+- [ ] Avoid accidental compression-config rewrites
+- [ ] Run targeted tests for provider routing and compression feasibility
+- [ ] Check `git diff --stat` before commit
+- [ ] Write a conventional commit message with a detailed body
+- [ ] Push branch and open PR against upstream Hermes
+- [ ] Watch GitHub checks and fix only what CI reports
+
+---
+
+## Suggested commit shape
+
+- `fix: preserve custom provider routing metadata`
+- body should mention:
+  - custom providers now keep their transport/api_mode
+  - `provider_key` becomes the stable slug when present
+  - compression feasibility now sees custom provider context lengths
+  - no new runtime provider abstractions were introduced
+
+---
+
+## Notes for implementation
+
+- Keep `run_agent.py` changes tightly scoped to the compression feasibility path
+- Do not reintroduce compression config auto-sync in `/model --global`
+- Prefer existing test files over inventing new coverage locations
+- If a test needs small fixture adjustments, keep those changes local and mechanical

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9198,8 +9198,12 @@ class GatewayRunner:
                 model_cfg = cfg.setdefault("model", {})
                 model_cfg["default"] = result.new_model
                 model_cfg["provider"] = result.target_provider
-                if result.base_url:
-                    model_cfg["base_url"] = result.base_url
+                model_cfg["api_mode"] = result.api_mode or model_cfg.get("api_mode", "")
+                # Keep config honest: when switching from a custom endpoint back
+                # to OAuth/built-in providers, clear stale base_url instead of
+                # leaving the previous custom URL behind.
+                model_cfg["base_url"] = result.base_url or ""
+
                 from hermes_cli.config import save_config
                 save_config(cfg)
             except Exception as e:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2851,7 +2851,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "provider_key", "description",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2903,7 +2903,7 @@ def _normalize_custom_provider_entry(
         "base_url": base_url,
     }
 
-    provider_key = provider_key.strip()
+    provider_key = (provider_key.strip() or str(entry.get("provider_key", "") or "").strip())
     if provider_key:
         normalized["provider_key"] = provider_key
 
@@ -3103,7 +3103,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "provider_key", "description",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1580,6 +1580,8 @@ def list_authenticated_providers(
                 continue
 
             raw_name = (entry.get("name") or "").strip()
+            raw_provider_key = str(entry.get("provider_key", "") or "").strip()
+            provider_key_slug = f"custom:{raw_provider_key.lower().replace(' ', '-')}" if raw_provider_key else ""
             api_url = (
                 entry.get("base_url", "")
                 or entry.get("url", "")
@@ -1612,14 +1614,15 @@ def list_authenticated_providers(
                 ):
                     # Guard against bare "custom" slug left by a prior
                     # failed switch — always resolve to the canonical
-                    # custom:<name> form.  (GH #17478)
+                    # custom:<name> form. Prefer explicit provider_key when
+                    # present so stable short slugs like custom:cliproxy work.
                     slug = (
                         current_provider
                         if current_provider and current_provider != "custom"
-                        else custom_provider_slug(display_name)
+                        else (provider_key_slug or custom_provider_slug(display_name))
                     )
                 else:
-                    slug = custom_provider_slug(display_name)
+                    slug = provider_key_slug or custom_provider_slug(display_name)
                 groups[group_key] = {
                     "slug": slug,
                     "name": display_name,

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -619,13 +619,27 @@ def resolve_custom_provider(
             first_valid = (display_name, api_url)
 
         slug = custom_provider_slug(display_name)
-        if requested not in {display_name.lower(), slug}:
+        provider_key = str(entry.get("provider_key", "") or "").strip()
+        provider_key_norm = provider_key.lower().replace(" ", "-") if provider_key else ""
+        provider_slug = f"custom:{provider_key_norm}" if provider_key_norm else ""
+        if requested not in {display_name.lower(), slug, provider_key_norm, provider_slug}:
             continue
 
+        # Preserve custom provider wire protocol. Previously every custom provider
+        # resolved as openai_chat here, so /model labels and persisted switches
+        # could drift from the actual runtime api_mode (e.g. codex_responses for
+        # AutoCode/CN proxy).
+        api_mode = str(entry.get("api_mode") or entry.get("transport") or "").strip()
+        transport = "openai_chat"
+        if api_mode == "codex_responses":
+            transport = "codex_responses"
+        elif api_mode == "anthropic_messages":
+            transport = "anthropic_messages"
+
         return ProviderDef(
-            id=slug,
+            id=provider_slug or slug,
             name=display_name,
-            transport="openai_chat",
+            transport=transport,
             api_key_env_vars=(),
             base_url=api_url,
             is_aggregator=False,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3240,6 +3240,13 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            _aux_custom_providers = None
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+                _aux_cfg = load_config()
+                _aux_custom_providers = get_compatible_custom_providers(_aux_cfg)
+            except Exception:
+                _aux_custom_providers = None
 
             aux_context = get_model_context_length(
                 aux_model,
@@ -3250,7 +3257,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
-                custom_providers=self._custom_providers,
+                custom_providers=_aux_custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -205,6 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -258,6 +260,52 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
+    )
+
+
+def test_feasibility_check_passes_custom_provider_context_overrides():
+    """Compression feasibility must honor custom_providers context_length.
+
+    Otherwise a named custom endpoint can resolve the main model from config
+    as 400K while the same compression model falls through to the generic
+    256K default, causing a false auto-lowered threshold warning.
+    """
+    agent = _make_agent(main_context=400_000, threshold_percent=0.75)
+    agent.model = "gpt-5.5"
+    agent.provider = "custom:openai"
+    agent.base_url = "https://vip.auto-code.net/v1"
+
+    custom_providers = [
+        {
+            "name": "OpenAI",
+            "base_url": "https://vip.auto-code.net/v1",
+            "models": {"gpt-5.5": {"context_length": 400_000}},
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.base_url = "https://vip.auto-code.net/v1"
+    mock_client.api_key = "sk-custom"
+
+    with (
+        patch("hermes_cli.config.load_config", return_value={"custom_providers": custom_providers}),
+        patch("hermes_cli.config.get_compatible_custom_providers", return_value=custom_providers),
+        patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(mock_client, "gpt-5.5")),
+        patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("custom:openai", "gpt-5.5", "", "", {})),
+        patch("agent.model_metadata.get_model_context_length", return_value=400_000) as mock_ctx_len,
+    ):
+        messages = []
+        agent._emit_status = lambda msg: messages.append(msg)
+        agent._check_compression_model_feasibility()
+
+    assert messages == []
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.5",
+        base_url="https://vip.auto-code.net/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="custom:openai",
+        custom_providers=custom_providers,
     )
 
 


### PR DESCRIPTION
## Summary\n- Keep custom provider transport/api_mode instead of forcing openai_chat\n- Use provider_key for stable custom-provider slugs\n- Pass custom provider overrides into compression feasibility checks\n- Keep the scope tight: no new architecture, only Hermes plumbing\n\n## Why\nThis fixes cases where Hermes custom providers or proxy-backed setups lose their routing metadata during model switching and compression checks.\n\n## Test Plan\n- pytest tests/hermes_cli/test_provider_config_validation.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_runtime_provider_resolution.py -q\n- pytest tests/run_agent/test_compression_feasibility.py -q\n\n## Notes\n- No user secrets are included in this PR.\n- Plan/audit doc is included for reviewer context.