### PR TITLE
fix(kanban): pass accept-hooks to worker chat subprocess

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3979,6 +3979,11 @@ def _default_spawn(
     cmd = [
         *_resolve_hermes_argv(),
         "-p", profile_arg,
+        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
+        # so they see that profile's shell-hook allowlist instead of the
+        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
+        # profile-local worker sessions still register configured hooks.
+        "--accept-hooks",
         # Auto-load the kanban-worker skill so every dispatched worker
         # has the pattern library (good summary/metadata shapes, retry
         # diagnostics, block-reason examples) in its context, even if

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2672,6 +2672,10 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     assert cmd[idx + 1] == "kanban-worker", (
         f"expected 'kanban-worker', got {cmd[idx + 1]!r}"
     )
+    assert "--accept-hooks" in cmd, f"spawn argv missing --accept-hooks: {cmd}"
+    assert cmd.index("--accept-hooks") < cmd.index("chat"), (
+        f"--accept-hooks must come before 'chat' in argv: {cmd}"
+    )
     # Assignee + task env are still present
     assert "some-profile" in cmd
     env = captured["env"]


### PR DESCRIPTION
## Summary
- pass `--accept-hooks` through the kanban worker spawn argv
- keep worker shell-hook registration working after the spawn path rewrites `HERMES_HOME` to the assignee profile
- add a regression test that locks the worker argv contract in `_default_spawn`

## Testing
- `uv run --frozen pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -k default_spawn_auto_loads_kanban_worker_skill`
- `uv run --frozen ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py`
- `git diff --check`

Fixes #25204.
