### PR TITLE
Fail closed on malformed tool call arguments

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -872,6 +872,58 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     return "{}"
 
 
+def _parse_tool_call_arguments_for_execution(
+    raw_args: Any,
+    tool_name: str,
+) -> tuple[dict[str, Any], str | None]:
+    """Parse executable tool arguments, rejecting malformed/non-object payloads."""
+    if isinstance(raw_args, dict):
+        return raw_args, None
+
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+        except json.JSONDecodeError as exc:
+            return {}, json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Malformed tool call arguments for '{tool_name}': "
+                        f"{exc.msg} at line {exc.lineno} column {exc.colno}. "
+                        "Tool was not executed."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+    else:
+        return {}, json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Malformed tool call arguments for '{tool_name}': "
+                    f"expected a JSON object string, got {type(raw_args).__name__}. "
+                    "Tool was not executed."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    if not isinstance(parsed, dict):
+        return {}, json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Malformed tool call arguments for '{tool_name}': "
+                    f"expected a JSON object, got {type(parsed).__name__}. "
+                    "Tool was not executed."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    return parsed, None
+
+
 def _strip_non_ascii(text: str) -> str:
     """Remove non-ASCII characters, replacing with closest ASCII equivalent or removing.
 
@@ -10744,21 +10796,13 @@ class AIAgent:
         for tool_call in tool_calls:
             function_name = tool_call.function.name
 
-            # Reset nudge counters
-            if function_name == "memory":
-                self._turns_since_memory = 0
-            elif function_name == "skill_manage":
-                self._iters_since_skill = 0
-
-            try:
-                function_args = json.loads(tool_call.function.arguments)
-            except json.JSONDecodeError:
-                function_args = {}
-            if not isinstance(function_args, dict):
-                function_args = {}
+            function_args, argument_error_result = _parse_tool_call_arguments_for_execution(
+                tool_call.function.arguments,
+                function_name,
+            )
 
             # Checkpoint for file-mutating tools
-            if function_name in {"write_file", "patch"} and self._checkpoint_mgr.enabled:
+            if argument_error_result is None and function_name in {"write_file", "patch"} and self._checkpoint_mgr.enabled:
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
@@ -10768,7 +10812,7 @@ class AIAgent:
                     pass
 
             # Checkpoint before destructive terminal commands
-            if function_name == "terminal" and self._checkpoint_mgr.enabled:
+            if argument_error_result is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
@@ -10781,21 +10825,31 @@ class AIAgent:
 
             block_result = None
             blocked_by_guardrail = False
-            try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                block_message = get_pre_tool_call_block_message(
-                    function_name, function_args, task_id=effective_task_id or "",
-                )
-            except Exception:
-                block_message = None
-
-            if block_message is not None:
-                block_result = json.dumps({"error": block_message}, ensure_ascii=False)
+            if argument_error_result is not None:
+                block_result = argument_error_result
             else:
-                guardrail_decision = self._tool_guardrails.before_call(function_name, function_args)
-                if not guardrail_decision.allows_execution:
-                    block_result = self._guardrail_block_result(guardrail_decision)
-                    blocked_by_guardrail = True
+                try:
+                    from hermes_cli.plugins import get_pre_tool_call_block_message
+                    block_message = get_pre_tool_call_block_message(
+                        function_name, function_args, task_id=effective_task_id or "",
+                    )
+                except Exception:
+                    block_message = None
+
+                if block_message is not None:
+                    block_result = json.dumps({"error": block_message}, ensure_ascii=False)
+                else:
+                    guardrail_decision = self._tool_guardrails.before_call(function_name, function_args)
+                    if not guardrail_decision.allows_execution:
+                        block_result = self._guardrail_block_result(guardrail_decision)
+                        blocked_by_guardrail = True
+
+            if block_result is None:
+                # Reset nudge counters only when the relevant tool will run.
+                if function_name == "memory":
+                    self._turns_since_memory = 0
+                elif function_name == "skill_manage":
+                    self._iters_since_skill = 0
 
             parsed_calls.append((tool_call, function_name, function_args, block_result, blocked_by_guardrail))
 
@@ -11153,31 +11207,33 @@ class AIAgent:
 
             function_name = tool_call.function.name
 
-            try:
-                function_args = json.loads(tool_call.function.arguments)
-            except json.JSONDecodeError as e:
-                logging.warning(f"Unexpected JSON error after validation: {e}")
-                function_args = {}
-            if not isinstance(function_args, dict):
-                function_args = {}
+            function_args, argument_error_result = _parse_tool_call_arguments_for_execution(
+                tool_call.function.arguments,
+                function_name,
+            )
 
             # Check plugin hooks for a block directive before executing.
             _block_msg: Optional[str] = None
-            try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                _block_msg = get_pre_tool_call_block_message(
-                    function_name, function_args, task_id=effective_task_id or "",
-                )
-            except Exception:
-                pass
+            if argument_error_result is None:
+                try:
+                    from hermes_cli.plugins import get_pre_tool_call_block_message
+                    _block_msg = get_pre_tool_call_block_message(
+                        function_name, function_args, task_id=effective_task_id or "",
+                    )
+                except Exception:
+                    pass
 
             _guardrail_block_decision: ToolGuardrailDecision | None = None
-            if _block_msg is None:
+            if argument_error_result is None and _block_msg is None:
                 guardrail_decision = self._tool_guardrails.before_call(function_name, function_args)
                 if not guardrail_decision.allows_execution:
                     _guardrail_block_decision = guardrail_decision
 
-            _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
+            _execution_blocked = (
+                argument_error_result is not None
+                or _block_msg is not None
+                or _guardrail_block_decision is not None
+            )
 
             if _execution_blocked:
                 # Tool blocked by plugin or guardrail policy — skip counters,
@@ -11251,7 +11307,12 @@ class AIAgent:
 
             tool_start_time = time.time()
 
-            if _block_msg is not None:
+            if argument_error_result is not None:
+                # Reject malformed tool-call arguments instead of executing
+                # the requested tool with an accidental empty-argument dict.
+                function_result = argument_error_result
+                tool_duration = 0.0
+            elif _block_msg is not None:
                 # Tool blocked by plugin policy — return error without executing.
                 function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
                 tool_duration = 0.0

--- a/tests/run_agent/test_tool_call_argument_boundary.py
+++ b/tests/run_agent/test_tool_call_argument_boundary.py
@@ -1,0 +1,143 @@
+import json
+from types import SimpleNamespace
+
+from run_agent import AIAgent, _parse_tool_call_arguments_for_execution
+
+
+def _tool_call(name="read_file", arguments='{"path": "README.md"}'):
+    return SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _assistant_message(*tool_calls):
+    return SimpleNamespace(tool_calls=list(tool_calls))
+
+
+def _agent_for_tool_execution():
+    agent = object.__new__(AIAgent)
+    agent._interrupt_requested = False
+    agent.quiet_mode = True
+    agent.verbose_logging = False
+    agent.tool_delay = 0
+    agent.tool_progress_callback = None
+    agent.tool_start_callback = None
+    agent.tool_complete_callback = None
+    agent._context_engine_tool_names = set()
+    agent._memory_manager = None
+    agent.valid_tool_names = {"read_file"}
+    agent.session_id = "test-session"
+    agent.log_prefix_chars = 80
+    agent.log_prefix = ""
+    agent._current_tool = None
+    agent._subdirectory_hints = SimpleNamespace(check_tool_call=lambda *_args, **_kwargs: "")
+    agent._checkpoint_mgr = SimpleNamespace(enabled=False)
+    agent._tool_guardrails = SimpleNamespace(
+        before_call=lambda *_args, **_kwargs: SimpleNamespace(allows_execution=True)
+    )
+    agent._touch_activity = lambda *_args, **_kwargs: None
+    agent._apply_pending_steer_to_tool_results = lambda *_args, **_kwargs: None
+    agent._append_guardrail_observation = lambda _name, _args, result, failed=False: result
+    agent._record_file_mutation_result = lambda *_args, **_kwargs: None
+    agent._should_emit_quiet_tool_messages = lambda: False
+    agent._should_start_quiet_spinner = lambda: False
+    return agent
+
+
+def test_parse_tool_call_arguments_accepts_valid_json_object():
+    args, error = _parse_tool_call_arguments_for_execution(
+        '{"path": "README.md"}',
+        "read_file",
+    )
+
+    assert error is None
+    assert args == {"path": "README.md"}
+
+
+def test_parse_tool_call_arguments_rejects_malformed_json():
+    args, error = _parse_tool_call_arguments_for_execution(
+        '{"path": "README.md"',
+        "read_file",
+    )
+
+    assert args == {}
+    payload = json.loads(error)
+    assert payload["success"] is False
+    assert "Malformed tool call arguments for 'read_file'" in payload["error"]
+    assert "Tool was not executed" in payload["error"]
+
+
+def test_parse_tool_call_arguments_rejects_non_object_json():
+    args, error = _parse_tool_call_arguments_for_execution(
+        '["README.md"]',
+        "read_file",
+    )
+
+    assert args == {}
+    payload = json.loads(error)
+    assert "expected a JSON object, got list" in payload["error"]
+
+
+def test_sequential_tool_call_with_malformed_arguments_fails_closed(monkeypatch):
+    agent = _agent_for_tool_execution()
+    messages = []
+
+    def _should_not_execute(*_args, **_kwargs):
+        raise AssertionError("malformed tool call arguments must not execute tools")
+
+    monkeypatch.setattr("run_agent.handle_function_call", _should_not_execute)
+
+    agent._execute_tool_calls_sequential(
+        _assistant_message(_tool_call(arguments='{"path": "README.md"')),
+        messages,
+        effective_task_id="task-1",
+    )
+
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["name"] == "read_file"
+    assert messages[0]["tool_call_id"] == "call_1"
+    payload = json.loads(messages[0]["content"])
+    assert payload["success"] is False
+    assert "Malformed tool call arguments" in payload["error"]
+
+
+def test_concurrent_tool_call_with_malformed_arguments_fails_closed(monkeypatch):
+    agent = _agent_for_tool_execution()
+    messages = []
+
+    def _should_not_execute(*_args, **_kwargs):
+        raise AssertionError("malformed tool call arguments must not execute tools")
+
+    monkeypatch.setattr("run_agent.handle_function_call", _should_not_execute)
+
+    agent._execute_tool_calls_concurrent(
+        _assistant_message(_tool_call(arguments='{"path": "README.md"')),
+        messages,
+        effective_task_id="task-1",
+    )
+
+    payload = json.loads(messages[0]["content"])
+    assert payload["success"] is False
+    assert "Malformed tool call arguments" in payload["error"]
+
+
+def test_sequential_tool_call_with_valid_arguments_still_executes(monkeypatch):
+    agent = _agent_for_tool_execution()
+    messages = []
+
+    def _execute(name, args, *_pos, **_kwargs):
+        assert name == "read_file"
+        assert args == {"path": "README.md"}
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr("run_agent.handle_function_call", _execute)
+
+    agent._execute_tool_calls_sequential(
+        _assistant_message(_tool_call(arguments='{"path": "README.md"}')),
+        messages,
+        effective_task_id="task-1",
+    )
+
+    assert json.loads(messages[0]["content"]) == {"ok": True}


### PR DESCRIPTION
## Summary
- reject malformed or non-object tool-call argument payloads with a deterministic JSON error
- skip plugin hooks, guardrails, checkpoints, callbacks, and real execution for rejected calls
- cover malformed sequential/concurrent execution paths and preserve valid argument execution

## Validation
- `./scripts/run_tests.sh tests/run_agent/test_tool_call_argument_boundary.py tests/run_agent/test_dict_tool_call_args.py -q` (via temporary worktree `.venv` symlink to the main checkout venv): 7 passed, 1 existing SyntaxWarning in `cli.py`
- `git diff --check`: passed
- `./scripts/check.sh`: blocked, script is not present in this checkout

## Residual Risk
- Providers that emit scalar/list tool-call arguments now receive a fail-closed tool error instead of accidental empty-arg execution; this is intentional but may expose upstream adapter/model formatting bugs sooner.