### PR TITLE
fix(docker): accept PUID/PGID as aliases for HERMES_UID/HERMES_GID

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,15 @@ INSTALL_DIR="/opt/hermes"
 # optionally remap the hermes user/group to match host-side ownership, fix volume
 # permissions, then re-exec as hermes.
 if [ "$(id -u)" = "0" ]; then
+    # Accept PUID/PGID as aliases for HERMES_UID/HERMES_GID.  NAS users (UGOS,
+    # Synology, unRAID) expect the LinuxServer.io PUID/PGID convention and
+    # bind-mount /opt/data from a host directory owned by their own UID; without
+    # this alias those vars are silently ignored and the gosu drop to UID 10000
+    # leaves the runtime unable to read the volume.  HERMES_UID/HERMES_GID still
+    # win when both are set.  See #15290.
+    HERMES_UID="${HERMES_UID:-${PUID:-}}"
+    HERMES_GID="${HERMES_GID:-${PGID:-}}"
+
     if [ -n "$HERMES_UID" ] && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
         echo "Changing hermes UID to $HERMES_UID"
         usermod -u "$HERMES_UID" hermes

--- a/tests/tools/test_entrypoint_puid_pgid.py
+++ b/tests/tools/test_entrypoint_puid_pgid.py
@@ -1,0 +1,81 @@
+"""Contract test: the container entrypoint accepts PUID/PGID as aliases for
+HERMES_UID/HERMES_GID.
+
+Regression guard for #15290.  NAS platforms (UGOS, Synology, unRAID) bind-mount
+/opt/data from a host directory owned by the user's own UID and expect the
+LinuxServer.io PUID/PGID convention.  Without the alias those vars are silently
+ignored, the gosu drop lands on UID 10000, and the runtime cannot read the
+volume.  HERMES_UID/HERMES_GID must still take precedence when both are set.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+@pytest.fixture(scope="module")
+def entrypoint_text() -> str:
+    if not ENTRYPOINT.exists():
+        pytest.skip("docker/entrypoint.sh not present in this checkout")
+    return ENTRYPOINT.read_text()
+
+
+def _alias_lines(text: str) -> list[str]:
+    """The entrypoint lines that resolve HERMES_UID/HERMES_GID from their aliases."""
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().startswith(("HERMES_UID=", "HERMES_GID="))
+    ]
+
+
+def test_entrypoint_resolves_puid_pgid_aliases(entrypoint_text: str) -> None:
+    alias_lines = _alias_lines(entrypoint_text)
+    assert any("PUID" in line for line in alias_lines), (
+        "docker/entrypoint.sh must resolve HERMES_UID from a PUID alias; see #15290"
+    )
+    assert any("PGID" in line for line in alias_lines), (
+        "docker/entrypoint.sh must resolve HERMES_GID from a PGID alias; see #15290"
+    )
+
+
+def _resolve(entrypoint_text: str, env: dict[str, str]) -> str:
+    """Run the entrypoint's alias-resolution lines in isolation and report the
+    resolved ``HERMES_UID:HERMES_GID`` pair."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not available")
+    script = "\n".join(_alias_lines(entrypoint_text))
+    script += '\necho "${HERMES_UID:-}:${HERMES_GID:-}"\n'
+    proc = subprocess.run(
+        [bash, "-ec", script],
+        env={"PATH": os.environ.get("PATH", "")} | env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def test_puid_pgid_populate_hermes_uid_gid(entrypoint_text: str) -> None:
+    assert _resolve(entrypoint_text, {"PUID": "1000", "PGID": "10"}) == "1000:10"
+
+
+def test_hermes_uid_gid_take_precedence_over_aliases(entrypoint_text: str) -> None:
+    resolved = _resolve(
+        entrypoint_text,
+        {"HERMES_UID": "2000", "HERMES_GID": "2001", "PUID": "1000", "PGID": "10"},
+    )
+    assert resolved == "2000:2001"
+
+
+def test_no_uid_vars_leaves_values_empty(entrypoint_text: str) -> None:
+    # An empty resolution means the entrypoint keeps the default hermes user.
+    assert _resolve(entrypoint_text, {}) == ":"

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -445,10 +445,20 @@ Check logs: `docker logs hermes`. Common causes:
 
 ### "Permission denied" errors
 
-The container's entrypoint drops privileges to the non-root `hermes` user (UID 10000) via `gosu`. If your host `~/.hermes/` is owned by a different UID, set `HERMES_UID`/`HERMES_GID` to match your host user, or ensure the data directory is writable:
+The container's entrypoint drops privileges to the non-root `hermes` user (UID 10000) via `gosu`. If your host `~/.hermes/` is owned by a different UID, set `HERMES_UID`/`HERMES_GID` — or their `PUID`/`PGID` aliases, for parity with LinuxServer.io and NAS images — to match your host user, or ensure the data directory is writable:
 
 ```sh
 chmod -R 755 ~/.hermes
+```
+
+On a NAS (UGOS, Synology, unRAID) the data directory is typically a **bind mount** owned by a host UID the container cannot `chown`. Set `PUID`/`PGID` (or `HERMES_UID`/`HERMES_GID`) to that host user so the runtime runs as the owner of the mount rather than UID 10000:
+
+```sh
+docker run -d \
+  --name hermes \
+  -e PUID=1000 -e PGID=10 \
+  -v /volume1/docker/hermes:/opt/data \
+  nousresearch/hermes-agent gateway run
 ```
 
 ### Browser tools not working


### PR DESCRIPTION
## What changed and why

NAS users on #15290 (UGreen UGOS Pro, plus Synology/unRAID reports) bind-mount `/opt/data` from a host directory owned by their own UID. They set `PUID`/`PGID` — the LinuxServer.io convention NAS ecosystems expect — but `docker/entrypoint.sh` only read `HERMES_UID`/`HERMES_GID`, so those vars were silently ignored. The gosu privilege drop then landed on the default `hermes` user (UID 10000), which cannot read a bind mount owned by the host user, producing the persistent `[Errno 13] Permission denied: '/opt/data/config.yaml'`.

The entrypoint now resolves `HERMES_UID`/`HERMES_GID` from `PUID`/`PGID` when unset, so passing `PUID`/`PGID` makes the runtime drop to the host UID that already owns the bind mount. `HERMES_UID`/`HERMES_GID` still take precedence when both are set, so existing deployments are unaffected.

Per the reporter's 2026-05-14 diagnostics: a Docker **named volume** works while a NAS **bind mount** does not, and `PUID=1000`/`PGID=10` were confirmed ignored by the current `:latest` image — running the container as the host UID is the fix that lets bind mounts work without host-side `chown` loops. The troubleshooting docs in `website/docs/user-guide/docker.md` now document the alias and the NAS bind-mount pattern.

## How to test

- `pytest tests/tools/test_entrypoint_puid_pgid.py -q` — new contract test covering PUID/PGID alias resolution and `HERMES_UID`/`HERMES_GID` precedence.
- Manual: `docker run -e PUID=1000 -e PGID=10 -v /host/dir:/opt/data nousresearch/hermes-agent gateway run` against a bind mount owned by host UID 1000 — the entrypoint logs `Changing hermes UID to 1000` and the runtime can read/write `config.yaml` without a host-side `chown`.

## What platforms tested on

- macOS (Darwin 24.6.0): `pytest tests/tools/test_entrypoint_puid_pgid.py` (4 passed) plus the existing `tests/tools/test_docker*` and `test_dockerfile_*` suites (30 passed); `bash -n docker/entrypoint.sh` clean.
- The entrypoint change is shell-only and platform-agnostic; the target deployment is the Debian-based container image reported by NAS users (UGOS Pro / Btrfs bind mounts).

## Addressing maintainer feedback

@alt-glitch flagged this as related to **#13731** (CLOSED — duplicate of #15832) with the workaround `--user 0:0`. #13731 was fixed by commit `14c9f7272`, which removed `USER hermes` from the Dockerfile so the entrypoint runs as root. The reporter's diagnostics confirm they are on a post-fix `:latest` image, and that `--user 0:0` does not resolve their case: the entrypoint correctly detects container-root and drops to UID 10000 by design, which still mismatches the host-owned bind mount. The `PUID`/`PGID` alias addresses the remaining gap — it lets NAS users target the host UID directly instead of relying on a `chown` of a bind mount the host filesystem may reject.

Fixes #15290

<!-- autocontrib:worker-id=issue-followup-dc61946c kind=pr-open -->