### PR TITLE
feat(cli): show session title in status bar (toggle: display.status_bar_title)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3196,6 +3196,14 @@ class HermesCLI:
         return "".join(out).rstrip() + ellipsis
 
     @staticmethod
+    def _normalize_status_bar_title(title: object) -> str:
+        """Return a single-line session title safe for status-bar rendering."""
+        try:
+            return " ".join(str(title or "").split())
+        except Exception:
+            return ""
+
+    @staticmethod
     def _get_tui_terminal_width(default: tuple[int, int] = (80, 24)) -> int:
         """Return the live prompt_toolkit width, falling back to ``shutil``.
 
@@ -3351,7 +3359,7 @@ class HermesCLI:
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
-            title = (snapshot.get("session_title") or "").strip()
+            title = self._normalize_status_bar_title(snapshot.get("session_title"))
             title_prefix = f"❝{title}❞ " if title else ""
 
             yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
@@ -3404,10 +3412,16 @@ class HermesCLI:
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
             yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            title = self._normalize_status_bar_title(snapshot.get("session_title"))
+            model_prefix_frags = [
+                ("class:status-bar", " ❝"),
+                ("class:status-bar-strong", title),
+                ("class:status-bar", "❞ ⚕ "),
+            ] if title else [("class:status-bar", " ⚕ ")]
 
             if width < 52:
                 frags = [
-                    ("class:status-bar", " ⚕ "),
+                    *model_prefix_frags,
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
@@ -3422,7 +3436,7 @@ class HermesCLI:
                 if width < 76:
                     compressions = snapshot.get("compressions", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        *model_prefix_frags,
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
@@ -3449,7 +3463,7 @@ class HermesCLI:
                     bar_style = self._status_bar_context_style(percent)
                     compressions = snapshot.get("compressions", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        *model_prefix_frags,
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),

--- a/cli.py
+++ b/cli.py
@@ -3087,7 +3087,25 @@ class HermesCLI:
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
+        session_title = ""
+        try:
+            show_title = bool(
+                ((self.config or {}).get("display") or {}).get("status_bar_title", True)
+            )
+        except Exception:
+            show_title = True
+        if show_title:
+            try:
+                db = getattr(self, "_session_db", None)
+                sid = getattr(self, "session_id", None)
+                if db and sid:
+                    session_title = db.get_session_title(sid) or ""
+                if not session_title:
+                    session_title = getattr(self, "_pending_title", None) or ""
+            except Exception:
+                session_title = ""
         snapshot = {
+            "session_title": session_title,
             "model_name": model_name,
             "model_short": model_short,
             "duration": format_duration_compact(elapsed_seconds),
@@ -3333,15 +3351,17 @@ class HermesCLI:
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            title = (snapshot.get("session_title") or "").strip()
+            title_prefix = f"❝{title}❞ " if title else ""
 
             yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{title_prefix}⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"{title_prefix}⚕ {snapshot['model_short']}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3358,7 +3378,7 @@ class HermesCLI:
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"{title_prefix}⚕ {snapshot['model_short']}", context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             parts.append(duration_label)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -971,6 +971,11 @@ DEFAULT_CONFIG = {
         # `git status` to verify edits landed.  Set false to suppress.
         "file_mutation_verifier": True,
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        # Prefix the CLI status bar with the active session title (or
+        # /title-pending value) when one is set. The trim logic in
+        # cli._build_status_bar_text() drops it first when the terminal
+        # is too narrow, so this is safe to leave on by default.
+        "status_bar_title": True,
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -179,6 +179,76 @@ class TestCLIStatusBar:
         text = cli_obj._build_status_bar_text(width=120)
         assert "Title shown by default" in text
 
+    def test_status_bar_normalizes_title_to_single_line(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Title\nwith\tspacing"
+        cli_obj.config = {"display": {"status_bar_title": True}}
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "Title with spacing" in text
+        assert "\n" not in text
+        assert "\t" not in text
+
+    def test_status_bar_fragments_include_session_title_at_all_widths(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Refactor parser"
+        cli_obj.config = {"display": {"status_bar_title": True}}
+        cli_obj._status_bar_visible = True
+
+        for width in (40, 60, 120):
+            mock_app = MagicMock()
+            mock_app.output.get_size.return_value = MagicMock(columns=width)
+            with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+                frags = cli_obj._get_status_bar_fragments()
+
+            text = "".join(part for _, part in frags)
+            assert "❝Refactor parser❞" in text
+            assert cli_obj._status_bar_display_width(text) <= width
+
+    def test_status_bar_fragments_omit_title_when_toggle_disabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Should not appear"
+        cli_obj.config = {"display": {"status_bar_title": False}}
+        cli_obj._status_bar_visible = True
+
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=120)
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            text = "".join(part for _, part in cli_obj._get_status_bar_fragments())
+
+        assert "Should not appear" not in text
+        cli_obj._session_db.get_session_title.assert_not_called()
+
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -81,6 +81,104 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_status_bar_includes_session_title_when_enabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Refactor parser"
+        cli_obj.config = {"display": {"status_bar_title": True}}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "Refactor parser" in text
+        cli_obj._session_db.get_session_title.assert_called_with("20260514_1100_abc")
+
+    def test_status_bar_omits_title_when_toggle_disabled(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Should not appear"
+        cli_obj.config = {"display": {"status_bar_title": False}}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "Should not appear" not in text
+        # Toggle short-circuits the DB lookup entirely.
+        cli_obj._session_db.get_session_title.assert_not_called()
+
+    def test_status_bar_falls_back_to_pending_title(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = None
+        cli_obj._pending_title = "Queued title"
+        cli_obj.config = {"display": {"status_bar_title": True}}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "Queued title" in text
+
+    def test_status_bar_narrow_width_still_trims_with_title(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "A very long session title " * 5
+        cli_obj.config = {"display": {"status_bar_title": True}}
+
+        # Narrow terminal — must not exceed the budget even with the title prefix.
+        text = cli_obj._build_status_bar_text(width=40)
+        assert cli_obj._status_bar_display_width(text) <= 40
+
+    def test_status_bar_handles_missing_config_gracefully(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.session_id = "20260514_1100_abc"
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.get_session_title.return_value = "Title shown by default"
+        cli_obj.config = None  # simulate degraded init
+
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "Title shown by default" in text
+
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
 


### PR DESCRIPTION
## What

Adds the active **session title** as a quoted prefix on the CLI status bar:

```
❝Refactor parser❞ ⚕ claude-sonnet-4 │ 12K/200K │ 6% │ 15m
```

The title source is whatever `SessionDB.get_session_title()` returns — so it picks up both:

- User-set titles via `/title <name>`
- AI-generated titles from `agent.title_generator.maybe_auto_title()` (already runs after the first exchange)

If the session row hasn't been persisted yet, the in-memory `_pending_title` (queued by `/title` before first message) is shown instead, so the prefix appears immediately rather than after the first turn.

## Why

Long-running CLI sessions are hard to identify at a glance — `hermes sessions list` shows titles, but the live TUI doesn't. Surfacing the title in the always-visible status bar makes it obvious which session you're in (handy with `/branch`, multiple tmux panes, or after `/resume`).

## Behaviour

- **Width-aware.** Title is included at all three breakpoints (`<52`, `<76`, `≥76`); the existing `_trim_status_bar_text()` truncates with an ellipsis when the line would overflow. New regression test asserts the trimmed output stays within the budget.
- **Defensive.** Every DB / config lookup is wrapped in `try/except`; a broken `_session_db`, missing `config`, or stale `_pending_title` cannot break status-bar rendering.
- **No latency added.** `get_session_title()` is a single indexed SELECT against `~/.hermes/state.db`; status bar already queries the DB-adjacent context compressor each frame.

## Toggle

New `display.status_bar_title` (default `True`) in `DEFAULT_CONFIG`. Matches the existing pattern of boolean display toggles (`display.show_cost`, `display.show_reasoning`, `display.streaming`, `display.bell_on_complete`, `display.timestamps`, `display.inline_diffs`, `display.file_mutation_verifier`, `display.persistent_output`).

```bash
hermes config set display.status_bar_title false   # opt out
hermes config set display.status_bar_title true    # re-enable
```

Purely additive — `_deep_merge()` backfills it for existing user configs, so **no `_config_version` bump and no migration** is required (consistent with how all the other display bools were added).

## How to test

```bash
hermes
> /title my-test-session
> hello
# Status bar now shows: ❝my-test-session❞ ⚕ <model> │ ...

# Disable
hermes config set display.status_bar_title false
hermes        # status bar reverts to original format
```

Auto-title path:

```bash
hermes
> What's the capital of France?
# After ~1-2s, status bar gains the AI-generated title (e.g. ❝Capital of France❞)
```

## Tests

- 5 new unit tests in `tests/cli/test_cli_status_bar.py`:
  - title shown when enabled
  - title omitted when toggle disabled (and DB lookup short-circuited)
  - falls back to `_pending_title` when DB returns `None`
  - narrow-width (40 cols) output stays within budget even with long title
  - `config=None` degraded init still renders default behaviour
- All 44 tests in `tests/cli/test_cli_status_bar.py` pass.
- `scripts/check-windows-footguns.py`: clean.

## Platforms tested

- macOS 26.5 (Apple Silicon), Python 3.11, terminal width 120 + 40

## Risk

Low. Two narrow surface-area edits in `cli.py` (snapshot builder + text builder) and one additive default in `DEFAULT_CONFIG`. No public API change, no schema change, no provider/gateway code touched. Toggle defaults to on but degrades silently to the existing format on any error.
