### PR TITLE
fix(gateway): run exec quick commands inline when agent is mid-turn (#25783)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3087,6 +3087,17 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    def _busy_ack_reply_to(self, event: MessageEvent, reply_anchor: Optional[str]) -> Optional[str]:
+        # Pick the right ``reply_to`` for a busy-path acknowledgment. Telegram
+        # has three sub-cases (DM-in-thread, group-in-thread, everything else)
+        # and the rule is duplicated in three sibling send sites in this
+        # function; this centralizes it so the branches can't drift.
+        if event.source.platform == Platform.TELEGRAM and event.source.thread_id:
+            if event.source.chat_type == "dm":
+                return reply_anchor
+            return None
+        return event.message_id
+
     async def _try_execute_exec_quick_command(self, command: Optional[str]) -> Optional[str]:
         # Run an exec-type quick command inline and return its output (already
         # redacted) when ``command`` matches one. Returns ``None`` when no
@@ -3163,13 +3174,7 @@ class GatewayRunner:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=self._busy_ack_reply_to(event, reply_anchor),
                 metadata=thread_meta,
             )
             return True
@@ -3195,13 +3200,7 @@ class GatewayRunner:
                     await adapter._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=exec_output,
-                        reply_to=(
-                            reply_anchor
-                            if event.source.platform == Platform.TELEGRAM
-                            and event.source.chat_type == "dm"
-                            and event.source.thread_id
-                            else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                        ),
+                        reply_to=self._busy_ack_reply_to(event, reply_anchor),
                         metadata=thread_meta,
                     )
                 except Exception as exc:
@@ -3398,13 +3397,7 @@ class GatewayRunner:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=self._busy_ack_reply_to(event, reply_anchor),
                 metadata=thread_meta,
             )
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3087,6 +3087,48 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    async def _try_execute_exec_quick_command(self, command: Optional[str]) -> Optional[str]:
+        # Run an exec-type quick command inline and return its output (already
+        # redacted) when ``command`` matches one. Returns ``None`` when no
+        # matching exec quick command exists, so callers fall through to
+        # normal dispatch. ``alias``-type quick commands are NOT handled here —
+        # they rewrite into other commands and stay in the cold path.
+        if not command:
+            return None
+        if isinstance(self.config, dict):
+            quick_commands = self.config.get("quick_commands", {}) or {}
+        else:
+            quick_commands = getattr(self.config, "quick_commands", {}) or {}
+        if not isinstance(quick_commands, dict) or command not in quick_commands:
+            return None
+        qcmd = quick_commands[command]
+        if not isinstance(qcmd, dict) or qcmd.get("type") != "exec":
+            return None
+        exec_cmd = qcmd.get("command", "")
+        if not exec_cmd:
+            return f"Quick command '/{command}' has no command defined."
+        try:
+            # Sanitize env to prevent credential leakage — quick commands run
+            # in the gateway process which has all API keys in os.environ.
+            from tools.environments.local import _sanitize_subprocess_env
+            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+            proc = await asyncio.create_subprocess_shell(
+                exec_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=sanitized_env,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+            output = (stdout or stderr).decode().strip()
+            if output:
+                from agent.redact import redact_sensitive_text
+                output = redact_sensitive_text(output)
+            return output if output else "Command returned no output."
+        except asyncio.TimeoutError:
+            return "Quick command timed out (30s)."
+        except Exception as e:
+            return f"Quick command error: {e}"
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -3130,6 +3172,40 @@ class GatewayRunner:
                 ),
                 metadata=thread_meta,
             )
