### PR TITLE
fix(security): tighten .env file permissions to 0600 at all creation sites

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -70,6 +70,7 @@ mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,wo
 if [ ! -f "$HERMES_HOME/.env" ]; then
     cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
 fi
+chmod 600 "$HERMES_HOME/.env"
 
 # config.yaml
 if [ ! -f "$HERMES_HOME/config.yaml" ]; then

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -401,6 +401,10 @@ def run_doctor(args):
             if should_fix:
                 env_path.parent.mkdir(parents=True, exist_ok=True)
                 env_path.touch()
+                try:
+                    os.chmod(str(env_path), 0o600)
+                except (OSError, NotImplementedError):
+                    pass
                 check_ok(f"Created empty {_DHH}/.env")
                 check_info("Run 'hermes setup' to configure API keys")
                 fixed_count += 1

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -627,6 +627,11 @@ def create_profile(
                 src = source_dir / filename
                 if src.exists():
                     shutil.copy2(src, profile_dir / filename)
+                    if filename == ".env":
+                        try:
+                            os.chmod(str(profile_dir / filename), 0o600)
+                        except (OSError, NotImplementedError):
+                            pass
 
             # Clone installed skills from the source profile. The dashboard's
             # "clone from default" flow is expected to preserve both bundled

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1260,8 +1260,10 @@ copy_config_templates() {
             touch "$HERMES_HOME/.env"
             log_success "Created ~/.hermes/.env"
         fi
+        chmod 600 "$HERMES_HOME/.env"
     else
         log_info "~/.hermes/.env already exists, keeping it"
+        chmod 600 "$HERMES_HOME/.env"
     fi
 
     # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -276,9 +276,11 @@ fi
 if [ ! -f ".env" ]; then
     if [ -f ".env.example" ]; then
         cp .env.example .env
+        chmod 600 .env
         echo -e "${GREEN}✓${NC} Created .env from template"
     fi
 else
+    chmod 600 .env
     echo -e "${GREEN}✓${NC} .env exists"
 fi
 


### PR DESCRIPTION
## Summary

Fixes #25477

The Hermes installer and several code paths create `~/.hermes/.env` without restricting file permissions, leaving it at the system's default umask (typically `0664` — group/world readable). This file holds API keys, bot tokens, and other secrets.

The Python write functions (`save_env_value`, `remove_env_value`, `sanitize_env_file`) already call `_secure_file()` → `chmod 0600`, but these creation paths missed it:

## Changes

| File | Fix |
|------|-----|
| `scripts/install.sh` | `chmod 600` after cp/touch, also on existing `.env` |
| `docker/entrypoint.sh` | `chmod 600` after cp |
| `setup-hermes.sh` | `chmod 600` after cp, also on existing `.env` |
| `hermes_cli/doctor.py` | `os.chmod(0o600)` after `touch()` |
| `hermes_cli/profiles.py` | `os.chmod(0o600)` after `shutil.copy2()` for `.env` |

Also fixes permissions on the "already exists" path in `install.sh` and `setup-hermes.sh` so existing installations get tightened on next run.

## Testing

- All 149 tests in `test_profiles.py` + `test_doctor.py` pass
- Follows the same `try/except (OSError, NotImplementedError)` pattern as `_secure_file()` in `config.py`