### PR TITLE
fix(shutdown_forensics): only treat ppid==1 as systemd on Linux (salvage #25511)

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -108,7 +108,8 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
 
     * The signal number/name (so SIGINT vs SIGTERM is visible)
     * Our own PID/ppid + parent process info from /proc (Linux)
-    * Whether systemd is our parent (``ppid==1`` or ``INVOCATION_ID`` set)
+    * Whether systemd is our parent (``INVOCATION_ID`` set, or
+      ``ppid==1`` on Linux where PID 1 is reliably systemd)
     * Whether takeover/planned-stop markers exist (consumed lazily by the caller)
     * /proc/self limits + load average (1-min)
     * Wall-clock and monotonic timestamps for cross-correlating later phases
@@ -132,15 +133,18 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     }
 
     # systemd context.  If we were started by a systemd unit, INVOCATION_ID
-    # is set in our env.  ppid==1 (init) is also a strong signal that
-    # systemd reaped+forwarded the SIGTERM.
+    # is set in our env.  ppid==1 (init) is also a strong signal on Linux
+    # that systemd reaped+forwarded the SIGTERM.  On macOS, PID 1 is
+    # launchd (not systemd), so ppid==1 must NOT be treated as systemd.
     invocation_id = os.environ.get("INVOCATION_ID")
     if invocation_id:
         ctx["systemd_invocation_id"] = invocation_id
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    ctx["under_systemd"] = bool(invocation_id) or (
+        sys.platform.startswith("linux") and ppid == 1
+    )
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "62420081+kjames2001@users.noreply.github.com": "kjames2001",
     "132184373+wilsen0@users.noreply.github.com": "wilsen0",
     "ra2157218@gmail.com": "Abd0r",
+    "34071312+BowmanStephen@users.noreply.github.com": "BowmanStephen",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -74,11 +74,30 @@ class TestSnapshotShutdownContext:
     ):
         monkeypatch.delenv("INVOCATION_ID", raising=False)
         # We can't actually change ppid; skip if we happen to be reaped
-        # by init (e.g. running under tini).
-        if os.getppid() == 1:
-            pytest.skip("test process is reaped by init")
+        # by init (e.g. running under tini) on a non-Linux host where the
+        # fix still requires under_systemd=False.
+        if os.getppid() == 1 and sys.platform.startswith("linux"):
+            pytest.skip("test process is reaped by init on Linux")
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
         assert ctx["under_systemd"] is False
+
+    def test_under_systemd_false_on_darwin_even_when_ppid_is_one(
+        self, monkeypatch
+    ):
+        """On macOS, PID 1 is launchd (not systemd); under_systemd must be False."""
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(sf.sys, "platform", "darwin")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is False
+
+    def test_under_systemd_true_on_linux_when_ppid_is_one(self, monkeypatch):
+        """On Linux, ppid==1 is a strong signal that systemd reaped us."""
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(sf.sys, "platform", "linux")
+        monkeypatch.setattr(sf.os, "getppid", lambda: 1)
+        ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
+        assert ctx["under_systemd"] is True
 
     def test_completes_quickly(self):
         """Snapshot must NOT block — it runs inside the asyncio signal handler."""


### PR DESCRIPTION
## Summary

Salvage of [#25511](https://github.com/NousResearch/hermes-agent/pull/25511) (closed unmerged by author with no maintainer comment).

On macOS, PID 1 is **launchd**, not systemd, so `ppid == 1` must not be treated as a systemd-reaped signal. This gates the heuristic on `sys.platform.startswith("linux")`.

## Problem

`gateway/shutdown_forensics.snapshot_shutdown_context()` flags shutdown context with `under_systemd=True` whenever `ppid == 1` regardless of platform. On macOS that misidentifies launchd as systemd, polluting forensics logs and any downstream decision keyed on that flag.

## Root cause

```python
ctx["under_systemd"] = bool(invocation_id) or ppid == 1
```

The disjunct is platform-agnostic.

## Fix

```python
ctx["under_systemd"] = bool(invocation_id) or (
    sys.platform.startswith("linux") and ppid == 1
)
```

## Solution sketch

```mermaid
flowchart TD
    A[snapshot_shutdown_context called] --> B{INVOCATION_ID env set?}
    B -- yes --> Y[under_systemd = True]
    B -- no --> C{ppid == 1?}
    C -- no --> N[under_systemd = False]
    C -- yes --> D{platform startswith 'linux'?}
    D -- yes --> Y
    D -- no --> N
```

## Duplicate check

- No PR matching `shutdown_forensics` or `under_systemd` in `is:open`.
- No merged PR touching the `under_systemd` expression (searched merged with `launchd`, `macos systemd`).
- `#25511` is the canonical attempt; closed by author without explanation and no competing PR exists.

## Why salvage

- diff is 8 lines, scoped to one expression in one file
- preserves the author's intent (Stephen Bowman)
- adds proper tests that actually patch `sys.platform` rather than asserting against literal-string expressions

## Tests

```
python -m pytest tests/gateway/test_shutdown_forensics.py -q
# 28 passed, 4 skipped in 6.76s
```

Two new tests:

- `test_under_systemd_false_on_darwin_even_when_ppid_is_one`: monkeypatches `sys.platform` to `"darwin"` and `os.getppid` to `1`, asserts `under_systemd is False`.
- `test_under_systemd_true_on_linux_when_ppid_is_one`: same with `"linux"`, asserts `under_systemd is True`.

The existing `test_under_systemd_false_without_invocation_id_and_normal_ppid` is updated to keep skipping only when reaped by init on Linux.

## Risk

Low. The change tightens a heuristic on a non-Linux platform where the current behavior was wrong; Linux behavior is preserved bit-for-bit.

## Authorship

- Fix commit attributed to Stephen Bowman (original PR author).
- Test commit attributed to me (rewritten from the original test commit to use `monkeypatch` instead of literal-string assertions); Stephen co-authored.
- `scripts/release.py AUTHOR_MAP` updated so `check-attribution` passes for the salvage author.