### PR TITLE
Add platform-aware skill/tool filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,8 @@ niche skills belong in `optional-skills/`.
 ### SKILL.md frontmatter
 
 Standard fields: `name`, `description`, `version`, `author`, `license`,
-`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
+`platforms` (OS-gating list: `[macos]`, `[linux, wsl, macos]`, ...; valid
+keys are `windows`, `macos`, `linux`, `wsl`, and `linux` does not imply WSL),
 `metadata.hermes.tags`, `metadata.hermes.category`,
 `metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
 settings the skill needs — stored under `skills.config.<key>`, prompted

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -12,7 +12,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_hermes_home, get_runtime_platform, get_skills_dir, is_wsl
 from typing import Optional
 
 from agent.skill_utils import (
@@ -938,6 +938,12 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         frontmatter, _ = parse_frontmatter(raw)
 
         if not skill_matches_platform(frontmatter):
+            logger.debug(
+                "Skill excluded by platform: path=%s platforms=%s runtime=%s",
+                skill_file,
+                frontmatter.get("platforms"),
+                get_runtime_platform(),
+            )
             return False, frontmatter, ""
 
         return True, frontmatter, extract_skill_description(frontmatter)
@@ -1010,12 +1016,14 @@ def build_skills_system_prompt(
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
+    _runtime_platform = get_runtime_platform()
     disabled = get_disabled_skill_names()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        _runtime_platform,
         _platform_hint,
         tuple(sorted(disabled)),
     )
@@ -1041,6 +1049,12 @@ def build_skills_system_prompt(
             frontmatter_name = entry.get("frontmatter_name") or skill_name
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
+                logger.debug(
+                    "Skill excluded by platform: name=%s platforms=%s runtime=%s",
+                    frontmatter_name,
+                    platforms,
+                    _runtime_platform,
+                )
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -11,7 +11,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_runtime_platform
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -268,6 +268,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     frontmatter, body = _parse_frontmatter(content)
                     # Skip skills incompatible with the current OS platform
                     if not skill_matches_platform(frontmatter):
+                        logger.debug(
+                            "Skill command excluded by platform: path=%s platforms=%s runtime=%s",
+                            skill_md,
+                            frontmatter.get("platforms"),
+                            get_runtime_platform(),
+                        )
                         continue
                     name = frontmatter.get('name', skill_md.parent.name)
                     if name in seen_names:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -8,23 +8,15 @@ tool registration or provider resolution.
 import logging
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir
+from hermes_constants import get_config_path, get_runtime_platform, get_skills_dir
 
 logger = logging.getLogger(__name__)
 
-# ── Platform mapping ──────────────────────────────────────────────────────
-
-PLATFORM_MAP = {
-    "macos": "darwin",
-    "linux": "linux",
-    "windows": "win32",
-}
-
 EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
+VALID_RUNTIME_PLATFORMS = frozenset(("windows", "macos", "linux", "wsl"))
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
@@ -90,13 +82,13 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
 
 
 def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
-    """Return True when the skill is compatible with the current OS.
+    """Return True when the skill is compatible with the current runtime.
 
     Skills declare platform requirements via a top-level ``platforms`` list
     in their YAML frontmatter::
 
         platforms: [macos]          # macOS only
-        platforms: [macos, linux]   # macOS and Linux
+        platforms: [linux, wsl]     # native Linux and WSL
 
     If the field is absent or empty the skill is compatible with **all**
     platforms (backward-compatible default).
@@ -106,13 +98,22 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
         return True
     if not isinstance(platforms, list):
         platforms = [platforms]
-    current = sys.platform
-    for platform in platforms:
-        normalized = str(platform).lower().strip()
-        mapped = PLATFORM_MAP.get(normalized, normalized)
-        if current.startswith(mapped):
-            return True
-    return False
+    normalized_platforms = {
+        str(platform).lower().strip()
+        for platform in platforms
+        if str(platform).strip()
+    }
+    if not normalized_platforms:
+        return True
+    current = get_runtime_platform()
+    matches = current in normalized_platforms
+    if not matches:
+        logger.debug(
+            "Skill excluded by platform: required=%s current=%s",
+            sorted(normalized_platforms),
+            current,
+        )
+    return matches
 
 
 # ── Disabled skills ───────────────────────────────────────────────────────

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -304,6 +304,7 @@ class PluginContext:
         is_async: bool = False,
         description: str = "",
         emoji: str = "",
+        platforms: list | str | None = None,
     ) -> None:
         """Register a tool in the global registry **and** track it as plugin-provided."""
         from tools.registry import registry
@@ -318,6 +319,7 @@ class PluginContext:
             is_async=is_async,
             description=description,
             emoji=emoji,
+            platforms=platforms,
         )
         self._manager._plugin_tool_names.add(name)
         logger.debug("Plugin %s registered tool: %s", self.manifest.name, name)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,7 +5,9 @@ without risk of circular imports.
 """
 
 import os
+import sys
 from pathlib import Path
+from typing import Literal
 
 
 _profile_fallback_warned: bool = False
@@ -238,6 +240,26 @@ def is_wsl() -> bool:
     except Exception:
         _wsl_detected = False
     return _wsl_detected
+
+
+RuntimePlatform = Literal["windows", "macos", "linux", "wsl"]
+
+
+def get_runtime_platform() -> RuntimePlatform:
+    """Return Hermes' canonical host runtime platform key.
+
+    WSL is intentionally distinct from native Linux so skills and tools can
+    opt into either environment explicitly.
+    """
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("linux"):
+        return "wsl" if is_wsl() else "linux"
+    # Hermes only supports the canonical keys above. Unknown Unix-like hosts
+    # use Linux as the closest conservative fallback for existing behavior.
+    return "linux"
 
 
 _container_detected: bool | None = None

--- a/model_tools.py
+++ b/model_tools.py
@@ -302,11 +302,17 @@ def get_tool_definitions(
             cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
+        try:
+            from hermes_constants import get_runtime_platform
+            runtime_platform = get_runtime_platform()
+        except Exception:
+            runtime_platform = None
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            runtime_platform,
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:

--- a/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/blackbox/SKILL.md
@@ -4,7 +4,7 @@ description: Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent w
 version: 1.0.0
 author: Hermes Agent (Nous Research)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, Blackbox, Multi-Agent, Judge, Multi-Model]

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -4,7 +4,7 @@ description: Configure and use Honcho memory with Hermes -- cross-session user m
 version: 2.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Honcho, Memory, Profiles, Observation, Dialectic, User-Modeling, Session-Summary]

--- a/optional-skills/blockchain/base/SKILL.md
+++ b/optional-skills/blockchain/base/SKILL.md
@@ -4,7 +4,7 @@ description: Query Base (Ethereum L2) blockchain data with USD pricing — walle
 version: 0.1.0
 author: youssefea
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Base, Blockchain, Crypto, Web3, RPC, DeFi, EVM, L2, Ethereum]

--- a/optional-skills/blockchain/solana/SKILL.md
+++ b/optional-skills/blockchain/solana/SKILL.md
@@ -4,7 +4,7 @@ description: Query Solana blockchain data with USD pricing — wallet balances, 
 version: 0.2.0
 author: Deniz Alagoz (gizdusum), enhanced by Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Solana, Blockchain, Crypto, Web3, RPC, DeFi, NFT]

--- a/optional-skills/communication/one-three-one-rule/SKILL.md
+++ b/optional-skills/communication/one-three-one-rule/SKILL.md
@@ -8,7 +8,7 @@ description: >
   and one concrete recommendation with definition of done and implementation plan.
   Use when the user asks for a "1-3-1", says "give me options", or needs help
   choosing between competing approaches.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 version: 1.0.0
 author: Willard Moore
 license: MIT

--- a/optional-skills/creative/blender-mcp/SKILL.md
+++ b/optional-skills/creative/blender-mcp/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 requires: Blender 4.3+ (desktop instance required, headless not supported)
 author: alireza78a
 tags: [blender, 3d, animation, modeling, bpy, mcp]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Blender MCP

--- a/optional-skills/creative/concept-diagrams/SKILL.md
+++ b/optional-skills/creative/concept-diagrams/SKILL.md
@@ -5,7 +5,7 @@ version: 0.1.0
 author: v1k22 (original PR), ported into hermes-agent
 license: MIT
 dependencies: []
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [diagrams, svg, visualization, education, physics, chemistry, engineering]

--- a/optional-skills/creative/hyperframes/SKILL.md
+++ b/optional-skills/creative/hyperframes/SKILL.md
@@ -4,7 +4,7 @@ description: Create HTML-based video compositions, animated title cards, social 
 version: 1.0.0
 author: heygen-com
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   commands: [node, ffmpeg, npx]
 metadata:

--- a/optional-skills/creative/kanban-video-orchestrator/SKILL.md
+++ b/optional-skills/creative/kanban-video-orchestrator/SKILL.md
@@ -4,7 +4,7 @@ description: Plan, set up, and monitor a multi-agent video production pipeline b
 version: 1.0.0
 author: [SHL0MS, alt-glitch]
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [video, kanban, multi-agent, orchestration, production-pipeline]

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -4,7 +4,7 @@ description: Generate real meme images by picking a template and overlaying text
 version: 2.0.0
 author: adanaleycio
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [creative, memes, humor, images]

--- a/optional-skills/devops/cli/SKILL.md
+++ b/optional-skills/devops/cli/SKILL.md
@@ -4,7 +4,7 @@ description: "Run 150+ AI apps via inference.sh CLI (infsh) — image generation
 version: 1.0.0
 author: okaris
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [AI, image-generation, video, LLM, search, inference, FLUX, Veo, Claude]

--- a/optional-skills/devops/docker-management/SKILL.md
+++ b/optional-skills/devops/docker-management/SKILL.md
@@ -4,7 +4,7 @@ description: Manage Docker containers, images, volumes, networks, and Compose st
 version: 1.0.0
 author: sprmn24
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [docker, containers, devops, infrastructure, compose, images, volumes, networks, debugging]

--- a/optional-skills/devops/watchers/SKILL.md
+++ b/optional-skills/devops/watchers/SKILL.md
@@ -4,7 +4,7 @@ description: Poll RSS, JSON APIs, and GitHub with watermark dedup.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [cron, polling, rss, github, http, automation, monitoring]

--- a/optional-skills/dogfood/adversarial-ux-test/SKILL.md
+++ b/optional-skills/dogfood/adversarial-ux-test/SKILL.md
@@ -4,7 +4,7 @@ description: Roleplay the most difficult, tech-resistant user for your product. 
 version: 1.0.0
 author: Omni @ Comelse
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [qa, ux, testing, adversarial, dogfood, personas, user-testing]

--- a/optional-skills/email/agentmail/SKILL.md
+++ b/optional-skills/email/agentmail/SKILL.md
@@ -2,7 +2,7 @@
 name: agentmail
 description: Give the agent its own dedicated email inbox via AgentMail. Send, receive, and manage email autonomously using agent-owned email addresses (e.g. hermes-agent@agentmail.to).
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [email, communication, agentmail, mcp]

--- a/optional-skills/finance/3-statement-model/SKILL.md
+++ b/optional-skills/finance/3-statement-model/SKILL.md
@@ -4,7 +4,7 @@ description: Build fully-integrated 3-statement models (IS, BS, CF) in Excel wit
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [finance, three-statement, income-statement, balance-sheet, cash-flow, excel, openpyxl, modeling]

--- a/optional-skills/finance/comps-analysis/SKILL.md
+++ b/optional-skills/finance/comps-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Build comparable company analysis in Excel — operating metrics, v
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [finance, valuation, comps, excel, openpyxl, modeling, investment-banking]

--- a/optional-skills/finance/dcf-model/SKILL.md
+++ b/optional-skills/finance/dcf-model/SKILL.md
@@ -4,7 +4,7 @@ description: Build institutional-quality DCF valuation models in Excel — reven
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [finance, valuation, dcf, excel, openpyxl, modeling, investment-banking]

--- a/optional-skills/finance/excel-author/SKILL.md
+++ b/optional-skills/finance/excel-author/SKILL.md
@@ -4,7 +4,7 @@ description: Build auditable Excel workbooks headless with openpyxl — blue/bla
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [excel, openpyxl, finance, spreadsheet, modeling]

--- a/optional-skills/finance/lbo-model/SKILL.md
+++ b/optional-skills/finance/lbo-model/SKILL.md
@@ -4,7 +4,7 @@ description: Build leveraged buyout models in Excel — sources & uses, debt sch
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [finance, valuation, lbo, private-equity, excel, openpyxl, modeling]

--- a/optional-skills/finance/merger-model/SKILL.md
+++ b/optional-skills/finance/merger-model/SKILL.md
@@ -4,7 +4,7 @@ description: Build accretion/dilution (merger) models in Excel — pro-forma P&L
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [finance, m-and-a, merger, accretion-dilution, excel, openpyxl, modeling, investment-banking]

--- a/optional-skills/finance/pptx-author/SKILL.md
+++ b/optional-skills/finance/pptx-author/SKILL.md
@@ -4,7 +4,7 @@ description: Build PowerPoint decks headless with python-pptx. Pairs with excel-
 version: 1.0.0
 author: Anthropic (adapted by Nous Research)
 license: Apache-2.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [powerpoint, pptx, python-pptx, presentation, finance]

--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -6,7 +6,7 @@ description: >
   foods via USDA FoodData Central. Compute BMI, TDEE, one-rep max, macro
   splits, and body fat — pure Python, no pip installs. Built for anyone
   chasing gains, cutting weight, or just trying to eat better.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 version: 1.0.0
 authors:
   - haileymarshall

--- a/optional-skills/health/neuroskill-bci/SKILL.md
+++ b/optional-skills/health/neuroskill-bci/SKILL.md
@@ -6,7 +6,7 @@ description: >
   heart rate, HRV, sleep staging, and 40+ derived EXG scores) into responses.
   Requires a BCI wearable (Muse 2/S or OpenBCI) and the NeuroSkill desktop app
   running locally.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 version: 1.0.0
 author: Hermes Agent + Nous Research
 license: MIT

--- a/optional-skills/mcp/fastmcp/SKILL.md
+++ b/optional-skills/mcp/fastmcp/SKILL.md
@@ -4,7 +4,7 @@ description: Build, test, inspect, install, and deploy MCP servers with FastMCP 
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [MCP, FastMCP, Python, Tools, Resources, Prompts, Deployment]

--- a/optional-skills/mcp/mcporter/SKILL.md
+++ b/optional-skills/mcp/mcporter/SKILL.md
@@ -4,7 +4,7 @@ description: Use the mcporter CLI to list, configure, auth, and call MCP servers
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Tools, API, Integrations, Interop]

--- a/optional-skills/migration/openclaw-migration/SKILL.md
+++ b/optional-skills/migration/openclaw-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migrate a user's OpenClaw customization footprint into Hermes Agent
 version: 1.0.0
 author: Hermes Agent (Nous Research)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Migration, OpenClaw, Hermes, Memory, Persona, Import]

--- a/optional-skills/mlops/accelerate/SKILL.md
+++ b/optional-skills/mlops/accelerate/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [accelerate, torch, transformers]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Distributed Training, HuggingFace, Accelerate, DeepSpeed, FSDP, Mixed Precision, PyTorch, DDP, Unified API, Simple]

--- a/optional-skills/mlops/chroma/SKILL.md
+++ b/optional-skills/mlops/chroma/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [chromadb, sentence-transformers]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [RAG, Chroma, Vector Database, Embeddings, Semantic Search, Open Source, Self-Hosted, Document Retrieval, Metadata Filtering]

--- a/optional-skills/mlops/clip/SKILL.md
+++ b/optional-skills/mlops/clip/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [transformers, torch, pillow]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Multimodal, CLIP, Vision-Language, Zero-Shot, Image Classification, OpenAI, Image Search, Cross-Modal Retrieval, Content Moderation]

--- a/optional-skills/mlops/faiss/SKILL.md
+++ b/optional-skills/mlops/faiss/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [faiss-cpu, faiss-gpu, numpy]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [RAG, FAISS, Similarity Search, Vector Search, Facebook AI, GPU Acceleration, Billion-Scale, K-NN, HNSW, High Performance, Large Scale]

--- a/optional-skills/mlops/flash-attention/SKILL.md
+++ b/optional-skills/mlops/flash-attention/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [flash-attn, torch, transformers]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Optimization, Flash Attention, Attention Optimization, Memory Efficiency, Speed Optimization, Long Context, PyTorch, SDPA, H100, FP8, Transformers]

--- a/optional-skills/mlops/guidance/SKILL.md
+++ b/optional-skills/mlops/guidance/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [guidance, transformers]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Prompt Engineering, Guidance, Constrained Generation, Structured Output, JSON Validation, Grammar, Microsoft Research, Format Enforcement, Multi-Step Workflows]

--- a/optional-skills/mlops/hermes-atropos-environments/SKILL.md
+++ b/optional-skills/mlops/hermes-atropos-environments/SKILL.md
@@ -4,7 +4,7 @@ description: Build, test, and debug Hermes Agent RL environments for Atropos tra
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [atropos, rl, environments, training, reinforcement-learning, reward-functions]

--- a/optional-skills/mlops/huggingface-tokenizers/SKILL.md
+++ b/optional-skills/mlops/huggingface-tokenizers/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [tokenizers, transformers, datasets]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Tokenization, HuggingFace, BPE, WordPiece, Unigram, Fast Tokenization, Rust, Custom Tokenizer, Alignment Tracking, Production]

--- a/optional-skills/mlops/inference/outlines/SKILL.md
+++ b/optional-skills/mlops/inference/outlines/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [outlines, transformers, vllm, pydantic]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Prompt Engineering, Outlines, Structured Generation, JSON Schema, Pydantic, Local Models, Grammar-Based Generation, vLLM, Transformers, Type Safety]

--- a/optional-skills/mlops/instructor/SKILL.md
+++ b/optional-skills/mlops/instructor/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [instructor, pydantic, openai, anthropic]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Prompt Engineering, Instructor, Structured Output, Pydantic, Data Extraction, JSON Parsing, Type Safety, Validation, Streaming, OpenAI, Anthropic]

--- a/optional-skills/mlops/lambda-labs/SKILL.md
+++ b/optional-skills/mlops/lambda-labs/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [lambda-cloud-client>=1.0.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Infrastructure, GPU Cloud, Training, Inference, Lambda Labs]

--- a/optional-skills/mlops/llava/SKILL.md
+++ b/optional-skills/mlops/llava/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [transformers, torch, pillow]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [LLaVA, Vision-Language, Multimodal, Visual Question Answering, Image Chat, CLIP, Vicuna, Conversational AI, Instruction Tuning, VQA]

--- a/optional-skills/mlops/modal/SKILL.md
+++ b/optional-skills/mlops/modal/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [modal>=0.64.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Infrastructure, Serverless, GPU, Cloud, Deployment, Modal]

--- a/optional-skills/mlops/nemo-curator/SKILL.md
+++ b/optional-skills/mlops/nemo-curator/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [nemo-curator, cudf, dask, rapids]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Data Processing, NeMo Curator, Data Curation, GPU Acceleration, Deduplication, Quality Filtering, NVIDIA, RAPIDS, PII Redaction, Multimodal, LLM Training Data]

--- a/optional-skills/mlops/peft/SKILL.md
+++ b/optional-skills/mlops/peft/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [peft>=0.13.0, transformers>=4.45.0, torch>=2.0.0, bitsandbytes>=0.43.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Fine-Tuning, PEFT, LoRA, QLoRA, Parameter-Efficient, Adapters, Low-Rank, Memory Optimization, Multi-Adapter]

--- a/optional-skills/mlops/pinecone/SKILL.md
+++ b/optional-skills/mlops/pinecone/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [pinecone-client]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [RAG, Pinecone, Vector Database, Managed Service, Serverless, Hybrid Search, Production, Auto-Scaling, Low Latency, Recommendations]

--- a/optional-skills/mlops/pytorch-fsdp/SKILL.md
+++ b/optional-skills/mlops/pytorch-fsdp/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [torch>=2.0, transformers]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Distributed Training, PyTorch, FSDP, Data Parallel, Sharding, Mixed Precision, CPU Offloading, FSDP2, Large-Scale Training]

--- a/optional-skills/mlops/pytorch-lightning/SKILL.md
+++ b/optional-skills/mlops/pytorch-lightning/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [lightning, torch, transformers]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [PyTorch Lightning, Training Framework, Distributed Training, DDP, FSDP, DeepSpeed, High-Level API, Callbacks, Best Practices, Scalable]

--- a/optional-skills/mlops/qdrant/SKILL.md
+++ b/optional-skills/mlops/qdrant/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [qdrant-client>=1.12.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [RAG, Vector Search, Qdrant, Semantic Search, Embeddings, Similarity Search, HNSW, Production, Distributed]

--- a/optional-skills/mlops/saelens/SKILL.md
+++ b/optional-skills/mlops/saelens/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [sae-lens>=6.0.0, transformer-lens>=2.0.0, torch>=2.0.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Sparse Autoencoders, SAE, Mechanistic Interpretability, Feature Discovery, Superposition]

--- a/optional-skills/mlops/simpo/SKILL.md
+++ b/optional-skills/mlops/simpo/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [torch, transformers, datasets, trl, accelerate]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Post-Training, SimPO, Preference Optimization, Alignment, DPO Alternative, Reference-Free, LLM Alignment, Efficient Training]

--- a/optional-skills/mlops/slime/SKILL.md
+++ b/optional-skills/mlops/slime/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [sglang-router>=0.2.3, ray, torch>=2.0.0, transformers>=4.40.0]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Reinforcement Learning, Megatron-LM, SGLang, GRPO, Post-Training, GLM]

--- a/optional-skills/mlops/stable-diffusion/SKILL.md
+++ b/optional-skills/mlops/stable-diffusion/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [diffusers>=0.30.0, transformers>=4.41.0, accelerate>=0.31.0, torch>=2.0.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Image Generation, Stable Diffusion, Diffusers, Text-to-Image, Multimodal, Computer Vision]

--- a/optional-skills/mlops/tensorrt-llm/SKILL.md
+++ b/optional-skills/mlops/tensorrt-llm/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [tensorrt-llm, torch]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Inference Serving, TensorRT-LLM, NVIDIA, Inference Optimization, High Throughput, Low Latency, Production, FP8, INT4, In-Flight Batching, Multi-GPU]

--- a/optional-skills/mlops/torchtitan/SKILL.md
+++ b/optional-skills/mlops/torchtitan/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [torch>=2.6.0, torchtitan>=0.2.0, torchao>=0.5.0]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Model Architecture, Distributed Training, TorchTitan, FSDP2, Tensor Parallel, Pipeline Parallel, Context Parallel, Float8, Llama, Pretraining]

--- a/optional-skills/mlops/training/axolotl/SKILL.md
+++ b/optional-skills/mlops/training/axolotl/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [axolotl, torch, transformers, datasets, peft, accelerate, deepspeed]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Fine-Tuning, Axolotl, LLM, LoRA, QLoRA, DPO, KTO, ORPO, GRPO, YAML, HuggingFace, DeepSpeed, Multimodal]

--- a/optional-skills/mlops/training/trl-fine-tuning/SKILL.md
+++ b/optional-skills/mlops/training/trl-fine-tuning/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [trl, transformers, datasets, peft, accelerate, torch]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Post-Training, TRL, Reinforcement Learning, Fine-Tuning, SFT, DPO, PPO, GRPO, RLHF, Preference Alignment, HuggingFace]

--- a/optional-skills/mlops/training/unsloth/SKILL.md
+++ b/optional-skills/mlops/training/unsloth/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [unsloth, torch, transformers, trl, datasets, peft]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Fine-Tuning, Unsloth, Fast Training, LoRA, QLoRA, Memory-Efficient, Optimization, Llama, Mistral, Gemma, Qwen]

--- a/optional-skills/mlops/whisper/SKILL.md
+++ b/optional-skills/mlops/whisper/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [openai-whisper, transformers, torch]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Whisper, Speech Recognition, ASR, Multimodal, Multilingual, OpenAI, Speech-To-Text, Transcription, Translation, Audio Processing]

--- a/optional-skills/productivity/canvas/SKILL.md
+++ b/optional-skills/productivity/canvas/SKILL.md
@@ -4,7 +4,7 @@ description: Canvas LMS integration — fetch enrolled courses and assignments u
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   env_vars: [CANVAS_API_TOKEN, CANVAS_BASE_URL]
 metadata:

--- a/optional-skills/productivity/here-now/SKILL.md
+++ b/optional-skills/productivity/here-now/SKILL.md
@@ -6,7 +6,7 @@ author: here.now
 license: MIT
 prerequisites:
   commands: [curl, file, jq]
-platforms: [macos, linux]
+platforms: [macos, linux, wsl]
 metadata:
   hermes:
     tags: [here.now, herenow, publish, deploy, hosting, static-site, web, share, URL, drive, storage]

--- a/optional-skills/productivity/memento-flashcards/SKILL.md
+++ b/optional-skills/productivity/memento-flashcards/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 version: 1.0.0
 author: Memento AI
 license: MIT
-platforms: [macos, linux]
+platforms: [macos, linux, wsl]
 metadata:
   hermes:
     tags: [Education, Flashcards, Spaced Repetition, Learning, Quiz, YouTube]

--- a/optional-skills/productivity/shop-app/SKILL.md
+++ b/optional-skills/productivity/shop-app/SKILL.md
@@ -4,7 +4,7 @@ description: "Shop.app: product search, order tracking, returns, reorder."
 version: 0.0.28
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   commands: [curl]
 metadata:

--- a/optional-skills/productivity/shopify/SKILL.md
+++ b/optional-skills/productivity/shopify/SKILL.md
@@ -4,7 +4,7 @@ description: Shopify Admin & Storefront GraphQL APIs via curl. Products, orders,
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   env_vars: [SHOPIFY_ACCESS_TOKEN, SHOPIFY_STORE_DOMAIN]
   commands: [curl, jq]

--- a/optional-skills/productivity/siyuan/SKILL.md
+++ b/optional-skills/productivity/siyuan/SKILL.md
@@ -4,7 +4,7 @@ description: SiYuan Note API for searching, reading, creating, and managing bloc
 version: 1.0.0
 author: FEUAZUR
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [SiYuan, Notes, Knowledge Base, PKM, API]

--- a/optional-skills/productivity/telephony/SKILL.md
+++ b/optional-skills/productivity/telephony/SKILL.md
@@ -4,7 +4,7 @@ description: Give Hermes phone capabilities without core tool changes. Provision
 version: 1.0.0
 author: Nous Research
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [telephony, phone, sms, mms, voice, twilio, bland.ai, vapi, calling, texting]

--- a/optional-skills/research/bioinformatics/SKILL.md
+++ b/optional-skills/research/bioinformatics/SKILL.md
@@ -2,7 +2,7 @@
 name: bioinformatics
 description: Gateway to 400+ bioinformatics skills from bioSkills and ClawBio. Covers genomics, transcriptomics, single-cell, variant calling, pharmacogenomics, metagenomics, structural biology, and more. Fetches domain-specific reference material on demand.
 version: 1.0.0
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [bioinformatics, genomics, sequencing, biology, research, science]

--- a/optional-skills/research/domain-intel/SKILL.md
+++ b/optional-skills/research/domain-intel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: domain-intel
 description: Passive domain reconnaissance using Python stdlib. Subdomain discovery, SSL certificate inspection, WHOIS lookups, DNS records, domain availability checks, and bulk multi-domain analysis. No API keys required.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Domain Intelligence — Passive OSINT

--- a/optional-skills/research/drug-discovery/SKILL.md
+++ b/optional-skills/research/drug-discovery/SKILL.md
@@ -7,7 +7,7 @@ description: >
   OpenFDA, interpret ADMET profiles, and assist with lead optimization.
   Use for medicinal chemistry questions, molecule property analysis, clinical
   pharmacology, and open-science drug research.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 version: 1.0.0
 author: bennytimz
 license: MIT

--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -4,7 +4,7 @@ description: Free web search via DuckDuckGo — text, news, images, videos. No A
 version: 1.3.0
 author: gamedevCloudy
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [search, duckduckgo, web-search, free, fallback]

--- a/optional-skills/research/gitnexus-explorer/SKILL.md
+++ b/optional-skills/research/gitnexus-explorer/SKILL.md
@@ -4,7 +4,7 @@ description: Index a codebase with GitNexus and serve an interactive knowledge g
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [gitnexus, code-intelligence, knowledge-graph, visualization]

--- a/optional-skills/research/parallel-cli/SKILL.md
+++ b/optional-skills/research/parallel-cli/SKILL.md
@@ -4,7 +4,7 @@ description: Optional vendor skill for Parallel CLI — agent-native web search,
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Research, Web, Search, Deep-Research, Enrichment, CLI]

--- a/optional-skills/research/qmd/SKILL.md
+++ b/optional-skills/research/qmd/SKILL.md
@@ -4,7 +4,7 @@ description: Search personal knowledge bases, notes, docs, and meeting transcrip
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT
-platforms: [macos, linux]
+platforms: [macos, linux, wsl]
 metadata:
   hermes:
     tags: [Search, Knowledge-Base, RAG, Notes, MCP, Local-AI]

--- a/optional-skills/research/scrapling/SKILL.md
+++ b/optional-skills/research/scrapling/SKILL.md
@@ -4,7 +4,7 @@ description: Web scraping with Scrapling - HTTP fetching, stealth browser automa
 version: 1.0.0
 author: FEUAZUR
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Web Scraping, Browser, Cloudflare, Stealth, Crawling, Spider]

--- a/optional-skills/research/searxng-search/SKILL.md
+++ b/optional-skills/research/searxng-search/SKILL.md
@@ -4,7 +4,7 @@ description: Free meta-search via SearXNG — aggregates results from 70+ search
 version: 1.0.0
 author: hermes-agent
 license: MIT
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [search, searxng, meta-search, self-hosted, free, fallback]

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -4,7 +4,7 @@ description: Set up and use 1Password CLI (op). Use when installing the CLI, ena
 version: 1.0.0
 author: arceus77-7, enhanced by Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [security, secrets, 1password, op, cli]

--- a/optional-skills/security/oss-forensics/SKILL.md
+++ b/optional-skills/security/oss-forensics/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Covers deleted commit recovery, force-push detection, IOC extraction, multi-source evidence
   collection, hypothesis formation/validation, and structured forensic reporting.
   Inspired by RAPTOR's 1800+ line OSS Forensics system.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 category: security
 triggers:
   - "investigate this repository"

--- a/optional-skills/security/sherlock/SKILL.md
+++ b/optional-skills/security/sherlock/SKILL.md
@@ -4,7 +4,7 @@ description: OSINT username search across 400+ social networks. Hunt down social
 version: 1.0.0
 author: unmodeled-tyler
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [osint, security, username, social-media, reconnaissance]

--- a/optional-skills/web-development/page-agent/SKILL.md
+++ b/optional-skills/web-development/page-agent/SKILL.md
@@ -4,7 +4,7 @@ description: Embed alibaba/page-agent into your own web application — a pure-J
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [web, javascript, agent, browser, gui, alibaba, embed, copilot, saas]

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -4,7 +4,7 @@ description: "Delegate coding to Claude Code CLI (features, PRs)."
 version: 2.2.0
 author: Hermes Agent + Teknium
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, Claude, Anthropic, Code-Review, Refactoring, PTY, Automation]

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -4,7 +4,7 @@ description: "Delegate coding to OpenAI Codex CLI (features, PRs)."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, Codex, OpenAI, Code-Review, Refactoring]

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -4,7 +4,7 @@ description: "Configure, extend, or contribute to Hermes Agent."
 version: 2.1.0
 author: Hermes Agent + Teknium
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [hermes, setup, configuration, multi-agent, spawning, cli, gateway, development]

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -4,7 +4,7 @@ description: "Delegate coding to OpenCode CLI (features, PR review)."
 version: 1.2.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Coding-Agent, OpenCode, Autonomous, Refactoring, Code-Review]

--- a/skills/creative/architecture-diagram/SKILL.md
+++ b/skills/creative/architecture-diagram/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Cocoon AI (hello@cocoon-ai.com), ported by Hermes Agent
 license: MIT
 dependencies: []
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [architecture, diagrams, SVG, HTML, visualization, infrastructure, cloud]

--- a/skills/creative/ascii-art/SKILL.md
+++ b/skills/creative/ascii-art/SKILL.md
@@ -5,7 +5,7 @@ version: 4.0.0
 author: 0xbyt4, Hermes Agent
 license: MIT
 dependencies: []
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [ASCII, Art, Banners, Creative, Unicode, Text-Art, pyfiglet, figlet, cowsay, boxes]

--- a/skills/creative/ascii-video/SKILL.md
+++ b/skills/creative/ascii-video/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ascii-video
 description: "ASCII video: convert video/audio to colored ASCII MP4/GIF."
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # ASCII Video Production Pipeline

--- a/skills/creative/baoyu-comic/SKILL.md
+++ b/skills/creative/baoyu-comic/SKILL.md
@@ -4,7 +4,7 @@ description: "Knowledge comics (知识漫画): educational, biography, tutorial.
 version: 1.56.1
 author: 宝玉 (JimLiu)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [comic, knowledge-comic, creative, image-generation]

--- a/skills/creative/baoyu-infographic/SKILL.md
+++ b/skills/creative/baoyu-infographic/SKILL.md
@@ -4,7 +4,7 @@ description: "Infographics: 21 layouts x 21 styles (信息图, 可视化)."
 version: 1.56.1
 author: 宝玉 (JimLiu)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [infographic, visual-summary, creative, image-generation]

--- a/skills/creative/claude-design/SKILL.md
+++ b/skills/creative/claude-design/SKILL.md
@@ -4,7 +4,7 @@ description: Design one-off HTML artifacts (landing, deck, prototype).
 version: 1.0.0
 author: BadTechBandit
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [design, html, prototype, ux, ui, creative, artifact, deck, motion, design-system]

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate images, video, and audio with ComfyUI — install, launch
 version: 5.0.0
 author: [kshitijk4poor, alt-glitch]
 license: MIT
-platforms: [macos, linux, windows]
+platforms: [macos, linux, wsl, windows]
 compatibility: "Requires ComfyUI (local, Comfy Desktop, or Comfy Cloud) and comfy-cli (auto-installed via pipx/uvx by the setup script)."
 prerequisites:
   commands: ["python3"]

--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -5,7 +5,7 @@ description: "Generate project ideas via creative constraints."
 version: 1.0.0
 author: SHL0MS
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Creative, Ideation, Projects, Brainstorming, Inspiration]

--- a/skills/creative/design-md/SKILL.md
+++ b/skills/creative/design-md/SKILL.md
@@ -4,7 +4,7 @@ description: Author/validate/export Google's DESIGN.md token spec files.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [design, design-system, tokens, ui, accessibility, wcag, tailwind, dtcg, google]

--- a/skills/creative/excalidraw/SKILL.md
+++ b/skills/creative/excalidraw/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Hermes Agent
 license: MIT
 dependencies: []
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Excalidraw, Diagrams, Flowcharts, Architecture, Visualization, JSON]

--- a/skills/creative/humanizer/SKILL.md
+++ b/skills/creative/humanizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Humanize text: strip AI-isms and add real voice."
 version: 2.5.1
 author: Siqi Chen (@blader, https://github.com/blader/humanizer), ported by Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [writing, editing, humanize, anti-ai-slop, voice, prose, text]

--- a/skills/creative/manim-video/SKILL.md
+++ b/skills/creative/manim-video/SKILL.md
@@ -2,7 +2,7 @@
 name: manim-video
 description: "Manim CE animations: 3Blue1Brown math/algo videos."
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Manim Video Production Pipeline

--- a/skills/creative/p5js/SKILL.md
+++ b/skills/creative/p5js/SKILL.md
@@ -2,7 +2,7 @@
 name: p5js
 description: "p5.js sketches: gen art, shaders, interactive, 3D."
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [creative-coding, generative-art, p5js, canvas, interactive, visualization, webgl, shaders, animation]

--- a/skills/creative/pixel-art/SKILL.md
+++ b/skills/creative/pixel-art/SKILL.md
@@ -4,7 +4,7 @@ description: "Pixel art w/ era palettes (NES, Game Boy, PICO-8)."
 version: 2.0.0
 author: dodo-reach
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [creative, pixel-art, arcade, snes, nes, gameboy, retro, image, video]

--- a/skills/creative/popular-web-designs/SKILL.md
+++ b/skills/creative/popular-web-designs/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Hermes Agent + Teknium (design systems sourced from VoltAgent/awesome-design-md)
 license: MIT
 tags: [design, css, html, ui, web-development, design-systems, templates]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 triggers:
   - build a page that looks like
   - make it look like stripe

--- a/skills/creative/pretext/SKILL.md
+++ b/skills/creative/pretext/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when building creative browser demos with @chenglou/pretext â€
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [creative-coding, typography, pretext, ascii-art, canvas, generative, text-layout, kinetic-typography]

--- a/skills/creative/sketch/SKILL.md
+++ b/skills/creative/sketch/SKILL.md
@@ -4,7 +4,7 @@ description: "Throwaway HTML mockups: 2-3 design variants to compare."
 version: 1.0.0
 author: Hermes Agent (adapted from gsd-build/get-shit-done)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [sketch, mockup, design, ui, prototype, html, variants, exploration, wireframe, comparison]

--- a/skills/creative/songwriting-and-ai-music/SKILL.md
+++ b/skills/creative/songwriting-and-ai-music/SKILL.md
@@ -2,7 +2,7 @@
 name: songwriting-and-ai-music
 description: "Songwriting craft and Suno AI music prompts."
 tags: [songwriting, music, suno, parody, lyrics, creative]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 triggers:
   - writing a song
   - song lyrics

--- a/skills/creative/touchdesigner-mcp/SKILL.md
+++ b/skills/creative/touchdesigner-mcp/SKILL.md
@@ -4,7 +4,7 @@ description: "Control a running TouchDesigner instance via twozero MCP — creat
 version: 1.1.0
 author: kshitijk4poor
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [TouchDesigner, MCP, twozero, creative-coding, real-time-visuals, generative-art, audio-reactive, VJ, installation, GLSL]

--- a/skills/data-science/jupyter-live-kernel/SKILL.md
+++ b/skills/data-science/jupyter-live-kernel/SKILL.md
@@ -4,7 +4,7 @@ description: "Iterative Python via live Jupyter kernel (hamelnb)."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [jupyter, notebook, repl, data-science, exploration, iterative]

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -2,7 +2,7 @@
 name: kanban-orchestrator
 description: Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill is the deeper playbook when you're specifically playing the orchestrator role.
 version: 2.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [kanban, multi-agent, orchestration, routing]

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -2,7 +2,7 @@
 name: kanban-worker
 description: Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from agent/prompt_builder.py); this skill is what you load when you want deeper detail on specific scenarios.
 version: 2.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [kanban, multi-agent, collaboration, workflow, pitfalls]

--- a/skills/devops/webhook-subscriptions/SKILL.md
+++ b/skills/devops/webhook-subscriptions/SKILL.md
@@ -2,7 +2,7 @@
 name: webhook-subscriptions
 description: "Webhook subscriptions: event-driven agent runs."
 version: 1.1.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [webhook, events, automation, integrations, notifications, push]

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -2,7 +2,7 @@
 name: dogfood
 description: "Exploratory QA of web apps: find bugs, evidence, reports."
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [qa, testing, browser, web, dogfood]

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -4,7 +4,7 @@ description: "Himalaya CLI: IMAP/SMTP email from terminal."
 version: 1.1.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Email, IMAP, SMTP, CLI, Communication]

--- a/skills/gaming/minecraft-modpack-server/SKILL.md
+++ b/skills/gaming/minecraft-modpack-server/SKILL.md
@@ -2,7 +2,7 @@
 name: minecraft-modpack-server
 description: "Host modded Minecraft servers (CurseForge, Modrinth)."
 tags: [minecraft, gaming, server, neoforge, forge, modpack]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 ---
 
 # Minecraft Modpack Server Setup

--- a/skills/gaming/pokemon-player/SKILL.md
+++ b/skills/gaming/pokemon-player/SKILL.md
@@ -2,7 +2,7 @@
 name: pokemon-player
 description: "Play Pokemon via headless emulator + RAM reads."
 tags: [gaming, pokemon, emulator, pyboy, gameplay, gameboy]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 # Pokemon Player
 

--- a/skills/github/codebase-inspection/SKILL.md
+++ b/skills/github/codebase-inspection/SKILL.md
@@ -4,7 +4,7 @@ description: "Inspect codebases w/ pygount: LOC, languages, ratios."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [LOC, Code Analysis, pygount, Codebase, Metrics, Repository]

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -4,7 +4,7 @@ description: "GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Authentication, Git, gh-cli, SSH, Setup]

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -4,7 +4,7 @@ description: "Review PRs: diffs, inline comments via gh or REST."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Code-Review, Pull-Requests, Git, Quality]

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -4,7 +4,7 @@ description: "Create, triage, label, assign GitHub issues via gh or REST."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Issues, Project-Management, Bug-Tracking, Triage]

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -4,7 +4,7 @@ description: "GitHub PR lifecycle: branch, commit, open, CI, merge."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Pull-Requests, CI/CD, Git, Automation, Merge]

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -4,7 +4,7 @@ description: "Clone/create/fork repos; manage remotes, releases."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [GitHub, Repositories, Git, Releases, Secrets, Configuration]

--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -4,7 +4,7 @@ description: "MCP client: connect servers, register tools (stdio/HTTP)."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Tools, Integrations]

--- a/skills/media/gif-search/SKILL.md
+++ b/skills/media/gif-search/SKILL.md
@@ -4,7 +4,7 @@ description: "Search/download GIFs from Tenor via curl + jq."
 version: 1.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   env_vars: [TENOR_API_KEY]
   commands: [curl, jq]

--- a/skills/media/heartmula/SKILL.md
+++ b/skills/media/heartmula/SKILL.md
@@ -2,7 +2,7 @@
 name: heartmula
 description: "HeartMuLa: Suno-like song generation from lyrics + tags."
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [music, audio, generation, ai, heartmula, heartcodec, lyrics, songs]

--- a/skills/media/songsee/SKILL.md
+++ b/skills/media/songsee/SKILL.md
@@ -4,7 +4,7 @@ description: "Audio spectrograms/features (mel, chroma, MFCC) via CLI."
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Audio, Visualization, Spectrogram, Music, Analysis]

--- a/skills/media/spotify/SKILL.md
+++ b/skills/media/spotify/SKILL.md
@@ -4,7 +4,7 @@ description: "Spotify: play, search, queue, manage playlists and devices."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   tools: [spotify_playback, spotify_devices, spotify_queue, spotify_search, spotify_playlists, spotify_albums, spotify_library]
 metadata:

--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: youtube-content
 description: "YouTube transcripts to summaries, threads, blogs."
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # YouTube Content Tool

--- a/skills/mlops/evaluation/lm-evaluation-harness/SKILL.md
+++ b/skills/mlops/evaluation/lm-evaluation-harness/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [lm-eval, transformers, vllm]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Evaluation, LM Evaluation Harness, Benchmarking, MMLU, HumanEval, GSM8K, EleutherAI, Model Quality, Academic Benchmarks, Industry Standard]

--- a/skills/mlops/evaluation/weights-and-biases/SKILL.md
+++ b/skills/mlops/evaluation/weights-and-biases/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [wandb]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [MLOps, Weights And Biases, WandB, Experiment Tracking, Hyperparameter Tuning, Model Registry, Collaboration, Real-Time Visualization, PyTorch, TensorFlow, HuggingFace]

--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Hugging Face
 license: MIT
 tags: [huggingface, hf, models, datasets, hub, mlops]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Hugging Face CLI (`hf`) Reference Guide

--- a/skills/mlops/inference/llama-cpp/SKILL.md
+++ b/skills/mlops/inference/llama-cpp/SKILL.md
@@ -5,7 +5,7 @@ version: 2.1.2
 author: Orchestra Research
 license: MIT
 dependencies: [llama-cpp-python>=0.2.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [llama.cpp, GGUF, Quantization, Hugging Face Hub, CPU Inference, Apple Silicon, Edge Deployment, AMD GPUs, Intel GPUs, NVIDIA, URL-first]

--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -5,7 +5,7 @@ version: 2.0.0
 author: Hermes Agent
 license: MIT
 dependencies: [obliteratus, torch, transformers, bitsandbytes, accelerate, safetensors]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]

--- a/skills/mlops/inference/vllm/SKILL.md
+++ b/skills/mlops/inference/vllm/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [vllm, torch, transformers]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [vLLM, Inference Serving, PagedAttention, Continuous Batching, High Throughput, Production, OpenAI API, Quantization, Tensor Parallelism]

--- a/skills/mlops/models/audiocraft/SKILL.md
+++ b/skills/mlops/models/audiocraft/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [audiocraft, torch>=2.0.0, transformers>=4.30.0]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Multimodal, Audio Generation, Text-to-Music, Text-to-Audio, MusicGen]

--- a/skills/mlops/models/segment-anything/SKILL.md
+++ b/skills/mlops/models/segment-anything/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [segment-anything, transformers>=4.30.0, torch>=1.7.0]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Multimodal, Image Segmentation, Computer Vision, SAM, Zero-Shot]

--- a/skills/mlops/research/dspy/SKILL.md
+++ b/skills/mlops/research/dspy/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 dependencies: [dspy, openai, anthropic]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Prompt Engineering, DSPy, Declarative Programming, RAG, Agents, Prompt Optimization, LM Programming, Stanford NLP, Automatic Optimization, Modular AI]

--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: obsidian
 description: Read, search, create, and edit notes in the Obsidian vault.
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Obsidian Vault

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -4,7 +4,7 @@ description: Airtable REST API via curl. Records CRUD, filters, upserts.
 version: 1.1.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   env_vars: [AIRTABLE_API_KEY]
   commands: [curl]

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -4,7 +4,7 @@ description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
 version: 1.1.0
 author: Nous Research
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 required_credential_files:
   - path: google_token.json
     description: Google OAuth2 token (created by setup script)

--- a/skills/productivity/linear/SKILL.md
+++ b/skills/productivity/linear/SKILL.md
@@ -4,7 +4,7 @@ description: "Linear: manage issues, projects, teams via GraphQL + curl."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 prerequisites:
   env_vars: [LINEAR_API_KEY]
   commands: [curl]

--- a/skills/productivity/maps/SKILL.md
+++ b/skills/productivity/maps/SKILL.md
@@ -4,7 +4,7 @@ description: "Geocode, POIs, routes, timezones via OpenStreetMap/OSRM."
 version: 1.2.0
 author: Mibayy
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [maps, geocoding, places, routing, distance, directions, nearby, location, openstreetmap, nominatim, overpass, osrm]

--- a/skills/productivity/nano-pdf/SKILL.md
+++ b/skills/productivity/nano-pdf/SKILL.md
@@ -4,7 +4,7 @@ description: "Edit PDF text/typos/titles via nano-pdf CLI (NL prompts)."
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [PDF, Documents, Editing, NLP, Productivity]

--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -4,7 +4,7 @@ description: "Notion API via curl: pages, databases, blocks, search."
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Notion, Productivity, Notes, Database, API]

--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -4,7 +4,7 @@ description: "Extract text from PDFs/scans (pymupdf, marker-pdf)."
 version: 2.3.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [PDF, Documents, Research, Arxiv, Text-Extraction, OCR]

--- a/skills/productivity/powerpoint/SKILL.md
+++ b/skills/productivity/powerpoint/SKILL.md
@@ -2,7 +2,7 @@
 name: powerpoint
 description: "Create, read, edit .pptx decks, slides, notes, templates."
 license: Proprietary. LICENSE.txt has complete terms
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Powerpoint Skill

--- a/skills/red-teaming/godmode/SKILL.md
+++ b/skills/red-teaming/godmode/SKILL.md
@@ -4,7 +4,7 @@ description: "Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN."
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [jailbreak, red-teaming, G0DM0D3, Parseltongue, GODMODE, uncensoring, safety-bypass, prompt-engineering, L1B3RT4S]

--- a/skills/research/arxiv/SKILL.md
+++ b/skills/research/arxiv/SKILL.md
@@ -4,7 +4,7 @@ description: "Search arXiv papers by keyword, author, category, or ID."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Research, Arxiv, Papers, Academic, Science, API]

--- a/skills/research/blogwatcher/SKILL.md
+++ b/skills/research/blogwatcher/SKILL.md
@@ -4,7 +4,7 @@ description: "Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool."
 version: 2.0.0
 author: JulienTant (fork of Hyaxia/blogwatcher)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [RSS, Blogs, Feed-Reader, Monitoring]

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -4,7 +4,7 @@ description: "Karpathy's LLM Wiki: build/query interlinked markdown KB."
 version: 2.1.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]

--- a/skills/research/polymarket/SKILL.md
+++ b/skills/research/polymarket/SKILL.md
@@ -4,7 +4,7 @@ description: "Query Polymarket: markets, prices, orderbooks, history."
 version: 1.0.0
 author: Hermes Agent + Teknium
 tags: [polymarket, prediction-markets, market-data, trading]
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 ---
 
 # Polymarket — Prediction Market Data

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -6,7 +6,7 @@ version: 1.1.0
 author: Orchestra Research
 license: MIT
 dependencies: [semanticscholar, arxiv, habanero, requests, scipy, numpy, matplotlib, SciencePlots]
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]

--- a/skills/smart-home/openhue/SKILL.md
+++ b/skills/smart-home/openhue/SKILL.md
@@ -4,7 +4,7 @@ description: "Control Philips Hue lights, scenes, rooms via OpenHue CLI."
 version: 1.0.0
 author: community
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [Smart-Home, Hue, Lights, IoT, Automation]

--- a/skills/social-media/xurl/SKILL.md
+++ b/skills/social-media/xurl/SKILL.md
@@ -4,7 +4,7 @@ description: "X/Twitter via xurl CLI: post, search, DM, media, v2 API."
 version: 1.1.1
 author: xdevplatform + openclaw + Hermes Agent
 license: MIT
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 prerequisites:
   commands: [xurl]
 metadata:

--- a/skills/software-development/debugging-hermes-tui-commands/SKILL.md
+++ b/skills/software-development/debugging-hermes-tui-commands/SKILL.md
@@ -4,7 +4,7 @@ description: "Debug Hermes TUI slash commands: Python, gateway, Ink UI."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [debugging, hermes-agent, tui, slash-commands, typescript, python]

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -4,7 +4,7 @@ description: "Author in-repo SKILL.md: frontmatter, validator, structure."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [skills, authoring, hermes-agent, conventions, skill-md]

--- a/skills/software-development/node-inspect-debugger/SKILL.md
+++ b/skills/software-development/node-inspect-debugger/SKILL.md
@@ -4,7 +4,7 @@ description: "Debug Node.js via --inspect + Chrome DevTools Protocol CLI."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [debugging, nodejs, node-inspect, cdp, breakpoints, ui-tui]

--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Plan mode: write markdown plan to .hermes/plans/, no exec."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [planning, plan-mode, implementation, workflow]

--- a/skills/software-development/python-debugpy/SKILL.md
+++ b/skills/software-development/python-debugpy/SKILL.md
@@ -4,7 +4,7 @@ description: "Debug Python: pdb REPL + debugpy remote (DAP)."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
-platforms: [linux, macos]
+platforms: [linux, wsl, macos]
 metadata:
   hermes:
     tags: [debugging, python, pdb, debugpy, breakpoints, dap, post-mortem]

--- a/skills/software-development/requesting-code-review/SKILL.md
+++ b/skills/software-development/requesting-code-review/SKILL.md
@@ -4,7 +4,7 @@ description: "Pre-commit review: security scan, quality gates, auto-fix."
 version: 2.0.0
 author: Hermes Agent (adapted from obra/superpowers + MorAlekss)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [code-review, security, verification, quality, pre-commit, auto-fix]

--- a/skills/software-development/spike/SKILL.md
+++ b/skills/software-development/spike/SKILL.md
@@ -4,7 +4,7 @@ description: "Throwaway experiments to validate an idea before build."
 version: 1.0.0
 author: Hermes Agent (adapted from gsd-build/get-shit-done)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [spike, prototype, experiment, feasibility, throwaway, exploration, research, planning, mvp, proof-of-concept]

--- a/skills/software-development/subagent-driven-development/SKILL.md
+++ b/skills/software-development/subagent-driven-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute plans via delegate_task subagents (2-stage review)."
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [delegation, subagent, implementation, workflow, parallel]

--- a/skills/software-development/systematic-debugging/SKILL.md
+++ b/skills/software-development/systematic-debugging/SKILL.md
@@ -4,7 +4,7 @@ description: "4-phase root cause debugging: understand bugs before fixing."
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [debugging, troubleshooting, problem-solving, root-cause, investigation]

--- a/skills/software-development/test-driven-development/SKILL.md
+++ b/skills/software-development/test-driven-development/SKILL.md
@@ -4,7 +4,7 @@ description: "TDD: enforce RED-GREEN-REFACTOR, tests before code."
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [testing, tdd, development, quality, red-green-refactor]

--- a/skills/software-development/writing-plans/SKILL.md
+++ b/skills/software-development/writing-plans/SKILL.md
@@ -4,7 +4,7 @@ description: "Write implementation plans: bite-sized tasks, paths, code."
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [planning, design, implementation, workflow, documentation]

--- a/skills/yuanbao/SKILL.md
+++ b/skills/yuanbao/SKILL.md
@@ -2,7 +2,7 @@
 name: yuanbao
 description: "Yuanbao (元宝) groups: @mention users, query info/members."
 version: 1.0.0
-platforms: [linux, macos, windows]
+platforms: [linux, wsl, macos, windows]
 metadata:
   hermes:
     tags: [yuanbao, mention, at, group, members, 元宝, 派, 艾特]

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -200,8 +200,7 @@ class TestParseSkillFile:
         )
         from unittest.mock import patch
 
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             is_compat, _, _ = _parse_skill_file(skill_file)
         assert is_compat is False
 
@@ -299,8 +298,7 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             result = build_skills_system_prompt()
 
         assert "web-search" in result
@@ -318,12 +316,69 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             result = build_skills_system_prompt()
 
         assert "imessage" in result
         assert "Send iMessages" in result
+
+    def test_wsl_requires_explicit_platform(self, monkeypatch, tmp_path):
+        """WSL must not inherit native Linux-only skills implicitly."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "dev"
+        linux_skill = skills_dir / "linux-only"
+        wsl_skill = skills_dir / "wsl-ready"
+        linux_skill.mkdir(parents=True)
+        wsl_skill.mkdir()
+        (linux_skill / "SKILL.md").write_text(
+            "---\nname: linux-only\ndescription: Linux only\nplatforms: [linux]\n---\n"
+        )
+        (wsl_skill / "SKILL.md").write_text(
+            "---\nname: wsl-ready\ndescription: WSL ready\nplatforms: [linux, wsl]\n---\n"
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("agent.skill_utils.get_runtime_platform", return_value="wsl"),
+            patch("agent.prompt_builder.get_runtime_platform", return_value="wsl"),
+        ):
+            result = build_skills_system_prompt()
+
+        assert "wsl-ready" in result
+        assert "linux-only" not in result
+
+    def test_skills_prompt_cache_is_runtime_platform_scoped(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_root = tmp_path / "skills" / "dev"
+        linux_skill = skill_root / "linux-only"
+        wsl_skill = skill_root / "wsl-only"
+        linux_skill.mkdir(parents=True)
+        wsl_skill.mkdir()
+        (linux_skill / "SKILL.md").write_text(
+            "---\nname: linux-only\ndescription: Linux only\nplatforms: [linux]\n---\n"
+        )
+        (wsl_skill / "SKILL.md").write_text(
+            "---\nname: wsl-only\ndescription: WSL only\nplatforms: [wsl]\n---\n"
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("agent.skill_utils.get_runtime_platform", return_value="linux"),
+            patch("agent.prompt_builder.get_runtime_platform", return_value="linux"),
+        ):
+            linux_result = build_skills_system_prompt()
+        with (
+            patch("agent.skill_utils.get_runtime_platform", return_value="wsl"),
+            patch("agent.prompt_builder.get_runtime_platform", return_value="wsl"),
+        ):
+            wsl_result = build_skills_system_prompt()
+
+        assert "linux-only" in linux_result
+        assert "wsl-only" not in linux_result
+        assert "wsl-only" in wsl_result
+        assert "linux-only" not in wsl_result
 
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
@@ -1186,6 +1241,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -65,9 +65,8 @@ class TestScanSkillCommands:
         """macOS-only skills should not register slash commands on Linux."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="linux"),
         ):
-            mock_sys.platform = "linux"
             _make_skill(tmp_path, "imessage", frontmatter_extra="platforms: [macos]\n")
             _make_skill(tmp_path, "web-search")
             result = scan_skill_commands()
@@ -78,9 +77,8 @@ class TestScanSkillCommands:
         """macOS-only skills should register slash commands on macOS."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="macos"),
         ):
