### PR TITLE
fix(mcp): prevent tool registration race condition on startup

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -286,6 +286,16 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    try:
+        from tools.mcp_tool import wait_for_mcp_ready
+        if not wait_for_mcp_ready(timeout=30):
+            logger.warning(
+                "MCP discovery did not complete within 30s; "
+                "proceeding without MCP tools"
+            )
+    except ImportError:
+        pass
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).

--- a/model_tools.py
+++ b/model_tools.py
@@ -287,7 +287,12 @@ def get_tool_definitions(
         Filtered list of OpenAI-format tool definitions.
     """
     try:
-        from tools.mcp_tool import wait_for_mcp_ready
+        from tools.mcp_tool import wait_for_mcp_ready, discover_mcp_tools, _mcp_discovery_started
+        # ensure MCP discovery operates if this is a detached/singleton AIAgent instance. 
+        # discover_mcp_tools() is idempotent.
+        if not _mcp_discovery_started.is_set():
+            discover_mcp_tools()
+            
         if not wait_for_mcp_ready(timeout=30):
             logger.warning(
                 "MCP discovery did not complete within 30s; "

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1235,6 +1235,7 @@ class MCPServerTask:
                     self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
+                    self._register_tools()
                     self._ready.set()
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
@@ -1335,6 +1336,7 @@ class MCPServerTask:
                     self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
+                    self._register_tools()
                     self._ready.set()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
@@ -1382,6 +1384,7 @@ class MCPServerTask:
                         self.initialize_result = await session.initialize()
                         self.session = session
                         await self._discover_tools()
+                        self._register_tools()
                         self._ready.set()
                         reason = await self._wait_for_lifecycle_event()
                         if reason == "reconnect":
@@ -1405,6 +1408,7 @@ class MCPServerTask:
                     self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
+                    self._register_tools()
                     self._ready.set()
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
@@ -1423,6 +1427,20 @@ class MCPServerTask:
             tools_result.tools
             if hasattr(tools_result, "tools")
             else []
+        )
+
+    def _register_tools(self):
+        """Register discovered tools in the ToolRegistry and populate _servers.
+
+        Called inside transport methods BEFORE ``_ready.set()`` so that the
+        registry is populated before any waiter on ``_ready`` proceeds.
+        Setting ``_servers[self.name]`` here ensures ``_make_check_fn()``
+        closures can resolve the server immediately.
+        """
+        with _lock:
+            _servers[self.name] = self
+        self._registered_tool_names = _register_server_tools(
+            self.name, self, self._config
         )
 
     async def run(self, config: dict):
@@ -1605,6 +1623,21 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 
 _servers: Dict[str, MCPServerTask] = {}
+
+_mcp_discovery_started = threading.Event()
+_mcp_discovery_complete = threading.Event()
+
+
+def wait_for_mcp_ready(timeout: float = 30) -> bool:
+    """Block until MCP tool discovery and registration is complete.
+
+    Returns ``True`` if ready (or discovery was never started),
+    ``False`` if the timeout elapsed before discovery finished.
+    """
+    if not _mcp_discovery_started.is_set():
+        return True
+    return _mcp_discovery_complete.wait(timeout=timeout)
+
 
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
@@ -3013,6 +3046,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
+    Tool registration now happens inside ``MCPServerTask._register_tools()``
+    before ``_ready.set()`` fires, so by the time ``start()`` returns the
+    registry is already populated and ``_servers[name]`` is set.
+
     Returns list of registered tool names.
     """
     connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
@@ -3020,11 +3057,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _connect_server(name, config),
         timeout=connect_timeout,
     )
-    with _lock:
-        _servers[name] = server
-
-    registered_names = _register_server_tools(name, server, config)
-    server._registered_tool_names = list(registered_names)
+    registered_names = list(server._registered_tool_names)
 
     transport_type = "HTTP" if "url" in config else "stdio"
     logger.info(
@@ -3053,11 +3086,15 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     """
     if not _MCP_AVAILABLE:
         logger.debug("MCP SDK not available -- skipping explicit MCP registration")
+        _mcp_discovery_complete.set()
         return []
 
     if not servers:
         logger.debug("No explicit MCP servers provided")
+        _mcp_discovery_complete.set()
         return []
+
+    _mcp_discovery_started.set()
 
     # Only attempt servers that aren't already connected and are enabled
     # (enabled: false skips the server entirely without removing its config)
@@ -3069,6 +3106,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         }
 
     if not new_servers:
+        _mcp_discovery_complete.set()
         return _existing_tool_names()
 
     # Start the background event loop for MCP connections
@@ -3110,6 +3148,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     finally:
         if _was_interrupted:
             _set_interrupt(True)
+        _mcp_discovery_complete.set()
 
     # Log a summary so ACP callers get visibility into what was registered.
     with _lock:


### PR DESCRIPTION
## Root Cause
When an agent starts via CLI,  is called. In , the  flag was firing immediately after discovery, but **before**  actually populated the ToolRegistry.

Because  fetches the definitions immediately upon instantiation, the API payload was receiving  because the servers had connected but had not registered their endpoints.

## Fix
1. Moved  directly into the  loop, executed immediately before .
2. Added  logic inside  so that any detached instances or fast CLI calls properly block until MCP servers are fully registered.
3. If an agent (e.g., cron background task) executes but discovery was never started,  now synchronously invokes  first.

This closes the gap ensuring the model never generates text-only responses missing tools.