### PR TITLE
fix(telegram): set REQUIRES_EDIT_FINALIZE so final MarkdownV2 edit is not skipped

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -332,6 +332,13 @@ class TelegramAdapter(BasePlatformAdapter):
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
+    # Telegram's edit_message applies MarkdownV2 formatting only on the
+    # finalize=True path.  Without this flag, stream_consumer._send_or_edit
+    # short-circuits when the raw text is unchanged between the last streamed
+    # edit and the final edit, skipping the plain-text → MarkdownV2 conversion.
+    # Fixes #25710.
+    REQUIRES_EDIT_FINALIZE: bool = True
+
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":
     # ≤320 codepoints (one short paragraph) settles in ~180ms; ≤1024


### PR DESCRIPTION
## Summary

Set `REQUIRES_EDIT_FINALIZE = True` on `TelegramAdapter` so the stream consumer always delivers the `finalize=True` edit, even when the raw text is unchanged from the last streamed frame.

Fixes #25710

## Problem

Telegram's `edit_message()` applies MarkdownV2 formatting **only** on the `finalize=True` path — intermediate streaming edits are sent as plain text (by design, since partial Markdown is often invalid). However, `stream_consumer._send_or_edit` has a short-circuit:

```python
if text == self._last_sent_text and not (
    finalize and self._adapter_requires_finalize
):
    return True
```

Since `TelegramAdapter` did not set `REQUIRES_EDIT_FINALIZE`, this guard skipped the final edit when the raw text was identical to the last streamed frame. The message remained as raw plain text with visible Markdown syntax (backticks, asterisks, etc.).

## Fix

Add `REQUIRES_EDIT_FINALIZE: bool = True` to `TelegramAdapter`, matching the existing pattern used by DingTalk. This ensures the finalize edit is always delivered, triggering the `format_message()` → `ParseMode.MARKDOWN_V2` conversion.

## Changes

- `gateway/platforms/telegram.py`: Added `REQUIRES_EDIT_FINALIZE = True` class attribute with documentation comment.

## Testing

- All 122 existing stream consumer tests pass (`test_stream_consumer.py`, `test_stream_consumer_fresh_final.py`, `test_stream_consumer_draft.py`, `test_stream_consumer_thread_routing.py`).
- One-line class attribute addition; no logic changes to the stream consumer or adapter method.