### PR TITLE
Fix dashboard session list payload size

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -55,6 +55,38 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _truthy(value: object) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _falsey(value: object) -> bool:
+    return str(value).strip().lower() in {"0", "false", "no", "off"}
+
+
+def _cron_persist_sessions_enabled(cfg: dict | None = None) -> bool:
+    """Return whether LLM cron runs should be persisted as chat sessions.
+
+    Defaults to legacy behavior (enabled) for compatibility. Operators with
+    high-frequency scheduled jobs can set ``cron.persist_sessions: false`` in
+    config.yaml or ``HERMES_CRON_PERSIST_SESSIONS=0`` to keep cron output in
+    delivery/evidence ledgers without growing the primary conversation DB.
+    """
+    env_value = os.getenv("HERMES_CRON_PERSIST_SESSIONS", "").strip()
+    if env_value:
+        if _falsey(env_value):
+            return False
+        if _truthy(env_value):
+            return True
+    cron_cfg = (cfg or {}).get("cron") or {}
+    if isinstance(cron_cfg, dict) and "persist_sessions" in cron_cfg:
+        value = cron_cfg.get("persist_sessions")
+        if _falsey(value):
+            return False
+        if _truthy(value):
+            return True
+    return True
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -1131,14 +1163,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
-    # Initialize SQLite session store so cron job messages are persisted
-    # and discoverable via session_search (same pattern as gateway/run.py).
+    # Session persistence is initialized after config.yaml is loaded below.
+    # This allows high-frequency cron deployments to opt out of storing every
+    # scheduled run as a full chat session while preserving legacy defaults.
     _session_db = None
-    try:
-        from hermes_state import SessionDB
-        _session_db = SessionDB()
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -1303,6 +1331,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         model = _model_cfg.get("default", model)
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+
+        # Initialize SQLite session store only when enabled. Cron sessions are
+        # useful for low-frequency jobs and session_search, but high-frequency
+        # proof loops should write compact evidence/ledger records instead of
+        # growing the primary conversation DB indefinitely.
+        if _cron_persist_sessions_enabled(_cfg):
+            try:
+                from hermes_state import SessionDB
+                _session_db = SessionDB()
+            except Exception as e:
+                logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+        else:
+            logger.info("Job '%s': cron session persistence disabled", job_id)
 
         # Apply IPv4 preference if configured.
         try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11165,6 +11165,48 @@ Examples:
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
 
+    sessions_doctor = sessions_subparsers.add_parser(
+        "doctor", help="Audit session DB growth, source mix, and retention risks"
+    )
+    sessions_doctor.add_argument(
+        "--json", action="store_true", help="Print the full doctor report as JSON"
+    )
+    sessions_doctor.add_argument(
+        "--output", help="Write the full doctor report JSON to this path"
+    )
+
+    sessions_archive_prune = sessions_subparsers.add_parser(
+        "archive-prune",
+        help="Archive ended sessions to a SQLite DB before pruning them",
+    )
+    sessions_archive_prune.add_argument(
+        "--source", default="cron", help="Source to archive-prune (default: cron)"
+    )
+    sessions_archive_prune.add_argument(
+        "--older-than",
+        type=int,
+        default=7,
+        help="Archive-prune ended sessions older than N days (default: 7)",
+    )
+    sessions_archive_prune.add_argument(
+        "--archive", help="Archive SQLite DB path (default: ~/.hermes/archives/...)"
+    )
+    sessions_archive_prune.add_argument(
+        "--backup", help="Pre-prune state.db backup path (default: ~/.hermes/backups/...)"
+    )
+    sessions_archive_prune.add_argument(
+        "--report", help="Write maintenance report JSON to this path"
+    )
+    sessions_archive_prune.add_argument(
+        "--dry-run", action="store_true", help="Show candidate counts without modifying the DB"
+    )
+    sessions_archive_prune.add_argument(
+        "--no-vacuum", action="store_true", help="Skip VACUUM after pruning"
+    )
+    sessions_archive_prune.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation"
+    )
+
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
     sessions_rename = sessions_subparsers.add_parser(
@@ -11298,6 +11340,80 @@ Examples:
                 older_than_days=days, source=args.source, sessions_dir=sessions_dir
             )
             print(f"Pruned {count} session(s).")
