### PR TITLE
fix(gateway): avoid zsh status variable in update wrapper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12583,7 +12583,11 @@ class GatewayRunner:
                 update_cmd = (
                     f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway"
                     f" > {shlex.quote(str(output_path))} 2>&1; "
-                    f"status=$?; printf '%s' \"$status\" > {shlex.quote(str(exit_code_path))}"
+                    # Avoid `status=$?`: `status` is a read-only special parameter
+                    # in zsh, and this command string is copied/reused in macOS/zsh
+                    # operator wrappers. Keep the template zsh-safe even though this
+                    # specific subprocess currently runs under bash.
+                    f"rc=$?; printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}"
                 )
                 setsid_bin = shutil.which("setsid")
                 if setsid_bin:

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -237,6 +237,8 @@ class TestUpdateCommandGatewayFlag:
         cmd_string = call_args[-1] if isinstance(call_args, list) else str(call_args)
         assert "--gateway" in cmd_string
         assert "PYTHONUNBUFFERED" in cmd_string
+        assert "rc=$?" in cmd_string
+        assert "status=$?" not in cmd_string
         assert "stream progress" in result
 
 


### PR DESCRIPTION
## Summary
- replace the gateway update wrapper's `status=$?` shell variable with `rc=$?`
- add regression coverage so the generated update command remains zsh-safe

## Why
`status` is a read-only special parameter in zsh. The gateway update wrapper command is copied/reused in macOS/zsh operator contexts, where assigning `status=$?` can create a false failure after the update body completes.

## Test plan
- `/Users/am/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py tests/gateway/test_update_streaming.py`
- `/Users/am/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_update_streaming.py -q -o 'addopts='`
- `git diff --check`
- added-line secret scan: 0 findings
