### PR TITLE
fix: propagate archived Notion kanban sync status

### DIFF
--- a/docs/hermes-notion-kanban-sync.md
+++ b/docs/hermes-notion-kanban-sync.md
@@ -1,0 +1,53 @@
+# Hermes ↔ Notion Kanban Sync
+
+Production-safe sync for the SoLoVision Notion Task Board and Hermes Kanban.
+
+## Dry run
+
+```bash
+python -m hermes_cli.notion_kanban_sync --dry-run
+```
+
+The dry run writes a timestamped JSON report with:
+- current Notion status distribution
+- proposed legacy → canonical status migrations
+- proposed Hermes task creations
+- proposed two-way updates
+
+## Safe sample/backfill
+
+```bash
+python -m hermes_cli.notion_kanban_sync --apply --limit 3
+```
+
+For batched permanent backfill without flooding workers:
+
+```bash
+python -m hermes_cli.notion_kanban_sync --apply --quiet --max-creates 25
+```
+
+For targeted verification or repair, constrain a run to one or more linked Hermes task ids:
+
+```bash
+python -m hermes_cli.notion_kanban_sync --apply --hermes-task-id t_abc12345 --max-creates 0
+```
+
+No hard deletes are performed. Legacy Notion statuses are not mass-rewritten unless `--status-migration` is explicitly passed after reviewing a dry-run report. Hermes `archived` maps to an explicit Notion `Status=Archived` select option and `Hermes Status=archived`; the sync may create the Archived option on the Task Board if it is missing.
+
+## Permanent timer
+
+Install the operational script and systemd timer:
+
+```bash
+mkdir -p ~/.hermes/profiles/dev/scripts ~/.config/systemd/user
+install -m 700 scripts/notion_kanban_sync_watchdog.sh ~/.hermes/profiles/dev/scripts/notion_kanban_sync_watchdog.sh
+cp plugins/kanban/systemd/hermes-notion-kanban-sync.service ~/.config/systemd/user/
+cp plugins/kanban/systemd/hermes-notion-kanban-sync.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-notion-kanban-sync.timer
+systemctl --user list-timers hermes-notion-kanban-sync.timer --no-pager
+```
+
+The watchdog runs `python -m hermes_cli.notion_kanban_sync` from `~/.hermes/hermes-agent` when the module is available there, with a fallback to `~/.hermes/profiles/dev/scripts/notion_kanban_sync.py` for pre-merge installs. Override `HERMES_NOTION_SYNC_REPO`, `HERMES_NOTION_SYNC_SCRIPT`, `HERMES_NOTION_SYNC_PYTHON`, `HERMES_NOTION_SYNC_REPORT_DIR`, or `HERMES_NOTION_SYNC_MAX_CREATES` in the systemd service environment if needed. If `HERMES_NOTION_SYNC_REPORT_DIR` is unset, the module writes to the profile-safe default `~/.hermes/reports/hermes-notion-sync/`.
+
+The watchdog is quiet when no changes occur; non-empty stdout means a sync changed something or hit an error.

