### PR TITLE
feat(discord): add DISCORD_AGENT_USER_IDS for user-OAuth peer agents

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -961,6 +961,18 @@ def load_gateway_config() -> GatewayConfig:
                 if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
                     _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
                     os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str
+                # allow_bots: how to handle messages whose author.bot=true.
+                # Values: "none" (default), "mentions", "all".
+                if "allow_bots" in discord_cfg and not os.getenv("DISCORD_ALLOW_BOTS"):
+                    os.environ["DISCORD_ALLOW_BOTS"] = str(discord_cfg["allow_bots"]).lower()
+                # agent_user_ids: peer agents that auth via user-OAuth (not bot
+                # accounts). Treated under the allow_bots policy so plain-word
+                # mutual-wake between agents sharing a channel can be blocked.
+                aui = discord_cfg.get("agent_user_ids")
+                if aui is not None and not os.getenv("DISCORD_AGENT_USER_IDS"):
+                    if isinstance(aui, list):
+                        aui = ",".join(str(v) for v in aui)
+                    os.environ["DISCORD_AGENT_USER_IDS"] = str(aui)
 
             # Bridge top-level require_mention to Telegram when the telegram: section
             # does not already provide one.  Users often write "require_mention: true"

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -735,22 +735,35 @@ class DiscordAdapter(BasePlatformAdapter):
                 if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
                     return
 
-                # Bot message filtering (DISCORD_ALLOW_BOTS):
+                # Bot / agent-user message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
                 #   "mentions" — accept bot messages only when they @mention us
                 #   "all"      — accept all bot messages
                 # Must run BEFORE the user allowlist check so that bots
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
-                if getattr(message.author, "bot", False):
+                #
+                # DISCORD_AGENT_USER_IDS: comma-separated Discord user IDs of
+                # peer agents that auth via user-OAuth (not bot accounts) — they
+                # are treated under the same allow_bots policy to prevent
+                # plain-word mutual-wake spam between agents sharing a channel.
+                _author_id = str(getattr(message.author, "id", ""))
+                _is_bot_author = bool(getattr(message.author, "bot", False))
+                _agent_user_ids = {
+                    s.strip()
+                    for s in os.getenv("DISCORD_AGENT_USER_IDS", "").split(",")
+                    if s.strip()
+                }
+                _is_agent_user = (not _is_bot_author) and (_author_id in _agent_user_ids)
+                if _is_bot_author or _is_agent_user:
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
                         if not self._client.user or self._client.user not in message.mentions:
                             return
