### PR TITLE
fix(skills_hub): keep bundle metadata aligned with fetched source

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -108,32 +108,42 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
 
 def _resolve_source_meta_and_bundle(identifier: str, sources):
     """Resolve metadata and bundle for a specific identifier."""
-    meta = None
-    bundle = None
-    matched_source = None
+    first_meta = None
+    first_meta_source = None
 
     for src in sources:
-        if meta is None:
-            try:
-                meta = src.inspect(identifier)
-                if meta:
-                    matched_source = src
-            except Exception:
-                meta = None
+        src_meta = None
+        try:
+            src_meta = src.inspect(identifier)
+        except Exception:
+            src_meta = None
+        if first_meta is None and src_meta:
+            first_meta = src_meta
+            first_meta_source = src
+
         try:
             bundle = src.fetch(identifier)
         except Exception:
             bundle = None
         if bundle:
             matched_source = src
-            if meta is None:
+            if src_meta is None:
+                bundle_identifier = getattr(bundle, "identifier", "") or identifier
                 try:
-                    meta = src.inspect(identifier)
+                    src_meta = src.inspect(bundle_identifier)
                 except Exception:
-                    meta = None
-            break
+                    src_meta = None
+            if src_meta is None:
+                src_meta = SkillMeta(
+                    name=bundle.name,
+                    description="",
+                    source=bundle.source,
+                    identifier=getattr(bundle, "identifier", "") or identifier,
+                    trust_level=bundle.trust_level,
+                )
+            return src_meta, bundle, matched_source
 
-    return meta, bundle, matched_source
+    return first_meta, None, first_meta_source
 
 
 def _derive_category_from_install_path(install_path: str) -> str:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -492,6 +492,56 @@ def test_url_install_cancel_name_prompt_aborts(monkeypatch, tmp_path, hub_env):
     assert "Installation cancelled" in sink.getvalue()
 
 
+def test_resolve_source_meta_and_bundle_keeps_meta_aligned_with_bundle_source():
+    from tools.skills_hub import SkillBundle, SkillMeta
+    from hermes_cli.skills_hub import _resolve_source_meta_and_bundle
+
+    official_meta = SkillMeta(
+        name="openclaw-migration",
+        description="official metadata",
+        source="official",
+        identifier="official/migration/openclaw-migration",
+        trust_level="builtin",
+    )
+    community_meta = SkillMeta(
+        name="openclaw-migration",
+        description="community metadata",
+        source="github",
+        identifier="github/someone/openclaw-migration",
+        trust_level="community",
+    )
+    community_bundle = SkillBundle(
+        name="openclaw-migration",
+        files={"SKILL.md": "# community content\n"},
+        source="github",
+        identifier="github/someone/openclaw-migration",
+        trust_level="community",
+    )
+
+    class OfficialMetaOnly:
+        def inspect(self, identifier):
+            return official_meta if identifier == official_meta.identifier else None
+
+        def fetch(self, identifier):
+            return None
+
+    class CommunityBundleSource:
+        def inspect(self, identifier):
+            return community_meta
+
+        def fetch(self, identifier):
+            return community_bundle
+
+    meta, bundle, matched_source = _resolve_source_meta_and_bundle(
+        "official/migration/openclaw-migration",
+        [OfficialMetaOnly(), CommunityBundleSource()],
+    )
+
+    assert bundle is community_bundle
+    assert meta is community_meta
+    assert matched_source.__class__.__name__ == "CommunityBundleSource"
+
+
 # ── _existing_categories ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- keep skills-hub metadata aligned with the source that actually produced the fetched bundle
- fall back to bundle-derived metadata instead of reusing stale metadata from an earlier source
- add a regression test covering official metadata plus community bundle mismatch resolution

## Testing
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-21810-20260511-skill-dir/.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_skills_hub.py -k resolve_source_meta_and_bundle_keeps_meta_aligned_with_bundle_source
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-21810-20260511-skill-dir/.venv/bin/ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py
- git diff --check

Fixes #24945
