### PR TITLE
fix(agent/gemini-cloudcode): seed delta defaults for reasoning-only stream chunks

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -450,7 +450,13 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": None,
+        "reasoning": None,
+        "reasoning_content": None,
+    }
     if content:
         delta_kwargs["content"] = content
     if tool_call_delta is not None:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -913,6 +913,35 @@ class TestTranslateStreamEvent:
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
 
+class TestMakeStreamChunk:
+    def test_reasoning_only_chunk_has_content_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", reasoning="think")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.reasoning == "think"
+
+    def test_content_only_chunk_has_reasoning_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", content="hello")
+        delta = chunk.choices[0].delta
+        assert delta.content == "hello"
+        assert delta.reasoning is None
+        assert delta.tool_calls is None
+
+    def test_finish_only_chunk_has_all_fields_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", finish_reason="stop")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.reasoning is None
+        assert delta.tool_calls is None
+        assert chunk.choices[0].finish_reason == "stop"
+
+
 class TestGeminiCloudCodeClient:
     def test_client_exposes_openai_interface(self):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient


### PR DESCRIPTION
## What does this PR do?

`_make_stream_chunk()` in `agent/gemini_cloudcode_adapter.py` built `delta_kwargs` with only the `role` key, then only inserted `content` / `tool_calls` / `reasoning` / `reasoning_content` when the corresponding argument was truthy. A reasoning-only chunk therefore produced a `SimpleNamespace` delta with no `.content` attribute, and downstream consumers reading `delta.content` raised `AttributeError` on Gemini 2.5 Flash (whose thinking delta arrives before any content delta).

The fix seeds all four optional delta fields as `None` up front, mirroring the pattern already used in `gemini_native_adapter.py:555`. Key-present arguments still override the defaults, so behavior for content / tool-call / reasoning chunks is unchanged. A new `TestMakeStreamChunk` exercises the three shapes (reasoning-only, content-only, finish-only) and asserts the missing-field invariant.

## Related Issue

Fixes #24974

Related: open PR #24984 (luyao618) applies the same 1-line adapter fix without adding a test; this PR carries the same fix plus a regression test covering all three delta shapes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/gemini_cloudcode_adapter.py`: expand `_make_stream_chunk`'s `delta_kwargs` baseline to seed `content`, `tool_calls`, `reasoning`, `reasoning_content` as `None`.
- `tests/agent/test_gemini_cloudcode.py`: add `TestMakeStreamChunk` with three cases — reasoning-only chunk has `content is None`, content-only chunk has `reasoning is None`, finish-only chunk has all optional fields `None`.

## How to Test

1. From the issue's minimal reproduction:
   ```python
   from agent.gemini_cloudcode_adapter import _make_stream_chunk
   d = _make_stream_chunk(model="m", reasoning="think").choices[0].delta
   assert d.content is None   # AttributeError pre-patch
   ```
2. `pytest tests/agent/test_gemini_cloudcode.py::TestMakeStreamChunk -q` — 3 passed.
3. `pytest tests/agent/test_gemini_cloudcode.py -q` — full file still green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests; new `TestMakeStreamChunk` cases pass and the rest of `tests/agent/test_gemini_cloudcode.py` remains green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12.3

### Documentation & Housekeeping

- [x] N/A — internal adapter fix, no user-visible config or doc surface
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] N/A — pure-Python adapter logic, no platform-specific code paths touched
- [x] N/A — tool schemas/descriptions unchanged