-            mock_sys.platform = "darwin"
             _make_skill(tmp_path, "imessage", frontmatter_extra="platforms: [macos]\n")
             result = scan_skill_commands()
         assert "/imessage" in result
@@ -89,12 +87,23 @@ class TestScanSkillCommands:
         """Skills without platforms field should register on any platform."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="windows"),
         ):
-            mock_sys.platform = "win32"
             _make_skill(tmp_path, "generic-tool")
             result = scan_skill_commands()
         assert "/generic-tool" in result
+
+    def test_wsl_requires_explicit_platform(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("agent.skill_utils.get_runtime_platform", return_value="wsl"),
+            patch("agent.skill_commands.get_runtime_platform", return_value="wsl"),
+        ):
+            _make_skill(tmp_path, "linux-only", frontmatter_extra="platforms: [linux]\n")
+            _make_skill(tmp_path, "wsl-ready", frontmatter_extra="platforms: [linux, wsl]\n")
+            result = scan_skill_commands()
+        assert "/wsl-ready" in result
+        assert "/linux-only" not in result
 
     def test_excludes_disabled_skills(self, tmp_path):
         """Disabled skills should not register slash commands."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -557,6 +557,7 @@ class TestPluginContext:
             '        toolset="plugin_tool_plugin",\n'
             '        schema={"name": "plugin_echo", "description": "Echo", "parameters": {"type": "object", "properties": {}}},\n'
             '        handler=lambda args, **kw: "echo",\n'
