### PR TITLE
fix(mcp): repair array schemas missing items

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -266,6 +266,45 @@ class TestSchemaConversion:
 
         assert schema["properties"]["items"]["items"]["properties"] == {}
 
+    def test_array_schema_without_items_gets_empty_items_schema(self):
+        """OpenAI rejects array-typed function parameters that omit items."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "description": "Replacement tags (max 50)",
+                },
+            },
+        })
+
+        assert schema["properties"]["tags"] == {
+            "type": "array",
+            "description": "Replacement tags (max 50)",
+            "items": {},
+        }
+
+    def test_array_schema_with_prefix_items_does_not_get_extra_items_schema(self):
+        """Tuple-style arrays are already constrained by prefixItems."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "pair": {
+                    "type": "array",
+                    "prefixItems": [{"type": "string"}, {"type": "integer"}],
+                },
+            },
+        })
+
+        assert schema["properties"]["pair"] == {
+            "type": "array",
+            "prefixItems": [{"type": "string"}, {"type": "integer"}],
+        }
+
     def test_optional_nullable_field_is_collapsed_to_non_null_schema(self):
         """Anthropic rejects MCP/Pydantic anyOf-null optional parameter schemas."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -38,6 +38,27 @@ def test_nested_object_without_properties_gets_empty_properties():
     assert args["description"] == "free-form"
 
 
+def test_array_without_items_gets_empty_items_schema():
+    tools = [_tool("mcp_canva_canva_update_assets", {
+        "type": "object",
+        "properties": {
+            "tags": {
+                "type": "array",
+                "description": "Replacement tags (max 50)",
+            },
+        },
+    })]
+
+    out = sanitize_tool_schemas(tools)
+
+    tags = out[0]["function"]["parameters"]["properties"]["tags"]
+    assert tags == {
+        "type": "array",
+        "description": "Replacement tags (max 50)",
+        "items": {},
+    }
+
+
 def test_bare_string_object_value_replaced_with_schema_dict():
     # Malformed: a property's schema value is the bare string "object".
     # This is the exact shape llama.cpp reports as `Unrecognized schema: "object"`.
@@ -61,6 +82,18 @@ def test_bare_string_primitive_value_replaced_with_schema_dict():
     })]
     out = sanitize_tool_schemas(tools)
     assert out[0]["function"]["parameters"]["properties"]["name"] == {"type": "string"}
+
+
+def test_bare_string_array_value_gets_items_schema():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"tags": "array"},
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["properties"]["tags"] == {
+        "type": "array",
+        "items": {},
+    }
 
 
 def test_nullable_type_array_collapsed_to_single_string():

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2599,6 +2599,9 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
       nullable branches in tool input schemas, so nullable unions are collapsed
       to the non-null branch and optionality remains represented solely by the
       parent object's ``required`` list.
+    * Array nodes with no ``items`` or ``prefixItems`` schema are given a
+      permissive empty schema; OpenAI rejects function schemas with ``array
+      schema missing items``.
 
     All repairs are provider-agnostic and ideally produce a schema valid on
     OpenAI, Anthropic, Gemini, and Moonshot in one pass.
@@ -2668,6 +2671,9 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
                         repaired["required"] = valid
                     else:
                         repaired.pop("required", None)
+
+        if repaired.get("type") == "array" and "items" not in repaired and "prefixItems" not in repaired:
+            repaired["items"] = {}
 
         return repaired
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -20,6 +20,9 @@ The failure modes we've seen in the wild:
 * ``anyOf`` / ``oneOf`` unions whose only purpose is to permit ``null`` for
   optional fields (common Pydantic/MCP shape). Anthropic rejects these at
   the top of ``input_schema``; collapse them to the non-null branch.
+* ``{"type": "array"}`` or bare ``"array"`` with no ``items`` /
+  ``prefixItems`` — OpenAI rejects function parameter schemas with ``array
+  schema missing items``.
 * Unconstrained ``additionalProperties`` on objects with empty properties.
 
 This module walks the final tool schema tree (after MCP-level normalization
@@ -209,10 +212,17 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 "with {'type': %r}",
                 path, node, node,
             )
-            return {"type": node} if node != "object" else {
-                "type": "object",
-                "properties": {},
-            }
+            if node == "object":
+                return {
+                    "type": "object",
+                    "properties": {},
+                }
+            if node == "array":
+                return {
+                    "type": "array",
+                    "items": {},
+                }
+            return {"type": node}
         # Any other stray string is not a schema — drop it by replacing with
         # a permissive object schema rather than propagate something the
         # backend will reject.
@@ -283,6 +293,14 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Array nodes must declare an ``items`` or ``prefixItems`` schema for
+    # OpenAI-compatible function calling. Some MCP servers omit both for
+    # loosely typed lists (for example Canva asset ``tags``). Use the
+    # permissive empty schema so we repair the invalid shape without inventing
+    # a stricter element type.
+    if out.get("type") == "array" and "items" not in out and "prefixItems" not in out:
+        out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
## Summary
- normalize MCP input schemas so `type: array` nodes that omit both `items` and `prefixItems` receive permissive `items: {}` during MCP ingestion
- apply the same fallback in the final tool-schema sanitizer, including bare-string `"array"` schema nodes
- add regression coverage for the Canva MCP `tags` shape and prefixItems-preservation behavior

## Why
Some MCP servers emit loose array schemas such as Canva's `mcp_canva_canva_update_assets.tags`:

```json
{
  "type": "array",
  "description": "Replacement tags (max 50)"
}
```

OpenAI-compatible providers reject the whole tool list before inference with `array schema missing items`. This keeps the array unconstrained without inventing an element type, while avoiding provider-side function-schema rejection.

Related issue/comment: #14927. This overlaps the final-sanitizer part of #22056 / #24158, but also repairs the MCP ingestion path and includes the Canva repro.

## Test Plan
- [x] `source venv/bin/activate && python -m py_compile tools/mcp_tool.py tools/schema_sanitizer.py`
- [x] `source venv/bin/activate && python -m pytest tests/tools/test_schema_sanitizer.py tests/tools/test_mcp_tool.py -q`
- [x] `git diff --check`
- [x] independent reviewer pass
