### PR TITLE
feat(tools): add http tool for structured HTTP requests

### DIFF
--- a/tests/tools/test_http_tool.py
+++ b/tests/tools/test_http_tool.py
@@ -1,0 +1,294 @@
+"""Tests for the http tool — structured HTTP without going through bash.
+
+The whole point of this tool is to skip the bash-quoting bug class. Tests
+mock httpx.Client.request directly so they don't make real network calls,
+and verify that the JSON-encoded result envelope matches the convention.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import tools.http_tool as ht
+from tools.http_tool import (
+    HTTP_SCHEMA,
+    _MAX_RESPONSE_BYTES,
+    http_tool,
+)
+
+
+def _mock_response(
+    status: int = 200,
+    body: bytes = b"ok",
+    headers: dict | None = None,
+    encoding: str = "utf-8",
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.content = body
+    resp.headers = headers or {}
+    resp.encoding = encoding
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def reset_module_client():
+    """Reset the module-level httpx.Client between tests so monkeypatching is clean."""
+    ht._http_client = None
+    yield
+    ht._http_client = None
+
+
+class TestHttpToolBasics:
+    @patch("tools.http_tool._get_http_client")
+    def test_get_happy_path_returns_status_headers_body(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response(
+            status=200, body=b"hello", headers={"Content-Type": "text/plain"}
+        )
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://localhost/foo"))
+
+        assert result["status"] == 200
+        assert result["headers"]["Content-Type"] == "text/plain"
+        assert result["body"] == "hello"
+        assert "elapsed_ms" in result and isinstance(result["elapsed_ms"], int)
+
+        client.request.assert_called_once()
+        kwargs = client.request.call_args.kwargs
+        assert kwargs["method"] == "GET"
+        assert kwargs["url"] == "http://localhost/foo"
+
+    @patch("tools.http_tool._get_http_client")
+    def test_method_lowercase_is_normalised(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response()
+        mock_get_client.return_value = client
+
+        http_tool(method="post", url="http://x/y")
+        assert client.request.call_args.kwargs["method"] == "POST"
+
+    def test_invalid_method_returns_error(self):
+        result = json.loads(http_tool(method="INVALID", url="http://x"))
+        assert "error" in result
+        assert "INVALID" in result["error"]
+
+    def test_missing_url_returns_error(self):
+        result = json.loads(http_tool(method="GET", url=""))
+        assert "error" in result
+        assert "url" in result["error"].lower()
+
+
+class TestHttpToolBodyResolution:
+    @patch("tools.http_tool._get_http_client")
+    def test_post_json_routes_to_httpx_json_kwarg(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response(status=201, body=b'{"id":1}')
+        mock_get_client.return_value = client
+
+        result = json.loads(
+            http_tool(
+                method="POST",
+                url="http://localhost:3100/api/issues/AOS-8",
+                json_body={"status": "done", "comment": "It's done"},
+            )
+        )
+
+        assert result["status"] == 201
+        assert result["body"] == '{"id":1}'
+
+        kwargs = client.request.call_args.kwargs
+        # Crucial: the JSON body goes through httpx's `json` kwarg — never
+        # through any string-quoting layer. The apostrophe in "It's done"
+        # would have killed the bash path.
+        assert kwargs["json"] == {"status": "done", "comment": "It's done"}
+        assert "content" not in kwargs
+        assert "body" not in kwargs
+
+    @patch("tools.http_tool._get_http_client")
+    def test_post_body_routes_to_httpx_content_kwarg(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response()
+        mock_get_client.return_value = client
+
+        http_tool(
+            method="POST",
+            url="http://x/y",
+            body="raw text body with 'apostrophe'",
+        )
+        kwargs = client.request.call_args.kwargs
+        assert kwargs["content"] == "raw text body with 'apostrophe'"
+        assert "json" not in kwargs
+
+    def test_json_and_body_together_returns_error(self):
+        result = json.loads(
+            http_tool(
+                method="POST",
+                url="http://x",
+                json_body={"a": 1},
+                body="raw",
+            )
+        )
+        assert "error" in result
+        assert "either" in result["error"].lower() or "both" in result["error"].lower()
+
+
+class TestHttpToolErrorHandling:
+    @patch("tools.http_tool._get_http_client")
+    def test_4xx_response_returned_as_success_envelope(self, mock_get_client):
+        # 4xx is a successful HTTP exchange — only transport errors become tool_error.
+        client = MagicMock()
+        client.request.return_value = _mock_response(
+            status=404, body=b'{"error":"not found"}'
+        )
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://x/missing"))
+        assert result["status"] == 404
+        assert "error" not in result  # the tool envelope itself succeeded
+        assert result["body"] == '{"error":"not found"}'
+
+    @patch("tools.http_tool._get_http_client")
+    def test_timeout_returns_tool_error_with_elapsed(self, mock_get_client):
+        client = MagicMock()
+        client.request.side_effect = httpx.TimeoutException("read timeout")
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://slow", timeout=1))
+        assert "error" in result
+        assert "timeout" in result["error"].lower()
+        assert result.get("timeout") is True
+        assert "elapsed_ms" in result
+
+    @patch("tools.http_tool._get_http_client")
+    def test_connection_refused_returns_tool_error(self, mock_get_client):
+        client = MagicMock()
+        client.request.side_effect = httpx.ConnectError("Connection refused")
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://localhost:9"))
+        assert "error" in result
+        assert "Transport error" in result["error"]
+        assert "ConnectError" in result["error"]
+
+    def test_invalid_timeout_type_returns_error(self):
+        result = json.loads(
+            http_tool(method="GET", url="http://x", timeout="thirty")
+        )
+        assert "error" in result
+        assert "timeout" in result["error"].lower()
+
+    def test_timeout_above_max_returns_error(self):
+        result = json.loads(http_tool(method="GET", url="http://x", timeout=999))
+        assert "error" in result
+        assert "maximum" in result["error"].lower()
+
+
+class TestHttpToolBodyCap:
+    @patch("tools.http_tool._get_http_client")
+    def test_oversized_body_is_truncated_with_hint(self, mock_get_client):
+        big = b"a" * (_MAX_RESPONSE_BYTES + 100)
+        client = MagicMock()
+        client.request.return_value = _mock_response(body=big)
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://x/big"))
+        assert result["status"] == 200
+        assert result.get("truncated") is True
+        assert "_hint" in result
+        # body string length matches the byte cap (single-byte chars).
+        assert len(result["body"]) == _MAX_RESPONSE_BYTES
+
+
+class TestHttpToolHeaderRedaction:
+    @patch("tools.http_tool._get_http_client")
+    def test_authorization_header_redacted_in_response(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response(
+            headers={
+                "Authorization": "Bearer super-secret",
+                "Set-Cookie": "session=abc123",
+                "X-Custom-Token": "leaked-token",
+                "Content-Type": "application/json",
+            }
+        )
+        mock_get_client.return_value = client
+
+        result = json.loads(http_tool(method="GET", url="http://x"))
+        assert result["headers"]["Authorization"] == "[REDACTED]"
+        assert result["headers"]["Set-Cookie"] == "[REDACTED]"
+        assert result["headers"]["X-Custom-Token"] == "[REDACTED]"
+        # Non-sensitive headers pass through untouched.
+        assert result["headers"]["Content-Type"] == "application/json"
+
+
+class TestHttpToolSchemaShape:
+    """Schema must advertise both `json` and `body` so the model can pick."""
+
+    def test_schema_has_method_and_url_required(self):
+        params = HTTP_SCHEMA["parameters"]
+        assert params["required"] == ["method", "url"]
+
+    def test_schema_advertises_json_and_body_separately(self):
+        props = HTTP_SCHEMA["parameters"]["properties"]
+        assert "json" in props
+        assert "body" in props
+        # Description should make the auto-serialisation contract clear.
+        assert "Content-Type" in props["json"]["description"]
+        assert "json" in props["body"]["description"].lower()
+
+    def test_schema_has_method_enum_in_description(self):
+        props = HTTP_SCHEMA["parameters"]["properties"]
+        # Methods enumerated in description (provider-safe vs JSON Schema enum
+        # rejection by some sanitisers — same workaround as PATCH_SCHEMA).
+        desc = props["method"]["description"]
+        for m in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+            assert m in desc
+
+    def test_tool_registered_under_http_toolset(self):
+        from tools.registry import registry
+        entry = registry._tools.get("http")
+        assert entry is not None, "http tool not registered"
+        assert entry.toolset == "http"
+        assert entry.handler is not None
+
+
+class TestHttpToolRequestParams:
+    @patch("tools.http_tool._get_http_client")
+    def test_query_params_passed_through(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response()
+        mock_get_client.return_value = client
+
+        http_tool(method="GET", url="http://x", params={"q": "abc", "page": "2"})
+        kwargs = client.request.call_args.kwargs
+        assert kwargs["params"] == {"q": "abc", "page": "2"}
+
+    @patch("tools.http_tool._get_http_client")
+    def test_request_headers_passed_through(self, mock_get_client):
+        client = MagicMock()
+        client.request.return_value = _mock_response()
+        mock_get_client.return_value = client
+
+        http_tool(
+            method="POST",
+            url="http://x",
+            headers={"Authorization": "Bearer xyz", "X-Run-Id": "r1"},
+            json_body={"a": 1},
+        )
+        kwargs = client.request.call_args.kwargs
+        assert kwargs["headers"]["Authorization"] == "Bearer xyz"
+        assert kwargs["headers"]["X-Run-Id"] == "r1"
+
+    def test_invalid_headers_type_returns_error(self):
+        result = json.loads(
+            http_tool(method="GET", url="http://x", headers="not-a-dict")  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert "headers" in result["error"].lower()

--- a/tools/http_tool.py
+++ b/tools/http_tool.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""HTTP tool — structured HTTP requests without going through a shell.
+
+The `terminal` tool is general-purpose but routes every command through
+`bash -c`, which forces the model to escape JSON bodies into shell-safe
+strings. A single apostrophe in a JSON value (`"It's done"`) breaks the
+outer single-quoting and the request fails with `unexpected EOF while
+looking for matching '` — costing a wasted model turn.
+
+This tool takes structured args (`{method, url, headers, json, body, ...}`)
+and dispatches via httpx directly. No shell, no quoting, no per-call bash
+fork+exec overhead (~30-80 ms saved per call).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from agent.redact import redact_sensitive_text
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults & caps
+# ---------------------------------------------------------------------------
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_MAX_TIMEOUT_SECONDS = 300.0
+_MAX_RESPONSE_BYTES = 1_000_000  # 1 MB; matches registry max_result_size_chars
+
+# Headers that should never be echoed back to the model (request-side leakage
+# protection — the response body is separately run through redact_sensitive_text).
+_SENSITIVE_HEADER_NAMES = frozenset({
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+})
+
+_ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
+
+# ---------------------------------------------------------------------------
+# Module-level httpx client (connection pool reused across calls).
+# Module-level so unit tests can monkeypatch tools.http_tool._http_client.
+# ---------------------------------------------------------------------------
+_http_client: httpx.Client | None = None
+
+
+def _get_http_client() -> httpx.Client:
+    """Return the singleton httpx.Client, constructing it on first use."""
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.Client(
+            timeout=httpx.Timeout(_DEFAULT_TIMEOUT_SECONDS, connect=10.0),
+            follow_redirects=False,
+        )
+    return _http_client
+
+
+def _redact_response_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop sensitive header names from the echoed response."""
+    return {
+        k: ("[REDACTED]" if k.lower() in _SENSITIVE_HEADER_NAMES or k.lower().endswith("-token") else v)
+        for k, v in headers.items()
+    }
+
+
+def http_tool(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None = None,
+    json_body: Any | None = None,
+    body: str | None = None,
+    params: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+    task_id: str = "default",  # noqa: ARG001 — reserved for future per-task scoping
+) -> str:
+    """Issue a single HTTP request and return a JSON-encoded result string."""
+    # ── Validate method ──────────────────────────────────────────────
+    if not isinstance(method, str):
+        return tool_error("method must be a string (one of GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS)")
+    method_upper = method.upper().strip()
+    if method_upper not in _ALLOWED_METHODS:
+        return tool_error(
+            f"method '{method}' not allowed. Use one of: {sorted(_ALLOWED_METHODS)}"
+        )
+
+    # ── Validate url ─────────────────────────────────────────────────
+    if not isinstance(url, str) or not url:
+        return tool_error("url must be a non-empty string")
+
+    # ── Mutually exclusive body fields ───────────────────────────────
+    if json_body is not None and body is not None:
+        return tool_error(
+            "Provide either 'json' (auto-serialised object) or 'body' (raw string), not both."
+        )
+
+    # ── Resolve timeout ──────────────────────────────────────────────
+    eff_timeout: float = _DEFAULT_TIMEOUT_SECONDS
+    if timeout is not None:
+        try:
+            eff_timeout = float(timeout)
+        except (TypeError, ValueError):
+            return tool_error(f"timeout must be a number, got {type(timeout).__name__}")
+        if eff_timeout <= 0:
+            return tool_error("timeout must be positive")
+        if eff_timeout > _MAX_TIMEOUT_SECONDS:
+            return tool_error(
+                f"timeout {eff_timeout}s exceeds maximum {_MAX_TIMEOUT_SECONDS}s"
+            )
+
+    # ── Build request kwargs ─────────────────────────────────────────
+    request_kwargs: dict[str, Any] = {
+        "method": method_upper,
+        "url": url,
+        "timeout": eff_timeout,
+    }
+    if headers:
+        if not isinstance(headers, dict):
+            return tool_error("headers must be an object mapping header name to value")
+        request_kwargs["headers"] = headers
+    if params:
+        if not isinstance(params, dict):
+            return tool_error("params must be an object mapping query-param name to value")
+        request_kwargs["params"] = params
+    if json_body is not None:
+        # httpx auto-serialises and sets Content-Type: application/json
+        request_kwargs["json"] = json_body
+    elif body is not None:
+        if not isinstance(body, str):
+            return tool_error("body must be a string; use 'json' for objects")
+        request_kwargs["content"] = body
+
+    # ── Dispatch ─────────────────────────────────────────────────────
+    client = _get_http_client()
+    started = time.monotonic()
+    try:
+        response = client.request(**request_kwargs)
+    except httpx.TimeoutException as e:
+        return tool_error(
+            f"Request timed out after {eff_timeout}s: {e}",
+            timeout=True,
+            elapsed_ms=int((time.monotonic() - started) * 1000),
+        )
+    except httpx.RequestError as e:
+        return tool_error(
+            f"Transport error: {type(e).__name__}: {e}",
+            elapsed_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    # ── Body cap + decode ────────────────────────────────────────────
+    raw_body = response.content or b""
+    truncated = False
+    if len(raw_body) > _MAX_RESPONSE_BYTES:
+        raw_body = raw_body[:_MAX_RESPONSE_BYTES]
+        truncated = True
+    try:
+        decoded_body = raw_body.decode(response.encoding or "utf-8", errors="replace")
+    except (LookupError, TypeError):
+        decoded_body = raw_body.decode("utf-8", errors="replace")
+
+    # Redact secrets that may appear in echoed bodies (api keys, tokens, etc.).
+    redacted_body = redact_sensitive_text(decoded_body, code_file=False)
+
+    result: dict[str, Any] = {
+        "status": response.status_code,
+        "headers": _redact_response_headers(dict(response.headers)),
+        "body": redacted_body,
+        "elapsed_ms": elapsed_ms,
+    }
+    if truncated:
+        result["truncated"] = True
+        result["_hint"] = (
+            f"Response body exceeded {_MAX_RESPONSE_BYTES:,} bytes and was truncated. "
+            "If you need more, request a smaller slice (e.g. via Range header or pagination)."
+        )
+    return tool_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Schema + Registration
+# ---------------------------------------------------------------------------
+
+HTTP_TOOL_DESCRIPTION = (
+    "Issue a structured HTTP request without going through a shell. "
+    "Prefer this over `terminal` curl for ALL API calls — it eliminates "
+    "the bash-quoting bug class (e.g. apostrophes in JSON bodies) and "
+    "saves ~30-80 ms per call. "
+    "Body: pass `json` (object → auto-serialised + Content-Type set) OR "
+    "`body` (raw string), not both. "
+    "GET/HEAD requests are safe to retry; POST/PUT/PATCH/DELETE may have "
+    "side effects — do not retry blindly. "
+    "Returns: {status, headers, body, elapsed_ms} on success; "
+    "{error, ...} on transport failure (timeout, DNS, connection refused). "
+    "Note: body cap is 1 MB; egress is unrestricted (parity with terminal)."
+)
+
+HTTP_SCHEMA = {
+    "name": "http",
+    "description": HTTP_TOOL_DESCRIPTION,
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "method": {
+                "type": "string",
+                "description": "HTTP method: GET, POST, PUT, PATCH, DELETE, HEAD, or OPTIONS.",
+            },
+            "url": {
+                "type": "string",
+                "description": "Absolute URL (http:// or https://).",
+            },
+            "headers": {
+                "type": "object",
+                "description": "Request headers as a flat name→value map. Authorization / Cookie / Set-Cookie are redacted from the echoed response.",
+                "additionalProperties": {"type": "string"},
+            },
+            "json": {
+                "type": "object",
+                "description": "Request body as a JSON object — httpx serialises it and sets Content-Type: application/json. Use this for almost every API write; mutually exclusive with `body`.",
+                "additionalProperties": True,
+            },
+            "body": {
+                "type": "string",
+                "description": "Raw request body as a string. Use only when sending non-JSON (e.g. form-encoded, plain text). Mutually exclusive with `json`.",
+            },
+            "params": {
+                "type": "object",
+                "description": "Query-string parameters as a flat name→value map. Appended to the URL.",
+                "additionalProperties": {"type": "string"},
+            },
+            "timeout": {
+                "type": "integer",
+                "description": f"Request timeout in seconds (default {int(_DEFAULT_TIMEOUT_SECONDS)}, max {int(_MAX_TIMEOUT_SECONDS)}).",
+                "minimum": 1,
+                "maximum": int(_MAX_TIMEOUT_SECONDS),
+            },
+        },
+        "required": ["method", "url"],
+    },
+}
+
+
+def _handle_http(args, **kw):
+    return http_tool(
+        method=args.get("method"),
+        url=args.get("url"),
+        headers=args.get("headers"),
+        json_body=args.get("json"),
+        body=args.get("body"),
+        params=args.get("params"),
+        timeout=args.get("timeout"),
+        task_id=kw.get("task_id", "default"),
+    )
+
+
+registry.register(
+    name="http",
+    toolset="http",
+    schema=HTTP_SCHEMA,
+    handler=_handle_http,
+    emoji="🌐",
+    max_result_size_chars=_MAX_RESPONSE_BYTES,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -133,6 +133,12 @@ TOOLSETS = {
         "tools": ["terminal", "process"],
         "includes": []
     },
+
+    "http": {
+        "description": "Structured HTTP requests (no shell). Prefer over `terminal` curl for API calls — eliminates the bash-quoting bug class on JSON bodies.",
+        "tools": ["http"],
+        "includes": []
+    },
     
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",


### PR DESCRIPTION
## What does this PR do?

Adds a new \`http\` tool that takes structured args (\`{method, url, headers, json, body, params, timeout}\`) and dispatches via \`httpx.Client\` directly. Bypasses bash entirely, matching the codex/OpenClaw model where the tool runtime never re-parses the model's arguments.

**Why:** The \`terminal\` tool routes every command through \`bash -c <string>\`, which forces the model to escape JSON bodies into shell-safe strings. A single apostrophe in a JSON value (e.g. \`\"It's done\"\`) breaks the outer single-quoting and the call returns:

\`\`\`
/usr/bin/bash: eval: line 3: unexpected EOF while looking for matching ''
\`\`\`

We observed this live in production telemetry for an issue-disposition flow that PATCHes JSON to an internal API: a single typo'd payload was retried repeatedly because the model couldn't see why bash kept failing. The new \`http\` tool eliminates the whole class of bug for HTTP-shaped requests AND saves the per-call bash fork+parse overhead (~30–80 ms), which dominates run time on disposition-heavy workloads.

## Related Issue

(opportunistic perf + reliability fix surfaced by production telemetry)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- New file \`tools/http_tool.py\` (~250 lines): module-level httpx.Client singleton, sync handler, schema, registration. Body resolution: \`json\` (object → auto-serialised + Content-Type set) OR \`body\` (raw string), mutually exclusive. 30 s default timeout, 300 s max. 1 MB response body cap with truncation hint. Authorization / Cookie / Set-Cookie / *-token response headers redacted before returning. Body run through \`agent.redact.redact_sensitive_text\`.
- New \`http\` toolset in \`toolsets.py\` (separate from \`web\` so callers can opt in independently of \`web_search\` / \`web_extract\`).
- \`tests/tools/test_http_tool.py\` (21 tests): happy path, body resolution (json vs body vs both), 4xx surfaced as success envelope (only transport errors become \`tool_error\`), timeout, connection-refused, body-cap truncation, response-header redaction, schema shape, registration-into-toolset.

## How to Test

1. \`pytest tests/tools/test_http_tool.py -q\` — 21 passed.
2. Live smoke (mirrors what we did locally):
   \`\`\`python
   from tools.http_tool import http_tool
   import json
   print(json.loads(http_tool(method='GET', url='http://localhost:3100/api/health'))['status'])
   # → 200
   \`\`\`
3. Verify the tool registers under the \`http\` toolset and is exposed when the platform toolsets list includes \`http\`.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (\`feat(tools):\`)
- [x] I searched for existing PRs to avoid duplicates
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run \`pytest tests/tools/test_http_tool.py -q\` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / WSL2 on Windows 11 (aarch64)
- [x] No documentation update needed — schema description is the model-facing surface
- [x] No \`cli-config.yaml.example\` keys added — the \`http\` toolset name is self-documenting
- [x] Cross-platform: pure Python + httpx; no platform-specific code
- [x] Tool description and schema make the json-vs-body contract explicit and warn about the 1 MB body cap

## Behaviour notes

- **Response body cap (1 MB)** with a hint to use Range / pagination if you need more.
- **No SSRF guard for v1** — the existing \`terminal\` tool already has unrestricted egress, so the \`http\` tool matches that capability. Worth a follow-up if security review pushes back.
- **Sync handler** — registered with the existing sync-handler convention; httpx.Client (sync) is used. AsyncClient is a separate refactor if anyone needs it.
- **GET/HEAD safe to retry** — POST/PUT/PATCH/DELETE may have side effects. The schema description tells the model not to retry mutating calls blindly.
- **Connection pooling** — module-level \`_http_client\` singleton, mirroring the per-vendor client pattern in \`tools/web_tools.py\`.