### PR TITLE
feat: /continue slash command for session continuation with context handoff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6051,6 +6051,195 @@ class HermesCLI:
         _cprint(f"  Original session: {parent_session_id}")
         _cprint(f"  Branch session:   {new_session_id}")
 
+    def _handle_continue_command(self, cmd_original: str) -> None:
+        """Handle /continue [focus] -- new session with context carried forward.
+
+        Generates a handoff summary from the current conversation and injects it
+        into a fresh session so the agent can continue where it left off with a
+        clean context window.  Inspired by Claude Code's ``/compact`` but starts
+        a brand-new session instead of compressing in-place.
+        """
+        if not self.conversation_history or len(self.conversation_history) < 2:
+            _cprint("  No conversation to continue -- send a message first.")
+            return
+
+        # -- extract optional focus topic --
+        focus = ""
+        parts = cmd_original.strip().split(None, 1)
+        if len(parts) > 1:
+            focus = parts[1].strip()
+
+        # -- build continuation context --
+        summary = self._build_continuation_context(focus)
+
+        old_session_id = self.session_id
+
+        # -- start a fresh session --
+        self.new_session(silent=True)
+
+        # -- inject the handoff as the first user message --
+        handoff_msg = {"role": "user", "content": summary}
+        self.conversation_history = [handoff_msg]
+
+        # persist to session DB
+        if self._session_db:
+            try:
+                self._session_db.append_message(
+                    session_id=self.session_id,
+                    role="user",
+                    content=summary,
+                )
+            except Exception:
+                pass
+
+        # -- set a descriptive title --
+        try:
+            from hermes_state import SessionDB
+            short_old = old_session_id[:19] if old_session_id else "unknown"
+            title = SessionDB.sanitize_title(f"Continue from {short_old}")
+            if title:
+                self._session_db.set_session_title(self.session_id, title)
+        except Exception:
+            pass
+
+        # -- auto-trigger the agent --
+        # The handoff context is already in conversation_history as the first
+        # user message.  This trigger tells the agent to read it and continue.
+        self._pending_input.put(
+            "Read the session continuation context above and pick up "
+            "where the previous session left off."
+        )
+
+        _cprint(f"  Session continued from {old_session_id[:19]}...")
+        _cprint("  Context handoff injected. Agent will pick up automatically.")
+
+    def _build_continuation_context(self, focus: str = "") -> str:
+        """Build a handoff summary from the current conversation history.
+
+        Extracts: primary task, recent exchanges, tool activity, files touched,
+        and optional project context from carry_forward.  Mechanical -- no LLM.
+        """
+        import json as _json
+
+        sections = []
+
+        # -- primary task: find the most substantive user message --
+        # The first message might be "yes" or "go ahead" -- look for the
+        # longest substantive one (heuristic: longest content that looks
+        # like a task description).
+        user_msgs = [
+            m for m in self.conversation_history
+            if m.get("role") == "user" and m.get("content")
+        ]
+        if user_msgs:
+            # Pick the longest user message as the primary task description,
+            # falling back to the first one.
+            primary = max(user_msgs, key=lambda m: len(m.get("content", "")))
+            # But if the first message is close in length (>=50%), prefer it
+            # since it's the original intent.
+            first = user_msgs[0]
+            if len(first.get("content", "")) >= len(primary.get("content", "")) * 0.5:
+                primary = first
+            task_text = primary["content"][:800]
+            sections.append(f"## Task\n{task_text}")
+
+        # -- recent exchanges (last 10 content-bearing messages) --
+        recent_lines = []
+        for msg in self.conversation_history[-16:]:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if not content or role not in ("user", "assistant"):
+                continue
+            tag = "USER" if role == "user" else "ASST"
+            # For assistant messages, take the first meaningful paragraph
+            if role == "assistant" and len(content) > 500:
+                content = content[:500] + "..."
+            recent_lines.append(f"[{tag}]: {content[:500]}")
+            if len(recent_lines) >= 10:
+                break
+        if recent_lines:
+            sections.append("## Recent Exchanges\n" + "\n".join(recent_lines))
+
+        # -- tool calls: extract names, key args, and file paths --
+        tool_lines = []
+        files_touched = set()
+        for msg in self.conversation_history[-20:]:
+            tcs = msg.get("tool_calls")
+            if tcs:
+                for tc in tcs:
+                    fn = tc.get("function", {})
+                    name = fn.get("name", tc.get("name", ""))
+                    args_str = fn.get("arguments", "")
+                    if isinstance(args_str, str) and args_str:
+                        try:
+                            args = _json.loads(args_str)
+                            # Collect file paths from common args
+                            for key in ("path", "file_path", "workdir", "command"):
+                                val = args.get(key, "")
+                                if val and isinstance(val, str):
+                                    if "/" in val and len(val) < 300:
+                                        files_touched.add(val)
+                            short = {
+                                k: (str(v)[:80] if len(str(v)) > 80 else v)
+                                for k, v in list(args.items())[:5]
+                            }
+                            tool_lines.append(f"  {name}({short})")
+                        except Exception:
+                            tool_lines.append(f"  {name}(...)")
+            elif msg.get("role") == "tool" and msg.get("content"):
+                # Extract file paths from tool results
+                result_text = msg["content"][:300]
+                tool_lines.append(f"  -> {result_text}")
+                # Quick scan for file paths in results
+                import re as _re
+                for match in _re.finditer(r'[\w/.-]+\.\w{1,10}', result_text):
+                    candidate = match.group(0)
+                    if "/" in candidate and not candidate.startswith("http"):
+                        files_touched.add(candidate)
+        if tool_lines:
+            sections.append("## Tool Activity\n" + "\n".join(tool_lines[-12:]))
+
+        # -- files touched --
+        # Filter out noise (system paths, very long paths) and deduplicate
+        clean_files = set()
+        for f in files_touched:
+            if len(f) > 5 and not f.startswith(("/usr/", "/tmp/", "/proc/")):
+                clean_files.add(f)
+        if clean_files:
+            file_list = sorted(clean_files)[:15]
+            sections.append("## Files Touched\n" + "\n".join(f"  {f}" for f in file_list))
+
+        # -- carry_forward project context (best-effort) --
+        try:
+            import subprocess
+            cf_path = os.path.expanduser(
+                "~/zion/projects/carry_forward/carry_forward/carry_forward.py"
+            )
+            if os.path.isfile(cf_path):
+                result = subprocess.run(
+                    ["python3", cf_path, "context"],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    sections.append(
+                        "## Project Context (carry_forward)\n"
+                        + result.stdout[:2000]
+                    )
+        except Exception:
+            pass
+
+        # -- focus topic --
+        if focus:
+            sections.append(f"## Focus\n{focus}")
+
+        msg_count = len(self.conversation_history)
+        header = (
+            f"[SESSION CONTINUATION -- previous session had {msg_count} messages "
+            f"and ran out of context. Pick up where we left off. "
+            f"Review the context below and continue working.]\n"
+        )
+        return header + "\n\n".join(sections)
+
     def save_conversation(self):
         """Save the current conversation to a JSON snapshot under ~/.hermes/sessions/saved/.
 
@@ -7518,6 +7707,8 @@ class HermesCLI:
             ) is None:
                 return
             self.undo_last()
+        elif canonical == "continue":
+            self._handle_continue_command(cmd_original)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
         elif canonical == "save":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -65,6 +65,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
+    CommandDef("continue", "Start a new session carrying forward context from this one", "Session",
+               aliases=("chain",), args_hint="[focus topic]",
+               cli_only=True),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -41,6 +41,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/status` | Show session info |
 | `/agents` (alias: `/tasks`) | Show active agents and running tasks across the current session. |
 | `/background <prompt>` (alias: `/bg`, `/btw`) | Run a prompt in a separate background session. The agent processes your prompt independently — your current session stays free for other work. Results appear as a panel when the task finishes. See [CLI Background Sessions](/docs/user-guide/cli#background-sessions). |
+| `/continue [focus topic]` (alias: `/chain`) | Start a fresh session carrying forward context from the current one. Extracts the primary task, recent exchanges, tool activity, files touched, and optional carry_forward project context — then injects it all into a new session and auto-triggers the agent to pick up where you left off. No LLM summarization cost (mechanical extraction). Add a focus topic to guide what the agent prioritizes (e.g. `/continue the RISC-V MMU`). Useful when your session runs out of context window. |
 | `/branch [name]` (alias: `/fork`) | Branch the current session (explore a different path) |
 | `/handoff <platform>` | **CLI only.** Hand the current session off to a messaging platform (Telegram, Discord, Slack, WhatsApp, Signal, Matrix). The gateway picks it up immediately, creates a fresh thread on platforms that support threads (Telegram topics, Discord text-channel threads, Slack message-anchored threads), re-binds the destination to your CLI session_id so the full role-aware transcript replays, and forges a synthetic user turn so the agent confirms it's working in the new place. Your CLI exits cleanly on success with a `/resume` hint; resume locally any time with `/resume <title>`. Refused mid-turn. Requires the gateway to be running and a home channel configured for the target platform (`/sethome` from the destination chat). See [Cross-Platform Handoff](/docs/user-guide/sessions#cross-platform-handoff). |
 
@@ -216,7 +217,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 ## Notes
 
-- `/skin`, `/snapshot`, `/gquota`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/skills`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, and `/quit` are **CLI-only** commands.
+- `/skin`, `/snapshot`, `/gquota`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/skills`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/continue`, and `/quit` are **CLI-only** commands.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, and `/commands` are **messaging-only** commands.
 - `/status`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -208,6 +208,39 @@ When a session's context is compressed (manually via `/compress` or automaticall
 
 When you resume by name (`hermes -c "my project"`), it automatically picks the most recent session in the lineage.
 
+### Session Continuation (`/continue`)
+
+When your session runs out of context window (you see the model truncating responses or losing track of earlier conversation), use `/continue` to start a fresh session that carries the important context forward:
+
+```
+/continue                    # carry full context forward
+/continue the database schema  # carry forward with a focus topic
+/chain                       # alias
+```
+
+**What it does:**
+
+1. Extracts a handoff summary from the current session:
+   - **Task** — the primary user intent (finds the most substantive user message)
+   - **Recent exchanges** — last 10 user/assistant messages
+   - **Tool activity** — recent tool calls, arguments, and results
+   - **Files touched** — file paths extracted from tool arguments and results
+   - **Project context** — carry_forward state (if available)
+2. Starts a completely new session (fresh ID, clean context window)
+3. Injects the handoff summary as the first user message
+4. Auto-triggers the agent to pick up where you left off
+
+**How it differs from related commands:**
+
+| Command | What happens |
+|---------|-------------|
+| `/new` | Blank session, no context carried over |
+| `/compress` | Summarizes in-place using an LLM call (costs tokens), stays in same session lineage |
+| `/continue` | Starts a new session with mechanical context extraction (no LLM cost, no token spend) |
+| `/branch` | Copies the full conversation history to a new session (no summarization, full fidelity) |
+
+`/continue` is the right choice when you want a clean context window but don't want to lose the thread. The extraction is mechanical (no LLM call), so it's instant and free. The trade-off is that the handoff is a structured dump rather than a concise LLM-generated summary.
+
 ### /title in Messaging Platforms
 
 The `/title` command works in all gateway platforms (Telegram, Discord, Slack, WhatsApp):


### PR DESCRIPTION
## Problem

When a session runs out of context window, the user currently has to manually copy context, type `/new`, and paste it back in — or accept losing the thread entirely.

## Solution

New `/continue` (alias: `/chain`) CLI-only slash command that:

1. **Extracts** a handoff summary from the current session (mechanical — no LLM call, zero token cost):
   - Primary task intent (finds the most substantive user message)
   - Last 10 user/assistant exchanges
   - Recent tool calls, arguments, and results
   - Files touched (extracted from tool args and results)
   - Optional carry_forward project context
2. **Starts** a completely new session (fresh ID, clean context window)
3. **Injects** the handoff as the first user message
4. **Auto-triggers** the agent to pick up where it left off

### Usage

```
/continue                    # carry full context forward
/continue the database schema  # with a focus topic
/chain                       # alias
```

### How it differs from related commands

| Command | What happens |
|---------|-------------|
| `/new` | Blank session, no context carried over |
| `/compress` | LLM-summarizes in-place (costs tokens), stays in same session lineage |
| `/continue` | New session, mechanical context extraction (no LLM cost) |
| `/branch` | Copies full conversation history to new session (no summarization) |

## Files changed

- `hermes_cli/commands.py` — `CommandDef("continue", ...)` with alias `("chain",)`, `cli_only=True`
- `cli.py` — dispatch, `_handle_continue_command()`, `_build_continuation_context()`
- `website/docs/reference/slash-commands.md` — added to Session table and CLI-only notes
- `website/docs/user-guide/sessions.md` — new "Session Continuation" subsection

## Testing

- Syntax-checked both modified Python files
- Verified registry entry resolves correctly for both `/continue` and `/chain`
- TUI rebuilt (`npm --prefix ui-tui run build`) — compiles clean
- Logic follows the same patterns as `/branch` and `/compress`

## Notes

- `cli_only=True` — gateway sessions use different session management
- The `carry_forward` integration is best-effort (15s timeout, silently skipped if unavailable)
- The auto-trigger uses `_pending_input.put()` to avoid recursive calls inside `process_loop`