### PR TITLE
fix(hermes_time): add missing reset_cache helper (based on #13487)

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -88,6 +88,14 @@ def get_timezone() -> Optional[ZoneInfo]:
     return _cached_tz
 
 
+def reset_cache() -> None:
+    """Clear the cached timezone so the next call re-resolves it."""
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def now() -> datetime:
     """
     Return the current time as a timezone-aware datetime.


### PR DESCRIPTION
## Summary

Small current-main salvage based on #13487.

This adds the missing `reset_cache()` helper in `hermes_time.py`, matching the module comments and the cache-reset behavior that tests already simulate by directly mutating module globals.

## Problem

`hermes_time.reset_cache()` is referenced in comments/docstrings but was never implemented, so any caller trying to invalidate timezone cache through the public helper would hit `AttributeError`.

## Root cause

The module carried cache state and cache-reset expectations, but the public invalidation helper itself was missing.

## Fix

- add `reset_cache()` that clears cached timezone state and resolution bookkeeping

## Solution sketch

```mermaid
flowchart TD
    A[Timezone config changes] --> B[Call reset_cache]
    B --> C[Clear cached tz state]
    C --> D[Next access re-resolves timezone]
```

## Why salvage

- original PR #13487 is tiny and still open
- no blocking duplicate comment is present on that PR
- the diff applies cleanly to current `main`

## Duplicate check

I did not find a stronger open salvage for this exact missing helper.

## Tests

Local verification in this environment:
- `python -m py_compile hermes_time.py`

I did not rerun the full timezone test module locally in this worktree.

## Risk

Low. Single helper addition with no broader control-flow changes.

Based on #13487 by @hobostay.
