### PR TITLE
fix(context): read oMLX admin context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -289,6 +289,7 @@ _CONTEXT_LENGTH_KEYS = (
     "context_window",
     "context_size",
     "max_context_length",
+    "max_context_window",
     "max_position_embeddings",
     "max_model_len",
     "max_input_tokens",
@@ -591,6 +592,40 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         if pricing:
             return pricing
     return {}
+
+
+def _query_omlx_admin_context_length(
+    client: Any,
+    model: str,
+    server_url: str,
+) -> Optional[int]:
+    """Read oMLX's loaded runtime context window from the admin API."""
+    try:
+        resp = client.get(f"{server_url}/admin/api/models")
+        if resp.status_code != 200:
+            return None
+        payload = resp.json()
+    except Exception:
+        return None
+
+    entries: list[Dict[str, Any]] = []
+    if isinstance(payload, dict):
+        models = payload.get("models")
+        if isinstance(models, list):
+            entries = [entry for entry in models if isinstance(entry, dict)]
+        else:
+            entries = [payload]
+
+    if not entries:
+        return None
+
+    for entry in entries:
+        if _model_id_matches(entry.get("id", ""), model):
+            return _extract_context_length(entry)
+
+    if len(entries) == 1:
+        return _extract_context_length(entries[0])
+    return None
 
 
 def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: Dict[str, Any]) -> None:
@@ -1176,11 +1211,18 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
             if resp.status_code == 200:
                 data = resp.json()
                 models_list = data.get("data", [])
+                is_omlx = False
                 for m in models_list:
+                    if m.get("owned_by") == "omlx":
+                        is_omlx = True
                     if _model_id_matches(m.get("id", ""), model):
                         ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
                         if ctx and isinstance(ctx, (int, float)):
                             return int(ctx)
+                if is_omlx:
+                    ctx = _query_omlx_admin_context_length(client, model, server_url)
+                    if ctx is not None:
+                        return ctx
     except Exception:
         pass
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -244,6 +244,67 @@ class TestQueryLocalContextLengthModelsList:
         assert result is None
 
 
+class TestQueryLocalContextLengthOMLX:
+    """oMLX keeps runtime context in the admin API, not the OpenAI /v1/models list."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_omlx_admin_models_fallback_reads_max_context_window(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {"id": "MiniMax-M2.7-4bit-mxfp4", "owned_by": "omlx"},
+            ]
+        })
+        admin_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "id": "MiniMax-M2.7-4bit-mxfp4",
+                    "settings": {"max_context_window": 120000},
+                }
+            ]
+        })
+
+        call_count = [0]
+
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp
+            if call_count[0] == 2:
+                return list_resp
+            if call_count[0] == 3:
+                return admin_resp
+            return self._make_resp(404, {})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "MiniMax-M2.7-4bit-mxfp4",
+                "http://192.168.5.125:8098/v1",
+                api_key="secret",
+            )
+
+        assert result == 120000
+        assert [call.args[0] for call in client_mock.get.call_args_list] == [
+            "http://192.168.5.125:8098/v1/models/MiniMax-M2.7-4bit-mxfp4",
+            "http://192.168.5.125:8098/v1/models",
+            "http://192.168.5.125:8098/admin/api/models",
+        ]
+
+
 class TestQueryLocalContextLengthLmStudio:
     """_query_local_context_length with LM Studio native /api/v1/models response."""
 


### PR DESCRIPTION
## Summary
- detect oMLX local endpoints from their OpenAI-compatible /v1/models payload
- fall back to /admin/api/models to read settings.max_context_window when /v1 metadata omits context size
- add a local context regression test for the oMLX admin fallback

Fixes #24640