### PR TITLE
fix(batch_runner): avoid IndexError on unexpected batch filename (based on #13491)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1023,7 +1023,8 @@ class BatchRunner:
         with open(combined_file, 'w', encoding='utf-8') as outfile:
             for batch_file in all_batch_files:
                 batch_files_found += 1
-                batch_num = batch_file.stem.split("_")[1]  # Extract batch number for logging
+                parts = batch_file.stem.split("_")
+                batch_num = parts[1] if len(parts) > 1 else "?"  # Extract batch number for logging
                 
                 with open(batch_file, 'r', encoding='utf-8') as infile:
                     for line in infile:


### PR DESCRIPTION
## Summary

Small current-main salvage based on #13491.

This hardens `batch_runner.py` so the combine/logging path does not raise `IndexError` when a batch filename does not match the expected underscore pattern.

## Problem

`batch_file.stem.split("_")[1]` assumes an underscore is always present. If a file in the directory does not match that exact pattern, the combine step can crash with `IndexError`.

## Root cause

The code parsed the batch suffix positionally instead of defensively.

## Fix

- use defensive parsing with a fallback marker for unexpected filenames

## Solution sketch

```mermaid
flowchart TD
    A[Batch filename] --> B{Contains expected underscore part?}
    B -->|Yes| C[Use parsed suffix]
    B -->|No| D[Use safe fallback for logging]
    C --> E[Continue combine step]
    D --> E
```

## Why salvage

- original PR #13491 is tiny and still open
- no blocking duplicate comment is present on that PR
- the diff applies cleanly to current `main`

## Duplicate check

I did not find a stronger open salvage for this exact defensive filename parsing fix.

## Tests

Local verification in this environment:
- `python -m py_compile batch_runner.py`

I did not rerun a focused batch-runner test locally in this worktree.

## Risk

Low. Tiny defensive fix in a narrow code path.

Based on #13491 by @hobostay.