+            '        platforms=["wsl"],\n'
             '    )\n'
         )
         hermes_home = tmp_path / "hermes_test"
@@ -572,6 +573,7 @@ class TestPluginContext:
 
         from tools.registry import registry
         assert "plugin_echo" in registry._tools
+        assert registry.get_entry("plugin_echo").platforms == ("wsl",)
 
 
 # ── TestPluginToolVisibility ───────────────────────────────────────────────

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -17,6 +17,7 @@ These tests pin:
 from __future__ import annotations
 
 import pytest
+from unittest.mock import patch
 
 import model_tools
 
@@ -51,6 +52,13 @@ class TestQuietModeCacheIsolation:
         assert first is not second
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert second is not cached
+
+    def test_cache_key_includes_runtime_platform(self):
+        with patch("hermes_constants.get_runtime_platform", return_value="linux"):
+            model_tools.get_tool_definitions(quiet_mode=True)
+        with patch("hermes_constants.get_runtime_platform", return_value="wsl"):
+            model_tools.get_tool_definitions(quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 2
 
     def test_caller_mutation_does_not_poison_cache(self):
         """Simulate run_agent appending LCM tool schemas to the returned

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,6 +10,7 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     get_default_hermes_root,
+    get_runtime_platform,
     is_container,
     parse_reasoning_effort,
 )
@@ -117,6 +118,26 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestGetRuntimePlatform:
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        assert get_runtime_platform() == "windows"
+
+    def test_macos(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants.sys, "platform", "darwin")
+        assert get_runtime_platform() == "macos"
+
+    def test_native_linux(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+        monkeypatch.setattr(hermes_constants, "is_wsl", lambda: False)
+        assert get_runtime_platform() == "linux"
+
+    def test_wsl(self, monkeypatch):
+        monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+        monkeypatch.setattr(hermes_constants, "is_wsl", lambda: True)
+        assert get_runtime_platform() == "wsl"
 
 
 class TestParseReasoningEffort:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -111,6 +111,53 @@ class TestGetDefinitions:
         assert len(defs) == 2
         assert calls["count"] == 1
 
+    def test_platform_restricted_tool_included_on_matching_runtime(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="wsl_tool",
+            toolset="s",
+            schema=_make_schema("wsl_tool"),
+            handler=_dummy_handler,
+            platforms=["wsl"],
+        )
+        with patch("tools.registry.get_runtime_platform", return_value="wsl"):
+            defs = reg.get_definitions({"wsl_tool"})
+        assert [d["function"]["name"] for d in defs] == ["wsl_tool"]
+
+    def test_platform_restricted_tool_excluded_on_other_runtime(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="linux_tool",
+            toolset="s",
+            schema=_make_schema("linux_tool"),
+            handler=_dummy_handler,
+            platforms=["linux"],
+        )
+        with patch("tools.registry.get_runtime_platform", return_value="wsl"):
+            defs = reg.get_definitions({"linux_tool"})
+        assert defs == []
+
+    def test_platform_excluded_tool_does_not_run_check_fn(self):
+        reg = ToolRegistry()
+        calls = {"count": 0}
+
+        def check():
+            calls["count"] += 1
+            return True
+
+        reg.register(
+            name="linux_tool",
+            toolset="s",
+            schema=_make_schema("linux_tool"),
+            handler=_dummy_handler,
+            check_fn=check,
+            platforms=["linux"],
+        )
+        with patch("tools.registry.get_runtime_platform", return_value="wsl"):
+            defs = reg.get_definitions({"linux_tool"})
+        assert defs == []
+        assert calls["count"] == 0
+
 
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -639,62 +639,62 @@ class TestSkillMatchesPlatform:
         assert skill_matches_platform({"platforms": None}) is True
 
     def test_macos_on_darwin(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             assert skill_matches_platform({"platforms": ["macos"]}) is True
 
     def test_macos_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": ["macos"]}) is False
 
     def test_linux_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": ["linux"]}) is True
 
     def test_linux_on_darwin(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             assert skill_matches_platform({"platforms": ["linux"]}) is False
 
+    def test_linux_does_not_match_wsl(self):
+        with patch("agent.skill_utils.get_runtime_platform", return_value="wsl"):
+            assert skill_matches_platform({"platforms": ["linux"]}) is False
+
+    def test_wsl_only_matches_wsl(self):
+        with patch("agent.skill_utils.get_runtime_platform", return_value="wsl"):
+            assert skill_matches_platform({"platforms": ["wsl"]}) is True
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
+            assert skill_matches_platform({"platforms": ["wsl"]}) is False
+
     def test_windows_on_win32(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "win32"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="windows"):
             assert skill_matches_platform({"platforms": ["windows"]}) is True
 
     def test_windows_on_linux(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": ["windows"]}) is False
 
     def test_multi_platform_match(self):
         """Skills listing multiple platforms should match any of them."""
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is True
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is True
-            mock_sys.platform = "win32"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="windows"):
             assert skill_matches_platform({"platforms": ["macos", "linux"]}) is False
 
     def test_string_instead_of_list(self):
         """A single string value should be treated as a one-element list."""
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             assert skill_matches_platform({"platforms": "macos"}) is True
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": "macos"}) is False
 
     def test_case_insensitive(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "darwin"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
             assert skill_matches_platform({"platforms": ["MacOS"]}) is True
             assert skill_matches_platform({"platforms": ["MACOS"]}) is True
 
     def test_unknown_platform_no_match(self):
-        with patch("agent.skill_utils.sys") as mock_sys:
-            mock_sys.platform = "linux"
+        with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
             assert skill_matches_platform({"platforms": ["freebsd"]}) is False
 
 
@@ -709,9 +709,8 @@ class TestFindAllSkillsPlatformFiltering:
     def test_excludes_incompatible_platform(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="linux"),
         ):
-            mock_sys.platform = "linux"
             _make_skill(tmp_path, "universal-skill")
             _make_skill(tmp_path, "mac-only", frontmatter_extra="platforms: [macos]\n")
             skills = _find_all_skills()
@@ -722,9 +721,8 @@ class TestFindAllSkillsPlatformFiltering:
     def test_includes_matching_platform(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="macos"),
         ):
-            mock_sys.platform = "darwin"
             _make_skill(tmp_path, "mac-only", frontmatter_extra="platforms: [macos]\n")
             skills = _find_all_skills()
         names = {s["name"] for s in skills}
@@ -734,9 +732,8 @@ class TestFindAllSkillsPlatformFiltering:
         """Skills without platforms field should appear on any platform."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
+            patch("agent.skill_utils.get_runtime_platform", return_value="windows"),
         ):
