### PR TITLE
fix(kanban): use worker profile git identity for kanban spawns (salvage #25201)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,28 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _kanban_worker_git_identity(profile: str) -> tuple[str, str]:
+    """Return the Git author/committer identity for a spawned worker.
+
+    Kanban workers are autonomous agents, so commits they create should be
+    attributable to the profile that did the work rather than to a shared host
+    account, a human operator, or a generic ``Hermes Agent`` identity.  Use a
+    deterministic, non-secret noreply-style address so the mapping covers all
+    current and future profiles without per-profile bootstrap config.
+    """
+    safe_profile = profile.strip() or "hermes-worker"
+    return safe_profile, f"{safe_profile}@users.noreply.github.com"
+
+
+def _inject_kanban_worker_git_identity(env: dict[str, str], profile: str) -> None:
+    """Force Git commits in a spawned worker to use that worker profile."""
+    git_name, git_email = _kanban_worker_git_identity(profile)
+    env["GIT_AUTHOR_NAME"] = git_name
+    env["GIT_AUTHOR_EMAIL"] = git_email
+    env["GIT_COMMITTER_NAME"] = git_name
+    env["GIT_COMMITTER_EMAIL"] = git_email
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3975,6 +3997,11 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+    # Git reads these environment variables before repository/global config.
+    # Setting them at dispatcher spawn time makes commit author/committer
+    # metadata match the worker profile in every workspace, without touching
+    # per-profile secrets or relying on mutable ~/.gitconfig bootstrap state.
+    _inject_kanban_worker_git_identity(env, profile_arg)
 
     cmd = [
         *_resolve_hermes_argv(),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "62420081+kjames2001@users.noreply.github.com": "kjames2001",
     "132184373+wilsen0@users.noreply.github.com": "wilsen0",
     "ra2157218@gmail.com": "Abd0r",
+    "ottobytebeaver@users.noreply.github.com": "fleeco",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1084,6 +1084,57 @@ class TestSharedBoardPaths:
             default_home / "kanban" / "workspaces"
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_PROFILE"] == "coder"
+        assert env["GIT_AUTHOR_NAME"] == "coder"
+        assert env["GIT_AUTHOR_EMAIL"] == "coder@users.noreply.github.com"
+        assert env["GIT_COMMITTER_NAME"] == "coder"
+        assert env["GIT_COMMITTER_EMAIL"] == "coder@users.noreply.github.com"
+
+    def test_dispatcher_spawn_overrides_parent_git_identity_with_worker_profile(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Hermes Agent")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "hermes-agent@users.noreply.github.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "flees")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "flees@example.com")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4343
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_dispatch_git_identity",
+            title="x",
+            body=None,
+            assignee="PixelPanda",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        assert env["HERMES_PROFILE"] == "pixelpanda"
+        assert env["GIT_AUTHOR_NAME"] == "pixelpanda"
+        assert env["GIT_AUTHOR_EMAIL"] == "pixelpanda@users.noreply.github.com"
+        assert env["GIT_COMMITTER_NAME"] == "pixelpanda"
+        assert env["GIT_COMMITTER_EMAIL"] == "pixelpanda@users.noreply.github.com"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Salvage of [#25201](https://github.com/NousResearch/hermes-agent/pull/25201) (closed unmerged by author with no maintainer comment, no competing PR).

Kanban workers are autonomous agents — commits they produce should be attributable to the profile that did the work, not to the dispatcher host's ambient git identity.

## Problem

When the dispatcher spawns a worker via `_default_spawn`, the worker subprocess inherits `GIT_AUTHOR_*` / `GIT_COMMITTER_*` from the dispatcher environment. Any commit produced inside the worker workspace ends up attributed to the operator (or to a generic "Hermes Agent") rather than to the profile that actually authored the work.

## Root cause

`hermes_cli/kanban_db.py:_default_spawn` propagates the parent env unchanged for git identity vars. There's no per-profile override.

## Fix

Add two small helpers and call the second one right after `HERMES_PROFILE` is injected:

```python
def _kanban_worker_git_identity(profile: str) -> tuple[str, str]:
    safe_profile = profile.strip() or "hermes-worker"
    return safe_profile, f"{safe_profile}@users.noreply.github.com"

def _inject_kanban_worker_git_identity(env: dict[str, str], profile: str) -> None:
    git_name, git_email = _kanban_worker_git_identity(profile)
    env["GIT_AUTHOR_NAME"] = git_name
    env["GIT_AUTHOR_EMAIL"] = git_email
    env["GIT_COMMITTER_NAME"] = git_name
    env["GIT_COMMITTER_EMAIL"] = git_email
```

`GIT_AUTHOR_*` / `GIT_COMMITTER_*` take precedence over `~/.gitconfig` and `repo/.git/config`, so the override is reliable in every workspace without per-profile bootstrap.

## Solution sketch

```mermaid
flowchart TD
    A[Dispatcher claims task] --> B[_default_spawn builds env]
    B --> C[Inject HERMES_PROFILE = profile_arg]
    C --> D[Inject GIT_AUTHOR_* and GIT_COMMITTER_*]
    D --> E[subprocess.Popen worker]
    E --> F[Worker commits use profile identity]
```

## Duplicate check

- No PR in `is:open` matching "worker profile git identity" or `kanban_db.py` git env injection.
- The one open PR returned by adjacent searches (`#24616` — Slack visual identities) is unrelated.
- `#25201` is the only attempt; closed by author without explanation.

## Tests

```
python -m pytest tests/hermes_cli/test_kanban_db.py -k dispatcher_spawn -q
# 2 passed in 4.41s
```

Two tests:

- `test_dispatcher_spawn_injects_kanban_db_and_workspaces_root` — extended to assert the new git env vars match the worker profile.
- `test_dispatcher_spawn_overrides_parent_git_identity_with_worker_profile` — new test: sets contradictory `GIT_AUTHOR_*` / `GIT_COMMITTER_*` in the parent env and verifies the worker env still gets the profile identity.

## Risk

Low. The change is additive to the spawn env. Workers continue to commit; only the author/committer strings change. Profiles already exist for every spawned worker, so there's no missing-data path.

## Authorship

- Fix and tests cherry-picked from `#25201` with `fleeco`'s authorship preserved.
- `scripts/release.py AUTHOR_MAP` updated so `check-attribution` resolves `ottobytebeaver@users.noreply.github.com` to `fleeco`.