### PR TITLE
chore(release): add johnisag to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -82,6 +82,7 @@ AUTHOR_MAP = {
     "aubrey@freeman-wisco.com": "Freeman-Consulting",
     "don.rhm@gmail.com": "rahimsais",
     "40222899+rahimsais@users.noreply.github.com": "rahimsais",
+    "agorgianitisj@hotmail.com": "johnisag",
     "alfred@Alfreds-Mac-mini.local": "NivOO5",
     "231191380+NivOO5@users.noreply.github.com": "NivOO5",
     "jameshuang@gmail.com": "kjames2001",


### PR DESCRIPTION
## Summary

Adds `agorgianitisj@hotmail.com -> johnisag` to `AUTHOR_MAP` so future salvages preserving @johnisag's original commit authorship can pass contributor attribution cleanly.

## Why

The `fix(gateway): cross-platform pid_is_alive helper, fixing Windows crashes` line of work is a plausible salvage candidate, but its preserved authorship needs an explicit release mapping first.

## Solution sketch

```mermaid
flowchart TD
    A[Cherry-picked commit author email] --> B{Present in AUTHOR_MAP?}
    B -->|No| C[Attribution check fails]
    B -->|Yes| D[Salvage PR can keep original authorship]
```

## Tests

- `python -m py_compile scripts/release.py`

## Risk

Low. Single-line metadata update only.
