### PR TITLE
fix(agent): propagate reasoning_effort to Ollama + curator fork

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1659,6 +1659,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     # (canonical aux-task slot, wired through `hermes model` → auxiliary
     # picker and the dashboard Models tab), with a legacy fallback to
     # `curator.auxiliary.{provider,model,...}`. See docs/user-guide/features/curator.md.
+    _reasoning_config = None
     _api_key = None
     _base_url = None
     _api_mode = None
@@ -1680,6 +1681,16 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
         _resolved_provider = _rp.get("provider") or _provider
+        # Propagate reasoning_config so the curator fork respects
+        # agent.reasoning_effort (e.g. "none" to disable thinking).
+        # Without this, the fork defaults to medium and can spiral on
+        # thinking-capable models (see issue #25758).
+        try:
+            from hermes_constants import parse_reasoning_effort
+            _effort_raw = _cfg.get("agent", {}).get("reasoning_effort", "")
+            _reasoning_config = parse_reasoning_effort(str(_effort_raw))
+        except Exception:
+            pass
     except Exception as e:
         logger.debug("Curator provider resolution failed: %s", e, exc_info=True)
 
@@ -1704,6 +1715,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             platform="curator",
             skip_context_files=True,
             skip_memory=True,
+            reasoning_config=_reasoning_config,
         )
         # Disable recursive nudges — the curator must never spawn its own review.
         review_agent._memory_nudge_interval = 0

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -3,7 +3,9 @@
 Covers any endpoint registered as provider="custom", including local
 Ollama instances. Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → extra_body.think = False
+  - reasoning_config disabled → extra_body.think = False + top-level
+    reasoning_effort = "none" (Ollama ignores extra_body.think but
+    respects the top-level field — see ollama/ollama#14820)
 """
 
 from typing import Any
@@ -23,6 +25,7 @@ class CustomProfile(ProviderProfile):
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
 
         # Ollama context window
         if ollama_num_ctx:
@@ -30,14 +33,19 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Disable thinking when reasoning is turned off.
+        # Ollama's /v1/chat/completions silently ignores extra_body.think
+        # (ollama/ollama#14820) but respects the top-level reasoning_effort
+        # field. Emit both so this works on Ollama and on other custom
+        # endpoints (vLLM, llama.cpp) that may honour either form.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+                top_level["reasoning_effort"] = "none"
 
-        return extra_body, {}
+        return extra_body, top_level
 
     def fetch_models(
         self,


### PR DESCRIPTION
## Summary

Fixes #25758 — `agent.reasoning_effort: none` was silently ignored on Ollama-backed custom providers, causing thinking-capable models to spiral (up to 65k output tokens / 28 min GPU blocking).

## Root Cause

Two distinct defects:

### Defect 1 — Custom provider only emits `extra_body.think=False`

`plugins/model-providers/custom/__init__.py` set `extra_body["think"] = False` when reasoning was disabled, but Ollama's `/v1/chat/completions` endpoint silently ignores this field ([ollama/ollama#14820](https://github.com/ollama/ollama/issues/14820)). Ollama respects the **top-level** `reasoning_effort` parameter instead.

### Defect 2 — Curator fork drops `reasoning_config`

`agent/curator.py` `_run_llm_review()` creates a forked `AIAgent` without passing `reasoning_config`. The fork defaults to `medium` effort, so even when defect 1 is fixed, background review tasks still think at full intensity. Structurally similar to #15543 (fork missing `api_key`/`base_url`/`api_mode`).

## Changes

| File | Change |
|------|--------|
| `plugins/model-providers/custom/__init__.py` | Emit `reasoning_effort="none"` as a **top-level** API kwarg (in addition to `extra_body.think=False`) when reasoning is disabled |
| `agent/curator.py` | Resolve `reasoning_config` from `config.yaml` via `parse_reasoning_effort()` and pass it to the forked `AIAgent` |

## Testing

- All 889 existing tests pass (`pytest -k "custom or curator or reasoning"`)
- Manual verification: with `agent.reasoning_effort: none` and an Ollama endpoint, the API call now includes `reasoning_effort="none"` at the top level