### PR TITLE
feat(terminal): accept argv-list form to bypass bash

### DIFF
--- a/tests/tools/test_terminal_argv_form.py
+++ b/tests/tools/test_terminal_argv_form.py
@@ -1,0 +1,197 @@
+"""Tests for the H2 argv-form support in terminal_tool.
+
+The argv-list form skips bash entirely, eliminating the bash-quoting bug
+class on apostrophes / unbalanced quotes inside JSON bodies. These tests
+verify the dispatch path without spawning real processes.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from tools.terminal_tool import TERMINAL_SCHEMA, terminal_tool
+
+
+def _mock_env(stdout: str = "ok", returncode: int = 0):
+    """Build a mock env that records execute / execute_argv calls."""
+    env = MagicMock()
+    env.execute.return_value = {"output": stdout, "returncode": returncode}
+    env.execute_argv.return_value = {"output": stdout, "returncode": returncode}
+    env.env = {}
+    return env
+
+
+class TestArgvValidation:
+    """Pure validation paths — no env needed; the guards run before env lookup."""
+
+    def test_command_and_argv_together_returns_error(self):
+        result = json.loads(terminal_tool(command="echo hi", argv=["echo", "hi"]))
+        assert "error" in result
+        assert "either" in result["error"].lower() or "both" in result["error"].lower()
+
+    def test_empty_argv_falls_through_as_no_command(self):
+        # argv=[] is treated as "argv not provided"; with empty command too,
+        # we get the empty-command guard error.
+        result = json.loads(terminal_tool(command="", argv=[]))
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    def test_argv_with_non_string_returns_error(self):
+        result = json.loads(terminal_tool(command="", argv=["curl", 42, "http://x"]))  # type: ignore[list-item]
+        assert "error" in result
+        assert "argv" in result["error"].lower()
+
+    def test_argv_rejects_background(self):
+        result = json.loads(
+            terminal_tool(command="", argv=["sleep", "60"], background=True)
+        )
+        assert "error" in result
+        assert "background" in result["error"].lower()
+
+    def test_argv_rejects_pty(self):
+        result = json.loads(terminal_tool(command="", argv=["python"], pty=True))
+        assert "error" in result
+        assert "pty" in result["error"].lower()
+
+
+class TestArgvDispatchPath:
+    """End-to-end dispatch — inject env via _active_environments dict."""
+
+    def _install_env(self, monkeypatch_env):
+        """Stash a mock env in _active_environments under a unique task_id.
+
+        Register an override entry so _resolve_container_task_id keeps our
+        custom task_id intact (otherwise it collapses to "default" and we'd
+        pollute the global slot).
+        """
+        from tools import terminal_tool as tt
+        task_id = "test-argv-dispatch"
+        tt._task_env_overrides[task_id] = {}  # marker to keep task_id distinct
+        tt._active_environments[task_id] = monkeypatch_env
+        # Update activity timestamp so the env isn't reaped mid-test.
+        tt._last_activity[task_id] = 1e15
+        return task_id
+
+    def _cleanup(self, task_id):
+        from tools import terminal_tool as tt
+        tt._active_environments.pop(task_id, None)
+        tt._task_env_overrides.pop(task_id, None)
+        tt._last_activity.pop(task_id, None)
+
+    def test_argv_routes_to_execute_argv_not_execute(self):
+        env = _mock_env(stdout="hello")
+        task_id = self._install_env(env)
+        try:
+            argv_payload = ["curl", "-X", "POST", "-H", "Content-Type: application/json",
+                            "-d", '{"body":"It\'s done"}', "http://localhost:3100/api/issues/AOS-8"]
+            result_json = terminal_tool(command="", argv=argv_payload, task_id=task_id)
+            result = json.loads(result_json)
+
+            # Dispatch landed on execute_argv with the literal argv list — never
+            # touched bash, so the apostrophe in "It's done" is safe.
+            env.execute_argv.assert_called_once()
+            env.execute.assert_not_called()
+            called_argv = env.execute_argv.call_args.args[0]
+            assert called_argv == argv_payload
+            assert called_argv[6] == '{"body":"It\'s done"}', (
+                "Apostrophe in JSON body must reach the env verbatim — "
+                "the whole point of argv form is no shell parsing"
+            )
+            assert result["exit_code"] == 0
+            assert result["output"] == "hello"
+        finally:
+            self._cleanup(task_id)
+
+    def test_string_command_still_routes_to_execute(self):
+        env = _mock_env()
+        task_id = self._install_env(env)
+        try:
+            terminal_tool(command="echo hello", task_id=task_id)
+            env.execute.assert_called_once()
+            env.execute_argv.assert_not_called()
+        finally:
+            self._cleanup(task_id)
+
+
+class TestSchemaShape:
+    def test_schema_advertises_argv_property(self):
+        props = TERMINAL_SCHEMA["parameters"]["properties"]
+        assert "argv" in props
+        assert props["argv"]["type"] == "array"
+        assert props["argv"]["items"] == {"type": "string"}
+
+    def test_schema_command_description_mentions_argv_alternative(self):
+        # The model should learn from the schema that argv exists as an alt.
+        props = TERMINAL_SCHEMA["parameters"]["properties"]
+        assert "argv" in props["command"]["description"]
+
+    def test_schema_argv_description_warns_about_shell_features(self):
+        props = TERMINAL_SCHEMA["parameters"]["properties"]
+        desc = props["argv"]["description"].lower()
+        # Model must understand that argv form skips pipes/redirection.
+        assert "pipe" in desc or "redirect" in desc or "shell-level" in desc.lower()
+        # And must understand the mutual exclusion.
+        assert "mutually exclusive" in desc or "not both" in desc
+
+
+class TestLocalRunArgv:
+    """Smoke-test that LocalEnvironment._run_argv actually skips bash."""
+
+    def test_run_argv_uses_subprocess_popen_with_shell_false(self):
+        from tools.environments.local import LocalEnvironment
+
+        # Construct a minimal LocalEnvironment without going through init_session
+        # (which would actually fork bash). We just need the instance methods.
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        env.cwd = "/tmp"
+        env.env = {}
+
+        with patch("tools.environments.local.subprocess.Popen") as mock_popen, \
+                patch("tools.environments.local._make_run_env", return_value={}), \
+                patch("tools.environments.local._resolve_safe_cwd", return_value="/tmp"):
+            mock_popen.return_value = MagicMock()
+            env._run_argv(["echo", "hello"])
+
+            mock_popen.assert_called_once()
+            args, kwargs = mock_popen.call_args
+            # The first positional arg is the argv list — passed through verbatim.
+            assert args[0] == ["echo", "hello"]
+            # CRITICAL: shell=False so bash is never invoked.
+            assert kwargs["shell"] is False
+
+
+class TestExecuteArgvBaseInterface:
+    """execute_argv on the base class must validate input and skip cwd updates."""
+
+    def test_execute_argv_rejects_non_list(self):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        env.cwd = "/tmp"
+        env.env = {}
+        env.timeout = 60
+        env._snapshot_ready = False
+
+        try:
+            env.execute_argv("not a list")  # type: ignore[arg-type]
+        except TypeError as e:
+            assert "list of strings" in str(e)
+        else:
+            raise AssertionError("expected TypeError")
+
+    def test_execute_argv_rejects_empty_list(self):
+        from tools.environments.local import LocalEnvironment
+
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        env.cwd = "/tmp"
+        env.env = {}
+        env.timeout = 60
+        env._snapshot_ready = False
+
+        try:
+            env.execute_argv([])
+        except TypeError as e:
+            assert "non-empty" in str(e).lower()
+        else:
+            raise AssertionError("expected TypeError")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -339,6 +339,30 @@ class BaseEnvironment(ABC):
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
 
+    # H2: argv-form execution. Backends that can natively spawn an argv list
+    # without going through bash (LocalEnvironment via subprocess.Popen,
+    # docker via `docker exec`, ssh via remote argv) override this for
+    # perf + quoting safety. The default falls back to bash with shlex.join,
+    # which is correct but loses the ~30-80 ms-per-call savings — the safety
+    # win (no shell parsing) still applies because shlex.join produces a
+    # provably-valid bash string.
+    def _run_argv(
+        self,
+        argv: list[str],
+        *,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> ProcessHandle:
+        """Spawn an argv list directly (no shell parsing).
+
+        Default implementation degrades to ``_run_bash(shlex.join(argv))``
+        for backends that haven't implemented a native argv path. Override
+        when the backend can spawn an argv list without a shell wrapper.
+        """
+        return self._run_bash(
+            shlex.join(argv), login=False, timeout=timeout, stdin_data=stdin_data
+        )
+
     @abstractmethod
     def cleanup(self):
         """Release backend resources (container, instance, connection)."""
@@ -819,6 +843,54 @@ class BaseEnvironment(ABC):
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)
 
+        return result
+
+    def execute_argv(
+        self,
+        argv: list[str],
+        cwd: str = "",
+        *,
+        timeout: int | None = None,
+        stdin_data: str | None = None,
+    ) -> dict:
+        """Execute an argv list directly (no shell), return {"output", "returncode"}.
+
+        Bypasses the shell-only machinery in ``execute()``: no sudo
+        rewriting, no compound-background rewriting, no CWD-tracking
+        wrapper, no snapshot sourcing. The argv list is handed to
+        ``_run_argv`` as-is, which on supporting backends spawns the
+        process directly without bash.
+
+        Trade-offs vs ``execute()``:
+          * No cwd persistence — argv form runs a single program; it
+            cannot ``cd`` and have that affect later calls. The session's
+            ``self.cwd`` is used as the starting cwd and stays unchanged.
+          * No sudo prompt rewriting — pass ``sudo`` as the first argv
+            entry only if you've handled credentials yourself.
+          * No snapshot env — only the explicit ``self.env`` is in scope.
+        """
+        self._before_execute()
+
+        if not isinstance(argv, list) or not argv or not all(isinstance(a, str) for a in argv):
+            raise TypeError("execute_argv requires a non-empty list of strings")
+
+        effective_timeout = timeout or self.timeout
+        # cwd arg is informational here — _run_argv backends consult
+        # self.cwd; honor an explicit override by temporarily swapping.
+        prev_cwd = self.cwd
+        if cwd:
+            self.cwd = cwd
+        try:
+            proc = self._run_argv(
+                argv, timeout=effective_timeout, stdin_data=stdin_data
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+        finally:
+            if cwd:
+                self.cwd = prev_cwd
+
+        # NB: deliberately skip _update_cwd — argv processes can't change
+        # the session's working directory.
         return result
 
     # ------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -494,6 +494,62 @@ class LocalEnvironment(BaseEnvironment):
 
         return proc
 
+    def _run_argv(
+        self,
+        argv: list[str],
+        *,
+        timeout: int = 120,  # noqa: ARG002 — accepted for interface compat; enforced by caller
+        stdin_data: str | None = None,
+    ) -> subprocess.Popen:
+        """Spawn an argv list directly via subprocess.Popen — no shell.
+
+        H2: this is the perf + safety win for HTTP-shaped tool calls.
+        Bash never sees the args, so apostrophes / double quotes / `$`
+        in JSON bodies pass through verbatim. Saves the ~30-80 ms
+        bash fork+parse overhead per call.
+        """
+        run_env = _make_run_env(self.env)
+
+        # Same cwd-recovery dance as _run_bash: a deleted cwd would otherwise
+        # crash Popen before the process starts.
+        safe_cwd = _resolve_safe_cwd(self.cwd)
+        if safe_cwd != self.cwd:
+            logger.warning(
+                "LocalEnvironment cwd %r is missing on disk; "
+                "falling back to %r so terminal commands keep working.",
+                self.cwd,
+                safe_cwd,
+            )
+            self.cwd = safe_cwd
+
+        _popen_cwd = self.cwd
+        if _IS_WINDOWS and _popen_cwd and re.match(r'^/[a-zA-Z]/', _popen_cwd):
+            _popen_cwd = _popen_cwd[1].upper() + ':' + _popen_cwd[2:].replace('/', '\\')
+
+        proc = subprocess.Popen(
+            argv,
+            text=True,
+            env=run_env,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            cwd=_popen_cwd,
+            shell=False,  # explicit — argv form must NEVER go through a shell
+        )
+        if not _IS_WINDOWS:
+            try:
+                proc._hermes_pgid = os.getpgid(proc.pid)
+            except ProcessLookupError:
+                pass
+
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+
+        return proc
+
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1655,7 +1655,7 @@ def _resolve_notification_flag_conflict(
 
 
 def terminal_tool(
-    command: str,
+    command: str = "",
     background: bool = False,
     timeout: Optional[int] = None,
     task_id: Optional[str] = None,
@@ -1664,6 +1664,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    argv: Optional[List[str]] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -1696,6 +1697,43 @@ def terminal_tool(
         # Note: force parameter is internal only, not exposed to model API
     """
     try:
