### PR TITLE
fix(windows): create hermes.bat to work around uv exe launcher path quoting bug

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -980,7 +980,24 @@ function Set-PathVariable {
     
     # Update current session
     $env:Path = "$hermesBin;$env:Path"
-    
+
+    # Work around a uv bug on Windows where the generated hermes.exe launcher
+    # embeds the Python path with a leading double-quote, producing the error:
+    #   No Python at '"C:\...\python.exe'
+    # A .bat file in the same directory takes CMD/PowerShell precedence over
+    # the .exe, so writing hermes.bat here is a transparent, non-destructive fix.
+    if (-not $NoVenv) {
+        $pythonExe = "$InstallDir\venv\Scripts\python.exe"
+        $batPath   = "$InstallDir\venv\Scripts\hermes.bat"
+        $batContent = "@echo off`r`n`"$pythonExe`" -c `"from hermes_cli.main import main; main()`" %*`r`n"
+        try {
+            [System.IO.File]::WriteAllText($batPath, $batContent, [System.Text.Encoding]::ASCII)
+            Write-Success "Created hermes.bat launcher (uv exe workaround)"
+        } catch {
+            Write-Warn "Could not create hermes.bat: $_"
+        }
+    }
+
     Write-Success "hermes command ready"
 }
 


### PR DESCRIPTION
## Problem

On Windows, `hermes setup` (and any `hermes` invocation) fails immediately after a fresh install with:

```
No Python at '"C:\Users\...\venv\Scripts\python.exe'
```

The leading `"` inside the path is a uv bug: the generated `.exe` console-script launcher
embeds the Python interpreter path with a spurious leading double-quote under certain
conditions (different filesystem drive, relative-path install, or specific PATH state at
install time). This was reproduced on Windows 11, PowerShell 5.1, uv 0.11.14.

## Fix

Add a `hermes.bat` shim in `venv\Scripts\` at the end of `Set-PathVariable` in
`scripts/install.ps1`.

On Windows, CMD and PowerShell resolve `.bat` before `.exe` when both exist in the same
directory, so the shim takes effect transparently — no removal or patching of the existing
`.exe` is needed.

The `.bat` calls the venv Python directly via its absolute path:

```bat
@echo off
"C:\...\venv\Scripts\python.exe" -c "from hermes_cli.main import main; main()" %*
```

## Testing

Reproduced on Windows 11 (PowerShell 5.1, uv 0.11.14). After applying this change,
`hermes --version`, `hermes setup`, and interactive `hermes` all work correctly from a
fresh terminal session.
