### PR TITLE
fix(vision): preserve auxiliary system prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6775,6 +6775,8 @@ class GatewayRunner:
         event: MessageEvent,
         source: SessionSource,
         history: List[Dict[str, Any]],
+        context_prompt: str = "",
+        channel_prompt: Optional[str] = None,
     ) -> Optional[str]:
         """Prepare inbound event text for the agent.
 
@@ -6839,9 +6841,20 @@ class GatewayRunner:
                         "Image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
                         _img_mode, len(image_paths),
                     )
+                    combined_system_prompt = context_prompt or ""
+                    event_channel_prompt = (channel_prompt or "").strip()
+                    if event_channel_prompt:
+                        combined_system_prompt = (
+                            combined_system_prompt + "\n\n" + event_channel_prompt
+                        ).strip()
+                    if self._ephemeral_system_prompt:
+                        combined_system_prompt = (
+                            combined_system_prompt + "\n\n" + self._ephemeral_system_prompt
+                        ).strip()
                     message_text = await self._enrich_message_with_vision(
                         message_text,
                         image_paths,
+                        system_prompt=combined_system_prompt or None,
                     )
 
             if audio_paths:
@@ -7575,6 +7588,8 @@ class GatewayRunner:
             event=event,
             source=source,
             history=history,
+            context_prompt=context_prompt,
+            channel_prompt=event.channel_prompt,
         )
         if message_text is None:
             return
@@ -13104,6 +13119,7 @@ class GatewayRunner:
         self,
         user_text: str,
         image_paths: List[str],
+        system_prompt: Optional[str] = None,
     ) -> str:
         """
         Auto-analyze user-attached images with the vision tool and prepend
@@ -13137,6 +13153,7 @@ class GatewayRunner:
                 result_json = await vision_analyze_tool(
                     image_url=path,
                     user_prompt=analysis_prompt,
+                    system_prompt=system_prompt,
                 )
                 result = json.loads(result_json)
                 if result.get("success"):
@@ -16169,6 +16186,8 @@ class GatewayRunner:
                         event=pending_event,
                         source=next_source,
                         history=updated_history,
+                        context_prompt=context_prompt,
+                        channel_prompt=getattr(pending_event, "channel_prompt", None),
                     )
                     if next_message is None:
                         return result

--- a/run_agent.py
+++ b/run_agent.py
@@ -9131,8 +9131,14 @@ class AIAgent:
         path = Path(tmp.name)
         return str(path), path
 
-    def _describe_image_for_anthropic_fallback(self, image_url: str, role: str) -> str:
-        cache_key = hashlib.sha256(str(image_url or "").encode("utf-8")).hexdigest()
+    def _describe_image_for_anthropic_fallback(
+        self,
+        image_url: str,
+        role: str,
+        system_prompt: str = "",
+    ) -> str:
+        cache_material = f"{image_url or ''}\n\n{system_prompt or ''}"
+        cache_key = hashlib.sha256(cache_material.encode("utf-8")).hexdigest()
         cached = self._anthropic_image_fallback_cache.get(cache_key)
         if cached:
             return cached
@@ -9157,7 +9163,11 @@ class AIAgent:
             from tools.vision_tools import vision_analyze_tool
 
             result_json = asyncio.run(
-                vision_analyze_tool(image_url=vision_source, user_prompt=analysis_prompt)
+                vision_analyze_tool(
+                    image_url=vision_source,
+                    user_prompt=analysis_prompt,
+                    system_prompt=system_prompt or None,
+                )
             )
             result = json.loads(result_json) if isinstance(result_json, str) else {}
             description = (result.get("analysis") or "").strip()
@@ -9206,6 +9216,12 @@ class AIAgent:
         if not self._content_has_image_parts(content):
             return content
 
+        effective_system_prompt = self._cached_system_prompt or ""
+        if self.ephemeral_system_prompt:
+            effective_system_prompt = (
+                effective_system_prompt + "\n\n" + self.ephemeral_system_prompt
+            ).strip()
+
         text_parts: List[str] = []
         image_notes: List[str] = []
         for part in content:
