### PR TITLE
fix(tui): align wrapped composer cursor

### DIFF
--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { offsetFromPosition } from '../components/textInput.js'
+import {
+  cursorRenderParts,
+  offsetFromPosition,
+  shouldHideHardwareInputCursor,
+  shouldUseNativeInputCursor
+} from '../components/textInput.js'
 import { composerPromptWidth, cursorLayout, inputVisualHeight, stableComposerColumns } from '../lib/inputMetrics.js'
 
 describe('cursorLayout — word-wrap parity with wrap-ansi', () => {
@@ -61,6 +66,46 @@ describe('input metrics helpers', () => {
     expect(stableComposerColumns(100, 5)).toBe(91)
     expect(stableComposerColumns(10, 3)).toBe(5)
     expect(stableComposerColumns(6, 3)).toBe(1)
+  })
+})
+
+describe('text input cursor mode', () => {
+  it('splits text into in-band cursor render parts without losing the covered character', () => {
+    expect(cursorRenderParts('abcd', 2)).toEqual({ after: 'd', before: 'ab', cursor: 'c' })
+    expect(cursorRenderParts('abcd', 4)).toEqual({ after: '', before: 'abcd', cursor: ' ' })
+  })
+
+  it('uses the native terminal cursor for focused single-line TTY input', () => {
+    expect(
+      shouldUseNativeInputCursor({ cursorLine: 0, focus: true, isTty: true, selected: false, termFocus: true })
+    ).toBe(true)
+  })
+
+  it('uses an in-band cursor after wrapping so paste labels stay visually aligned', () => {
+    const text = 'hello world baby chickens are so cool its really rainy outside but wish'
+    const layout = cursorLayout(text, text.length, 70)
+
+    expect(layout).toEqual({ column: 4, line: 1 })
+    expect(
+      shouldUseNativeInputCursor({
+        cursorLine: layout.line,
+        focus: true,
+        isTty: true,
+        selected: false,
+        termFocus: true
+      })
+    ).toBe(false)
+    expect(shouldHideHardwareInputCursor({ focus: true, isTty: true, nativeCursor: false })).toBe(true)
+  })
+
+  it('does not use the native cursor for inactive or selected input', () => {
+    expect(
+      shouldUseNativeInputCursor({ cursorLine: 0, focus: false, isTty: true, selected: false, termFocus: true })
+    ).toBe(false)
+    expect(
+      shouldUseNativeInputCursor({ cursorLine: 0, focus: true, isTty: true, selected: true, termFocus: true })
+    ).toBe(false)
+    expect(shouldHideHardwareInputCursor({ focus: true, isTty: true, nativeCursor: true })).toBe(false)
   })
 })
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -297,6 +297,7 @@ const ComposerPane = memo(function ComposerPane({
                 {/* Reserve the transcript scrollbar gutter too so typing never rewraps when the scrollbar column repaints. */}
                 <TextInput
                   columns={inputColumns}
+                  cursorColor={ui.theme.color.prompt}
                   mouseApiRef={inputMouseRef}
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,6 +1,6 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
-import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type MutableRefObject, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
@@ -179,15 +179,17 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
 
 export { offsetFromPosition }
 
-function renderWithCursor(value: string, cursor: number) {
+export function cursorRenderParts(value: string, cursor: number) {
   const pos = Math.max(0, Math.min(cursor, value.length))
 
-  let out = '',
+  let before = '',
+    cursorCell = ' ',
+    after = '',
     done = false
 
   for (const { segment, index } of seg().segment(value)) {
     if (!done && index >= pos) {
-      out += invert(index === pos && segment !== '\n' ? segment : ' ')
+      cursorCell = index === pos && segment !== '\n' ? segment : ' '
       done = true
 
       if (index === pos && segment !== '\n') {
@@ -195,10 +197,38 @@ function renderWithCursor(value: string, cursor: number) {
       }
     }
 
-    out += segment
+    if (done) {
+      after += segment
+    } else {
+      before += segment
+    }
   }
 
-  return done ? out : out + invert(' ')
+  return done ? { after, before, cursor: cursorCell } : { after: '', before, cursor: ' ' }
+}
+
+function renderCursorCell(cursor: string, cursorColor?: string, cursorTextColor?: string) {
+  if (!cursorColor) {
+    return invert(cursor)
+  }
+
+  return (
+    <Text backgroundColor={cursorColor} color={cursorTextColor}>
+      {cursor}
+    </Text>
+  )
+}
+
+function renderWithCursor(value: string, cursor: number, cursorColor?: string, cursorTextColor?: string): ReactNode {
+  const parts = cursorRenderParts(value, cursor)
+
+  return (
+    <>
+      {parts.before}
+      {renderCursorCell(parts.cursor, cursorColor, cursorTextColor)}
+      {parts.after}
+    </>
+  )
 }
 
 function renderWithSelection(value: string, start: number, end: number) {
@@ -240,6 +270,8 @@ const isPasteResultPromise = (
 
 export function TextInput({
   columns = 80,
+  cursorColor,
+  cursorTextColor = 'black',
   value,
   onChange,
   onPaste,
@@ -292,17 +324,21 @@ export function TextInput({
 
   const layout = useMemo(() => cursorLayout(display, cur, columns), [columns, cur, display])
 
+  const nativeCursor = shouldUseNativeInputCursor({
+    cursorLine: layout.line,
+    focus,
+    isTty: !!stdout?.isTTY,
+    selected: !!selected,
+    termFocus
+  })
+
   const boxRef = useDeclaredCursor({
     line: layout.line,
     column: layout.column,
-    active: focus && termFocus && !selected
+    active: nativeCursor
   })
 
-  // Hide the hardware cursor while a selection is active (prevents
-  // auto-wrap onto the next row when inverted text fills the column
-  // exactly) or when the terminal loses focus (suppresses the hollow-rect
-  // ghost most terminals draw at the parked position).
-  const hideHardwareCursor = focus && !!stdout?.isTTY && (!!selected || !termFocus)
+  const hideHardwareCursor = shouldHideHardwareInputCursor({ focus, isTty: !!stdout?.isTTY, nativeCursor })
 
   useEffect(() => {
     if (!hideHardwareCursor || !stdout) {
@@ -316,8 +352,6 @@ export function TextInput({
     }
   }, [hideHardwareCursor, stdout])
 
-  const nativeCursor = focus && termFocus && !selected && !!stdout?.isTTY
-
   // Placeholder text is just a hint, not a selection — render it dim
   // without inverse styling. In a TTY the hardware cursor parks at column
   // 0 and visually marks the input start. Non-TTY surfaces still need the
@@ -328,15 +362,22 @@ export function TextInput({
     }
 
     if (!display && placeholder) {
-      return nativeCursor ? dim(placeholder) : invert(placeholder[0] ?? ' ') + dim(placeholder.slice(1))
+      return nativeCursor ? (
+        dim(placeholder)
+      ) : (
+        <>
+          {renderCursorCell(placeholder[0] ?? ' ', cursorColor, cursorTextColor)}
+          {dim(placeholder.slice(1))}
+        </>
+      )
     }
 
     if (selected) {
       return renderWithSelection(display, selected.start, selected.end)
     }
 
-    return nativeCursor ? display || ' ' : renderWithCursor(display, cur)
-  }, [cur, display, focus, nativeCursor, placeholder, selected])
+    return nativeCursor ? display || ' ' : renderWithCursor(display, cur, cursorColor, cursorTextColor)
+  }, [cur, cursorColor, cursorTextColor, display, focus, nativeCursor, placeholder, selected])
 
   useEffect(() => {
     if (self.current) {
@@ -1037,6 +1078,8 @@ export interface PasteEvent {
 
 interface TextInputProps {
   columns?: number
+  cursorColor?: string
+  cursorTextColor?: string
   focus?: boolean
   mask?: string
   mouseApiRef?: MutableRefObject<null | TextInputMouseApi>
@@ -1050,9 +1093,38 @@ interface TextInputProps {
   voiceRecordKey?: ParsedVoiceRecordKey
 }
 
-export type RightClickDecision =
-  | { action: 'copy'; text: string }
-  | { action: 'paste' }
+export type RightClickDecision = { action: 'copy'; text: string } | { action: 'paste' }
+
+export function shouldUseNativeInputCursor({
+  cursorLine,
+  focus,
+  isTty,
+  selected,
+  termFocus
+}: {
+  cursorLine: number
+  focus: boolean
+  isTty: boolean
+  selected: boolean
+  termFocus: boolean
+}): boolean {
+  // Once the composer wraps, Ink and the terminal are both doing line layout.
+  // Rendering the caret in-band keeps it tied to the same wrapped text stream
+  // the user sees instead of parking the hardware cursor from parallel metrics.
+  return focus && termFocus && !selected && isTty && cursorLine === 0
+}
+
+export function shouldHideHardwareInputCursor({
+  focus,
+  isTty,
+  nativeCursor
+}: {
+  focus: boolean
+  isTty: boolean
+  nativeCursor: boolean
+}): boolean {
+  return focus && isTty && !nativeCursor
+}
 
 /**
  * Decide what right-click should do on the composer:


### PR DESCRIPTION
## Rationale

Long pasted composer input can wrap across multiple terminal rows. The TUI previously parked the native terminal cursor separately from Ink's wrapped text layout, which could make the cursor drift or show a second cursor after paste. Switching wrapped input to an in-band cursor fixed the double cursor, but the fallback inverse-video cursor lost the Hermes cursor color.

## Summary

- Use the native terminal cursor only for focused, unselected single-line TTY input.
- Render wrapped composer cursors in-band with the same text stream so they stay aligned with word wrapping.
- Hide the hardware cursor while the in-band cursor is active to prevent double cursors.
- Pass the Hermes prompt color into `TextInput` so the synthetic cursor remains visually consistent on multiline input.
- Add focused cursor-mode and render-part regression coverage.

## Test Plan

- [x] `npm run build --prefix packages/hermes-ink`
- [x] `npm run test -- textInputWrap.test.ts`
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm exec eslint -- src/components/textInput.tsx src/components/appLayout.tsx src/__tests__/textInputWrap.test.ts` (0 errors; existing warnings only)
