### PR TITLE
fix(state): use AUTOINCREMENT id for message ordering instead of timestamp (#25589)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1597,10 +1597,10 @@ class SessionDB:
         self._execute_write(_do)
 
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
-        """Load all messages for a session, ordered by timestamp."""
+        """Load all messages for a session, ordered by insertion order."""
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
                 (session_id,),
             )
             rows = cursor.fetchall()
@@ -1700,7 +1700,7 @@ class SessionDB:
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
                 "codex_reasoning_items, codex_message_items "
-                f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
+                f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
 


### PR DESCRIPTION
Message ordering was `ORDER BY timestamp, id`, which causes duplicates and crashes on systems where timestamps can collide (WSL2 clock granularity, fast batched writes). The `id` column is already AUTOINCREMENT and monotonic — ordering by id alone is sufficient and correct.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25589 by @yifengingit.