### PR TITLE
fix(tui): recover stuck prompt submissions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6942,6 +6942,79 @@ def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+@pytest.mark.parametrize("handoff", ["direct", "queued"])
+def test_interrupt_after_worker_handoff_releases_same_owner_claim(
+    monkeypatch, handoff
+):
+    """A stop between Thread.start() and run() must release that worker's claim.
+
+    Both a normal dispatch and the queued-prompt drain transfer ownership through
+    _run_prompt_submit, so exercise the shared interleaving deterministically.
+    """
+    workers = []
+    calls = {"interrupted": False, "ran": False}
+
+    class _DeferredLiveThread:
+        def __init__(self, target=None, daemon=None):
+            self.target = target
+            workers.append(self)
+
+        def start(self):
+            return None
+
+        def is_alive(self):
+            return True
+
+    agent = types.SimpleNamespace(
+        interrupt=lambda: calls.__setitem__("interrupted", True),
+        run_conversation=lambda *args, **kwargs: calls.__setitem__("ran", True),
+    )
+    direct = handoff == "direct"
+    session = _session(
+        agent=agent,
+        running=direct,
+        queued_prompt=None
+        if direct
+        else {"text": "queued hello", "transport": None},
+        _run_thread=threading.current_thread() if direct else None,
+    )
+    server._sessions["sid"] = session
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _DeferredLiveThread)
+        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+        monkeypatch.setattr(server, "_session_uses_compute_host", lambda session: False)
+
+        if direct:
+            server._run_prompt_submit("1", "sid", session, "hello")
+        else:
+            assert server._drain_queued_prompt("1", "sid", session) is True
+
+        worker = workers[-1]
+        assert session["_run_thread"] is worker
+        assert session["running"] is True
+        assert isinstance(session.get("inflight_turn"), dict)
+
+        stop = server.handle_request(
+            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
+        )
+
+        assert stop.get("result"), f"got error: {stop.get('error')}"
+        assert calls["interrupted"] is True
+        assert session["_turn_cancel_requested"] is True
+        assert session["running"] is True
+        assert session["_run_thread"] is worker
+
+        worker.target()
+
+        assert calls["ran"] is False
+        assert session["running"] is False
+        assert session.get("inflight_turn") is None
+        assert session.get("_run_thread") is None
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_interrupt_drops_queued_prompt_for_session():
     """Explicit stop cancels a queued next turn instead of auto-draining it."""
     calls = {"interrupted": False}
@@ -8223,7 +8296,12 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("model-live", ""))
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, _session=None: {"model": agent.model},
+    )
 
     def _emit(event, sid, payload=None):
         if event == "message.complete":

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -78,20 +78,40 @@ def test_safe_cwd_tolerates_deleted_process_cwd(server, monkeypatch, tmp_path):
     assert server._safe_cwd() == str(tmp_path)
 
 
-def test_prompt_submit_dispatch_failure_clears_running(server, monkeypatch):
+def test_prompt_submit_pre_worker_failure_clears_turn_state(server, monkeypatch):
     emitted = []
     monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda session, cfg=None: False)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    failed_thread = MagicMock()
+    failed_thread.start.side_effect = RuntimeError("thread start failed")
+    monkeypatch.setattr(server.threading, "Thread", MagicMock(return_value=failed_thread))
+
+    sid = "sid1"
     session = {
+        "agent": MagicMock(),
+        "agent_ready": threading.Event(),
         "attached_images": [],
         "history": [],
         "history_lock": threading.Lock(),
         "history_version": 0,
-        "running": True,
+        "inflight_turn": None,
+        "running": False,
+        "session_key": "session-key",
     }
+    server._sessions[sid] = session
 
-    server._run_prompt_submit("r1", "sid1", session, "hello")
+    response = server._methods["prompt.submit"](
+        "r1", {"session_id": sid, "text": "hello"}
+    )
 
+    assert response["result"] == {"status": "streaming"}
     assert session["running"] is False
+    assert session["inflight_turn"] is None
+    assert session["_run_thread"] is None
     assert emitted
     assert emitted[-1][0] == "error"
     assert "prompt dispatch failed" in emitted[-1][2]["message"]

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -71,6 +71,32 @@ def test_err_envelope(server):
     }
 
 
+def test_safe_cwd_tolerates_deleted_process_cwd(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setattr(server.os, "getcwd", MagicMock(side_effect=OSError("gone")))
+
+    assert server._safe_cwd() == str(tmp_path)
+
+
+def test_prompt_submit_dispatch_failure_clears_running(server, monkeypatch):
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    session = {
+        "attached_images": [],
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+    }
+
+    server._run_prompt_submit("r1", "sid1", session, "hello")
+
+    assert session["running"] is False
+    assert emitted
+    assert emitted[-1][0] == "error"
+    assert "prompt dispatch failed" in emitted[-1][2]["message"]
+
+
 # ── write_json ───────────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -44,6 +44,37 @@ load_hermes_dotenv(
 )
 
 
