### PR TITLE
fix(dashboard): respect HERMES_BASE_PATH in WebSocket URLs (#25547)

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -30,6 +30,7 @@ import { Card } from "@/components/ui/card";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { HERMES_BASE_PATH } from "@/lib/api";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -160,7 +161,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     const qs = new URLSearchParams({ token, channel });
     const ws = new WebSocket(
-      `${proto}//${window.location.host}/api/events?${qs.toString()}`,
+      `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
     );
 
     // `unmounting` suppresses the banner during cleanup — `ws.close()`

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -13,6 +13,8 @@
  *   await gw.request("prompt.submit", { session_id, text: "hi" })
  */
 
+import { HERMES_BASE_PATH } from "@/lib/api";
+
 export type GatewayEventName =
   | "gateway.ready"
   | "session.info"
@@ -117,7 +119,7 @@ export class GatewayClient {
 
     const scheme = location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(
-      `${scheme}//${location.host}/api/ws?token=${encodeURIComponent(resolved)}`,
+      `${scheme}//${location.host}${HERMES_BASE_PATH}/api/ws?token=${encodeURIComponent(resolved)}`,
     );
     this.ws = ws;
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
+import { HERMES_BASE_PATH } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { Copy, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -44,7 +45,7 @@ function buildWsUrl(
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   const qs = new URLSearchParams({ token, channel });
   if (resume) qs.set("resume", resume);
-  return `${proto}//${window.location.host}/api/pty?${qs.toString()}`;
+  return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar


### PR DESCRIPTION
## Summary

Fixes #25547. When the dashboard is reverse-proxied under a path prefix (\`X-Forwarded-Prefix: /dashboard\`), three WebSocket URLs constructed by the SPA still rooted at \`/api/...\` and bypassed the proxy prefix, breaking the connection or forcing operators to forward root \`/api/...\` paths to the backend as a workaround.

REST traffic and built asset URLs already honour \`HERMES_BASE_PATH\` (injected by \`mount_spa()\` in \`hermes_cli/web_server.py\` based on \`X-Forwarded-Prefix\`). This PR brings the three remaining WebSocket URLs into the same model.

## Problem (from issue)

> Some paths are already prefix-aware via \`HERMES_BASE_PATH\`, but a few areas still appear to construct absolute root paths.
> Observed:
> - \`web/src/pages/ChatPage.tsx\` — \`/api/pty?...\`
> - \`web/src/components/ChatSidebar.tsx\` — \`/api/events?...\`
> - \`web/src/lib/gatewayClient.ts\` — \`/api/ws?...\`

The workaround (forwarding selected root API paths through the proxy) leaks dashboard-specific routing into the public root path and is easy to miss.

## Root cause

The three URLs were templated as \`\${proto}//\${host}/api/...\` without the \`HERMES_BASE_PATH\` segment that \`web/src/lib/api.ts\` reads from \`window.__HERMES_BASE_PATH__\`.

## Fix

Add \`\${HERMES_BASE_PATH}\` between \`host\` and \`/api/...\` in:

- \`web/src/pages/ChatPage.tsx\` (PTY WebSocket)
- \`web/src/components/ChatSidebar.tsx\` (events subscriber)
- \`web/src/lib/gatewayClient.ts\` (JSON-RPC gateway WebSocket)

When the dashboard is served at root, \`HERMES_BASE_PATH === \"\"\` and the URLs are bit-for-bit identical to before — only prefixed deployments change.

## Solution sketch

```mermaid
flowchart TD
    A[Browser opens dashboard at example.com/dashboard/] --> B[Backend injects __HERMES_BASE_PATH__='/dashboard']
    B --> C[REST calls use HERMES_BASE_PATH]
    B --> D[WebSocket URLs now also use HERMES_BASE_PATH]
    C --> E[wss://example.com/dashboard/api/pty]
    D --> E
    E --> F[Reverse proxy strips /dashboard]
    F --> G[Backend receives /api/pty as before]
```

## Out of scope

The issue also notes bundled dashboard plugins (\`plugins/kanban/dashboard/dist/index.js\`, \`plugins/hermes-achievements/dashboard/dist/index.js\`) embed root \`/api/plugins/...\` in their compiled output. Those need source-side fixes per plugin and a separate rebuild — left for follow-up PRs so this one stays focused.

## Tests

The web dashboard has no test runner configured in \`web/package.json\` (only \`dev\`, \`build\`, \`lint\`, \`preview\`). The change is a mechanical 3-line edit adding the existing \`HERMES_BASE_PATH\` constant to three URL templates. I confirmed:

- All three usages now import \`HERMES_BASE_PATH\` from \`@/lib/api\` (the same module other prefixed code already uses).
- No other \`/api/pty\`, \`/api/ws\`, or \`/api/events\` occurrence remains in \`web/src/\` source (the other matches are inside comments).

## Duplicate check

- \`gh pr list --state open --search \"25547 in:body,title\"\` -> 0
- No other open PR touching \`gatewayClient.ts\`, \`ChatPage.tsx\` WebSocket construction, or \`ChatSidebar.tsx\` events URL.

## Risk

Low. \`HERMES_BASE_PATH\` is an empty string at root; the existing \`readBasePath()\` in \`api.ts\` handles malformed prefixes already. Under a prefix, behaviour matches the documented X-Forwarded-Prefix contract that the rest of the SPA follows.

## Funnel discipline

Opened under the new funnel discipline doc. Confirmed no open competing PR before starting and no maintainer comment requesting a different approach on the issue.