### PR TITLE
fix: prevent dispatcher from spawning duplicate singleton tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4693,7 +4693,8 @@ class GatewayRunner:
                         # happened, so an idle gateway stays silent.
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                            "skipped_singleton=%d",
                             slug,
                             len(res.spawned),
                             res.reclaimed,
@@ -4701,6 +4702,7 @@ class GatewayRunner:
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            len(res.skipped_singleton) if hasattr(res, "skipped_singleton") else 0,
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1698,6 +1698,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_singleton": res.skipped_singleton,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -1721,6 +1722,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.skipped_singleton:
+        print(
+            f"Skipped (singleton — task with same skills already running): "
+            f"{', '.join(res.skipped_singleton)}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2913,6 +2913,11 @@ class DispatchResult:
     available) from "correctly idle" (nothing spawnable in the queue)."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
+    skipped_singleton: list[str] = field(default_factory=list)
+    """Ready task ids skipped because another task with identical skills
+    is already ``running``. Prevents simultaneous spawn of singleton agents
+    (e.g. groomer, sentinel) that check for duplicates at runtime —
+    by the time they run, the dispatcher has already spawned both."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
@@ -3800,6 +3805,23 @@ def dispatch_once(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
+        # Singleton guard: before claiming a task, check if another task
+        # with identical skills is already running. This prevents the
+        # dispatcher from spawning multiple singleton agents (groomer,
+        # sentinel, etc.) in the same tick — the runtime singleton check
+        # in the skill can't prevent duplicates when both tasks check
+        # simultaneously and neither sees the other as running yet.
+        task_skills = conn.execute(
+            "SELECT skills FROM tasks WHERE id = ?", (row["id"],)
+        ).fetchone()
+        if task_skills and task_skills["skills"]:
+            conflict = conn.execute(
+                "SELECT 1 FROM tasks WHERE status = 'running' AND id != ? AND skills = ? LIMIT 1",
+                (row["id"], task_skills["skills"]),
+            ).fetchone()
+            if conflict:
+                result.skipped_singleton.append(row["id"])
+                continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -748,6 +748,71 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     assert res.reclaimed == 1
 
 
+def test_dispatch_skips_singleton_duplicates(
+    kanban_home, all_assignees_spawnable
+):
+    """When two tasks with identical skills are in ready, only one spawns.
+
+    This prevents the race condition where the dispatcher spawns multiple
+    singleton agents (groomer, sentinel, etc.) simultaneously before any
+    of them can transition to ``running`` — the runtime singleton check
+    in the skill can't prevent duplicates when both check together.
+    """
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        # Create two tasks with identical skills and assignee
+        a = kb.create_task(
+            conn, title="groomer-a", assignee="groomer",
+            skills=["sdlc-groomer", "kanban-worker"],
+        )
+        b = kb.create_task(
+            conn, title="groomer-b", assignee="groomer",
+            skills=["sdlc-groomer", "kanban-worker"],
+        )
+        # First dispatch spawns a, which transitions to running
+        res1 = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert a in [tid for tid, _, _ in res1.spawned]
+        assert b in res1.skipped_singleton
+        assert len(spawns) == 1
+
+        # Simulate a completing, then dispatch again — b should now spawn
+        kb.complete_task(conn, a)
+        res2 = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert b in [tid for tid, _, _ in res2.spawned]
+        assert len(spawns) == 2
+
+
+def test_dispatch_allows_different_skills_concurrently(
+    kanban_home, all_assignees_spawnable
+):
+    """Tasks with different skills should still run concurrently.
+
+    ``agentneo-sdlc`` workers and ``sdlc-groomer`` singleton tasks
+    have different skill sets — they should not block each other.
+    """
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        groomer = kb.create_task(
+            conn, title="groomer", assignee="groomer",
+            skills=["sdlc-groomer", "kanban-worker"],
+        )
+        worker = kb.create_task(
+            conn, title="worker", assignee="worker",
+            skills=["agentneo-sdlc"],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        assert len(res.spawned) == 2
+        assert len(spawns) == 2
+
+
 # ---------------------------------------------------------------------------
 # Workspace resolution
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The dispatcher spawns workers from the `ready` queue in a single tick. When two tasks with identical skills (e.g., two groomer tasks both with `sdlc-groomer`) are both `ready`, the dispatcher spawns both simultaneously before either can transition to `running`. 

The runtime singleton guard in the skill can't prevent this — both workers check simultaneously and neither sees the other as running yet.

**Evidence:** Two groomer tasks (`t_e63ec091`, `t_a776e9f2`) were spawned at the exact same second (1778768750), both reaching `running`.

## Fix

Before claiming a task in `dispatch_once`, check if another task with **identical skills** (same JSON `skills` column) is already `running`. Skip if so.

This uses exact skills match, so tasks with different skill sets (e.g., a groomer with `sdlc-groomer` and a worker with `agentneo-sdlc`) are allowed to run concurrently — only identical-skill duplicates are blocked.

### Changes

1. **`kanban_db.py`**: Add `skipped_singleton` to `DispatchResult`, add singleton check before `claim_task`
2. **`gateway/run.py`**: Include `skipped_singleton` count in telemetry
3. **`kanban.py`**: Include `skipped_singleton` in CLI dispatch report (JSON + text)
4. **`test_kanban_db.py`**: 2 new tests — duplicate-prevention and concurrency-allowance

### Test results

```
84 passed (test_kanban_db.py)
190 passed (test_kanban_core_functionality.py + test_kanban_cli.py)
```

## Closes

Refs #1365 (agentneo tracker)