### PR TITLE
fix: honor disabled toolsets in cron runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -55,6 +55,43 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _normalize_toolset_list(value) -> list[str]:
+    """Normalize config-provided toolset names while preserving order."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        raw_items = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = value
+    else:
+        return []
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for item in raw_items:
+        name = str(item).strip()
+        if name and name not in seen:
+            seen.add(name)
+            normalized.append(name)
+    return normalized
+
+
+def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
+    """Resolve toolsets a cron-spawned agent must never receive.
+
+    Cron always withholds tools that would recurse or require interactive
+    user input from unattended jobs. User-level ``agent.disabled_toolsets``
+    must be layered on top so per-job ``enabled_toolsets`` cannot bypass the
+    same policy that applies to ordinary agent runs.
+    """
+    disabled = ["cronjob", "messaging", "clarify"]
+    if isinstance(cfg, dict):
+        agent_cfg = cfg.get("agent", {})
+        if isinstance(agent_cfg, dict):
+            disabled.extend(_normalize_toolset_list(agent_cfg.get("disabled_toolsets")))
+    return _normalize_toolset_list(disabled)
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -1442,7 +1479,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
-            disabled_toolsets=["cronjob", "messaging", "clarify"],
+            disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -959,6 +959,39 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_keeps_config_disabled_toolsets_with_per_job_enabled_toolsets(self, tmp_path):
+        """Per-job enabled_toolsets must not bypass user-disabled toolsets."""
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  disabled_toolsets:\n"
+            "    - terminal\n"
+            "    - file\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "policy-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["web", "terminal", "file"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
+        assert set(kwargs["disabled_toolsets"]) >= {
+            "cronjob",
+            "messaging",
+            "clarify",
+            "terminal",
+            "file",
+        }
+
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
         resolves them from ``hermes tools`` platform config for ``cron``


### PR DESCRIPTION
## Summary
- Ensures cron-spawned agents inherit user-level `agent.disabled_toolsets`
- Keeps cron's hard-disabled `cronjob`, `messaging`, and `clarify` protections
- Adds regression coverage for per-job `enabled_toolsets` not bypassing disabled toolsets

## Test Plan
- `git diff --check origin/main...HEAD`
- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