-            mock_sys.platform = "win32"
             _make_skill(tmp_path, "generic-skill")
             skills = _find_all_skills()
         assert len(skills) == 1
@@ -745,17 +742,16 @@ class TestFindAllSkillsPlatformFiltering:
     def test_multi_platform_skill(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
-            patch("agent.skill_utils.sys") as mock_sys,
         ):
             _make_skill(
                 tmp_path, "cross-plat", frontmatter_extra="platforms: [macos, linux]\n"
             )
-            mock_sys.platform = "darwin"
-            skills_darwin = _find_all_skills()
-            mock_sys.platform = "linux"
-            skills_linux = _find_all_skills()
-            mock_sys.platform = "win32"
-            skills_win = _find_all_skills()
+            with patch("agent.skill_utils.get_runtime_platform", return_value="macos"):
+                skills_darwin = _find_all_skills()
+            with patch("agent.skill_utils.get_runtime_platform", return_value="linux"):
+                skills_linux = _find_all_skills()
+            with patch("agent.skill_utils.get_runtime_platform", return_value="windows"):
+                skills_win = _find_all_skills()
         assert len(skills_darwin) == 1
         assert len(skills_linux) == 1
         assert len(skills_win) == 0

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -23,6 +23,8 @@ import time
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
+from hermes_constants import get_runtime_platform
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,12 +82,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "platforms",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 platforms=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -104,6 +107,24 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        self.platforms = _normalize_platforms(platforms)
+
+
+def _normalize_platforms(platforms) -> tuple[str, ...]:
+    """Normalize optional runtime platform restrictions."""
+    if not platforms:
+        return ()
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    try:
+        values = {
+            str(platform).lower().strip()
+            for platform in platforms
+            if str(platform).strip()
+        }
+    except TypeError:
+        values = {str(platforms).lower().strip()}
+    return tuple(sorted(v for v in values if v))
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +265,7 @@ class ToolRegistry:
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
+        platforms: list | str | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         with self._lock:
@@ -282,6 +304,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                platforms=platforms,
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
@@ -334,9 +357,19 @@ class ToolRegistry:
         # TTL clock.
         check_results: Dict[Callable, bool] = {}
         entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
