### PR TITLE
Support Discord guild slash command sync

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1068,6 +1068,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if sync_policy == "bulk":
                 synced = await asyncio.wait_for(self._client.tree.sync(), timeout=30)
                 logger.info("[%s] Synced %d slash command(s) via bulk tree sync", self.name, len(synced))
+                await self._sync_guild_slash_commands()
                 return
 
             app_id = getattr(self._client, "application_id", None) or getattr(getattr(self._client, "user", None), "id", None)
@@ -1075,6 +1076,7 @@ class DiscordAdapter(BasePlatformAdapter):
             skip_reason = self._command_sync_skip_reason(app_id, fingerprint)
             if skip_reason:
                 logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
+                await self._sync_guild_slash_commands()
                 return
             self._record_command_sync_attempt(app_id, fingerprint)
 
@@ -1120,6 +1122,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["created"],
                 summary["deleted"],
             )
+            await self._sync_guild_slash_commands()
         except asyncio.TimeoutError:
             logger.warning(
                 "[%s] Slash command sync timed out — Discord rate-limit bucket "
@@ -1142,6 +1145,91 @@ class DiscordAdapter(BasePlatformAdapter):
                 raw,
             )
         return "safe"
+
+    def _get_discord_command_sync_guild_ids(self) -> List[int]:
+        """Return guild IDs that should receive immediate guild command sync.
+
+        Global application commands can take time to appear in every guild.
+        Operators who need commands to be visible immediately can set
+        ``DISCORD_COMMAND_SYNC_GUILDS`` to a comma-separated list of guild IDs,
+        or to ``auto`` to sync every guild the bot is currently connected to.
+        ``discord.command_sync_guilds`` in config.yaml accepts the same values.
+        """
+        raw: Any = os.getenv("DISCORD_COMMAND_SYNC_GUILDS", "").strip()
+        if not raw:
+            try:
+                from hermes_cli.config import load_config
+
+                cfg = load_config()
+                discord_cfg = cfg.get("discord") if isinstance(cfg, dict) else None
+                if isinstance(discord_cfg, dict):
+                    raw = discord_cfg.get("command_sync_guilds") or ""
+            except Exception as exc:
+                logger.debug("Could not read discord.command_sync_guilds: %s", exc)
+                raw = ""
+
+        if isinstance(raw, (list, tuple, set)):
+            parts = [str(item).strip() for item in raw]
+        else:
+            text = str(raw or "").strip()
+            if not text:
+                return []
+            if text.lower() == "auto":
+                guilds = getattr(self._client, "guilds", []) if self._client else []
+                ids: List[int] = []
+                for guild in guilds or []:
+                    gid = getattr(guild, "id", None)
+                    try:
+                        if gid is not None:
+                            ids.append(int(gid))
+                    except (TypeError, ValueError):
+                        continue
+                return sorted(set(ids))
+            parts = [item.strip() for item in text.split(",")]
+
+        ids = []
+        for item in parts:
+            if not item:
+                continue
+            try:
+                guild_id = int(item)
+            except (TypeError, ValueError):
+                logger.warning("[%s] Ignoring invalid Discord command sync guild ID: %r", self.name, item)
+                continue
+            if guild_id > 0:
+                ids.append(guild_id)
+        return sorted(set(ids))
+
+    async def _sync_guild_slash_commands(self) -> None:
+        """Sync commands into configured guilds for immediate visibility."""
+        if not self._client:
+            return
+        guild_ids = self._get_discord_command_sync_guild_ids()
+        if not guild_ids:
+            return
+
+        tree = self._client.tree
+        for guild_id in guild_ids:
+            try:
+                guild = discord.Object(id=guild_id)
+                copy_global_to = getattr(tree, "copy_global_to", None)
+                if callable(copy_global_to):
+                    copy_global_to(guild=guild)
+                synced = await asyncio.wait_for(tree.sync(guild=guild), timeout=30)
+                logger.info(
+                    "[%s] Synced %d slash command(s) to Discord guild %s",
+                    self.name,
+                    len(synced),
+                    guild_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Guild slash command sync failed for guild %s: %s",
+                    self.name,
+                    guild_id,
+                    exc,
+                    exc_info=True,
+                )
 
     def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Reduce command payloads to the semantic fields Hermes manages."""

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -624,6 +624,64 @@ async def test_post_connect_initialization_respects_discord_retry_after(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_post_connect_initialization_syncs_configured_guilds_even_when_global_fingerprint_matches(tmp_path, monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_COMMAND_SYNC_GUILDS", "12345")
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {"name": "status", "description": "Show Hermes status", "type": 1, "options": []}
+
+    class _Tree:
+        def __init__(self):
+            self.sync = AsyncMock(return_value=[object()])
+            self.copy_global_to = MagicMock()
+
+        def get_commands(self):
+            return [_DesiredCommand()]
+
+    tree = _Tree()
+    adapter._client = SimpleNamespace(
+        tree=tree,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+        guilds=[SimpleNamespace(id=12345)],
+    )
+    fingerprint = adapter._desired_command_sync_fingerprint()
+    adapter._record_command_sync_success(
+        999,
+        fingerprint,
+        {"total": 1, "unchanged": 1, "updated": 0, "recreated": 0, "created": 0, "deleted": 0},
+    )
+    safe_sync = AsyncMock()
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", safe_sync)
+
+    await adapter._run_post_connect_initialization()
+
+    safe_sync.assert_not_awaited()
+    tree.copy_global_to.assert_called_once()
+    tree.sync.assert_awaited_once()
+    discord_platform.discord.Object.assert_called_with(id=12345)
+    assert tree.sync.await_args.kwargs["guild"] is discord_platform.discord.Object.return_value
+
+
+def test_discord_command_sync_guild_ids_auto(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setenv("DISCORD_COMMAND_SYNC_GUILDS", "auto")
+    adapter._client = SimpleNamespace(
+        guilds=[
+            SimpleNamespace(id=333),
+            SimpleNamespace(id="222"),
+            SimpleNamespace(id=333),
+            SimpleNamespace(id=None),
+        ]
+    )
+
+    assert adapter._get_discord_command_sync_guild_ids() == [222, 333]
+
+
+@pytest.mark.asyncio
 async def test_post_connect_initialization_reraises_non_rate_limit_exceptions(tmp_path, monkeypatch):
     """Arbitrary failures during sync must surface, not be swallowed as rate-limits."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))


### PR DESCRIPTION
## Summary

- add optional Discord guild slash-command sync via `DISCORD_COMMAND_SYNC_GUILDS` or `discord.command_sync_guilds`
- support comma-separated guild IDs and `auto` for all connected guilds
- run guild sync after global bulk/safe sync and also when global sync is skipped due to a matching fingerprint
- add regression coverage for the case where global sync is skipped but guild commands still need to be installed

Fixes #25805

## Test plan

```bash
venv/bin/python -m pytest tests/gateway/test_discord_connect.py -q
```

Local result: `18 passed in 1.45s`.

I also verified against a live private Discord bot: before guild sync, the app had 45 global commands and the guild had 0 commands; after enabling guild sync, startup logs showed `Synced 45 slash command(s) to Discord guild ...`, and the guild command API returned 45 commands.
