### PR TITLE
Fix MCP shutdown after timed-out agent runs

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -139,3 +139,21 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
 
+
+def test_oauth_flow_lock_is_shared_across_providers(tmp_path, monkeypatch):
+    """All provider instances must share one OAuth handshake lock.
+
+    This prevents Supabase/Vercel from starting interactive browser auth in
+    parallel and trampling each other's loopback callback state.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+    reset_manager_for_tests()
+
+    mgr = MCPOAuthManager()
+    p1 = mgr.get_or_build_provider("supabase", "https://example.com/mcp", None)
+    p2 = mgr.get_or_build_provider("vercel", "https://example.com/mcp", None)
+
+    assert p1 is not None and p2 is not None
+    assert p1._get_auth_flow_lock() is p2._get_auth_flow_lock()
+

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1186,6 +1186,36 @@ class TestShutdown:
 
         assert len(_servers) == 0
 
+    def test_shutdown_cancels_pending_loop_tasks_before_closing_loop(self):
+        """Shutdown drains pending loop tasks so stdio subprocess startup is not destroyed."""
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import shutdown_mcp_servers, _servers
+
+        _servers.clear()
+        mcp_mod._ensure_mcp_loop()
+        loop = mcp_mod._mcp_loop
+        assert loop is not None
+
+        async def wait_forever():
+            await asyncio.Event().wait()
+
+        async def create_pending_task():
+            task = asyncio.create_task(wait_forever())
+            await asyncio.sleep(0)
+            return task
+
+        pending_task = asyncio.run_coroutine_threadsafe(create_pending_task(), loop).result(timeout=5)
+        assert not pending_task.done()
+
+        try:
+            shutdown_mcp_servers()
+        finally:
+            mcp_mod._mcp_loop = None
+            mcp_mod._mcp_thread = None
+
+        assert pending_task.done()
+        assert pending_task.cancelled()
+
     def test_shutdown_is_parallel(self):
         """Multiple servers are shut down in parallel via asyncio.gather."""
         import tools.mcp_tool as mcp_mod

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -295,6 +295,13 @@ class HermesTokenStorage:
         data = _read_json(self._client_info_path())
         if data is None:
             return None
+        # Some hosted OAuth MCP providers (notably Supabase) dynamically
+        # register a confidential client and return ``client_secret`` without
+        # echoing ``token_endpoint_auth_method``. The MCP SDK only sends the
+        # secret when that method is explicit, so normalize cached client info
+        # before validation to avoid 422 "Required parameter: client_secret".
+        if data.get("client_secret") and not data.get("token_endpoint_auth_method"):
+            data["token_endpoint_auth_method"] = "client_secret_post"
         try:
             return OAuthClientInformationFull.model_validate(data)
         except (ValueError, TypeError, KeyError) as exc:
@@ -302,7 +309,10 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
-        _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+        payload = client_info.model_dump(mode="json", exclude_none=True)
+        if payload.get("client_secret") and not payload.get("token_endpoint_auth_method"):
+            payload["token_endpoint_auth_method"] = "client_secret_post"
+        _write_json(self._client_info_path(), payload)
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- oauth server metadata --------------------------------------------

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -95,17 +95,22 @@ def _make_hermes_provider_class() -> Optional[type]:
     class HermesMCPOAuthProvider(OAuthClientProvider):
         """OAuthClientProvider with pre-flow disk-mtime reload.
 
