### PR TITLE
fix(gateway): enable faulthandler so C-extension crashes leave a traceback (#25666)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3099,6 +3099,38 @@ def _guard_official_docker_root_gateway() -> None:
     sys.exit(1)
 
 
+def _enable_faulthandler_for_gateway() -> bool:
+    """Enable Python's native fault handler for the gateway process.
+
+    Surfaces a Python+C traceback to stderr on SIGSEGV / SIGFPE /
+    SIGABRT / SIGBUS / SIGILL inside a C extension (httpx, openssl,
+    grpc, cryptography on ARM, etc.) instead of leaving operators with
+    just ``status=11/SEGV`` in journald and no clue which call frame
+    triggered the crash. Particularly relevant on ARM/aarch64 hosts
+    (Raspberry Pi) where C-extension crashes have been observed in
+    Telegram reconnect paths (#25666).
+
+    Returns ``True`` if faulthandler is enabled after this call,
+    ``False`` if disabled by env var or skipped due to an exception.
+
+    Opt-out via ``HERMES_DISABLE_FAULTHANDLER=1`` for platforms where
+    faulthandler itself is unstable. Best-effort: any exception during
+    ``enable()`` is silently swallowed so an environment without
+    writable stderr can't break gateway startup.
+    """
+    if os.environ.get(
+        "HERMES_DISABLE_FAULTHANDLER", ""
+    ).strip().lower() in ("1", "true", "yes"):
+        return False
+    try:
+        import faulthandler
+        if not faulthandler.is_enabled():
+            faulthandler.enable(all_threads=True)
+        return faulthandler.is_enabled()
+    except Exception:
+        return False
+
+
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """Run the gateway in foreground.
     
@@ -3111,6 +3143,9 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """
     _guard_official_docker_root_gateway()
     sys.path.insert(0, str(PROJECT_ROOT))
+
+    # Surface a Python+C traceback on any C-extension crash (#25666).
+    _enable_faulthandler_for_gateway()
 
     # Detached Windows gateway runs must ignore console-control broadcasts
     # from sibling CLI processes, but foreground `hermes gateway run` still

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -165,6 +165,52 @@ def test_run_gateway_windows_detached_absorbs_console_controls(monkeypatch):
     assert (gateway.signal.SIGINT, gateway.signal.SIG_IGN) in signal_calls
 
 
+class TestEnableFaulthandler:
+    """#25666: gateway must enable faulthandler so the next C-extension
+    crash surfaces a usable Python+C traceback to stderr."""
+
+    def test_enable_returns_true_when_module_available(self, monkeypatch):
+        # Ensure no opt-out is set
+        monkeypatch.delenv("HERMES_DISABLE_FAULTHANDLER", raising=False)
+        import faulthandler
+        # Some test runners pre-enable faulthandler; record state to restore.
+        was_enabled = faulthandler.is_enabled()
+        if was_enabled:
+            faulthandler.disable()
+        try:
+            assert gateway._enable_faulthandler_for_gateway() is True
+            assert faulthandler.is_enabled() is True
+        finally:
+            if not was_enabled:
+                faulthandler.disable()
+
+    def test_opt_out_skips_enable(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISABLE_FAULTHANDLER", "1")
+        import faulthandler
+        was_enabled = faulthandler.is_enabled()
+        if was_enabled:
+            faulthandler.disable()
+        try:
+            assert gateway._enable_faulthandler_for_gateway() is False
+            assert faulthandler.is_enabled() is False
+        finally:
+            if was_enabled:
+                faulthandler.enable(all_threads=True)
+
+    def test_opt_out_accepts_common_truthy_values(self, monkeypatch):
+        for value in ("true", "TRUE", "yes", "Yes", "1"):
+            monkeypatch.setenv("HERMES_DISABLE_FAULTHANDLER", value)
+            import faulthandler
+            was_enabled = faulthandler.is_enabled()
+            if was_enabled:
+                faulthandler.disable()
+            try:
+                assert gateway._enable_faulthandler_for_gateway() is False
+            finally:
+                if was_enabled:
+                    faulthandler.enable(all_threads=True)
+
+
 class TestSystemdLingerStatus:
     def test_reports_enabled(self, monkeypatch):
         monkeypatch.setattr(gateway, "is_linux", lambda: True)


### PR DESCRIPTION
## What does this PR do?

Diagnostic fix for #25666. Reporter @rab1dd0g hit recurring `status=11/SEGV` (exit 139) on Raspberry Pi aarch64, with the last visible output being a `gateway.platforms.telegram` `httpx.ReadError` reconnect loop. No Python traceback was captured before the crash, so neither the reporter nor maintainers can tell which C-extension call frame triggered the SIGSEGV — making the bug essentially un-diagnosable without more data.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- New helper `hermes_cli.gateway._enable_faulthandler_for_gateway()` enables faulthandler at gateway startup.
- `run_gateway()` calls it right after the docker-root guard and `sys.path` setup, so any C-extension import that follows is covered.
- Opt-out via `HERMES_DISABLE_FAULTHANDLER=1` for the rare platforms where faulthandler itself is unstable (accepts `1`, `true`, `yes`, case-insensitive).
- Best-effort: any exception during `enable()` is silently swallowed so an environment without writable stderr can't break gateway startup.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Fixes #25666

<details>
<summary>Original body</summary>

## Summary

Diagnostic fix for #25666. Reporter @rab1dd0g hit recurring `status=11/SEGV` (exit 139) on Raspberry Pi aarch64, with the last visible output being a `gateway.platforms.telegram` `httpx.ReadError` reconnect loop. No Python traceback was captured before the crash, so neither the reporter nor maintainers can tell which C-extension call frame triggered the SIGSEGV — making the bug essentially un-diagnosable without more data.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Diagnostic fix for #25666. Reporter @rab1dd0g hit recurring `status=11/SEGV` (exit 139) on Raspberry Pi aarch64, with the last visible output being a `gateway.platforms.telegram` `httpx.ReadError` reconnect loop. No Python traceback was captured before the crash, so neither the reporter nor maintainers can tell which C-extension call frame triggered the SIGSEGV — making the bug essentially un-diagnosable without more data.

This PR doesn't fix the SIGSEGV. It makes the **next** SIGSEGV self-document so it *can* be fixed.

## Why a diagnostic-only PR

The root cause is almost certainly in a transitive C extension (httpx → h11/h2 → openssl/cryptography, or grpc, or PyO3-based crypto on aarch64). Without a stack trace, picking the right upstream package to file against is guessing. With faulthandler enabled, the next crash gives:

- Python frame at the crash site (which call into the C lib triggered it)
- C-level signal type (SEGV / BUS / FPE / etc.)
- All-threads dump (`all_threads=True`) so a thread crashing while another holds the GIL is visible

That's enough to turn this issue from "Telegram gateway crashes silently" into a pinpoint actionable report.

## Fix

- New helper `hermes_cli.gateway._enable_faulthandler_for_gateway()` enables faulthandler at gateway startup.
- `run_gateway()` calls it right after the docker-root guard and `sys.path` setup, so any C-extension import that follows is covered.
- Opt-out via `HERMES_DISABLE_FAULTHANDLER=1` for the rare platforms where faulthandler itself is unstable (accepts `1`, `true`, `yes`, case-insensitive).
- Best-effort: any exception during `enable()` is silently swallowed so an environment without writable stderr can't break gateway startup.

## Solution sketch

```mermaid
flowchart TD
    A[hermes -p P gateway run] --> B[run_gateway]
    B --> C[_enable_faulthandler_for_gateway]
    C --> D{HERMES_DISABLE_FAULTHANDLER set?}
    D -- yes --> E[skip]
    D -- no --> F[faulthandler.enable all_threads=True]
    F --> G[gateway boot continues]
    G --> H[Some C extension crashes later]
    H --> I[faulthandler dumps Python+C traceback to stderr]
    I --> J[journald captures it -> actionable bug report]
```

## Tests

```
python -m pytest tests/hermes_cli/test_gateway.py::TestEnableFaulthandler -q
# 3 passed
```

3 new cases on the new `TestEnableFaulthandler` class:

- `test_enable_returns_true_when_module_available` — happy path.
- `test_opt_out_skips_enable` — env var disables it.
- `test_opt_out_accepts_common_truthy_values` — `1`, `true`, `yes` (case-insensitive) all work.

## Risk

- The faulthandler module is stdlib and stable on the platforms Hermes targets.
- The call is guarded with `try/except: pass` so it can't break gateway startup even on a broken interpreter.
- Behaviour with the opt-out env set is bit-for-bit identical to before.
- The faulthandler output goes to stderr only on a fatal signal — no overhead in normal operation.

## Duplicate check

- `gh pr list --state open --search "25666 in:body,title"` → 0
- `gh pr list --state open --search "faulthandler"` → 0
- `gh pr list --state open --search "SIGSEGV"` → 0
- `gh pr list --search "faulthandler is:merged"` → 0

## Funnel discipline

Opened under doc 23. Diagnostic-only contributions for hard-to-reproduce bugs are explicitly endorsed in the doc as a legitimate funnel category — see the #22388 reference pattern in `hermes/23-funnel-discipline.md`.

## Related Issue

Fixes #25666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_gateway.py::TestEnableFaulthandler -q`.
2. Confirm the scoped behavior described above still holds after the focused checks.
3. Confirm the scoped behavior described above still holds after the focused checks.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_