### PR TITLE
fix(memory): send only incremental turns in Hindsight append mode

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -572,6 +572,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
+        self._last_retained_turn_count = 0  # how many turns have been sent to Hindsight (for append-mode incremental retain)
 
         # Recall controls
         self._auto_recall = True
@@ -1099,6 +1100,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
+        self._last_retained_turn_count = 0
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1431,9 +1433,30 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
-        content = "[" + ",".join(self._session_turns) + "]"
+        # Resolve append capability early so we can send only new turns.
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+
+        if update_mode == "append":
+            # Hindsight >=0.5.0 supports append-only documents. Sending the
+            # full accumulated session on every retain would create quadratic
+            # token usage (turn 1, then turns 1+2, then turns 1+2+3...) and
+            # duplicate memories. Instead, send only turns buffered since the
+            # last retain. _session_turns itself is NOT cleared — it must
+            # remain populated so on_session_switch() can still flush partial
+            # buffers when retain_every_n_turns > 1.
+            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
+        else:
+            # Legacy overwrite mode: send the full session snapshot so the
+            # document replaces prior content without data loss.
+            turns_to_retain = list(self._session_turns)
+
+        logger.debug("sync_turn: retaining %d turns (%d new of %d total), content %d chars, mode=%s",
+                     len(turns_to_retain), len(turns_to_retain), len(self._session_turns),
+                     sum(len(t) for t in turns_to_retain), update_mode)
+        content = "[" + ",".join(turns_to_retain) + "]"
+
+        if update_mode == "append":
+            self._last_retained_turn_count = len(self._session_turns)
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1444,11 +1467,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(self._session_turns) * 2,
+            message_count=len(turns_to_retain) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(self._session_turns)
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        num_turns = len(turns_to_retain)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
@@ -1676,6 +1698,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
+        self._last_retained_turn_count = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -756,8 +756,8 @@ class TestSyncTurn:
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
 
-    def test_sync_turn_accumulates_full_session(self, provider_with_config):
-        """Each retain sends the ENTIRE session, not just the latest batch."""
+    def test_sync_turn_accumulates_full_session_for_legacy_overwrite_mode(self, provider_with_config):
+        """Legacy APIs without append support need full snapshots to avoid overwrite data loss."""
         p = provider_with_config(retain_every_n_turns=2)
 
         p.sync_turn("turn1-user", "turn1-asst")
@@ -771,11 +771,42 @@ class TestSyncTurn:
         p._retain_queue.join()
 
         content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
-        # Should contain ALL turns from the session
+        # Legacy overwrite mode should contain ALL turns from the session.
         assert "turn1-user" in content
         assert "turn2-user" in content
         assert "turn3-user" in content
         assert "turn4-user" in content
+
+    def test_sync_turn_append_mode_sends_only_new_buffered_turns(self, provider_with_config, monkeypatch):
+        """Append mode must not resend prior turns, or token usage becomes quadratic."""
+        p = provider_with_config(retain_every_n_turns=2)
+        monkeypatch.setattr(p, "_resolve_retain_target", lambda fallback: ("test-session", "append"))
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        first = p._client.aretain_batch.call_args.kwargs
+        first_content = first["items"][0]["content"]
+        assert first["document_id"] == "test-session"
+        assert first["items"][0]["update_mode"] == "append"
+        assert "turn1-user" in first_content
+        assert "turn2-user" in first_content
+
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+
+        second = p._client.aretain_batch.call_args.kwargs
+        second_content = second["items"][0]["content"]
+        assert second["document_id"] == "test-session"
+        assert second["items"][0]["update_mode"] == "append"
+        assert "turn1-user" not in second_content
+        assert "turn2-user" not in second_content
+        assert "turn3-user" in second_content
+        assert "turn4-user" in second_content
 
     def test_sync_turn_passes_document_id(self, provider):
         """sync_turn should pass document_id (session_id + per-startup ts)."""


### PR DESCRIPTION
## What does this PR do?

Fixes quadratic token usage in `HindsightMemoryProvider.sync_turn()` when the Hindsight API supports `update_mode="append"` (>=0.5.0).

**The bug:** `sync_turn()` sends the full accumulated `_session_turns` on every retain. With append-mode documents, this means turn 1 is sent N times, turn 2 is sent N-1 times, etc. — O(n²) token usage that burns through API credits on long sessions.

**The fix:** Track how many turns have already been retained (`_last_retained_turn_count`). In append mode, send only `_session_turns[_last_retained_turn_count:]` (the new turns since last retain). Legacy overwrite mode is unchanged — full-session snapshots are still required.

`_session_turns` itself is NOT cleared, so `on_session_switch()` can still flush partial buffers when `retain_every_n_turns > 1`.

## Related Issue

Fixes the token-cost half of the append-mode integration gap introduced in 3082fa082 (feat: probe API for update_mode='append' support, dedupe across processes).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: Add `_last_retained_turn_count` counter, use it to slice only new turns in append mode, reset in `__init__`/`initialize()`/`on_session_switch()`
- `tests/plugins/memory/test_hindsight_provider.py`: Rename existing test to clarify it covers legacy overwrite mode, add new test `test_sync_turn_append_mode_sends_only_new_buffered_turns` that verifies incremental sends

## How to Test

1. `pytest tests/plugins/memory/test_hindsight_provider.py -q` — 97 tests pass
2. `pytest tests -q -k 'hindsight'` — 102 tests pass, 1 skipped
3. The new test `test_sync_turn_append_mode_sends_only_new_buffered_turns` specifically verifies that the second retain does NOT contain turns from the first retain

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(memory): ...`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes

## Notes

The `on_session_switch()` flush in append mode will re-send some already-retained turns (redundant but safe). This is the correct tradeoff — data safety > perfect efficiency. The flush code is upstream and should not be touched in this PR.