-        Before every ``async_auth_flow`` invocation, asks the manager to
-        check whether the tokens file on disk has been modified externally.
-        If so, the manager resets ``_initialized`` so the next flow
-        re-reads from storage.
-
-        This makes external-process refreshes (cron, another CLI instance)
-        visible to the running MCP session without requiring a restart.
-
-        Reference: Claude Code's ``invalidateOAuthCacheIfDiskChanged``
-        (``src/utils/auth.ts:1320``, CC-1096 / GH#24317).
+        OAuth flows are serialized across all MCP servers to avoid cross-talk
+        between concurrent loopback callback listeners. Supabase and Vercel
+        both use browser-based OAuth, and starting them in parallel can race
+        the shared callback state / port bookkeeping in the MCP SDK.
         """
+
+        _auth_flow_lock: asyncio.Lock | None = None
+
+        @classmethod
+        def _get_auth_flow_lock(cls) -> asyncio.Lock:
+            """Return the shared lock guarding interactive OAuth flows."""
+            lock = cls._auth_flow_lock
+            if lock is None:
+                lock = asyncio.Lock()
+                cls._auth_flow_lock = lock
+            return lock
 
         def __init__(self, *args: Any, server_name: str = "", **kwargs: Any):
             super().__init__(*args, **kwargs)
@@ -298,31 +303,36 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
-            # Manually bridge the bidirectional generator protocol. httpx's
-            # auth_flow driver (httpx._client._send_handling_auth) calls
-            # ``auth_flow.asend(response)`` to feed HTTP responses back into
-            # the generator. A naive wrapper using ``async for item in inner:
-            # yield item`` DISCARDS those .asend(response) values and resumes
-            # the inner generator with None, so the SDK's
-            # ``response = yield request`` branch in
-            # mcp/client/auth/oauth2.py sees response=None and crashes at
-            # ``if response.status_code == 401`` with AttributeError.
-            #
-            # The bridge below forwards each .asend() value into the inner
-            # generator via inner.asend(incoming), preserving the bidirectional
-            # contract. Regression from PR #11383 caught by
-            # tests/tools/test_mcp_oauth_bidirectional.py.
-            inner = super().async_auth_flow(request)
-            try:
-                outgoing = await inner.__anext__()
-                while True:
-                    incoming = yield outgoing
-                    outgoing = await inner.asend(incoming)
-            except StopAsyncIteration:
-                # Persist any metadata the SDK discovered lazily during the
-                # 401 branch so a subsequent cold-load skips discovery.
-                self._persist_oauth_metadata_if_changed()
-                return
+            # Serialize interactive OAuth handshakes across all MCP servers.
+            # Supabase/Vercel both use loopback redirect listeners and can
+            # race each other if two providers start browser auth at once.
+            async with self._get_auth_flow_lock():
+                # Manually bridge the bidirectional generator protocol.
+                # httpx's auth_flow driver (httpx._client._send_handling_auth)
+                # calls ``auth_flow.asend(response)`` to feed HTTP responses
+                # back into the generator. A naive wrapper using ``async for
+                # item in inner: yield item`` DISCARDS those
+                # .asend(response) values and resumes the inner generator with
+                # None, so the SDK's ``response = yield request`` branch in
+                # mcp/client/auth/oauth2.py sees response=None and crashes at
+                # ``if response.status_code == 401`` with AttributeError.
+                #
+                # The bridge below forwards each .asend() value into the inner
+                # generator via inner.asend(incoming), preserving the
+                # bidirectional contract. Regression from PR #11383 caught by
+                # tests/tools/test_mcp_oauth_bidirectional.py.
+                inner = super().async_auth_flow(request)
+                try:
+                    outgoing = await inner.__anext__()
+                    while True:
+                        incoming = yield outgoing
+                        outgoing = await inner.asend(incoming)
+                except StopAsyncIteration:
+                    # Persist any metadata the SDK discovered lazily during
+                    # the 401 branch so a subsequent cold-load skips
+                    # discovery.
+                    self._persist_oauth_metadata_if_changed()
+                    return
 
     return HermesMCPOAuthProvider
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2026,17 +2026,28 @@ def _mcp_loop_exception_handler(loop, context):
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
     global _mcp_loop, _mcp_thread
+    started = threading.Event()
     with _lock:
         if _mcp_loop is not None and _mcp_loop.is_running():
             return
-        _mcp_loop = asyncio.new_event_loop()
-        _mcp_loop.set_exception_handler(_mcp_loop_exception_handler)
+        def _run_loop():
+            global _mcp_loop
+            loop = asyncio.new_event_loop()
+            loop.set_exception_handler(_mcp_loop_exception_handler)
+            asyncio.set_event_loop(loop)
+            with _lock:
+                _mcp_loop = loop
+            started.set()
+            loop.run_forever()
+
+        _mcp_loop = None
         _mcp_thread = threading.Thread(
-            target=_mcp_loop.run_forever,
+            target=_run_loop,
             name="mcp-event-loop",
             daemon=True,
         )
         _mcp_thread.start()
+    started.wait(timeout=1)
 
 
 def _run_on_mcp_loop(coro, timeout: float = 30):
@@ -3395,7 +3406,28 @@ def _stop_mcp_loop():
         _mcp_loop = None
         _mcp_thread = None
     if loop is not None:
-        loop.call_soon_threadsafe(loop.stop)
+        if loop.is_running():
+            async def _cancel_pending_tasks():
+                current = asyncio.current_task()
+                pending = [
+                    task for task in asyncio.all_tasks()
+                    if task is not current and not task.done()
+                ]
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+
+            try:
+                future = asyncio.run_coroutine_threadsafe(_cancel_pending_tasks(), loop)
+                future.result(timeout=5)
+            except Exception as exc:
+                logger.debug("Error draining pending MCP loop tasks during shutdown: %s", exc)
+
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError:
+            pass
         if thread is not None:
             thread.join(timeout=5)
         try:


### PR DESCRIPTION
## Summary
- start the MCP event loop inside its worker thread and wait until it is ready before scheduling work
- cancel and drain pending MCP-loop tasks before stopping/closing the loop, preventing destroyed pending subprocess pipe tasks after timeouts
- harden hosted MCP OAuth handling by normalizing confidential client metadata and serializing auth flows across providers

## Root cause
A Linear-triggered Hermes agent run hit repeated non-streaming model-call timeouts. During process cleanup, `shutdown_mcp_servers()` stopped and closed the MCP background loop while stdio MCP subprocess startup/reconnect tasks were still pending. That left asyncio subprocess pipe coroutines half-open and produced the observed `BaseSubprocessTransport._connect_pipes` / `coroutine ignored GeneratorExit` warnings.

## Tests
- `pytest tests/tools/test_mcp_tool.py::TestShutdown tests/tools/test_mcp_oauth_manager.py -q` — 14 passed
- `pytest tests/tools/test_mcp_tool.py::TestShutdown::test_shutdown_cancels_pending_loop_tasks_before_closing_loop -q` — 1 passed
- `pytest tests/tools/test_mcp_tool.py -q` — 184 passed
- `pytest tests/tools/test_mcp_probe.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_bidirectional.py -q` — 80 passed, 1 existing warning
- `python -m py_compile tools/mcp_tool.py tools/mcp_oauth.py tools/mcp_oauth_manager.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_oauth_manager.py`
- `git diff --check`

Full suite note: `pytest -q` was also run and reached completion, but the existing repository-wide suite currently reports unrelated failures outside this change area: 100 failed, 22242 passed, 77 skipped, 214 warnings.
