### PR TITLE
fix(agent): activate fallback chain on stale stream kill (#25689)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7822,6 +7822,11 @@ class AIAgent:
         if self._interrupt_requested:
             raise InterruptedError("Agent interrupted before streaming API call")
 
+        # One-shot guard for the stale-stream fallback activation (#25689).
+        # Reset per call so each new attempt gets one chance to advance the
+        # fallback chain when the stale detector fires.
+        self._stale_fallback_activated_this_call = False
+
         if self.api_mode == "codex_responses":
             # Codex streams internally via _run_codex_stream. The main dispatch
             # in _interruptible_api_call already calls it; we just need to
@@ -8606,6 +8611,8 @@ class AIAgent:
                     self._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
                 except Exception:
                     pass
+                # Eager fallback on stale stream (#25689). See helper.
+                self._maybe_activate_fallback_on_stale_stream()
                 # Reset the timer so we don't kill repeatedly while
                 # the inner thread processes the closure.
                 last_chunk_time["t"] = time.time()
@@ -8693,6 +8700,50 @@ class AIAgent:
         return result["response"]
 
     # ── Provider fallback ──────────────────────────────────────────────────
+
+    def _maybe_activate_fallback_on_stale_stream(self) -> bool:
+        """Advance the fallback chain (if configured) on the first stale
+        stream kill of the current ``_interruptible_streaming_api_call``
+        call.
+
+        An unresponsive primary that holds the SSE connection without
+        delivering chunks won't recover by retrying itself — retries just
+        burn another ``_stream_stale_timeout`` window per attempt. By
+        activating the fallback eagerly, the outer retry loop comes back
+        with the next provider's client.
+
+        Returns ``True`` if a fallback was activated this call, ``False``
+        otherwise. The one-shot guard
+        (``_stale_fallback_activated_this_call``) prevents
+        double-activation when multiple stale ticks fire before the
+        worker thread sees the connection closure. The guard is reset at
+        the top of each ``_interruptible_streaming_api_call`` call.
+        Fixes #25689.
+        """
+        if getattr(self, "_stale_fallback_activated_this_call", False):
+            return False
+        self._stale_fallback_activated_this_call = True
+        try:
+            if (
+                getattr(self, "_fallback_index", 0)
+                >= len(getattr(self, "_fallback_chain", []) or [])
+            ):
+                return False
+            from agent.error_classifier import FailoverReason as _FR
+            if not self._try_activate_fallback(reason=_FR.timeout):
+                return False
+            try:
+                self._emit_status(
+                    "⚠️ Stale stream — switching to fallback provider."
+                )
+            except Exception:
+                pass
+            return True
+        except Exception:
+            logger.debug(
+                "stale stream fallback activation failed", exc_info=True
+            )
+            return False
 
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Switch to the next fallback model/provider in the chain.

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -668,6 +668,83 @@ class TestStreamingFallback:
         assert mock_client.chat.completions.create.call_count == 1
 
 
+class TestStaleStreamFallbackActivation:
+    """#25689 — when the stream stale detector fires, the fallback chain
+    should be activated so the outer retry loop comes back with the next
+    provider, not the same unresponsive one."""
+
+    def _make_agent(self):
+        from run_agent import AIAgent
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://primary.example.com/v1",
+            model="primary/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    def test_first_stale_kill_activates_fallback(self):
+        agent = self._make_agent()
+        agent._stale_fallback_activated_this_call = False
+        agent._fallback_chain = [{"provider": "z", "model": "next/model"}]
+        agent._fallback_index = 0
+        called = {}
+        def _fake(reason=None):
+            called["reason"] = reason
+            agent._fallback_index += 1
+            return True
+        agent._try_activate_fallback = _fake  # type: ignore[assignment]
+        assert agent._maybe_activate_fallback_on_stale_stream() is True
+        assert called.get("reason") is not None
+        assert called["reason"].value == "timeout"
+
+    def test_second_stale_kill_in_same_call_is_noop(self):
+        """Multiple stale ticks within one call must not double-advance
+        the chain — the one-shot guard handles it."""
+        agent = self._make_agent()
+        agent._stale_fallback_activated_this_call = False
+        agent._fallback_chain = [
+            {"provider": "z", "model": "next/model"},
+            {"provider": "z", "model": "third/model"},
+        ]
+        agent._fallback_index = 0
+        agent._try_activate_fallback = lambda reason=None: (  # type: ignore[assignment]
+            setattr(agent, "_fallback_index", agent._fallback_index + 1) or True
+        )
+        assert agent._maybe_activate_fallback_on_stale_stream() is True
+        assert agent._fallback_index == 1
+        # Second call within the same _interruptible_streaming_api_call:
+        assert agent._maybe_activate_fallback_on_stale_stream() is False
+        assert agent._fallback_index == 1
+
+    def test_no_fallback_when_chain_exhausted(self):
+        agent = self._make_agent()
+        agent._stale_fallback_activated_this_call = False
+        agent._fallback_chain = [{"provider": "z", "model": "next/model"}]
+        agent._fallback_index = 1  # already past the end
+        called = {"count": 0}
+        def _fake(reason=None):
+            called["count"] += 1
+            return False
+        agent._try_activate_fallback = _fake  # type: ignore[assignment]
+        assert agent._maybe_activate_fallback_on_stale_stream() is False
+        assert called["count"] == 0
+
+    def test_no_fallback_when_chain_empty(self):
+        agent = self._make_agent()
+        agent._stale_fallback_activated_this_call = False
+        agent._fallback_chain = []
+        agent._fallback_index = 0
+        called = {"count": 0}
+        agent._try_activate_fallback = (
+            lambda reason=None: called.__setitem__("count", called["count"] + 1)
+            or False
+        )
+        assert agent._maybe_activate_fallback_on_stale_stream() is False
+        assert called["count"] == 0
+
+
 # ── Test: Reasoning Streaming ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #25689 (P1). When the stream stale detector kills an unresponsive primary, the retry comes back with the **same** primary's rebuilt client and burns another stale-timeout window. If the primary is alive-but-stuck (proxy hung, model stalled, gateway holding the SSE socket without delivering chunks), the agent loops on the same provider until `max_retries` is exhausted — even though a configured `fallback_providers` chain is sitting idle.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

On the **first** stale kill of an `_interruptible_streaming_api_call` invocation, advance the fallback chain via `_try_activate_fallback(reason=FailoverReason.timeout)`. The outer retry loop comes back with the next provider's client instead of the stuck primary's.

- New helper `_maybe_activate_fallback_on_stale_stream` encapsulates the decision so it's unit-testable in isolation and the call site stays a single line.
- One-shot guard `_stale_fallback_activated_this_call` prevents multiple stale ticks from double-advancing the chain inside a single call. Reset at the top of `_interruptible_streaming_api_call`.
- Uses `FailoverReason.timeout` — matches the existing classifier enum used for connection-level timeouts and integrates with the rate-limit cooldown logic already in `_try_activate_fallback`.
- The original behaviour (close request client, rebuild primary pool) is unchanged when no fallback chain is configured.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Fixes #25689 (P1). When the stream stale detector kills an unresponsive primary, the retry comes back with the **same** primary's rebuilt client and burns another stale-timeout window. If the primary is alive-but-stuck (proxy hung, model stalled, gateway holding the SSE socket without delivering chunks), the agent loops on the same provider until `max_retries` is exhausted — even though a configured `fallback_providers` chain is sitting idle.

<details>
<summary>Original body</summary>

## Summary

Fixes #25689 (P1). When the stream stale detector kills an unresponsive primary, the retry comes back with the **same** primary's rebuilt client and burns another stale-timeout window. If the primary is alive-but-stuck (proxy hung, model stalled, gateway holding the SSE socket without delivering chunks), the agent loops on the same provider until `max_retries` is exhausted — even though a configured `fallback_providers` chain is sitting idle.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Fixes #25689 (P1). When the stream stale detector kills an unresponsive primary, the retry comes back with the **same** primary's rebuilt client and burns another stale-timeout window. If the primary is alive-but-stuck (proxy hung, model stalled, gateway holding the SSE socket without delivering chunks), the agent loops on the same provider until `max_retries` is exhausted — even though a configured `fallback_providers` chain is sitting idle.

## Root cause (from issue)

Reporter @vibegin pinpointed `run_agent.py` around line 7514-7546 (current line 8505 in main):

```python
_stale_elapsed = time.time() - last_chunk_time["t"]
if _stale_elapsed > _stream_stale_timeout:
    # ... logs warning, emits status, closes client, rebuilds primary client
    last_chunk_time["t"] = time.time()
    # NEVER calls _try_activate_fallback()
```

The empty/malformed response branch (`run_agent.py:11510-11519`) already activates fallback correctly. The stale-stream branch had the same gap.

## Fix

On the **first** stale kill of an `_interruptible_streaming_api_call` invocation, advance the fallback chain via `_try_activate_fallback(reason=FailoverReason.timeout)`. The outer retry loop comes back with the next provider's client instead of the stuck primary's.

- New helper `_maybe_activate_fallback_on_stale_stream` encapsulates the decision so it's unit-testable in isolation and the call site stays a single line.
- One-shot guard `_stale_fallback_activated_this_call` prevents multiple stale ticks from double-advancing the chain inside a single call. Reset at the top of `_interruptible_streaming_api_call`.
- Uses `FailoverReason.timeout` — matches the existing classifier enum used for connection-level timeouts and integrates with the rate-limit cooldown logic already in `_try_activate_fallback`.
- The original behaviour (close request client, rebuild primary pool) is unchanged when no fallback chain is configured.

## Solution sketch

```mermaid
flowchart TD
    A[Stream stale > _stream_stale_timeout] --> B[Close request client]
    B --> C[Rebuild primary pool]
    C --> D{first stale kill this call?}
    D -- no --> E[Reset timer, continue loop]
    D -- yes --> F{fallback_chain has more entries?}
    F -- no --> E
    F -- yes --> G[_try_activate_fallback timeout]
    G --> H{succeeded?}
    H -- no --> E
    H -- yes --> I[Emit 'switching to fallback' status]
    I --> E
    E --> J[Worker thread sees closed connection]
    J --> K[Outer retry loop, now with next provider's client]
```

## Tests

```
python -m pytest tests/run_agent/test_streaming.py::TestStaleStreamFallbackActivation -q
# 4 passed
```

4 new test cases:

- `test_first_stale_kill_activates_fallback` — fallback chain has entries, `_try_activate_fallback` is called with `FailoverReason.timeout`.
- `test_second_stale_kill_in_same_call_is_noop` — the one-shot guard prevents double-advance.
- `test_no_fallback_when_chain_exhausted` — chain at end → no call.
- `test_no_fallback_when_chain_empty` — empty chain → no call.

## Risk

Low.

- The behaviour change is additive: when no fallback chain is configured, every code path is identical to before.
- When a chain IS configured and stale detection fires, the next attempt uses the documented next-provider semantics already validated by the empty/malformed response branch and `_try_activate_fallback`'s own deduplication and skip logic.
- The one-shot guard protects against multiple stale ticks within one streaming call.

## Duplicate check

- `gh pr list --state open --search "25689 in:body,title"` → 0
- `gh pr list --state open --search "stale stream fallback"` → 0
- `gh pr list --search "stale stream is:merged author:teknium1"` → 0

## Funnel discipline

Opened under doc 23. Reporter offered an explicit suggested fix in the issue; this PR is essentially that suggestion, extracted into a testable helper and gated with a one-shot guard.

## Related Issue

Fixes #25689 (P1). When the stream stale detector kills an unresponsive primary, the retry comes back with the **same** primary's rebuilt client and burns another stale-timeout window. If the primary is alive-but-stuck (proxy hung, model stalled, gateway holding the SSE socket without delivering chunks), the agent loops on the same provider until `max_retries` is exhausted — even though a configured `fallback_providers` chain is sitting idle.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Run `python -m pytest tests/run_agent/test_streaming.py::TestStaleStreamFallbackActivation -q`.
2. Confirm the scoped behavior described above still holds after the focused checks.
3. Confirm the scoped behavior described above still holds after the focused checks.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_