### PR TITLE
chore: ignore local Hermes runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ testlogs
 # CLI config (may contain sensitive SSH paths)
 cli-config.yaml
 
+# Local Hermes runtime state
+.hermes/
+
 # Skills Hub state (lives in ~/.hermes/skills/.hub/ at runtime, but just in case)
 skills/.hub/
 ignored/


### PR DESCRIPTION
## Outcome
Ignore local Hermes runtime artifacts to keep working tree clean.

## Evidence
- Added `.hermes/` to root `.gitignore`
- Verified with:
  - `git check-ignore -v ./.hermes`
  - `git check-ignore -v ./.hermes/plans/kanban-protocol-violation-repro.md`

## Why
`.hermes/` is local runtime/session state and should not appear as untracked noise in development workflows.