### PR TITLE
fix(install): preserve pip entry point when re-running on symlinked install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1281,6 +1281,10 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
+    # Older installs created this path as a symlink to $HERMES_BIN. Without
+    # the rm, `cat >` follows the symlink and overwrites the venv pip entry
+    # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
+    rm -f "$command_link_dir/hermes"
     cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -1,0 +1,123 @@
+"""Regression for #21454: re-running install.sh on a symlinked prior install.
+
+Older versions of ``install.sh`` created ``$command_link_dir/hermes`` as a
+symlink to the pip-generated entry point at ``$HERMES_BIN`` (i.e.
+``venv/bin/hermes``). When ``setup_path()`` later switched to writing a bash
+shim with ``cat > "$command_link_dir/hermes" <<EOF``, the redirect followed
+the existing symlink and overwrote the pip entry point with the shim. The
+shim's ``exec "$HERMES_BIN" "$@"`` then self-recursed and ``hermes`` hung on
+every invocation.
+
+These tests pin the fix: ``setup_path()`` must remove ``$command_link_dir/hermes``
+before writing through the redirect, so the shim is created as a regular file
+in ``command_link_dir`` and the venv entry point is left intact.
+"""
+
+from __future__ import annotations
+
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_setup_path_shim_block() -> str:
+    """Return the install.sh shim-write block used by setup_path()."""
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "Could not locate the setup_path shim-write block in scripts/install.sh"
+    )
+    return match["block"]
+
+
+def test_setup_path_shim_block_removes_old_link_before_writing() -> None:
+    """Static guard: the rm must precede the cat heredoc, not follow it."""
+    block = _extract_setup_path_shim_block()
+    rm_idx = block.find('rm -f "$command_link_dir/hermes"')
+    cat_idx = block.find('cat > "$command_link_dir/hermes" <<EOF')
+    assert rm_idx != -1, (
+        "setup_path() must `rm -f` $command_link_dir/hermes before the "
+        "`cat >` heredoc, otherwise an existing symlink (left by older "
+        "installs) will be followed and the pip entry point overwritten. "
+        "See #21454."
+    )
+    assert cat_idx != -1, "expected `cat >` heredoc still present"
+    assert rm_idx < cat_idx, (
+        "`rm -f` must come *before* the `cat >` heredoc, not after."
+    )
+
+
+def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -> None:
+    """Behavioral repro: simulate prior-install symlink + new-install heredoc.
+
+    Layout mirrors a real install:
+
+        tmp/
+          venv/bin/hermes        <- pip entry point (the one we must preserve)
+          local_bin/hermes       <- symlink → ../venv/bin/hermes  (old install)
+
+    Then we run the exact shim-write block from setup_path() with
+    ``HERMES_BIN`` and ``command_link_dir`` pointed at this fixture. The fix
+    requires that, after the run:
+
+      * ``venv/bin/hermes`` still contains its original pip-script body
+      * ``local_bin/hermes`` is a regular file (not a symlink) holding the shim
+    """
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    pip_entry = venv_bin / "hermes"
+    pip_marker = "#!/usr/bin/env python\n# pip-generated entry point — must not be overwritten\n"
+    pip_entry.write_text(pip_marker)
+    pip_entry.chmod(pip_entry.stat().st_mode | stat.S_IXUSR)
+
+    command_link_dir = tmp_path / "local_bin"
+    command_link_dir.mkdir()
+    shim_path = command_link_dir / "hermes"
+    # Reproduce the prior-install state: shim path is a symlink to the
+    # pip-generated entry point.
+    shim_path.symlink_to(pip_entry)
+    assert shim_path.is_symlink()
+
+    block = _extract_setup_path_shim_block()
+    # Drive the block with the real env vars setup_path() sets.
+    script = f'set -e\nHERMES_BIN={pip_entry!s}\ncommand_link_dir={command_link_dir!s}\n{block}\n'
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, (
+        f"shim-write block failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    # The pip entry point must still be the original pip script — not a
+    # re-written self-recursing bash shim.
+    assert pip_entry.read_text() == pip_marker, (
+        "venv/bin/hermes was overwritten by setup_path() — symlink-stomp "
+        "regression (#21454)."
+    )
+
+    # The shim path itself must now be a regular file holding the launcher.
+    assert shim_path.exists()
+    assert not shim_path.is_symlink(), (
+        "command_link_dir/hermes must be replaced with a regular file, not "
+        "left as a symlink — otherwise the next install will stomp again."
+    )
+    shim_text = shim_path.read_text()
+    assert "unset PYTHONPATH" in shim_text
+    assert "unset PYTHONHOME" in shim_text
+    assert f'exec "{pip_entry}"' in shim_text
+    shim_mode = shim_path.stat().st_mode
+    assert shim_mode & stat.S_IXUSR, "shim must be user-executable"


### PR DESCRIPTION
Re-running `scripts/install.sh` on a system installed with an older layout overwrites the pip-generated `venv/bin/hermes` console script with a self-execing bash wrapper, so `hermes` hangs silently with no output.

## Root cause

`setup_path()` writes the user-facing launcher with `cat > "$command_link_dir/hermes" <<EOF`. Older installs created `$command_link_dir/hermes` as a symlink to `$HERMES_BIN` (`venv/bin/hermes`). The redirect follows the symlink and overwrites the pip entry point with the wrapper body. `$HERMES_BIN` then resolves to the same wrapper — `exec` calls itself, infinite loop.

This is the trigger behind the recursive-wrapper hang reported across #21802, #21454, #21513, and #24834.

## Fix

One-line: `rm -f "$command_link_dir/hermes"` before the `cat >` heredoc, so the redirect always creates a fresh regular file and never follows a symlink back into the venv.

## Salvage attribution

Cherry-picked from @Tranquil-Flow's #21513. Three contributors independently converged on this exact one-line fix — credit also to @wesleysimplicio (#22472) and @luyao618 (#24850).

## Validation

| | Before fix | After fix |
|---|---|---|
| `venv/bin/hermes` survives re-install | overwritten with wrapper | preserved as pip script |
| `~/.local/bin/hermes` after install | symlink (will stomp again) | regular file |
| `hermes` invocation | hangs (recursive exec) | runs |

Confirmed live by reproducing the symlink-stomp end-to-end against the actual shim block in install.sh: pre-fix overwrites the pip entry point, post-fix leaves it intact.

Pinned by @Tranquil-Flow's regression test `tests/test_install_sh_symlink_stomp.py` (2/2 passing) — both a static guard that `rm -f` precedes the heredoc, and a behavioural reproducer that drives the real shim-write block.

## Closes

- Closes #21454
- Closes #21513
- Closes #21802
- Closes #24834

Supersedes #22472, #24850 (same fix, later submissions).