### PR TITLE
fix(kanban): diagnose unavailable triage automation

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1265,7 +1265,14 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # of show output so CLI users see them before scrolling through
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
-    diags = kd.compute_task_diagnostics(task, events, runs)
+    try:
+        from hermes_cli.config import read_raw_config
+        diagnostics_config = kd.config_from_runtime_config(read_raw_config())
+    except Exception:
+        diagnostics_config = None
+    diags = kd.compute_task_diagnostics(
+        task, events, runs, config=diagnostics_config,
+    )
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
         print(f"\n  Diagnostics ({len(diags)}):")
@@ -1393,6 +1400,11 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     the dashboard uses, so CLI output matches what the UI shows.
     """
     from hermes_cli import kanban_diagnostics as kd
+    try:
+        from hermes_cli.config import read_raw_config
+        diagnostics_config = kd.config_from_runtime_config(read_raw_config())
+    except Exception:
+        diagnostics_config = None
 
     with kb.connect() as conn:
         # Either one-task mode or fleet mode.
@@ -1406,6 +1418,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                     task,
                     kb.list_events(conn, args.task),
                     kb.list_runs(conn, args.task),
+                    config=diagnostics_config,
                 )
             }
         else:
@@ -1433,7 +1446,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                 diags_by_task = {}
                 for r in rows:
                     tid = r["id"]
-                    dl = kd.compute_task_diagnostics(r, ev_by.get(tid, []), run_by.get(tid, []))
+                    dl = kd.compute_task_diagnostics(
+                        r,
+                        ev_by.get(tid, []),
+                        run_by.get(tid, []),
+                        config=diagnostics_config,
+                    )
                     if dl:
                         diags_by_task[tid] = dl
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -230,6 +230,52 @@ def _generic_recovery_actions(task: Any, *, running: bool) -> list[DiagnosticAct
 RuleFn = Callable[[Any, list[Any], list[Any], int, dict], list[Diagnostic]]
 
 
+def triage_specifier_configured(config: Optional[dict]) -> Optional[bool]:
+    """Return whether config clearly provides a triage specifier backend.
+
+    ``None`` means "unknown" and suppresses the diagnostic. The diagnostics
+    engine is called from tests and low-level helpers that may not have loaded
+    user config; guessing in those paths would create noisy false positives.
+    """
+    if not isinstance(config, dict):
+        return None
+
+    explicit = config.get("triage_specifier_configured")
+    if explicit is not None:
+        return bool(explicit)
+
+    aux = config.get("auxiliary")
+    if isinstance(aux, dict) and "triage_specifier" in aux:
+        spec = aux.get("triage_specifier")
+        if not isinstance(spec, dict):
+            return False
+        provider = str(spec.get("provider") or "").strip().lower()
+        if provider == "auto":
+            return True
+        for key in ("provider", "model", "base_url", "api_key"):
+            if str(spec.get(key) or "").strip():
+                return True
+        return False
+
+    if isinstance(aux, dict):
+        model_cfg = config.get("model")
+        if isinstance(model_cfg, dict):
+            provider = str(model_cfg.get("provider") or "").strip()
+            model = str(
+                model_cfg.get("default")
+                or model_cfg.get("model")
+                or model_cfg.get("name")
+                or ""
+            ).strip()
+            if provider and model:
+                return True
+        elif str(model_cfg or "").strip():
+            return True
+        return False
+
+    return None
+
+
 def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
     """Blocked-hallucination gate fires: a worker called kanban_complete
     with created_cards that didn't exist or weren't created by the
@@ -274,6 +320,58 @@ def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_seen_at=last,
         count=len(hits),
         data={"phantom_ids": phantom_ids},