+def _safe_cwd(preferred: str | os.PathLike[str] | None = None) -> str:
+    """Return an existing local cwd even if the process cwd was deleted."""
+    candidates: list[str | os.PathLike[str] | None] = [
+        preferred,
+        os.environ.get("TERMINAL_CWD"),
+    ]
+    try:
+        candidates.append(os.getcwd())
+    except OSError:
+        pass
+    candidates.extend(
+        [
+            os.environ.get("PWD"),
+            _hermes_home,
+            os.path.expanduser("~"),
+            os.path.abspath(os.sep),
+        ]
+    )
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            resolved = os.path.abspath(os.path.expanduser(os.fspath(candidate)))
+            if os.path.isdir(resolved):
+                return resolved
+        except (OSError, TypeError, ValueError):
+            continue
+    return os.path.abspath(os.sep)
+
+
 # ── Panic logger ─────────────────────────────────────────────────────
 # Gateway crashes in a TUI session leave no forensics: stdout is the
 # JSON-RPC pipe (TUI side parses it, doesn't log raw), the root logger
@@ -338,7 +369,7 @@ class _SlashWorker:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=_safe_cwd(),
             env=env,
             creationflags=windows_hide_flags(),
             start_new_session=True,
@@ -1160,7 +1191,7 @@ def _default_session_cwd() -> str:
     than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
     ``TERMINAL_CWD``.
     """
-    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
+    return _safe_cwd(_launch_configured_cwd())
 
 
 def write_json(obj: dict) -> bool:
@@ -1310,6 +1341,7 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         session["running"] = False
         session["last_active"] = time.time()
         _clear_inflight_turn(session)
+        session["_run_thread"] = None
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
         _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
@@ -1745,15 +1777,8 @@ def _completion_cwd(params: dict | None = None) -> str:
         # configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
         or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
     )
-    try:
-        resolved = os.path.abspath(os.path.expanduser(str(raw)))
-        if os.path.isdir(resolved):
-            return resolved
-    except Exception:
-        pass
-    return os.getcwd()
+    return _safe_cwd(raw)
 
 
 def _terminal_task_cwd(session: dict | None) -> str:
@@ -5554,6 +5579,37 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
+def _clear_prompt_turn(
+    session: dict, *, owner: threading.Thread | None = None
+) -> bool:
+    """Release a claimed turn if ``owner`` still owns its run-thread slot."""
+    with session["history_lock"]:
+        current_owner = session.get("_run_thread")
+        if owner is not None and current_owner not in (None, owner):
+            return False
+        session["running"] = False
+        session["last_active"] = time.time()
+        _clear_inflight_turn(session)
+        session["_run_thread"] = None
+    return True
+
+
+def _emit_prompt_failure(
+    sid: str,
+    session: dict,
+    message: str,
+    *,
+    owner: threading.Thread | None = None,
+) -> None:
+    """Surface a pre-worker failure and release the matching turn claim."""
+    try:
+        _emit("error", sid, {"message": message or "prompt dispatch failed"})
+    except Exception:
+        logger.exception("failed to emit prompt dispatch error for session %s", sid)
+    finally:
+        _clear_prompt_turn(session, owner=owner)
+
+
 def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     """Stash a message to run as the very next turn once the live one ends.
 
@@ -5668,6 +5724,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             return False
         session["queued_prompt"] = None
         session["running"] = True
+        session["_run_thread"] = threading.current_thread()
         if queued.get("transport") is not None:
             session["transport"] = queued["transport"]
     try:
@@ -5675,9 +5732,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             resp = _submit_prompt_to_compute_host(rid, sid, session, queued["text"])
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
-                with session["history_lock"]:
-                    session["running"] = False
-                    _clear_inflight_turn(session)
+                _clear_prompt_turn(session, owner=threading.current_thread())
                 _emit("error", sid, {"message": message})
         else:
             _run_prompt_submit(rid, sid, session, queued["text"])
@@ -5687,8 +5742,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
             f"{type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
-        with session["history_lock"]:
-            session["running"] = False
+        _clear_prompt_turn(session, owner=threading.current_thread())
     return True
 
 
@@ -9067,11 +9121,8 @@ def _(rid, params: dict) -> dict:
     with session["history_lock"]:
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
-    if not run_thread_alive:
-        with session["history_lock"]:
-            if session.get("running"):
-                session["running"] = False
-                _clear_inflight_turn(session)
+    if not run_thread_alive and session.get("running"):
+        _clear_prompt_turn(session, owner=run_thread)
 
     # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
     # foreground subprocess). Background processes the agent started (dev servers,
@@ -9366,6 +9417,7 @@ def _(rid, params: dict) -> dict:
         return err
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
+    dispatch_owner = threading.current_thread()
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
@@ -9422,53 +9474,81 @@ def _(rid, params: dict) -> dict:
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
+        session["_run_thread"] = dispatch_owner
         _start_inflight_turn(session, text)
 
-    if turn_isolation:
-        isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
-        if not isolated_response.get("error"):
-            return isolated_response
-        logger.warning(
-            "compute-host dispatch failed for session %s; falling back inline: %s",
-            sid,
-            isolated_response["error"].get("message", "unknown error"),
-        )
+    try:
+        if turn_isolation:
+            isolated_response = _submit_prompt_to_compute_host(rid, sid, session, text)
+            if not isolated_response.get("error"):
+                return isolated_response
+            logger.warning(
+                "compute-host dispatch failed for session %s; falling back inline: %s",
+                sid,
+                isolated_response["error"].get("message", "unknown error"),
+            )
 
