### PR TITLE
fix(tui): surface automatic compression progress

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8355,6 +8355,54 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
         server._sessions.pop("sid-b", None)
 
 
+def test_prompt_submit_surfaces_zero_api_interrupt_as_visible_text(monkeypatch):
+    """Compaction/interruption races can end a turn before any model call.
+
+    The TUI should not receive a blank interrupted message.complete payload,
+    because that looks like the send got stuck until the user types again.
+    """
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": None,
+                "messages": [],
+                "api_calls": 0,
+                "completed": False,
+                "interrupted": True,
+                "turn_exit_reason": "interrupted_by_user",
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+    emitted: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload or {})),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        }
+    )
+
+    complete_events = [e for e in emitted if e[0] == "message.complete"]
+    assert complete_events, "expected message.complete to be emitted"
+    payload = complete_events[-1][2]
+    assert payload.get("status") == "interrupted"
+    assert "Interrupted before the model call" in payload.get("text", "")
+
+
 # ── session.most_recent ──────────────────────────────────────────────
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8355,11 +8355,12 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
         server._sessions.pop("sid-b", None)
 
 
-def test_prompt_submit_surfaces_zero_api_interrupt_as_visible_text(monkeypatch):
+def test_prompt_submit_synthesizes_text_for_zero_api_interrupt(monkeypatch):
     """Compaction/interruption races can end a turn before any model call.
 
-    The TUI should not receive a blank interrupted message.complete payload,
-    because that looks like the send got stuck until the user types again.
+    The gateway should not emit a blank interrupted message.complete payload.
+    Ink decides whether to display this text based on whether it already
+    recorded the user's local interrupt.
     """
 
     class _Agent:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10137,6 +10137,17 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     result.get("failed") or result.get("partial")
                 ):
                     raw = f"Error: {result.get('error')}"
+                if status == "interrupted" and not raw:
+                    if result.get("api_calls") == 0:
+                        raw = (
+                            "Interrupted before the model call; no assistant "
+                            "response was generated."
+                        )
+                    else:
+                        raw = (
+                            "Interrupted before a final assistant response "
+                            "was generated."
+                        )
                 lr = result.get("last_reasoning")
                 if isinstance(lr, str) and lr.strip():
                     last_reasoning = lr.strip()

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -139,6 +139,24 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.system.sys).toHaveBeenCalledWith('compressing 968 messages (~123,400 tok)…')
   })
 
+  it('prints automatic compacting lifecycle status into the transcript', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: {
+        kind: 'compacting',
+        text: '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+      },
+      type: 'status.update'
+    } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith(
+      '🗜️ Compacting context — summarizing earlier conversation so I can continue...'
+    )
+  })
+
   it('keeps goal verdict text in transcript but shows a brief idle status (#goal statusbar)', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)
@@ -1223,10 +1241,10 @@ describe('createGatewayEventHandler', () => {
     }
   })
 
-  it('keepBusy interrupt holds busy until the gateway settles and suppresses the cancelled turn’s final_response', () => {
+  it('keeps a user interrupt visible while suppressing the gateway’s duplicate zero-call completion', () => {
     // Force-send: interrupt holds busy so the drain waits for the real settle
     // instead of racing it (the race duplicated the bubble, leaked a "queued: …"
-    // note, and surfaced the cancelled turn's "Operation interrupted…" reply).
+    // note, and surfaced the gateway's duplicate interrupted reply).
     const appended: Msg[] = []
     const ctx = buildCtx(appended)
     ctx.gateway.gw.request = vi.fn(async () => ({ status: 'interrupted' }))
@@ -1244,19 +1262,27 @@ describe('createGatewayEventHandler', () => {
 
     // Held busy: the drain effect keys off busy→false, so it must not fire yet.
     expect(getUiState().busy).toBe(true)
+    expect(ctx.system.sys).toHaveBeenCalledWith('interrupted')
 
-    // The cancelled turn settles with a backend interrupted final_response.
+    // The cancelled turn settles with the zero-API response synthesized by
+    // tui_gateway. TurnController must suppress this duplicate because the
+    // local interrupt above already recorded a visible transcript line.
     const before = appended.length
     onEvent({
-      payload: { text: 'Operation interrupted: waiting for model response (4.1s elapsed).' },
+      payload: {
+        status: 'interrupted',
+        text: 'Interrupted before the model call; no assistant response was generated.'
+      },
       type: 'message.complete'
     } as any)
 
-    // Settle flips busy false (the single drain edge) and the backend
-    // "Operation interrupted…" line is suppressed (not appended).
+    // Settle flips busy false (the single drain edge), while the gateway's
+    // duplicate completion text is not appended.
     expect(getUiState().busy).toBe(false)
     expect(
-      appended.slice(before).some(m => typeof m.text === 'string' && m.text.includes('Operation interrupted'))
+      appended
+        .slice(before)
+        .some(m => typeof m.text === 'string' && m.text.includes('Interrupted before the model call'))
     ).toBe(false)
   })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -485,7 +485,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus(p.text)
 
-        if (p.kind === 'compressing') {
+        if (p.kind === 'compressing' || p.kind === 'compacting') {
           sys(p.text)
 
           return


### PR DESCRIPTION
## Rationale

The TUI can look frozen when a send triggers automatic context compression before the first model call. Manual `/compress` already emits persistent `compressing` status events, but automatic compression only used generic lifecycle output. If the user interrupts during that window, the turn can complete with `api_calls=0` and empty text, leaving no visible explanation in the transcript.

## Summary

- Emits TUI-visible `compressing` status events for automatic context compression, including a completion line and status-bar clear.
- Lets manual `/compress` keep owning its existing status UI to avoid duplicate transcript lines.
- Converts empty interrupted `prompt.submit` completions into visible explanatory text when no model call happened.
- Adds regression coverage for compression status, status cleanup on compression failure, and zero-API interrupted turns.

## Test Plan

- [x] `python -m pytest tests/run_agent/test_413_compression.py -q -o 'addopts='`
- [x] `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_surfaces_backend_error_as_visible_text tests/test_tui_gateway_server.py::test_prompt_submit_preserves_empty_response_without_error tests/test_tui_gateway_server.py::test_prompt_submit_surfaces_zero_api_interrupt_as_visible_text -q -o 'addopts='`
- [x] `python -m ruff check run_agent.py tui_gateway/server.py tests/run_agent/test_413_compression.py tests/test_tui_gateway_server.py`
- [x] `git diff --check`
