### PR TITLE
fix(cli): discover plugins before warning about unknown toolsets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2728,6 +2728,16 @@ class HermesCLI:
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
             invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
             if invalid:
+                # Plugins haven't been discovered yet at this point — try
+                # loading them and re-validate before warning. Mirrors the
+                # logic in hermes_cli/oneshot.py and tui_gateway/server.py.
+                try:
+                    from hermes_cli.plugins import discover_plugins
+                    discover_plugins()
+                    invalid = [t for t in invalid if not validate_toolset(t)]
+                except Exception:
+                    pass
+            if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         
         # Filesystem checkpoints: CLI flag > config

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "rewalu@gmail.com": "rewasa",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
-def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
+def _make_cli(env_overrides=None, config_overrides=None, module_overrides=None, **kwargs):
     """Create a HermesCLI instance with minimal mocking."""
     import importlib
 
@@ -50,7 +50,7 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
         import cli as _cli_mod
         _cli_mod = importlib.reload(_cli_mod)
         with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
-             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config, **(module_overrides or {})}):
             return _cli_mod.HermesCLI(**kwargs)
 
 
@@ -89,6 +89,37 @@ class TestMaxTurnsResolution:
         """The value passed to AIAgent must never be None (causes TypeError in run_conversation)."""
         cli = _make_cli()
         assert isinstance(cli.max_turns, int) and cli.max_turns == 90
+
+
+class TestToolsetValidation:
+    def test_plugin_toolsets_are_discovered_before_warning(self):
+        """Plugin-contributed toolsets should not emit false unknown-toolset warnings."""
+        discover_plugins = MagicMock()
+
+        def validate_toolset(name):
+            return discover_plugins.called and name == "plugin_toolset"
+
+        with patch("hermes_cli.plugins.discover_plugins", discover_plugins):
+            cli = _make_cli(
+                module_overrides={"validate_toolset": validate_toolset},
+                toolsets=["plugin_toolset"],
+            )
+
+        discover_plugins.assert_called_once_with()
+        assert cli.enabled_toolsets == ["plugin_toolset"]
+
+    def test_genuinely_unknown_toolsets_still_warn_after_discovery(self, capsys):
+        discover_plugins = MagicMock()
+        with patch("hermes_cli.plugins.discover_plugins", discover_plugins):
+            cli = _make_cli(
+                module_overrides={"validate_toolset": lambda _name: False},
+                toolsets=["missing_toolset"],
+            )
+
+        discover_plugins.assert_called_once_with()
+        assert cli.enabled_toolsets == ["missing_toolset"]
+        output = capsys.readouterr().out
+        assert "Warning: Unknown toolsets: missing_toolset" in output
 
 
 class TestVerboseAndToolProgress:


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive CLI startup warning for plugin-contributed toolsets.

When `HermesCLI.__init__` validates `--toolsets`/configured toolsets, plugin discovery has not necessarily happened yet. That caused valid plugin toolsets (for example `code_intel`) to print:

```text
Warning: Unknown toolsets: code_intel
```

The CLI now mirrors the existing lazy-discovery behavior from `hermes_cli/oneshot.py` and `tui_gateway/server.py`: if any requested toolset is initially unknown, it runs `discover_plugins()` and re-validates before warning. Truly unknown toolsets still warn.


Related plugin/example: [`rewasa/hermes-code-intel-plugin`](https://github.com/rewasa/hermes-code-intel-plugin) — AST-aware code intelligence plugin for Hermes Agent. This PR fixes the CLI validation path so plugin-provided toolsets like `code_intel` can be discovered before being reported as unknown.

## Related Issue

Fixes false-positive plugin toolset validation warnings. No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: discover plugins and re-run `validate_toolset()` before emitting unknown-toolset warnings.
- `tests/cli/test_cli_init.py`: add regression tests for:
  - plugin toolsets becoming valid after discovery without warning
  - genuinely unknown toolsets still warning after discovery

## How to Test

1. Configure a plugin-contributed toolset such as `code_intel` in a Hermes profile.
2. Start Hermes with that profile.
3. Confirm no false `Warning: Unknown toolsets: code_intel` is printed.
4. Configure a deliberately missing toolset and confirm the warning is still printed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ pytest tests/cli/test_cli_init.py -q
bringing up nodes...
bringing up nodes...

........................................                                 [100%]
40 passed in 8.10s

$ python -m py_compile cli.py tests/cli/test_cli_init.py
# no output (success)
```