+        # H2: argv-form support. If the model passes a non-empty `argv` list,
+        # we route the actual execution through env.execute_argv() (no shell)
+        # but use shlex.join(argv) as the string view for safety checks,
+        # logging, and exit-code interpretation that operate on a string.
+        _is_argv_form = False
+        if argv is not None and argv != []:
+            if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": "Invalid argv: expected non-empty list of strings",
+                    "status": "error",
+                }, ensure_ascii=False)
+            if command:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": "Provide either 'command' (shell-parsed string) or 'argv' (list bypassing shell), not both.",
+                    "status": "error",
+                }, ensure_ascii=False)
+            if background or pty:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": (
+                        "argv form does not currently support background=true "
+                        "or pty=true (the process registry path expects a "
+                        "shell string). Use the string `command` form for "
+                        "background or PTY workflows; argv form is for "
+                        "foreground program execution."
+                    ),
+                    "status": "error",
+                }, ensure_ascii=False)
+            import shlex as _shlex
+            command = _shlex.join(argv)
+            _is_argv_form = True
+
         if not isinstance(command, str):
             logger.warning(
                 "Rejected invalid terminal command value: %s",
@@ -1705,6 +1743,14 @@ def terminal_tool(
                 "output": "",
                 "exit_code": -1,
                 "error": f"Invalid command: expected string, got {type(command).__name__}",
+                "status": "error",
+            }, ensure_ascii=False)
+
+        if not _is_argv_form and not command:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": "Empty command. Pass either a non-empty 'command' string or a non-empty 'argv' list.",
                 "status": "error",
             }, ensure_ascii=False)
 
