### PR TITLE
fix(cli): read approvals.timeout from config in CLI approval callback (#25559)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10064,7 +10064,7 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = 60
+            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()
 
             self._approval_state = {


### PR DESCRIPTION
The CLI approval callback hardcoded `timeout = 60` at `cli.py:10067`, ignoring the `approvals.timeout` config. Other approval paths already honor the setting; this brings CLI in line.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25559 by @Arkmusn. Same one-line fix was also opened by @alaamohanad169-ship-it (#25609, closed) — credit to both for noticing the bug; @Arkmusn submitted first.