### PR TITLE
[codex] Fix compression session sync on failed turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7685,8 +7685,10 @@ class GatewayRunner:
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
-            if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
+            agent_session_id = agent_result.get("session_id")
+            agent_session_was_split = bool(agent_session_id and agent_session_id != session_entry.session_id)
+            if agent_session_was_split:
+                session_entry.session_id = agent_session_id
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:
@@ -7874,10 +7876,36 @@ class GatewayRunner:
                 # message so the next message can load a transcript that
                 # reflects what was said.  Skip the assistant error text since
                 # it's a gateway-generated hint, not model output. (#7100)
-                self.session_store.append_to_transcript(
-                    session_entry.session_id,
-                    {"role": "user", "content": message_text, "timestamp": ts},
-                )
+                #
+                # Exception: if the failed run also split the session during
+                # compression, persist the compressed transcript into the new
+                # session. Otherwise the session-store pointer moves forward
+                # but the new transcript contains only this user turn, losing
+                # the compacted summary/tail.
+                if agent_session_was_split and agent_result.get("history_offset", len(history)) == 0:
+                    agent_persisted = self._session_db is not None
+                    compressed_messages = [
+                        msg for msg in agent_messages
+                        if isinstance(msg, dict) and msg.get("role") != "system"
+                    ]
+                    if compressed_messages:
+                        for msg in compressed_messages:
+                            entry = {**msg, "timestamp": ts}
+                            self.session_store.append_to_transcript(
+                                session_entry.session_id,
+                                entry,
+                                skip_db=agent_persisted,
+                            )
+                    else:
+                        self.session_store.append_to_transcript(
+                            session_entry.session_id,
+                            {"role": "user", "content": message_text, "timestamp": ts},
+                        )
+                else:
+                    self.session_store.append_to_transcript(
+                        session_entry.session_id,
+                        {"role": "user", "content": message_text, "timestamp": ts},
+                    )
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
@@ -15507,6 +15535,30 @@ class GatewayRunner:
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
+            # Compression can rotate the agent to a new session before the
+            # follow-up model call succeeds. Sync that rotation before any
+            # early return so retries load the compressed transcript.
+            agent = agent_holder[0]
+            _session_was_split = False
+            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
+            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
+                _session_was_split = True
+                logger.info(
+                    "Session split detected: %s → %s (compression)",
+                    session_id, agent.session_id,
+                )
+                entry = self.session_store._entries.get(session_key)
+                if entry:
+                    entry.session_id = agent.session_id
+                    self.session_store._save()
+
+            # When compression created a new session, the messages list was
+            # shortened.  Using the original history offset would produce an
+            # empty new_messages slice, causing the gateway to write only a
+            # user/assistant pair — losing the compressed summary and tail.
+            # Reset to 0 so the gateway writes ALL compressed messages.
+            _effective_history_offset = 0 if _session_was_split else len(agent_history)
+
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
@@ -15521,7 +15573,8 @@ class GatewayRunner:
                     "error": result.get("error"),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
-                    "history_offset": len(agent_history),
+                    "history_offset": _effective_history_offset,
+                    "session_id": effective_session_id,
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
@@ -15564,32 +15617,6 @@ class GatewayRunner:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
             