-                    # "all" falls through; bot is permitted — skip the
-                    # human-user allowlist below (bots aren't in it).
+                    # "all" falls through; bot/agent is permitted — skip the
+                    # human-user allowlist below.
                 else:
                     # Non-bot: enforce the configured user/role allowlists.
                     # Pass guild + is_dm so role checks are scoped to the

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -41,13 +41,18 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
 class TestDiscordBotFilter(unittest.TestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
-    def _run_filter(self, message, allow_bots="none", client_user=None):
+    def _run_filter(self, message, allow_bots="none", client_user=None, agent_user_ids=None):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
         if message.author == client_user:
             return False  # own messages always ignored
 
-        if getattr(message.author, "bot", False):
+        agent_ids = {str(s) for s in (agent_user_ids or [])}
+        author_id = str(getattr(message.author, "id", ""))
+        is_bot_author = bool(getattr(message.author, "bot", False))
+        is_agent_user = (not is_bot_author) and (author_id in agent_ids)
+
+        if is_bot_author or is_agent_user:
             allow = allow_bots.lower().strip()
             if allow == "none":
                 return False
@@ -55,7 +60,7 @@ class TestDiscordBotFilter(unittest.TestCase):
                 if not client_user or client_user not in message.mentions:
                     return False
             # "all" falls through
-        
+
         return True  # message accepted
 
     def test_own_messages_always_ignored(self):
@@ -111,6 +116,55 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "All"))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
+
+    def test_agent_user_id_treated_as_bot_under_none(self):
+        """User-OAuth peer agent (author.bot=False) listed in DISCORD_AGENT_USER_IDS
+        is rejected under allow_bots=none."""
+        peer = _make_author(bot=False)
+        peer.id = 1503473217581350993
+        msg = _make_message(author=peer)
+        self.assertFalse(
+            self._run_filter(msg, "none", agent_user_ids=["1503473217581350993"])
+        )
+
+    def test_agent_user_id_rejected_without_mention_under_mentions(self):
+        """Peer agent posting plain words on shared channel is rejected when
+        allow_bots=mentions and we are not @-mentioned."""
+        our_user = _make_author(is_self=True)
+        peer = _make_author(bot=False)
+        peer.id = 1503473217581350993
+        msg = _make_message(author=peer, mentions=[])
+        self.assertFalse(
+            self._run_filter(
+                msg, "mentions", our_user, agent_user_ids=["1503473217581350993"]
+            )
+        )
+
+    def test_agent_user_id_accepted_with_mention_under_mentions(self):
+        """Peer agent that explicitly @-mentions us is accepted under
+        allow_bots=mentions."""
+        our_user = _make_author(is_self=True)
+        peer = _make_author(bot=False)
+        peer.id = 1503473217581350993
+        msg = _make_message(author=peer, mentions=[our_user])
+        self.assertTrue(
+            self._run_filter(
+                msg, "mentions", our_user, agent_user_ids=["1503473217581350993"]
+            )
+        )
+
+    def test_agent_user_id_not_in_list_treated_as_human(self):
+        """Non-listed user is treated as a regular human and falls through
+        the bot filter regardless of allow_bots policy."""
+        random_user = _make_author(bot=False)
+        random_user.id = 42
+        msg = _make_message(author=random_user)
+        self.assertTrue(
+            self._run_filter(msg, "none", agent_user_ids=["1503473217581350993"])
+        )
+        self.assertTrue(
+            self._run_filter(msg, "mentions", agent_user_ids=["1503473217581350993"])
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When multiple agents share a Discord channel, the existing `DISCORD_ALLOW_BOTS` filter only catches accounts where `message.author.bot == True`. Agents that authenticate via user-OAuth flows (instead of classic bot accounts) appear as ordinary users in the Discord API, so they bypass the filter entirely. In practice this means two user-OAuth agents in the same channel can wake each other on every plain-word message and create mutual-wake / spam loops.

This PR plugs that gap:

- **New `DISCORD_AGENT_USER_IDS` env** (comma-separated Discord user IDs) and matching `discord.agent_user_ids` YAML key. Users in that set are routed through the same `DISCORD_ALLOW_BOTS` policy as bot accounts:
  - `none` — drop their messages (default policy)
  - `mentions` — accept only when we are @-mentioned
  - `all` — accept everything
- **`discord.allow_bots` YAML key** plumbed through `gateway/config.py` (Slack and Feishu already supported the YAML form; Discord was env-only).
- **4 new test cases** in `tests/gateway/test_discord_bot_filter.py`:
  - agent_user listed → rejected under `none`
  - agent_user listed → rejected without mention under `mentions`
  - agent_user listed → accepted with mention under `mentions`
  - unlisted user still treated as a normal human (regression guard)

Default behavior is fully preserved: if `DISCORD_AGENT_USER_IDS` is unset, the filter operates exactly as before.

## Test plan

- [x] `pytest tests/gateway/test_discord_bot_filter.py` — 12 pass (4 new + 8 existing)
- [x] `pytest tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_config.py` — 87 pass (no regressions in adjacent suites)
- [x] Live verification in a real multi-agent Discord channel: peer agent posting plain words is rejected as `bot_no_mention` (filter_counts confirms); explicit `<@agent>` mention is accepted and starts an agent turn; non-listed humans continue to wake via the existing free-response path.

## Notes

- Reuses existing `bot_not_allowed` / `bot_no_mention` filter-count keys rather than minting new ones, to keep the discord health-marker schema stable.
- Order in `on_message` is unchanged: agent/bot policy still runs before the human user/role allowlist, so peer agents permitted by `allow_bots=all` are not later rejected for not being in `DISCORD_ALLOWED_USERS`.