### PR TITLE
feat(terminal): hint at structured tools when bash fails to parse a command

### DIFF
--- a/tests/tools/test_terminal_quoting_hint.py
+++ b/tests/tools/test_terminal_quoting_hint.py
@@ -1,0 +1,67 @@
+"""Tests for the H4 bash-quoting-error hint detector.
+
+When bash itself fails to parse a command (typically an apostrophe inside a
+single-quoted JSON body in a curl call), it exits 2 with a recognizable
+message. The terminal tool surfaces an actionable hint pointing at the new
+`http` tool so the model stops retrying the same broken quoting.
+"""
+
+from tools.terminal_tool import (
+    _BASH_QUOTING_ERROR_MARKERS,
+    _detect_bash_quoting_error,
+)
+
+
+class TestDetectBashQuotingError:
+    def test_unexpected_eof_returns_hint(self):
+        # The exact string we observed in /home/rkt2/.hermes-paperclip/logs.
+        out = "/usr/bin/bash: eval: line 3: unexpected EOF while looking for matching ''"
+        hint = _detect_bash_quoting_error(out, returncode=2)
+        assert hint is not None
+        assert "http" in hint  # points at the new tool
+        assert "apostrophe" in hint.lower() or "quote" in hint.lower()
+
+    def test_eof_variant_without_unexpected_returns_hint(self):
+        out = "bash: line 1: EOF while looking for matching '\""
+        hint = _detect_bash_quoting_error(out, returncode=2)
+        assert hint is not None
+
+    def test_syntax_error_near_unexpected_token_returns_hint(self):
+        out = "bash: -c: line 0: syntax error near unexpected token `)`"
+        hint = _detect_bash_quoting_error(out, returncode=2)
+        assert hint is not None
+
+    def test_nonzero_exit_without_marker_returns_none(self):
+        # `false`, `grep` no-match, etc. — exit 1 or other codes. Never trigger.
+        assert _detect_bash_quoting_error("permission denied", returncode=1) is None
+        assert _detect_bash_quoting_error("not found", returncode=127) is None
+
+    def test_exit_zero_with_marker_in_output_returns_none(self):
+        # If a real command happens to print the marker text in stdout but
+        # exits 0, we must NOT fire the hint — the command succeeded.
+        out = "echo unexpected EOF while looking for matching"
+        assert _detect_bash_quoting_error(out, returncode=0) is None
+
+    def test_empty_output_returns_none(self):
+        assert _detect_bash_quoting_error("", returncode=2) is None
+
+    def test_exit_2_without_marker_returns_none(self):
+        # bash exit 2 is also used for `usage` errors in many programs.
+        # Without the parser-error marker we don't claim quoting was the cause.
+        assert _detect_bash_quoting_error("usage: foo [-x]", returncode=2) is None
+
+    def test_hint_advertises_http_tool_first(self):
+        out = "bash: -c: line 0: unexpected EOF while looking for matching '"
+        hint = _detect_bash_quoting_error(out, returncode=2)
+        assert hint is not None
+        # The whole point of this hint is to redirect the model to `http`.
+        assert "http" in hint.lower()
+        # And it should explicitly tell the model NOT to retry blindly.
+        assert "do not just retry" in hint.lower() or "do not retry" in hint.lower()
+
+    def test_all_documented_markers_actually_fire(self):
+        """If we list a marker in the constant, the detector must match on it."""
+        for marker in _BASH_QUOTING_ERROR_MARKERS:
+            out = f"bash: -c: line 0: {marker} something"
+            hint = _detect_bash_quoting_error(out, returncode=2)
+            assert hint is not None, f"marker {marker!r} did not trigger detector"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1544,6 +1544,44 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
+# H4: Bash quoting failures surface in stdout with one of these markers and
+# exit_code=2. Detected at result-package time so the model gets an actionable
+# hint rather than just the raw bash error.
+_BASH_QUOTING_ERROR_MARKERS = (
+    "unexpected EOF while looking for matching",  # `bash -c "..."` parser hit EOF before close-quote
+    "EOF while looking for matching",             # variant without "unexpected" on some bash builds
+    "unexpected end of file",                     # heredoc / brace variants
+    "syntax error near unexpected token",         # related class: bad escape produced an unexpected token
+)
+
+
+def _detect_bash_quoting_error(output: str, returncode: int) -> str | None:
+    """Return an actionable hint when output looks like a bash-parser failure.
+
+    Triggered on exit code 2 (bash's parse-error exit) AND a known marker in
+    output. Hint points the model at (1) the new `http` tool — eliminates the
+    shell entirely for HTTP-shaped calls — and (2) better quoting strategies
+    for raw shell use.
+    """
+    if returncode != 2 or not output:
+        return None
+    if not any(marker in output for marker in _BASH_QUOTING_ERROR_MARKERS):
+        return None
+    return (
+        "Bash failed to parse the command — almost always an unclosed or "
+        "mismatched quote. Common cause: a single-quoted string with a "
+        "literal apostrophe inside (e.g. `-d '{\"body\":\"It's done\"}'`). "
+        "Fastest fixes: "
+        "(1) If this was an HTTP request, call the `http` tool instead — "
+        "it takes structured args ({method, url, headers, json}) and skips "
+        "the shell entirely, eliminating this whole bug class. "
+        "(2) For raw shell, use double quotes around the body and escape "
+        "internal double quotes, OR end-quote-concat: "
+        "`'{\"body\":\"It'\"'\"'s done\"}'`. "
+        "Do NOT just retry the same command — bash will fail the same way."
+    )
+
+
 _SHELL_LEVEL_BACKGROUND_RE = re.compile(
     r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b", re.IGNORECASE | re.MULTILINE
 )