-    # Persist the DB row lazily, now that the user has actually sent a message.
-    _ensure_session_db_row(session)
-    # A branch becomes real here: copy its parent's transcript into the row so it
-    # resumes with full context (the agent won't persist the seed itself).
-    _persist_branch_seed(session)
-    _start_agent_build(sid, session)
+        # Persist the DB row lazily, now that the user has actually sent a message.
+        _ensure_session_db_row(session)
+        # A branch becomes real here: copy its parent's transcript into the row so it
+        # resumes with full context (the agent won't persist the seed itself).
+        _persist_branch_seed(session)
+        _start_agent_build(sid, session)
+    except Exception as exc:
+        _emit_prompt_failure(
+            sid,
+            session,
+            f"prompt dispatch failed: {exc}",
+            owner=dispatch_owner,
+        )
+        return _ok(rid, {"status": "streaming"})
+
+    run_thread = None
 
     def run_after_agent_ready() -> None:
-        err = _wait_agent(session, rid)
-        if err:
-            _emit(
-                "error",
-                sid,
-                {
-                    "message": err.get("error", {}).get(
-                        "message", "agent initialization failed"
-                    )
-                },
-            )
+        owner = run_thread or threading.current_thread()
+        try:
+            err = _wait_agent(session, rid)
             with session["history_lock"]:
-                session["running"] = False
-                _clear_inflight_turn(session)
-            return
-        with session["history_lock"]:
-            if session.get("_turn_cancel_requested") or not session.get("running"):
-                session["running"] = False
-                _clear_inflight_turn(session)
+                if session.get("_run_thread") is not owner:
+                    return
+                cancelled = session.get("_turn_cancel_requested") or not session.get(
+                    "running"
+                )
+            if err:
+                message = err.get("error", {}).get(
+                    "message", "agent initialization failed"
+                )
+                _emit_prompt_failure(sid, session, message, owner=owner)
                 return
-        _run_prompt_submit(rid, sid, session, text)
+            if cancelled:
+                _clear_prompt_turn(session, owner=owner)
+                return
+            _run_prompt_submit(rid, sid, session, text)
+        except Exception as exc:
+            _emit_prompt_failure(
+                sid,
+                session,
+                f"prompt dispatch failed: {exc}",
+                owner=owner,
+            )
 
-    run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
-    # Keep a handle so session.interrupt can tell a live turn from a stuck
-    # `running` flag (a turn that died without clearing it) and recover the latter.
-    session["_run_thread"] = run_thread
-    run_thread.start()
+    try:
+        run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
+        # Keep a handle so session.interrupt can tell a live turn from a stuck
+        # `running` flag (a turn that died without clearing it) and recover the latter.
+        with session["history_lock"]:
+            if session.get("_run_thread") is not dispatch_owner:
+                return _ok(rid, {"status": "streaming"})
+            session["_run_thread"] = run_thread
+        run_thread.start()
+    except Exception as exc:
+        _emit_prompt_failure(
+            sid,
+            session,
+            f"prompt dispatch failed: {exc}",
+            owner=run_thread,
+        )
     return _ok(rid, {"status": "streaming"})
 
 
