### PR TITLE
feat(memory): daemon_env passthrough for Hindsight embedded config

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -399,7 +399,13 @@ def _load_simple_env(path) -> dict[str, str]:
 
 
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
-    """Build the profile-scoped env file that standalone hindsight-embed consumes."""
+    """Build the profile-scoped env file that standalone hindsight-embed consumes.
+
+    Supports a ``daemon_env`` dict in config.json for passing arbitrary
+    ``HINDSIGHT_API_*`` env vars to the embedded daemon (e.g. worker slots,
+    batch sizes, concurrency limits).  Keys must start with ``HINDSIGHT_``;
+    non-matching keys and ``None`` values are silently ignored.
+    """
     current_key = llm_api_key
     if current_key is None:
         current_key = (
@@ -415,12 +421,20 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
 
-    env_values = {
-        "HINDSIGHT_API_LLM_PROVIDER": str(daemon_provider),
-        "HINDSIGHT_API_LLM_API_KEY": str(current_key or ""),
-        "HINDSIGHT_API_LLM_MODEL": str(current_model),
-        "HINDSIGHT_API_LOG_LEVEL": "info",
-    }
+    # Start with daemon_env passthrough (applied first so explicit keys below always win).
+    env_values: dict[str, str] = {}
+    daemon_env = config.get("daemon_env")
+    if isinstance(daemon_env, dict):
+        for key, value in daemon_env.items():
+            if key.startswith("HINDSIGHT_") and value is not None:
+                env_values[str(key)] = str(value)
+
+    # Explicitly-bridged config.json keys always overwrite daemon_env.
+    env_values["HINDSIGHT_API_LLM_PROVIDER"] = str(daemon_provider)
+    env_values["HINDSIGHT_API_LLM_API_KEY"] = str(current_key or "")
+    env_values["HINDSIGHT_API_LLM_MODEL"] = str(current_model)
+    env_values["HINDSIGHT_API_LOG_LEVEL"] = "info"
+
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
 
@@ -433,6 +447,7 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
     return env_values
 
 
@@ -863,6 +878,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
+            {"key": "daemon_env", "description": "Arbitrary HINDSIGHT_API_* env vars passed to the embedded daemon (JSON object). Example: {\"HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS\": \"4\"}", "default": {}, "when": {"mode": "local_embedded"}},
         ]
 
     def _get_client(self):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -273,6 +273,48 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_daemon_env_passthrough(self):
+        """daemon_env dict passes arbitrary HINDSIGHT_API_* vars to daemon."""
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "daemon_env": {
+                "HINDSIGHT_API_WORKER_MAX_SLOTS": "10",
+                "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE": "16",
+                "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true",
+                "NON_HINDSIGHT_KEY": "ignored",
+                "HINDSIGHT_API_NULL": None,
+            },
+        })
+
+        assert env["HINDSIGHT_API_WORKER_MAX_SLOTS"] == "10"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE"] == "16"
+        assert env["HINDSIGHT_API_SKIP_LLM_VERIFICATION"] == "true"
+        assert "NON_HINDSIGHT_KEY" not in env
+        assert "HINDSIGHT_API_NULL" not in env
+
+    def test_embedded_profile_env_daemon_env_none_or_missing(self):
+        """daemon_env=None or missing doesn't break anything."""
+        for cfg in [
+            {"llm_provider": "openai", "llm_model": "m", "daemon_env": None},
+            {"llm_provider": "openai", "llm_model": "m"},
+        ]:
+            env = _build_embedded_profile_env(cfg)
+            assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+
+    def test_embedded_profile_env_daemon_env_does_not_clobber_explicit_keys(self):
+        """daemon_env cannot override explicitly-bridged keys like llm_model."""
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "real-model",
+            "daemon_env": {
+                "HINDSIGHT_API_LLM_MODEL": "hijacked",
+            },
+        })
+        # Explicit config.json key wins because daemon_env is processed first
+        # and the explicit key overwrites it later.
+        assert env["HINDSIGHT_API_LLM_MODEL"] == "real-model"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Problem

The Hindsight embedded daemon exposes 50+ configurable env vars (worker slots, batch sizes, concurrency, timeouts, retry settings), but the Hermes plugin only bridges ~6 high-level keys from config.json to the daemon env file. Users who want to tune daemon behavior (e.g. consolidation throughput, retain concurrency) have no way to do it through config.json — changes to the env file get wiped on any config update.

## Solution

Add a generic `daemon_env` dict to config.json that passes arbitrary `HINDSIGHT_API_*` env vars to the embedded daemon.

Usage in config.json:
```
"daemon_env": {
  "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS": "4",
  "HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE": "16",
  "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true"
}
```

## Implementation

- `daemon_env` is processed **first** in `_build_embedded_profile_env()`
- Explicitly-bridged keys (provider, model, key, base_url, idle_timeout) are set **after**, so they always win
- Keys must start with `HINDSIGHT_` (non-matching ignored)
- `None` values are silently skipped
- Added to `get_config_schema()` with description and `when: {mode: local_embedded}`

## Tests

3 new tests:
- `test_embedded_profile_env_daemon_env_passthrough` — values forwarded, invalid keys/values filtered
- `test_embedded_profile_env_daemon_env_none_or_missing` — graceful handling
- `test_embedded_profile_env_daemon_env_does_not_clobber_explicit_keys` — explicit config.json keys always win

Full suite: 99 plugin tests + 88 memory provider tests = 187 pass.