### PR TITLE
feat(gateway): add reviewer.py module for structured h2reviewer verdicts

### DIFF
--- a/gateway/reviewer.py
+++ b/gateway/reviewer.py
@@ -1,0 +1,303 @@
+"""
+gateway/reviewer.py — automated code-review via the h2reviewer profile.
+
+Public API
+----------
+review(artifact_kind, *, paths, diff, branch, context, profile) -> ReviewVerdict
+
+The function:
+1. Renders a prompt asking the reviewer to assess the artifact and output a
+   fenced ``reviewer-verdict`` JSON block.
+2. Shells out via ``hermes -p <profile> chat -q "<prompt>"`` (same pattern as
+   ``_default_spawn`` in kanban_db.py), capturing stdout.
+3. Parses the LAST fenced ``reviewer-verdict`` block in the response.
+4. Returns a structured ``ReviewVerdict``.
+
+Fail-safe: on any parse error the verdict is BLOCKED and ``parsed_ok=False``
+so a human can inspect ``raw_response`` and decide.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Finding:
+    severity: Literal["critical", "warning", "info"]
+    file: str         # "path:line" or plain "path"
+    issue: str
+
+
+@dataclass
+class ReviewVerdict:
+    verdict: Literal["APPROVED", "BLOCKED", "NEEDS_INFO"]
+    findings: list[Finding]
+    needs_info: str | None
+    summary: str
+    raw_response: str
+    parsed_ok: bool   # False when the fenced block was missing or malformed
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+_PROMPT_TEMPLATE = """\
+You are a code reviewer. Evaluate the following artifact carefully.
+
+Artifact kind: {kind}
+{extra_sections}
+{context_section}
+Instructions
+------------
+* Identify issues by severity: critical (must-fix before merge), warning
+  (should-fix), or info (nice-to-have / stylistic).
+* After your review prose, output **exactly one** fenced block tagged
+  ``reviewer-verdict`` containing a JSON object with keys:
+    - "verdict": one of "APPROVED", "BLOCKED", or "NEEDS_INFO"
+    - "findings": list of {{"severity": ..., "file": ..., "issue": ...}}
+    - "needs_info": null or a string describing what clarification is needed
+    - "summary": one-sentence summary of the overall assessment
+
+Example fence:
+
+```reviewer-verdict
+{{"verdict": "APPROVED", "findings": [], "needs_info": null, "summary": "Looks good."}}
+```
+
+Now write your review:
+"""
+
+_VALID_VERDICTS: frozenset[str] = frozenset({"APPROVED", "BLOCKED", "NEEDS_INFO"})
+_VALID_SEVERITIES: frozenset[str] = frozenset({"critical", "warning", "info"})
+
+
+def _render_prompt(
+    artifact_kind: Literal["pr", "branch", "files"],
+    *,
+    paths: list[str] | None,
+    diff: str | None,
+    branch: str | None,
+    context: str | None,
+) -> str:
+    sections: list[str] = []
+
+    if branch:
+        sections.append(f"Branch: {branch}")
+
+    if paths:
+        sections.append("Files:\n" + "\n".join(f"  - {p}" for p in paths))
+
+    if diff:
+        # Truncate diffs that are very large to avoid prompt bloat; reviewers
+        # can always ask for more via NEEDS_INFO.
+        max_diff_chars = 40_000
+        if len(diff) > max_diff_chars:
+            diff = diff[:max_diff_chars] + "\n... [diff truncated] ..."
+        sections.append(f"Diff:\n```diff\n{diff}\n```")
+
+    extra = "\n\n".join(sections)
+    context_section = (
+        f"\nAdditional context:\n{context}" if context else ""
+    )
+
+    return _PROMPT_TEMPLATE.format(
+        kind=artifact_kind,
+        extra_sections=extra,
+        context_section=context_section,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+# Matches the LAST ```reviewer-verdict ... ``` block in the response.
+_FENCE_RE = re.compile(
+    r"```reviewer-verdict\s*\n(.*?)```",
+    re.DOTALL,
+)
+
+
+def _parse_response(raw: str) -> ReviewVerdict:
+    """Extract and validate the last ``reviewer-verdict`` fence in *raw*.
+
+    Returns a BLOCKED / parsed_ok=False verdict on any failure.
+    """
+
+    def _blocked(msg: str = "") -> ReviewVerdict:
+        return ReviewVerdict(
+            verdict="BLOCKED",
+            findings=[],
+            needs_info=None,
+            summary=msg or "Parse failure — human review required.",
+            raw_response=raw,
+            parsed_ok=False,
+        )
+
+    matches = _FENCE_RE.findall(raw)
+    if not matches:
+        return _blocked("No reviewer-verdict block found in response.")
+
+    json_text = matches[-1].strip()  # use the LAST match
+
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        return _blocked(f"JSON parse error: {exc}")
+
+    if not isinstance(data, dict):
+        return _blocked("reviewer-verdict block is not a JSON object.")
+
+    verdict_raw = data.get("verdict", "")
+    if verdict_raw not in _VALID_VERDICTS:
+        return _blocked(
+            f"Invalid verdict value {verdict_raw!r}; expected one of "
+            f"{sorted(_VALID_VERDICTS)}."
+        )
+
+    verdict: Literal["APPROVED", "BLOCKED", "NEEDS_INFO"] = verdict_raw  # type: ignore[assignment]
+
+    raw_findings = data.get("findings", [])
+    if not isinstance(raw_findings, list):
+        return _blocked("'findings' must be a JSON array.")
+
+    findings: list[Finding] = []
+    for i, f in enumerate(raw_findings):
+        if not isinstance(f, dict):
+            return _blocked(f"findings[{i}] is not an object.")
+        sev = f.get("severity", "")
+        if sev not in _VALID_SEVERITIES:
+            return _blocked(
+                f"findings[{i}].severity {sev!r} is not one of "
+                f"{sorted(_VALID_SEVERITIES)}."
+            )
+        file_loc = f.get("file", "")
+        issue = f.get("issue", "")
+        if not isinstance(file_loc, str) or not isinstance(issue, str):
+            return _blocked(f"findings[{i}] 'file' and 'issue' must be strings.")
+        findings.append(
+            Finding(
+                severity=sev,  # type: ignore[arg-type]
+                file=file_loc,
+                issue=issue,
+            )
+        )
+
+    needs_info = data.get("needs_info")
+    if needs_info is not None and not isinstance(needs_info, str):
+        needs_info = str(needs_info)
+
+    summary = data.get("summary", "")
+    if not isinstance(summary, str):
+        summary = str(summary)
+
+    return ReviewVerdict(
+        verdict=verdict,
+        findings=findings,
+        needs_info=needs_info,
+        summary=summary,
+        raw_response=raw,
+        parsed_ok=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profile invocation
+# ---------------------------------------------------------------------------
+
+def _resolve_hermes_argv() -> list[str]:
+    """Return the argv prefix that invokes hermes (same logic as kanban_db.py)."""
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _invoke_profile(profile: str, prompt: str) -> str:
+    """Run ``hermes -p <profile> chat -q <prompt>`` and return stdout.
+
+    Raises ``subprocess.CalledProcessError`` on non-zero exit,
+    ``FileNotFoundError`` if the hermes executable is missing.
+    """
+    cmd = [
+        *_resolve_hermes_argv(),
+        "-p", profile,
+        "chat",
+        "-q", prompt,
+    ]
+    result = subprocess.run(  # noqa: S603
+        cmd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def review(
+    artifact_kind: Literal["pr", "branch", "files"],
+    *,
+    paths: list[str] | None = None,
+    diff: str | None = None,
+    branch: str | None = None,
+    context: str | None = None,
+    profile: str = "h2reviewer",
+) -> ReviewVerdict:
+    """Spawn the reviewer profile, capture stdout, parse the verdict block.
+
+    Parameters
+    ----------
+    artifact_kind:
+        One of ``"pr"``, ``"branch"``, or ``"files"``.
+    paths:
+        List of file paths (or "path:line" strings) that are in scope.
+    diff:
+        Unified diff to include in the prompt (e.g. from ``git diff``).
+    branch:
+        Branch name to mention in the prompt.
+    context:
+        Free-form additional context appended to the prompt.
+    profile:
+        Hermes profile name to invoke.  Defaults to ``"h2reviewer"``.
+
+    Returns
+    -------
+    ReviewVerdict
+        Structured verdict.  On any parse failure the verdict is ``"BLOCKED"``
+        and ``parsed_ok`` is ``False``; ``raw_response`` always contains the
+        full subprocess output so a human can inspect it.
+    """
+    prompt = _render_prompt(
+        artifact_kind,
+        paths=paths,
+        diff=diff,
+        branch=branch,
+        context=context,
+    )
+
+    try:
+        raw = _invoke_profile(profile, prompt)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        raw = f"[reviewer invocation failed: {exc}]"
+        return ReviewVerdict(
+            verdict="BLOCKED",
+            findings=[],
+            needs_info=None,
+            summary=f"Reviewer process error: {exc}",
+            raw_response=raw,
+            parsed_ok=False,
+        )
+
+    return _parse_response(raw)

--- a/tests/gateway/test_reviewer.py
+++ b/tests/gateway/test_reviewer.py
@@ -1,0 +1,382 @@
+"""Tests for gateway/reviewer.py.
+
+All tests mock the subprocess boundary so hermes is never actually invoked.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from gateway.reviewer import (
+    Finding,
+    ReviewVerdict,
+    _parse_response,
+    _render_prompt,
+    review,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fence(payload: dict) -> str:
+    """Wrap *payload* in a reviewer-verdict fence."""
+    return "```reviewer-verdict\n" + json.dumps(payload) + "\n```"
+
+
+def _approved_payload(**overrides) -> dict:
+    base = {
+        "verdict": "APPROVED",
+        "findings": [],
+        "needs_info": None,
+        "summary": "All good.",
+    }
+    base.update(overrides)
+    return base
+
+
+def _blocked_payload(**overrides) -> dict:
+    base = {
+        "verdict": "BLOCKED",
+        "findings": [
+            {"severity": "critical", "file": "src/foo.py:42", "issue": "SQL injection"},
+        ],
+        "needs_info": None,
+        "summary": "Critical issue found.",
+    }
+    base.update(overrides)
+    return base
+
+
+def _needs_info_payload(**overrides) -> dict:
+    base = {
+        "verdict": "NEEDS_INFO",
+        "findings": [],
+        "needs_info": "Please clarify the auth flow.",
+        "summary": "Awaiting clarification.",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — happy paths (each verdict variant)
+# ---------------------------------------------------------------------------
+
+class TestParseResponseApproved:
+    def test_verdict_is_approved(self):
+        raw = "Great work!\n\n" + _make_fence(_approved_payload())
+        result = _parse_response(raw)
+        assert result.verdict == "APPROVED"
+        assert result.parsed_ok is True
+        assert result.findings == []
+        assert result.needs_info is None
+        assert result.summary == "All good."
+        assert result.raw_response == raw
+
+    def test_approved_with_info_findings(self):
+        payload = _approved_payload(findings=[
+            {"severity": "info", "file": "README.md", "issue": "Typo on line 3"},
+        ])
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "APPROVED"
+        assert len(result.findings) == 1
+        assert result.findings[0].severity == "info"
+        assert result.findings[0].file == "README.md"
+        assert result.parsed_ok is True
+
+
+class TestParseResponseBlocked:
+    def test_verdict_is_blocked(self):
+        raw = _make_fence(_blocked_payload())
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is True
+        assert len(result.findings) == 1
+        f: Finding = result.findings[0]
+        assert f.severity == "critical"
+        assert f.file == "src/foo.py:42"
+        assert f.issue == "SQL injection"
+
+    def test_blocked_multiple_findings(self):
+        payload = _blocked_payload(findings=[
+            {"severity": "critical", "file": "a.py:1", "issue": "Issue A"},
+            {"severity": "warning", "file": "b.py:99", "issue": "Issue B"},
+        ])
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert len(result.findings) == 2
+        assert result.findings[0].severity == "critical"
+        assert result.findings[1].severity == "warning"
+
+
+class TestParseResponseNeedsInfo:
+    def test_verdict_is_needs_info(self):
+        raw = _make_fence(_needs_info_payload())
+        result = _parse_response(raw)
+        assert result.verdict == "NEEDS_INFO"
+        assert result.parsed_ok is True
+        assert result.needs_info == "Please clarify the auth flow."
+        assert result.summary == "Awaiting clarification."
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — failure cases
+# ---------------------------------------------------------------------------
+
+class TestParseResponseMissingBlock:
+    def test_no_fence_returns_blocked_not_parsed(self):
+        raw = "Some review prose with no verdict block."
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+        assert "No reviewer-verdict block" in result.summary
+        assert result.raw_response == raw
+
+    def test_wrong_fence_tag_name(self):
+        raw = "```review-result\n{\"verdict\": \"APPROVED\"}\n```"
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+    def test_empty_string(self):
+        result = _parse_response("")
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+
+class TestParseResponseMalformedJson:
+    def test_truncated_json(self):
+        raw = "```reviewer-verdict\n{\"verdict\": \"APPROVED\"\n```"
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+        assert "JSON parse error" in result.summary
+
+    def test_not_json_object(self):
+        raw = "```reviewer-verdict\n[\"APPROVED\"]\n```"
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+    def test_plain_text_in_fence(self):
+        raw = "```reviewer-verdict\nnot json at all\n```"
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+
+class TestParseResponseInvalidValues:
+    def test_invalid_verdict_enum(self):
+        payload = _approved_payload(verdict="MAYBE")
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+        assert "Invalid verdict" in result.summary
+
+    def test_invalid_finding_severity(self):
+        payload = _approved_payload(findings=[
+            {"severity": "blocker", "file": "x.py", "issue": "Bad"},
+        ])
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+    def test_findings_not_a_list(self):
+        payload = _approved_payload(findings="bad")
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+    def test_finding_not_a_dict(self):
+        payload = _approved_payload(findings=["not-a-dict"])
+        raw = _make_fence(payload)
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — extra prose around the fence
+# ---------------------------------------------------------------------------
+
+class TestParseResponseWithProse:
+    def test_prose_before_fence(self):
+        raw = (
+            "Here is my detailed review...\n\n"
+            "The code has several concerns.\n\n"
+            + _make_fence(_approved_payload())
+        )
+        result = _parse_response(raw)
+        assert result.verdict == "APPROVED"
+        assert result.parsed_ok is True
+
+    def test_prose_after_fence(self):
+        raw = (
+            _make_fence(_blocked_payload())
+            + "\n\nPlease address these before merging."
+        )
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is True
+
+    def test_prose_before_and_after(self):
+        raw = (
+            "Summary: multiple issues.\n\n"
+            + _make_fence(_blocked_payload())
+            + "\n\nFeel free to ask questions."
+        )
+        result = _parse_response(raw)
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is True
+
+    def test_uses_last_fence_when_multiple(self):
+        """If the reviewer outputs multiple verdict blocks, we use the last."""
+        first = _make_fence(_blocked_payload())
+        last = _make_fence(_approved_payload(summary="Final verdict"))
+        raw = first + "\n\nActually, on reflection:\n\n" + last
+        result = _parse_response(raw)
+        assert result.verdict == "APPROVED"
+        assert result.summary == "Final verdict"
+        assert result.parsed_ok is True
+
+
+# ---------------------------------------------------------------------------
+# _render_prompt
+# ---------------------------------------------------------------------------
+
+class TestRenderPrompt:
+    def test_includes_artifact_kind(self):
+        prompt = _render_prompt("pr", paths=None, diff=None, branch=None, context=None)
+        assert "pr" in prompt
+        assert "reviewer-verdict" in prompt
+
+    def test_includes_branch(self):
+        prompt = _render_prompt("branch", paths=None, diff=None, branch="feat/x", context=None)
+        assert "feat/x" in prompt
+
+    def test_includes_paths(self):
+        prompt = _render_prompt("files", paths=["a.py", "b.py"], diff=None, branch=None, context=None)
+        assert "a.py" in prompt
+        assert "b.py" in prompt
+
+    def test_includes_diff(self):
+        diff = "- old line\n+ new line"
+        prompt = _render_prompt("files", paths=None, diff=diff, branch=None, context=None)
+        assert "- old line" in prompt
+        assert "+ new line" in prompt
+
+    def test_truncates_large_diff(self):
+        big_diff = "x" * 50_000
+        prompt = _render_prompt("pr", paths=None, diff=big_diff, branch=None, context=None)
+        assert "truncated" in prompt
+
+    def test_includes_context(self):
+        prompt = _render_prompt("pr", paths=None, diff=None, branch=None, context="ticket: ABC-123")
+        assert "ticket: ABC-123" in prompt
+
+    def test_no_extra_sections_when_none(self):
+        prompt = _render_prompt("pr", paths=None, diff=None, branch=None, context=None)
+        # Should not crash and should still contain instructions
+        assert "reviewer-verdict" in prompt
+
+
+# ---------------------------------------------------------------------------
+# review() — mocked subprocess boundary
+# ---------------------------------------------------------------------------
+
+_FAKE_APPROVED_RESPONSE = (
+    "Looking good overall.\n\n"
+    + _make_fence(_approved_payload(summary="Passes review."))
+)
+
+_FAKE_BLOCKED_RESPONSE = (
+    "There is a critical issue.\n\n"
+    + _make_fence(_blocked_payload(summary="Must fix before merge."))
+)
+
+
+class TestReviewMocked:
+    def test_approved_verdict_end_to_end(self):
+        with patch("gateway.reviewer._invoke_profile", return_value=_FAKE_APPROVED_RESPONSE):
+            result = review("pr", diff="+ foo = 1")
+        assert result.verdict == "APPROVED"
+        assert result.parsed_ok is True
+        assert result.summary == "Passes review."
+
+    def test_blocked_verdict_end_to_end(self):
+        with patch("gateway.reviewer._invoke_profile", return_value=_FAKE_BLOCKED_RESPONSE):
+            result = review("branch", branch="feat/bad-code")
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is True
+        assert len(result.findings) == 1
+
+    def test_needs_info_end_to_end(self):
+        fake = "Need more info.\n\n" + _make_fence(_needs_info_payload())
+        with patch("gateway.reviewer._invoke_profile", return_value=fake):
+            result = review("files", paths=["gateway/foo.py"])
+        assert result.verdict == "NEEDS_INFO"
+        assert result.needs_info == "Please clarify the auth flow."
+        assert result.parsed_ok is True
+
+    def test_subprocess_error_returns_blocked(self):
+        import subprocess
+        with patch(
+            "gateway.reviewer._invoke_profile",
+            side_effect=subprocess.CalledProcessError(1, "hermes"),
+        ):
+            result = review("pr")
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+        assert "Reviewer process error" in result.summary
+
+    def test_file_not_found_returns_blocked(self):
+        with patch(
+            "gateway.reviewer._invoke_profile",
+            side_effect=FileNotFoundError("hermes not found"),
+        ):
+            result = review("pr")
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+
+    def test_default_profile_is_h2reviewer(self):
+        """Verify the default profile arg is passed through to _invoke_profile."""
+        calls: list[tuple] = []
+
+        def fake_invoke(profile: str, prompt: str) -> str:
+            calls.append((profile, prompt))
+            return _FAKE_APPROVED_RESPONSE
+
+        with patch("gateway.reviewer._invoke_profile", side_effect=fake_invoke):
+            review("pr")
+
+        assert calls[0][0] == "h2reviewer"
+
+    def test_custom_profile_is_forwarded(self):
+        calls: list[tuple] = []
+
+        def fake_invoke(profile: str, prompt: str) -> str:
+            calls.append((profile, prompt))
+            return _FAKE_APPROVED_RESPONSE
+
+        with patch("gateway.reviewer._invoke_profile", side_effect=fake_invoke):
+            review("pr", profile="custom-reviewer")
+
+        assert calls[0][0] == "custom-reviewer"
+
+    def test_raw_response_preserved_on_parse_failure(self):
+        junk = "The model hallucinated and returned no verdict block."
+        with patch("gateway.reviewer._invoke_profile", return_value=junk):
+            result = review("pr")
+        assert result.verdict == "BLOCKED"
+        assert result.parsed_ok is False
+        assert result.raw_response == junk


### PR DESCRIPTION
## Summary
- New `gateway/reviewer.py` exposing `review()` + `ReviewVerdict` dataclass for programmatic invocation of the h2reviewer profile with parsed structured output (verdict + findings + summary)
- Parses fenced \`reviewer-verdict\` JSON blocks from h2reviewer response; fails safe (`BLOCKED + parsed_ok=False`) on missing/malformed block
- Companion update to `~/.hermes/profiles/h2reviewer/SOUL.md` (not in this PR — user-level config) instructing h2reviewer to always emit the fenced verdict block

Wire-in (not in this PR): on `kanban_block(reason="review-required: ...")`, dispatcher calls `gateway.reviewer.review(...)` → on APPROVED, transition card to done; on BLOCKED/NEEDS_INFO, post raw response as comment and keep card blocked.

## Test plan
- [x] 34 tests in `tests/gateway/test_reviewer.py` (each verdict variant, missing/malformed fence, prose around block, multi-fence-uses-last, 7 prompt-render tests, 8 mocked end-to-end)
- [x] All green: \`pytest tests/gateway/test_reviewer.py -o addopts="" -v\`
- [x] No live h2reviewer invocation in tests (mocked at subprocess boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)