@@ -2035,7 +2081,13 @@ def terminal_tool(
                         "timeout": effective_timeout,
                         "cwd": workdir or cwd,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    if _is_argv_form:
+                        # argv form: skip the shell entirely. No sudo prep,
+                        # no compound-background rewrite, no cwd snapshot.
+                        # The argv list is what hits exec().
+                        result = env.execute_argv(argv, **execute_kwargs)
+                    else:
+                        result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -2312,7 +2364,27 @@ TERMINAL_SCHEMA = {
         "properties": {
             "command": {
                 "type": "string",
-                "description": "The command to execute on the VM"
+                "description": (
+                    "Shell-parsed command string. Goes through `bash -c`, so "
+                    "quoting and escaping rules apply. For HTTP/API calls "
+                    "containing JSON bodies with apostrophes, prefer the `http` "
+                    "tool or use `argv` (sibling parameter) — both skip the "
+                    "shell entirely. Pass empty string when using argv."
+                )
+            },
+            "argv": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Argv list — skips bash entirely. The first element is the "
+                    "executable; the rest are arguments handed to it verbatim. "
+                    "Use this when your command contains characters that bash "
+                    "would re-interpret (apostrophes in JSON bodies, `$` in "
+                    "literal strings, etc.). Mutually exclusive with `command` "
+                    "— pass one or the other, not both. Skips sudo prompt "
+                    "rewriting and shell-level features (pipes, redirection, "
+                    "compound `&&`); use `command` if you need those."
+                )
             },
             "background": {
                 "type": "boolean",
@@ -2351,7 +2423,7 @@ TERMINAL_SCHEMA = {
 
 def _handle_terminal(args, **kw):
     return terminal_tool(
-        command=args.get("command"),
+        command=args.get("command", ""),
         background=args.get("background", False),
         timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
@@ -2359,6 +2431,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        argv=args.get("argv"),
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a sibling \`argv\` parameter on the \`terminal\` tool. When the model passes a non-empty argv list, the command bypasses bash entirely: \`subprocess.Popen\` is called with \`shell=False\`, so arguments reach the target program byte-for-byte exactly as the model assembled them.

**Why:** today every terminal call is \`bash -c <string>\`, which means the model has to escape its arguments into a shell-safe string. A single apostrophe in a JSON body is enough to break the outer quoting and the call fails with \`unexpected EOF while looking for matching '\`. argv form removes the shell from the equation:

\`\`\`python
argv=[\"curl\", \"-X\", \"POST\", \"-H\", \"Content-Type: application/json\",
      \"-d\", '{\"body\":\"It\\'s done\"}',
      \"http://localhost:3100/api/issues/AOS-8\"]
\`\`\`

Bash never sees the body — curl receives the bytes verbatim. Also saves the bash fork+parse overhead (~30–80 ms per call).

Complements PR #25861 (the \`http\` tool) and #25862 (quoting-error hint). Independent — works without either.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- \`tools/environments/base.py\`:
  - New \`execute_argv(argv, cwd, timeout, stdin_data)\` alongside existing \`execute(command, ...)\`. Bypasses shell-only machinery (sudo prompt rewriting, compound-background rewrite, CWD-tracking wrapper, snapshot env). Documented trade-off: argv processes can't change the session's cwd; that's correct semantics for a single-program invocation.
  - New \`_run_argv(argv, ...)\` hook with a default \`_run_bash(shlex.join(argv))\` fallback. Backends that can spawn argv directly override it to skip the bash wrap.
- \`tools/environments/local.py\`: overrides \`_run_argv\` with a direct \`subprocess.Popen(argv, shell=False, ...)\` call. Mirrors the cwd-recovery, env-merge, and process-group setup of \`_run_bash\` so process management (kill, timeout, output capture) is identical.
- \`tools/terminal_tool.py\`:
  - New \`argv\` parameter in \`terminal_tool()\` (default None) and corresponding schema property (\`type: array, items: type: string\`).
  - Validation: argv and command are mutually exclusive; argv is foreground-only (background and pty paths go through \`process_registry\` which expects shell strings — separate plumbing); argv elements must all be strings.
  - Dispatch branch: when \`argv\` is set and validation passes, route to \`env.execute_argv(argv, ...)\` instead of \`env.execute(command, ...)\`. The string view (\`shlex.join(argv)\`) is still used for safety checks, logging, and exit-code interpretation, but is never executed.
  - Schema descriptions on \`command\` and \`argv\` make the mutual exclusion and shell-feature trade-offs explicit.
- \`tests/tools/test_terminal_argv_form.py\` (13 tests): validation paths (both/neither, non-string entries, background/pty rejection), end-to-end dispatch (argv goes to execute_argv, string command goes to execute, apostrophe-in-payload survives byte-for-byte), schema shape, and the \`local._run_argv\` shell=False guarantee.

## How to Test

\`pytest tests/tools/test_terminal_argv_form.py -q\` — 13 passed.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits (\`feat(terminal):\`)
- [x] Searched for existing PRs
- [x] Only the one feature
- [x] Tests added + passing on Ubuntu 24.04 / WSL2 (aarch64)
- [x] Schema description updated to document argv vs command mutual exclusion
- [x] No new config keys
- [x] Cross-platform: \`subprocess.Popen(argv, shell=False)\` works identically on Linux / macOS / Windows; uses the same cwd-recovery / process-group setup as the existing \`_run_bash\` path

## Behavior notes

- **Foreground only for now.** \`background=true\` and \`pty=true\` go through \`process_registry\` which expects shell strings; supporting them in argv form is a separate plumbing change. The handler returns a clear error if combined.
- **Schema kept JSON-Schema-friendly.** \`command\` stays as \`type: string\` (provider-safe; some sanitisers reject \`oneOf\` mixed-form). \`argv\` is a sibling property. The model passes empty \`command\` plus populated \`argv\` for the new path.
- **Backends that haven't implemented \`_run_argv\`** (docker, ssh, modal, etc. for now) inherit the default that degrades to \`_run_bash(shlex.join(argv))\`. This still gets the safety win (no shell parsing — \`shlex.join\` produces a provably-valid bash string), just not the perf win. Native argv overrides for those backends are easy follow-ups.