@@ -9227,7 +9243,13 @@ class AIAgent:
                 image_data = part.get("image_url", {})
                 image_url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data or "")
                 if image_url:
-                    image_notes.append(self._describe_image_for_anthropic_fallback(image_url, role))
+                    image_notes.append(
+                        self._describe_image_for_anthropic_fallback(
+                            image_url,
+                            role,
+                            system_prompt=effective_system_prompt,
+                        )
+                    )
                 else:
                     image_notes.append("[An image was attached but no image source was available.]")
                 continue

--- a/tests/gateway/test_vision_memory_leak.py
+++ b/tests/gateway/test_vision_memory_leak.py
@@ -78,3 +78,20 @@ class TestEnrichMessageWithVision:
         assert "photograph of a dog" in out
         assert "fenced leak" not in out
         assert "<memory-context>" not in out
+
+    def test_system_prompt_forwarded_to_auxiliary_vision(self, gateway_runner):
+        fake_result = json.dumps({
+            "success": True,
+            "analysis": "A monochrome dashboard screenshot.",
+        })
+        mock_vision = AsyncMock(return_value=fake_result)
+        with patch("tools.vision_tools.vision_analyze_tool", new=mock_vision):
+            out = _run(
+                gateway_runner._enrich_message_with_vision(
+                    "caption",
+                    ["/tmp/img.jpg"],
+                    system_prompt="You are a UI critic.",
+                )
+            )
+        assert "dashboard screenshot" in out
+        assert mock_vision.await_args.kwargs["system_prompt"] == "You are a UI critic."

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4171,6 +4171,8 @@ class TestAnthropicImageFallback:
     def test_build_api_kwargs_converts_multimodal_user_image_to_text(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.reasoning_config = None
+        agent._cached_system_prompt = "You are a designer."
+        agent.ephemeral_system_prompt = "Focus on typography."
 
         api_messages = [{
             "role": "user",
@@ -4180,8 +4182,11 @@ class TestAnthropicImageFallback:
             ],
         }]
 
+        mock_vision = AsyncMock(
+            return_value=json.dumps({"success": True, "analysis": "A cat sitting on a chair."})
+        )
         with (
-            patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock(return_value=json.dumps({"success": True, "analysis": "A cat sitting on a chair."}))),
+            patch("tools.vision_tools.vision_analyze_tool", new=mock_vision),
             patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build,
         ):
             mock_build.return_value = {"model": "claude-sonnet-4-20250514", "messages": [], "max_tokens": 4096}
@@ -4196,6 +4201,9 @@ class TestAnthropicImageFallback:
         assert "A cat sitting on a chair." in transformed[0]["content"]
         assert "Can you see this now?" in transformed[0]["content"]
         assert "vision_analyze with image_url: https://example.com/cat.png" in transformed[0]["content"]
+        assert mock_vision.await_args.kwargs["system_prompt"] == (
+            "You are a designer.\n\nFocus on typography."
+        )
 
     def test_build_api_kwargs_reuses_cached_image_analysis_for_duplicate_images(self, agent):
         agent.api_mode = "anthropic_messages"
@@ -4228,6 +4236,31 @@ class TestAnthropicImageFallback:
             agent._build_api_kwargs(api_messages)
 
         assert mock_vision.await_count == 1
+
+    def test_anthropic_image_cache_includes_system_prompt(self, agent):
+        agent._anthropic_image_fallback_cache = {}
+        mock_vision = AsyncMock(
+            side_effect=[
+                json.dumps({"success": True, "analysis": "A product screenshot."}),
+                json.dumps({"success": True, "analysis": "A UI audit of a product screenshot."}),
+            ]
+        )
+
+        with patch("tools.vision_tools.vision_analyze_tool", new=mock_vision):
+            first = agent._describe_image_for_anthropic_fallback(
+                "https://example.com/ui.png",
+                "user",
+                system_prompt="You are a generic assistant.",
+            )
+            second = agent._describe_image_for_anthropic_fallback(
+                "https://example.com/ui.png",
+                "user",
+                system_prompt="You are a UI auditor.",
+            )
+
+        assert mock_vision.await_count == 2
+        assert "A product screenshot." in first
+        assert "UI audit of a product screenshot." in second
 
 
 class TestFallbackAnthropicProvider:

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -368,6 +368,38 @@ class TestErrorLoggingExcInfo:
 
 class TestVisionConfig:
     @pytest.mark.asyncio
