### PR TITLE
fix(cli): marshal sudo password modal setup onto loop thread (#25707)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11244,31 +11244,45 @@ class HermesCLI:
     def _sudo_password_callback(self) -> str:
         """
         Prompt for sudo password through the prompt_toolkit UI.
-        
+
         Called from the agent thread when a sudo command is encountered.
         Uses the same clarify-style mechanism: sets UI state, waits on a
         queue for the user's response via the Enter key binding.
+
+        Setup and teardown (snapshot capture/restore, ``_sudo_state``
+        assignment, invalidate) are marshalled onto the prompt_toolkit
+        event-loop thread via ``call_soon_threadsafe`` when invoked from
+        a worker thread (the common case — sudo runs on the agent
+        thread, not main).  ``Buffer.reset()`` triggers the buffer's
+        ``on_text_changed`` event synchronously, which can race with the
+        renderer on certain terminals (WSL2 + VSCode Windows Terminal,
+        issue #25707): the reset is silently dropped, the modal widget
+        never renders, and keystrokes leak into the agent input buffer
+        instead of the password prompt.
         """
         import time as _time
 
         timeout = 45
         response_queue = queue.Queue()
 
-        self._capture_modal_input_snapshot()
-        self._sudo_state = {
-            "response_queue": response_queue,
-        }
-        self._sudo_deadline = _time.monotonic() + timeout
+        def _setup() -> None:
+            self._capture_modal_input_snapshot()
+            self._sudo_state = {"response_queue": response_queue}
+            self._sudo_deadline = _time.monotonic() + timeout
+            self._invalidate()
 
-        self._invalidate()
+        def _teardown() -> None:
+            self._sudo_state = None
+            self._sudo_deadline = 0
+            self._restore_modal_input_snapshot()
+            self._invalidate()
+
+        self._run_on_loop_thread(_setup)
 
         while True:
             try:
                 result = response_queue.get(timeout=1)
-                self._sudo_state = None
-                self._sudo_deadline = 0
-                self._restore_modal_input_snapshot()
-                self._invalidate()
+                self._run_on_loop_thread(_teardown)
                 if result:
                     _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
                 else:
@@ -11280,10 +11294,7 @@ class HermesCLI:
                     break
                 self._invalidate()
 
-        self._sudo_state = None
-        self._sudo_deadline = 0
-        self._restore_modal_input_snapshot()
-        self._invalidate()
+        self._run_on_loop_thread(_teardown)
         _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
         return ""
 
@@ -11562,6 +11573,73 @@ class HermesCLI:
 
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
         return prompt_for_secret(self, var_name, prompt, metadata)
+
+    def _run_on_loop_thread(self, func, *, wait_timeout: float = 2.0) -> None:
+        """Run ``func`` on the prompt_toolkit event-loop thread.
+
+        Mirrors the cross-thread scheduling pattern used by ``_cprint``
+        (see cli.py module-level helper).  Buffer mutations
+        (``buf.reset()``, ``buf.text = ...``) trigger the buffer's
+        ``on_text_changed`` event synchronously and need consistent
+        thread context to avoid racing the renderer.  When invoked from
+        a worker thread, schedule on the loop and wait briefly for
+        completion so callers see the side effects before they continue.
+
+        When the app or its loop is not available (tests, app shutdown),
+        run ``func`` inline so existing call sites without a live
+        prompt_toolkit loop still work.
+        """
+        app = getattr(self, "_app", None)
+        if app is None:
+            try:
+                func()
+            except Exception:
+                pass
+            return
+
+        try:
+            loop = app.loop  # type: ignore[attr-defined]
+        except Exception:
+            loop = None
+        if loop is None or not getattr(loop, "is_running", lambda: False)():
+            try:
+                func()
+            except Exception:
+                pass
+            return
+
+        import asyncio as _asyncio
+        try:
+            current_loop = _asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        except Exception:
+            current_loop = None
+        if current_loop is loop:
+            try:
+                func()
+            except Exception:
+                pass
+            return
+
+        done = threading.Event()
+
+        def _run_and_signal() -> None:
+            try:
+                func()
+            finally:
+                done.set()
+
+        try:
+            loop.call_soon_threadsafe(_run_and_signal)
+        except Exception:
+            try:
+                func()
+            except Exception:
+                pass
+            return
+
+        done.wait(timeout=wait_timeout)
 
     def _capture_modal_input_snapshot(self) -> None:
         """Temporarily clear the input buffer and save the user's in-progress draft."""

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -177,6 +177,138 @@ class TestCliApprovalUi:
         assert "keyring.gpg" in rendered
         assert "status=progress" in rendered
 
+    def test_sudo_prompt_marshals_buffer_reset_to_loop_thread(self):
+        """Regression for #25707: buffer mutations from a worker thread can be
+        silently dropped by some terminals (WSL2 + VSCode Windows Terminal), so
+        ``_sudo_password_callback`` must route snapshot capture + state setup
+        through the prompt_toolkit event-loop thread via ``call_soon_threadsafe``.
+        """
+
+        cli = _make_cli_stub()
+
+        # _FakeLoop captures call_soon_threadsafe callbacks so the test can
+        # drive them on a chosen "loop thread", mirroring what prompt_toolkit
+        # does in production.
+        scheduled: list = []
+        scheduled_lock = threading.Lock()
+        mutation_thread_ids: list = []
+
+        class _FakeLoop:
+            def is_running(self):
+                return True
+
+            def call_soon_threadsafe(self, cb, *args):
+                with scheduled_lock:
+                    scheduled.append((cb, args))
+
+        class _TrackingBuffer(_FakeBuffer):
+            def reset(self, append_to_history=False):
+                mutation_thread_ids.append(threading.get_ident())
+                super().reset(append_to_history=append_to_history)
+
+        cli._app = SimpleNamespace(
+            invalidate=MagicMock(),
+            current_buffer=_TrackingBuffer("draft command", cursor_position=5),
+            loop=_FakeLoop(),
+        )
+        loop_thread_id = threading.get_ident()
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        with patch.object(cli_module, "_cprint"):
+            worker = threading.Thread(target=_run_callback, daemon=True)
+            worker.start()
+
+            # Setup must NOT have happened on the worker yet — the worker is
+            # blocked waiting on the scheduled callback to run on the loop
+            # thread.  Poll the schedule queue instead of the state field.
+            deadline = time.time() + 2
+            while not scheduled and time.time() < deadline:
+                time.sleep(0.005)
+            assert scheduled, "setup was not scheduled via call_soon_threadsafe"
+            assert cli._sudo_state is None, (
+                "_sudo_state was assigned on the worker thread before the loop "
+                "ran the scheduled setup — the marshalling regressed."
+            )
+            assert cli._app.current_buffer.text == "draft command", (
+                "Buffer was reset on the worker thread before the loop ran the "
+                "scheduled setup — the marshalling regressed."
+            )
+
+            # Drive the loop on this (test main) thread.
+            with scheduled_lock:
+                setup_cb, _args = scheduled.pop(0)
+            setup_cb()
+
+            # After the loop ran setup, the modal state and reset buffer are
+            # both visible to the worker.
+            assert cli._sudo_state is not None
+            assert cli._app.current_buffer.text == ""
+            assert mutation_thread_ids == [loop_thread_id], (
+                "buf.reset() must execute on the loop thread, not the worker"
+            )
+
+            # Worker is now waiting on the response_queue.  Deliver password.
+            cli._app.current_buffer.text = "secret"
+            cli._app.current_buffer.cursor_position = len("secret")
+            cli._sudo_state["response_queue"].put("secret")
+
+            # Teardown is scheduled via the same call_soon_threadsafe path.
+            deadline = time.time() + 2
+            while not scheduled and time.time() < deadline:
+                time.sleep(0.005)
+            assert scheduled, "teardown was not scheduled via call_soon_threadsafe"
+            with scheduled_lock:
+                teardown_cb, _args = scheduled.pop(0)
+            teardown_cb()
+
+            worker.join(timeout=2)
+
+        assert result["value"] == "secret"
+        assert cli._sudo_state is None
+        assert cli._app.current_buffer.text == "draft command"
+        assert cli._app.current_buffer.cursor_position == 5
+
+    def test_run_on_loop_thread_runs_inline_without_app(self):
+        """Fallback path: callers without a live prompt_toolkit app (tests,
+        shutdown, pre-init) still get ``_run_on_loop_thread`` to execute the
+        callable inline instead of blocking indefinitely on an Event."""
+
+        cli = _make_cli_stub()
+        cli._app = None
+        ran = []
+
+        cli._run_on_loop_thread(lambda: ran.append(threading.get_ident()))
+
+        assert ran == [threading.get_ident()]
+
+    def test_run_on_loop_thread_runs_inline_when_loop_not_running(self):
+        """If the app exists but its loop is not running, fall back to inline
+        execution rather than scheduling a callback that nothing will drive."""
+
+        cli = _make_cli_stub()
+
+        class _IdleLoop:
+            def is_running(self):
+                return False
+
+            def call_soon_threadsafe(self, cb, *args):  # pragma: no cover
+                raise AssertionError("must not schedule when loop is idle")
+
+        cli._app = SimpleNamespace(
+            invalidate=MagicMock(),
+            current_buffer=_FakeBuffer(),
+            loop=_IdleLoop(),
+        )
+        ran = []
+
+        cli._run_on_loop_thread(lambda: ran.append(True))
+
+        assert ran == [True]
+
     def test_approval_display_preserves_command_and_choices_with_long_description(self):
         """Regression: long tirith descriptions used to push approve/deny off-screen.
 


### PR DESCRIPTION
## Summary

- Fixes the sudo password TUI freeze reported in #25707 by marshalling `_sudo_password_callback`'s modal setup/teardown onto the prompt_toolkit event-loop thread via `call_soon_threadsafe`.
- Adds a new `_run_on_loop_thread` helper that mirrors the existing cross-thread scheduling pattern used by `_cprint` (cli.py:1495).
- Adds a regression test that exercises the marshalling path with a fake loop and asserts buffer mutations happen on the loop thread, not the worker.

## The bug

`_sudo_password_callback` runs on the agent worker thread when a sudo command is encountered. The previous implementation called `_capture_modal_input_snapshot()` directly from that worker thread, which invokes `Buffer.reset()` on prompt_toolkit's `current_buffer`. `Buffer.reset()` synchronously fires the buffer's `on_text_changed` event (the heavyweight `_on_text_changed` handler in cli.py that does paste detection, mouse-report scrubbing, terminal-mode recovery, etc.).

Running that handler off the loop thread can race the renderer. On WSL2 + VSCode Windows Terminal the reset is silently dropped — the modal widget never renders, and the user's keystrokes leak into the agent input buffer instead of the password prompt (100% reproducible per the reporter).

This is the same root-cause class as the slash-command input hang fixed by commit `c5f1f863a` for `_prompt_text_input` (issue #23185): a prompt_toolkit primitive that must run on the loop thread was being invoked from a daemon thread, with the side effects silently dropped.

## The fix

Add a `_run_on_loop_thread(func)` helper that:

1. Falls back to inline execution if no app, no loop, or loop not running (tests, shutdown, pre-init).
2. Runs ``func`` inline when already on the loop thread.
3. Otherwise schedules ``func`` via ``loop.call_soon_threadsafe`` and waits briefly on a ``threading.Event`` so the worker thread only proceeds after the loop thread has applied the mutations.

Wrap ``_sudo_password_callback``'s setup (snapshot capture + ``_sudo_state`` assignment + ``_invalidate``) and teardown (state clear + snapshot restore + ``_invalidate``) in this helper. Loop-driven blocking on ``response_queue.get(timeout=1)`` stays on the worker thread — only the prompt_toolkit-touching side effects move to the loop thread.

## Test plan

- [x] Focused regression test: ``tests/cli/test_cli_approval_ui.py::TestCliApprovalUi::test_sudo_prompt_marshals_buffer_reset_to_loop_thread`` — installs a fake loop that captures ``call_soon_threadsafe`` callbacks and a tracking buffer that records the thread its ``reset()`` ran on. Asserts (1) setup is scheduled, (2) ``_sudo_state`` stays ``None`` and the buffer text is unchanged on the worker thread until the loop runs the callback, (3) ``buf.reset()`` executes on the loop thread, (4) teardown is scheduled the same way, (5) draft is restored end-to-end.
- [x] New fallback tests: ``test_run_on_loop_thread_runs_inline_without_app`` and ``test_run_on_loop_thread_runs_inline_when_loop_not_running``.
- [x] Pre-existing ``test_sudo_prompt_restores_existing_draft_after_response`` continues to pass via the no-loop inline-fallback path (the test stub's ``SimpleNamespace`` ``_app`` has no ``loop`` attribute, so the helper falls through to inline execution).
- [x] Regression guard: stashed the production change, the new marshalling test failed with ``AssertionError: setup was not scheduled via call_soon_threadsafe``; restored the change, all 14 ``test_cli_approval_ui.py`` tests pass plus the 5 ``test_prompt_text_input_thread_safety.py`` tests.

```
$ uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
    tests/cli/test_cli_approval_ui.py tests/cli/test_prompt_text_input_thread_safety.py -v
============================== 19 passed in 1.69s ==============================
```

## Contract protected

**Invariant**: any prompt_toolkit ``Buffer`` mutation performed inside ``_sudo_password_callback`` (snapshot capture, state assignment, invalidate) executes on the same thread that drives the event loop. The worker thread blocks only on ``response_queue.get``, which is genuinely thread-safe.

- Known-bad input: ``_sudo_password_callback`` invoked from a non-loop thread (the production agent-thread path); prior to this PR the buffer reset raced the renderer.
- Future-input coverage: ``_run_on_loop_thread`` is reusable; sibling modal entry points (see Related) can adopt it as a one-line wrap if/when the same regression surfaces there.
- Negative case: no-loop / pre-init / shutdown — the helper falls back to inline execution so existing callers without a live loop are not broken.

## Related

- Fixes #25707
- Same root-cause class as #23185 / commit ``c5f1f863a`` (``_prompt_text_input`` slash-command hang), #15216 / PR #16574 (approval prompt deadlock).
- Adopts the cross-thread scheduling pattern from ``_cprint`` at cli.py:1495.

> Sibling code paths that may need the same fix: ``_approval_callback`` (cli.py:10049), ``_prompt_text_input_modal`` (cli.py:6224), ``_secret_capture_callback`` / ``prompt_for_secret``. All three follow the same ``_capture_modal_input_snapshot() → set state → wait on queue`` pattern from a worker thread. Intentionally left out of this PR's scope to keep the diff small and focused on the reported regression — happy to widen if preferred.