### PR TITLE
fix(tui): steady scrollbar after transcript shrink

### DIFF
--- a/ui-tui/src/__tests__/viewportStore.test.ts
+++ b/ui-tui/src/__tests__/viewportStore.test.ts
@@ -82,4 +82,22 @@ describe('viewportStore', () => {
 
     expect(getScrollbarSnapshot(handle as any).top).toBe(10)
   })
+
+  it('uses fresh scroll height to clear stale scrollbar non-bottom state after shrink', () => {
+    const handle = {
+      getFreshScrollHeight: () => 40,
+      getScrollHeight: () => 60,
+      getScrollTop: () => 20,
+      getViewportHeight: () => 20
+    }
+
+    const snap = getScrollbarSnapshot(handle as any)
+
+    expect(snap).toEqual({
+      scrollHeight: 40,
+      top: 20,
+      viewportHeight: 20
+    })
+    expect(scrollbarSnapshotKey(snap)).toBe('20:20:40')
+  })
 })

--- a/ui-tui/src/lib/viewportStore.ts
+++ b/ui-tui/src/lib/viewportStore.ts
@@ -70,12 +70,24 @@ export function getScrollbarSnapshot(s?: ScrollBoxHandle | null): ScrollbarSnaps
   }
 
   const viewportHeight = Math.max(0, s.getViewportHeight())
-  const scrollHeight = Math.max(viewportHeight, s.getScrollHeight())
-  const maxTop = Math.max(0, scrollHeight - viewportHeight)
+  const top = Math.max(0, s.getScrollTop())
+  const cachedScrollHeight = Math.max(viewportHeight, s.getScrollHeight())
+  let scrollHeight = cachedScrollHeight
+  let maxTop = Math.max(0, scrollHeight - viewportHeight)
+
+  if (top < maxTop) {
+    const freshScrollHeight = Math.max(viewportHeight, s.getFreshScrollHeight?.() ?? cachedScrollHeight)
+    const freshMaxTop = Math.max(0, freshScrollHeight - viewportHeight)
+
+    if (top >= freshMaxTop) {
+      scrollHeight = freshScrollHeight
+      maxTop = freshMaxTop
+    }
+  }
 
   return {
     scrollHeight,
-    top: Math.max(0, Math.min(maxTop, s.getScrollTop())),
+    top: Math.max(0, Math.min(maxTop, top)),
     viewportHeight
   }
 }


### PR DESCRIPTION
## Summary
- teach `getScrollbarSnapshot()` to fall back to fresh scroll height when the cached height is one frame stale after transcript shrink
- keep the committed scrollbar thumb pinned to the real bottom instead of briefly rendering a false mid-track state during wrap/resize shrink
- add a targeted regression test for the stale-shrink path

## Testing
- `npm test -- src/__tests__/viewportStore.test.ts src/__tests__/virtualHistoryOffsetCache.test.ts`
- `npx eslint src/lib/viewportStore.ts src/__tests__/viewportStore.test.ts`
- `git diff --check`

Refs #24137.
