### PR TITLE
fix(ollama): skip local num_ctx probe for explicit chat completions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1271,7 +1271,14 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+        self._api_mode_was_explicit = api_mode in {
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+            "bedrock_converse",
+            "codex_app_server",
+        }
+        if self._api_mode_was_explicit:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
@@ -2428,7 +2435,14 @@ class AIAgent:
                 self._ollama_num_ctx = int(_ollama_num_ctx_override)
             except (TypeError, ValueError):
                 logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-        if self._ollama_num_ctx is None and self.base_url and is_local_endpoint(self.base_url):
+        should_probe_ollama_num_ctx = (
+            self._ollama_num_ctx is None
+            and self.base_url
+            and is_local_endpoint(self.base_url)
+            and self.api_mode == "chat_completions"
+            and (not self._api_mode_was_explicit or self.provider == "ollama")
+        )
+        if should_probe_ollama_num_ctx:
             try:
                 _detected = query_ollama_num_ctx(self.model, self.base_url, api_key=self.api_key or "")
                 if _detected and _detected > 0:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -193,6 +193,70 @@ class TestProviderModelNormalization:
         assert agent.model == "anthropic/claude-sonnet-4.6"
 
 
+class TestOllamaNumCtxAutodetect:
+    def test_explicit_chat_completions_skips_local_ollama_probe(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.query_ollama_num_ctx") as probe,
+        ):
+            agent = AIAgent(
+                model="gpt-4o-mini",
+                provider="custom",
+                base_url="http://localhost:4000/v1",
+                api_mode="chat_completions",
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        probe.assert_not_called()
+        assert agent._ollama_num_ctx is None
+
+    def test_auto_chat_completions_still_probes_local_ollama_num_ctx(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.query_ollama_num_ctx", return_value=32768) as probe,
+        ):
+            agent = AIAgent(
+                model="llama3.2",
+                provider="custom",
+                base_url="http://localhost:11434/v1",
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        probe.assert_called_once_with("llama3.2", "http://localhost:11434/v1", api_key="test-key-1234567890")
+        assert agent._ollama_num_ctx == 32768
+
+    def test_explicit_chat_completions_still_probes_for_ollama_provider(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.query_ollama_num_ctx", return_value=65536) as probe,
+        ):
+            agent = AIAgent(
+                model="llama3.2",
+                provider="ollama",
+                base_url="http://localhost:11434/v1",
+                api_mode="chat_completions",
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        probe.assert_called_once_with("llama3.2", "http://localhost:11434/v1", api_key="test-key-1234567890")
+        assert agent._ollama_num_ctx == 65536
+
+
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #25629

## Summary
- remember when `api_mode` was explicitly configured at agent init
- skip local Ollama `num_ctx` auto-probing for explicit `chat_completions` runtimes unless the provider is explicitly `ollama`
- add regression tests covering explicit proxy, auto-detected local Ollama, and explicit Ollama provider paths

## Testing
- `uv run --frozen pytest -o addopts= tests/run_agent/test_run_agent.py -k 'explicit_chat_completions_skips_local_ollama_probe or auto_chat_completions_still_probes_local_ollama_num_ctx or explicit_chat_completions_still_probes_for_ollama_provider'`\n- `uv run --frozen ruff check run_agent.py tests/run_agent/test_run_agent.py`\n- `git diff --check`