### PR TITLE
Allow custom providers to skip live model discovery

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2851,7 +2851,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "discover_models",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2942,6 +2942,14 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    discover_models = entry.get("discover_models")
+    if isinstance(discover_models, bool):
+        normalized["discover_models"] = discover_models
+    elif isinstance(discover_models, str) and discover_models.strip():
+        normalized["discover_models"] = discover_models.strip().lower() not in {
+            "false", "no", "0"
+        }
 
     return normalized
 
@@ -3103,7 +3111,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "discover_models",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1687,8 +1687,28 @@ def list_authenticated_providers(
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
             # Live model discovery from custom provider endpoints (matches
-            # Section 3 behavior for user ``providers:`` entries).
-            if api_url and api_key:
+            # Section 3 behavior for user ``providers:`` entries). Allow
+            # dedicated gateways to opt out: some OpenAI-compatible routers
+            # expose their entire multimodal/provider-prefixed catalog from
+            # /models, while the picker should show only the chat models the
+            # user configured for this custom provider.
+            discover = True
+            for entry in custom_providers:
+                if not isinstance(entry, dict):
+                    continue
+                entry_url = (
+                    entry.get("base_url", "")
+                    or entry.get("url", "")
+                    or entry.get("api", "")
+                    or ""
+                ).strip().rstrip("/")
+                entry_key = (entry.get("api_key") or "").strip()
+                if entry_url == api_url and entry_key == api_key:
+                    discover = entry.get("discover_models", True)
+                    break
+            if isinstance(discover, str):
+                discover = discover.lower() not in {"false", "no", "0"}
+            if api_url and api_key and discover:
                 try:
                     from hermes_cli.models import fetch_api_models
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -682,6 +682,31 @@ class TestCustomProviderCompatibility:
         models = [e.get("model") for e in compatible]
         assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
 
+    def test_compatible_custom_providers_preserves_discover_models(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": [
+                        {
+                            "name": "Gateway",
+                            "base_url": "https://gateway.example.com/v1",
+                            "api_key": "sk-test",
+                            "discover_models": False,
+                            "model": "gateway-chat",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert compatible[0]["discover_models"] is False
+
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -567,3 +567,46 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
         "gateway-model-c",
     ], "Live models must replace the static subset"
     assert gateway_prov["total_models"] == 3
+
+
+def test_custom_providers_can_disable_live_model_discovery(monkeypatch):
+    """Dedicated routers can pin /model to configured chat models only."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["gateway-chat", "gateway-image", "gateway-embedding"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        {
+            "name": "my-gateway",
+            "api_key": "sk-gateway-key",
+            "base_url": "https://gateway.example.com/v1",
+            "discover_models": False,
+            "model": "gateway-chat",
+            "models": {
+                "gateway-chat": {},
+                "gateway-coder": {},
+            },
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="custom:my-gateway",
+        current_base_url="https://gateway.example.com/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    gateway_prov = next(
+        p for p in providers if p.get("api_url") == "https://gateway.example.com/v1"
+    )
+
+    assert calls == []
+    assert gateway_prov["models"] == ["gateway-chat", "gateway-coder"]
+    assert gateway_prov["total_models"] == 2


### PR DESCRIPTION
## Summary

- preserve `discover_models` in normalized custom provider config
- allow `custom_providers` to opt out of live `/models` discovery
- keep `/model` pinned to configured custom-provider chat models when `discover_models: false`
- add regression coverage for the opt-out path and config normalization

Fixes #25810

## Test plan

```bash
venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_config.py -q
```

Local result: `75 passed in 4.67s`.

I also verified against a live Bifrost custom provider: before this change `/model` showed 129 gateway models including image/audio/embedding routes; with `discover_models: false`, it shows only the 15 configured chat routes and no `gpt-image-2`.