--- a/hermes_cli/notion_kanban_sync.py
+++ b/hermes_cli/notion_kanban_sync.py
@@ -1,0 +1,828 @@
+"""Two-way sync between Hermes Kanban and the SoLoVision Notion Task Board.
+
+This module is intentionally runnable as a quiet operational script:
+
+    python -m hermes_cli.notion_kanban_sync --dry-run
+    python -m hermes_cli.notion_kanban_sync --apply --limit 25
+    python -m hermes_cli.notion_kanban_sync --apply --daemon --interval 180
+
+No hard deletes are performed.  All audit artifacts are written under
+``~/.hermes/reports/hermes-notion-sync/`` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import requests
+
+from hermes_constants import get_default_hermes_root
+from hermes_cli import kanban_db
+
+TASK_BOARD_DATABASE_ID = "8e85701f-81a6-490f-a859-5c0bc9e52827"
+NOTION_READ_VERSION = "2025-09-03"
+NOTION_WRITE_VERSION = "2022-06-28"
+REPORT_SUBDIR = "hermes-notion-sync"
+CANONICAL_NOTION_STATUSES = ("Triage", "Todo", "Ready", "Running", "Done", "Archived")
+
+NOTION_TO_CANONICAL = {
+    "triage": "Triage",
+    "todo": "Todo",
+    "to do": "Todo",
+    "not started": "Todo",
+    "ready": "Ready",
+    "ready for creation": "Ready",
+    "running": "Running",
+    "in progress": "Running",
+    "in review": "Running",
+    "blocked": "Triage",
+    "done": "Done",
+    "completed": "Done",
+    "complete": "Done",
+    "cancelled": "Done",
+    "canceled": "Done",
+    "archived": "Archived",
+}
+
+HERMES_TO_NOTION = {
+    "triage": "Triage",
+    "todo": "Todo",
+    "ready": "Ready",
+    "running": "Running",
+    "blocked": "Triage",
+    "done": "Done",
+    "archived": "Archived",
+}
+
+NOTION_TO_HERMES = {
+    "Triage": "triage",
+    "Todo": "todo",
+    "Ready": "ready",
+    "Running": "running",
+    "Done": "done",
+    "Archived": "archived",
+}
+
+PRIORITY_TO_INT = {
+    "urgent": 100,
+    "critical": 100,
+    "high": 75,
+    "medium": 50,
+    "normal": 50,
+    "low": 25,
+}
+
+
+@dataclass
+class SyncStats:
+    notion_pages_seen: int = 0
+    notion_status_counts: dict[str, int] = field(default_factory=dict)
+    canonical_status_counts: dict[str, int] = field(default_factory=dict)
+    proposed_status_migrations: dict[str, int] = field(default_factory=dict)
+    notion_pages_updated: int = 0
+    notion_pages_would_update: int = 0
+    hermes_tasks_seen: int = 0
+    hermes_tasks_created: int = 0
+    hermes_tasks_would_create: int = 0
+    hermes_tasks_updated: int = 0
+    hermes_tasks_would_update: int = 0
+    hermes_to_notion_updates: int = 0
+    hermes_to_notion_would_update: int = 0
+    notion_to_hermes_updates: int = 0
+    notion_to_hermes_would_update: int = 0
+    comments_appended: int = 0
+    comments_would_append: int = 0
+    conflicts: int = 0
+    errors: list[str] = field(default_factory=list)
+    changed: bool = False
+
+
+@dataclass
+class NotionTask:
+    page_id: str
+    url: str
+    title: str
+    status: str
+    canonical_status: str
+    assigned_agent: str | None
+    priority: str | None
+    blockers: str | None
+    notes: str | None
+    source: str | None
+    last_edited_time: str | None
+    hermes_task_id: str | None
+    hermes_status: str | None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_notion_time(value: str | None) -> float:
+    if not value:
+        return 0.0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _plain_text(items: list[dict[str, Any]] | None) -> str:
+    if not items:
+        return ""
+    return "".join(str(item.get("plain_text") or item.get("text", {}).get("content") or "") for item in items)
+
+
+def _rich_text_prop(prop: dict[str, Any] | None) -> str:
+    if not prop:
+        return ""
+    if prop.get("type") == "rich_text":
+        return _plain_text(prop.get("rich_text"))
+    if prop.get("type") == "title":
+        return _plain_text(prop.get("title"))
+    if prop.get("type") == "url":
+        return prop.get("url") or ""
+    return ""
+
+
+def _select_name(prop: dict[str, Any] | None) -> str:
+    if not prop:
+        return ""
+    if prop.get("type") == "select":
+        val = prop.get("select")
+        return val.get("name", "") if isinstance(val, dict) else ""
+    if prop.get("type") == "status":
+        val = prop.get("status")
+        return val.get("name", "") if isinstance(val, dict) else ""
+    return ""
+
+
+def normalize_notion_status(status: str | None) -> str:
+    key = (status or "").strip().casefold()
+    return NOTION_TO_CANONICAL.get(key, "Triage")
+
+
+def hermes_status_to_notion(status: str | None) -> str:
+    return HERMES_TO_NOTION.get((status or "").strip().casefold(), "Triage")
+
+
+def notion_status_to_hermes(status: str | None) -> str:
+    return NOTION_TO_HERMES.get(normalize_notion_status(status), "triage")
+
+
+def normalize_assignee(value: str | None, valid_profiles: set[str]) -> str | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    # Strip common labels and punctuation from Notion human text.
+    candidate = raw.split(",", 1)[0].strip().lower()
+    candidate = re.sub(r"[^a-z0-9_-]+", "-", candidate).strip("-")
+    aliases = {
+        "developer": "dev",
+        "engineering": "dev",
+        "head-of-engineering": "dev",
+    }
+    candidate = aliases.get(candidate, candidate)
+    return candidate if candidate in valid_profiles else None
+
+
+def priority_to_int(value: str | None) -> int:
+    return PRIORITY_TO_INT.get((value or "").strip().casefold(), 0)
+
+
+def report_root(root: Path | None = None) -> Path:
+    base = root or get_default_hermes_root()
+    return base / "reports" / REPORT_SUBDIR
+
+
+def load_notion_key() -> str:
+    env = os.environ.get("NOTION_KEY") or os.environ.get("NOTION_API_KEY")
+    if env and env.strip():
+        return env.strip()
+    candidates = [
+        Path.home() / ".config" / "notion" / "api_key",
+        get_default_hermes_root() / ".config" / "notion" / "api_key",
+    ]
+    for path in candidates:
+        try:
+            if path.exists():
+                key = path.read_text(encoding="utf-8").strip()
+                if key:
+                    return key
+        except OSError:
+            continue
+    raise RuntimeError("Notion API key not found in NOTION_KEY/NOTION_API_KEY or ~/.config/notion/api_key")
+
+
+class NotionClient:
+    def __init__(self, token: str, database_id: str = TASK_BOARD_DATABASE_ID, timeout: int = 30):
+        self.database_id = database_id
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        })
+
+    def _request(self, method: str, url: str, *, version: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        headers = {"Notion-Version": version}
+        last_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                resp = self.session.request(method, url, headers=headers, json=payload, timeout=self.timeout)
+                if resp.status_code >= 400:
+                    raise RuntimeError(f"Notion {method} {url} failed {resp.status_code}: {resp.text[:500]}")
+                if not resp.text:
+                    return {}
+                return resp.json()
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                last_error = exc
+                if attempt == 2:
+                    break
+                time.sleep(2 ** attempt)
+        raise RuntimeError(f"Notion {method} {url} failed after retries: {last_error}")
+
+    def retrieve_database(self) -> dict[str, Any]:
+        # Database schema reads must use the stable pre-data-source API shape;
+        # Notion-Version 2025-09-03 returns an empty database-level
+        # ``properties`` object for split data sources.
+        return self._request(
+            "GET",
+            f"https://api.notion.com/v1/databases/{self.database_id}",
+            version=NOTION_WRITE_VERSION,
+        )
+
+    def ensure_properties(self, *, dry_run: bool) -> dict[str, Any]:
+        db = self.retrieve_database()
+        props = db.get("properties", {})
+        updates: dict[str, Any] = {}
+
+        status = props.get("Status", {})
+        if status.get("type") != "select":
+            raise RuntimeError("Notion Task Board Status property is not a select")
+        existing = {opt.get("name") for opt in status.get("select", {}).get("options", [])}
+        missing_statuses = [name for name in CANONICAL_NOTION_STATUSES if name not in existing]
+        if missing_statuses:
+            options = status.get("select", {}).get("options", []) + [{"name": name} for name in missing_statuses]
+            updates["Status"] = {"select": {"options": options}}
+
+        desired = {
+            "Hermes Task ID": {"rich_text": {}},
+            "Hermes Status": {"rich_text": {}},
+            "Last Synced At": {"date": {}},
+            "Sync Source": {"rich_text": {}},
+            "Sync Error": {"rich_text": {}},
+        }
+        for name, spec in desired.items():
+            if name not in props:
+                updates[name] = spec
+
+        if updates and not dry_run:
+            self._request(
+                "PATCH",
+                f"https://api.notion.com/v1/databases/{self.database_id}",
+                version=NOTION_WRITE_VERSION,
+                payload={"properties": updates},
+            )
+        return {"missing_statuses": missing_statuses, "properties_added": [k for k in updates if k != "Status"]}
+
+    def query_tasks(self, *, page_size: int = 100, since: str | None = None, limit: int | None = None) -> list[dict[str, Any]]:
+        payload: dict[str, Any] = {"page_size": min(max(page_size, 1), 100)}
+        if since:
+            payload["filter"] = {"timestamp": "last_edited_time", "last_edited_time": {"on_or_after": since}}
+        rows: list[dict[str, Any]] = []
+        while True:
+            data = self._request(
+                "POST",
+                f"https://api.notion.com/v1/databases/{self.database_id}/query",
+                version=NOTION_WRITE_VERSION,
+                payload=payload,
+            )
+            rows.extend(data.get("results", []))
+            if limit and len(rows) >= limit:
+                return rows[:limit]
+            if not data.get("has_more"):
+                return rows
+            payload["start_cursor"] = data.get("next_cursor")
+
+    def update_page_properties(self, page_id: str, properties: dict[str, Any]) -> None:
+        self._request(
+            "PATCH",
+            f"https://api.notion.com/v1/pages/{page_id}",
+            version=NOTION_WRITE_VERSION,
+            payload={"properties": properties},
+        )
+
+    def append_activity(self, page_id: str, text: str) -> None:
+        self._request(
+            "PATCH",
+            f"https://api.notion.com/v1/blocks/{page_id}/children",
+            version=NOTION_READ_VERSION,
+            payload={"children": [{"paragraph": {"rich_text": [{"text": {"content": text[:1900]}}]}}]},
+        )
+
+
+def parse_notion_task(page: dict[str, Any]) -> NotionTask:
+    props = page.get("properties", {})
+    title = _rich_text_prop(props.get("Task")) or _rich_text_prop(props.get("Name")) or "Untitled Notion task"
+    status = _select_name(props.get("Status"))
+    return NotionTask(
+        page_id=page.get("id", ""),
+        url=page.get("url", ""),
+        title=title,
+        status=status,
+        canonical_status=normalize_notion_status(status),
+        assigned_agent=(
+            _select_name(props.get("Assigned Agent"))
+            or _rich_text_prop(props.get("Assigned Agent"))
+            or _rich_text_prop(props.get("Assigned To"))
+            or _select_name(props.get("Assigned To"))
+            or None
+        ),
+        priority=_select_name(props.get("Priority")) or _rich_text_prop(props.get("Priority")) or None,
+        blockers=_rich_text_prop(props.get("Blockers")) or None,
+        notes=_rich_text_prop(props.get("Notes")) or None,
+        source=_rich_text_prop(props.get("Source")) or None,
+        last_edited_time=page.get("last_edited_time"),
+        hermes_task_id=_rich_text_prop(props.get("Hermes Task ID")) or None,
+        hermes_status=_rich_text_prop(props.get("Hermes Status")) or None,
+    )
+
+
+def notion_page_id_from_task(task: kanban_db.Task) -> str | None:
+    key = task.idempotency_key or ""
+    if key.startswith("notion:"):
+        return key.split(":", 1)[1]
+    body = task.body or ""
+    match = re.search(r"Notion Page ID:\s*([0-9a-fA-F-]{32,36})", body)
+    return match.group(1) if match else None
+
+
+def task_last_event_ts(conn: sqlite3.Connection, task_id: str) -> float:
+    row = conn.execute("SELECT MAX(created_at) AS ts FROM task_events WHERE task_id = ?", (task_id,)).fetchone()
+    return float(row["ts"] or 0)
+
+
+def add_kanban_comment(conn: sqlite3.Connection, task_id: str, body: str, author: str = "notion-sync") -> None:
+    now = int(time.time())
+    with kanban_db.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, author, body, now),
+        )
+        kanban_db._append_event(conn, task_id, "commented", {"author": author})
+
+
+def set_kanban_status(conn: sqlite3.Connection, task_id: str, status: str, *, reason: str) -> bool:
+    if status not in kanban_db.VALID_STATUSES:
+        raise ValueError(f"invalid Hermes status: {status}")
+    now = int(time.time())
+    with kanban_db.write_txn(conn):
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if not row or row["status"] == status:
+            return False
+        updates = "status = ?"
+        params: list[Any] = [status]
+        if status == "running":
+            updates += ", started_at = COALESCE(started_at, ?)"
+            params.append(now)
+        if status == "done":
+            updates += ", completed_at = COALESCE(completed_at, ?), claim_lock = NULL, claim_expires = NULL, worker_pid = NULL"
+            params.append(now)
+        if status in {"triage", "todo", "ready", "blocked"}:
+            updates += ", claim_lock = NULL, claim_expires = NULL, worker_pid = NULL"
+        params.append(task_id)
+        conn.execute(f"UPDATE tasks SET {updates} WHERE id = ?", tuple(params))
+        kanban_db._append_event(conn, task_id, "notion_sync_status", {"from": row["status"], "to": status, "reason": reason})
+        return True
+
+
+def set_kanban_assignee_priority(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    assignee: str | None,
+    priority: int | None,
+    reason: str,
+) -> bool:
+    changed = False
+    with kanban_db.write_txn(conn):
+        row = conn.execute("SELECT assignee, priority FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if not row:
+            return False
+        sets: list[str] = []
+        params: list[Any] = []
+        if assignee is not None and row["assignee"] != assignee:
+            sets.append("assignee = ?")
+            params.append(assignee)
+        if priority is not None and int(row["priority"] or 0) != int(priority):
+            sets.append("priority = ?")
+            params.append(int(priority))
+        if sets:
+            params.append(task_id)
+            conn.execute(f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", tuple(params))
+            kanban_db._append_event(conn, task_id, "notion_sync_fields", {"assignee": assignee, "priority": priority, "reason": reason})
+            changed = True
+    return changed
+
+
+def notion_properties_for_sync(
+    *,
+    status: str | None = None,
+    hermes_task_id: str | None = None,
+    hermes_status: str | None = None,
+    sync_source: str = "sync-engine",
+    sync_error: str = "",
+) -> dict[str, Any]:
+    props: dict[str, Any] = {
+        "Last Synced At": {"date": {"start": _now_iso()}},
+        "Sync Source": {"rich_text": [{"text": {"content": sync_source}}]},
+        "Sync Error": {"rich_text": [{"text": {"content": sync_error[:1900]}}] if sync_error else []},
+    }
+    if status:
+        props["Status"] = {"select": {"name": status}}
+    if hermes_task_id:
+        props["Hermes Task ID"] = {"rich_text": [{"text": {"content": hermes_task_id}}]}
+    if hermes_status:
+        props["Hermes Status"] = {"rich_text": [{"text": {"content": hermes_status}}]}
+    return props
+
+
+def make_task_body(notion: NotionTask) -> str:
+    parts = [
+        "Imported from Notion Task Board by Hermes-Notion sync.",
+        f"Notion Page ID: {notion.page_id}",
+        f"Notion URL: {notion.url}",
+        f"Original Notion Status: {notion.status or '(empty)'}",
+    ]
+    if notion.assigned_agent:
+        parts.append(f"Assigned Agent: {notion.assigned_agent}")
+    if notion.blockers:
+        parts.append(f"Blockers: {notion.blockers}")
+    if notion.notes:
+        parts.append(f"Notes: {notion.notes}")
+    if notion.source:
+        parts.append(f"Source: {notion.source}")
+    return "\n".join(parts)
+
+
+def valid_profiles() -> set[str]:
+    profiles = set(kanban_db.list_profiles_on_disk())
+    profiles.update({"halo", "dev"})
+    return profiles
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    try:
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {"pages": {}, "tasks": {}, "last_run_at": None}
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_report(root: Path, name: str, payload: dict[str, Any]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / name
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+    return path
+
+
+class NotionKanbanSync:
+    def __init__(
+        self,
+        *,
+        notion: NotionClient,
+        board: str | None = None,
+        report_dir: Path | None = None,
+        state_path: Path | None = None,
+    ):
+        self.notion = notion
+        self.board = board
+        self.report_dir = report_dir or report_root()
+        self.state_path = state_path or self.report_dir / "state.json"
+        self.state = load_state(self.state_path)
+
+    def run_once(
+        self,
+        *,
+        dry_run: bool,
+        limit: int | None = None,
+        since: str | None = None,
+        status_migration: bool = False,
+        max_creates: int | None = None,
+        hermes_task_ids: set[str] | None = None,
+        quiet: bool = False,
+    ) -> tuple[SyncStats, Path]:
+        stats = SyncStats()
+        ensure = self.notion.ensure_properties(dry_run=dry_run)
+        if ensure.get("missing_statuses") or ensure.get("properties_added"):
+            stats.changed = True
+
+        raw_pages = self.notion.query_tasks(limit=limit, since=since)
+        notion_tasks = [parse_notion_task(page) for page in raw_pages if not page.get("archived")]
+        if hermes_task_ids:
+            notion_tasks = [task for task in notion_tasks if task.hermes_task_id in hermes_task_ids]
+        stats.notion_pages_seen = len(notion_tasks)
+        stats.notion_status_counts = dict(Counter(task.status or "(empty)" for task in notion_tasks))
+        stats.canonical_status_counts = dict(Counter(task.canonical_status for task in notion_tasks))
+        stats.proposed_status_migrations = dict(Counter(
+            f"{task.status or '(empty)'} -> {task.canonical_status}"
+            for task in notion_tasks
+            if (task.status or "") != task.canonical_status
+        ))
+
+        profiles = valid_profiles()
+        with kanban_db.connect(board=self.board) as conn:
+            created_task_ids: set[str] = set()
+            tasks = kanban_db.list_tasks(conn, include_archived=True)
+            stats.hermes_tasks_seen = len(tasks)
+            by_notion_page = {notion_page_id_from_task(task): task for task in tasks if notion_page_id_from_task(task)}
+            by_task_id = {task.id: task for task in tasks}
+
+            for notion_task in notion_tasks:
+                self._sync_notion_task(
+                    conn,
+                    notion_task,
+                    profiles,
+                    by_notion_page,
+                    by_task_id,
+                    dry_run=dry_run,
+                    status_migration=status_migration,
+                    max_creates=max_creates,
+                    created_task_ids=created_task_ids,
+                    stats=stats,
+                )
+
+            # Refresh task list after any Notion-created tasks, then push Hermes runtime state to Notion.
+            tasks = kanban_db.list_tasks(conn, include_archived=True)
+            by_page_id = {task.page_id: task for task in notion_tasks}
+            for task in tasks:
+                if task.id in created_task_ids:
+                    continue
+                page_id = notion_page_id_from_task(task)
+                if not page_id or page_id not in by_page_id:
+                    continue
+                notion_task = by_page_id[page_id]
+                self._sync_hermes_task_to_notion(
+                    conn,
+                    task,
+                    notion_task,
+                    dry_run=dry_run,
+                    stats=stats,
+                )
+
+        report_payload = {
+            "generated_at": _now_iso(),
+            "dry_run": dry_run,
+            "board": self.board or kanban_db.get_current_board(),
+            "database_id": self.notion.database_id,
+            "ensure": ensure,
+            "stats": asdict(stats),
+        }
+        report_name = f"{'dry-run' if dry_run else 'sync'}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+        report_path = write_report(self.report_dir, report_name, report_payload)
+        if not dry_run:
+            self.state["last_run_at"] = _now_iso()
+            save_state(self.state_path, self.state)
+        if not quiet or dry_run or stats.changed or stats.errors:
+            print(json.dumps({"report": str(report_path), "stats": asdict(stats)}, indent=2, sort_keys=True))
+        return stats, report_path
+
+    def _sync_notion_task(
+        self,
+        conn: sqlite3.Connection,
+        notion_task: NotionTask,
+        profiles: set[str],
+        by_notion_page: dict[str | None, kanban_db.Task],
+        by_task_id: dict[str, kanban_db.Task],
+        *,
+        dry_run: bool,
+        status_migration: bool,
+        max_creates: int | None,
+        created_task_ids: set[str],
+        stats: SyncStats,
+    ) -> None:
+        existing = None
+        if notion_task.hermes_task_id:
+            existing = by_task_id.get(notion_task.hermes_task_id)
+        if existing is None:
+            existing = by_notion_page.get(notion_task.page_id)
+
+        if existing is None:
+            if max_creates is not None and stats.hermes_tasks_created >= max_creates and not dry_run:
+                return
+            assignee = normalize_assignee(notion_task.assigned_agent, profiles) or "halo"
+            triage = notion_task.canonical_status == "Triage"
+            hermes_status = notion_status_to_hermes(notion_task.status)
+            if dry_run:
+                stats.hermes_tasks_would_create += 1
+            else:
+                task_id = kanban_db.create_task(
+                    conn,
+                    title=notion_task.title,
+                    body=make_task_body(notion_task),
+                    assignee=assignee,
+                    created_by="notion-sync",
+                    priority=priority_to_int(notion_task.priority),
+                    triage=triage,
+                    idempotency_key=f"notion:{notion_task.page_id}",
+                )
+                created = kanban_db.get_task(conn, task_id)
+                if created and created.status != hermes_status:
+                    set_kanban_status(conn, task_id, hermes_status, reason="initial Notion import")
+                self.notion.update_page_properties(
+                    notion_task.page_id,
+                    notion_properties_for_sync(
+                        status=notion_task.canonical_status if status_migration else None,
+                        hermes_task_id=task_id,
+                        hermes_status=hermes_status,
+                    ),
+                )
+                by_task_id[task_id] = kanban_db.get_task(conn, task_id)  # type: ignore[assignment]
+                created_task_ids.add(task_id)
+                now = _now_iso()
+                self.state.setdefault("pages", {})[notion_task.page_id] = {"last_synced_at": now, "hermes_task_id": task_id}
+                self.state.setdefault("tasks", {})[task_id] = {"last_synced_at": now, "notion_page_id": notion_task.page_id}
+                stats.hermes_tasks_created += 1
+                stats.notion_pages_updated += 1
+            stats.changed = True
+            return
+
+        # Existing paired task: apply safe Notion -> Hermes field/status updates.
+        state_page = self.state.setdefault("pages", {}).get(notion_task.page_id, {})
+        last_sync_ts = _parse_notion_time(state_page.get("last_synced_at"))
+        notion_changed = _parse_notion_time(notion_task.last_edited_time) > last_sync_ts if last_sync_ts else True
+        hermes_changed = task_last_event_ts(conn, existing.id) > last_sync_ts if last_sync_ts else True
+        target_hermes_status = notion_status_to_hermes(notion_task.status)
+
+        # Archived Hermes tasks are terminal runtime state. A stale Notion row
+        # (often Status=Done / Hermes Status=done from pre-archive syncs) must
+        # not pull the task back out of the archive column; the later
+        # Hermes -> Notion pass will make the Notion archive state explicit.
+        if existing.status == "archived" and target_hermes_status != "archived":
+            return
+
+        if notion_changed and hermes_changed and existing.status != target_hermes_status:
+            stats.conflicts += 1
+            msg = f"Conflict: Notion status {notion_task.status!r} and Hermes status {existing.status!r} both changed since last sync; Hermes runtime state kept."
+            if dry_run:
+                stats.comments_would_append += 1
+            else:
+                add_kanban_comment(conn, existing.id, msg)
+                self.notion.update_page_properties(notion_task.page_id, notion_properties_for_sync(sync_error=msg, hermes_task_id=existing.id, hermes_status=existing.status))
+                now = _now_iso()
+                self.state.setdefault("pages", {})[notion_task.page_id] = {"last_synced_at": now, "hermes_task_id": existing.id}
+                self.state.setdefault("tasks", {})[existing.id] = {"last_synced_at": now, "notion_page_id": notion_task.page_id}
+                stats.comments_appended += 1
+                stats.notion_pages_updated += 1
+            stats.changed = True
+            return
+
+        if notion_changed:
+            status_changed = existing.status != target_hermes_status
+            assignee = normalize_assignee(notion_task.assigned_agent, profiles)
+            priority = priority_to_int(notion_task.priority) if notion_task.priority else None
+            if dry_run:
+                if status_changed or assignee or priority is not None:
+                    stats.notion_to_hermes_would_update += 1
+                    stats.changed = True
+            else:
+                did = False
+                if status_changed:
+                    did = set_kanban_status(conn, existing.id, target_hermes_status, reason="Notion Task Board status changed") or did
+                did = set_kanban_assignee_priority(conn, existing.id, assignee=assignee, priority=priority, reason="Notion Task Board field changed") or did
+                if did:
+                    stats.notion_to_hermes_updates += 1
+                    stats.changed = True
+                needs_notion_update = (
+                    did
+                    or notion_task.hermes_task_id != existing.id
+                    or (status_migration and notion_task.status != notion_task.canonical_status)
+                )
+                if needs_notion_update:
+                    self.notion.update_page_properties(
+                        notion_task.page_id,
+                        notion_properties_for_sync(
+                            hermes_task_id=existing.id,
+                            hermes_status=target_hermes_status,
+                            status=notion_task.canonical_status if status_migration and notion_task.status != notion_task.canonical_status else None,
+                        ),
+                    )
+                    stats.notion_pages_updated += 1
+                    now = _now_iso()
+                    self.state.setdefault("pages", {})[notion_task.page_id] = {"last_synced_at": now, "hermes_task_id": existing.id}
+                    self.state.setdefault("tasks", {})[existing.id] = {"last_synced_at": now, "notion_page_id": notion_task.page_id}
+        elif status_migration and notion_task.status != notion_task.canonical_status:
+            if dry_run:
+                stats.notion_pages_would_update += 1
+            else:
+                self.notion.update_page_properties(notion_task.page_id, notion_properties_for_sync(status=notion_task.canonical_status, hermes_task_id=existing.id, hermes_status=existing.status))
+                now = _now_iso()
+                self.state.setdefault("pages", {})[notion_task.page_id] = {"last_synced_at": now, "hermes_task_id": existing.id}
+                self.state.setdefault("tasks", {})[existing.id] = {"last_synced_at": now, "notion_page_id": notion_task.page_id}
+                stats.notion_pages_updated += 1
+            stats.changed = True
+
+    def _sync_hermes_task_to_notion(
+        self,
+        conn: sqlite3.Connection,
+        task: kanban_db.Task,
+        notion_task: NotionTask,
+        *,
+        dry_run: bool,
+        stats: SyncStats,
+    ) -> None:
+        desired = hermes_status_to_notion(task.status)
+        if (
+            notion_task.canonical_status == desired
+            and notion_task.hermes_task_id == task.id
+            and notion_task.hermes_status == task.status
+        ):
+            return
+        state_task = self.state.setdefault("tasks", {}).get(task.id, {})
+        last_sync_ts = _parse_notion_time(state_task.get("last_synced_at"))
+        hermes_changed = task_last_event_ts(conn, task.id) > last_sync_ts if last_sync_ts else True
+        if not hermes_changed:
+            return
+        if dry_run:
+            stats.hermes_to_notion_would_update += 1
+        else:
+            self.notion.update_page_properties(
+                notion_task.page_id,
+                notion_properties_for_sync(status=desired, hermes_task_id=task.id, hermes_status=task.status),
+            )
+            self.notion.append_activity(notion_task.page_id, f"Hermes sync: {task.id} moved to {task.status} at {_now_iso()}.")
+            stats.hermes_to_notion_updates += 1
+            stats.notion_pages_updated += 1
+            stats.comments_appended += 1
+            self.state.setdefault("tasks", {})[task.id] = {"last_synced_at": _now_iso(), "notion_page_id": notion_task.page_id}
+        stats.changed = True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sync Hermes Kanban with the SoLoVision Notion Task Board")
+    parser.add_argument("--apply", action="store_true", help="perform writes; default is dry-run")
+    parser.add_argument("--dry-run", action="store_true", help="force dry-run even if --apply is absent")
+    parser.add_argument("--database-id", default=TASK_BOARD_DATABASE_ID)
+    parser.add_argument("--board", default=None)
+    parser.add_argument("--limit", type=int, default=None, help="limit Notion pages processed (useful for safe samples)")
+    parser.add_argument("--since", default=None, help="only query Notion rows edited on/after this ISO timestamp")
+    parser.add_argument("--status-migration", action="store_true", help="rewrite legacy Notion statuses to canonical select values")
+    parser.add_argument("--max-creates", type=int, default=None, help="cap new Hermes tasks per apply run; useful for cron-safe batched backfill")
+    parser.add_argument("--hermes-task-id", action="append", default=[], help="only process Notion rows linked to this Hermes task id; repeat for a limited targeted apply")
+    parser.add_argument("--report-dir", default=None)
+    parser.add_argument("--state-path", default=None)
+    parser.add_argument("--daemon", action="store_true")
+    parser.add_argument("--interval", type=int, default=180)
+    parser.add_argument("--quiet", action="store_true", help="suppress no-change output in apply mode")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    dry_run = not args.apply or args.dry_run
+    notion = NotionClient(load_notion_key(), database_id=args.database_id)
+    sync = NotionKanbanSync(
+        notion=notion,
+        board=args.board,
+        report_dir=Path(args.report_dir).expanduser() if args.report_dir else None,
+        state_path=Path(args.state_path).expanduser() if args.state_path else None,
+    )
+    while True:
+        stats, _ = sync.run_once(
+            dry_run=dry_run,
+            limit=args.limit,
+            since=args.since,
+            status_migration=args.status_migration,
+            max_creates=args.max_creates,
+            hermes_task_ids=set(args.hermes_task_id) or None,
+            quiet=args.quiet,
+        )
+        if not args.daemon:
+            return 2 if stats.errors else 0
+        time.sleep(max(args.interval, 30))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/kanban/systemd/hermes-notion-kanban-sync.service
+++ b/plugins/kanban/systemd/hermes-notion-kanban-sync.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Hermes ↔ Notion Task Board sync watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=HERMES_HOME=%h/.hermes/profiles/dev
+ExecStart=%h/.hermes/profiles/dev/scripts/notion_kanban_sync_watchdog.sh

--- a/plugins/kanban/systemd/hermes-notion-kanban-sync.timer
+++ b/plugins/kanban/systemd/hermes-notion-kanban-sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Hermes ↔ Notion Task Board sync every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=hermes-notion-kanban-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/notion_kanban_sync_watchdog.sh
+++ b/scripts/notion_kanban_sync_watchdog.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PY=${HERMES_NOTION_SYNC_PYTHON:-/home/solo/.hermes/hermes-agent/venv/bin/python}
+if [[ ! -x "$PY" ]]; then
+  PY=python3
+fi
+DEFAULT_REPO="$HOME/.hermes/hermes-agent"
+if [[ -n "${HERMES_HOME:-}" && "$HERMES_HOME" == */profiles/* ]]; then
+  DEFAULT_REPO="${HERMES_HOME%%/profiles/*}/hermes-agent"
+fi
+REPO=${HERMES_NOTION_SYNC_REPO:-$DEFAULT_REPO}
+MAX_CREATES=${HERMES_NOTION_SYNC_MAX_CREATES:-25}
+ARGS=(--apply --quiet --max-creates "$MAX_CREATES")
+if [[ -n "${HERMES_NOTION_SYNC_REPORT_DIR:-}" ]]; then
+  ARGS+=(--report-dir "$HERMES_NOTION_SYNC_REPORT_DIR")
+fi
+cd "$REPO"
+if [[ -f "$REPO/hermes_cli/notion_kanban_sync.py" ]]; then
+  exec "$PY" -m hermes_cli.notion_kanban_sync "${ARGS[@]}"
+fi
+SCRIPT=${HERMES_NOTION_SYNC_SCRIPT:-$HOME/.hermes/profiles/dev/scripts/notion_kanban_sync.py}
+exec "$PY" "$SCRIPT" "${ARGS[@]}"

--- a/tests/hermes_cli/test_notion_kanban_sync.py
+++ b/tests/hermes_cli/test_notion_kanban_sync.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hermes_cli import kanban_db
+from hermes_cli.notion_kanban_sync import (
+    NotionKanbanSync,
+    NotionTask,
+    hermes_status_to_notion,
+    make_task_body,
+    normalize_assignee,
+    normalize_notion_status,
+    notion_page_id_from_task,
+    notion_properties_for_sync,
+    notion_status_to_hermes,
+    priority_to_int,
+    set_kanban_status,
+)
+
+
+def _conn(tmp_path: Path) -> sqlite3.Connection:
+    db = tmp_path / "kanban.db"
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    kanban_db.init_db(db_path=db)
+    return kanban_db.connect(db_path=db)
+
+
+def test_legacy_notion_statuses_normalize_to_canonical_lifecycle():
+    assert normalize_notion_status("Not Started") == "Todo"
+    assert normalize_notion_status("To Do") == "Todo"
+    assert normalize_notion_status("Ready for Creation") == "Ready"
+    assert normalize_notion_status("In Progress") == "Running"
+    assert normalize_notion_status("Blocked") == "Triage"
+    assert normalize_notion_status("Completed") == "Done"
+    assert normalize_notion_status("Cancelled") == "Done"
+    assert normalize_notion_status("weird custom status") == "Triage"
+
+
+def test_canonical_notion_statuses_map_to_hermes_runtime_statuses():
+    assert notion_status_to_hermes("Triage") == "triage"
+    assert notion_status_to_hermes("Todo") == "todo"
+    assert notion_status_to_hermes("Ready") == "ready"
+    assert notion_status_to_hermes("Running") == "running"
+    assert notion_status_to_hermes("Done") == "done"
+    assert notion_status_to_hermes("Archived") == "archived"
+    assert normalize_notion_status("Archived") == "Archived"
+    assert hermes_status_to_notion("blocked") == "Triage"
+    assert hermes_status_to_notion("archived") == "Archived"
+
+
+def test_assignee_and_priority_normalization_are_safe():
+    assert normalize_assignee("Dev", {"dev", "halo"}) == "dev"
+    assert normalize_assignee("Head of Engineering", {"dev", "halo"}) == "dev"
+    assert normalize_assignee("Unknown Agent", {"dev", "halo"}) is None
+    assert priority_to_int("High") > priority_to_int("Medium") > priority_to_int("Low")
+    assert priority_to_int(None) == 0
+
+
+def test_make_task_body_preserves_notion_cross_reference():
+    notion = NotionTask(
+        page_id="abc123",
+        url="https://notion.so/example",
+        title="Ship sync",
+        status="In Progress",
+        canonical_status="Running",
+        assigned_agent="Dev",
+        priority="High",
+        blockers="none",
+        notes="keep notes",
+        source="Canon",
+        last_edited_time="2026-05-14T13:00:00Z",
+        hermes_task_id=None,
+        hermes_status=None,
+    )
+
+    body = make_task_body(notion)
+
+    assert "Notion Page ID: abc123" in body
+    assert "Notion URL: https://notion.so/example" in body
+    assert "Blockers: none" in body
+    assert "Notes: keep notes" in body
+
+
+def test_notion_page_id_from_task_prefers_idempotency_key(tmp_path):
+    with _conn(tmp_path) as conn:
+        task_id = kanban_db.create_task(
+            conn,
+            title="Imported",
+            assignee="dev",
+            idempotency_key="notion:page-123",
+        )
+        task = kanban_db.get_task(conn, task_id)
+
+    assert task is not None
+    assert notion_page_id_from_task(task) == "page-123"
+
+
+def test_set_kanban_status_appends_a_sync_event(tmp_path):
+    with _conn(tmp_path) as conn:
+        task_id = kanban_db.create_task(conn, title="Imported", assignee="dev")
+
+        changed = set_kanban_status(conn, task_id, "done", reason="Notion says complete")
+
+        task = kanban_db.get_task(conn, task_id)
+        events = kanban_db.list_events(conn, task_id)
+
+    assert changed is True
+    assert task is not None
+    assert task.status == "done"
+    assert any(event.kind == "notion_sync_status" for event in events)
+
+
+def test_notion_properties_for_sync_never_hard_deletes_or_overwrites_notes():
+    props = notion_properties_for_sync(status="Running", hermes_task_id="t_1234", hermes_status="running")
+
+    assert props["Status"] == {"select": {"name": "Running"}}
+    assert props["Hermes Task ID"]["rich_text"][0]["text"]["content"] == "t_1234"
+    assert "Notes" not in props
+    assert "Blockers" not in props
+
+
+class _FakeNotion:
+    database_id = "db-test"
+
+    def __init__(self, pages):
+        self.pages = pages
+        self.updated = []
+
+    def ensure_properties(self, *, dry_run: bool):
+        return {"missing_statuses": [], "properties_added": []}
+
+    def query_tasks(self, *, limit=None, since=None):
+        return self.pages[:limit] if limit else self.pages
+
+    def update_page_properties(self, page_id, properties):
+        self.updated.append((page_id, properties))
+
+    def append_activity(self, page_id, text):
+        pass
+
+
+def _notion_page(
+    page_id: str,
+    title: str,
+    status: str,
+    hermes_task_id: str | None = None,
+    hermes_status: str | None = None,
+):
+    properties = {
+        "Task": {"type": "title", "title": [{"plain_text": title}]},
+        "Status": {"type": "select", "select": {"name": status}},
+        "Assigned Agent": {"type": "rich_text", "rich_text": [{"plain_text": "Dev"}]},
+    }
+    if hermes_task_id:
+        properties["Hermes Task ID"] = {"type": "rich_text", "rich_text": [{"plain_text": hermes_task_id}]}
+    if hermes_status:
+        properties["Hermes Status"] = {"type": "rich_text", "rich_text": [{"plain_text": hermes_status}]}
+    return {
+        "id": page_id,
+        "url": f"https://notion.so/{page_id}",
+        "archived": False,
+        "last_edited_time": "2026-05-14T13:00:00Z",
+        "properties": properties,
+    }
+
+
+def test_initial_notion_import_preserves_todo_runtime_status(tmp_path, monkeypatch):
+    db = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    notion = _FakeNotion([_notion_page("page-todo", "Todo task", "To Do")])
+    sync = NotionKanbanSync(notion=notion, report_dir=tmp_path / "reports", state_path=tmp_path / "state.json")
+
+    stats, _ = sync.run_once(dry_run=False, quiet=True)
+
+    with kanban_db.connect(db_path=db) as conn:
+        tasks = kanban_db.list_tasks(conn, include_archived=True)
+
+    assert stats.hermes_tasks_created == 1
+    assert len(tasks) == 1
+    assert tasks[0].idempotency_key == "notion:page-todo"
+    assert tasks[0].status == "todo"
+
+
+def test_conflict_resolution_records_sync_state_to_prevent_repeated_comments(tmp_path, monkeypatch):
+    db = tmp_path / "kanban.db"
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    with kanban_db.connect(db_path=db) as conn:
+        task_id = kanban_db.create_task(
+            conn,
+            title="Conflicted task",
+            assignee="dev",
+            idempotency_key="notion:page-conflict",
+        )
+    notion = _FakeNotion([_notion_page("page-conflict", "Conflicted task", "To Do", hermes_task_id=task_id)])
+    state_path.write_text(
+        '{"pages":{"page-conflict":{"last_synced_at":"2026-05-14T00:00:00Z","hermes_task_id":"%s"}},"tasks":{}}' % task_id,
+        encoding="utf-8",
+    )
+    sync = NotionKanbanSync(notion=notion, report_dir=tmp_path / "reports", state_path=state_path)
+
+    stats, _ = sync.run_once(dry_run=False, quiet=True)
+
+    assert stats.conflicts == 1
+    assert sync.state["pages"]["page-conflict"]["last_synced_at"] > "2026-05-14T00:00:00Z"
+    assert sync.state["tasks"][task_id]["notion_page_id"] == "page-conflict"
+
+
+def test_archived_hermes_task_updates_notion_status_and_stale_diagnostic(tmp_path, monkeypatch):
+    db = tmp_path / "kanban.db"
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    with kanban_db.connect(db_path=db) as conn:
+        task_id = kanban_db.create_task(
+            conn,
+            title="Archived task",
+            assignee="dev",
+            idempotency_key="notion:page-archived",
+        )
+        set_kanban_status(conn, task_id, "done", reason="completed before archive")
+        set_kanban_status(conn, task_id, "archived", reason="operator archived completed task")
+    notion = _FakeNotion([
+        _notion_page("page-archived", "Archived task", "Done", hermes_task_id=task_id, hermes_status="done")
+    ])
+    state_path.write_text(
+        '{"pages":{"page-archived":{"last_synced_at":"2026-05-14T00:00:00Z","hermes_task_id":"%s"}},'
+        '"tasks":{"%s":{"last_synced_at":"2026-05-14T00:00:00Z","notion_page_id":"page-archived"}}}' % (task_id, task_id),
+        encoding="utf-8",
+    )
+    sync = NotionKanbanSync(notion=notion, report_dir=tmp_path / "reports", state_path=state_path)
+
+    stats, _ = sync.run_once(dry_run=False, quiet=True)
+
+    assert stats.hermes_to_notion_updates == 1
+    page_id, props = notion.updated[-1]
+    assert page_id == "page-archived"
+    assert props["Status"] == {"select": {"name": "Archived"}}
+    assert props["Hermes Status"]["rich_text"][0]["text"]["content"] == "archived"
+
+
+def test_stale_hermes_status_updates_even_when_notion_status_is_already_desired(tmp_path, monkeypatch):
+    db = tmp_path / "kanban.db"
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    with kanban_db.connect(db_path=db) as conn:
+        task_id = kanban_db.create_task(
+            conn,
+            title="Running task",
+            assignee="dev",
+            idempotency_key="notion:page-running",
+        )
+        set_kanban_status(conn, task_id, "running", reason="worker claimed task")
+    notion = _FakeNotion([
+        _notion_page("page-running", "Running task", "Running", hermes_task_id=task_id, hermes_status="done")
+    ])
+    state_path.write_text(
+        '{"pages":{"page-running":{"last_synced_at":"2026-05-14T00:00:00Z","hermes_task_id":"%s"}},'
+        '"tasks":{"%s":{"last_synced_at":"2026-05-14T00:00:00Z","notion_page_id":"page-running"}}}' % (task_id, task_id),
+        encoding="utf-8",
+    )
+    sync = NotionKanbanSync(notion=notion, report_dir=tmp_path / "reports", state_path=state_path)
+
+    stats, _ = sync.run_once(dry_run=False, quiet=True)
+
+    assert stats.hermes_to_notion_updates == 1
+    page_id, props = notion.updated[-1]
+    assert page_id == "page-running"
+    assert "Status" in props
+    assert props["Status"] == {"select": {"name": "Running"}}
+    assert props["Hermes Status"]["rich_text"][0]["text"]["content"] == "running"
+
+
+def test_run_once_can_limit_apply_to_specific_hermes_task_ids(tmp_path, monkeypatch):
+    db = tmp_path / "kanban.db"
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db))
+    with kanban_db.connect(db_path=db) as conn:
+        first_id = kanban_db.create_task(conn, title="First", assignee="dev", idempotency_key="notion:page-first")
+        second_id = kanban_db.create_task(conn, title="Second", assignee="dev", idempotency_key="notion:page-second")
+        set_kanban_status(conn, first_id, "running", reason="first changed")
+        set_kanban_status(conn, second_id, "running", reason="second changed")
+    notion = _FakeNotion([
+        _notion_page("page-first", "First", "Todo", hermes_task_id=first_id, hermes_status="todo"),
+        _notion_page("page-second", "Second", "Todo", hermes_task_id=second_id, hermes_status="todo"),
+    ])
+    state_path.write_text(
+        '{"pages":{"page-first":{"last_synced_at":"2026-05-15T00:00:00Z","hermes_task_id":"%s"},'
+        '"page-second":{"last_synced_at":"2026-05-15T00:00:00Z","hermes_task_id":"%s"}},'
+        '"tasks":{"%s":{"last_synced_at":"2026-05-14T00:00:00Z","notion_page_id":"page-first"},'
+        '"%s":{"last_synced_at":"2026-05-14T00:00:00Z","notion_page_id":"page-second"}}}' % (first_id, second_id, first_id, second_id),
+        encoding="utf-8",
+    )
+    sync = NotionKanbanSync(notion=notion, report_dir=tmp_path / "reports", state_path=state_path)
+
+    stats, _ = sync.run_once(dry_run=False, quiet=True, hermes_task_ids={first_id})
+
+    assert stats.hermes_to_notion_updates == 1
+    assert [page_id for page_id, _ in notion.updated] == ["page-first"]


### PR DESCRIPTION
Fixes Hermes ↔ Notion Task Board archive propagation for SoLoVision workflows.\n\nHighlights:\n- Maps Hermes archived tasks to explicit Notion Status=Archived instead of folding into Done.\n- Parses and updates diagnostic Hermes Status so stale done values become archived/running even when the visible Status is already mapped.\n- Adds targeted --hermes-task-id runs for limited real-data repair/verification.\n- Documents archive semantics and the watchdog install path.\n\nVerification:\n- python -m pytest tests/hermes_cli/test_notion_kanban_sync.py -q -o 'addopts='\n- bash -n scripts/notion_kanban_sync_watchdog.sh\n- python -m hermes_cli.notion_kanban_sync --dry-run --hermes-task-id t_bc162760 --hermes-task-id t_60450448 --hermes-task-id t_e102d84a\n- python -m hermes_cli.notion_kanban_sync --apply --hermes-task-id t_bc162760 --hermes-task-id t_60450448 --hermes-task-id t_e102d84a --max-creates 0\n\nReal-data verification: Notion pages 360c7b06-9816-814e-ab26-eefdc5909361, 30ac7b06-9816-816f-8e1b-cbb7e407bec8, and 30ac7b06-9816-81e6-8bd3-e87ff3f95dfe now show Status=Archived and Hermes Status=archived.