### PR TITLE
fix: honor cron toolset denylist

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -73,17 +73,29 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
-    if per_job:
-        return per_job
+    per_job_toolsets = [str(t).strip() for t in per_job if str(t).strip()] if per_job else None
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        platform_toolsets = set(_get_platform_tools(cfg or {}, "cron"))
     except Exception as exc:
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",
             exc,
         )
-        return None
+        return per_job_toolsets or None
+
+    if per_job_toolsets:
+        resolved = [toolset for toolset in per_job_toolsets if toolset in platform_toolsets]
+        dropped = [toolset for toolset in per_job_toolsets if toolset not in platform_toolsets]
+        if dropped:
+            logger.warning(
+                "Cron job %r requested disabled toolsets %s; dropping them",
+                job.get("name") or job.get("id"),
+                dropped,
+            )
+        return resolved
+
+    return sorted(platform_toolsets)
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -990,9 +990,8 @@ class TestRunJobSessionPersistence:
         # run cannot accidentally spin up frontier models.
         assert "moa" not in kwargs["enabled_toolsets"]
 
-    def test_run_job_per_job_toolsets_win_over_platform_config(self, tmp_path):
-        """Per-job enabled_toolsets (via cronjob tool) always take precedence
-        over the platform-level ``hermes tools`` config."""
+    def test_run_job_per_job_toolsets_narrow_platform_config(self, tmp_path):
+        """Per-job enabled_toolsets can narrow the platform-level cron config."""
         job = {
             "id": "override-job",
             "name": "test",
@@ -1000,13 +999,13 @@ class TestRunJobSessionPersistence:
             "enabled_toolsets": ["terminal"],
         }
         fake_db, patches = self._make_run_job_patches(tmp_path)
-        # Even if the user has ``hermes tools`` configured to enable web+file
-        # for cron, the per-job override wins.
+        # The user has ``hermes tools`` configured to enable web+file+terminal
+        # for cron, and the job narrows that to terminal.
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
              patch("run_agent.AIAgent") as mock_agent_cls, \
              patch(
                  "hermes_cli.tools_config._get_platform_tools",
-                 return_value={"web", "file"},
+                 return_value={"web", "file", "terminal"},
              ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -1015,6 +1014,28 @@ class TestRunJobSessionPersistence:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["terminal"]
+
+    def test_run_job_drops_per_job_toolsets_disabled_by_platform_config(self, tmp_path):
+        job = {
+            "id": "denied-toolset-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["terminal", "file"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch(
+                 "hermes_cli.tools_config._get_platform_tools",
+                 return_value={"file", "web"},
+             ):
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["file"]
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).


### PR DESCRIPTION
﻿## Summary
- intersect cron job `enabled_toolsets` with the platform cron toolset allowlist
- drop per-job toolsets that are disabled by user/platform config instead of re-enabling them
- add a regression test for mixed allowed/denied per-job toolsets

Fixes #25752.

## To verify
- `python -m pytest tests\cron\test_scheduler.py -q --basetemp .tmp\pytest -p no:cacheprovider -n 0`
- `python -m ruff check cron\scheduler.py tests\cron\test_scheduler.py`
- `git diff --check`
