### PR TITLE
fix(tui): clean up sessions on gateway shutdown

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -15,7 +15,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -386,6 +386,35 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         raise
 
 
+def _normalize_profile(profile: Optional[str]) -> Optional[str]:
+    """Normalize the canonical per-job profile assignment field.
+
+    ``profile`` is the canonical field name for global cron jobs that should
+    execute under a named Hermes profile.  ``None``/empty means the scheduler
+    uses its own current HERMES_HOME, preserving legacy jobs.  Profile names are
+    constrained to simple directory names under ``<Hermes root>/profiles`` so a
+    hand-edited global jobs.json cannot escape into arbitrary paths.
+    """
+    if profile is None:
+        return None
+    raw = str(profile).strip()
+    if not raw:
+        return None
+    if raw in {".", ".."} or "/" in raw or "\\" in raw:
+        raise ValueError(f"Cron profile must be a simple profile name (got {raw!r})")
+    if not re.match(r"^[A-Za-z0-9_.-]+$", raw):
+        raise ValueError(
+            f"Cron profile contains unsupported characters: {raw!r}. "
+            "Use letters, numbers, dash, underscore, and dot only."
+        )
+    profile_home = get_default_hermes_root() / "profiles" / raw
+    if not profile_home.exists():
+        raise ValueError(f"Cron profile does not exist: {raw!r} ({profile_home})")
+    if not profile_home.is_dir():
+        raise ValueError(f"Cron profile path is not a directory: {profile_home}")
+    return raw
+
+
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     """Normalize and validate a cron job workdir.
 
@@ -436,6 +465,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -480,6 +510,11 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        profile: Optional canonical profile assignment.  When set on a global
+                cron job, the scheduler runs that job with
+                ``HERMES_HOME=<root>/profiles/<profile>`` so profile config,
+                env, SOUL.md, skills, scripts, sessions, and memory resolve
+                under the intended agent.
 
     Returns:
         The created job dict
@@ -514,6 +549,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_profile = _normalize_profile(profile)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -566,6 +602,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "profile": normalized_profile,
     }
 
     jobs = load_jobs()
@@ -601,6 +638,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         # Validate / normalize workdir if present in updates.  Empty string or
         # None both mean "clear the field" (restore old behaviour).
+        if "profile" in updates:
+            _profile = updates["profile"]
+            if _profile in (None, "", False):
+                updates["profile"] = None
+            else:
+                updates["profile"] = _normalize_profile(_profile)
+
         if "workdir" in updates:
             _wd = updates["workdir"]
             if _wd in (None, "", False):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import concurrent.futures
 import contextvars
 import json
+import re
 import logging
 import os
 import subprocess
@@ -26,6 +27,7 @@ except ImportError:
         import msvcrt
     except ImportError:
         msvcrt = None
+from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Optional
 
@@ -34,7 +36,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
@@ -141,6 +143,68 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _job_profile_name(job: dict) -> str:
+    """Return the canonical per-job profile assignment, if any.
+
+    ``profile`` is the canonical field.  ``agent_id`` is accepted as a
+    read-only compatibility alias for hand-authored/imported configs, but new
+    writes should use ``profile``.
+    """
+    raw = job.get("profile") or job.get("agent_id") or ""
+    profile = str(raw).strip()
+    if not profile:
+        return ""
+    if profile in {".", ".."} or "/" in profile or "\\" in profile:
+        raise ValueError(f"Invalid cron job profile assignment: {profile!r}")
+    if not re.match(r"^[A-Za-z0-9_.-]+$", profile):
+        raise ValueError(f"Invalid cron job profile assignment: {profile!r}")
+    return profile
+
+
+def _profile_home_for_job(job: dict) -> Optional[Path]:
+    profile = _job_profile_name(job)
+    if not profile:
+        return None
+    profile_home = (get_default_hermes_root() / "profiles" / profile).resolve()
+    if not profile_home.is_dir():
+        raise ValueError(f"Cron job profile {profile!r} does not exist at {profile_home}")
+    return profile_home
+
+
+@contextmanager
+def _temporary_job_profile_env(job: dict):
+    """Temporarily execute one global cron job under its assigned profile.
+
+    The global scheduler still reads/writes the global jobs.json, but runtime
+    code that resolves config/env/SOUL/skills/scripts/sessions via
+    ``get_hermes_home()`` sees the target profile's home.  We snapshot and
+    restore the entire process environment because loading a profile .env uses
+    override=True.  Profile-assigned jobs are serialized in ``tick()`` so these
+    process-wide mutations cannot race other cron jobs.
+    """
+    profile_home = _profile_home_for_job(job)
+    if profile_home is None:
+        yield
+        return
+
+    old_env = dict(os.environ)
+    os.environ["HERMES_HOME"] = str(profile_home)
+    profile_sub_home = profile_home / "home"
+    if profile_sub_home.is_dir():
+        os.environ["HOME"] = str(profile_sub_home)
+    try:
+        logger.info(
+            "Job '%s': using profile %s (%s)",
+            job.get("id"),
+            _job_profile_name(job),
+            profile_home,
+        )
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -992,7 +1056,7 @@ def _scan_assembled_cron_prompt(assembled: str, job: dict) -> str:
     return assembled
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def _run_job_under_current_home(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -1615,6 +1679,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+    """Execute a cron job, honoring canonical per-job ``profile`` assignment.
+
+    Jobs without ``profile`` retain legacy behavior and run under the
+    scheduler's current HERMES_HOME.  Assigned global jobs run with
+    HERMES_HOME pointed at ``<Hermes root>/profiles/<profile>`` for the
+    duration of the job only.
+    """
+    with _temporary_job_profile_env(job):
+        return _run_job_under_current_home(job)
+
+
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     """
     Check and run all due jobs.
