### PR TITLE
feat(memory): expose per-operation LLM config for Hindsight daemon

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -463,6 +463,15 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
                     value = "openai"
                 env_values[env_var] = str(value)
 
+    # Generic daemon env passthrough — lets config.json set arbitrary
+    # HINDSIGHT_API_* env vars without requiring per-key bridge code.
+    # Usage in config.json: "daemon_env": {"HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS": "4"}
+    daemon_env = config.get("daemon_env")
+    if isinstance(daemon_env, dict):
+        for key, value in daemon_env.items():
+            if key.startswith("HINDSIGHT_") and value is not None:
+                env_values[str(key)] = str(value)
+
     return env_values
 
 
@@ -602,6 +611,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
+        self._last_retained_turn_count = 0  # how many turns have been sent to Hindsight (for append-mode incremental retain)
 
         # Recall controls
         self._auto_recall = True
@@ -1129,6 +1139,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
+        self._last_retained_turn_count = 0
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1461,9 +1472,30 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
-        content = "[" + ",".join(self._session_turns) + "]"
+        # Resolve append capability early so we can send only new turns.
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+
+        if update_mode == "append":
+            # Hindsight >=0.5.0 supports append-only documents. Sending the
+            # full accumulated session on every retain would create quadratic
+            # token usage (turn 1, then turns 1+2, then turns 1+2+3...) and
+            # duplicate memories. Instead, send only turns buffered since the
+            # last retain. _session_turns itself is NOT cleared — it must
+            # remain populated so on_session_switch() can still flush partial
+            # buffers when retain_every_n_turns > 1.
+            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
+        else:
+            # Legacy overwrite mode: send the full session snapshot so the
+            # document replaces prior content without data loss.
+            turns_to_retain = list(self._session_turns)
+
+        logger.debug("sync_turn: retaining %d turns (%d new of %d total), content %d chars, mode=%s",
+                     len(turns_to_retain), len(turns_to_retain), len(self._session_turns),
+                     sum(len(t) for t in turns_to_retain), update_mode)
+        content = "[" + ",".join(turns_to_retain) + "]"
+
+        if update_mode == "append":
+            self._last_retained_turn_count = len(self._session_turns)
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1474,11 +1506,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(self._session_turns) * 2,
+            message_count=len(turns_to_retain) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(self._session_turns)
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        num_turns = len(turns_to_retain)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
@@ -1706,6 +1737,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
+        self._last_retained_turn_count = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -463,15 +463,6 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
                     value = "openai"
                 env_values[env_var] = str(value)
 
-    # Generic daemon env passthrough — lets config.json set arbitrary
-    # HINDSIGHT_API_* env vars without requiring per-key bridge code.
-    # Usage in config.json: "daemon_env": {"HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS": "4"}
-    daemon_env = config.get("daemon_env")
-    if isinstance(daemon_env, dict):
-        for key, value in daemon_env.items():
-            if key.startswith("HINDSIGHT_") and value is not None:
-                env_values[str(key)] = str(value)
-
     return env_values
 
 
@@ -611,7 +602,6 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
-        self._last_retained_turn_count = 0  # how many turns have been sent to Hindsight (for append-mode incremental retain)
 
         # Recall controls
         self._auto_recall = True