@@ -2119,6 +2157,15 @@ def terminal_tool(
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")
             exit_note = _interpret_exit_code(command, returncode)
 
+            # H4: Bash quoting-error recovery hint.
+            # When bash itself fails to parse the command (most commonly an
+            # apostrophe inside a single-quoted JSON body), it exits 2 with a
+            # very specific message. Without an actionable hint, the model
+            # tends to retry the same broken quoting. Detect the pattern and
+            # surface a hint that points at the new `http` tool (no shell at
+            # all) or at structuring the curl differently.
+            quoting_hint = _detect_bash_quoting_error(output, returncode)
+
             result_dict = {
                 "output": output,
                 "exit_code": returncode,
@@ -2128,6 +2175,8 @@ def terminal_tool(
                 result_dict["approval"] = approval_note
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
+            if quoting_hint:
+                result_dict["_hint"] = quoting_hint
 
             return json.dumps(result_dict, ensure_ascii=False)
 


### PR DESCRIPTION
## What does this PR do?

When the \`terminal\` tool's \`bash -c <string>\` invocation fails to parse the command (almost always an unclosed quote, e.g. an apostrophe inside a single-quoted JSON body), bash exits 2 with a recognizable message in stdout. Today the model just sees:

\`\`\`
/usr/bin/bash: eval: line 3: unexpected EOF while looking for matching ''
\`\`\`

…and frequently retries the same broken quoting because the error doesn't say what to do.

This PR adds a detector that catches the parser-error markers (with \`returncode == 2\`) and attaches an actionable \`_hint\` to the tool result, pointing the model at:

1. The new \`http\` tool (#25861) — eliminates the shell entirely for any HTTP-shaped call. Single best fix.
2. End-quote-concat or double-quoted alternatives for raw shell.

Standalone — works without #25861, but recommends it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that improves recovery from a recurring class of failures)

## Changes Made

- \`tools/terminal_tool.py\`:
  - New module-level \`_BASH_QUOTING_ERROR_MARKERS\` tuple covering the bash parser's known failure messages.
  - New \`_detect_bash_quoting_error(output, returncode)\` helper. Conservative gate: requires BOTH \`returncode == 2\` AND a known marker present in \`output\`.
  - Result-package wiring: when the helper returns a hint, attach it to \`result_dict[\"_hint\"]\`.
- \`tests/tools/test_terminal_quoting_hint.py\` (9 tests).

## How to Test

\`pytest tests/tools/test_terminal_quoting_hint.py -q\` — 9 passed.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits (\`feat(terminal):\`)
- [x] Searched for existing PRs
- [x] Only the one fix
- [x] Tests added + passing on Ubuntu 24.04 / WSL2 (aarch64)
- [x] No documentation, config, or schema changes needed
- [x] Pure-Python string check; cross-platform