### PR TITLE
test(toolsets): lock web search into default platform coverage (salvage #25269)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "62420081+kjames2001@users.noreply.github.com": "kjames2001",
     "132184373+wilsen0@users.noreply.github.com": "wilsen0",
     "ra2157218@gmail.com": "Abd0r",
+    "oswaldb22@users.noreply.github.com": "oswaldb22",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -83,6 +83,12 @@ def test_get_platform_tools_default_telegram_includes_messaging():
     assert "messaging" in enabled
 
 
+def test_get_platform_tools_default_whatsapp_includes_web():
+    enabled = _get_platform_tools({}, "whatsapp")
+
+    assert "web" in enabled
+
+
 def test_get_platform_tools_homeassistant_platform_keeps_homeassistant_toolset():
     enabled = _get_platform_tools({}, "homeassistant")
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -246,3 +246,11 @@ class TestPluginToolsets:
         all_toolsets = get_all_toolsets()
         assert "plugin_bundle" in all_toolsets
         assert all_toolsets["plugin_bundle"]["tools"] == ["plugin_tool"]
+
+
+class TestDefaultPlatformWebSearchCoverage:
+    def test_hermes_whatsapp_toolset_includes_web_search(self):
+        assert "web_search" in resolve_toolset("hermes-whatsapp")
+
+    def test_hermes_api_server_toolset_includes_web_search(self):
+        assert "web_search" in resolve_toolset("hermes-api-server")


### PR DESCRIPTION
## Summary

Salvage of [#25269](https://github.com/NousResearch/hermes-agent/pull/25269) (closed unmerged by author, no review, no competing PR).

Adds three regression tests that assert `web` / `web_search` is enabled by default for the WhatsApp platform tools and for the `hermes-whatsapp` and `hermes-api-server` toolsets. These lock in current behaviour so a future tools-config refactor cannot silently drop web search from those defaults.

## Why salvage

- pure tests, no production code touched
- no competing or duplicate PR
- the original author closed it without explanation; nothing in the comments suggested the assertions are wrong

## Tests

```
python -m pytest tests/hermes_cli/test_tools_config.py::test_get_platform_tools_default_whatsapp_includes_web tests/test_toolsets.py::TestDefaultPlatformWebSearchCoverage -q
# 3 passed in 5.57s
```

## Solution sketch

```mermaid
flowchart TD
    A[Refactor touches default platform tools] --> B[CI runs new regression tests]
    B --> C{'web' in whatsapp defaults?}
    C -- yes --> P[Pass]
    C -- no --> F[Fail and surface the regression]
```

## Risk

None. Tests-only, no runtime change.

## Authorship

- Test commit cherry-picked from `#25269` preserving `oswaldb22`'s authorship.
- `scripts/release.py AUTHOR_MAP` updated so `check-attribution` resolves `oswaldb22@users.noreply.github.com` to `oswaldb22`.