### PR TITLE
fix(tui): show original URL instead of slug when title fetch fails

### DIFF
--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -2,7 +2,7 @@ import { Box, Link, stringWidth, Text } from '@hermes/ink'
 import { Fragment, memo, type ReactNode, useMemo } from 'react'
 
 import { ensureEmojiPresentation } from '../lib/emoji.js'
-import { normalizeExternalUrl, urlSlugTitleLabel, useLinkTitle } from '../lib/externalLink.js'
+import { normalizeExternalUrl, useLinkTitle } from '../lib/externalLink.js'
 import { BOX_CLOSE, BOX_OPEN, texToUnicode } from '../lib/mathUnicode.js'
 import { highlightLine, isHighlightable } from '../lib/syntax.js'
 import type { Theme } from '../theme.js'
@@ -145,7 +145,7 @@ const autolinkUrl = (raw: string) =>
   raw.startsWith('mailto:') || raw.startsWith('http') || !raw.includes('@') ? raw : `mailto:${raw}`
 
 const defaultLinkLabel = (url: string) =>
-  url.startsWith('mailto:') ? url.replace(/^mailto:/, '') : /^https?:\/\//i.test(url) ? urlSlugTitleLabel(url) : url
+  url.startsWith('mailto:') ? url.replace(/^mailto:/, '') : url
 
 const pickFallbackLabel = (label: string | undefined, target: string): string | undefined => {
   const trimmed = label?.trim()


### PR DESCRIPTION
## Problem

Issue #25606: When the async title fetch for a URL fails or returns no result, the TUI falls back to `urlSlugTitleLabel()` which parses the URL path and title-cases the last segment. This produces unintelligible single-word labels:

- `https://x.com/OpenAI/status/1234` → `Status`
- `https://github.com/NousResearch/hermes-agent/pull/25606` → `25606`

## Fix

`defaultLinkLabel()` in `markdown.tsx` now returns the original URL as-is for `http(s)` links instead of passing it through `urlSlugTitleLabel()`. This means when title fetch fails, users see the full readable URL.

Also removed the now-unused `urlSlugTitleLabel` import.

## Changed file

- `ui-tui/src/components/markdown.tsx` — 2 lines changed (1 logic, 1 import cleanup)

## Testing

- All 548 existing vitest tests pass (16 pre-existing failures unrelated to this change — they require a built `hermes-ink` package)
