### PR TITLE
gateway: suppress status/lifecycle messages in group chats

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2491,6 +2491,7 @@ class BasePlatformAdapter(ABC):
         metadata: Any = None,
         max_retries: int = 2,
         base_delay: float = 2.0,
+        *,
         kind: str = "reply",
     ) -> "SendResult":
         """

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1035,6 +1035,11 @@ class SendResult:
     error: Optional[str] = None
     raw_response: Any = None
     retryable: bool = False  # True for transient connection errors — base will retry automatically
+    # True when the adapter deliberately did not deliver the message because
+    # an adapter-level policy suppressed it (e.g. kind="status" in a group
+    # chat on a non-editing platform like iMessage).  The send is reported
+    # successful so callers don't retry, but no platform message was sent.
+    suppressed: bool = False
     # When the adapter had to split an oversized payload across multiple
     # platform messages (e.g. Telegram edit_message overflow split-and-deliver),
     # ``message_id`` is the LAST visible message id (so subsequent edits target
@@ -2450,6 +2455,34 @@ class BasePlatformAdapter(ABC):
             return response.text, int(ttl or 0)
         return response, 0
 
+    async def _should_suppress_status(
+        self,
+        chat_id: str,
+        *,
+        kind: str = "status",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Policy hook: should a ``kind="status"`` message be dropped here?
+
+        Receives the target ``chat_id``, the declared ``kind`` (always
+        ``"status"`` from the current call site, kept as a kwarg so future
+        kinds can route through the same hook without breaking overrides),
+        and any caller-supplied ``metadata`` (thread/topic info, chat_type
+        hint, etc.).  Default returns ``False`` — every adapter delivers
+        status messages like a normal reply.  Adapters that target chat
+        surfaces where status bubbles are intrusive (e.g. iMessage groups,
+        where every message is a permanent, un-editable bubble visible to
+        everyone) override this to return ``True`` for the affected chats.
+
+        Called from :meth:`_send_with_retry` *before* the actual provider
+        send when ``kind="status"``.  Returning ``True`` causes the call to
+        return ``SendResult(success=True, suppressed=True)`` with no
+        platform delivery and a local audit log line.  DMs and
+        editing-capable platforms should keep status messages visible —
+        they are useful progress signal there.
+        """
+        return False
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -2458,6 +2491,7 @@ class BasePlatformAdapter(ABC):
         metadata: Any = None,
         max_retries: int = 2,
         base_delay: float = 2.0,
+        kind: str = "reply",
     ) -> "SendResult":
         """
         Send a message with automatic retry for transient network errors.
@@ -2466,7 +2500,33 @@ class BasePlatformAdapter(ABC):
         to a plain-text version before giving up. If all attempts fail due to
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
+
+        ``kind`` declares the message category so the adapter can apply a
+        per-platform policy.  Default ``"reply"`` is the normal user-facing
+        agent response.  ``"status"`` marks lifecycle / interrupt-ack /
+        queue-ack / steer-ack / provider-stall / warn messages that may be
+        suppressed on platforms where they would otherwise pollute a shared
+        chat (e.g. iMessage groups).  Other values are passed through
+        unchanged so future kinds can be added without breaking adapters.
         """