+    )]
+
+
+def _rule_triage_missing_specifier(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A triage task cannot be auto-specified without a configured helper.
+
+    The dispatcher does not run rough ``triage`` cards directly; they need
+    ``hermes kanban specify`` (or the dashboard button) to flesh the request
+    out and promote it to ``todo``. If the config is missing the specifier
+    backend, those tasks can sit in triage indefinitely with no visible reason.
+    """
+    if _task_field(task, "status") != "triage":
+        return []
+
+    configured = triage_specifier_configured(cfg)
+    if configured is not False:
+        return []
+
+    task_id = _task_field(task, "id") or "<task_id>"
+    actions = [
+        DiagnosticAction(
+            kind="cli_hint",
+            label="Configure auxiliary.triage_specifier",
+            payload={
+                "command": (
+                    "hermes config set auxiliary.triage_specifier.provider auto"
+                )
+            },
+            suggested=True,
+        ),
+        DiagnosticAction(
+            kind="cli_hint",
+            label=f"Specify manually: hermes kanban specify {task_id}",
+            payload={"command": f"hermes kanban specify {task_id}"},
+        ),
+    ]
+    return [Diagnostic(
+        kind="triage_missing_specifier",
+        severity="warning",
+        title="Triage specifier is not configured",
+        detail=(
+            "This task is still in triage, but the current config does not "
+            "define auxiliary.triage_specifier and no main model fallback is "
+            "visible to diagnostics. Triage tasks are not dispatched until "
+            "they are specified and promoted, so configure the specifier or "
+            "run the specify command after fixing model config."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=1,
+        data={"task_id": task_id},
     )]
 
 
@@ -695,6 +793,7 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
     _rule_hallucinated_cards,
+    _rule_triage_missing_specifier,
     _rule_prose_phantom_refs,
     _rule_repeated_failures,
     _rule_repeated_crashes,
@@ -707,6 +806,7 @@ _RULES: list[RuleFn] = [
 # rules are added.
 DIAGNOSTIC_KINDS = (
     "hallucinated_cards",
+    "triage_missing_specifier",
     "prose_phantom_refs",
     "repeated_failures",
     "repeated_crashes",
@@ -716,6 +816,7 @@ DIAGNOSTIC_KINDS = (
 
 
 DEFAULT_CONFIG = {
+    "triage_specifier_configured": None,
     "failure_threshold": 3,
     # Legacy alias accepted at read time by _rule_repeated_failures.
     "spawn_failure_threshold": 3,
@@ -726,6 +827,25 @@ DEFAULT_CONFIG = {
     # next dispatcher tick (default 60s) and would just be noise.
     "stranded_threshold_seconds": 30 * 60,
 }
+
+
+def config_from_runtime_config(raw_config: Optional[dict]) -> dict:
+    """Build diagnostics config from the full Hermes runtime config."""
+    raw_config = raw_config or {}
+    cfg: dict = {}
+    if isinstance(raw_config, dict):
+        kanban_cfg = raw_config.get("kanban")
+        if isinstance(kanban_cfg, dict):
+            builder = globals().get("config_from_kanban_config")
+            if callable(builder):
+                cfg.update(builder(kanban_cfg))
+        aux = raw_config.get("auxiliary")
+        if aux is not None:
+            cfg["auxiliary"] = aux
+        model = raw_config.get("model")
+        if model is not None:
+            cfg["model"] = model
+    return cfg
 
 
 def compute_task_diagnostics(

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -230,8 +230,11 @@ def _generic_recovery_actions(task: Any, *, running: bool) -> list[DiagnosticAct
 RuleFn = Callable[[Any, list[Any], list[Any], int, dict], list[Diagnostic]]
 
 
-def triage_specifier_configured(config: Optional[dict]) -> Optional[bool]:
-    """Return whether config clearly provides a triage specifier backend.
+def _auxiliary_task_configured(
+    config: Optional[dict],
+    task_name: str,
+) -> Optional[bool]:
+    """Return whether config clearly provides an auxiliary backend.
 
     ``None`` means "unknown" and suppresses the diagnostic. The diagnostics
     engine is called from tests and low-level helpers that may not have loaded
@@ -240,13 +243,9 @@ def triage_specifier_configured(config: Optional[dict]) -> Optional[bool]:
     if not isinstance(config, dict):
         return None
 
-    explicit = config.get("triage_specifier_configured")
-    if explicit is not None:
-        return bool(explicit)
-
     aux = config.get("auxiliary")
-    if isinstance(aux, dict) and "triage_specifier" in aux:
-        spec = aux.get("triage_specifier")
+    if isinstance(aux, dict) and task_name in aux:
+        spec = aux.get(task_name)
         if not isinstance(spec, dict):
             return False
         provider = str(spec.get("provider") or "").strip().lower()
@@ -274,6 +273,18 @@ def triage_specifier_configured(config: Optional[dict]) -> Optional[bool]:
         return False
 
     return None
+
+
+def triage_automation_configured(config: Optional[dict]) -> Optional[bool]:
+    """Return whether the active triage automation path has a backend."""
+    if not isinstance(config, dict):
+        return None
+    explicit = config.get("triage_automation_configured")
+    if explicit is not None:
+        return bool(explicit)
+    auto_decompose = bool(config.get("auto_decompose", True))
+    task_name = "kanban_decomposer" if auto_decompose else "triage_specifier"
+    return _auxiliary_task_configured(config, task_name)
 
 
 def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
@@ -323,55 +334,58 @@ def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
-def _rule_triage_missing_specifier(task, events, runs, now, cfg) -> list[Diagnostic]:
-    """A triage task cannot be auto-specified without a configured helper.
+def _rule_triage_automation_unavailable(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A triage task cannot advance without the active automation backend.
 
-    The dispatcher does not run rough ``triage`` cards directly; they need
-    ``hermes kanban specify`` (or the dashboard button) to flesh the request
-    out and promote it to ``todo``. If the config is missing the specifier
-    backend, those tasks can sit in triage indefinitely with no visible reason.
+    With auto-decompose enabled, triage uses ``auxiliary.kanban_decomposer``.
+    In manual mode, the fallback single-task path uses
+    ``auxiliary.triage_specifier``. If the active helper is missing and no
+    main model fallback is visible, triage cards can sit indefinitely.
     """
     if _task_field(task, "status") != "triage":
         return []
 
-    configured = triage_specifier_configured(cfg)
+    configured = triage_automation_configured(cfg)
     if configured is not False:
         return []
 
     task_id = _task_field(task, "id") or "<task_id>"
+    auto_decompose = bool(cfg.get("auto_decompose", True))
+    helper = "kanban_decomposer" if auto_decompose else "triage_specifier"
+    command = "decompose" if auto_decompose else "specify"
     actions = [
         DiagnosticAction(
             kind="cli_hint",
-            label="Configure auxiliary.triage_specifier",
+            label=f"Configure auxiliary.{helper}",
             payload={
                 "command": (
-                    "hermes config set auxiliary.triage_specifier.provider auto"
+                    f"hermes config set auxiliary.{helper}.provider auto"
                 )
             },
             suggested=True,
         ),
         DiagnosticAction(
             kind="cli_hint",
-            label=f"Specify manually: hermes kanban specify {task_id}",
-            payload={"command": f"hermes kanban specify {task_id}"},
+            label=f"Run manually: hermes kanban {command} {task_id}",
+            payload={"command": f"hermes kanban {command} {task_id}"},
         ),
     ]
     return [Diagnostic(
-        kind="triage_missing_specifier",
+        kind="triage_automation_unavailable",
         severity="warning",
-        title="Triage specifier is not configured",
+        title="Triage automation backend is not configured",
         detail=(
             "This task is still in triage, but the current config does not "
-            "define auxiliary.triage_specifier and no main model fallback is "
-            "visible to diagnostics. Triage tasks are not dispatched until "
-            "they are specified and promoted, so configure the specifier or "
-            "run the specify command after fixing model config."
+            f"define auxiliary.{helper} and no main model fallback is visible "
+            "to diagnostics. Triage tasks are not dispatched until they are "
+            "decomposed or specified and promoted, so configure the active "
+            "triage helper or run the command after fixing model config."
         ),
         actions=actions,
         first_seen_at=now,
         last_seen_at=now,
         count=1,
-        data={"task_id": task_id},
+        data={"task_id": task_id, "helper": helper},
     )]
 
 
@@ -793,7 +807,7 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
     _rule_hallucinated_cards,
-    _rule_triage_missing_specifier,
+    _rule_triage_automation_unavailable,
     _rule_prose_phantom_refs,
     _rule_repeated_failures,
     _rule_repeated_crashes,
@@ -806,7 +820,7 @@ _RULES: list[RuleFn] = [
 # rules are added.
 DIAGNOSTIC_KINDS = (
     "hallucinated_cards",
-    "triage_missing_specifier",
+    "triage_automation_unavailable",
     "prose_phantom_refs",
     "repeated_failures",
     "repeated_crashes",
@@ -816,7 +830,7 @@ DIAGNOSTIC_KINDS = (
 
 
 DEFAULT_CONFIG = {
-    "triage_specifier_configured": None,
+    "triage_automation_configured": None,
     "failure_threshold": 3,
     # Legacy alias accepted at read time by _rule_repeated_failures.
     "spawn_failure_threshold": 3,
@@ -839,6 +853,8 @@ def config_from_runtime_config(raw_config: Optional[dict]) -> dict:
             builder = globals().get("config_from_kanban_config")
             if callable(builder):
                 cfg.update(builder(kanban_cfg))
+            if "auto_decompose" in kanban_cfg:
+                cfg["auto_decompose"] = bool(kanban_cfg.get("auto_decompose"))
         aux = raw_config.get("auxiliary")
         if aux is not None:
             cfg["auxiliary"] = aux

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -224,6 +224,11 @@ def _compute_task_diagnostics(
     rule definitions.
     """
     from hermes_cli import kanban_diagnostics as kd
+    try:
+        from hermes_cli.config import read_raw_config
+        diagnostics_config = kd.config_from_runtime_config(read_raw_config())
+    except Exception:
+        diagnostics_config = None
 
     # Build the candidate task list. We need each task's row + its
     # events + its runs. Doing N separate queries works but scales
@@ -270,6 +275,7 @@ def _compute_task_diagnostics(
             r,
             events_by_task.get(tid, []),
             runs_by_task.get(tid, []),
+            config=diagnostics_config,
         )
         if diags:
             out[tid] = [d.to_dict() for d in diags]

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -129,43 +129,76 @@ def test_prose_phantom_refs_clears_on_later_clean_edit():
     assert diags == []
 
 
-def test_triage_missing_specifier_fires_when_config_missing():
+def test_triage_automation_unavailable_fires_when_decomposer_missing():
     task = _task(id="t_triage1", status="triage")
     diags = kd.compute_task_diagnostics(
         task,
         [],
         [],
-        config={"auxiliary": {}},
+        config={"auto_decompose": True, "auxiliary": {}},
     )
-    triage = [d for d in diags if d.kind == "triage_missing_specifier"]
+    triage = [d for d in diags if d.kind == "triage_automation_unavailable"]
     assert len(triage) == 1
     d = triage[0]
     assert d.severity == "warning"
-    assert "auxiliary.triage_specifier" in d.detail
+    assert "auxiliary.kanban_decomposer" in d.detail
+    assert d.data["helper"] == "kanban_decomposer"
     suggested = [a for a in d.actions if a.suggested]
     assert suggested
-    assert "auxiliary.triage_specifier.provider" in suggested[0].payload["command"]
+    assert "auxiliary.kanban_decomposer.provider" in suggested[0].payload["command"]
 
 
-def test_triage_missing_specifier_silent_when_configured_auto():
+def test_triage_automation_unavailable_silent_when_decomposer_configured():
     task = _task(status="triage")
     diags = kd.compute_task_diagnostics(
         task,
         [],
         [],
-        config={"auxiliary": {"triage_specifier": {"provider": "auto"}}},
+        config={
+            "auto_decompose": True,
+            "auxiliary": {"kanban_decomposer": {"provider": "auto"}},
+        },
     )
-    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+    assert [d for d in diags if d.kind == "triage_automation_unavailable"] == []
 
 
-def test_triage_missing_specifier_silent_without_config_context():
+def test_triage_automation_unavailable_checks_specifier_in_manual_mode():
+    task = _task(status="triage")
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        [],
+        config={"auto_decompose": False, "auxiliary": {}},
+    )
+    triage = [d for d in diags if d.kind == "triage_automation_unavailable"]
+    assert len(triage) == 1
+    assert "auxiliary.triage_specifier" in triage[0].detail
+    assert triage[0].data["helper"] == "triage_specifier"
+
+
+def test_triage_automation_unavailable_silent_when_manual_specifier_configured():
+    task = _task(status="triage")
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        [],
+        config={
+            "auto_decompose": False,
+            "auxiliary": {"triage_specifier": {"provider": "auto"}},
+        },
+    )
+    assert [d for d in diags if d.kind == "triage_automation_unavailable"] == []
+
+
+def test_triage_automation_unavailable_silent_without_config_context():
     task = _task(status="triage")
     diags = kd.compute_task_diagnostics(task, [], [])
