### PR TITLE
feat(config): add browser.headed toggle with dashboard UI and AGENT_BROWSER_HEADED wiring

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -614,6 +614,10 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        # Run browser in headed mode (visible window).  When disabled,
+        # the browser runs headless (no visible window).
+        # This directly sets AGENT_BROWSER_HEADED env var.
+        "headed": False,
         # Browser engine for local mode.  Passed as ``--engine <value>`` to
         # agent-browser v0.25.3+.
         # "auto"       — use Chrome (default, don't pass --engine at all)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -344,6 +344,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Reasoning effort for delegated subagents",
         "options": ["", "low", "medium", "high"],
     },
+    "browser.headed": {
+        "type": "boolean",
+        "description": "Run browser in headed mode (visible window).  Enable to show a visible browser window via AGENT_BROWSER_HEADED.",
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1859,6 +1859,17 @@ def _run_browser_command(
         browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
 
+        # Honor browser.headed config — when enabled, show a visible
+        # browser window so the user can watch what the agent is doing.
+        if not session_info.get("cdp_url") and not _is_camofox_mode():
+            try:
+                from hermes_cli.config import read_raw_config
+                _cfg = read_raw_config()
+                if _cfg.get("browser", {}).get("headed", False):
+                    browser_env["AGENT_BROWSER_HEADED"] = "true"
+            except Exception:
+                pass
+
         # Tell the agent-browser daemon to self-terminate after being idle
         # for our configured inactivity timeout.  This is the daemon-side
         # counterpart to our Python-side _cleanup_inactive_browser_sessions


### PR DESCRIPTION
## Summary

Add a `browser.headed` config option (default: `false`) that controls whether the local Chromium runs in headed (visible window) or headless mode.

Aligns with naming from PR #13433 (`headed` config key).

## Changes

1. **`hermes_cli/config.py`** — Added `"headed": False` to the `browser` section of `DEFAULT_CONFIG`. The dashboard auto-discovers it from the schema.

2. **`hermes_cli/web_server.py`** — Added a schema override with a proper description so the toggle renders correctly in the dashboard browser config section.

3. **`tools/browser_tool.py`** — When `headed: true` in local (non-CDP/non-Camofox) mode, sets `AGENT_BROWSER_HEADED=true` in the subprocess environment so agent-browser launches a visible browser window.

## Key difference from PR #13433

- Uses `AGENT_BROWSER_HEADED` env var (the canonical agent-browser env var) instead of the `--headed` CLI flag
- Adds the **dashboard UI toggle** with schema override and description — something #13433 does not include

## Testing

- Dashboard shows "Browser 14" (was 10) in the config page.
- Searching "headed" finds the `browser.headed` field with a switch toggle.
- Toggling on and saving persists `headed: true` to `~/.hermes/config.yaml`.
- Runtime wiring activates `AGENT_BROWSER_HEADED=true` on the next browser command (local mode only, not CDP/Camofox).