### PR TITLE
fix: keep credential pool aligned across fallback runtime switches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1718,6 +1718,7 @@ def init_agent(
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "credential_pool": getattr(agent, "_credential_pool", None),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -32,10 +32,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.credential_pool import STATUS_EXHAUSTED, get_custom_provider_pool_key, load_pool
+from agent.message_sanitization import (
+    _repair_tool_call_arguments,
+    _sanitize_surrogates,
+)
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
-from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
@@ -61,6 +65,57 @@ def agent_runtime_owns_post_tool_hook(agent: Any, function_name: str) -> bool:
         return True
     memory_manager = getattr(agent, "_memory_manager", None)
     return bool(memory_manager and memory_manager.has_tool(function_name))
+
+
+def load_runtime_credential_pool(
+    provider: str,
+    *,
+    base_url: Optional[str] = None,
+    runtime_api_key: Optional[str] = None,
+    current_provider: Optional[str] = None,
+    current_base_url: Optional[str] = None,
+    current_pool=None,
+):
+    """Load or reuse the credential pool appropriate for a runtime backend."""
+    provider_norm = str(provider or "").strip().lower()
+    base_norm = str(base_url or "").strip().rstrip("/")
+    current_provider_norm = str(current_provider or "").strip().lower()
+    current_base_norm = str(current_base_url or "").strip().rstrip("/")
+
+    if (
+        current_pool is not None
+        and provider_norm
+        and provider_norm == current_provider_norm
+        and base_norm == current_base_norm
+    ):
+        if hasattr(current_pool, "align_current_to_runtime"):
+            current_pool.align_current_to_runtime(
+                runtime_api_key=runtime_api_key,
+                runtime_base_url=base_url,
+            )
+        return current_pool
+
+    if not provider_norm:
+        return None
+
+    pool_key = provider_norm
+    if provider_norm == "custom":
+        pool_key = get_custom_provider_pool_key(base_norm) or provider_norm
+
+    try:
+        pool = load_pool(pool_key)
+    except Exception:
+        return None
+
+    if not pool.has_credentials():
+        return None
+    if hasattr(pool, "align_current_to_runtime"):
+        pool.align_current_to_runtime(
+            runtime_api_key=runtime_api_key,
+            runtime_base_url=base_url,
+        )
+    return pool
+
 
 
 def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
@@ -772,6 +827,7 @@ def try_recover_primary_transport(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent._credential_pool = rt.get("credential_pool")
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -927,6 +983,7 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent._credential_pool = rt.get("credential_pool")
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
@@ -1386,6 +1443,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_base_url = agent.base_url
+    old_pool = getattr(agent, "_credential_pool", None)
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -1511,6 +1570,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 pass
         raise
 
+    agent._credential_pool = load_runtime_credential_pool(
+        agent.provider,
+        base_url=agent.base_url,
+        runtime_api_key=getattr(agent, "api_key", ""),
+        current_provider=old_provider,
+        current_base_url=old_base_url,
+        current_pool=old_pool,
+    )
+
     # ── Re-evaluate prompt caching ──
     agent._use_prompt_caching, agent._use_native_cache_layout = (
         agent._anthropic_prompt_cache_policy(
@@ -1571,6 +1639,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "credential_pool": getattr(agent, "_credential_pool", None),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1168,6 +1168,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        old_provider = agent.provider
+        old_base_url = agent.base_url
+        old_pool = getattr(agent, "_credential_pool", None)
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1244,6 +1247,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # timeout takes effect on the very next fallback request,
                 # not only after a later credential-rotation rebuild.
                 agent._replace_primary_openai_client(reason="fallback_timeout_apply")
+
+        agent._credential_pool = agent._load_runtime_credential_pool(
+            fb_provider,
+            base_url=fb_base_url,
+            runtime_api_key=getattr(agent, "api_key", ""),
+            current_provider=old_provider,
+            current_base_url=old_base_url,
+            current_pool=old_pool,
+        )
 
         # Re-evaluate prompt caching for the new provider/model
         agent._use_prompt_caching, agent._use_native_cache_layout = (

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -471,6 +471,34 @@ class CredentialPool:
             return None
         return next((entry for entry in self._entries if entry.id == self._current_id), None)
 
+    def align_current_to_runtime(
+        self,
+        *,
+        runtime_api_key: Optional[str],
+        runtime_base_url: Optional[str] = None,
+    ) -> Optional[PooledCredential]:
+        """Align the selected entry to the credential currently backing the runtime.
+
+        Updates only the in-memory current selection. Lease counters and
+        persisted entry ordering remain untouched.
+        """
+        runtime_key = str(runtime_api_key or "").strip()
+        if not runtime_key:
+            return self.current()
+
+        base_norm = str(runtime_base_url or "").strip().rstrip("/").lower()
+        with self._lock:
+            for entry in self._entries:
+                entry_key = str(getattr(entry, "runtime_api_key", "") or "").strip()
+                if entry_key != runtime_key:
+                    continue
+                entry_base = str(getattr(entry, "runtime_base_url", "") or "").strip().rstrip("/").lower()
+                if base_norm and entry_base and entry_base != base_norm:
+                    continue
+                self._current_id = entry.id
+                return entry
+            return self.current()
+
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order."""
         for idx, entry in enumerate(self._entries):

--- a/run_agent.py
+++ b/run_agent.py
@@ -3880,6 +3880,7 @@ class AIAgent:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        runtime_base_norm = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
@@ -3890,20 +3891,32 @@ class AIAgent:
                 pass
 
             self._anthropic_api_key = runtime_key
-            self._anthropic_base_url = runtime_base
+            self._anthropic_base_url = runtime_base_norm
             self._anthropic_client = build_anthropic_client(
-                runtime_key, runtime_base,
+                runtime_key, runtime_base_norm,
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
             self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
             self.api_key = runtime_key
-            self.base_url = runtime_base
+            self.base_url = runtime_base_norm
+            if hasattr(self, "_primary_runtime") and isinstance(self._primary_runtime, dict):
+                self._primary_runtime["api_key"] = runtime_key
+                self._primary_runtime["base_url"] = runtime_base_norm
+                self._primary_runtime["anthropic_api_key"] = runtime_key
+                self._primary_runtime["anthropic_base_url"] = runtime_base_norm
             return
 
         self.api_key = runtime_key
-        self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
+        self.base_url = runtime_base_norm
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
+        if hasattr(self, "_primary_runtime") and isinstance(self._primary_runtime, dict):
+            self._primary_runtime["api_key"] = self.api_key
+            self._primary_runtime["base_url"] = self.base_url
+            _rt_client_kwargs = self._primary_runtime.get("client_kwargs")
+            if isinstance(_rt_client_kwargs, dict):
+                _rt_client_kwargs["api_key"] = self.api_key
+                _rt_client_kwargs["base_url"] = self.base_url
         self._apply_client_headers_for_base_url(self.base_url)
         self._replace_primary_openai_client(reason="credential_rotation")
 
@@ -3918,6 +3931,27 @@ class AIAgent:
         """Forwarder — see ``agent.agent_runtime_helpers.recover_with_credential_pool``."""
         from agent.agent_runtime_helpers import recover_with_credential_pool
         return recover_with_credential_pool(self, status_code=status_code, has_retried_429=has_retried_429, classified_reason=classified_reason, error_context=error_context)
+
+    @staticmethod
+    def _load_runtime_credential_pool(
+        provider: str,
+        *,
+        base_url: Optional[str] = None,
+        runtime_api_key: Optional[str] = None,
+        current_provider: Optional[str] = None,
+        current_base_url: Optional[str] = None,
+        current_pool=None,
+    ):
+        from agent.agent_runtime_helpers import load_runtime_credential_pool
+
+        return load_runtime_credential_pool(
+            provider,
+            base_url=base_url,
+            runtime_api_key=runtime_api_key,
+            current_provider=current_provider,
+            current_base_url=current_base_url,
+            current_pool=current_pool,
+        )
 
     def _credential_pool_may_recover_rate_limit(self) -> bool:
         """Whether a rate-limit retry should wait for same-provider credentials."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1471,6 +1471,7 @@ AUTHOR_MAP = {
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
     "egilewski@egilewski.com": "egilewski",  # PR #30432 (MEDIA path traversal fix, GHSA-jmf9-9729-7pp8)
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
+    "loicnico96@gmail.com": "loicnico96",
     "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
     "490408354@qq.com": "daizhonggeng",  # PR #9020 (numbered /resume selection)
     "claw@openclaw.ai": "wanwan2qq",  # PR #10215 (strip brackets/quotes from /resume; gateway session-ID lookup)

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2200,6 +2200,61 @@ def test_release_lease_decrements_counter(tmp_path, monkeypatch):
     assert pool._active_leases.get("cred-1", 0) == 0
 
 
+def test_align_current_to_runtime_updates_selection_without_touching_leases(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "key-a",
+                        "base_url": "https://openrouter.ai/api/v1",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "key-b",
+                        "base_url": "https://openrouter.ai/api/v1",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    first = pool.acquire_lease("cred-1")
+    second = pool.acquire_lease("cred-2")
+
+    assert first == "cred-1"
+    assert second == "cred-2"
+    assert pool._active_leases.get("cred-1", 0) == 1
+    assert pool._active_leases.get("cred-2", 0) == 1
+
+    aligned = pool.align_current_to_runtime(
+        runtime_api_key="key-a",
+        runtime_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert aligned is not None
+    assert aligned.id == "cred-1"
+    assert pool.current() is not None
+    assert pool.current().id == "cred-1"
+    assert pool._active_leases.get("cred-1", 0) == 1
+    assert pool._active_leases.get("cred-2", 0) == 1
+
+
 def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_path, monkeypatch):
     """Claude Code credentials must not be auto-seeded when the user never selected anthropic."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,7 +30,63 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+class _FakePool:
+    def __init__(self, name: str, has_credentials: bool = True):
+        self.name = name
+        self._has_credentials = has_credentials
+
+    def has_credentials(self):
+        return self._has_credentials
+
+    def has_available(self):
+        return self._has_credentials
+
+    def current(self):
+        return None
+
+    def entries(self):
+        return []
+
+    def align_current_to_runtime(self, *, runtime_api_key: str, runtime_base_url: str | None = None):
+        return None
+
+
+def _make_pool_entry(
+    entry_id: str,
+    *,
+    provider: str,
+    api_key: str,
+    base_url: str,
+    priority: int,
+):
+    from agent.credential_pool import PooledCredential
+
+    return PooledCredential(
+        provider=provider,
+        id=entry_id,
+        label=entry_id,
+        auth_type="api_key",
+        priority=priority,
+        source="manual",
+        access_token=api_key,
+        base_url=base_url,
+    )
+
+
+def _make_credential_pool(provider: str, entries: list, *, current_id: str | None = None):
+    from agent.credential_pool import CredentialPool
+
+    pool = CredentialPool(provider, entries)
+    pool._current_id = current_id
+    return pool
+
+
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    credential_pool=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -45,6 +101,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            credential_pool=credential_pool,
         )
         agent.client = MagicMock()
         return agent
@@ -83,6 +140,11 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["compressor_context_length"] == cc.context_length
         assert rt["compressor_threshold_tokens"] == cc.threshold_tokens
 
+    def test_snapshot_includes_credential_pool(self):
+        primary_pool = _FakePool("primary")
+        agent = _make_agent(credential_pool=primary_pool)
+        assert agent._primary_runtime["credential_pool"] is primary_pool
+
     def test_snapshot_includes_anthropic_state_when_applicable(self):
         """Anthropic-mode agents should snapshot Anthropic-specific state."""
         with (
@@ -109,6 +171,54 @@ class TestPrimaryRuntimeSnapshot:
         agent = _make_agent(provider="custom")
         rt = agent._primary_runtime
         assert "anthropic_api_key" not in rt
+
+    def test_primary_openai_credential_rotation_updates_snapshot(self):
+        rotated_entry = _make_pool_entry(
+            "entry-b",
+            provider="custom",
+            api_key="rotated-key-abcdef",
+            base_url="https://my-llm.example.com/v1",
+            priority=0,
+        )
+        agent = _make_agent()
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent._swap_credential(rotated_entry)
+
+        assert agent._primary_runtime["api_key"] == "rotated-key-abcdef"
+        assert agent._primary_runtime["client_kwargs"]["api_key"] == "rotated-key-abcdef"
+        assert agent._primary_runtime["base_url"] == "https://my-llm.example.com/v1"
+
+    def test_primary_anthropic_credential_rotation_updates_snapshot(self):
+        rotated_entry = _make_pool_entry(
+            "entry-b",
+            provider="anthropic",
+            api_key="sk-ant...cdef",
+            base_url="https://api.anthropic.com",
+            priority=0,
+        )
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-ant...5678",
+                base_url="https://api.anthropic.com",
+                provider="anthropic",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        with patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()):
+            agent._swap_credential(rotated_entry)
+
+        assert agent._primary_runtime["api_key"] == "sk-ant...cdef"
+        assert agent._primary_runtime["anthropic_api_key"] == "sk-ant...cdef"
+        assert agent._primary_runtime["anthropic_base_url"] == "https://api.anthropic.com"
 
 
 # =============================================================================
@@ -188,6 +298,81 @@ class TestRestorePrimaryRuntime:
         assert agent.context_compressor.context_length == original_ctx_len
         assert agent.context_compressor.threshold_tokens == original_threshold
 
+    def test_fallback_realigns_credential_pool_and_restore_recovers_primary_pool(self):
+        primary_pool = _FakePool("primary")
+        fallback_pool = _FakePool("fallback")
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            credential_pool=primary_pool,
+        )
+
+        mock_client = _mock_resolve()
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch.object(AIAgent, "_load_runtime_credential_pool", return_value=fallback_pool, create=True),
+        ):
+            agent._try_activate_fallback()
+
+        assert agent._credential_pool is fallback_pool
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent._restore_primary_runtime()
+
+        assert agent._credential_pool is primary_pool
+
+    def test_fallback_clears_credential_pool_when_target_provider_has_none(self):
+        primary_pool = _FakePool("primary")
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            credential_pool=primary_pool,
+        )
+
+        mock_client = _mock_resolve()
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch.object(AIAgent, "_load_runtime_credential_pool", return_value=None, create=True),
+        ):
+            agent._try_activate_fallback()
+
+        assert agent._credential_pool is None
+
+    def test_same_runtime_fallback_preserves_existing_pool_identity(self):
+        entry_a = _make_pool_entry(
+            "entry-a",
+            provider="openrouter",
+            api_key="key-a",
+            base_url="https://openrouter.ai/api/v1",
+            priority=0,
+        )
+        entry_b = _make_pool_entry(
+            "entry-b",
+            provider="openrouter",
+            api_key="key-b",
+            base_url="https://openrouter.ai/api/v1",
+            priority=1,
+        )
+        primary_pool = _make_credential_pool("openrouter", [entry_a, entry_b], current_id="entry-a")
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "model-b"},
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            credential_pool=primary_pool,
+        )
+        agent.model = "model-a"
+        agent._primary_runtime["model"] = "model-a"
+
+        mock_client = _mock_resolve(base_url="https://openrouter.ai/api/v1", api_key="key-b")
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        assert agent._credential_pool is primary_pool
+        assert agent._credential_pool.current() is not None
+        assert agent._credential_pool.current().id == "entry-b"
+
     def test_restores_prompt_caching_flag(self):
         agent = _make_agent()
         original_caching = agent._use_prompt_caching
@@ -210,6 +395,42 @@ class TestRestorePrimaryRuntime:
             result = agent._restore_primary_runtime()
 
         assert result is False
+
+    def test_restore_rebuilds_with_rotated_primary_credential(self):
+        entry_a = _make_pool_entry(
+            "entry-a",
+            provider="custom",
+            api_key="startup-key-abcdef",
+            base_url="https://my-llm.example.com/v1",
+            priority=0,
+        )
+        entry_b = _make_pool_entry(
+            "entry-b",
+            provider="custom",
+            api_key="rotated-key-abcdef",
+            base_url="https://my-llm.example.com/v1",
+            priority=1,
+        )
+        primary_pool = _make_credential_pool("custom", [entry_a, entry_b], current_id="entry-a")
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            credential_pool=primary_pool,
+        )
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent._swap_credential(entry_b)
+
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        with patch.object(agent, "_create_openai_client", return_value=MagicMock()) as mock_create:
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        kwargs = mock_create.call_args.args[0]
+        assert kwargs["api_key"] == "rotated-key-abcdef"
+        assert kwargs["base_url"] == "https://my-llm.example.com/v1"
 
 
 # =============================================================================
@@ -235,6 +456,59 @@ class TestTryRecoverPrimaryTransport:
             )
 
         assert result is True
+
+    def test_recovers_primary_credential_pool_from_snapshot(self):
+        primary_pool = _FakePool("primary")
+        drifted_pool = _FakePool("drifted")
+        agent = _make_agent(provider="custom", credential_pool=primary_pool)
+        agent._credential_pool = drifted_pool
+        error = _make_transport_error("ReadTimeout")
+
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch("time.sleep"),
+        ):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+        assert agent._credential_pool is primary_pool
+
+    def test_recovery_rebuilds_with_rotated_primary_credential(self):
+        entry_a = _make_pool_entry(
+            "entry-a",
+            provider="custom",
+            api_key="startup-key-abcdef",
+            base_url="https://my-llm.example.com/v1",
+            priority=0,
+        )
+        entry_b = _make_pool_entry(
+            "entry-b",
+            provider="custom",
+            api_key="rotated-key-abcdef",
+            base_url="https://my-llm.example.com/v1",
+            priority=1,
+        )
+        primary_pool = _make_credential_pool("custom", [entry_a, entry_b], current_id="entry-a")
+        agent = _make_agent(provider="custom", credential_pool=primary_pool)
+        error = _make_transport_error("ReadTimeout")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            agent._swap_credential(entry_b)
+
+        with (
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()) as mock_create,
+            patch("time.sleep"),
+        ):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+        kwargs = mock_create.call_args.args[0]
+        assert kwargs["api_key"] == "rotated-key-abcdef"
+        assert kwargs["base_url"] == "https://my-llm.example.com/v1"
 
     def test_recovers_on_connect_timeout(self):
         agent = _make_agent(provider="custom")


### PR DESCRIPTION
## What does this PR do?

### Root Cause Analysis (optional)

Runtime state capture and restoration are currently not centralized. The active runtime can change, but the saved/restored primary snapshot doesnot always carry a fully coherent view of the associated credential-routing state. In particular:
- `_primary_runtime` snapshots does not consistently behave as the single source of truth for all state needed to rebuild the runtime safely
- `_credential_pool` needs explicit realignment to the credentials used by the active runtime, not just reloading by provider key
- restoration paths can recover transport/client settings without ensuring the provider-scoped credential pool matches them

### Proposed Fix (optional)

1. **Centralized primary runtime snapshots**
   - capture the primary runtime through a dedicated snapshot path
   - include the fields needed to restore the runtime coherently, including `primary_runtime`, `credential_pool`, and related client kwargs

2. **Centralized credential-pool realignment**
   - add `CredentialPool.align_current_to_runtime(...)` so the pool can atomically align its current entry to the credential that actually backs the active runtime
   - keep that alignment logic inside the pool abstraction instead of open-coding selection logic in `run_agent.py`

3. **Restore-path consistency**
   - ensure restoration and fallback recovery paths rehydrate runtime state through the same coherent mechanisms instead of partially reconstructing it in multiple places

This preserves the important invariant that when Hermes says a runtime is active, its provider/model/client/base URL and credential-pool state all describe the same backend.

## Related Issue

Fixes #25727

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

1. Have Codex as primary model
2. Have API-key-based fallback model (e.g. OpenRouter), potentially multiple
3. Run out of Codex sub usage
4. Chat with Hermes and observe whether the first API key fallback is successfully called

I've also run my main Hermes instance on my fork for over 24h without notable incident.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Before:
```
2026-05-12 14:38:11,424 WARNING [20260512_142918_7f15f488] run_agent: API call failed (attempt 1/3) error_type=RateLimitError thread=asyncio_2:127820875130560 provider=openai-codex base_url=https://chatgpt.com/backend-api/codex model=gpt-5.4 summary=HTTP 429: The usage limit has been reached
2026-05-12 14:38:59,522 WARNING [20260512_143858_6112b6] run_agent: API call failed (attempt 1/3) error_type=NotFoundError thread=ThreadPoolExecutor-2_0:127820608038592 provider=openrouter base_url=https://chatgpt.com/backend-api/codex model=moonshotai/kimi-k2.6 summary=HTTP 404: Error code: 404 - {'detail': 'Not Found'}
2026-05-12 14:38:59,523 WARNING [20260512_143858_6112b6] run_agent: Retrying API call in 2.9340521998419535s (attempt 1/3) thread=ThreadPoolExecutor-2_0:127820608038592 provider=openrouter base_url=https://chatgpt.com/backend-api/codex model=moonshotai/kimi-k2.6 error=Error code: 404 - {'detail': 'Not Found'}
2026-05-12 14:39:02,625 WARNING [20260512_143858_6112b6] run_agent: API call failed (attempt 2/3) error_type=NotFoundError thread=ThreadPoolExecutor-2_0:127820608038592 provider=openrouter base_url=https://chatgpt.com/backend-api/codex model=moonshotai/kimi-k2.6 summary=HTTP 404: Error code: 404 - {'detail': 'Not Found'}
2026-05-12 14:39:02,627 WARNING [20260512_143858_6112b6] run_agent: Retrying API call in 4.791363739445803s (attempt 2/3) thread=ThreadPoolExecutor-2_0:127820608038592 provider=openrouter base_url=https://chatgpt.com/backend-api/codex model=moonshotai/kimi-k2.6 error=Error code: 404 - {'detail': 'Not Found'}
2026-05-12 14:39:07,523 WARNING [20260512_143858_6112b6] run_agent: API call failed (attempt 3/3) error_type=NotFoundError thread=ThreadPoolExecutor-2_0:127820608038592 provider=openrouter base_url=https://chatgpt.com/backend-api/codex model=moonshotai/kimi-k2.6 summary=HTTP 404: Error code: 404 - {'detail': 'Not Found'}
```

After (at that time I had already switched to deepseek as first fallback):
```
2026-05-13 15:53:00,227 WARNING [20260513_155240_e15303] run_agent: API call failed (attempt 1/3) error_type=RateLimitError thread=Thread-4 (run_agent):135757929899712 provider=openai-codex base_url=https://chatgpt.com/backend-api/codex model=gpt-5.4 summary=HTTP 429: The usage limit has been reached
2026-05-13 15:53:00,639 INFO [20260513_155240_e15303] root: Fallback activated: gpt-5.4 → deepseek/deepseek-v4-pro (openrouter)
2026-05-13 15:53:00,665 INFO run_agent: OpenAI client created (chat_completion_stream_request, shared=False) thread=Thread-6 (_call):135757920458432 provider=openrouter base_url=https://openrouter.ai/api/v1/ model=deepseek/deepseek-v4-pro
2026-05-13 15:53:13,152 INFO run_agent: OpenAI client closed (stream_request_complete, shared=False, tcp_force_closed=0) thread=Thread-6 (_call):135757920458432 provider=openrouter base_url=https://openrouter.ai/api/v1/ model=deepseek/deepseek-v4-pro
2026-05-13 15:53:13,153 INFO [20260513_155240_e15303] run_agent: API call #1: model=deepseek/deepseek-v4-pro provider=openrouter in=17259 out=274 total=17533 latency=14.1s
```