### PR TITLE
fix: restrict .env file permissions to 0600 (#25562)

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -379,6 +379,12 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
             new_lines.append(f"{key}={val}")
 
     env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    # Restrict permissions — .env holds API keys and tokens.
+    try:
+        import stat
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    except OSError:
+        pass  # Windows or read-only FS
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1426,6 +1426,10 @@ copy_config_templates() {
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi
+    # Restrict .env permissions — this file holds API keys and tokens.
+    # 0600 ensures only the file owner can read/write, matching standard
+    # practice for credential files (.netrc, .aws/credentials, .ssh/config).
+    chmod 600 "$HERMES_HOME/.env"
     configure_browser_env_from_system_browser
 
     # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)


### PR DESCRIPTION
API keys in `~/.hermes/.env` were created with default permissions (often 0644 = world-readable). Locks them down to 0600 in two places:

1. `scripts/install.sh` — initial install
2. `hermes_cli/memory_setup._write_env_vars` — re-saves through `hermes setup memory`

Closes #25477. Same intent as @alaamohanad169-ship-it's #25560 (closed); we picked this one for the broader Python-side coverage.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25562 by @vanthinh6886.