### PR TITLE
fix(mcp_oauth): preserve refresh_token when refresh response omits one (RFC 6749 §10.4)

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -271,6 +271,34 @@ class HermesTokenStorage:
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
         payload = tokens.model_dump(mode="json", exclude_none=True)
+
+        # Per RFC 6749 §10.4, when a client uses ``grant_type=refresh_token``,
+        # the authorization server MAY rotate the refresh token (return a new
+        # one) OR keep the existing one (return no refresh_token field in the
+        # response). Both are spec-compliant.
+        #
+        # Bug: when the server's refresh response omits the refresh_token,
+        # ``model_dump(exclude_none=True)`` above drops the field from
+        # ``payload``, and the unconditional ``_write_json`` below overwrites
+        # the stored file with no refresh_token. The original refresh_token
+        # is lost. On the NEXT access-token expiry, the SDK has no
+        # refresh_token to use and falls back to a full ``authorization_code``
+        # browser flow — i.e. the user sees the OAuth dance again roughly
+        # one TTL after their last successful auth, every time.
+        #
+        # Fix: if the refresh response didn't include a refresh_token,
+        # preserve the existing one from on-disk storage. Standard
+        # well-behaved OAuth client behavior.
+        if "refresh_token" not in payload:
+            existing = _read_json(self._tokens_path())
+            if existing and existing.get("refresh_token"):
+                payload["refresh_token"] = existing["refresh_token"]
+                logger.debug(
+                    "OAuth refresh response for %s omitted refresh_token; "
+                    "preserving existing one from disk",
+                    self._server_name,
+                )
+
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's
         # ``_initialize`` reloads a relative ``expires_in`` which has no


### PR DESCRIPTION
## Summary

Fix \`HermesTokenStorage.set_tokens()\` to preserve the existing \`refresh_token\` when the OAuth server's refresh response omits one. Per RFC 6749 §10.4, omission is spec-compliant: the authorization server MAY rotate the refresh token OR keep the existing one (returning no \`refresh_token\` field).

## Bug

When the MCP server's response to \`grant_type=refresh_token\` doesn't include a new \`refresh_token\` field:

\`\`\`python
async def set_tokens(self, tokens: "OAuthToken") -> None:
    payload = tokens.model_dump(mode="json", exclude_none=True)  # drops missing fields
    ...
    _write_json(self._tokens_path(), payload)  # overwrites file outright
\`\`\`

The \`model_dump(exclude_none=True)\` drops the missing \`refresh_token\` from \`payload\`, and the unconditional \`_write_json\` overwrites the on-disk token store with no \`refresh_token\`. The previously-stored refresh_token is lost.

On the next access_token expiry, the SDK has no \`refresh_token\` to use → falls back to a full \`authorization_code\` browser flow → **the user sees the OAuth dance approximately every TTL** (e.g., every ~1 hour for a 3600s access_token TTL) regardless of having ever had a valid refresh_token.

## Fix

If the new payload lacks \`refresh_token\`, read the existing on-disk store and preserve the prior \`refresh_token\` into the new payload before writing. ~10 lines of logic + RFC reference in comments. Standard well-behaved OAuth client behavior.

## Repro

Against any MCP server that doesn't rotate refresh_tokens on refresh:

1. Authenticate normally (initial auth_code flow). Confirm \`~/.hermes/mcp-tokens/<server>.json\` has \`refresh_token\`.
2. Force-expire the access_token:
   \`\`\`bash
   python -c "import json,time; p='~/.hermes/mcp-tokens/<server>.json'; d=json.load(open(p)); d['expires_at']=time.time()-1; json.dump(d,open(p,'w'))"
   \`\`\`
3. Run any \`hermes chat\` call to trigger refresh.
4. Inspect the file:
   \`\`\`bash
   python -c "import json; d=json.load(open('~/.hermes/mcp-tokens/<server>.json')); print('has refresh_token:', 'refresh_token' in d)"
   \`\`\`

**Before patch:** silent refresh succeeds, but file post-refresh shows \`has refresh_token: False\`. The chain breaks on next expiry; the auth_code dance fires again.

**After patch:** silent refresh succeeds AND \`refresh_token\` is preserved. Chain stable indefinitely.

## Test

Force-expiry → refresh → file-inspection cycle confirmed working against batcave-mcp-server (custom MCP server using Google OAuth federation). No new unit test added in this PR; happy to add one if you'd like — pattern would be: mock an \`OAuthToken\` without a \`refresh_token\` field, pre-seed \`HermesTokenStorage\` with a token that has one, call \`set_tokens(mocked)\`, assert the on-disk file still has the original \`refresh_token\`.

## Affected use cases

Any MCP server whose refresh response omits \`refresh_token\` (spec-compliant). Some servers always rotate; others (including the one I tested against) do not. The bug is symmetric across all such servers.

## Backward compatibility

When the server DOES include a \`refresh_token\` in the refresh response (the more common case for rotating servers), behavior is unchanged — the new refresh_token is written from \`payload\` as before. The preserve-from-disk branch only fires when the response omits the field.