### PR TITLE
fix: report missing CDP endpoint in doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1887,9 +1887,12 @@ def run_doctor(args):
         
         for item in unavailable:
             env_vars = item.get("missing_vars") or item.get("env_vars") or []
+            reason = item.get("reason")
             if env_vars:
                 vars_str = ", ".join(env_vars)
                 check_warn(item["name"], f"(missing {vars_str})")
+            elif reason:
+                check_warn(item["name"], f"({reason})")
             else:
                 check_warn(item["name"], "(system dependency not met)")
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -658,6 +658,43 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "npm install -g agent-browser && agent-browser install" in out
 
 
+def test_run_doctor_prints_specific_unavailable_toolset_reason(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (
+            [],
+            [
+                {
+                    "name": "browser-cdp",
+                    "env_vars": [],
+                    "tools": ["browser_cdp"],
+                    "reason": "CDP endpoint not configured",
+                }
+            ],
+        ),
+        TOOLSET_REQUIREMENTS={"browser-cdp": {"name": "browser-cdp"}},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "browser-cdp" in out
+    assert "CDP endpoint not configured" in out
+    assert "browser-cdp (system dependency not met)" not in out
+
+
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -201,6 +201,22 @@ def test_websockets_missing_returns_error(monkeypatch):
     assert "websockets" in result["error"].lower()
 
 
+def test_check_distinguishes_missing_cdp_endpoint_from_system_dependency(monkeypatch):
+    import sys
+    import types
+
+    fake_browser_tool = types.SimpleNamespace(
+        check_browser_requirements=lambda: True,
+        _get_cdp_override=lambda: "",
+    )
+    monkeypatch.setitem(sys.modules, "tools.browser_tool", fake_browser_tool)
+
+    assert browser_cdp_tool._browser_cdp_check() == (
+        False,
+        "CDP endpoint not configured",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Happy-path: browser-level call
 # ---------------------------------------------------------------------------
@@ -385,7 +401,10 @@ def test_check_fn_false_when_no_cdp_url(monkeypatch):
 
     monkeypatch.setattr(bt, "check_browser_requirements", lambda: True)
     monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
-    assert browser_cdp_tool._browser_cdp_check() is False
+    assert browser_cdp_tool._browser_cdp_check() == (
+        False,
+        "CDP endpoint not configured",
+    )
 
 
 def test_check_fn_true_when_cdp_url_set(monkeypatch):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -287,6 +287,28 @@ class TestCheckFnExceptionHandling:
         assert "works" in available
         assert any(u["name"] == "crashes" for u in unavailable)
 
+    def test_unavailable_toolset_can_report_specific_reason(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="browser_cdp",
+            toolset="browser-cdp",
+            schema=_make_schema("browser_cdp"),
+            handler=_dummy_handler,
+            check_fn=lambda: (False, "CDP endpoint not configured"),
+        )
+
+        available, unavailable = reg.check_tool_availability()
+
+        assert "browser-cdp" not in available
+        assert unavailable == [
+            {
+                "name": "browser-cdp",
+                "env_vars": [],
+                "tools": ["browser_cdp"],
+                "reason": "CDP endpoint not configured",
+            }
+        ]
+
 
 class TestBuiltinDiscovery:
     def test_discovers_all_real_self_registering_builtin_tool_modules(self):

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -523,7 +523,7 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
 }
 
 
-def _browser_cdp_check() -> bool:
+def _browser_cdp_check() -> bool | tuple[bool, str]:
     """Availability check for browser_cdp.
 
     The tool is only offered when the Python side can actually reach a CDP
@@ -550,7 +550,9 @@ def _browser_cdp_check() -> bool:
         return False
     if not check_browser_requirements():
         return False
-    return bool(_get_cdp_override())
+    if not _get_cdp_override():
+        return False, "CDP endpoint not configured"
+    return True
 
 
 registry.register(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -21,7 +21,7 @@ import logging
 import threading
 import time
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -119,26 +119,53 @@ class ToolEntry:
 # ---------------------------------------------------------------------------
 
 _CHECK_FN_TTL_SECONDS = 30.0
-_check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
+_check_fn_cache: Dict[Callable, tuple[float, bool, Optional[str]]] = {}
 _check_fn_cache_lock = threading.Lock()
 
 
-def _check_fn_cached(fn: Callable) -> bool:
-    """Return bool(fn()), TTL-cached across calls. Swallows exceptions as False."""
+def _normalize_check_result(value: Any) -> tuple[bool, Optional[str]]:
+    """Normalize a check_fn return value to ``(available, reason)``.
+
+    Historically check functions returned plain booleans.  Some toolsets need
+    to distinguish unavailable states (for example, missing system dependency
+    vs. missing user configuration), so checks may also return
+    ``(False, "human readable reason")`` or
+    ``{"available": False, "reason": "..."}``.
+    """
+    reason = None
+    if isinstance(value, tuple):
+        available = bool(value[0]) if value else False
+        if not available and len(value) > 1 and value[1]:
+            reason = str(value[1])
+        return available, reason
+    if isinstance(value, dict) and "available" in value:
+        available = bool(value.get("available"))
+        detail = value.get("reason") or value.get("message")
+        if not available and detail:
+            reason = str(detail)
+        return available, reason
+    return bool(value), None
+
+
+def _check_fn_cached(fn: Callable) -> tuple[bool, Optional[str]]:
+    """Return normalized ``fn()`` result, TTL-cached across calls.
+
+    Exceptions are swallowed as unavailable without a specific reason.
+    """
     now = time.monotonic()
     with _check_fn_cache_lock:
         cached = _check_fn_cache.get(fn)
         if cached is not None:
-            ts, value = cached
+            ts, available, reason = cached
             if now - ts < _CHECK_FN_TTL_SECONDS:
-                return value
+                return available, reason
     try:
-        value = bool(fn())
+        available, reason = _normalize_check_result(fn())
     except Exception:
-        value = False
+        available, reason = False, None
     with _check_fn_cache_lock:
-        _check_fn_cache[fn] = (now, value)
-    return value
+        _check_fn_cache[fn] = (now, available, reason)
+    return available, reason
 
 
 def invalidate_check_fn_cache() -> None:
@@ -181,13 +208,20 @@ class ToolRegistry:
 
     def _evaluate_toolset_check(self, toolset: str, check: Callable | None) -> bool:
         """Run a toolset check, treating missing or failing checks as unavailable/available."""
+        available, _reason = self._evaluate_toolset_check_detail(toolset, check)
+        return available
+
+    def _evaluate_toolset_check_detail(
+        self, toolset: str, check: Callable | None
+    ) -> tuple[bool, Optional[str]]:
+        """Run a toolset check and return availability plus optional reason."""
         if not check:
-            return True
+            return True, None
         try:
-            return bool(check())
+            return _normalize_check_result(check())
         except Exception:
             logger.debug("Toolset %s check raised; marking unavailable", toolset)
-            return False
+            return False, None
 
     def get_entry(self, name: str) -> Optional[ToolEntry]:
         """Return a registered tool entry by name, or None."""
@@ -357,7 +391,8 @@ class ToolRegistry:
                 continue
             if entry.check_fn:
                 if entry.check_fn not in check_results:
-                    check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
+                    available, _reason = _check_fn_cached(entry.check_fn)
+                    check_results[entry.check_fn] = available
                 if not check_results[entry.check_fn]:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
@@ -529,14 +564,20 @@ class ToolRegistry:
             if ts in seen:
                 continue
             seen.add(ts)
-            if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
+            is_available, reason = self._evaluate_toolset_check_detail(
+                ts, toolset_checks.get(ts)
+            )
+            if is_available:
                 available.append(ts)
             else:
-                unavailable.append({
+                item = {
                     "name": ts,
                     "env_vars": entry.requires_env,
                     "tools": [e.name for e in entries if e.toolset == ts],
-                })
+                }
+                if reason:
+                    item["reason"] = reason
+                unavailable.append(item)
         return available, unavailable
 
 


### PR DESCRIPTION
## Summary
- allow tool availability checks to return an optional unavailable reason
- report `browser-cdp` as `CDP endpoint not configured` when browser dependencies pass but no CDP URL is configured
- teach `hermes doctor` to print that specific reason instead of the generic `system dependency not met`

Fixes #25753.

## Test Plan
- `python -m pytest tests/tools/test_browser_cdp_tool.py tests/hermes_cli/test_doctor.py tests/tools/test_registry.py::TestCheckFnExceptionHandling -q -o 'addopts='`
- `git diff --check`

## Notes
- A broader local run including full `tests/tools/test_registry.py` surfaced an unrelated existing discovery expectation drift: `tools.video_generation_tool` is discovered but not listed in `TestBuiltinDiscovery.test_matches_previous_manual_builtin_tool_set`.
