### PR TITLE
feat(delegate): per-task and top-level model override for cost-aware routing

### DIFF
--- a/tests/tools/test_delegate_model_override.py
+++ b/tests/tools/test_delegate_model_override.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Tests for the per-task and top-level model override in delegate_task.
+
+This patch adds the ability to spawn child agents on different models
+than the parent — typical use case is cost-aware routing:
+
+    delegate_task(
+        tasks=[
+            {"goal": "list files in /tmp", "model": "anthropic/claude-haiku-4"},
+            {"goal": "refactor auth module", "model": "anthropic/claude-opus-4.7"},
+        ],
+    )
+
+Precedence rules verified here:
+    1. per-task t["model"]
+    2. top-level model arg
+    3. delegation.model config (creds["model"])
+    4. parent_agent.model (resolved inside _build_child_agent)
+
+Plus: when delegation.provider is configured, user model overrides are
+ignored so credentials/model stay coherent.
+
+Run with:  python -m pytest tests/tools/test_delegate_model_override.py -v
+"""
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_dynamic_schema_overrides,
+    delegate_task,
+)
+
+
+def _make_mock_parent(depth=0, model="anthropic/claude-sonnet-4"):
+    """Mock parent agent compatible with delegate_task's expectations."""
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = model
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+class TestSchemaExposesModel(unittest.TestCase):
+    """The new `model` fields must be visible in both static and dynamic schemas."""
+
+    def test_top_level_model_in_static_schema(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "string")
+
+    def test_per_task_model_in_static_schema(self):
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"][
+            "properties"
+        ]
+        self.assertIn("model", task_props)
+        self.assertEqual(task_props["model"]["type"], "string")
+
+    def test_dynamic_schema_preserves_model_fields(self):
+        """`_build_dynamic_schema_overrides` re-emits the static schema with
+        runtime-aware descriptions for `tasks` and `role`. Both `model`
+        fields must survive that rewrite."""
+        overrides = _build_dynamic_schema_overrides()
+        props = overrides["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+
+    def test_model_description_mentions_cost_routing(self):
+        """The schema description must teach the LLM what this field is for —
+        otherwise it won't think to use it. The description in both
+        top-level and per-task slots should mention model routing."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props["model"]["description"].lower())
+        per_task = props["tasks"]["items"]["properties"]["model"]["description"]
+        self.assertIn("haiku", per_task.lower())
+        self.assertIn("opus", per_task.lower())
+
+
+class TestModelOverrideHonored(unittest.TestCase):
+    """`delegate_task` should pass the resolved model into AIAgent(...)."""
+
+    def test_per_task_model_passed_to_child(self):
+        """A per-task `model` in `tasks=[{...}]` should reach AIAgent."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "trivial task",
+                        "model": "anthropic/claude-haiku-4"}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku-4")
+
+    def test_top_level_model_passed_to_child(self):
+        """A top-level `model` arg should reach AIAgent."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="some task",
+                model="anthropic/claude-opus-4.7",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-opus-4.7")
+
+    def test_per_task_beats_top_level(self):
+        """When both are set, the per-task value wins."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task A",
+                        "model": "anthropic/claude-haiku-4"}],
+                model="anthropic/claude-opus-4.7",  # top-level fallback
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku-4")
+
+    def test_top_level_model_propagates_in_batch(self):
+        """Top-level `model` should apply to every batch task that didn't set
+        its own — mixed batch verifies the precedence cleanly."""
+        parent = _make_mock_parent()
+
+        captured_models = []
+
+        def _capture(*args, **kwargs):
+            captured_models.append(kwargs.get("model"))
+            child = MagicMock()
+            child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            return child
+
+        with patch("run_agent.AIAgent", side_effect=_capture):
+            delegate_task(
+                tasks=[
+                    {"goal": "task A"},  # uses top-level
+                    {"goal": "task B",
+                     "model": "anthropic/claude-opus-4.7"},  # overrides
+                    {"goal": "task C"},  # uses top-level
+                ],
+                model="anthropic/claude-haiku-4",
+                parent_agent=parent,
+            )
+
+        self.assertEqual(captured_models, [
+            "anthropic/claude-haiku-4",
+            "anthropic/claude-opus-4.7",
+            "anthropic/claude-haiku-4",
+        ])
+
+    def test_no_override_inherits_parent_model(self):
+        """When no `model` override anywhere, child uses parent's model
+        (because creds["model"] is None and _build_child_agent falls
+        back to parent.model)."""
+        parent = _make_mock_parent(model="anthropic/claude-sonnet-4")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="task", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4")
+
+
+class TestModelOverrideValidation(unittest.TestCase):
+    """Edge cases around the model field type and falsy values."""
+
+    def test_empty_string_model_falls_back(self):
+        """An empty per-task `model: ""` should NOT override — falls back
+        to top-level / creds / parent."""
+        parent = _make_mock_parent(model="anthropic/claude-sonnet-4")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task", "model": ""}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4")
+
+    def test_whitespace_only_model_falls_back(self):
+        """`model: "   "` is treated as not-set."""
+        parent = _make_mock_parent(model="anthropic/claude-sonnet-4")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task", "model": "   "}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4")
+
+    def test_non_string_model_falls_back(self):
+        """`model: 123` (wrong type) is silently ignored rather than crashing."""
+        parent = _make_mock_parent(model="anthropic/claude-sonnet-4")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task", "model": 123}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4")
+
+    def test_model_value_is_stripped(self):
+        """Leading/trailing whitespace in model name is stripped."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task",
+                        "model": "  anthropic/claude-haiku-4  "}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku-4")
+
+
+class TestDelegationProviderTrumpsOverride(unittest.TestCase):
+    """When `delegation.provider` is configured, the user-supplied model
+    override is silently ignored so the provider-pinned credential
+    bundle stays coherent (credentials + model from one source).
+    """
+
+    def test_provider_override_ignores_per_task_model(self):
+        """If `_resolve_delegation_credentials` returns provider=set, the
+        per-task model override is dropped in favour of creds["model"].
+        """
+        parent = _make_mock_parent()
+
+        # Make _resolve_delegation_credentials return a "provider configured"
+        # bundle so the precedence rule triggers.
+        fake_creds = {
+            "model": "z-ai/glm-4.6",  # delegation.model from config
+            "provider": "z-ai",
+            "base_url": "https://api.z.ai/v1",
+            "api_key": "secret",
+            "api_mode": "chat_completions",
+        }
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value=fake_creds,
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[{"goal": "task",
+                        "model": "anthropic/claude-haiku-4"}],
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            # delegation.model wins; user override ignored.
+            self.assertEqual(kwargs["model"], "z-ai/glm-4.6")
+            self.assertEqual(kwargs["provider"], "z-ai")
+
+    def test_provider_override_ignores_top_level_model(self):
+        """Same rule applies to the top-level `model` arg."""
+        parent = _make_mock_parent()
+        fake_creds = {
+            "model": "z-ai/glm-4.6",
+            "provider": "z-ai",
+            "base_url": "https://api.z.ai/v1",
+            "api_key": "secret",
+            "api_mode": "chat_completions",
+        }
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value=fake_creds,
+        ), patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="task",
+                model="anthropic/claude-opus-4.7",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "z-ai/glm-4.6")
+
+
+class TestRegistryHandlerPlumbsModel(unittest.TestCase):
+    """The registry handler must forward `args["model"]` into delegate_task."""
+
+    def test_registry_handler_forwards_model(self):
+        """The auto-generated lambda in registry.register must include
+        model=args.get("model"). We verify by invoking the registry
+        handler directly."""
+        from tools.registry import registry
+
+        entry = registry.get_entry("delegate_task")
+        self.assertIsNotNone(entry, "delegate_task must be registered")
+
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            entry.handler(
+                {
+                    "goal": "test",
+                    "model": "anthropic/claude-haiku-4",
+                },
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku-4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1915,19 +1915,31 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, model)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, model}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'model' parameter lets the caller override which model a child uses
+    on a per-task basis — useful for cost-aware routing (e.g. spawn a
+    haiku child for a trivial subtask while the main session is on opus).
+    Precedence: per-task model > top-level model > delegation.model
+    config > parent_agent.model.  When a model is overridden but
+    delegation.provider is NOT set, the child still inherits the parent's
+    provider/base_url/api_key — only the model identifier changes.  Any
+    override is silently ignored when delegation.provider IS set (the
+    delegation config wins) so users explicitly routing children to a
+    different provider get predictable credentials.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2008,7 +2020,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": model,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2042,6 +2060,22 @@ def delegate_task(
     # Build all child agents on the main thread (thread-safe construction)
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
+    # Precedence for the child model:
+    #   1. per-task `model` field
+    #   2. top-level `model` arg (already plumbed into the synthesized
+    #      single-task dict above; in batch mode the caller can set it
+    #      per task instead)
+    #   3. delegation.model from config (resolved into creds["model"])
+    #   4. parent_agent.model (resolved inside _build_child_agent when
+    #      effective_model is still None)
+    #
+    # When delegation.provider IS set, the user has explicitly routed
+    # children to a different provider — honour that bundle's model so
+    # credentials/model stay coherent (and skip the override).  When
+    # delegation.provider is NOT set, the user-supplied per-task model
+    # rides on top of the parent's credentials (provider/base_url/api_key
+    # are inherited unchanged).
+    _provider_override_active = bool(creds.get("provider"))
     children = []
     try:
         for i, t in enumerate(task_list):
@@ -2049,12 +2083,32 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Honour per-task model override only when the delegation
+            # config has NOT pinned a provider bundle (see comment above).
+            # Precedence (highest to lowest):
+            #   - per-task t["model"]
+            #   - top-level `model` arg (applies to every task in batch
+            #     mode that didn't set its own)
+            #   - creds["model"] (delegation.model config, or None for
+            #     parent inheritance via _build_child_agent)
+            task_model = t.get("model") or model
+            if (
+                task_model
+                and isinstance(task_model, str)
+                and task_model.strip()
+                and not _provider_override_active
+            ):
+                child_model = task_model.strip()
+            else:
+                child_model = creds["model"]
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=child_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2713,6 +2767,18 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'anthropic/claude-haiku-4' or 'anthropic/claude-opus-4.7'). "
+                                "Lets the parent route this child to a cheaper or more powerful model "
+                                "than its own — typical cost-aware routing: trivial subtasks go to haiku, "
+                                "deep reasoning goes to opus. "
+                                "Precedence: per-task model > top-level model > delegation.model config > parent model. "
+                                "Silently ignored when delegation.provider is configured (the delegation "
+                                "config wins so credentials and model stay coherent)."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2748,6 +2814,18 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Top-level model override applied to every child in this call "
+                    "(e.g. 'anthropic/claude-haiku-4'). Equivalent to setting "
+                    "`model` on every task in `tasks`; per-task `model` still "
+                    "wins when both are set. Useful for cost-aware routing: "
+                    "send a batch of trivial subtasks to a cheaper model "
+                    "without overriding your main session model. "
+                    "Silently ignored when delegation.provider is configured."
+                ),
+            },
         },
         "required": [],
     },
@@ -2770,6 +2848,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary

`delegate_task` already supports rich subagent fan-out, but every child currently inherits the parent's model (or `delegation.model` when configured). This PR adds an optional `model` field at both the per-task level and the top level so callers can route individual children to cheaper or more powerful models without touching the main session.

Typical use — cost-aware routing inside a single fan-out:

```python
delegate_task(tasks=[
    {"goal": "list files in /tmp",       "model": "anthropic/claude-haiku-4"},
    {"goal": "refactor auth module",     "model": "anthropic/claude-opus-4.7"},
    {"goal": "summarise the changelog",  "model": "anthropic/claude-haiku-4"},
])
```

## Why

Right now the only way to use a different model for a subagent is to change `delegation.model` for the whole session — which means trivial subtasks pay opus prices alongside the deep ones. Per-task model override lets a single `delegate_task` call send the cheap legwork to haiku and the hard reasoning to opus, which is exactly the pattern users keep building manually around `delegate_task` today.

## Precedence

```
per-task  tasks[i].model
    ↓
top-level model arg
    ↓
delegation.model config (creds["model"])
    ↓
parent_agent.model (existing fallback inside _build_child_agent)
```

When `delegation.provider` is configured, user-supplied model overrides are silently ignored so the delegation-config credential bundle (`provider` + `base_url` + `api_key` + `model`) stays coherent. This matches the existing pattern where `delegation.provider` trumps inherited credentials.

Empty string, whitespace-only, and non-string `model` values fall back to the next level in the precedence chain rather than crashing.

## What changed

- **`tools/delegate_tool.py`** — added `model: Optional[str] = None` to `delegate_task()` signature, threaded it into the synthesized single-task dict and the batch loop, plumbed it through `registry.register(...handler=...)`, and added `model` properties to both the per-task and top-level schema slots with descriptions that teach the LLM what they're for (e.g. "trivial subtasks → haiku, deep reasoning → opus").
- **`tests/tools/test_delegate_model_override.py`** — new file, 16 tests:
  - schema exposure (static + dynamic overrides)
  - all four precedence rules (per-task wins, top-level wins, batch propagation, parent fallback)
  - `delegation.provider` trumps both per-task and top-level overrides
  - validation edge cases (empty / whitespace / non-string / trimming)
  - registry handler forwards `args["model"]`

## Test results

```
$ pytest tests/tools/test_delegate*.py
153 passed in 17.13s
```

That's 137 existing delegate tests + 16 new ones, all green. Zero regressions in:
- `tests/tools/test_delegate.py`
- `tests/tools/test_delegate_composite_toolsets.py`
- `tests/tools/test_delegate_toolset_scope.py`

(There's one pre-existing failure in `tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set` about `tools.video_generation_tool` being in the discovered set — it fails on unmodified `main` too, so it's not from this PR.)

## Notes for reviewers

- **Backwards compatibility:** the new `model` parameter is fully optional and defaults to `None`. Calls that don't pass it behave bit-for-bit identically to before — every existing test still passes.
- **No new dependencies.**
- **No schema breakage:** `delegate_task`'s `parameters.required` list is unchanged.
- **The `_provider_override_active` gate is intentional.** Without it, a user with `delegation.provider: minimax-cn` who also passed `model="anthropic/claude-haiku-4"` would silently get an Anthropic model name on a MiniMax provider — broken credentials. Better to silently ignore the override and stick with the provider-pinned bundle (`creds["model"]`).
- The dynamic schema rebuild path (`_build_dynamic_schema_overrides`) is untouched logic-wise; it deep-copies the static `properties` dict so the new `model` field rides along automatically.

I'm happy to split this into separate commits, rename anything, or rework the precedence rule if you'd prefer a different default. Thanks for considering it!
