### PR TITLE
fix(cron): honor agent.disabled_toolsets — prevent LLM from bypassing tool restrictions (#25752)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -61,6 +61,10 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     Precedence:
     1. Per-job ``enabled_toolsets`` (set via ``cronjob`` tool on create/update).
        Keeps the agent's job-scoped toolset override intact — #6130.
+       WARNING: the per-job value is NOT trusted blindly — it is intersected
+       with the platform toolset so that ``agent.disabled_toolsets`` from
+       config.yaml is always honoured. An LLM can inject a job-scoped override
+       to re-enable disabled tools, which is a security risk (#25752).
     2. Per-platform ``hermes tools`` config for the ``cron`` platform.
        Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``)
        so users can gate cron toolsets globally without recreating every job.
@@ -73,17 +77,25 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
-    if per_job:
-        return per_job
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        platform_toolsets = _get_platform_tools(cfg or {}, "cron")
     except Exception as exc:
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",
             exc,
         )
         return None
+
+    if per_job:
+        # Intersect: keep per-job override but honour disabled_toolsets from
+        # config.yaml.  An LLM can set any per-job value but should never be
+        # able to re-enable tools the operator has globally disabled.
+        # _get_platform_tools already applied disabled_toolsets; intersect
+        # with the per-job list so agents can still narrow toolsets (not widen).
+        return sorted(set(per_job) & platform_toolsets)
+
+    return sorted(platform_toolsets)
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.


### PR DESCRIPTION
## Summary

`_resolve_cron_enabled_toolsets` in `cron/scheduler.py:74-86` returns the LLM-supplied `enabled_toolsets` argument verbatim when present, bypassing `_get_platform_tools` — the only place `agent.disabled_toolsets` from `~/.hermes/config.yaml` (or a profile config) is applied.

**Security impact**: An LLM-injected per-job override can re-enable disabled toolsets (e.g. `terminal`, `file`, `code_execution`, `web`), bypassing operator-configured restrictions in cron job execution context.

## Root Cause

```python
# BEFORE (buggy):
def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
    per_job = job.get("enabled_toolsets")
    if per_job:
        return per_job  # <-- returns LLM-injected value directly, no check
    try:
        from hermes_cli.tools_config import _get_platform_tools
        return sorted(_get_platform_tools(cfg or {}, "cron"))  # disabled_toolsets applied here
    except Exception:
        return None
```

The `_get_platform_tools()` path correctly applies `agent.disabled_toolsets` from config (via `tools_config.py:1212-1220`), but the per-job short-circuit bypasses it entirely.

## Fix

```python
# AFTER (fixed):
def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
    per_job = job.get("enabled_toolsets")
    try:
        from hermes_cli.tools_config import _get_platform_tools
        platform_toolsets = _get_platform_tools(cfg or {}, "cron")  # always compute
    except Exception as exc:
        logger.warning("Cron toolset resolution failed, falling back to full default toolset: %s", exc)
        return None

    if per_job:
        # Intersect: per-job override is allowed to narrow, never widen.
        # _get_platform_tools already applied disabled_toolsets, so intersection
        # ensures agents cannot re-enable globally-disabled tools.
        return sorted(set(per_job) & platform_toolsets)

    return sorted(platform_toolsets)
```

**Key changes**:
1. `_get_platform_tools()` is always called (not short-circuited by per-job value)
2. Per-job `enabled_toolsets` is intersected with `platform_toolsets`
3. This mirrors how gateway/cron platforms work — operator restrictions always win

## Testing

1. Set in `~/.hermes/config.yaml`:
   ```yaml
   agent:
     disabled_toolsets:
       - terminal
       - file
       - code_execution
   ```
2. Confirm `hermes tools list` shows those toolsets as disabled
3. Create a cron job with per-job `enabled_toolsets: [terminal, memory]` via `cronjob` tool
4. Verify the job runs with only `memory` (intersection of `{terminal, memory}` & platform_toolsets where `terminal` is removed)

Resolves: #25752