### PR TITLE
fix(update): handle missing refs/stash ref in _stash_local_changes_if_needed

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6245,14 +6245,38 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         cwd=cwd,
         check=True,
     )
-    stash_ref = subprocess.run(
-        git_cmd + ["rev-parse", "--verify", "refs/stash"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    return stash_ref
+    # git stash push can return 0 even when nothing was saved (e.g. phantom
+    # deletions in the index).  Verify a ref was actually created before using it.
+    try:
+        r = subprocess.run(
+            git_cmd + ["rev-parse", "--verify", "refs/stash"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        r = None
+    if r is not None and r.returncode == 0:
+        return r.stdout.strip()
+
+    # Fallback: find the newest stash entry (the one we just created) from list.
+    try:
+        stash_list = subprocess.run(
+            git_cmd + ["stash", "list", "--format=%gd %H"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for line in stash_list.stdout.splitlines():
+            selector, _, commit = line.partition(" ")
+            if commit.strip():
+                return commit.strip()
+    except subprocess.CalledProcessError:
+        pass  # stash list failed — nothing to restore anyway.
+
+    # Still nothing — caller handles gracefully (returns None).
+    return None
 
 
 def _resolve_stash_selector(

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -273,7 +273,9 @@ def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_pa
     assert len(reset_calls) == 1
 
 
-def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
+def test_stash_local_changes_if_needed_returns_none_when_ref_missing(monkeypatch, tmp_path):
+    """When stash push succeeds but refs/stash doesn't exist (phantom deletion),
+    the function falls back to stash list and returns None if empty."""
     def fake_run(cmd, **kwargs):
         if cmd[-2:] == ["status", "--porcelain"]:
             return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
@@ -283,12 +285,16 @@ def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch
             return SimpleNamespace(stdout="Saved working directory\n", returncode=0)
         if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
             raise CalledProcessError(returncode=128, cmd=cmd)
+        if cmd[1:4] == ["stash", "list"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        # Handle stash list with format argument (fallback path)
+        if len(cmd) >= 3 and cmd[1] == "stash" and cmd[2] == "list":
+            return SimpleNamespace(stdout="", returncode=0)
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
 
-    with pytest.raises(CalledProcessError):
-        hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+    assert hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path)) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

git stash push can return exit code 0 even when nothing is saved (e.g. phantom deletions in the index). The original code assumed rev-parse --verify refs/stash would always succeed after stash push, causing an unhandled CalledProcessError that crashed the update process.

## Fix

- Wrap rev-parse in try/except to catch the missing ref case
- Fall back to git stash list --format=%gd %H if the ref doesn't exist
- Returns None gracefully when no stash can be found (caller handles it)

## Tests

- Updated existing test: expects None instead of raised exception
- Confirmed same 2 pre-existing test failures on main (lazy deps, unrelated)