-    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+    assert [d for d in diags if d.kind == "triage_automation_unavailable"] == []
 
 
-def test_triage_specifier_configured_recognises_main_model_fallback():
-    assert kd.triage_specifier_configured({
+def test_triage_automation_configured_recognises_main_model_fallback():
+    assert kd.triage_automation_configured({
+        "auto_decompose": True,
         "auxiliary": {},
         "model": {"provider": "openrouter", "default": "qwen/qwen3"},
     }) is True
@@ -173,14 +206,16 @@ def test_triage_specifier_configured_recognises_main_model_fallback():
 
 def test_config_from_runtime_config_exposes_triage_context():
     cfg = kd.config_from_runtime_config({
-        "auxiliary": {"triage_specifier": {"provider": "auto"}},
+        "kanban": {"auto_decompose": True},
+        "auxiliary": {"kanban_decomposer": {"provider": "auto"}},
         "model": {"provider": "openrouter", "default": "qwen/qwen3"},
     })
-    assert cfg["auxiliary"]["triage_specifier"]["provider"] == "auto"
+    assert cfg["auto_decompose"] is True
+    assert cfg["auxiliary"]["kanban_decomposer"]["provider"] == "auto"
     assert cfg["model"]["default"] == "qwen/qwen3"
 
 
-def test_triage_missing_specifier_skips_non_triage_tasks():
+def test_triage_automation_unavailable_skips_non_triage_tasks():
     task = _task(status="todo")
     diags = kd.compute_task_diagnostics(
         task,
@@ -188,7 +223,7 @@ def test_triage_missing_specifier_skips_non_triage_tasks():
         [],
         config={"auxiliary": {}},
     )
-    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+    assert [d for d in diags if d.kind == "triage_automation_unavailable"] == []
 
 
 def test_repeated_failures_fires_at_threshold_on_spawn():

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -129,6 +129,68 @@ def test_prose_phantom_refs_clears_on_later_clean_edit():
     assert diags == []
 
 
+def test_triage_missing_specifier_fires_when_config_missing():
+    task = _task(id="t_triage1", status="triage")
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        [],
+        config={"auxiliary": {}},
+    )
+    triage = [d for d in diags if d.kind == "triage_missing_specifier"]
+    assert len(triage) == 1
+    d = triage[0]
+    assert d.severity == "warning"
+    assert "auxiliary.triage_specifier" in d.detail
+    suggested = [a for a in d.actions if a.suggested]
+    assert suggested
+    assert "auxiliary.triage_specifier.provider" in suggested[0].payload["command"]
+
+
+def test_triage_missing_specifier_silent_when_configured_auto():
+    task = _task(status="triage")
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        [],
+        config={"auxiliary": {"triage_specifier": {"provider": "auto"}}},
+    )
+    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+
+
+def test_triage_missing_specifier_silent_without_config_context():
+    task = _task(status="triage")
+    diags = kd.compute_task_diagnostics(task, [], [])
+    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+
+
+def test_triage_specifier_configured_recognises_main_model_fallback():
+    assert kd.triage_specifier_configured({
+        "auxiliary": {},
+        "model": {"provider": "openrouter", "default": "qwen/qwen3"},
+    }) is True
+
+
+def test_config_from_runtime_config_exposes_triage_context():
+    cfg = kd.config_from_runtime_config({
+        "auxiliary": {"triage_specifier": {"provider": "auto"}},
+        "model": {"provider": "openrouter", "default": "qwen/qwen3"},
+    })
+    assert cfg["auxiliary"]["triage_specifier"]["provider"] == "auto"
+    assert cfg["model"]["default"] == "qwen/qwen3"
+
+
+def test_triage_missing_specifier_skips_non_triage_tasks():
+    task = _task(status="todo")
+    diags = kd.compute_task_diagnostics(
+        task,
+        [],
+        [],
+        config={"auxiliary": {}},
+    )
+    assert [d for d in diags if d.kind == "triage_missing_specifier"] == []
+
+
 def test_repeated_failures_fires_at_threshold_on_spawn():
     """A task with multiple spawn_failed runs gets a spawn-flavoured
     diagnostic (title mentions 'spawn', suggested action is ``doctor``).


### PR DESCRIPTION
## What does this PR do?

Surfaces a Kanban diagnostic when a task is stuck in `triage` and diagnostics can see that the active triage automation backend is not configured.

After #27572, triage can advance through two paths:

- Auto orchestration mode (`kanban.auto_decompose=true`) uses `auxiliary.kanban_decomposer`.
- Manual/single-task mode (`kanban.auto_decompose=false`) uses `auxiliary.triage_specifier`.

Without this, a rough triage card can sit indefinitely with no operator-facing reason. `hermes kanban decompose` / `hermes kanban specify` already return `no auxiliary client configured` when they cannot resolve the helper model, but board/task diagnostics did not expose that configuration gap.

## Related Issue

#25641

Follow-up to #27572.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a `triage_automation_unavailable` diagnostic for triage tasks when config clearly lacks the backend for the active triage automation path.
- Checks `auxiliary.kanban_decomposer` when `kanban.auto_decompose=true`.
- Checks `auxiliary.triage_specifier` when `kanban.auto_decompose=false`.
- Kept the rule conservative:
  - no diagnostic when config context is unavailable
  - no diagnostic when the active helper has `provider: auto`
  - no diagnostic when a main model fallback is visible
- Added suggested CLI actions to configure the active helper or run the matching `hermes kanban decompose <task_id>` / `hermes kanban specify <task_id>` command.
- Passed runtime config into Kanban diagnostics from both CLI and dashboard paths.
- Added focused diagnostics tests for auto-decompose mode, manual mode, main-model fallback, no-context suppression, and non-triage suppression.

## Reproduction

Before the fix, a triage task with missing auto-decompose auxiliary config produced no diagnostic:

```text
task = {'id': 't_triage', 'status': 'triage', 'title': 'rough task'}
config = {'kanban': {'auto_decompose': True}, 'auxiliary': {}}
diags = kd.compute_task_diagnostics(
    task,
    [],
    [],
    config=kd.config_from_runtime_config(config),
)
diagnostic_kinds = []
```

After the fix, the same state surfaces the unavailable triage automation backend:

```text
diagnostic_kinds = ['triage_automation_unavailable']
suggested_commands = ['hermes config set auxiliary.kanban_decomposer.provider auto']
```

Manual mode checks the single-task specifier path instead:

```text
config = {'kanban': {'auto_decompose': False}, 'auxiliary': {}}
diagnostic_kinds = ['triage_automation_unavailable']
suggested_commands = ['hermes config set auxiliary.triage_specifier.provider auto']
```

## How to Test

```text
PYTHONDONTWRITEBYTECODE=1 python - <<'PY'
from hermes_cli import kanban_diagnostics as kd

task = {'id': 't_triage', 'status': 'triage', 'title': 'rough task'}
config = {'kanban': {'auto_decompose': True}, 'auxiliary': {}}
diags = kd.compute_task_diagnostics(
    task,
    [],
    [],
    config=kd.config_from_runtime_config(config),
)
print('diagnostic_kinds =', [d.kind for d in diags])
print('suggested_commands =', [a.payload.get('command') for d in diags for a in d.actions if a.suggested])
PY
```

Result:

```text
diagnostic_kinds = ['triage_automation_unavailable']
suggested_commands = ['hermes config set auxiliary.kanban_decomposer.provider auto']
```

```text
python -m py_compile hermes_cli/kanban_diagnostics.py hermes_cli/kanban.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_diagnostics.py
```

Result: passed.

```text
pytest -q tests/hermes_cli/test_kanban_diagnostics.py -k "triage_automation or config_from_runtime_config"
```

Result: `8 passed`.

```text
python -m ruff check hermes_cli/kanban.py hermes_cli/kanban_diagnostics.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_diagnostics.py
```

Result: passed.

```text
git diff --check -- hermes_cli/kanban_diagnostics.py hermes_cli/kanban.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_diagnostics.py
```

Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (WSL-style dev environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

See reproduction and test logs above.