@@ -9654,6 +9734,11 @@ def _notification_poller_loop(
     events whose owner is gone; ownerless legacy notifications remain global.
     """
     from tools.process_registry import process_registry, format_process_notification
+    from tools.async_delegation import (
+        claim_event_delivery,
+        complete_event_delivery,
+        release_event_delivery,
+    )
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
     while not stop_event.is_set() and not session.get("_finalized"):
@@ -9718,6 +9803,7 @@ def _notification_poller_loop(
                 _requeued = True
             else:
                 session["running"] = True
+                session["_run_thread"] = threading.current_thread()
         if _requeued:
             # Back off before re-polling: the re-queued event keeps the queue
             # non-empty, so without a sleep this loop spins at full speed
@@ -9726,11 +9812,14 @@ def _notification_poller_loop(
             continue
 
         rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            _clear_prompt_turn(session, owner=threading.current_thread())
+            logger.warning("notification claim failed for session %s: %s", sid, exc)
+            continue
         if _claim is None:
+            _clear_prompt_turn(session, owner=threading.current_thread())
             continue
         try:
             _emit("message.start", sid)
@@ -9743,8 +9832,7 @@ def _notification_poller_loop(
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
-            with session["history_lock"]:
-                session["running"] = False
+            _clear_prompt_turn(session, owner=threading.current_thread())
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
@@ -9792,13 +9880,17 @@ def _notification_poller_loop(
                 process_registry.completion_queue.put(evt)
                 break
             session["running"] = True
+            session["_run_thread"] = threading.current_thread()
 
         rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            _clear_prompt_turn(session, owner=threading.current_thread())
+            logger.warning("notification claim failed for session %s: %s", sid, exc)
+            continue
         if _claim is None:
+            _clear_prompt_turn(session, owner=threading.current_thread())
             continue
         try:
             _emit("message.start", sid)
@@ -9811,8 +9903,7 @@ def _notification_poller_loop(
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
-            with session["history_lock"]:
-                session["running"] = False
+            _clear_prompt_turn(session, owner=threading.current_thread())
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -9878,22 +9969,48 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
-    with session["history_lock"]:
-        history = list(session["history"])
-        history_version = int(session.get("history_version", 0))
-        images = list(session.get("attached_images", []))
-        session["attached_images"] = []
-        if not isinstance(session.get("inflight_turn"), dict):
-            _start_inflight_turn(session, text)
-    agent = session["agent"]
-    if hasattr(agent, "clear_interrupt"):
-        try:
-            agent.clear_interrupt()
-        except Exception:
-            pass
-    _emit("message.start", sid)
+    dispatch_owner = threading.current_thread()
+    try:
+        with session["history_lock"]:
+            # The calling thread owns pre-worker initialization. Ownership moves
+            # to the actual turn thread immediately before it starts.
+            dispatch_owner = session.get("_run_thread") or dispatch_owner
+            session["_run_thread"] = dispatch_owner
+            history = list(session["history"])
+            history_version = int(session.get("history_version", 0))
+            images = list(session.get("attached_images", []))
+            session["attached_images"] = []
+            if not isinstance(session.get("inflight_turn"), dict):
+                _start_inflight_turn(session, text)
+        agent = session["agent"]
+        if hasattr(agent, "clear_interrupt"):
+            try:
+                agent.clear_interrupt()
+            except Exception:
+                pass
+        _emit("message.start", sid)
+    except Exception as exc:
+        _emit_prompt_failure(
+            sid,
+            session,
+            f"prompt dispatch failed: {exc}",
+            owner=dispatch_owner,
+        )
+        return
+
+    run_thread = None
 
     def run():
+        worker_owner = run_thread or threading.current_thread()
+        with session["history_lock"]:
+            if session.get("_run_thread") is not worker_owner:
+                return
+            cancelled = session.get("_turn_cancel_requested") or not session.get(
+                "running"
+            )
+        if cancelled:
+            _clear_prompt_turn(session, owner=worker_owner)
+            return
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
@@ -10332,10 +10449,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             _clear_session_context(session_tokens)
-            with session["history_lock"]:
-                session["running"] = False
-                session["last_active"] = time.time()
-                _clear_inflight_turn(session)
+            _clear_prompt_turn(session, owner=worker_owner)
             _emit("session.info", sid, _session_info(agent, session))
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
@@ -10357,6 +10471,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     # the judge will re-run on the next turn anyway.
                     return
                 session["running"] = True
+                session["_run_thread"] = threading.current_thread()
             try:
                 _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, goal_followup)
@@ -10366,8 +10481,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     f"{type(_cont_exc).__name__}: {_cont_exc}",
                     file=sys.stderr,
                 )
-                with session["history_lock"]:
-                    session["running"] = False
+                _clear_prompt_turn(session, owner=threading.current_thread())
 
         # Drain completion notifications that arrived during this turn.
         # The background poller handles between-turn delivery; this is
@@ -10379,6 +10493,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # the poller then delivers it to a live owner or drops an orphan.
         try:
             from tools.process_registry import process_registry
+            from tools.async_delegation import (
+                claim_event_delivery,
+                complete_event_delivery,
+                release_event_delivery,
+            )
 
             # Positive-proof ownership (compression-chain aware) — the same
             # fail-closed gate the poller uses, so the post-turn drain can't
@@ -10397,11 +10516,19 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                             process_registry.completion_queue.put(pending_evt)
                         break
                     session["running"] = True
-                from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
-                )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
+                    session["_run_thread"] = threading.current_thread()
+                try:
+                    _claim = claim_event_delivery(_evt, "tui-post-turn")
+                except Exception as _claim_exc:
+                    _clear_prompt_turn(session, owner=threading.current_thread())
+                    logger.warning(
+                        "post-turn notification claim failed for session %s: %s",
+                        sid,
+                        _claim_exc,
+                    )
+                    continue
                 if _claim is None:
+                    _clear_prompt_turn(session, owner=threading.current_thread())
                     continue
                 try:
                     _emit("message.start", sid)
@@ -10414,8 +10541,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         f"{type(_n_exc).__name__}: {_n_exc}",
                         file=sys.stderr,
                     )
-                    with session["history_lock"]:
-                        session["running"] = False
+                    _clear_prompt_turn(session, owner=threading.current_thread())
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "
@@ -10423,9 +10549,20 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 file=sys.stderr,
             )
 
-    run_thread = threading.Thread(target=run, daemon=True)
-    session["_run_thread"] = run_thread
-    run_thread.start()
+    try:
+        run_thread = threading.Thread(target=run, daemon=True)
+        with session["history_lock"]:
+            if session.get("_run_thread") is not dispatch_owner:
+                return
+            session["_run_thread"] = run_thread
+        run_thread.start()
+    except Exception as exc:
+        _emit_prompt_failure(
+            sid,
+            session,
+            f"prompt dispatch failed: {exc}",
+            owner=run_thread or dispatch_owner,
+        )
 
 
 @method("clipboard.paste")
@@ -12894,7 +13031,7 @@ def _(rid, params: dict) -> dict:
             capture_output=True,
             text=True,
             timeout=min(int(params.get("timeout", 240)), 600),
-            cwd=os.getcwd(),
+            cwd=_safe_cwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
@@ -15385,7 +15522,7 @@ def _(rid, params: dict) -> dict:
             {
                 "title": "Environment",
                 "rows": [
-                    ["Working Dir", os.getcwd()],
+                    ["Working Dir", _safe_cwd()],
                     ["Config File", str(_hermes_home / "config.yaml")],
                 ],
             },
@@ -15858,7 +15995,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=_safe_cwd(),
             stdin=subprocess.DEVNULL,
         )
         return _ok(

--- a/ui-tui/src/__tests__/submissionCore.test.ts
+++ b/ui-tui/src/__tests__/submissionCore.test.ts
@@ -1,8 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { isSessionBusyError, markSubmitting, submitPrompt, type SubmitPromptDeps } from '../app/submissionCore.js'
+import { turnController } from '../app/turnController.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
+
+function deferred<T = unknown>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
+const flushPromises = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
 // A gateway double whose `input.detect_drop` resolution we control, so we can
 // observe UI state DURING the async gap — the exact window the queue-mode race
@@ -44,13 +62,37 @@ function makeDeps(gw: GatewayClient, over: Partial<SubmitPromptDeps> = {}): Subm
   }
 }
 
+function makeLifecycleGateway() {
+  const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+  const drops: ReturnType<typeof deferred>[] = []
+  const submits: ReturnType<typeof deferred>[] = []
+
+  const gw = {
+    request: vi.fn((method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+      const pending = deferred()
+
+      if (method === 'input.detect_drop') {
+        drops.push(pending)
+      } else if (method === 'prompt.submit') {
+        submits.push(pending)
+      }
+
+      return pending.promise
+    })
+  } as unknown as GatewayClient
+
+  return { calls, drops, gw, submits }
+}
+
 describe('submissionCore.submitPrompt — synchronous busy (queue-race fix)', () => {
   beforeEach(() => {
+    turnController.reset()
     resetUiState()
     patchUiState({ sid: 'sess-1' })
   })
 
-  it('flips busy=true SYNCHRONOUSLY, before input.detect_drop resolves', () => {
+  it('flips busy=true SYNCHRONOUSLY, before input.detect_drop resolves', async () => {
     const { gw, resolveDrop } = makeDeferredGateway()
 
     expect(getUiState().busy).toBe(false)
@@ -65,6 +107,7 @@ describe('submissionCore.submitPrompt — synchronous busy (queue-race fix)', ()
     expect(getUiState().status).toBe('running…')
 
     resolveDrop()
+    await flushPromises()
   })
 
   it('regression: two back-to-back sends — the SECOND sees busy=true in the gap', async () => {
@@ -103,10 +146,123 @@ describe('submissionCore.submitPrompt — synchronous busy (queue-race fix)', ()
     expect(calls).toEqual(['input.detect_drop'])
 
     resolveDrop({ matched: false })
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushPromises()
 
     expect(calls).toContain('prompt.submit')
+  })
+})
+
+describe('submissionCore.submitPrompt — asynchronous ownership', () => {
+  beforeEach(() => {
+    turnController.reset()
+    resetUiState()
+    patchUiState({ sid: 'sess-1' })
+  })
+
+  it('drops an old detect-drop completion after interrupt', async () => {
+    const { drops, gw, submits } = makeLifecycleGateway()
+    const appendMessage = vi.fn()
+
+    submitPrompt('old prompt', makeDeps(gw, { appendMessage }))
+
+    turnController.interruptTurn({
+      appendMessage: vi.fn(),
+      gw: { request: vi.fn(() => Promise.resolve({})) },
+      sid: 'sess-1',
+      sys: vi.fn()
+    })
+    drops[0]!.reject(new Error('old detect failure'))
+    await flushPromises()
+
+    expect(submits).toHaveLength(0)
+    expect(appendMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not resurrect an old preflight in a switched session after a newer submit', async () => {
+    const { calls, drops, gw, submits } = makeLifecycleGateway()
+    const appendMessage = vi.fn()
+    const deps = makeDeps(gw, { appendMessage })
+
+    submitPrompt('old prompt', deps)
+    patchUiState({ sid: 'sess-2' })
+    submitPrompt('new prompt', deps)
+
+    drops[0]!.resolve({ matched: false })
+    await flushPromises()
+    expect(submits).toHaveLength(0)
+
+    drops[1]!.resolve({ matched: false })
+    await flushPromises()
+
+    expect(submits).toHaveLength(1)
+    expect(calls.filter(call => call.method === 'prompt.submit')).toEqual([
+      { method: 'prompt.submit', params: { session_id: 'sess-2', text: 'new prompt' } }
+    ])
+    expect(appendMessage).toHaveBeenCalledTimes(1)
+    expect(appendMessage).toHaveBeenCalledWith({ role: 'user', text: 'new prompt' })
+
+    submits[0]!.resolve({ status: 'streaming' })
+    await flushPromises()
+  })
+
+  it('ignores a stale prompt rejection while a newer prompt owns busy state', async () => {
+    const { drops, gw, submits } = makeLifecycleGateway()
+    const enqueue = vi.fn()
+    const sys = vi.fn()
+    const deps = makeDeps(gw, { enqueue, sys })
+
+    submitPrompt('old prompt', deps)
+    drops[0]!.resolve({ matched: false })
+    await flushPromises()
+
+    submitPrompt('new prompt', deps)
+    drops[1]!.resolve({ matched: false })
+    await flushPromises()
+
+    submits[0]!.reject(new Error('old failure'))
+    await flushPromises()
+
+    expect(getUiState()).toMatchObject({ busy: true, sid: 'sess-1', status: 'running…' })
+    expect(enqueue).not.toHaveBeenCalled()
+    expect(sys).not.toHaveBeenCalled()
+
+    submits[1]!.resolve({ status: 'streaming' })
+    await flushPromises()
+  })
+
+  it.each([
+    {
+      busy: false,
+      error: new Error('provider failed'),
+      expectedStatus: 'ready',
+      expectedSys: 'error: provider failed',
+      queued: false
+    },
+    {
+      busy: true,
+      error: new Error('session busy'),
+      expectedStatus: 'queued for next turn',
+      expectedSys: 'queued: "current prompt"',
+      queued: true
+    }
+  ])('lets the current rejection perform its expected error/queue behavior', async scenario => {
+    const { drops, gw, submits } = makeLifecycleGateway()
+    const enqueue = vi.fn()
+    const sys = vi.fn()
+
+    submitPrompt('current prompt', makeDeps(gw, { enqueue, sys }))
+    drops[0]!.resolve({ matched: false })
+    await flushPromises()
+    submits[0]!.reject(scenario.error)
+    await flushPromises()
+
+    expect(getUiState()).toMatchObject({ busy: scenario.busy, status: scenario.expectedStatus })
+    expect(sys).toHaveBeenCalledWith(scenario.expectedSys)
+    expect(enqueue).toHaveBeenCalledTimes(scenario.queued ? 1 : 0)
+
+    if (scenario.queued) {
+      expect(enqueue).toHaveBeenCalledWith('current prompt')
+    }
   })
 })
 

--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { promptAcceptedWithoutEvents } from '../app/useSubmission.js'
+
+describe('promptAcceptedWithoutEvents', () => {
+  it('detects an accepted prompt that produced no stream events while still busy', () => {
+    expect(promptAcceptedWithoutEvents({ busy: true, sid: 's1' }, 's1', 7, 7)).toBe(true)
+  })
+
+  it('does not fire after stream events, session changes, or busy clears', () => {
+    expect(promptAcceptedWithoutEvents({ busy: true, sid: 's1' }, 's1', 7, 8)).toBe(false)
+    expect(promptAcceptedWithoutEvents({ busy: true, sid: 's2' }, 's1', 7, 7)).toBe(false)
+    expect(promptAcceptedWithoutEvents({ busy: false, sid: 's1' }, 's1', 7, 7)).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { turnController } from '../app/turnController.js'
 import { promptAcceptedWithoutEvents } from '../app/useSubmission.js'
 
 describe('promptAcceptedWithoutEvents', () => {
@@ -11,5 +12,57 @@ describe('promptAcceptedWithoutEvents', () => {
     expect(promptAcceptedWithoutEvents({ busy: true, sid: 's1' }, 's1', 7, 8)).toBe(false)
     expect(promptAcceptedWithoutEvents({ busy: true, sid: 's2' }, 's1', 7, 7)).toBe(false)
     expect(promptAcceptedWithoutEvents({ busy: false, sid: 's1' }, 's1', 7, 7)).toBe(false)
+  })
+})
+
+describe('prompt acceptance watchdog ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    turnController.reset()
+  })
+
+  afterEach(() => {
+    turnController.reset()
+    vi.useRealTimers()
+  })
+
+  it('cancels an interrupted submission watchdog without touching the newer prompt', () => {
+    const fired: string[] = []
+    const oldGeneration = turnController.resetForSubmit()
+
+    expect(turnController.acceptPromptSubmission(oldGeneration, 60_000, () => fired.push('old'))).toBe(true)
+    vi.advanceTimersByTime(30_000)
+
+    turnController.interruptTurn({
+      appendMessage: vi.fn(),
+      gw: { request: vi.fn(() => Promise.resolve({})) },
+      sid: 's1',
+      sys: vi.fn()
+    })
+
+    const newGeneration = turnController.resetForSubmit()
+
+    expect(turnController.acceptPromptSubmission(newGeneration, 60_000, () => fired.push('new'))).toBe(true)
+
+    // The old deadline arrives while the newer prompt still owns busy state.
+    vi.advanceTimersByTime(30_000)
+    expect(fired).toEqual([])
+
+    vi.advanceTimersByTime(30_000)
+
+    expect(fired).toEqual(['new'])
+  })
+
+  it('ignores a late older acceptance without cancelling the newer watchdog', () => {
+    const fired: string[] = []
+    const oldGeneration = turnController.resetForSubmit()
+    const newGeneration = turnController.resetForSubmit()
+
+    expect(turnController.acceptPromptSubmission(newGeneration, 60_000, () => fired.push('new'))).toBe(true)
+    expect(turnController.acceptPromptSubmission(oldGeneration, 60_000, () => fired.push('old'))).toBe(false)
+
+    vi.advanceTimersByTime(60_000)
+
+    expect(fired).toEqual(['new'])
   })
 })

--- a/ui-tui/src/app/submissionCore.ts
+++ b/ui-tui/src/app/submissionCore.ts
@@ -15,6 +15,7 @@ export interface SubmitPromptDeps {
   enqueue: (text: string) => void
   expand: (text: string) => string
   gw: GatewayClient
+  onPromptAccepted?: (sid: string, eventSeq: number, generation: number) => void
   setLastUserMsg: (value: string) => void
   sys: (text: string) => void
 }
@@ -49,14 +50,15 @@ export function submitPrompt(text: string, deps: SubmitPromptDeps, showUserMessa
     return deps.sys('session not ready yet')
   }
 
-  // Close the async-busy gap up front, before the detect_drop round-trip.
+  // Give this submit its own lifecycle identity and close the async-busy gap
+  // up front, before the detect_drop round-trip.
+  const generation = turnController.resetForSubmit()
+  const ownsSubmission = () => getUiState().sid === sid && turnController.ownsPromptSubmission(generation)
   markSubmitting()
 
   const startSubmit = (displayText: string, submitText: string, show = true) => {
-    const liveSid = getUiState().sid
-
-    if (!liveSid) {
-      return deps.sys('session not ready yet')
+    if (!ownsSubmission()) {
+      return
     }
 
     turnController.clearStatusTimer()
@@ -67,12 +69,20 @@ export function submitPrompt(text: string, deps: SubmitPromptDeps, showUserMessa
     }
 
     patchUiState({ busy: true, status: 'running…' })
-    turnController.bufRef = ''
-    turnController.interrupted = false
+    const eventSeq = turnController.eventSeq
 
     deps.gw
-      .request<PromptSubmitResponse>('prompt.submit', { session_id: liveSid, text: submitText })
+      .request<PromptSubmitResponse>('prompt.submit', { session_id: sid, text: submitText })
+      .then(r => {
+        if (r?.status === 'streaming' && ownsSubmission()) {
+          deps.onPromptAccepted?.(sid, eventSeq, generation)
+        }
+      })
       .catch((e: Error) => {
+        if (!ownsSubmission() || !turnController.rejectPromptSubmission(generation)) {
+          return
+        }
+
         // Defensive: prompt.submit no longer rejects a mid-turn send with
         // "session busy" (the gateway queues it and returns success), but keep
         // the re-queue path as a safety net for any future/legacy gateway that
@@ -95,6 +105,10 @@ export function submitPrompt(text: string, deps: SubmitPromptDeps, showUserMessa
   deps.gw
     .request<InputDetectDropResponse>('input.detect_drop', { session_id: sid, text })
     .then(r => {
+      if (!ownsSubmission()) {
+        return
+      }
+
       if (!r?.matched) {
         return startSubmit(text, deps.expand(text), showUserMessage)
       }
@@ -107,5 +121,9 @@ export function submitPrompt(text: string, deps: SubmitPromptDeps, showUserMessa
 
       startSubmit(r.text || text, deps.expand(r.text || text), showUserMessage)
     })
-    .catch(() => startSubmit(text, deps.expand(text), showUserMessage))
+    .catch(() => {
+      if (ownsSubmission()) {
+        startSubmit(text, deps.expand(text), showUserMessage)
+      }
+    })
 }

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -111,6 +111,7 @@ const clear = (t: Timer): null => {
 
 class TurnController {
   bufRef = ''
+  eventSeq = 0
   interrupted = false
   lastStatusNote = ''
   persistedToolLabels = new Set<string>()
@@ -541,7 +542,13 @@ class TurnController {
     })
   }
 
+  resetForSubmit() {
+    this.bufRef = ''
+    this.interrupted = false
+  }
+
   recordError() {
+    this.eventSeq += 1
     this.idle()
     this.clearReasoning()
     this.clearStatusTimer()
@@ -555,6 +562,7 @@ class TurnController {
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
+    this.eventSeq += 1
     this.closeReasoningSegment()
 
     // Ink renders markdown via <Md>; the gateway's Rich-rendered ANSI
@@ -656,6 +664,8 @@ class TurnController {
     if (this.interrupted || !text) {
       return
     }
+
+    this.eventSeq += 1
 
     this.pruneTransient()
     this.endReasoningPhase()
@@ -936,6 +946,7 @@ class TurnController {
   }
 
   startMessage() {
+    this.eventSeq += 1
     this.endReasoningPhase()
     this.clearReasoning()
     this.activeTools = []

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -130,6 +130,8 @@ class TurnController {
   private activityId = 0
   private reasoningStreamingTimer: Timer = null
   private reasoningTimer: Timer = null
+  private promptAcceptGeneration = 0
+  private promptAcceptTimer: Timer = null
   private streamTimer: Timer = null
   private streamDelay = STREAM_IDLE_BATCH_MS
   private toolProgressTimer: Timer = null
@@ -295,6 +297,7 @@ class TurnController {
   // duplicated the user bubble, leaked a "queued: …" note, and surfaced the
   // cancelled turn's "[interrupted]" reply.
   interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps, opts: { keepBusy?: boolean } = {}) {
+    this.invalidatePromptSubmission()
     this.interrupted = true
     gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
 
@@ -542,12 +545,56 @@ class TurnController {
     })
   }
 
-  resetForSubmit() {
+  resetForSubmit(): number {
+    this.invalidatePromptSubmission()
     this.bufRef = ''
     this.interrupted = false
+
+    return this.promptAcceptGeneration
+  }
+
+  ownsPromptSubmission(generation: number): boolean {
+    return generation === this.promptAcceptGeneration
+  }
+
+  acceptPromptSubmission(generation: number, timeoutMs: number, onTimeout: () => void): boolean {
+    if (!this.ownsPromptSubmission(generation)) {
+      return false
+    }
+
+    this.promptAcceptTimer = clear(this.promptAcceptTimer)
+    const acceptedGeneration = ++this.promptAcceptGeneration
+
+    this.promptAcceptTimer = setTimeout(() => {
+      if (this.promptAcceptGeneration !== acceptedGeneration) {
+        return
+      }
+
+      this.promptAcceptTimer = null
+      this.promptAcceptGeneration += 1
+      onTimeout()
+    }, timeoutMs)
+
+    return true
+  }
+
+  rejectPromptSubmission(generation: number): boolean {
+    if (!this.ownsPromptSubmission(generation)) {
+      return false
+    }
+
+    this.invalidatePromptSubmission()
+
+    return true
+  }
+
+  invalidatePromptSubmission() {
+    this.promptAcceptGeneration += 1
+    this.promptAcceptTimer = clear(this.promptAcceptTimer)
   }
 
   recordError() {
+    this.invalidatePromptSubmission()
     this.eventSeq += 1
     this.idle()
     this.clearReasoning()
@@ -562,6 +609,7 @@ class TurnController {
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
+    this.invalidatePromptSubmission()
     this.eventSeq += 1
     this.closeReasoningSegment()
 
@@ -885,6 +933,7 @@ class TurnController {
   }
 
   reset() {
+    this.invalidatePromptSubmission()
     this.clearReasoning()
     this.clearStatusTimer()
     this.idle()
@@ -946,6 +995,7 @@ class TurnController {
   }
 
   startMessage() {
+    this.invalidatePromptSubmission()
     this.eventSeq += 1
     this.endReasoningPhase()
     this.clearReasoning()

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -15,6 +15,14 @@ import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const DOUBLE_ENTER_MS = 450
+const PROMPT_ACCEPT_WATCHDOG_MS = 60000
+
+export const promptAcceptedWithoutEvents = (
+  ui: { busy: boolean; sid: null | string },
+  sid: string,
+  acceptedEventSeq: number,
+  currentEventSeq: number
+) => ui.sid === sid && ui.busy && currentEventSeq === acceptedEventSeq
 
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()
@@ -36,6 +44,23 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const lastEmptyAt = useRef(0)
   const typingIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const armPromptAcceptWatchdog = useCallback(
+    (sid: string, eventSeq: number, generation: number) => {
+      turnController.acceptPromptSubmission(generation, PROMPT_ACCEPT_WATCHDOG_MS, () => {
+        if (!promptAcceptedWithoutEvents(getUiState(), sid, eventSeq, turnController.eventSeq)) {
+          return
+        }
+
+        turnController.recordError()
+        sys('error: prompt accepted but no stream events arrived; cleared stuck busy state')
+        patchUiState({ busy: false, status: 'ready' })
+      })
+    },
+    [sys]
+  )
+
+  useEffect(() => () => turnController.invalidatePromptSubmission(), [])
 
   useEffect(() => {
     if (typingIdleTimer.current) {
@@ -77,17 +102,19 @@ export function useSubmission(opts: UseSubmissionOptions) {
           enqueue: composerActions.enqueue,
           expand,
           gw,
+          onPromptAccepted: armPromptAcceptWatchdog,
           setLastUserMsg,
           sys
         },
         showUserMessage
       )
     },
-    [appendMessage, composerActions, composerState.pasteSnips, gw, setLastUserMsg, sys]
+    [appendMessage, armPromptAcceptWatchdog, composerActions, composerState.pasteSnips, gw, setLastUserMsg, sys]
   )
 
   const shellExec = useCallback(
     (cmd: string) => {
+      turnController.invalidatePromptSubmission()
       appendMessage({ role: 'user', text: `!${cmd}` })
       patchUiState({ busy: true, status: 'running…' })
 
@@ -117,6 +144,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const interpolate = useCallback(
     (text: string, then: (result: string) => void) => {
+      turnController.invalidatePromptSubmission()
       patchUiState({ status: 'interpolating…' })
       const matches = [...text.matchAll(new RegExp(INTERPOLATION_RE.source, 'g'))]
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -302,6 +302,7 @@ export interface SessionSteerResponse {
 
 export interface PromptSubmitResponse {
   ok?: boolean
+  status?: 'streaming'
 }
 
 export interface BackgroundStartResponse {


### PR DESCRIPTION
## Rationale

The TUI can accept a prompt and enter `running…` before the backend has safely
started the turn dispatcher or reached the model/API call. If dispatch setup,
lazy agent initialization, or cwd resolution fails in that pre-streaming window,
the backend can leave `session["running"]` set and the frontend has no watchdog
for an accepted prompt that never emits stream events.

## Summary

- Add safe cwd resolution for TUI gateway paths so deleted process CWDs do not
  crash eager `os.getcwd()` fallbacks.
- Harden `prompt.submit` dispatch so failures after `running=True` emit an error
  and release the backend busy guard.
- Emit visible `initializing agent…` status while lazy agent construction blocks
  before a model/API request starts.
- Add a frontend accepted-prompt watchdog that clears a stuck busy state if no
  stream events arrive after the backend returns `streaming`.
- Add focused backend and frontend regression coverage.

## Test Plan

- [x] `python -m pytest tests/tui_gateway/test_protocol.py -q -o 'addopts='`
- [x] `cd ui-tui && npm run type-check`
- [x] `cd ui-tui && npm test -- --run src/__tests__/useSubmission.test.ts`
- [x] `cd ui-tui && npx eslint src/app/useSubmission.ts src/app/turnController.ts src/gatewayTypes.ts src/__tests__/useSubmission.test.ts` (0 errors; existing React compiler warning on `submitRef.current = submit` remains)
- [x] `git diff --cached --check`
