### PR TITLE
fix(qqbot): handle gateway reconnect opcodes

### DIFF
--- a/gateway/platforms/qqbot/__init__.py
+++ b/gateway/platforms/qqbot/__init__.py
@@ -18,6 +18,7 @@ New modules:
 from .adapter import (  # noqa: F401
     QQAdapter,
     QQCloseError,
+    QQGatewayReconnect,
     check_qq_requirements,
     _coerce_list,
     _ssrf_redirect_guard,
@@ -59,6 +60,7 @@ __all__ = [
     # adapter
     "QQAdapter",
     "QQCloseError",
+    "QQGatewayReconnect",
     "check_qq_requirements",
     "_coerce_list",
     "_ssrf_redirect_guard",

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -87,6 +87,14 @@ class QQCloseError(Exception):
         super().__init__(f"WebSocket closed (code={self.code}, reason={self.reason})")
 
 
+class QQGatewayReconnect(Exception):
+    """Raised when QQ sends an application-level reconnect control opcode."""
+
+    def __init__(self, reason: str = "Server requested reconnect"):
+        self.reason = str(reason) if reason else "Server requested reconnect"
+        super().__init__(self.reason)
+
+
 # ---------------------------------------------------------------------------
 # Constants — imported from the shared constants module.
 # ---------------------------------------------------------------------------
@@ -225,6 +233,8 @@ class QQAdapter(BasePlatformAdapter):
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
+        self._gateway_reconnect_requested = False
+        self._gateway_reconnect_reason: Optional[str] = None
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
@@ -494,6 +504,30 @@ class QQAdapter(BasePlatformAdapter):
                 quick_disconnect_count = 0
             except asyncio.CancelledError:
                 return
+            except QQGatewayReconnect as exc:
+                if not self._running:
+                    return
+
+                logger.info(
+                    "[%s] Gateway requested reconnect: %s",
+                    self._log_tag,
+                    exc.reason,
+                )
+                self._mark_transport_disconnected()
+                self._fail_pending("Gateway requested reconnect")
+
+                if await self._reconnect(backoff_idx):
+                    backoff_idx = 0
+                    quick_disconnect_count = 0
+                else:
+                    backoff_idx += 1
+                    if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error(
+                            "[%s] Max reconnect attempts reached (gateway reconnect)",
+                            self._log_tag,
+                        )
+                        self._mark_disconnected()
+                        return
             except QQCloseError as exc:
                 if not self._running:
                     return
@@ -662,6 +696,14 @@ class QQAdapter(BasePlatformAdapter):
                 payload = self._parse_json(msg.data)
                 if payload:
                     self._dispatch_payload(payload)
+                    if self._gateway_reconnect_requested:
+                        reason = (
+                            self._gateway_reconnect_reason
+                            or "Server requested reconnect"
+                        )
+                        self._gateway_reconnect_requested = False
+                        self._gateway_reconnect_reason = None
+                        raise QQGatewayReconnect(reason)
             elif msg.type in {aiohttp.WSMsgType.PING,}:
                 # aiohttp auto-replies with PONG
                 pass
@@ -824,6 +866,26 @@ class QQAdapter(BasePlatformAdapter):
 
         # op 11 = Heartbeat ACK
         if op == 11:
+            return
+
+        # QQ Bot official docs define op 7 Reconnect as:
+        # "服务端通知客户端重新连接" — server tells client to reconnect.
+        # Preserve session_id / seq so the next Hello can send op 6 Resume.
+        if op == 7:
+            logger.info("[%s] Server requested reconnect", self._log_tag)
+            self._gateway_reconnect_requested = True
+            self._gateway_reconnect_reason = "Server requested reconnect"
+            return
+
+        # QQ Bot official docs define op 9 Invalid Session as returned when
+        # Identify or Resume parameters are invalid. Clear resume state so the
+        # next Hello sends Identify instead of retrying an invalid Resume.
+        if op == 9:
+            logger.info("[%s] Invalid session, clearing resume state", self._log_tag)
+            self._session_id = None
+            self._last_seq = None
+            self._gateway_reconnect_requested = True
+            self._gateway_reconnect_reason = "Invalid session"
             return
 
         logger.debug("[%s] Unknown op: %s", self._log_tag, op)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -410,6 +410,18 @@ class TestQQCloseError:
 
 
 # ---------------------------------------------------------------------------
+# QQGatewayReconnect
+# ---------------------------------------------------------------------------
+
+class TestQQGatewayReconnect:
+    def test_reason(self):
+        from gateway.platforms.qqbot import QQGatewayReconnect
+        err = QQGatewayReconnect("Invalid session")
+        assert err.reason == "Invalid session"
+        assert "Invalid session" in str(err)
+
+
+# ---------------------------------------------------------------------------
 # _dispatch_payload
 # ---------------------------------------------------------------------------
 
@@ -447,6 +459,72 @@ class TestDispatchPayload:
         adapter._dispatch_payload({"op": 0, "t": "READY", "s": 5, "d": {}})
         adapter._dispatch_payload({"op": 0, "t": "SOME_EVENT", "s": 10, "d": {}})
         assert adapter._last_seq == 10
+
+    def test_op7_requests_reconnect_without_clearing_resume_state(self):
+        """QQ docs define op 7 as server-requested Reconnect."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._session_id = "sess_abc"
+        adapter._last_seq = 50
+
+        adapter._dispatch_payload({"op": 7, "d": {}})
+
+        assert adapter._gateway_reconnect_requested is True
+        assert adapter._gateway_reconnect_reason == "Server requested reconnect"
+        assert adapter._session_id == "sess_abc"
+        assert adapter._last_seq == 50
+
+    def test_op9_invalid_session_clears_resume_state_and_requests_reconnect(self):
+        """QQ docs define op 9 as Invalid Session after bad Identify/Resume."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._session_id = "sess_abc"
+        adapter._last_seq = 50
+
+        adapter._dispatch_payload({"op": 9, "d": False})
+
+        assert adapter._gateway_reconnect_requested is True
+        assert adapter._gateway_reconnect_reason == "Invalid session"
+        assert adapter._session_id is None
+        assert adapter._last_seq is None
+
+
+# ---------------------------------------------------------------------------
+# _read_events reconnect op handling
+# ---------------------------------------------------------------------------
+
+class TestReadEventsReconnectOps:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_op7_exits_read_loop_for_reconnect(self):
+        """Server op 7 should break read loop so the listener reconnects."""
+        aiohttp = pytest.importorskip("aiohttp")
+        from gateway.platforms.qqbot import QQGatewayReconnect
+
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._session_id = "sess_abc"
+        adapter._last_seq = 50
+
+        class FakeMessage:
+            type = aiohttp.WSMsgType.TEXT
+            data = json.dumps({"op": 7, "d": {}})
+
+        class FakeWebSocket:
+            closed = False
+
+            async def receive(self):
+                self.closed = True
+                return FakeMessage()
+
+        adapter._ws = FakeWebSocket()
+
+        with pytest.raises(QQGatewayReconnect) as exc_info:
+            asyncio.run(adapter._read_events())
+
+        assert exc_info.value.reason == "Server requested reconnect"
+        assert adapter._session_id == "sess_abc"
+        assert adapter._last_seq == 50
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Handles QQ Bot gateway application-level reconnect opcodes instead of treating them as ordinary WebSocket close failures.

Fixes #24357.

QQ Bot’s official gateway docs define:

- op `7` as `Reconnect` / `服务端通知客户端重新连接`
- op `9` as `Invalid Session`

Before this change, the QQBot adapter did not explicitly handle these control opcodes. This could leave the read loop running after the server had requested a reconnect, or retry an invalid resume session after op `9`.

This PR adds explicit handling for both cases:

- op `7` requests a reconnect while preserving `session_id` and sequence state, so the next connection can use Resume.
- op `9` requests a reconnect after clearing resume state, so the next connection falls back to Identify.
- Gateway-level reconnects use a dedicated `QQGatewayReconnect` signal instead of `QQCloseError`, keeping WebSocket close-code handling reserved for real transport closes and avoiding quick-disconnect false positives.

## Official references:

- Opcode table: https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/interface-framework/opcode.html
- Event / Resume flow: https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/interface-framework/event-emit.html
- WebSocket error codes: https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/error-trace/websocket.html

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`
  - Added `QQGatewayReconnect` for QQ gateway application-level reconnect control messages.
  - Handles op `7` by requesting reconnect while preserving resume state.
  - Handles op `9` by clearing invalid resume state and requesting reconnect.
  - Makes `_read_events()` exit on op `7` / op `9` so `_listen_loop()` can reconnect promptly.
  - Bypasses generic WebSocket close / quick-disconnect handling for these documented gateway control opcodes.

- `gateway/platforms/qqbot/__init__.py`
  - Exports `QQGatewayReconnect`.

- `tests/gateway/test_qqbot.py`
  - Adds coverage for op `7` preserving resume state and requesting reconnect.
  - Adds coverage for op `9` clearing resume state and requesting reconnect.
  - Adds coverage that op `7` exits the read loop via `QQGatewayReconnect`.
  - Adds coverage for the new reconnect signal type.