@@ -1139,7 +1129,6 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
-        self._last_retained_turn_count = 0
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1472,30 +1461,9 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        # Resolve append capability early so we can send only new turns.
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
-
-        if update_mode == "append":
-            # Hindsight >=0.5.0 supports append-only documents. Sending the
-            # full accumulated session on every retain would create quadratic
-            # token usage (turn 1, then turns 1+2, then turns 1+2+3...) and
-            # duplicate memories. Instead, send only turns buffered since the
-            # last retain. _session_turns itself is NOT cleared — it must
-            # remain populated so on_session_switch() can still flush partial
-            # buffers when retain_every_n_turns > 1.
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
-        else:
-            # Legacy overwrite mode: send the full session snapshot so the
-            # document replaces prior content without data loss.
-            turns_to_retain = list(self._session_turns)
-
-        logger.debug("sync_turn: retaining %d turns (%d new of %d total), content %d chars, mode=%s",
-                     len(turns_to_retain), len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain), update_mode)
-        content = "[" + ",".join(turns_to_retain) + "]"
-
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
+                     len(self._session_turns), sum(len(t) for t in self._session_turns))
+        content = "[" + ",".join(self._session_turns) + "]"
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1506,10 +1474,11 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
+            message_count=len(self._session_turns) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(turns_to_retain)
+        num_turns = len(self._session_turns)
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
@@ -1737,7 +1706,6 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
-        self._last_retained_turn_count = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -399,7 +399,16 @@ def _load_simple_env(path) -> dict[str, str]:
 
 
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
-    """Build the profile-scoped env file that standalone hindsight-embed consumes."""
+    """Build the profile-scoped env file that standalone hindsight-embed consumes.
+
+    Supports per-operation LLM overrides via config.json keys:
+      retain_llm_provider, retain_llm_model, retain_llm_api_key, retain_llm_base_url
+      reflect_llm_provider, reflect_llm_model, reflect_llm_api_key, reflect_llm_base_url
+      consolidation_llm_provider, consolidation_llm_model, consolidation_llm_api_key, consolidation_llm_base_url
+
+    When set, these override the default HINDSIGHT_API_LLM_* for that operation.
+    The daemon falls back to the default when per-op vars are unset.
+    """
     current_key = llm_api_key
     if current_key is None:
         current_key = (
@@ -433,6 +442,27 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    # Per-operation LLM overrides (retain, reflect, consolidation).
+    # Each falls back to the default if not set in config.json.
+    _PER_OP_PREFIXES = {
+        "retain": "HINDSIGHT_API_RETAIN_LLM",
+        "reflect": "HINDSIGHT_API_REFLECT_LLM",
+        "consolidation": "HINDSIGHT_API_CONSOLIDATION_LLM",
+    }
+    _PER_OP_FIELDS = ("provider", "model", "api_key", "base_url")
+
+    for op_name, env_prefix in _PER_OP_PREFIXES.items():
+        for field in _PER_OP_FIELDS:
+            config_key = f"{op_name}_llm_{field}"
+            value = config.get(config_key)
+            if value is not None and str(value).strip():
+                env_var = f"{env_prefix}_{field.upper()}"
+                # Map provider aliases the same way as the default
+                if field == "provider" and str(value) in ("openai_compatible", "openrouter"):
+                    value = "openai"
+                env_values[env_var] = str(value)
+
     return env_values
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -273,6 +273,39 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_per_operation_llm_config(self):
+        """Per-operation LLM overrides in config.json produce daemon env vars."""
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "default-model",
+            "llmApiKey": "default-key",
+            "retain_llm_model": "retain-model",
+            "retain_llm_api_key": "retain-key",
+            "consolidation_llm_provider": "openrouter",
+            "consolidation_llm_model": "consolidation-model",
+            "consolidation_llm_api_key": "consolidation-key",
+            "consolidation_llm_base_url": "https://openrouter.ai/api/v1",
+        })
+
+        # Default LLM
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_LLM_MODEL"] == "default-model"
+        assert env["HINDSIGHT_API_LLM_API_KEY"] == "default-key"
+
+        # Retain overrides (model + key only, inherits default provider)
+        assert env["HINDSIGHT_API_RETAIN_LLM_MODEL"] == "retain-model"
+        assert env["HINDSIGHT_API_RETAIN_LLM_API_KEY"] == "retain-key"
+        assert "HINDSIGHT_API_RETAIN_LLM_PROVIDER" not in env
+
+        # Consolidation overrides (all fields, provider mapped from openrouter)
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_MODEL"] == "consolidation-model"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY"] == "consolidation-key"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL"] == "https://openrouter.ai/api/v1"
+
+        # Reflect not set — no per-op vars
+        assert "HINDSIGHT_API_REFLECT_LLM_MODEL" not in env
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -306,6 +306,36 @@ class TestConfig:
         # Reflect not set — no per-op vars
         assert "HINDSIGHT_API_REFLECT_LLM_MODEL" not in env
 
+    def test_embedded_profile_env_daemon_env_passthrough(self):
+        """daemon_env dict in config.json passes arbitrary HINDSIGHT_API_* vars to daemon."""
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "default-model",
+            "llmApiKey": "default-key",
+            "daemon_env": {
+                "HINDSIGHT_API_WORKER_MAX_SLOTS": "10",
+                "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE": "16",
+                "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true",
+                "NON_HINDSIGHT_KEY": "should-be-ignored",
+                "HINDSIGHT_API_NULL_VALUE": None,
+            },
+        })
+
+        assert env["HINDSIGHT_API_WORKER_MAX_SLOTS"] == "10"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"] == "16"
+        assert env["HINDSIGHT_API_SKIP_LLM_VERIFICATION"] == "true"
+        assert "NON_HINDSIGHT_KEY" not in env
+        assert "HINDSIGHT_API_NULL_VALUE" not in env
+
+    def test_embedded_profile_env_daemon_env_none_or_missing(self):
+        """daemon_env=None or missing doesn't crash and doesn't affect other keys."""
+        for config in [
+            {"llm_provider": "openai", "llmApiKey": "k", "llm_model": "m", "daemon_env": None},
+            {"llm_provider": "openai", "llmApiKey": "k", "llm_model": "m"},
+        ]:
+            env = _build_embedded_profile_env(config)
+            assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
@@ -789,8 +819,8 @@ class TestSyncTurn:
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
 
