### PR TITLE
fix(web): make sync-assets script cross-platform

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync-assets": "rm -rf public/fonts public/ds-assets && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets",
+    "sync-assets": "node -e \"const fs=require('fs');fs.rmSync('public/fonts',{recursive:true,force:true});fs.rmSync('public/ds-assets',{recursive:true,force:true});fs.cpSync('node_modules/@nous-research/ui/dist/fonts','public/fonts',{recursive:true});fs.cpSync('node_modules/@nous-research/ui/dist/assets','public/ds-assets',{recursive:true});\"",
     "predev": "npm run sync-assets",
     "prebuild": "npm run sync-assets",
     "dev": "vite",


### PR DESCRIPTION
## Summary
- `npm run build` fails on Windows because the `sync-assets` prebuild step shells out to `rm -rf` and `cp -r`, which don't exist on `cmd.exe`/PowerShell.
- Replaced the inline shell with a Node one-liner using `fs.rmSync` / `fs.cpSync` (Node ≥ 16.7). No new dependencies, no new files.