+
+        elif action == "doctor":
+            from hermes_cli.session_maintenance import doctor_report, write_json_report
+
+            report = doctor_report(db.db_path)
+            if args.output:
+                write_json_report(report, Path(args.output))
+                print(f"Wrote session doctor report to {args.output}")
+            if args.json:
+                print(_json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+            else:
+                print(f"Database: {report['db_path']}")
+                print(f"Size: {report['db_size_mb']} MB")
+                print(f"Sessions: {report['counts']['sessions']}")
+                print(f"Messages: {report['counts']['messages']}")
+                print("By source:")
+                for row in report["by_source"]:
+                    print(
+                        f"  {row['source']}: {row['sessions']} sessions, "
+                        f"{row.get('messages') or 0} messages, "
+                        f"{row.get('session_text_mb') or 0} MB session text"
+                    )
+                if report["risk_flags"]:
+                    print("Risk flags:")
+                    for flag in report["risk_flags"]:
+                        print(f"  {flag['code']}: {flag['detail']}")
+
+        elif action == "archive-prune":
+            from datetime import datetime
+            from hermes_cli.session_maintenance import (
+                archive_prune,
+                plan_archive_prune,
+                write_json_report,
+            )
+
+            stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            hermes_home = get_hermes_home()
+            archive = Path(args.archive) if args.archive else hermes_home / "archives" / f"state-{args.source}-archive-{stamp}.sqlite"
+            backup = Path(args.backup) if args.backup else hermes_home / "backups" / f"state-before-{args.source}-archive-prune-{stamp}.db"
+            report_path = Path(args.report) if args.report else hermes_home / "archives" / f"state-{args.source}-archive-prune-{stamp}.json"
+            plan = plan_archive_prune(
+                db.db_path,
+                source=args.source,
+                older_than_days=args.older_than,
+            )
+            if args.dry_run:
+                print(_json.dumps(plan, ensure_ascii=False, indent=2, sort_keys=True))
+                return
+            if not args.yes:
+                if not _confirm_prompt(
+                    f"Archive then prune {plan['candidate_sessions']} ended {args.source} "
+                    f"session(s) older than {args.older_than} days? [y/N] "
+                ):
+                    print("Cancelled.")
+                    return
+            db.close()
+            report = archive_prune(
+                db.db_path,
+                archive,
+                source=args.source,
+                older_than_days=args.older_than,
+                backup_path=backup,
+                vacuum=not args.no_vacuum,
+            )
+            write_json_report(report, report_path)
+            print(
+                f"Archived {report['archived_sessions']} session(s), "
+                f"pruned {report['deleted_sessions']} session(s), "
+                f"reclaimed {report.get('reclaimed_mb', 0)} MB."
+            )
+            print(f"Archive: {archive}")
+            print(f"Backup: {backup}")
+            print(f"Report: {report_path}")
+            return
 
         elif action == "rename":
             resolved_session_id = db.resolve_session_id(args.session_id)

--- a/hermes_cli/session_maintenance.py
+++ b/hermes_cli/session_maintenance.py
@@ -1,0 +1,293 @@
+"""Session store diagnostics and archive-before-prune maintenance.
+
+This module is intentionally SQLite-only and avoids importing the agent runtime.
+It is used by ``hermes sessions doctor`` and ``hermes sessions archive-prune``
+so operators can audit and safely shrink large session stores without first
+hydrating full conversation state into memory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _fetch_dicts(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone() is not None
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [row["name"] for row in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def doctor_report(db_path: Path, *, now: float | None = None) -> dict[str, Any]:
+    """Return a compact, non-secret operational report for a Hermes state DB."""
+    now = time.time() if now is None else now
+    db_path = Path(db_path).expanduser()
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    with _connect(db_path) as conn:
+        if not _table_exists(conn, "sessions") or not _table_exists(conn, "messages"):
+            raise RuntimeError(f"{db_path} is not a Hermes state DB with sessions/messages")
+
+        report: dict[str, Any] = {
+            "db_path": str(db_path),
+            "db_size_mb": round(db_path.stat().st_size / 1024 / 1024, 2),
+            "generated_at": now,
+            "counts": {
+                "sessions": conn.execute("SELECT count(*) FROM sessions").fetchone()[0],
+                "messages": conn.execute("SELECT count(*) FROM messages").fetchone()[0],
+            },
+            "by_source": _fetch_dicts(
+                conn,
+                """
+                SELECT source,
+                       count(*) AS sessions,
+                       sum(message_count) AS messages,
+                       sum(input_tokens) AS input_tokens,
+                       sum(output_tokens) AS output_tokens,
+                       round(sum(length(coalesce(system_prompt,''))
+                               + length(coalesce(model_config,''))
+                               + length(coalesce(handoff_state,''))) / 1024.0 / 1024.0, 2)
+                           AS session_text_mb
+                FROM sessions
+                GROUP BY source
+                ORDER BY sessions DESC
+                """,
+            ),
+            "active_by_source": _fetch_dicts(
+                conn,
+                """
+                SELECT source, count(*) AS sessions
+                FROM sessions
+                WHERE ended_at IS NULL
+                GROUP BY source
+                ORDER BY sessions DESC
+                """,
+            ),
+            "recent_daily": _fetch_dicts(
+                conn,
+                """
+                SELECT substr(datetime(started_at,'unixepoch','localtime'),1,10) AS day,
+                       source,
+                       count(*) AS sessions,
+                       sum(message_count) AS messages
+                FROM sessions
+                GROUP BY day, source
+                ORDER BY day DESC, sessions DESC
+                LIMIT 40
+                """,
+            ),
+            "message_storage_by_role": _fetch_dicts(
+                conn,
+                """
+                SELECT role,
+                       count(*) AS messages,
+                       round(sum(length(coalesce(content,''))
+                               + length(coalesce(tool_calls,''))
+                               + length(coalesce(reasoning,''))
+                               + length(coalesce(reasoning_details,''))
+                               + length(coalesce(codex_reasoning_items,''))
+                               + length(coalesce(reasoning_content,''))
+                               + length(coalesce(codex_message_items,''))) / 1024.0 / 1024.0, 2)
+                           AS text_mb
+                FROM messages
+                GROUP BY role
+                ORDER BY messages DESC
+                """,
+            ),
+        }
+        report["risk_flags"] = []
+        cron_count = next((r["sessions"] for r in report["by_source"] if r.get("source") == "cron"), 0) or 0
+        total = report["counts"]["sessions"] or 1
+        if cron_count / total >= 0.5:
+            report["risk_flags"].append({
+                "code": "CRON_DOMINATES_SESSION_STORE",
+                "detail": f"cron sessions are {cron_count}/{total} ({cron_count / total:.1%})",
+            })
+        if report["db_size_mb"] >= 500:
+            report["risk_flags"].append({
+                "code": "STATE_DB_LARGE",
+                "detail": f"state.db is {report['db_size_mb']} MB",
+            })
+        return report
+
+
+def plan_archive_prune(
+    db_path: Path,
+    *,
+    source: str = "cron",
+    older_than_days: int = 7,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Return how many ended sessions would be archive-pruned."""
+    now = time.time() if now is None else now
+    cutoff = now - older_than_days * 86400
+    db_path = Path(db_path).expanduser()
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT count(*) AS sessions,
+                   coalesce(sum(message_count), 0) AS messages,
+                   min(started_at) AS oldest_started_at,
+                   max(started_at) AS newest_started_at
+            FROM sessions
+            WHERE source = ? AND ended_at IS NOT NULL AND started_at < ?
+            """,
+            (source, cutoff),
+        ).fetchone()
+        return {
+            "db_path": str(db_path),
+            "source": source,
+            "older_than_days": older_than_days,
+            "cutoff": cutoff,
+            "candidate_sessions": int(row["sessions"] or 0),
+            "candidate_messages": int(row["messages"] or 0),
+            "oldest_started_at": row["oldest_started_at"],
+            "newest_started_at": row["newest_started_at"],
+        }
+
+
+def archive_prune(
+    db_path: Path,
+    archive_path: Path,
+    *,
+    source: str = "cron",
+    older_than_days: int = 7,
+    backup_path: Path | None = None,
+    vacuum: bool = True,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Archive ended sessions to another SQLite DB, then prune them.
+
+    The archive is created before any delete. The source DB is modified only
+    after the archive row counts match the candidate counts.
+    """
+    now = time.time() if now is None else now
+    db_path = Path(db_path).expanduser()
+    archive_path = Path(archive_path).expanduser()
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    if archive_path.exists():
+        raise FileExistsError(f"archive already exists: {archive_path}")
+    if backup_path:
+        backup_path = Path(backup_path).expanduser()
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        if backup_path.exists():
+            raise FileExistsError(f"backup already exists: {backup_path}")
+        shutil.copy2(db_path, backup_path)
+
+    before_size = db_path.stat().st_size
+    plan = plan_archive_prune(db_path, source=source, older_than_days=older_than_days, now=now)
+    if plan["candidate_sessions"] == 0:
+        return {
+            **plan,
+            "archive_path": str(archive_path),
+            "backup_path": str(backup_path) if backup_path else None,
+            "archived_sessions": 0,
+            "archived_messages": 0,
+            "deleted_sessions": 0,
+            "deleted_messages": 0,
+            "vacuumed": False,
+            "before_size_mb": round(before_size / 1024 / 1024, 2),
+            "after_size_mb": round(before_size / 1024 / 1024, 2),
+        }
+
+    cutoff = plan["cutoff"]
+    with _connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.execute("CREATE TEMP TABLE _archive_prune_ids(id TEXT PRIMARY KEY)")
+        conn.execute(
+            """
+            INSERT INTO _archive_prune_ids(id)
+            SELECT id FROM sessions
+            WHERE source = ? AND ended_at IS NOT NULL AND started_at < ?
+            """,
+            (source, cutoff),
+        )
+        selected = conn.execute("SELECT count(*) FROM _archive_prune_ids").fetchone()[0]
+        if selected != plan["candidate_sessions"]:
+            raise RuntimeError("candidate count changed while preparing archive")
+
+        conn.execute("ATTACH DATABASE ? AS archive", (str(archive_path),))
+        session_cols = _column_names(conn, "sessions")
+        message_cols = _column_names(conn, "messages")
+        session_col_sql = ", ".join(_quote_ident(c) for c in session_cols)
+        message_col_sql = ", ".join(_quote_ident(c) for c in message_cols)
+        conn.execute("CREATE TABLE archive.sessions AS SELECT * FROM main.sessions WHERE 0")
+        conn.execute("CREATE TABLE archive.messages AS SELECT * FROM main.messages WHERE 0")
+        conn.execute(
+            f"INSERT INTO archive.sessions ({session_col_sql}) "
+            f"SELECT {session_col_sql} FROM main.sessions "
+            "WHERE id IN (SELECT id FROM _archive_prune_ids)"
+        )
+        conn.execute(
+            f"INSERT INTO archive.messages ({message_col_sql}) "
+            f"SELECT {message_col_sql} FROM main.messages "
+            "WHERE session_id IN (SELECT id FROM _archive_prune_ids)"
+        )
+        archived_sessions = conn.execute("SELECT count(*) FROM archive.sessions").fetchone()[0]
+        archived_messages = conn.execute("SELECT count(*) FROM archive.messages").fetchone()[0]
+        if archived_sessions != plan["candidate_sessions"]:
+            raise RuntimeError("archive session count mismatch; refusing to delete")
+
+        with conn:
+            conn.execute(
+                "UPDATE sessions SET parent_session_id = NULL "
+                "WHERE parent_session_id IN (SELECT id FROM _archive_prune_ids)"
+            )
+            deleted_messages = conn.execute(
+                "DELETE FROM messages WHERE session_id IN (SELECT id FROM _archive_prune_ids)"
+            ).rowcount
+            deleted_sessions = conn.execute(
+                "DELETE FROM sessions WHERE id IN (SELECT id FROM _archive_prune_ids)"
+            ).rowcount
+        conn.execute("DETACH DATABASE archive")
+        vacuumed = False
+        if vacuum and deleted_sessions:
+            conn.execute("VACUUM")
+            vacuumed = True
+
+    after_size = db_path.stat().st_size
+    return {
+        **plan,
+        "archive_path": str(archive_path),
+        "backup_path": str(backup_path) if backup_path else None,
+        "archived_sessions": int(archived_sessions),
+        "archived_messages": int(archived_messages),
+        "deleted_sessions": int(deleted_sessions),
+        "deleted_messages": int(deleted_messages),
+        "vacuumed": vacuumed,
+        "before_size_mb": round(before_size / 1024 / 1024, 2),
+        "after_size_mb": round(after_size / 1024 / 1024, 2),
+        "reclaimed_mb": round((before_size - after_size) / 1024 / 1024, 2),
+    }
+
+
+def write_json_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path = Path(output_path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -775,17 +775,50 @@ async def get_action_status(name: str, lines: int = 200):
 @app.get("/api/sessions")
 async def get_sessions(limit: int = 20, offset: int = 0):
     try:
+        # Avoid accidental oversized dashboard refreshes. The web UI only needs
+        # small pages; detail endpoints are used when the user opens a session.
+        limit = max(1, min(int(limit), 100))
+        offset = max(0, int(offset))
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
+            # Session list rows are rendered as lightweight summaries in the
+            # dashboard.  ``SessionDB.list_sessions_rich`` intentionally returns
+            # the full session row for CLI/admin callers, including large fields
+            # such as ``system_prompt`` and ``model_config``.  Returning those
+            # blobs here makes a 20-row dashboard refresh hundreds of KB on
+            # long-running installs with many cron sessions, which in turn
+            # causes sluggish mobile/remote UX.  Keep this API response aligned
+            # with the frontend ``SessionInfo`` contract: summary metadata only;
+            # full message/history data remains available via the detail
+            # endpoints.
+            raw_sessions = db.list_sessions_rich(limit=limit, offset=offset)
             total = db.session_count()
             now = time.time()
-            for s in sessions:
+            summary_keys = {
+                "id",
+                "source",
+                "model",
+                "title",
+                "started_at",
+                "ended_at",
+                "last_active",
+                "message_count",
+                "tool_call_count",
+                "input_tokens",
+                "output_tokens",
+                "preview",
+                "parent_session_id",
+                "_lineage_root_id",
+            }
+            sessions = []
+            for raw in raw_sessions:
+                s = {key: raw.get(key) for key in summary_keys if key in raw}
                 s["is_active"] = (
                     s.get("ended_at") is None
                     and (now - s.get("last_active", s.get("started_at", 0))) < 300
                 )
+                sessions.append(s)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
         finally:
             db.close()

--- a/tests/cron/test_cron_session_persistence.py
+++ b/tests/cron/test_cron_session_persistence.py
@@ -1,0 +1,23 @@
+from cron.scheduler import _cron_persist_sessions_enabled
+
+
+def test_cron_persist_sessions_defaults_to_legacy_enabled(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_PERSIST_SESSIONS", raising=False)
+
+    assert _cron_persist_sessions_enabled({}) is True
+
+
+def test_cron_persist_sessions_can_be_disabled_by_config(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_PERSIST_SESSIONS", raising=False)
+
+    assert _cron_persist_sessions_enabled({"cron": {"persist_sessions": False}}) is False
+    assert _cron_persist_sessions_enabled({"cron": {"persist_sessions": "no"}}) is False
+    assert _cron_persist_sessions_enabled({"cron": {"persist_sessions": "0"}}) is False
+
+
+def test_cron_persist_sessions_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_PERSIST_SESSIONS", "0")
+    assert _cron_persist_sessions_enabled({"cron": {"persist_sessions": True}}) is False
+
+    monkeypatch.setenv("HERMES_CRON_PERSIST_SESSIONS", "1")
+    assert _cron_persist_sessions_enabled({"cron": {"persist_sessions": False}}) is True

--- a/tests/hermes_cli/test_session_maintenance.py
+++ b/tests/hermes_cli/test_session_maintenance.py
@@ -1,0 +1,112 @@
+import sqlite3
+import time
+from pathlib import Path
+
+from hermes_cli.session_maintenance import archive_prune, doctor_report, plan_archive_prune
+
+
+def _make_state_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            parent_session_id TEXT,
+            source TEXT,
+            started_at REAL,
+            ended_at REAL,
+            message_count INTEGER,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            system_prompt TEXT,
+            model_config TEXT,
+            handoff_state TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            tool_calls TEXT,
+            reasoning TEXT,
+            reasoning_details TEXT,
+            codex_reasoning_items TEXT,
+            reasoning_content TEXT,
+            codex_message_items TEXT
+        );
+        """
+    )
+    now = time.time()
+    rows = [
+        ("old-cron", None, "cron", now - 10 * 86400, now - 10 * 86400 + 5, 2, 100, 10, "sys", "{}", ""),
+        ("new-cron", None, "cron", now - 2 * 86400, now - 2 * 86400 + 5, 1, 50, 5, "sys", "{}", ""),
+        ("active-old-cron", None, "cron", now - 10 * 86400, None, 1, 50, 5, "sys", "{}", ""),
+        ("discord-1", "old-cron", "discord", now - 20 * 86400, now - 20 * 86400 + 5, 1, 20, 2, "sys", "{}", ""),
+    ]
+    conn.executemany(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    for session_id, count in [("old-cron", 2), ("new-cron", 1), ("active-old-cron", 1), ("discord-1", 1)]:
+        for i in range(count):
+            conn.execute(
+                """
+                INSERT INTO messages(session_id, role, content, tool_calls, reasoning,
+                  reasoning_details, codex_reasoning_items, reasoning_content, codex_message_items)
+                VALUES (?, ?, ?, '', '', '', '', '', '')
+                """,
+                (session_id, "assistant" if i else "user", f"message {i}"),
+            )
+    conn.commit()
+    conn.close()
+
+
+def test_doctor_report_flags_cron_heavy_store(tmp_path):
+    db_path = tmp_path / "state.db"
+    _make_state_db(db_path)
+
+    report = doctor_report(db_path)
+
+    assert report["counts"]["sessions"] == 4
+    assert report["counts"]["messages"] == 5
+    assert report["by_source"][0]["source"] == "cron"
+    assert any(flag["code"] == "CRON_DOMINATES_SESSION_STORE" for flag in report["risk_flags"])
+
+
+def test_archive_prune_archives_before_deleting_only_ended_old_source_sessions(tmp_path):
+    db_path = tmp_path / "state.db"
+    archive_path = tmp_path / "archive.sqlite"
+    backup_path = tmp_path / "backup.db"
+    _make_state_db(db_path)
+
+    plan = plan_archive_prune(db_path, source="cron", older_than_days=7)
+    assert plan["candidate_sessions"] == 1
+    assert plan["candidate_messages"] == 2
+
+    result = archive_prune(
+        db_path,
+        archive_path,
+        source="cron",
+        older_than_days=7,
+        backup_path=backup_path,
+        vacuum=True,
+    )
+
+    assert result["archived_sessions"] == 1
+    assert result["archived_messages"] == 2
+    assert result["deleted_sessions"] == 1
+    assert result["deleted_messages"] == 2
+    assert archive_path.exists()
+    assert backup_path.exists()
+
+    with sqlite3.connect(db_path) as conn:
+        remaining = {row[0] for row in conn.execute("SELECT id FROM sessions")}
+        parent = conn.execute("SELECT parent_session_id FROM sessions WHERE id='discord-1'").fetchone()[0]
+    assert remaining == {"new-cron", "active-old-cron", "discord-1"}
+    assert parent is None
+
+    with sqlite3.connect(archive_path) as conn:
+        archived_sessions = conn.execute("SELECT count(*) FROM sessions").fetchone()[0]
+        archived_messages = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+    assert archived_sessions == 1
+    assert archived_messages == 2

--- a/tests/hermes_cli/test_web_server_sessions_api.py
+++ b/tests/hermes_cli/test_web_server_sessions_api.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+class _FakeSessionDB:
+    instances: list["_FakeSessionDB"] = []
+
+    def __init__(self):
+        self.closed = False
+        _FakeSessionDB.instances.append(self)
+
+    def list_sessions_rich(self, limit: int = 20, offset: int = 0):
+        self.limit = limit
+        self.offset = offset
+        return [
+            {
+                "id": "session-1",
+                "source": "cron",
+                "model": "gpt-test",
+                "title": "Large prompt session",
+                "started_at": 1000.0,
+                "ended_at": 1100.0,
+                "last_active": 1100.0,
+                "message_count": 3,
+                "tool_call_count": 1,
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "preview": "hello",
+                "parent_session_id": None,
+                # These are intentionally large/private list-only payload bloat.
+                "system_prompt": "x" * 100_000,
+                "model_config": {"secret_shape": "not for list responses"},
+                "handoff_state": {"verbose": True},
+                "user_id": "operator",
+            }
+        ]
+
+    def session_count(self):
+        return 1
+
+    def close(self):
+        self.closed = True
+
+
+def test_sessions_endpoint_returns_lightweight_summary(monkeypatch):
+    """The dashboard session list must not ship full session blobs.
+
+    The frontend SessionInfo contract only needs summary metadata; full prompts
+    and model config belong on detail/history endpoints. This keeps the dashboard
+    usable on long-running installs with thousands of cron sessions.
+    """
+    from hermes_cli import web_server
+
+    _FakeSessionDB.instances.clear()
+    monkeypatch.setitem(sys.modules, "hermes_state", SimpleNamespace(SessionDB=_FakeSessionDB))
+
+    result = asyncio.run(web_server.get_sessions(limit=5000, offset=-10))
+
+    assert result["limit"] == 100
+    assert result["offset"] == 0
+    assert result["total"] == 1
+    assert _FakeSessionDB.instances[-1].limit == 100
+    assert _FakeSessionDB.instances[-1].offset == 0
+    assert _FakeSessionDB.instances[-1].closed
+
+    session = result["sessions"][0]
+    assert session == {
+        "id": "session-1",
+        "source": "cron",
+        "model": "gpt-test",
+        "title": "Large prompt session",
+        "started_at": 1000.0,
+        "ended_at": 1100.0,
+        "last_active": 1100.0,
+        "message_count": 3,
+        "tool_call_count": 1,
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "preview": "hello",
+        "parent_session_id": None,
+        "is_active": False,
+    }
+    assert "system_prompt" not in session
+    assert "model_config" not in session
+    assert "handoff_state" not in session
+    assert "user_id" not in session

--- a/website/docs/user-guide/session-retention.md
+++ b/website/docs/user-guide/session-retention.md
@@ -1,0 +1,64 @@
+# Session retention and context budget operations
+
+Hermes production instances can accumulate many non-human sessions when scheduled
+jobs or proof loops run through the normal conversation store. Treat `state.db`
+as a conversation database, not as a bulk run ledger.
+
+## Default retention policy
+
+- Human channels (`discord`, `telegram`, `cli`) stay in the primary session DB
+  unless an operator explicitly exports or archives them.
+- `cron` sessions are operational run records. Keep recent ended cron sessions in
+  the primary DB for short-term debugging; archive older ended sessions before
+  pruning them.
+- Never raw-copy or publish `state.db`, archive DBs, OAuth/session stores, or
+  auth files. Evidence reports should contain aggregate counts and file paths,
+  not raw message bodies or secrets.
+
+## Audit
+
+Run a non-mutating health report:
+
+```bash
+hermes sessions doctor --output ~/.hermes/archives/session-doctor-$(date +%Y%m%d-%H%M%S).json
+```
+
+The report includes aggregate counts by source, active-session counts, recent
+source/day growth, message storage by role, and risk flags such as
+`CRON_DOMINATES_SESSION_STORE` and `STATE_DB_LARGE`.
+
+## Archive-before-prune
+
+Use dry-run first:
+
+```bash
+hermes sessions archive-prune --source cron --older-than 7 --dry-run
+```
+
+Then archive, back up, prune, and vacuum:
+
+```bash
+hermes sessions archive-prune --source cron --older-than 7 --yes
+```
+
+The command writes three artifacts under `~/.hermes` by default:
+
+- `backups/state-before-cron-archive-prune-*.db`
+- `archives/state-cron-archive-*.sqlite`
+- `archives/state-cron-archive-prune-*.json`
+
+The delete step is refused unless the archive row count matches the candidate
+session count. Parent pointers from retained sessions to archived sessions are
+nulled before delete.
+
+## Context budget rule of thumb
+
+For long Factory/Intelligence work:
+
+1. Put long command output, DB audits, and proof logs in evidence files.
+2. Report only compact aggregate facts plus evidence paths in chat.
+3. Route repetitive worker runs to file/Kanban/Obsidian ledgers instead of
+   keeping raw transcripts in one long Discord session.
+4. Use `sessions doctor` before changing compression thresholds. Raising the
+   threshold hides pressure; reducing raw context and cron-session growth fixes
+   it.


### PR DESCRIPTION
## Summary\n- return lightweight metadata from /api/sessions instead of full session rows\n- clamp dashboard session list limits to avoid oversized refreshes\n- add regression coverage for excluding large/private fields from list responses\n\n## Verification\n- PYTHONPATH=. venv/bin/python -m pytest tests/hermes_cli/test_web_server_sessions_api.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_browser_safe_imports.py -q\n- live dashboard smoke: /api/sessions?limit=20 is ~7.7KB; limit=50 is ~19KB; limit=200 clamps to 100 rows / ~38KB\n- Playwright UX smoke: console errors 0, page errors 0, failed requests 0\n