### PR TITLE
fix(cli): allow rotating broken OpenRouter / AI Gateway key in `hermes model` flow

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2414,30 +2414,31 @@ def _prompt_provider_choice(choices, *, default=0):
 def _model_flow_openrouter(config, current_model=""):
     """OpenRouter provider: ensure API key, then pick model."""
     from hermes_cli.auth import (
+        ProviderConfig,
         _prompt_model_selection,
         _save_model_choice,
         deactivate_provider,
     )
-    from hermes_cli.config import get_env_value, save_env_value
+    from hermes_cli.config import get_env_value
 
-    api_key = get_env_value("OPENROUTER_API_KEY")
-    if not api_key:
-        print("No OpenRouter API key configured.")
+    # Route through _prompt_api_key so users can replace a stale/broken key
+    # in-flow (K/R/C) instead of having to edit ~/.hermes/.env by hand. The
+    # previous bypass-when-key-exists branch left no way to recover from a
+    # bad paste short of re-running `hermes setup` from scratch. OpenRouter
+    # isn't in PROVIDER_REGISTRY so we synthesize a minimal pconfig.
+    pconfig = ProviderConfig(
+        id="openrouter",
+        name="OpenRouter",
+        auth_type="api_key",
+        api_key_env_vars=("OPENROUTER_API_KEY",),
+    )
+    existing_key = get_env_value("OPENROUTER_API_KEY") or ""
+    if not existing_key:
         print("Get one at: https://openrouter.ai/keys")
         print()
-        try:
-            import getpass
-
-            key = getpass.getpass("OpenRouter API key (or Enter to cancel): ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            return
-        if not key:
-            print("Cancelled.")
-            return
-        save_env_value("OPENROUTER_API_KEY", key)
-        print("API key saved.")
-        print()
+    _resolved, abort = _prompt_api_key(pconfig, existing_key, provider_id="openrouter")
+    if abort:
+        return
 
     from hermes_cli.models import model_ids, get_pricing_for_provider
 
@@ -2473,33 +2474,26 @@ def _model_flow_openrouter(config, current_model=""):
 def _model_flow_ai_gateway(config, current_model=""):
     """Vercel AI Gateway provider: ensure API key, then pick model with pricing."""
     from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
         _prompt_model_selection,
         _save_model_choice,
         deactivate_provider,
     )
-    from hermes_cli.config import get_env_value, save_env_value
+    from hermes_cli.config import get_env_value
 
-    api_key = get_env_value("AI_GATEWAY_API_KEY")
-    if not api_key:
-        print("No Vercel AI Gateway API key configured.")
+    # Route through _prompt_api_key so users can replace a stale/broken key
+    # in-flow (K/R/C) instead of having to edit ~/.hermes/.env by hand.
+    pconfig = PROVIDER_REGISTRY["ai-gateway"]
+    existing_key = get_env_value("AI_GATEWAY_API_KEY") or ""
+    if not existing_key:
         print(
             "Create API key here: https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway&title=AI+Gateway"
         )
         print("Add a payment method to get $5 in free credits.")
         print()
-        try:
-            import getpass
-
-            key = getpass.getpass("AI Gateway API key (or Enter to cancel): ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            return
-        if not key:
-            print("Cancelled.")
-            return
-        save_env_value("AI_GATEWAY_API_KEY", key)
-        print("API key saved.")
-        print()
+    _resolved, abort = _prompt_api_key(pconfig, existing_key, provider_id="ai-gateway")
+    if abort:
+        return
 
     from hermes_cli.models import ai_gateway_model_ids, get_pricing_for_provider
 


### PR DESCRIPTION
## Summary

`hermes model openrouter` and `hermes model ai-gateway` now let users replace a broken / expired / wrong API key in-flow.

## Problem

Before this PR, both `_model_flow_openrouter` and `_model_flow_ai_gateway` checked "is the key already set?" and **skipped the prompt entirely** if yes. A user with a stale or wrong key had no way to recover from inside `hermes model` — they had to either edit `~/.hermes/.env` by hand or re-run `hermes setup` from scratch (and even `hermes setup` skips the LLM-provider step when a key already exists).

Real-world hit: user ran `hermes setup`, it skipped the OpenRouter key step because a broken key was already in `.env`, no in-CLI path to fix it.

## Fix

Route both flows through the existing `_prompt_api_key()` helper, which already surfaces **[K]eep / [R]eplace / [C]lear** when a key is configured. This is the same UX the generic API-key providers (z.ai, MiniMax, Gemini, NVIDIA, etc.) and Daytona setup already use — these two flows were just bypassing it with ad-hoc code.

OpenRouter isn't in `PROVIDER_REGISTRY`, so we synthesize a minimal `ProviderConfig` inline. AI Gateway already has an entry and uses it directly.

## Validation

Verified live (isolated `HERMES_HOME`, real `.env` writes, real `_prompt_api_key` call):

| Scenario | Behavior |
|---|---|
| Existing key, user picks **Replace** | Key updated on disk to new value |
| Existing key, user picks **Keep** | Key unchanged on disk |
| Existing key, user picks **Clear** | Key set to empty on disk |
| No existing key, user enters new | Key saved on disk |

Diff is -34 / +28 — net deletion, replacing duplicated ad-hoc prompts with a shared helper call.