### PR TITLE
feat(stt): add OpenRouter speech-to-text provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1018,13 +1018,16 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "openrouter" (OpenRouter STT) | "mistral" (Voxtral Transcribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+        },
+        "openrouter": {
+            "model": "openai/whisper-1",  # openai/whisper-1, groq/whisper-large-v3-turbo, openai/gpt-4o-mini-transcribe
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -287,7 +287,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "openai"],
+        "options": ["local", "openai", "openrouter"],
     },
     "display.skin": {
         "type": "select",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -49,6 +49,7 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -1363,3 +1364,212 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# _transcribe_openrouter
+# ============================================================================
+
+
+class TestTranscribeOpenRouter:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_openrouter
+        result = _transcribe_openrouter("/tmp/test.ogg", "openai/whisper-1")
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "text": "hello world",
+            "usage": {"seconds": 1.5, "cost": 0.0001},
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello world"
+        assert result["provider"] == "openrouter"
+
+    def test_whitespace_stripped(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "  bonjour  \n"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        assert result["transcript"] == "bonjour"
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 422
+        mock_response.json.return_value = {"error": {"message": "Model not found"}}
+        mock_response.text = '{"error": {"message": "Model not found"}}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_ogg, "invalid/model")
+
+        assert result["success"] is False
+        assert "HTTP 422" in result["error"]
+        assert "Model not found" in result["error"]
+
+    def test_empty_transcript_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "   "}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "empty transcript" in result["error"].lower()
+
+    def test_permission_error(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        from tools.transcription_tools import _transcribe_openrouter
+        result = _transcribe_openrouter("/root/denied.ogg", "openai/whisper-1")
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+    def test_network_error_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", side_effect=ConnectionError("no route")):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "OpenRouter STT transcription failed" in result["error"]
+
+    def test_sends_base64_json_body(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        call_kwargs = mock_post.call_args
+        # Should send JSON, not multipart
+        sent_json = call_kwargs[1]["json"]
+        assert sent_json["model"] == "openai/whisper-1"
+        assert "input_audio" in sent_json
+        assert "data" in sent_json["input_audio"]
+        assert "format" in sent_json["input_audio"]
+
+    def test_custom_base_url(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "test"}
+
+        config = {"openrouter": {"base_url": "https://custom.example.com/api/v1"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_ogg, "openai/whisper-1")
+
+        call_url = mock_post.call_args[0][0]
+        assert call_url.startswith("https://custom.example.com/api/v1/audio/transcriptions")
+
+
+# ============================================================================
+# _get_provider — openrouter
+# ============================================================================
+
+
+class TestGetProviderOpenRouter:
+    def test_openrouter_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "openrouter"}) == "openrouter"
+
+    def test_openrouter_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "openrouter"}) == "none"
+
+    def test_auto_detect_openrouter_after_openai(self, monkeypatch):
+        """Auto-detect: openrouter is tried after openai when no local/groq is available."""
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._has_openai_audio_backend", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "openrouter"
+
+    def test_openrouter_skipped_when_no_key(self):
+        """Auto-detect: openrouter skipped when no key is set."""
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._has_openai_audio_backend", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "none"
+
+
+# ============================================================================
+# transcribe_audio — openrouter dispatch
+# ============================================================================
+
+
+class TestTranscribeAudioOpenRouter:
+    def test_dispatches_to_openrouter(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openrouter"}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi", "provider": "openrouter"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "openrouter"
+        mock_or.assert_called_once()
+
+    def test_passes_default_model(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openrouter"}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg)
+
+        assert mock_or.call_args[0][1] == "openai/whisper-1"
+
+    def test_model_override_passed_to_openrouter(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="groq/whisper-large-v3-turbo")
+
+        assert mock_or.call_args[0][1] == "groq/whisper-large-v3-turbo"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,14 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **openrouter** — OpenRouter STT API, requires ``OPENROUTER_API_KEY``.
+    Routes to whisper models across providers with unified billing.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
@@ -91,6 +93,15 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+
+# OpenRouter STT constants
+DEFAULT_OPENROUTER_STT_MODEL = os.getenv("STT_OPENROUTER_MODEL", "openai/whisper-1")
+OPENROUTER_STT_BASE_URL = os.getenv("STT_OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+OPENROUTER_STT_MODELS = {
+    "openai/whisper-1", "openai/whisper-large-v3",
+    "openai/gpt-4o-mini-transcribe", "openai/gpt-4o-transcribe",
+    "groq/whisper-large-v3", "groq/whisper-large-v3-turbo",
+}
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -273,9 +284,17 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "openrouter":
+            if get_env_value("OPENROUTER_API_KEY"):
+                return "openrouter"
+            logger.warning(
+                "STT provider 'openrouter' configured but OPENROUTER_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > xai ---
+    # --- Auto-detect (no explicit provider): local > groq > openai > openrouter > xai ---
     # mistral is intentionally skipped while `mistralai` is quarantined on
     # PyPI (malicious 2.4.6 release on 2026-05-12).
 
@@ -289,6 +308,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
+    if get_env_value("OPENROUTER_API_KEY"):
+        logger.info("No local STT available, using OpenRouter STT API")
+        return "openrouter"
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
@@ -786,6 +808,102 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: openrouter (OpenRouter STT API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_openrouter(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using OpenRouter STT API.
+
+    Uses the ``POST /api/v1/audio/transcriptions`` endpoint with JSON body
+    containing base64-encoded audio.  Requires ``OPENROUTER_API_KEY``.
+    """
+    import base64
+
+    api_key = get_env_value("OPENROUTER_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "OPENROUTER_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    openrouter_cfg = stt_config.get("openrouter", {})
+    base_url = str(
+        openrouter_cfg.get("base_url")
+        or get_env_value("STT_OPENROUTER_BASE_URL")
+        or OPENROUTER_STT_BASE_URL
+    ).strip().rstrip("/")
+
+    audio_path = Path(file_path)
+    audio_format = audio_path.suffix.lstrip(".").lower()
+    # Normalise a few common aliases
+    if audio_format in ("mpga", "mpeg"):
+        audio_format = "mp3"
+    elif audio_format == "aiff":
+        audio_format = "wav"
+
+    try:
+        import requests
+
+        with open(file_path, "rb") as f:
+            audio_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+        response = requests.post(
+            f"{base_url}/audio/transcriptions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model_name,
+                "input_audio": {
+                    "data": audio_b64,
+                    "format": audio_format,
+                },
+            },
+            timeout=120,
+        )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"OpenRouter STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = result.get("text", "").strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "OpenRouter STT returned empty transcript",
+            }
+
+        usage = result.get("usage", {})
+        logger.info(
+            "Transcribed %s via OpenRouter STT (%s, %.1fs audio, %d chars)",
+            audio_path.name,
+            model_name,
+            usage.get("seconds", 0),
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "openrouter"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("OpenRouter STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"OpenRouter STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -858,6 +976,10 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "openrouter":
+        model_name = model or DEFAULT_OPENROUTER_STT_MODEL
+        return _transcribe_openrouter(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -865,7 +987,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
+            "set GROQ_API_KEY for free Groq Whisper, set OPENROUTER_API_KEY for OpenRouter STT, "
+            "set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),


### PR DESCRIPTION
## Summary

Adds `openrouter` as STT provider via OpenRouter `/api/v1/audio/transcriptions`.

## Benchmark (68KB OGG voice message)

| Model | Time | Cost | Quality |
|---|---|---|---|
| `whisper-large-v3-turbo` | **0.49s** | $0.0004 | Good |
| `gpt-4o-mini-transcribe` | 1.81s | ~$0 | Best |
| `google/chirp-3` | 1.81s | $0.0088 | Poor |
| `whisper-1` | 2.45s | ~$0 | Poor |
| **local (base)** | **3.64s** | $0 (CPU) | Slowest |

turbo is 7x faster than local with better accuracy.

## Changes
- `tools/transcription_tools.py` — _transcribe_openrouter(), constants, dispatch
- `hermes_cli/config.py` — openrouter config section
- `hermes_cli/web_server.py` — "openrouter" option

## Testing
- [x] Live transcription
- [x] 5-model benchmark
- [x] Auto-detection
- [x] Error handling