-    def test_sync_turn_accumulates_full_session(self, provider_with_config):
-        """Each retain sends the ENTIRE session, not just the latest batch."""
+    def test_sync_turn_accumulates_full_session_for_legacy_overwrite_mode(self, provider_with_config):
+        """Legacy APIs without append support need full snapshots to avoid overwrite data loss."""
         p = provider_with_config(retain_every_n_turns=2)
 
         p.sync_turn("turn1-user", "turn1-asst")
@@ -804,11 +834,42 @@ class TestSyncTurn:
         p._retain_queue.join()
 
         content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
-        # Should contain ALL turns from the session
+        # Legacy overwrite mode should contain ALL turns from the session.
         assert "turn1-user" in content
         assert "turn2-user" in content
         assert "turn3-user" in content
         assert "turn4-user" in content
+
+    def test_sync_turn_append_mode_sends_only_new_buffered_turns(self, provider_with_config, monkeypatch):
+        """Append mode must not resend prior turns, or token usage becomes quadratic."""
+        p = provider_with_config(retain_every_n_turns=2)
+        monkeypatch.setattr(p, "_resolve_retain_target", lambda fallback: ("test-session", "append"))
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        first = p._client.aretain_batch.call_args.kwargs
+        first_content = first["items"][0]["content"]
+        assert first["document_id"] == "test-session"
+        assert first["items"][0]["update_mode"] == "append"
+        assert "turn1-user" in first_content
+        assert "turn2-user" in first_content
+
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+
+        second = p._client.aretain_batch.call_args.kwargs
+        second_content = second["items"][0]["content"]
+        assert second["document_id"] == "test-session"
+        assert second["items"][0]["update_mode"] == "append"
+        assert "turn1-user" not in second_content
+        assert "turn2-user" not in second_content
+        assert "turn3-user" in second_content
+        assert "turn4-user" in second_content
 
     def test_sync_turn_passes_document_id(self, provider):
         """sync_turn should pass document_id (session_id + per-startup ts)."""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -306,36 +306,6 @@ class TestConfig:
         # Reflect not set — no per-op vars
         assert "HINDSIGHT_API_REFLECT_LLM_MODEL" not in env
 
-    def test_embedded_profile_env_daemon_env_passthrough(self):
-        """daemon_env dict in config.json passes arbitrary HINDSIGHT_API_* vars to daemon."""
-        env = _build_embedded_profile_env({
-            "llm_provider": "openai",
-            "llm_model": "default-model",
-            "llmApiKey": "default-key",
-            "daemon_env": {
-                "HINDSIGHT_API_WORKER_MAX_SLOTS": "10",
-                "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE": "16",
-                "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true",
-                "NON_HINDSIGHT_KEY": "should-be-ignored",
-                "HINDSIGHT_API_NULL_VALUE": None,
-            },
-        })
-
-        assert env["HINDSIGHT_API_WORKER_MAX_SLOTS"] == "10"
-        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"] == "16"
-        assert env["HINDSIGHT_API_SKIP_LLM_VERIFICATION"] == "true"
-        assert "NON_HINDSIGHT_KEY" not in env
-        assert "HINDSIGHT_API_NULL_VALUE" not in env
-
-    def test_embedded_profile_env_daemon_env_none_or_missing(self):
-        """daemon_env=None or missing doesn't crash and doesn't affect other keys."""
-        for config in [
-            {"llm_provider": "openai", "llmApiKey": "k", "llm_model": "m", "daemon_env": None},
-            {"llm_provider": "openai", "llmApiKey": "k", "llm_model": "m"},
-        ]:
-            env = _build_embedded_profile_env(config)
-            assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
-
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
@@ -819,8 +789,8 @@ class TestSyncTurn:
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
 
-    def test_sync_turn_accumulates_full_session_for_legacy_overwrite_mode(self, provider_with_config):
-        """Legacy APIs without append support need full snapshots to avoid overwrite data loss."""
+    def test_sync_turn_accumulates_full_session(self, provider_with_config):
+        """Each retain sends the ENTIRE session, not just the latest batch."""
         p = provider_with_config(retain_every_n_turns=2)
 
         p.sync_turn("turn1-user", "turn1-asst")
