### PR TITLE
fix(agent/gemini-cloudcode): seed delta defaults for reasoning-only stream chunks (#25762)

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -450,7 +450,13 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": None,
+        "reasoning": None,
+        "reasoning_content": None,
+    }
     if content:
         delta_kwargs["content"] = content
     if tool_call_delta is not None:

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -913,6 +913,35 @@ class TestTranslateStreamEvent:
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
 
+class TestMakeStreamChunk:
+    def test_reasoning_only_chunk_has_content_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", reasoning="think")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.reasoning == "think"
+
+    def test_content_only_chunk_has_reasoning_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", content="hello")
+        delta = chunk.choices[0].delta
+        assert delta.content == "hello"
+        assert delta.reasoning is None
+        assert delta.tool_calls is None
+
+    def test_finish_only_chunk_has_all_fields_none(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", finish_reason="stop")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.reasoning is None
+        assert delta.tool_calls is None
+        assert chunk.choices[0].finish_reason == "stop"
+
+
 class TestGeminiCloudCodeClient:
     def test_client_exposes_openai_interface(self):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient


### PR DESCRIPTION
Gemini cloudcode adapter could emit stream chunks where the delta has only reasoning content and no `role`/`content`/`tool_calls` defaults, causing downstream code to KeyError when it expected the standard delta shape.

Seeds default fields on reasoning-only chunks so they match the standard shape. Includes 3 regression tests covering all delta variants — supersedes the test-less #24984.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25762 by @EthanGuo-coder.