-            # Sync session_id: the agent may have created a new session during
-            # mid-run context compression (_compress_context splits sessions).
-            # If so, update the session store entry so the NEXT message loads
-            # the compressed transcript, not the stale pre-compression one.
-            agent = agent_holder[0]
-            _session_was_split = False
-            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
-                _session_was_split = True
-                logger.info(
-                    "Session split detected: %s → %s (compression)",
-                    session_id, agent.session_id,
-                )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
-
-            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
-
-            # When compression created a new session, the messages list was
-            # shortened.  Using the original history offset would produce an
-            # empty new_messages slice, causing the gateway to write only a
-            # user/assistant pair — losing the compressed summary and tail.
-            # Reset to 0 so the gateway writes ALL compressed messages.
-            _effective_history_offset = 0 if _session_was_split else len(agent_history)
-
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
                 try:

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -1,0 +1,199 @@
+import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+SESSION_KEY = "agent:main:telegram:dm:12345"
+
+
+class _SaveTrackingSessionStore:
+    def __init__(self):
+        self.entry = SimpleNamespace(session_id="session-before-compression")
+        self._entries = {SESSION_KEY: self.entry}
+        self.save_calls = 0
+
+    def _save(self):
+        self.save_calls += 1
+
+
+class _CompressionThenFailureAgent:
+    def __init__(self, **kwargs):
+        self.session_id = kwargs["session_id"]
+        self.model = kwargs["model"]
+        self.tools = []
+        self.context_compressor = SimpleNamespace(
+            last_prompt_tokens=4321,
+            context_length=200000,
+        )
+        self.session_prompt_tokens = 4321
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None):
+        self.session_id = "session-after-compression"
+        return {
+            "failed": True,
+            "error": (
+                "APIConnectionError: Codex auxiliary Responses stream exceeded "
+                "120.0s total timeout"
+            ),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "[Context compressed: previous long transcript was "
+                        "summarized before retry]"
+                    ),
+                },
+                {"role": "user", "content": user_message},
+            ],
+            "api_calls": 1,
+        }
+
+    def interrupt(self, *_args, **_kwargs):
+        pass
+
+
+class _ImmediateStreamConsumer:
+    final_response_sent = False
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def run(self):
+        return None
+
+    def finish(self):
+        pass
+
+
+class _QuietAdapter:
+    SUPPORTS_MESSAGE_EDITING = True
+    _pending_messages = {}
+
+    def get_pending_message(self, _session_key):
+        return None
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompressionThenFailureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner(session_store):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {
+        Platform.TELEGRAM: _QuietAdapter(),
+    }
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._pending_skills_reload_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner._draining = False
+    runner.config = SimpleNamespace(streaming=None)
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.session_store = session_store
+    runner._get_proxy_url = lambda: None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5.4",
+        {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "token",
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._resolve_turn_agent_config = lambda message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+    }
+    runner._load_service_tier = lambda: None
+    runner._agent_config_signature = lambda *_args, **_kwargs: ("sig",)
+    runner._extract_cache_busting_config = lambda _config: ()
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: None
+    runner._is_telegram_topic_lane = lambda _source: False
+    runner._release_running_agent_state = MagicMock()
+    return runner
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
+    """A post-compression API failure must not leave the session store on the
+    stale pre-compression transcript.
+
+    Production sample:
+
+    - Preflight compression fires around 136k tokens.
+    - The agent rotates ``session_id`` while compacting.
+    - The follow-up Codex call times out and returns no ``final_response``.
+
+    Before this regression fix, the early failure return skipped the session
+    split sync block, so the next inbound message loaded the old long session
+    again and the context kept growing.
+    """
+    _install_fake_agent(monkeypatch)
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        "gateway.stream_consumer.GatewayStreamConsumer",
+        _ImmediateStreamConsumer,
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config,
+        "_get_platform_tools",
+        lambda *_args, **_kwargs: {"core"},
+    )
+
+    session_store = _SaveTrackingSessionStore()
+    runner = _make_runner(session_store)
+
+    result = asyncio.run(
+        asyncio.wait_for(
+            runner._run_agent(
+                message="continue",
+                context_prompt="",
+                history=[
+                    {"role": "user", "content": "old question"},
+                    {"role": "assistant", "content": "old answer"},
+                ],
+                source=_source(),
+                session_id="session-before-compression",
+                session_key=SESSION_KEY,
+            ),
+            timeout=2,
+        ),
+    )
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "session-after-compression"
+    assert session_store.save_calls == 1


### PR DESCRIPTION
## Summary

Fix a gateway persistence bug where a context-compression session split could be lost when the subsequent model call failed before producing a `final_response`.

The agent already rotates `agent.session_id` during compression. The gateway previously synced that new session id only on the success path, after `final_response` existed. If the compacted retry then hit a transient provider/API failure, `_run_agent()` returned early before updating `SessionStore`, so the next inbound message loaded the stale pre-compression transcript again.

This makes auto compact look like it failed: compression may have run, but the gateway keeps reusing the old long session.

## Error Sample

Observed gateway/error log shape from a long Telegram session:

```text
📦 Preflight compression: ~139,040 tokens >= 136,000 threshold. This may take a moment.
⚠ Compression summary failed: Codex auxiliary Responses stream exceeded 120.0s total timeout. Inserted a fallback context marker.
APIConnectionError: Codex auxiliary Responses stream exceeded 120.0s total timeout
```

Earlier successful compactions also show the intended session rotation:

```text
Session split detected: 20260514_000504_1c66a1 → 20260514_023048_68cddf (compression)
```

The failing shape was:

1. A large session reaches the preflight compression threshold.
2. `AIAgent._compress_context()` rotates `agent.session_id` to a new compressed session.
3. The follow-up provider call fails before `final_response`.
4. `_run_agent()` returns through the early failure branch.
5. The old code skipped the session-split sync block, so `sessions.json` still pointed at the stale long session.
6. The next message loads the stale pre-compression transcript and the context keeps growing.

## Changes

- Move compression session-split sync immediately after `run_conversation()`, before the `not final_response` early return.
- Return the effective `session_id` and corrected `history_offset` on failed turns too.
- When a transient failure follows a compression split, persist the compressed transcript into the new session instead of writing only the current user message.
- Add a focused regression test that simulates:
  - compression rotating `agent.session_id`
  - a Codex-style timeout/API connection failure
  - no `final_response`
  - gateway session store still being updated to the compressed session

## Validation

```text
python -m py_compile gateway/run.py tests/gateway/test_compression_failure_session_sync.py
pytest -q -o addopts='' tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_transcript_offset.py tests/gateway/test_7100_transient_failure_transcript.py
```

Result:

```text
18 passed
```
