### PR TITLE
fix(gateway): load streaming config from nested gateway.streaming key

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -735,6 +735,10 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
 
             streaming_cfg = yaml_cfg.get("streaming")
+            if not isinstance(streaming_cfg, dict):
+                # Fall back to nested gateway.streaming written by
+                # ``hermes config set gateway.streaming.*``
+                streaming_cfg = yaml_cfg.get("gateway", {}).get("streaming")
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
 

--- a/tests/test_gateway_streaming_nested_config.py
+++ b/tests/test_gateway_streaming_nested_config.py
@@ -1,0 +1,46 @@
+"""Regression test for #25676 — nested gateway.streaming config must be loaded."""
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import json
+
+import pytest
+import yaml
+
+
+def _load_with_yaml_dict(yaml_dict: dict):
+    """Patch filesystem so load_gateway_config() sees *yaml_dict* as config.yaml."""
+    from gateway.config import load_gateway_config
+
+    fake_home = Path("/tmp/fake_hermes_home_25676")
+
+    def fake_exists(self):
+        return str(self).endswith("config.yaml")
+
+    with patch("gateway.config.get_hermes_home", return_value=fake_home), \
+         patch.object(Path, "exists", fake_exists), \
+         patch("builtins.open", create=True) as mock_file:
+        mock_file.return_value.__enter__ = lambda s: s
+        mock_file.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("yaml.safe_load", return_value=yaml_dict):
+            return load_gateway_config()
+
+
+class TestStreamingConfigNested:
+    def test_top_level_streaming(self):
+        cfg = _load_with_yaml_dict({"streaming": {"enabled": True, "transport": "draft"}})
+        assert cfg.streaming.enabled is True
+        assert cfg.streaming.transport == "draft"
+
+    def test_nested_gateway_streaming(self):
+        """Regression for #25676."""
+        cfg = _load_with_yaml_dict({"gateway": {"streaming": {"enabled": True, "transport": "draft"}}})
+        assert cfg.streaming.enabled is True
+        assert cfg.streaming.transport == "draft"
+
+    def test_top_level_takes_precedence(self):
+        cfg = _load_with_yaml_dict({
+            "streaming": {"enabled": True, "transport": "edit"},
+            "gateway": {"streaming": {"enabled": False, "transport": "draft"}},
+        })
+        assert cfg.streaming.enabled is True
+        assert cfg.streaming.transport == "edit"


### PR DESCRIPTION
## Summary

Fix silent config drop when streaming is configured via `hermes config set gateway.streaming.*`.

## Problem

`hermes config set gateway.streaming.enabled true` writes the streaming block **nested** under a `gateway:` key in `config.yaml`:

```yaml
gateway:
  streaming:
    enabled: true
    transport: draft
```

But `load_gateway_config()` (line 737) only checked for a **top-level** `streaming:` key — silently ignoring the nested variant. Users following the `telegram.md` docs hit this and got no streaming with zero diagnostics.

## Fix

In `gateway/config.py`, fall back to `yaml_cfg["gateway"]["streaming"]` when the top-level key is absent. Top-level still takes precedence when both exist. This matches the existing pattern for other nested config sections (e.g. `platforms`).

## Test

Added `tests/test_gateway_streaming_nested_config.py` with 3 cases:
- Top-level streaming config (existing behavior ✓)
- Nested gateway.streaming config (regression for #25676 ✓)
- Top-level takes precedence when both present ✓

All 3 pass. Existing test suite unaffected.

Closes #25676