### PR TITLE
fix(discord): avoid retrying partially delivered chunks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2428,6 +2428,24 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
+    @staticmethod
+    def _has_partial_delivery(result: Optional["SendResult"]) -> bool:
+        """Return True when a failed send already put some content on screen.
+
+        Retrying a chunked platform send after one or more chunks already
+        landed will duplicate the visible response. Adapters report this via
+        ``raw_response.partial_delivery`` plus the delivered ``message_ids``.
+        """
+        if not result or getattr(result, "success", False):
+            return False
+        raw = getattr(result, "raw_response", None)
+        if not isinstance(raw, dict):
+            return False
+        if raw.get("partial_delivery"):
+            return True
+        message_ids = raw.get("message_ids") or ()
+        return any(message_ids)
+
     def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
@@ -2480,6 +2498,13 @@ class BasePlatformAdapter(ABC):
 
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
+
+        if self._has_partial_delivery(result):
+            logger.warning(
+                "[%s] Send failed after partial delivery; skipping retry to avoid duplicates",
+                self.name,
+            )
+            return result
 
         # Timeout errors are not safe to retry (message may have been
         # delivered) and not formatting errors — return the failure as-is.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1456,6 +1456,18 @@ class DiscordAdapter(BasePlatformAdapter):
                             reference=None,
                         )
                     else:
+                        if message_ids:
+                            return SendResult(
+                                success=False,
+                                error=(
+                                    "Partial Discord send failed after "
+                                    f"{len(message_ids)} chunk(s): {e}"
+                                ),
+                                raw_response={
+                                    "message_ids": list(message_ids),
+                                    "partial_delivery": True,
+                                },
+                            )
                         raise
                 message_ids.append(str(msg.id))
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -160,6 +160,41 @@ async def test_send_does_not_retry_on_unrelated_errors():
     assert send_calls[0]["reference"] is reference_obj
 
 
+@pytest.mark.asyncio
+async def test_chunked_send_reports_partial_delivery_after_late_failure():
+    """If a later Discord chunk fails, surface partial delivery so the retry
+    wrapper does not resend the whole response."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 20
+
+    sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        if len(send_calls) <= 2:
+            return sent_msgs[len(send_calls) - 1]
+        raise RuntimeError("Connection reset by peer")
+
+    channel = SimpleNamespace(
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "A" * 60)
+
+    assert result.success is False
+    assert "Partial Discord send failed after 2 chunk(s)" in (result.error or "")
+    assert result.raw_response == {
+        "message_ids": ["1001", "1002"],
+        "partial_delivery": True,
+    }
+    assert channel.send.await_count == 3
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -259,6 +259,27 @@ class TestEmptyResponseNotSuppressed:
     for that') and then silence — the '(empty)' sentinel is swallowed by
     already_sent=True."""
 
+
+class TestPartialDeliverySkipsRetry:
+    @pytest.mark.asyncio
+    async def test_send_with_retry_does_not_replay_partially_delivered_chunks(self):
+        adapter = StubAdapter()
+        partial = SendResult(
+            success=False,
+            error="connection reset by peer",
+            raw_response={
+                "message_ids": ["msg-1", "msg-2"],
+                "partial_delivery": True,
+            },
+            retryable=True,
+        )
+        adapter.send = AsyncMock(return_value=partial)
+
+        result = await adapter._send_with_retry(chat_id="c1", content="hello")
+
+        assert result is partial
+        adapter.send.assert_awaited_once()
+
     def _make_mock_stream_consumer(self, already_sent=False, final_response_sent=False):
         return SimpleNamespace(
             already_sent=already_sent,


### PR DESCRIPTION
Fixes #25349.

## Summary
- mark Discord multi-chunk sends as partial delivery when a later chunk fails after earlier chunks already landed
- teach the base retry wrapper to stop retrying/falling back once a failed send already has visible delivered chunks
- cover the regression with focused Discord send and duplicate-suppression tests

## Proof
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-23810-outbound-redaction/.venv/bin/python -m pytest -o addopts='' tests/gateway/test_discord_send.py tests/gateway/test_duplicate_reply_suppression.py -k 'partial_delivery or partially_delivered_chunks'
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-23810-outbound-redaction/.venv/bin/python -m ruff check gateway/platforms/base.py gateway/platforms/discord.py tests/gateway/test_discord_send.py tests/gateway/test_duplicate_reply_suppression.py
- git diff --check