+    async def test_vision_forwards_system_prompt_as_system_message(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Configured image analysis"
+        mock_response.choices = [mock_choice]
+
+        with patch(
+            "tools.vision_tools.async_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm:
+            result = json.loads(
+                await vision_analyze_tool(
+                    str(img),
+                    "describe this",
+                    "test/model",
+                    system_prompt="You are a security analyst.",
+                )
+            )
+
+        assert result["success"] is True
+        sent_messages = mock_llm.await_args.kwargs["messages"]
+        assert sent_messages[0] == {
+            "role": "system",
+            "content": "You are a security analyst.",
+        }
+        assert sent_messages[1]["role"] == "user"
+
+    @pytest.mark.asyncio
     async def test_vision_uses_configured_temperature_and_timeout(self, tmp_path):
         img = tmp_path / "test.png"
         img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -634,6 +634,7 @@ async def vision_analyze_tool(
     image_url: str,
     user_prompt: str,
     model: str = None,
+    system_prompt: str | None = None,
 ) -> str:
     """
     Analyze an image from a URL or local file path using vision AI.
@@ -651,6 +652,8 @@ async def vision_analyze_tool(
                          Accepts http://, https:// URLs or absolute/relative file paths.
         user_prompt (str): The pre-formatted prompt for the vision model
         model (str): The vision model to use (default: google/gemini-3-flash-preview)
+        system_prompt (str | None): Optional session/system guidance for the
+                                    auxiliary vision model.
     
     Returns:
         str: JSON string containing the analysis results with the following structure:
@@ -669,11 +672,17 @@ async def vision_analyze_tool(
     """
     if not isinstance(user_prompt, str):
         user_prompt = str(user_prompt) if user_prompt is not None else ""
+    if system_prompt is not None and not isinstance(system_prompt, str):
+        system_prompt = str(system_prompt)
+    system_prompt = (system_prompt or "").strip() or None
     debug_call_data = {
         "parameters": {
             "image_url": image_url,
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
-            "model": model
+            "model": model,
+            "system_prompt": (
+                system_prompt[:200] + "..." if system_prompt and len(system_prompt) > 200 else system_prompt
+            ),
         },
         "error": None,
         "success": False,
@@ -759,7 +768,10 @@ async def vision_analyze_tool(
         comprehensive_prompt = user_prompt
         
         # Prepare the message with base64-encoded image
-        messages = [
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append(
             {
                 "role": "user",
                 "content": [
@@ -775,7 +787,7 @@ async def vision_analyze_tool(
                     }
                 ]
             }
-        ]
+        )
         
         logger.info("Processing image with vision model...")
         


### PR DESCRIPTION
Fixes #24697.

## Summary
- pass caller-supplied system prompts through `vision_analyze_tool()` so auxiliary vision calls keep the session persona
- thread the combined gateway context/channel/system prompt into auto image enrichment before the main agent run starts
- preserve the same prompt in Anthropic non-vision image fallback, and key the fallback cache by both image and prompt

## Testing
- `uv run --frozen pytest -o addopts='' tests/tools/test_vision_tools.py -k 'system_prompt_as_system_message'`
- `uv run --frozen pytest -o addopts='' tests/gateway/test_vision_memory_leak.py -k 'system_prompt_forwarded_to_auxiliary_vision'`
- `uv run --frozen pytest -o addopts='' tests/run_agent/test_run_agent.py -k 'converts_multimodal_user_image_to_text or reuses_cached_image_analysis_for_duplicate_images or anthropic_image_cache_includes_system_prompt'`
- `uv run --frozen ruff check gateway/run.py run_agent.py tools/vision_tools.py tests/gateway/test_vision_memory_leak.py tests/tools/test_vision_tools.py tests/run_agent/test_run_agent.py`
- `git diff --check`
