### PR TITLE
fix(security): guard os.chmod(parent) against / and system dirs (#25821)

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -491,10 +491,8 @@ def save_credentials(creds: GoogleCredentials) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds file.
     # On Windows this is a no-op (POSIX mode bits aren't enforced); ignore failures.
-    try:
-        os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
+    from hermes_constants import safe_chmod_parent
+    safe_chmod_parent(path)
     payload = json.dumps(creds.to_dict(), indent=2, sort_keys=True) + "\n"
 
     with _credentials_lock():

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -987,10 +987,8 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
-    try:
-        os.chmod(auth_file.parent, 0o700)
-    except OSError:
-        pass
+    from hermes_constants import safe_chmod_parent
+    safe_chmod_parent(auth_file)
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
@@ -1569,10 +1567,8 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
 def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     auth_path = _qwen_cli_auth_path()
     auth_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(auth_path.parent, 0o700)
-    except OSError:
-        pass
+    from hermes_constants import safe_chmod_parent
+    safe_chmod_parent(auth_path)
     # Per-process random temp suffix avoids collisions between concurrent
     # writers and stale leftovers from a crashed prior write.
     tmp_path = auth_path.with_name(f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
@@ -2987,10 +2983,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
             path.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                os.chmod(path.parent, 0o700)
-            except OSError:
-                pass
+            from hermes_constants import safe_chmod_parent
+            safe_chmod_parent(path)
             tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
             # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU
             # window where write_text() + post-write chmod briefly exposed Nous

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -29,6 +29,24 @@ def get_hermes_home() -> Path:
     """
     val = os.environ.get("HERMES_HOME", "").strip()
     if val:
+        resolved = Path(val).resolve()
+        if resolved == Path("/") or len(resolved.parts) < 2 or resolved in _PROTECTED_DIRS:
+            import sys, logging
+            msg = (
+                f"[HERMES_HOME DANGER] HERMES_HOME={val!r} resolves to {resolved} — "
+                f"a protected system directory. Credential-store chmod calls will "
+                f"skip this path to avoid bricking the host (see #25821). "
+                f"Set HERMES_HOME to a safe subdirectory (e.g. ~/.hermes)."
+            )
+            try:
+                sys.stderr.write(msg + "\n")
+                sys.stderr.flush()
+            except Exception:
+                pass
+            try:
+                logging.getLogger(__name__).error(msg)
+            except Exception:
+                pass
         return Path(val)
 
     # Guard: if a non-default profile is sticky-active, warn once that
@@ -337,6 +355,62 @@ def apply_ipv4_preference(force: bool = False) -> None:
 
     _ipv4_getaddrinfo._hermes_ipv4_patched = True  # type: ignore[attr-defined]
     socket.getaddrinfo = _ipv4_getaddrinfo  # type: ignore[assignment]
+
+
+# ── Protected system paths ────────────────────────────────────────────
+# chmod(0o700) on any of these would break non-root system services
+# (systemd-resolved, journald, Docker containers that drop privileges, …).
+# See https://github.com/NousResearch/hermes-agent/issues/25821
+_PROTECTED_DIRS: frozenset[Path] = frozenset({
+    Path("/"),
+    Path("/etc"),
+    Path("/var"),
+    Path("/usr"),
+    Path("/home"),
+    Path("/root"),
+    Path("/opt"),
+    Path("/tmp"),
+    Path("/proc"),
+    Path("/sys"),
+    Path("/dev"),
+    Path("/run"),
+    Path("/boot"),
+})
+
+
+def safe_chmod_parent(path: Path, mode: int = 0o700) -> None:
+    """chmod *path.parent* only if it is a safe, non-system directory.
+
+    Prevents the catastrophic scenario where a malformed HERMES_HOME or
+    unexpected path resolution causes ``os.chmod("/", 0o700)`` — which
+    bricks every non-root user on the host (systemd-resolved, journald,
+    Docker containers, …).
+
+    This is the single authoritative guard for all credential-store parent
+    directory chmod calls.  Use it everywhere you would otherwise write::
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError:
+            pass
+
+    Instead write::
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        safe_chmod_parent(path)
+    """
+    parent = path.parent.resolve()
+    # Refuse to chmod root or any top-level directory.
+    if parent == Path("/") or len(parent.parts) < 2:
+        return
+    # Refuse well-known system roots.
+    if parent in _PROTECTED_DIRS:
+        return
+    try:
+        os.chmod(parent, mode)
+    except OSError:
+        pass
 
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -175,10 +175,8 @@ def _write_json(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds.
     # No-op on Windows (POSIX mode bits aren't enforced); ignore failures.
-    try:
-        os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
+    from hermes_constants import safe_chmod_parent
+    safe_chmod_parent(path)
     # Per-process random suffix avoids collisions between concurrent
     # writers and stale leftovers from a prior crashed write.
     tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")


### PR DESCRIPTION
## Summary

Prevents `os.chmod(path.parent, 0o700)` from running on `/` or well-known system directories, which bricks every non-root user on the host.

Fixes #25821

## Changes

- Add `safe_chmod_parent()` to `hermes_constants.py` — refuses to chmod root or system dirs (`/etc`, `/var`, `/usr`, `/home`, `/root`, `/opt`, `/tmp`, `/proc`, `/sys`, `/dev`, `/run`, `/boot`)
- Replace all 5 unprotected `os.chmod(path.parent, 0o700)` call sites:
  - `hermes_cli/auth.py` (3 sites: `_save_auth_store`, `_save_qwen_cli_tokens`, `_save_nous_shared_token`)
  - `tools/mcp_oauth.py` (`_write_json`)
  - `agent/google_oauth.py` (`save_credentials`)
- Add startup warning in `get_hermes_home()` when `HERMES_HOME` resolves to a protected directory

## Why

Without this guard, a malformed `HERMES_HOME=/` causes `chmod("/", 0o700)` which breaks systemd-resolved, journald, Docker containers, and every non-root service. See issue for production incident report.