@@ -1730,17 +1806,23 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 mark_job_run(job["id"], False, str(e))
                 return False
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —
+        # Partition due jobs: those with a per-job workdir or profile mutate
+        # process-wide os.environ inside run_job (TERMINAL_CWD/HERMES_HOME/.env),
         # so they MUST run sequentially to avoid corrupting each other.  Jobs
-        # without a workdir leave env untouched and stay parallel-safe.
-        workdir_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        # without either leave env untouched and stay parallel-safe.
+        isolated_jobs = [
+            j for j in due_jobs
+            if (j.get("workdir") or "").strip() or _job_profile_name(j)
+        ]
+        parallel_jobs = [
+            j for j in due_jobs
+            if not ((j.get("workdir") or "").strip() or _job_profile_name(j))
+        ]
 
         _results: list = []
 
-        # Sequential pass for workdir jobs.
-        for job in workdir_jobs:
+        # Sequential pass for jobs that need process-env isolation.
+        for job in isolated_jobs:
             _ctx = contextvars.copy_context()
             _results.append(_ctx.run(_process_job, job))
 

--- a/scripts/verify_cron_profile_migration.py
+++ b/scripts/verify_cron_profile_migration.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify OpenClaw profile-local cron jobs were migrated to global jobs.json.
+
+Checks the known imported OpenClaw profiles under ~/.hermes/profiles/*/cron/jobs.json:
+- every profile-local job id exists in ~/.hermes/cron/jobs.json
+- the global copy has canonical `profile` equal to the source profile
+- profile-local duplicates are neutralized (not enabled/scheduled)
+- the existing global Haven watchdog remains present
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from hermes_constants import get_default_hermes_root
+
+PROFILES = [
+    "dev",
+    "knox",
+    "atlas",
+    "vector",
+    "orion",
+    "nova",
+    "canon",
+    "halo",
+    "snip",
+    "haven",
+    "elon",
+    "sterling",
+]
+HAVEN_WATCHDOG_ID = "698ce0ffa615"
+
+
+def load_jobs(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return list(data.get("jobs", []))
+
+
+def is_neutralized(job: dict) -> bool:
+    return job.get("enabled") is False or job.get("state") in {
+        "migrated_to_global",
+        "paused",
+        "disabled",
+    }
+
+
+def main() -> int:
+    root = get_default_hermes_root()
+    global_path = root / "cron" / "jobs.json"
+    global_jobs = load_jobs(global_path)
+    global_by_id = {job.get("id"): job for job in global_jobs if job.get("id")}
+
+    errors: list[str] = []
+    checked = 0
+
+    if HAVEN_WATCHDOG_ID not in global_by_id:
+        errors.append(f"existing global Haven watchdog missing: {HAVEN_WATCHDOG_ID}")
+
+    for profile in PROFILES:
+        local_path = root / "profiles" / profile / "cron" / "jobs.json"
+        for local in load_jobs(local_path):
+            job_id = local.get("id")
+            if not job_id:
+                errors.append(f"{local_path}: job missing id")
+                continue
+            checked += 1
+            migrated = global_by_id.get(job_id)
+            if not migrated:
+                errors.append(f"{profile}:{job_id} remains only in profile-local cron file")
+                continue
+            if migrated.get("profile") != profile:
+                errors.append(
+                    f"{profile}:{job_id} global profile mismatch: "
+                    f"expected {profile!r}, got {migrated.get('profile')!r}"
+                )
+            if not is_neutralized(local):
+                errors.append(f"{profile}:{job_id} profile-local duplicate is still active")
+
+    if errors:
+        print("Cron profile migration verification FAILED:")
+        for error in errors:
+            print(f"- {error}")
+        print(f"Checked profile-local jobs: {checked}")
+        print(f"Global jobs: {len(global_jobs)}")
+        return 1
+
+    print("Cron profile migration verification OK")
+    print(f"Checked profile-local jobs: {checked}")
+    print(f"Global jobs: {len(global_jobs)}")
+    print("Canonical assignment field: profile")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cron/test_cron_profile_assignment.py
+++ b/tests/cron/test_cron_profile_assignment.py
@@ -1,0 +1,98 @@
+"""Tests for global cron per-job profile assignment."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def root_with_profiles(tmp_path, monkeypatch):
+    """Use a synthetic Hermes root with a global home plus named profiles."""
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    (root / "cron").mkdir()
+    (root / "scripts").mkdir()
+    profiles = root / "profiles"
+    profiles.mkdir()
+    for name in ("dev", "nova"):
+        home = profiles / name
+        (home / "cron").mkdir(parents=True)
+        (home / "scripts").mkdir()
+        (home / "skills").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return root
+
+
+def test_create_job_stores_canonical_profile(root_with_profiles):
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="say hi",
+        schedule="every 5m",
+        deliver="local",
+        profile="dev",
+    )
+
+    assert job["profile"] == "dev"
+    assert get_job(job["id"])["profile"] == "dev"
+
+
+def test_create_job_rejects_profile_path_escape(root_with_profiles):
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="simple profile name|unsupported characters"):
+        create_job(
+            prompt="say hi",
+            schedule="every 5m",
+            deliver="local",
+            profile="../dev",
+        )
+
+
+def test_run_job_no_agent_uses_assigned_profile_home_and_restores_env(root_with_profiles):
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    global_script = root_with_profiles / "scripts" / "whoami.sh"
+    global_script.write_text("#!/bin/bash\necho global\n")
+    profile_script = root_with_profiles / "profiles" / "dev" / "scripts" / "whoami.sh"
+    profile_script.write_text("#!/bin/bash\nprintf 'home=%s\\n' \"$HERMES_HOME\"\n")
+
+    original_home = os.environ["HERMES_HOME"]
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="whoami.sh",
+        no_agent=True,
+        deliver="local",
+        profile="dev",
+    )
+
+    success, doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert str(root_with_profiles / "profiles" / "dev") in final_response
+    assert "global" not in final_response
+    assert os.environ["HERMES_HOME"] == original_home
+
+
+def test_tick_serializes_profile_jobs_and_leaves_plain_jobs_parallel(root_with_profiles):
+    from cron.scheduler import _job_profile_name
+
+    assert _job_profile_name({"profile": "nova"}) == "nova"
+    assert _job_profile_name({"agent_id": "dev"}) == "dev"
+    assert _job_profile_name({}) == ""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -755,6 +755,122 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_shutdown_sessions_finalizes_live_agent_id_and_closes_worker(monkeypatch):
+    ended: list[tuple[str, str]] = []
+    closed: list[str] = []
+
+    class _Worker:
+        def close(self):
+            closed.append("worker")
+
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: types.SimpleNamespace(end_session=lambda sid, reason: ended.append((sid, reason))),
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    server._sessions["stale-key"] = _session(
+        agent=types.SimpleNamespace(session_id="live-agent-id"),
+        slash_worker=_Worker(),
+    )
+
+    try:
+        server._shutdown_sessions()
+        server._shutdown_sessions()
+    finally:
+        server._sessions.pop("stale-key", None)
+
+    assert ended == [("live-agent-id", "tui_shutdown")]
+    assert closed == ["worker"]
+    assert "stale-key" not in server._sessions
+
+
+def test_shutdown_signal_runs_session_closeout_before_exit(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(server, "_shutdown_sessions", lambda: calls.append("shutdown"))
+
+    try:
+        server._handle_shutdown_signal(15, None)
+    except SystemExit as exc:
+        assert exc.code == 143
+    else:  # pragma: no cover - defensive
+        raise AssertionError("shutdown signal handler did not exit")
+
+    assert calls == ["shutdown"]
+
+
+def test_slash_worker_close_prefers_stdin_eof_before_terminate(monkeypatch):
+    events: list[str] = []
+
+    class _Stdin:
+        def close(self):
+            events.append("stdin.close")
+
+    class _Proc:
+        stdin = _Stdin()
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            events.append(f"wait:{timeout}")
+            return 0
+
+        def terminate(self):
+            events.append("terminate")
+
+        def kill(self):
+            events.append("kill")
+
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: _Proc())
+
+    worker = server._SlashWorker("session-key", "model")
+    worker.close()
+
+    assert events == ["stdin.close", "wait:1"]
+
+
+def test_slash_worker_close_terminates_when_eof_does_not_exit(monkeypatch):
+    events: list[str] = []
+
+    class _Stdin:
+        def close(self):
+            events.append("stdin.close")
+
+    class _Proc:
+        stdin = _Stdin()
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def __init__(self):
+            self.waits = 0
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.waits += 1
+            events.append(f"wait:{timeout}")
+            if self.waits == 1:
+                raise TimeoutError("still running")
+            return 0
+
+        def terminate(self):
+            events.append("terminate")
+
+        def kill(self):
+            events.append("kill")
+
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: _Proc())
+
+    worker = server._SlashWorker("session-key", "model")
+    worker.close()
+
+    assert events == ["stdin.close", "wait:1", "terminate", "wait:1"]
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -251,6 +251,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("profile"):
+        result["profile"] = job["profile"]
     return result
 
 
@@ -274,6 +276,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    profile: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -341,6 +344,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                profile=_normalize_optional_job_value(profile),
             )
             return json.dumps(
                 {
@@ -454,6 +458,10 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if profile is not None:
+                # Canonical per-job profile assignment for global cron jobs.
+                # Empty string clears the field; update_job() validates names.
+                updates["profile"] = _normalize_optional_job_value(profile) or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -605,7 +613,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "workdir": {
                 "type": "string",
-                "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
+                "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
+            },
+            "profile": {
+                "type": "string",
+                "description": "Optional canonical Hermes profile assignment for global cron jobs. When set, the scheduler executes this job with HERMES_HOME pointing at ~/.hermes/profiles/<profile>, so profile config, .env, SOUL.md, skills, scripts, sessions, and memory resolve under that agent. Empty string clears on update."
             },
         },
         "required": ["action"]
@@ -655,6 +667,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        profile=args.get("profile"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import queue
+import signal
 import subprocess
 import sys
 import threading
@@ -253,8 +254,21 @@ class _SlashWorker:
             )
 
     def close(self):
+        # Prefer a cooperative EOF so the worker can run its own finally blocks
+        # (notably closing/re-ending the resumed SessionDB row). A hard
+        # terminate is still the fallback for wedged command handlers.
         try:
             if self.proc.poll() is None:
+                try:
+                    if self.proc.stdin:
+                        self.proc.stdin.close()
+                except Exception:
+                    pass
+                try:
+                    self.proc.wait(timeout=1)
+                    return
+                except Exception:
+                    pass
                 self.proc.terminate()
                 self.proc.wait(timeout=1)
         except Exception:
@@ -319,7 +333,11 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
 
 def _shutdown_sessions() -> None:
-    for session in list(_sessions.values()):
+    for session_key, session in list(_sessions.items()):
+        # Remove before closeout so signal + atexit, or nested shutdown paths,
+        # cannot repeatedly finalize/kill the same worker.
+        if _sessions.get(session_key) is session:
+            _sessions.pop(session_key, None)
         _finalize_session(session, end_reason="tui_shutdown")
         try:
             worker = session.get("slash_worker")
@@ -327,6 +345,28 @@ def _shutdown_sessions() -> None:
                 worker.close()
         except Exception:
             pass
+
+
+def _handle_shutdown_signal(signum, _frame) -> None:
+    """Finalize TUI sessions before SIGTERM/SIGHUP/SIGINT exits the gateway.
+
+    The Node TUI calls ``ChildProcess.kill()`` during `/quit` and signal
+    cleanup. Python's default SIGTERM action exits immediately and skips
+    ``atexit``, which leaves SessionDB rows open and can orphan persistent
+    slash-worker subprocesses. Run the same closeout path explicitly before
+    exiting with the conventional signal-derived code.
+    """
+    try:
+        _shutdown_sessions()
+    finally:
+        raise SystemExit(128 + int(signum))
+
+
+for _sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    try:
+        signal.signal(_sig, _handle_shutdown_signal)
+    except Exception:
+        pass
 
 
 atexit.register(_shutdown_sessions)

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -43,6 +43,18 @@ def _run(cli: HermesCLI, command: str) -> str:
     return buf.getvalue().rstrip()
 
 
+def _close_cli_session(cli: HermesCLI, reason: str = "slash_worker_exit") -> None:
+    """Best-effort closeout for the resumed CLI session owned by this worker."""
+    session_id = getattr(cli, "session_id", None)
+    db = getattr(cli, "_session_db", None)
+    if not session_id or db is None:
+        return
+    try:
+        db.end_session(session_id, reason)
+    except Exception:
+        pass
+
+
 def main():
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--session-key", required=True)
@@ -55,21 +67,24 @@ def main():
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
 
-    for raw in sys.stdin:
-        line = raw.strip()
-        if not line:
-            continue
+    try:
+        for raw in sys.stdin:
+            line = raw.strip()
+            if not line:
+                continue
 
-        rid = None
-        try:
-            req = json.loads(line)
-            rid = req.get("id")
-            out = _run(cli, req.get("command", ""))
-            sys.stdout.write(json.dumps({"id": rid, "ok": True, "output": out}) + "\n")
-            sys.stdout.flush()
-        except Exception as e:
-            sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")
-            sys.stdout.flush()
+            rid = None
+            try:
+                req = json.loads(line)
+                rid = req.get("id")
+                out = _run(cli, req.get("command", ""))
+                sys.stdout.write(json.dumps({"id": rid, "ok": True, "output": out}) + "\n")
+                sys.stdout.flush()
+            except Exception as e:
+                sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")
+                sys.stdout.flush()
+    finally:
+        _close_cli_session(cli)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- finalize open TUI sessions when the gateway receives SIGTERM/SIGINT/SIGHUP
- make gateway shutdown idempotent and close slash workers cooperatively via stdin EOF before terminate/kill fallback
- end the slash worker's resumed CLI session in a best-effort finally block

## Tests
- source /home/solo/.hermes/hermes-agent/venv/bin/activate && pytest -q tests/test_tui_gateway_server.py
- source /home/solo/.hermes/hermes-agent/venv/bin/activate && pytest -q tests/tui_gateway/test_protocol.py tests/test_lazy_session_regressions.py
- source /home/solo/.hermes/hermes-agent/venv/bin/activate && python -m py_compile tui_gateway/server.py tui_gateway/slash_worker.py
- git diff --check