### PR TITLE
fix(agent): reset _disable_streaming per turn instead of per session (#25723)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11791,6 +11791,29 @@ class AIAgent:
 
         return final_response
 
+    def _reset_streaming_disable_for_new_turn(self) -> None:
+        """Reset the per-session ``_disable_streaming`` fallback at the start
+        of each user turn (#25723).
+
+        Without this, a single transient "stream not supported" error during
+        a session permanently disables streaming for every subsequent turn.
+        That compounds badly with upstream proxies that kill silent non-
+        stream connections (e.g. z.ai's 180s nginx ``proxy_read_timeout``)
+        — the agent ends up looping on non-streaming requests that always
+        die at the proxy boundary.
+
+        Re-enabling streaming per turn costs at most one extra failed retry
+        for providers that truly don't support streaming, and those users
+        already have a permanent opt-out via ``display.streaming: false``
+        in ``config.yaml``.
+        """
+        if getattr(self, "_disable_streaming", False):
+            logger.info(
+                "Re-enabling streaming for new turn — previous fallback "
+                "was scoped to the prior turn only (#25723)."
+            )
+            self._disable_streaming = False
+
     def run_conversation(
         self,
         user_message: str,
@@ -11822,6 +11845,9 @@ class AIAgent:
         # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
         # Installed once, transparent when streams are healthy, prevents crash on write.
         _install_safe_stdio()
+
+        # Per-turn reset of #25723's session-permanent streaming fallback.
+        self._reset_streaming_disable_for_new_turn()
 
         self._ensure_db_session()
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -508,6 +508,41 @@ class TestStreamingFallback:
         # The flag should be set so the main retry loop switches to non-streaming
         assert agent._disable_streaming is True
 
+    def test_reset_streaming_disable_for_new_turn_clears_flag(self):
+        """#25723: new user turns must re-attempt streaming so a single
+        false-positive fallback can't strand the whole session on
+        non-streaming behind a proxy that kills silent connections."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._disable_streaming = True
+        agent._reset_streaming_disable_for_new_turn()
+        assert agent._disable_streaming is False
+
+    def test_reset_streaming_disable_noop_when_unset(self):
+        """#25723: the reset must be safe to call when the flag was never
+        set, so we don't pay a log line for every healthy turn."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        # Default is unset; reset should be a noop and not introduce the attr.
+        agent._reset_streaming_disable_for_new_turn()
+        assert getattr(agent, "_disable_streaming", False) is False
+
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_non_transport_error_propagates(self, mock_close, mock_create):


### PR DESCRIPTION
## What does this PR do?

Fixes #25723. A single transient "stream not supported" error inside one turn was setting `self._disable_streaming = True` for the **rest of the session**, even when the error was a misclassified gateway hiccup. Subsequent turns went non-streaming forever, which compounds badly with upstream proxies that kill silent non-stream connections (e.g. z.ai's 180s nginx `proxy_read_timeout`).

## Root cause

`run_agent.py:8427` sets the flag, `run_agent.py:12584` reads it. The flag has session lifetime with no reset path, so one fault permanently strands the session on non-streaming behind any proxy that doesn't tolerate silent connections.

## Fix

Reset the flag at the top of each `run_conversation` call. Streaming is re-attempted on the new user turn. If the provider truly doesn't support streaming, the same code path sets the flag again — at the cost of one extra retry per turn. Users who hit that consistently already have the documented permanent opt-out (`display.streaming: false` in `config.yaml`, which the existing error-path message advises).

Extracted as `_reset_streaming_disable_for_new_turn` so it's unit-testable in isolation and the `run_conversation` call site stays a single line.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Fixes #25723. A single transient "stream not supported" error inside one turn was setting `self._disable_streaming = True` for the **rest of the session**, even when the error was a misclassified gateway hiccup. Subsequent turns went non-streaming forever, which compounds badly with upstream proxies that kill silent non-stream connections (e.g. z.ai's 180s nginx `proxy_read_timeout`).

<details>
<summary>Original body</summary>

## Summary

Fixes #25723. A single transient "stream not supported" error inside one turn was setting `self._disable_streaming = True` for the **rest of the session**, even when the error was a misclassified gateway hiccup. Subsequent turns went non-streaming forever, which compounds badly with upstream proxies that kill silent non-stream connections (e.g. z.ai's 180s nginx `proxy_read_timeout`).

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Fixes #25723. A single transient "stream not supported" error inside one turn was setting `self._disable_streaming = True` for the **rest of the session**, even when the error was a misclassified gateway hiccup. Subsequent turns went non-streaming forever, which compounds badly with upstream proxies that kill silent non-stream connections (e.g. z.ai's 180s nginx `proxy_read_timeout`).

## Problem (from issue)

`@michaelbubnov` reported the cascade:

```
stream attempt fails → _disable_streaming = True (PERMANENT per session)
    ↓
all subsequent requests use non-streaming
    ↓
zero bytes flow during model generation
    ↓
z.ai gateway sees 180s of silence → kills connection
    ↓
hermes-agent retries non-streaming → 180s of silence → killed again
    ↓
loops until max_iterations (~8-10 min of nothing)
```

## Root cause

`run_agent.py:8427` sets the flag, `run_agent.py:12584` reads it. The flag has session lifetime with no reset path, so one fault permanently strands the session on non-streaming behind any proxy that doesn't tolerate silent connections.

## Fix

Reset the flag at the top of each `run_conversation` call. Streaming is re-attempted on the new user turn. If the provider truly doesn't support streaming, the same code path sets the flag again — at the cost of one extra retry per turn. Users who hit that consistently already have the documented permanent opt-out (`display.streaming: false` in `config.yaml`, which the existing error-path message advises).

Extracted as `_reset_streaming_disable_for_new_turn` so it's unit-testable in isolation and the `run_conversation` call site stays a single line.

## Solution sketch

```mermaid
flowchart TD
    A[New user turn] --> B[run_conversation entry]
    B --> C[_reset_streaming_disable_for_new_turn]
    C --> D{Was _disable_streaming True?}
    D -- yes --> E[Set False + log info]
    D -- no --> F[Noop]
    E --> G[Build api_kwargs, _use_streaming defaults True]
    F --> G
    G --> H{Stream attempt succeeds?}
    H -- yes --> I[Done — streaming preserved next turn]
    H -- 'stream not supported' --> J[Flag set, this turn falls back]
    J --> K[Next user turn resets the flag again]
```

## Why this is safe

- Pure semantic narrowing: a flag that was set "forever" is now set "for this turn".
- `_disable_streaming` is read in exactly one site (`run_agent.py:12584`). No other consumer depends on its lifetime.
- The existing `display.streaming: false` config option is the documented permanent opt-out for providers that genuinely don't support streaming, so this PR doesn't remove that capability — it just stops accidentally turning it on session-wide.
- Cost on truly-unsupported providers: one extra failed-stream retry at the start of each turn. The original code's error-path print already advises those users to set the config option to avoid that retry cost.

## Tests

```
python -m pytest \
  tests/run_agent/test_streaming.py::TestStreamingFallback::test_reset_streaming_disable_for_new_turn_clears_flag \
  tests/run_agent/test_streaming.py::TestStreamingFallback::test_reset_streaming_disable_noop_when_unset \
  tests/run_agent/test_streaming.py::TestStreamingFallback::test_stream_not_supported_sets_flag_and_raises -q
# 3 passed
```

- `test_reset_streaming_disable_for_new_turn_clears_flag` — flag set, helper invoked, flag now False.
- `test_reset_streaming_disable_noop_when_unset` — safe to call when the flag was never set.
- existing `test_stream_not_supported_sets_flag_and_raises` still passes (flag is still set inside a turn on the actual error).

## Duplicate check

- `gh pr list --state open --search "25723 in:body,title"` → 0
- `gh pr list --state open --search "_disable_streaming"` → 0
- `gh pr list --search "disable_streaming is:merged author:teknium1"` → 0

## Funnel discipline

Opened under the funnel discipline doc. Issue has 0 open competing PRs and no merged fix in the same area at time of opening.

## Related Issue

Fixes #25723. A single transient "stream not supported" error inside one turn was setting `self._disable_streaming = True` for the **rest of the session**, even when the error was a misclassified gateway hiccup. Subsequent turns went non-streaming forever, which compounds badly with upstream proxies that kill silent non-stream connections (e.g. z.ai's 180s nginx `proxy_read_timeout`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Run `python -m pytest \`.
2. Confirm the scoped behavior described above still holds after the focused checks.
3. Confirm the scoped behavior described above still holds after the focused checks.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_