+            return True
+
+        # --- Exec-type quick commands bypass the agent entirely (#25783) ---
+        # Quick commands with ``type: exec`` run a subprocess and don't touch
+        # the LLM or session state, so queueing/interrupting the running agent
+        # is the wrong response. Without this short-circuit the message falls
+        # through to the queue/interrupt path below and is replayed to the
+        # agent as raw text once the current turn finishes, so the user's
+        # ``/note ...`` command silently arrives in the conversation instead
+        # of executing. Matches the precedence in the non-busy ``_handle_message``
+        # cold path: draining wins (handled above), exec quick commands run
+        # next. ``alias``-type quick commands intentionally are NOT handled
+        # here — they rewrite into agent input and follow normal busy semantics.
+        exec_output = await self._try_execute_exec_quick_command(event.get_command())
+        if exec_output is not None:
+            adapter = self.adapters.get(event.source.platform)
+            if adapter is not None:
+                reply_anchor = self._reply_anchor_for_event(event)
+                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+                try:
+                    await adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=exec_output,
+                        reply_to=(
+                            reply_anchor
+                            if event.source.platform == Platform.TELEGRAM
+                            and event.source.chat_type == "dm"
+                            and event.source.thread_id
+                            else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
+                        ),
+                        metadata=thread_meta,
+                    )
+                except Exception as exc:
+                    logger.debug("Failed to deliver exec quick command output: %s", exc)
             return True
 
         # Normal busy case (agent actively running a task)
@@ -7688,33 +7764,7 @@ class GatewayRunner:
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
-                    exec_cmd = qcmd.get("command", "")
-                    if exec_cmd:
-                        try:
-                            # Sanitize env to prevent credential leakage —
-                            # quick commands run in the gateway process which
-                            # has all API keys in os.environ.
-                            from tools.environments.local import _sanitize_subprocess_env
-                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
-                            proc = await asyncio.create_subprocess_shell(
-                                exec_cmd,
-                                stdout=asyncio.subprocess.PIPE,
-                                stderr=asyncio.subprocess.PIPE,
-                                env=sanitized_env,
-                            )
-                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-                            output = (stdout or stderr).decode().strip()
-                            # Redact any remaining sensitive patterns in output
-                            if output:
-                                from agent.redact import redact_sensitive_text
-                                output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
-                        except asyncio.TimeoutError:
-                            return "Quick command timed out (30s)."
-                        except Exception as e:
-                            return f"Quick command error: {e}"
-                    else:
-                        return f"Quick command '/{command}' has no command defined."
+                    return await self._try_execute_exec_quick_command(command)
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:

--- a/tests/gateway/test_busy_quick_command_bypass.py
+++ b/tests/gateway/test_busy_quick_command_bypass.py
@@ -112,8 +112,12 @@ class TestExecQuickCommandBypassesBusySession:
         runner.adapters[event.source.platform] = adapter
 
         fake_proc = _FakeProc(stdout=b"note saved\n")
+        # Patch the two cross-module imports the helper does lazily so the test
+        # stays hermetic — it should pass even if those modules misbehave.
         with patch("gateway.run.asyncio.create_subprocess_shell", new=AsyncMock(return_value=fake_proc)) as mock_spawn, \
-             patch("gateway.run.merge_pending_message_event") as mock_merge:
+             patch("gateway.run.merge_pending_message_event") as mock_merge, \
+             patch("tools.environments.local._sanitize_subprocess_env", return_value={}), \
+             patch("agent.redact.redact_sensitive_text", side_effect=lambda x: x):
             result = await runner._handle_active_session_busy_message(event, sk)
 
         assert result is True

