### PR TITLE
fix(webui): allow native text selection in chat via xterm.js bypass (#25720)

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -286,6 +286,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       fontWeight: "400",
       fontWeightBold: "700",
       macOptionIsMeta: true,
+      // Hold Option (Alt on Linux/Windows) to force native text selection
+      // even when the inner Hermes TUI has enabled xterm mouse-events
+      // mode (CSI ?1000h family). Without this, click-and-drag in the
+      // chat canvas selects nothing and Cmd+C falls back to copying the
+      // entire visible buffer, which is rarely what the user wants.
+      // See #25720.
+      macOptionClickForcesSelection: true,
+      // Right-click selects the word under the pointer. xterm.js default
+      // is false; enabling it gives users a single-action selection
+      // path on top of the modifier-based bypass above.
+      rightClickSelectsWord: true,
       // Single-scroll-system experiment:
       // let the inner Hermes TUI own transcript history/scroll behavior.
       // The outer browser xterm should act as a display/input bridge only.


### PR DESCRIPTION
## Summary

Fixes #25720. The chat panel renders via xterm.js, and when the inner Hermes TUI enables mouse-events mode (CSI ?1000h family — used for nav inside Ink overlays/pickers) every drag, double-click, triple-click, and Option+drag in the canvas is consumed by the terminal instead of producing a native text selection.

Reporter (macOS, Brave) confirmed click-and-drag selects nothing, Cmd+C with no selection copies the entire visible buffer, and existing CSS overrides at the document layer have no effect — the issue is at xterm.js's mouse layer, not the DOM.

## Fix

Two xterm.js options the user can opt into without disabling mouse-events mode for the inner TUI:

- `macOptionClickForcesSelection: true` — holding Option (macOS) or Alt (Linux/Windows) during a click-and-drag bypasses mouse-events mode and produces a native xterm selection. This is the documented xterm.js path for exactly this scenario. Selected text is then copyable via Cmd+C / Ctrl+C through the existing OSC 52 + manual handlers already present in `ChatPage.tsx`.
- `rightClickSelectsWord: true` — right-click highlights the word under the pointer. Single-action path on top of the modifier-based bypass.

Matches the issue's suggested fix #2 ("Ensure xterm.js Option-click selection bypass works as documented").

## Why these two

The two options coexist with the existing `macOptionIsMeta: true` (which only affects keyboard, not mouse). The alternative — disabling mouse-events mode entirely — would break inner-TUI behaviour (overlays, pickers, scroll-via-mouse in Ink components), and the reporter explicitly noted suggestion #1 as one option among several. The modifier-key bypass is the lowest-impact fix that solves the reporter's actual workflow ("copy code snippets / commands / URLs out of agent output").

## Solution sketch

```mermaid
flowchart TD
    A[User drags inside chat canvas] --> B{Mouse-events mode active?}
    B -- no --> C[Native selection works as today]
    B -- yes --> D{Option/Alt held?}
    D -- no --> E[Inner TUI consumes the drag]
    D -- yes --> F[xterm forces native selection]
    F --> G[Cmd+C copies selection via OSC 52]
```

## Tests

`web/package.json` does not ship a test runner — only `dev`, `build`, `lint`, `preview`. The change is two configuration flags inside the existing `new Terminal({...})` call. Verified:

- All three flags (`macOptionIsMeta`, `macOptionClickForcesSelection`, `rightClickSelectsWord`) are documented xterm.js v6 options (the version in `web/package.json: "@xterm/xterm": "^6.0.0"`).
- The existing OSC 52 + Cmd+Shift+C handlers in `ChatPage.tsx` already pick up arbitrary xterm selections, so adding the bypass automatically routes selected text through the system clipboard.

Manual verification path for reviewers:

1. macOS: open `/chat`, hold Option, drag across some agent output → highlight appears, Cmd+C copies.
2. Linux/Windows: same with Alt instead of Option.
3. Right-click on any word → that word is highlighted; Cmd+C / Ctrl+C copies just that word.

## Duplicate check

- `gh pr list --state open --search "25720 in:body,title"` → 0
- `gh pr list --state open --search "xterm macOptionClickForcesSelection rightClickSelectsWord"` → 0

## Funnel discipline

Opened under doc 23. Issue has 0 open competing PRs and no merged fix in the same area at time of opening.