+
+        # Adapter-level policy hook: a status message may be deliberately
+        # dropped (e.g. iMessage group chat) so callers don't have to know
+        # the per-platform rules.  Suppression is reported as success with
+        # ``suppressed=True`` so retry/fallback logic doesn't trigger.
+        if kind == "status":
+            try:
+                if await self._should_suppress_status(chat_id, kind=kind, metadata=metadata):
+                    logger.info(
+                        "[%s] kind=status suppressed for chat_id=%s (adapter policy)",
+                        self.name, chat_id,
+                    )
+                    return SendResult(success=True, suppressed=True)
+            except Exception as _policy_err:
+                logger.debug(
+                    "[%s] _should_suppress_status raised, falling through to send: %s",
+                    self.name, _policy_err,
+                )
 
         result = await self.send(
             chat_id=chat_id,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -90,6 +90,12 @@ def _normalize_server_url(raw: str) -> str:
     return value.rstrip("/")
 
 
+def _truthy(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 
@@ -124,6 +130,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        # Whether kind="status" messages are delivered into BlueBubbles / iMessage
+        # group chats. Default False because every iMessage send is a permanent,
+        # un-editable bubble visible to every member. DMs still receive status.
+        self.show_status_in_groups = _truthy(
+            os.getenv("BLUEBUBBLES_SHOW_STATUS_IN_GROUPS"),
+            bool(extra.get("show_status_in_groups", False)),
+        )
         self.client: Optional[httpx.AsyncClient] = None
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
@@ -669,9 +682,32 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 info["name"] = display_name
                 if participants:
                     info["participants"] = participants
+                    if len(participants) > 1:
+                        info["type"] = "group"
         except Exception:
             pass
         return info
+
+    async def _should_suppress_status(
+        self,
+        chat_id: str,
+        *,
+        kind: str = "status",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Drop kind="status" messages in BlueBubbles/iMessage groups by default."""
+        del kind, metadata
+        if self.show_status_in_groups:
+            return False
+        try:
+            info = await self.get_chat_info(str(chat_id or ""))
+        except Exception as exc:
+            logger.warning(
+                "[bluebubbles] get_chat_info failed during status policy check; dropping kind=status: %s",
+                exc,
+            )
+            return True
+        return (info or {}).get("type") == "group"
 
     def format_message(self, content: str) -> str:
         return strip_markdown(content)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2537,6 +2537,7 @@ class GatewayRunner:
                     else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
                 ),
                 metadata=thread_meta,
+                kind="status",
             )
             return True
 
@@ -2686,6 +2687,7 @@ class GatewayRunner:
                     else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
                 ),
                 metadata=thread_meta,
+                kind="status",
             )
         except Exception as e:
             logger.debug("Failed to send busy-ack: %s", e)
@@ -2807,7 +2809,12 @@ class GatewayRunner:
                 # correct forum topic / thread.
                 metadata = {"thread_id": thread_id} if thread_id else None
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                result = await adapter._send_with_retry(
+                    chat_id=chat_id,
+                    content=msg,
+                    metadata=metadata,
+                    kind="status",
+                )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -2853,9 +2860,18 @@ class GatewayRunner:
             try:
                 metadata = {"thread_id": home.thread_id} if home.thread_id else None
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await adapter._send_with_retry(
+                        chat_id=str(home.chat_id),
+                        content=msg,
+                        metadata=metadata,
+                        kind="status",
+                    )
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await adapter._send_with_retry(
+                        chat_id=str(home.chat_id),
+                        content=msg,
+                        kind="status",
+                    )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
@@ -14818,10 +14834,11 @@ class GatewayRunner:
                 return
             try:
                 _fut = asyncio.run_coroutine_threadsafe(
-                    _status_adapter.send(
-                        _status_chat_id,
-                        message,
+                    _status_adapter._send_with_retry(
+                        chat_id=_status_chat_id,
+                        content=message,
                         metadata=_status_thread_metadata,
+                        kind="status",
                     ),
                     _loop_for_step,
                 )

--- a/tests/gateway/test_bluebubbles_status_suppression.py
+++ b/tests/gateway/test_bluebubbles_status_suppression.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.bluebubbles import BlueBubblesAdapter
+from gateway.platforms.base import SendResult
+
+
+class _RecordingBlueBubblesAdapter(BlueBubblesAdapter):
+    def __init__(self, *, chat_type: str = "dm", show_status_in_groups: bool = False):
+        super().__init__(
+            PlatformConfig(
+                enabled=True,
+                extra={"show_status_in_groups": show_status_in_groups},
+            )
+        )
+        self._chat_type = chat_type
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="bb-1")
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": self._chat_type, "chat_id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_bluebubbles_suppresses_kind_status_in_groups_by_default():
+    adapter = _RecordingBlueBubblesAdapter(chat_type="group")
+
+    result = await adapter._send_with_retry(
+        chat_id="chat;+;guid",
+        content="⚡ Interrupting current task",
+        kind="status",
+    )
+
+    assert result.success is True
+    assert result.suppressed is True
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_bluebubbles_delivers_normal_replies_in_groups():
+    adapter = _RecordingBlueBubblesAdapter(chat_type="group")
+
+    result = await adapter._send_with_retry(
+        chat_id="chat;+;guid",
+        content="normal answer",
+    )
+
+    assert result.success is True
+    assert result.suppressed is False
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == "normal answer"
+
+
+@pytest.mark.asyncio
+async def test_bluebubbles_delivers_status_in_dms():
+    adapter = _RecordingBlueBubblesAdapter(chat_type="dm")
+
+    result = await adapter._send_with_retry(
+        chat_id="person@example.com",
+        content="⚡ Interrupting current task",
+        kind="status",
+    )
+
+    assert result.success is True
+    assert result.suppressed is False
+    assert len(adapter.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_bluebubbles_status_group_suppression_can_be_disabled():
+    adapter = _RecordingBlueBubblesAdapter(
+        chat_type="group",
+        show_status_in_groups=True,
+    )
+
+    result = await adapter._send_with_retry(
+        chat_id="chat;+;guid",
+        content="⚡ Interrupting current task",
+        kind="status",
+    )
+
+    assert result.success is True
+    assert result.suppressed is False
+    assert len(adapter.sent) == 1

--- a/tests/gateway/test_status_kind_adapter_policy.py
+++ b/tests/gateway/test_status_kind_adapter_policy.py
@@ -178,6 +178,7 @@ def test_kind_is_keyword_only_so_legacy_positional_callers_still_work():
     assert "kind" in names
     assert names.index("kind") > names.index("max_retries")
     assert names.index("kind") > names.index("base_delay")
+    assert sig.parameters["kind"].kind is inspect.Parameter.KEYWORD_ONLY
     assert sig.parameters["kind"].default == "reply"
 
 

--- a/tests/gateway/test_status_kind_adapter_policy.py
+++ b/tests/gateway/test_status_kind_adapter_policy.py
@@ -1,0 +1,293 @@
+"""
+Regression tests for the kind=status adapter-policy patch.
+
+Background — live bug (May 2026): status / lifecycle / interrupt-ack
+messages from the gateway (e.g. ``⚡ Interrupting current task
+(iteration 2/90, …)``, ``⚠️ No response from provider for Ns…``) were
+leaking into iMessage group chats as if they were normal agent replies,
+because the delivery path made no distinction between a user-facing
+reply and an internal status bubble.
+
+The fix lives centrally in :mod:`gateway.platforms.base`:
+
+  1. :class:`SendResult` gains ``suppressed: bool``.
+  2. :meth:`BasePlatformAdapter._send_with_retry` gains a keyword-only
+     ``kind`` argument (default ``"reply"``).
+  3. :meth:`BasePlatformAdapter._should_suppress_status` policy hook
+     (default ``False``) lets adapters opt out of delivering
+     ``kind="status"`` on chat surfaces where it would be intrusive
+     (e.g. iMessage groups, where every message is a permanent,
+     un-editable bubble visible to everyone).
+  4. Status call sites in ``gateway/run.py`` (interrupt/queue/steer-ack,
+     drain-ack, ``_status_callback_sync`` bridge, shutdown notifier)
+     pass ``kind="status"``.
+
+These tests pin down each of those guarantees so the fix can't quietly
+regress.  They are deliberately self-contained — they exercise the
+central contract via a stub adapter rather than any specific platform,
+so they work in CI without needing user-installed platform plugins.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+# tests/gateway/<this file>  →  repo root is parents[2].
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stub adapter
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal adapter that records send() calls.  Used to verify the
+    central ``_send_with_retry`` contract independent of any real
+    platform.  ``BasePlatformAdapter.__init__`` is bypassed because we
+    don't need its config / Platform plumbing for these tests."""
+
+    def __init__(self, *, suppress_status: bool = False):
+        self._suppress_status = suppress_status
+        self.sent: list[dict] = []
+        self._name = "stub"
+        # Mirror the few attributes _send_with_retry / its helpers may
+        # touch through ``self``.
+        self.config = None  # not used by the code paths we exercise
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return self._name
+
+    async def connect(self) -> bool:  # pragma: no cover
+        return True
+
+    async def disconnect(self) -> None:  # pragma: no cover
+        return None
+
+    async def send(  # type: ignore[override]
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id="stub-1")
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:  # type: ignore[override]
+        return {"name": str(chat_id), "type": "dm", "chat_id": str(chat_id)}
+
+    async def _should_suppress_status(  # type: ignore[override]
+        self,
+        chat_id: str,
+        *,
+        kind: str = "status",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        return self._suppress_status
+def test_send_with_retry_kind_defaults_to_reply_and_delivers():
+    """Default ``kind="reply"`` must always deliver — no policy intercept,
+    no behavior change for the thousands of existing call sites."""
+    a = _StubAdapter(suppress_status=True)  # would suppress *if* asked
+    result = asyncio.run(a._send_with_retry(chat_id="c1", content="hi"))
+    assert result.success
+    assert result.suppressed is False
+    assert len(a.sent) == 1
+    assert a.sent[0]["content"] == "hi"
+
+
+def test_send_with_retry_kind_status_suppressed_in_group():
+    """When ``kind="status"`` and the adapter policy returns True, the
+    message is NOT delivered and the result is flagged ``suppressed``."""
+    a = _StubAdapter(suppress_status=True)
+    result = asyncio.run(
+        a._send_with_retry(chat_id="c1", content="⚡ …", kind="status")
+    )
+    assert result.success is True
+    assert result.suppressed is True
+    assert result.message_id is None
+    assert a.sent == [], "suppressed status must not reach adapter.send()"
+
+
+def test_send_with_retry_kind_status_delivered_in_dm():
+    """When the policy returns False (e.g. DM), status goes through
+    normally — useful progress signal there."""
+    a = _StubAdapter(suppress_status=False)
+    result = asyncio.run(
+        a._send_with_retry(chat_id="c1", content="⚡ …", kind="status")
+    )
+    assert result.success is True
+    assert result.suppressed is False
+    assert len(a.sent) == 1
+
+
+def test_send_with_retry_policy_hook_exception_falls_through_to_send():
+    """If the policy hook raises, we MUST NOT drop the message silently
+    — log the error and deliver as if the hook had returned False.  The
+    fix is meant to silence noise, not silently swallow real
+    notifications."""
+    a = _StubAdapter()
+
+    async def _boom(chat_id, *, kind="status", metadata=None):
+        raise RuntimeError("simulated policy bug")
+
+    a._should_suppress_status = _boom  # type: ignore[assignment]
+    result = asyncio.run(
+        a._send_with_retry(chat_id="c1", content="⚡ …", kind="status")
+    )
+    assert result.success is True
+    assert result.suppressed is False
+    assert len(a.sent) == 1
+
+
+def test_suppressed_is_distinguishable_from_delivered():
+    """Audit/logging callers must be able to tell delivered from
+    suppressed without parsing message content."""
+    delivered = SendResult(success=True, message_id="m1")
+    suppressed = SendResult(success=True, suppressed=True)
+    assert delivered.success and not delivered.suppressed
+    assert suppressed.success and suppressed.suppressed
+    assert delivered.message_id and not suppressed.message_id
+
+
+def test_kind_is_keyword_only_so_legacy_positional_callers_still_work():
+    """``kind`` was added as a kwarg with a default — legacy callers
+    that pass ``max_retries`` / ``base_delay`` positionally must not
+    accidentally bind their value to ``kind``.
+
+    The signature uses ``max_retries: int = 2, base_delay: float = 2.0,
+    kind: str = "reply"`` so this verifies the order in code.
+    """
+    import inspect
+    sig = inspect.signature(BasePlatformAdapter._send_with_retry)
+    params = list(sig.parameters.values())
+    names = [p.name for p in params]
+    # ``kind`` must appear after the retry-knobs to preserve the
+    # historical positional contract for existing internal callers.
+    assert "kind" in names
+    assert names.index("kind") > names.index("max_retries")
+    assert names.index("kind") > names.index("base_delay")
+    assert sig.parameters["kind"].default == "reply"
+
+
+# ---------------------------------------------------------------------------
+# 2. Anti-regression: gateway/run.py status sites must use kind="status"
+# ---------------------------------------------------------------------------
+
+def _read_run_py() -> str:
+    return (REPO_ROOT / "gateway" / "run.py").read_text(encoding="utf-8")
+
+
+def test_every_adapter_send_with_retry_in_run_py_declares_kind_status():
+    """The two ``await adapter._send_with_retry(...)`` call blocks in
+    gateway/run.py are interrupt/queue/steer-ack and drain/busy-ack —
+    both are pure status bubbles.  Each must declare ``kind="status"``
+    so they route through the adapter policy and don't leak into
+    groups."""
+    src = _read_run_py()
+    lines = src.splitlines()
+    starts = [
+        i for i, ln in enumerate(lines)
+        if "await adapter._send_with_retry(" in ln
+    ]
+    assert starts, "expected at least one adapter._send_with_retry block in run.py"
+    bad: list[str] = []
+    for idx in starts:
+        # Capture forward until the closing ``)`` whose indentation
+        # matches the opening ``await adapter._send_with_retry(`` line
+        # — that's the end of the call.
+        open_indent = len(lines[idx]) - len(lines[idx].lstrip())
+        block_lines = [lines[idx]]
+        for j in range(idx + 1, min(idx + 60, len(lines))):
+            block_lines.append(lines[j])
+            stripped = lines[j].lstrip()
+            if stripped.startswith(")"):
+                close_indent = len(lines[j]) - len(stripped)
+                if close_indent == open_indent:
+                    break
+        block = "\n".join(block_lines)
+        if 'kind="status"' not in block:
+            bad.append(block)
+    assert not bad, (
+        "every adapter._send_with_retry block in gateway/run.py must "
+        "declare kind=\"status\" (these are interrupt/drain/queue acks); "
+        "missing in:\n\n" + "\n---\n".join(bad)
+    )
+
+
+def test_status_callback_bridge_routes_through_send_with_retry_with_kind_status():
+    """``_status_callback_sync`` is the bridge that posts agent-emitted
+    lifecycle/warn events (provider stalls, compression warnings, …) to
+    the user.  It used to call ``_status_adapter.send(...)`` directly,
+    which bypassed every policy — that's the original leak.  It must
+    now go through ``_send_with_retry`` with ``kind="status"``."""
+    src = _read_run_py()
+
+    # Locate the function and grab everything up to the next def at the
+    # same indentation level.  The function is nested inside _run_agent
+    # so its def starts at 8-space indent.
+    m = re.search(
+        r"^( {8})def _status_callback_sync\(.*?\)\s*->\s*None:\s*\n"
+        r"(?P<body>(?:\1 .*\n|\s*\n)+)",
+        src,
+        flags=re.MULTILINE,
+    )
+    assert m, "couldn't locate _status_callback_sync in gateway/run.py"
+    body = m.group("body")
+    assert "_send_with_retry" in body, (
+        "_status_callback_sync must route through _send_with_retry; "
+        "a raw _status_adapter.send() bypasses the kind=\"status\" "
+        "policy and is the original leak.\nBody was:\n" + body
+    )
+    assert 'kind="status"' in body, (
+        "_status_callback_sync must pass kind=\"status\" so the adapter "
+        "policy can suppress it in group chats.\nBody was:\n" + body
+    )
+
+
+def test_shutdown_notifier_uses_kind_status():
+    """``_notify_active_sessions_of_shutdown`` posts
+    ``⚠️ Gateway shutting down / restarting…`` to every active chat
+    plus home channels.  Those are lifecycle messages too — same
+    suppression rules apply."""
+    src = _read_run_py()
+    # Grab the whole function — find its def line, then capture until
+    # the next def at the same indent (4 spaces — method on the class).
+    m = re.search(
+        r"^( {4})async def _notify_active_sessions_of_shutdown\(.*?\)\s*->\s*None:\s*\n"
+        r"(?P<body>(?:\1 .*\n|\s*\n)+)",
+        src,
+        flags=re.MULTILINE,
+    )
+    assert m, "couldn't locate _notify_active_sessions_of_shutdown"
+    body = m.group("body")
+    # All adapter sends in this function should be status-tagged.
+    # We don't insist on _send_with_retry specifically because adapters
+    # may differ, but if .send( is used at all it would bypass the
+    # policy — flag that as a regression.
+    raw_sends = [
+        ln for ln in body.splitlines()
+        if "adapter.send(" in ln and not ln.lstrip().startswith("#")
+    ]
+    assert not raw_sends, (
+        "_notify_active_sessions_of_shutdown must not use raw adapter.send() "
+        "— route through _send_with_retry(..., kind=\"status\") so iMessage "
+        "groups don't get a shutdown bubble.\nFound raw adapter.send() in:\n"
+        + body
+    )
+    # And it must actually pass kind="status" somewhere.
+    assert 'kind="status"' in body, (
+        "_notify_active_sessions_of_shutdown must declare kind=\"status\" "
+        "on its adapter sends.\nBody was:\n" + body
+    )


### PR DESCRIPTION
## Problem

Two code paths in `gateway/run.py` emit internal gateway status through the same adapter send path as normal agent replies, which leaks them into group chats:

1. **Interrupt / queue / steer acks** (`gateway/run.py` ~line 2600) — `⚡ Interrupting current task…`, `⏳ Queued for the next turn…`, `⏩ Steered into current run…`
2. **Agent `_status_callback_sync`** (`gateway/run.py` ~line 14638) — `lifecycle` and `warn` events from `AIAgent._emit_status` / `_emit_warning`, including `⚠️ No response from provider for Ns…`, compression warnings, etc.
3. **`_notify_active_sessions_of_shutdown`** (`gateway/run.py` ~line 2703) — `⚠️ Gateway shutting down — …`

On platforms with shared group chats (iMessage groups, Telegram groups, Discord channels, Slack rooms) other humans in the thread see these as if the agent sent them. Spotted in production on iMessage: multiple users in the same group thread were seeing `⚡ Interrupting current task (iteration 2/90, running: session_search). I'll respond to your message shortly.` whenever anyone interrupted a busy session.

## Fix

Centralize the suppression in the adapter layer — don't regex specific strings out of the chat stream.

- Add keyword-only `kind: str = "reply"` to `BaseAdapter._send_with_retry`. Status-class sends use `kind="status"`.
- Add `SendResult.suppressed: bool` so callers can distinguish a policy-suppressed send from a delivery failure.
- Add `BaseAdapter._should_suppress_status()` policy hook. Default returns `False` (fail-open — existing behavior preserved on platforms that haven't opted in). Per-platform adapters override to suppress in group chats when `gateway.show_status_in_groups` is `False` (the default for opting platforms).
- Tag all three status call sites in `gateway/run.py` with `kind="status"`:
  - The interrupt/queue/steer-ack block
  - `_status_callback_sync` (now routed through `_send_with_retry` instead of raw `adapter.send`)
  - `_notify_active_sessions_of_shutdown` — both per-session and home-channel sends
- If the policy hook itself raises, fail open and deliver — a bug in policy code must never silently swallow user-facing output.

## Tests

New `tests/gateway/test_status_kind_adapter_policy.py` (9 tests, all passing):

- Default `kind="reply"` always delivers, regardless of policy.
- `kind="status"` with `_should_suppress_status() → True` returns a suppressed `SendResult` without an outbound send.
- `kind="status"` with `_should_suppress_status() → False` delivers normally (DM case).
- Policy-hook exceptions fail open to send.
- `kind` is keyword-only after `max_retries` / `base_delay` (no positional-arg breakage on existing callers).
- Source-level anti-regression checks that the three call sites in `gateway/run.py` still pass `kind="status"`.

```
tests/gateway/test_status_kind_adapter_policy.py ............................. 9 passed in 1.31s
tests/gateway/{test_send_retry,test_busy_session_ack,test_session_split_brain_11016,test_clean_shutdown_marker}.py ... 70 passed in 2.32s
```

No existing tests broken.

## Out of scope

Per-platform override implementations (e.g. iMessage adapter checking `chat_type == "group"`) live in their own platform adapters / plugins. This PR ships only the core `kind` plumbing + policy hook + default-off behavior, so upstream platforms keep their current behavior until they opt in.