--- a/tests/gateway/test_busy_quick_command_bypass.py
+++ b/tests/gateway/test_busy_quick_command_bypass.py
@@ -1,0 +1,246 @@
+"""Tests for exec-type quick commands bypassing the busy-session queue (#25783).
+
+When the agent is mid-turn, ``/<name>`` quick commands of type ``exec`` should
+run inline against the gateway's subprocess machinery instead of getting
+queued/interrupted and replayed to the LLM as raw text.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so we can import gateway code without heavy deps
+# ---------------------------------------------------------------------------
+import sys, types
+
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+
+
+def _make_event(text="/note hello world", chat_id="123", platform_val="telegram"):
+    source = SessionSource(
+        platform=MagicMock(value=platform_val),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg1",
+    )
+
+
+def _make_runner(quick_commands=None):
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = {"quick_commands": quick_commands or {}}
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda _e: "msg1"
+    runner._thread_metadata_for_source = lambda _src, _anchor=None: {}
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+def _make_adapter(platform_val="telegram"):
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value=platform_val)
+    return adapter
+
+
+class _FakeProc:
+    def __init__(self, stdout=b"note saved\n", stderr=b""):
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestExecQuickCommandBypassesBusySession:
+    """An exec quick command must run inline even when the agent is busy."""
+
+    @pytest.mark.asyncio
+    async def test_exec_quick_command_runs_inline_during_busy_session(self):
+        runner, _sentinel = _make_runner(
+            quick_commands={"note": {"type": "exec", "command": "bash daily-note.sh hello"}}
+        )
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/note remember to buy milk")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        fake_proc = _FakeProc(stdout=b"note saved\n")
+        with patch("gateway.run.asyncio.create_subprocess_shell", new=AsyncMock(return_value=fake_proc)) as mock_spawn, \
+             patch("gateway.run.merge_pending_message_event") as mock_merge:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        # The subprocess actually ran (the bug was that it didn't).
+        mock_spawn.assert_called_once()
+        # The exec output was delivered to the user.
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args.kwargs
+        assert call_kwargs.get("content") == "note saved"
+        # The running agent was NOT touched — no interrupt, no queue.
+        running_agent.interrupt.assert_not_called()
+        running_agent.steer.assert_not_called()
+        mock_merge.assert_not_called()
+        assert adapter._pending_messages == {}
+
+    @pytest.mark.asyncio
+    async def test_non_exec_command_falls_through_to_queue_logic(self):
+        # Regression guard: only ``exec`` quick commands bypass the queue.
+        # Plain user messages and ``alias`` quick commands keep their normal
+        # busy semantics (queue + ack), so the agent still hears them.
+        runner, _sentinel = _make_runner(
+            quick_commands={"hello": {"type": "alias", "target": "/help"}}
+        )
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="just a normal follow-up")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.asyncio.create_subprocess_shell", new=AsyncMock()) as mock_spawn, \
+             patch("gateway.run.merge_pending_message_event") as mock_merge:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        # No subprocess for a plain message.
+        mock_spawn.assert_not_called()
+        # Normal queue semantics applied.
+        mock_merge.assert_called_once()
+        # User got the queue ack.
+        adapter._send_with_retry.assert_called_once()
+        ack_content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in ack_content
+
+    @pytest.mark.asyncio
+    async def test_alias_quick_command_is_not_short_circuited(self):
+        # ``alias`` rewrites into other commands and ultimately reaches the
+        # agent. It must NOT be intercepted by the busy bypass — otherwise
+        # ``/foo`` aliased to ``/help`` would silently disappear during a
+        # busy session.
+        runner, _sentinel = _make_runner(
+            quick_commands={"foo": {"type": "alias", "target": "help"}}
+        )
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/foo")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.asyncio.create_subprocess_shell", new=AsyncMock()) as mock_spawn, \
+             patch("gateway.run.merge_pending_message_event") as mock_merge:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        mock_spawn.assert_not_called()
+        # Alias falls through to the queue path so the agent eventually sees it.
+        mock_merge.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exec_quick_command_blocked_during_drain(self):
+        # Symmetric with the non-busy ``_handle_message`` flow: when the
+        # gateway is draining, the user gets the draining message instead of
+        # the exec subprocess running. The exec bypass is positioned AFTER
+        # the draining branch in ``_handle_active_session_busy_message`` for
+        # exactly this reason.
+        runner, _sentinel = _make_runner(
+            quick_commands={"note": {"type": "exec", "command": "echo hi"}}
+        )
+        runner._busy_input_mode = "interrupt"
+        runner._draining = True
+        runner._status_action_gerund = lambda: "restarting"
+        runner._queue_during_drain_enabled = lambda: False
+        adapter = _make_adapter()
+
+        event = _make_event(text="/note while draining")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.asyncio.create_subprocess_shell", new=AsyncMock()) as mock_spawn:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        mock_spawn.assert_not_called()
+        ack = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "restarting" in ack
+
+    @pytest.mark.asyncio
+    async def test_helper_returns_none_for_non_exec_command(self):
+        # The helper drives both the cold path (``_handle_message``) and the
+        # busy path (``_handle_active_session_busy_message``). It must
+        # cleanly return None for non-matching inputs so callers fall
+        # through instead of swallowing the message.
+        runner, _ = _make_runner(
+            quick_commands={"note": {"type": "exec", "command": "echo hi"}}
+        )
+        assert await runner._try_execute_exec_quick_command(None) is None
+        assert await runner._try_execute_exec_quick_command("") is None
+        assert await runner._try_execute_exec_quick_command("not-registered") is None
+
+        # Wrong type → still None so the cold path's alias/unsupported
+        # branches handle it.
+        runner_alias, _ = _make_runner(
+            quick_commands={"foo": {"type": "alias", "target": "/help"}}
+        )
+        assert await runner_alias._try_execute_exec_quick_command("foo") is None
+
+    @pytest.mark.asyncio
+    async def test_helper_reports_missing_exec_command_string(self):
+        runner, _ = _make_runner(
+            quick_commands={"broken": {"type": "exec"}}  # no "command" key
+        )
+        output = await runner._try_execute_exec_quick_command("broken")
+        assert output == "Quick command '/broken' has no command defined."


### PR DESCRIPTION
## Summary

- Exec-type quick commands (\`quick_commands.<name>.type: exec\`) now run inline when a user sends them while the agent is mid-turn, instead of being queued and replayed to the LLM as raw text.
- Extracts the existing exec dispatch + execution into \`_try_execute_exec_quick_command\` so both \`_handle_message\` (cold path) and \`_handle_active_session_busy_message\` (busy path) share one source of truth.
- Adds a regression test that exercises the busy-path bypass, the alias-not-short-circuited contract, the draining-wins precedence, and the helper's None / error return paths.

## The bug

\`gateway/run.py\` registers \`_handle_active_session_busy_message\` as each adapter's \`busy_session_handler\`. Whenever a message arrives for an active session that's mid-turn, the adapter routes through that handler instead of the cold path \`_handle_message\` — so the existing exec dispatch at \`gateway/run.py:6582\` was unreachable. The busy handler only knew queue / interrupt / steer:

\`\`\`
user sends \`/note remember to buy milk\` during a tool-call turn
  → adapter detects active session
  → calls _handle_active_session_busy_message
  → merge_pending_message_event(...)   # queued
  → next turn: agent sees \"/note remember to buy milk\" as user text
\`\`\`

The user's daily-note script never runs; the agent receives the slash command as conversation input.

## The fix

1. \`_try_execute_exec_quick_command(command)\` — new helper that performs the dispatch lookup, runs the subprocess with the same env-sanitization + 30s timeout + redaction as the cold path, and returns the output string. Returns \`None\` when no exec quick command matches, so callers fall through. \`alias\`-type quick commands intentionally pass through (they rewrite into agent input and keep normal busy semantics).
2. \`_handle_active_session_busy_message\` — after the existing auth + draining branches, call the helper. If it returns a string, deliver via \`adapter._send_with_retry\` and return \`True\` (handled). Precedence mirrors the cold path: draining wins, exec quick commands next, queue/interrupt last.
3. \`_handle_message\` — refactored to call the same helper, so both call sites use one implementation.

## Test plan

- [x] \`tests/gateway/test_busy_quick_command_bypass.py\` (new):
  - \`test_exec_quick_command_runs_inline_during_busy_session\` — exec subprocess spawned, output delivered, \`interrupt\` and \`merge_pending_message_event\` never called.
  - \`test_non_exec_command_falls_through_to_queue_logic\` — plain message still queues + acks.
  - \`test_alias_quick_command_is_not_short_circuited\` — alias still falls through to queue.
  - \`test_exec_quick_command_blocked_during_drain\` — draining still wins; user sees the draining message.
  - \`test_helper_returns_none_for_non_exec_command\` + \`test_helper_reports_missing_exec_command_string\` — helper contract.
- [x] Adjacent suites pass with no regressions: \`tests/gateway/test_busy_session_ack.py\` + \`tests/cli/test_quick_commands.py\` (33 tests, including the cold-path exec coverage that now exercises the shared helper).
- [x] Regression guard: before this PR, \`_handle_active_session_busy_message\` had no exec branch, so the first test would call \`running_agent.interrupt\` and \`merge_pending_message_event\` instead of spawning the subprocess — \`mock_spawn.assert_called_once()\` fails on \`origin/main\`.

> Sibling code paths that may need the same fix: \`built-in slash commands like \`/new\`, \`/voice\`, \`/goal\` are also queued during a busy session even though their handlers don't touch agent state. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

## Related

- Fixes #25783