### PR TITLE
fix(web): make sync-assets script cross-platform (#25760)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync-assets": "rm -rf public/fonts public/ds-assets && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets",
+    "sync-assets": "node -e \"const fs=require('fs');fs.rmSync('public/fonts',{recursive:true,force:true});fs.rmSync('public/ds-assets',{recursive:true,force:true});fs.cpSync('node_modules/@nous-research/ui/dist/fonts','public/fonts',{recursive:true});fs.cpSync('node_modules/@nous-research/ui/dist/assets','public/ds-assets',{recursive:true});\"",
     "predev": "npm run sync-assets",
     "prebuild": "npm run sync-assets",
     "dev": "vite",


### PR DESCRIPTION
The `web/package.json` sync-assets script used Unix `rm -rf` and `cp -r`, which fail on native Windows. Replaces with Node.js fs API calls (Node ≥16.7) — same behavior on POSIX, works on Windows, no new deps.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25760 by @HxT9.