### PR TITLE
fix: add Discord strict mention alias

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -910,6 +910,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
                 if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
                     os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
+                if "strict_mention" in discord_cfg and not os.getenv("DISCORD_STRICT_MENTION"):
+                    os.environ["DISCORD_STRICT_MENTION"] = str(discord_cfg["strict_mention"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3590,11 +3590,16 @@ class DiscordAdapter(BasePlatformAdapter):
         unwanted cross-replies.
         """
         configured = self.config.extra.get("thread_require_mention")
+        if configured is None:
+            configured = self.config.extra.get("strict_mention")
         if configured is not None:
             if isinstance(configured, str):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
-        return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
+        env_value = os.getenv("DISCORD_THREAD_REQUIRE_MENTION")
+        if env_value is None:
+            env_value = os.getenv("DISCORD_STRICT_MENTION", "false")
+        return env_value.lower() in ("true", "1", "yes", "on")
 
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,7 @@ No LLM, no real platform connections.
 """
 
 import asyncio
+import os
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -215,6 +216,9 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner._show_reasoning = False
 
     runner._is_user_authorized = lambda _source: True
+    # Keep gateway command e2e tests deterministic: destructive slash
+    # confirmation is covered separately in tests/gateway/test_destructive_slash_confirm.py.
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": False}}
     runner._set_session_env = lambda _context: None
     runner._handle_message_with_agent = AsyncMock(return_value="agent-handled-default")
     runner._should_send_voice_reply = lambda *_a, **_kw: False
@@ -392,6 +396,14 @@ def _make_discord_adapter_wired(runner=None):
     """Create a DiscordAdapter wired to a GatewayRunner for e2e tests."""
     if runner is None:
         runner = make_runner(Platform.DISCORD)
+
+    for env_name in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_STRICT_MENTION",
+    ):
+        os.environ.pop(env_name, None)
 
     config = PlatformConfig(enabled=True, token="e2e-test-token")
     from gateway.platforms.helpers import ThreadParticipationTracker

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -87,6 +87,13 @@ def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
     monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+    for env_name in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_STRICT_MENTION",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
     # Clear DISCORD_* env vars the test file exercises so tests don't leak
     # process-env state from the contributor's shell into per-test behaviour.
@@ -387,6 +394,46 @@ async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "follow-up without mention"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_strict_mention_requires_fresh_mentions_in_known_threads(adapter, monkeypatch):
+    """strict_mention disables the participated-thread mention bypass."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_STRICT_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("456")
+
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(channel=thread, content="follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_strict_mention_keeps_free_response_parent_override(adapter, monkeypatch):
+    """strict_mention still lets configured free-response channels bypass mention gating."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_STRICT_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "222")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("333")
+
+    forum = FakeForumChannel(channel_id=222, name="support-forum")
+    thread = FakeThread(channel_id=333, name="Forum topic", parent=forum)
+    message = make_message(channel=thread, content="allowed from forum thread")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "allowed from forum thread"
     assert event.source.chat_type == "thread"
 
 


### PR DESCRIPTION
## Summary
- Adds `discord.strict_mention` / `DISCORD_STRICT_MENTION` as a backward-compatible alias for the new `thread_require_mention` Discord thread gating behavior.
- Keeps upstream `discord.thread_require_mention` behavior intact after rebasing onto latest `main`.
- Isolates Discord mention/e2e tests from operator-specific Discord channel env vars so local configured gateways do not break deterministic tests.

## Tracking
Closes #20742

## Test plan
- `python -m pytest tests/gateway/test_discord_free_response.py tests/e2e/test_discord_adapter.py -q -o 'addopts='` → 34 passed

## Notes
- Push went to `peacockesq/hermes-agent` fork because the active GitHub account does not have write permission on `NousResearch/hermes-agent`.