@@ -834,42 +804,11 @@ class TestSyncTurn:
         p._retain_queue.join()
 
         content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
-        # Legacy overwrite mode should contain ALL turns from the session.
+        # Should contain ALL turns from the session
         assert "turn1-user" in content
         assert "turn2-user" in content
         assert "turn3-user" in content
         assert "turn4-user" in content
-
-    def test_sync_turn_append_mode_sends_only_new_buffered_turns(self, provider_with_config, monkeypatch):
-        """Append mode must not resend prior turns, or token usage becomes quadratic."""
-        p = provider_with_config(retain_every_n_turns=2)
-        monkeypatch.setattr(p, "_resolve_retain_target", lambda fallback: ("test-session", "append"))
-
-        p.sync_turn("turn1-user", "turn1-asst")
-        p.sync_turn("turn2-user", "turn2-asst")
-        p._retain_queue.join()
-
-        first = p._client.aretain_batch.call_args.kwargs
-        first_content = first["items"][0]["content"]
-        assert first["document_id"] == "test-session"
-        assert first["items"][0]["update_mode"] == "append"
-        assert "turn1-user" in first_content
-        assert "turn2-user" in first_content
-
-        p._client.aretain_batch.reset_mock()
-
-        p.sync_turn("turn3-user", "turn3-asst")
-        p.sync_turn("turn4-user", "turn4-asst")
-        p._retain_queue.join()
-
-        second = p._client.aretain_batch.call_args.kwargs
-        second_content = second["items"][0]["content"]
-        assert second["document_id"] == "test-session"
-        assert second["items"][0]["update_mode"] == "append"
-        assert "turn1-user" not in second_content
-        assert "turn2-user" not in second_content
-        assert "turn3-user" in second_content
-        assert "turn4-user" in second_content
 
     def test_sync_turn_passes_document_id(self, provider):
         """sync_turn should pass document_id (session_id + per-startup ts)."""


### PR DESCRIPTION
## What does this PR do?

Exposes the Hindsight daemon's per-operation LLM configuration through the Hermes plugin's `config.json`, so users can use different models for retain, reflect, and consolidation without manually editing env files.

**Background:** The Hindsight daemon already supports per-operation LLM env vars (`HINDSIGHT_API_RETAIN_LLM_*`, `HINDSIGHT_API_REFLECT_LLM_*`, `HINDSIGHT_API_CONSOLIDATION_LLM_*`), but the Hermes plugin only wrote the default `HINDSIGHT_API_LLM_*` to the profile env file. Users who wanted per-operation models had to edit `~/.hindsight/profiles/hermes.env` manually — which gets overwritten on every daemon restart.

## Changes Made

Extend `_build_embedded_profile_env()` to read per-operation keys from `config.json`:

| config.json key | Daemon env var |
|---|---|
| `retain_llm_provider` | `HINDSIGHT_API_RETAIN_LLM_PROVIDER` |
| `retain_llm_model` | `HINDSIGHT_API_RETAIN_LLM_MODEL` |
| `retain_llm_api_key` | `HINDSIGHT_API_RETAIN_LLM_API_KEY` |
| `retain_llm_base_url` | `HINDSIGHT_API_RETAIN_LLM_BASE_URL` |
| `reflect_llm_*` | `HINDSIGHT_API_REFLECT_LLM_*` |
| `consolidation_llm_*` | `HINDSIGHT_API_CONSOLIDATION_LLM_*` |

When a per-op key is not set, the daemon falls back to the default — no behavior change for existing configs. Provider alias mapping (`openrouter`/`openai_compatible` -> `openai`) is applied consistently.

## Example config.json

```json
{
  "llm_provider": "openai",
  "llm_model": "MiniMax-M2.7",
  "llm_base_url": "https://api.minimax.io/v1",
  "consolidation_llm_model": "kimi-k2.6",
  "consolidation_llm_base_url": "https://api.kimi.com/v1"
}
```

This would use MiniMax for retain/reflect and Kimi for consolidation.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How to Test

1. `pytest tests/plugins/memory/test_hindsight_provider.py -q` — 97 tests pass
2. The new `test_embedded_profile_env_per_operation_llm_config` verifies all three paths: partial override (retain), full override (consolidation), and no override (reflect falls back to default)

## Checklist

- [x] Commit messages follow Conventional Commits (`feat(memory): ...`)
- [x] Searched for existing PRs — not a duplicate
- [x] PR contains only changes related to this feature
- [x] `pytest tests/ -q` passes
- [x] Added tests for changes