+        runtime_platform = get_runtime_platform()
+        logger.debug("Runtime platform for tool filtering: %s", runtime_platform)
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
             if not entry:
+                continue
+            if entry.platforms and runtime_platform not in entry.platforms:
+                logger.debug(
+                    "Tool excluded by platform: name=%s platforms=%s runtime=%s",
+                    name,
+                    list(entry.platforms),
+                    runtime_platform,
+                )
                 continue
             if entry.check_fn:
                 if entry.check_fn not in check_results:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -32,7 +32,7 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     version: 1.0.0                # Optional
     license: MIT                  # Optional (agentskills.io)
     platforms: [macos]            # Optional — restrict to specific OS platforms
-                                  #   Valid: macos, linux, windows
+                                  #   Valid: macos, linux, windows, wsl
                                   #   Omit to load on all platforms (default)
     prerequisites:                # Optional — legacy runtime requirements
       env_vars: [API_KEY]         #   Legacy env var names are normalized into
@@ -69,7 +69,7 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home, get_runtime_platform
 import os
 import re
 from enum import Enum
@@ -92,13 +92,6 @@ SKILLS_DIR = HERMES_HOME / "skills"
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 
-# Platform identifiers for the 'platforms' frontmatter field.
-# Maps user-friendly names to sys.platform prefixes.
-_PLATFORM_MAP = {
-    "macos": "darwin",
-    "linux": "linux",
-    "windows": "win32",
-}
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset(
@@ -583,6 +576,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 frontmatter, body = _parse_frontmatter(content)
 
                 if not skill_matches_platform(frontmatter):
+                    logger.debug(
+                        "Skill excluded by platform: path=%s platforms=%s runtime=%s",
+                        skill_md,
+                        frontmatter.get("platforms"),
+                        get_runtime_platform(),
+                    )
                     continue
 
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
@@ -780,6 +779,13 @@ def _serve_plugin_skill(
         pass
 
     if not skill_matches_platform(parsed_frontmatter):
+        logger.debug(
+            "Plugin skill excluded by platform: name=%s:%s platforms=%s runtime=%s",
+            namespace,
+            bare,
+            parsed_frontmatter.get("platforms"),
+            get_runtime_platform(),
+        )
         return json.dumps(
             {
                 "success": False,
@@ -1060,6 +1066,13 @@ def skill_view(
             parsed_frontmatter = {}
 
         if not skill_matches_platform(parsed_frontmatter):
+            logger.debug(
+                "Skill excluded by platform: name=%s path=%s platforms=%s runtime=%s",
+                name,
+                skill_md,
+                parsed_frontmatter.get("platforms"),
+                get_runtime_platform(),
+            )
             return json.dumps(
                 {
                     "success": False,
@@ -1530,4 +1543,3 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
-

--- a/website/docs/developer-guide/adding-tools.md
+++ b/website/docs/developer-guide/adding-tools.md
@@ -106,6 +106,9 @@ registry.register(
         units=args.get("units", "metric")),
     check_fn=check_weather_requirements,
     requires_env=["WEATHER_API_KEY"],
+    # Optional: restrict exposure to exact runtime platform keys.
+    # Omit or pass [] for universal availability.
+    # platforms=["linux", "wsl"],
 )
 ```
 
@@ -115,6 +118,7 @@ registry.register(
 - Handlers **MUST** return a JSON string (via `json.dumps()`), never raw dicts
 - Errors **MUST** be returned as `{"error": "message"}`, never raised as exceptions
 - The `check_fn` is called when building tool definitions — if it returns `False`, the tool is silently excluded
+- Optional `platforms` uses exact runtime keys: `windows`, `macos`, `linux`, `wsl`; `linux` does not imply `wsl`
 - The `handler` receives `(args: dict, **kwargs)` where `args` is the LLM's tool call arguments
 :::
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -50,8 +50,8 @@ description: Brief description (shown in skill search results)
 version: 1.0.0
 author: Your Name
 license: MIT
-platforms: [macos, linux]          # Optional — restrict to specific OS platforms
-                                   #   Valid: macos, linux, windows
+platforms: [macos, linux, wsl]     # Optional — restrict to specific OS platforms
+                                   #   Valid: macos, linux, windows, wsl
                                    #   Omit to load on all platforms (default)
 metadata:
   hermes:
@@ -99,11 +99,14 @@ Skills can restrict themselves to specific operating systems using the `platform
 
 ```yaml
 platforms: [macos]            # macOS only (e.g., iMessage, Apple Reminders)
-platforms: [macos, linux]     # macOS and Linux
+platforms: [macos, linux]     # macOS and native Linux
+platforms: [linux, wsl]       # native Linux and WSL
 platforms: [windows]          # Windows only
+platforms: [wsl]              # WSL only
 ```
 
 When set, the skill is automatically hidden from the system prompt, `skills_list()`, and slash commands on incompatible platforms. If omitted or empty, the skill loads on all platforms (backward compatible).
+`linux` and `wsl` are exact, separate keys; include both when a skill supports both native Linux and WSL.
 
 ### Conditional Skill Activation
 

--- a/website/docs/developer-guide/tools-runtime.md
+++ b/website/docs/developer-guide/tools-runtime.md
@@ -111,7 +111,7 @@ The main entry point is `model_tools.get_tool_definitions(enabled_toolsets, disa
 
 3. **If neither** — include all known toolsets.
 
-4. **Registry filtering** — the resolved tool name set is passed to `registry.get_definitions()`, which applies `check_fn` filtering and returns OpenAI-format schemas.
+4. **Registry filtering** — the resolved tool name set is passed to `registry.get_definitions()`, which applies runtime-platform filtering and `check_fn` filtering, then returns OpenAI-format schemas. Tools with no `platforms` metadata are universal; tools with `platforms` are exposed only on exact runtime keys: `windows`, `macos`, `linux`, or `wsl`.
 
 5. **Dynamic schema patching** — after filtering, `execute_code` and `browser_navigate` schemas are dynamically adjusted to only reference tools that actually passed filtering (prevents model hallucination of unavailable tools).
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -60,7 +60,7 @@ The agent only loads the full skill content when it actually needs it.
 name: my-skill
 description: Brief description of what this skill does
 version: 1.0.0
-platforms: [macos, linux]     # Optional — restrict to specific OS platforms
+platforms: [macos, linux, wsl] # Optional — restrict to specific OS platforms
 metadata:
   hermes:
     tags: [python, automation]
@@ -97,15 +97,18 @@ Skills can restrict themselves to specific operating systems using the `platform
 | Value | Matches |
 |-------|---------|
 | `macos` | macOS (Darwin) |
-| `linux` | Linux |
+| `linux` | Native Linux |
+| `wsl` | Windows Subsystem for Linux |
 | `windows` | Windows |
 
 ```yaml
 platforms: [macos]            # macOS only (e.g., iMessage, Apple Reminders, FindMy)
-platforms: [macos, linux]     # macOS and Linux
+platforms: [macos, linux]     # macOS and native Linux
+platforms: [linux, wsl]       # native Linux and WSL
 ```
 
 When set, the skill is automatically hidden from the system prompt, `skills_list()`, and slash commands on incompatible platforms. If omitted, the skill loads on all platforms.
+`linux` and `wsl` are exact, separate keys; include both when a skill supports both environments.
 
 ### Conditional Activation (Fallback Skills)
 


### PR DESCRIPTION
Detect the runtime platform as `windows`, `macos`, `linux`, or `wsl` and filter skills/tools before exposing them to the model. This prevents Linux-only instructions from appearing in native Windows prompts, which previously caused Hermes to suggest Linux commands or fall back to Python snippets for basic file operations like writing or copying files.

WSL is treated as a distinct platform, missing platforms remain universal, and prompt/tool caches now include the runtime platform.

## What does this PR do?

This PR adds runtime platform-aware filtering for Hermes skills and tools.

Hermes can now detect the current runtime platform as one of:

- `windows`
- `macos`
- `linux`
- `wsl`

Skills and tools can declare compatible platforms. Hermes filters them before exposing them to the model, so platform-specific instructions and tool schemas are only included when they match the current runtime environment.

This solves a real prompt-quality issue on native Windows. Before this change, Linux-specific skills could still be included in the system prompt, which made Hermes sometimes suggest Linux commands first or work around simple file operations by generating Python code instead of using the more appropriate Windows-aware path.

This approach keeps compatibility simple and explicit:

- missing or empty `platforms` means universal compatibility;
- `linux` means native Linux only;
- `wsl` is treated as a first-class platform;
- skills/tools that support both native Linux and WSL should declare `platforms: [linux, wsl]`.

The implementation also includes the runtime platform in prompt/tool cache keys to avoid cross-platform cache leakage.

## Related Issue

N/A — no linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added canonical runtime platform detection in `hermes_constants.py`.
- Added first-class `wsl` support.
- Updated skill platform matching in `agent/skill_utils.py` to use exact normalized platform keys.
- Updated skill prompt construction in `agent/prompt_builder.py` so runtime platform participates in filtering/cache behavior.
- Added optional `platforms` metadata to registered tools in `tools/registry.py`.
- Updated `model_tools.py` to filter tool definitions by runtime platform before exposing them to the model.
- Added plugin passthrough support for optional tool `platforms` metadata in `hermes_cli/plugins.py`.
- Added debug logging for platform-excluded skills and tools.
- Updated bundled/optional skill frontmatter so Linux skills that also support WSL explicitly include `wsl`.
- Updated tests for platform detection, skill filtering, tool registry behavior, tool definition cache isolation, and plugin compatibility.
- Updated docs for the `windows`, `macos`, `linux`, and `wsl` platform keys.

## How to Test

1. Run lint checks for the modified files:

   ```bash
   uv run ruff check hermes_constants.py agent/skill_utils.py agent/prompt_builder.py agent/skill_commands.py tools/skills_tool.py tools/registry.py model_tools.py hermes_cli/plugins.py tests/test_hermes_constants.py tests/tools/test_skills_tool.py tests/agent/test_prompt_builder.py tests/agent/test_skill_commands.py tests/tools/test_registry.py tests/test_get_tool_definitions_cache_isolation.py tests/hermes_cli/test_plugins.py ```

2. Run the focused test suite:

   ```bash
   uv run pytest -o addopts='' tests/test_hermes_constants.py tests/tools/test_skills_tool.py tests/agent/test_prompt_builder.py tests/agent/test_skill_commands.py tests/tools/test_registry.py tests/test_get_tool_definitions_cache_isolation.py tests/hermes_cli/test_plugins.py
   ```

3. Check whitespace issues:

   ```bash
   git diff --check
   ```

4. Optional manual smoke test on native Windows 11:

   * Confirm detected runtime platform is `windows`.
   * Confirm Linux-only and WSL-only skills are excluded from the system prompt.
   * Confirm universal and Windows-compatible tools are still exposed.
   * Confirm excluded tools do not run availability checks.

## Checklist

### Code

* [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
* [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains only changes related to this fix/feature (no unrelated commits)
* [x] I've run pytest tests/ -q and all tests pass
* [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
* [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
* [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
* [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
* [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
* [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Lint and focused tests passed:

```text
388 passed, 1 skipped
```

`git diff --check` is clean.
