### PR TITLE
fix(gateway): add codex runtime telegram alias

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -123,7 +123,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("model", "Switch model for this session", "Configuration",
                aliases=("provider",), args_hint="[model] [--provider name] [--global]"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
-               "Configuration", args_hint="[auto|codex_app_server]"),
+               "Configuration", aliases=("codex_runtime",),
+               args_hint="[auto|codex_app_server]"),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -107,6 +107,7 @@ class TestResolveCommand:
         assert resolve_command("gateway").name == "platforms"
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
+        assert resolve_command("codex_runtime").name == "codex-runtime"
         assert resolve_command("tasks").name == "agents"
 
     def test_topic_is_gateway_command(self):
@@ -250,6 +251,12 @@ class TestTelegramBotCommands:
         assert "background" in names
         assert "queue" in names
         assert "steer" in names
+
+    def test_hyphenated_codex_runtime_is_exposed_as_underscore_command(self):
+        """Telegram autocomplete exposes /codex-runtime as /codex_runtime."""
+        names = {name for name, _ in telegram_bot_commands()}
+        assert "codex_runtime" in names
+        assert "codex-runtime" not in names
 
 
 class TestSlackSubcommandMap:


### PR DESCRIPTION
## What does this PR do?

Adds `codex_runtime` as an explicit alias for the existing `/codex-runtime` slash command.

Telegram bot commands cannot contain hyphens, so Hermes exposes hyphenated commands in the Telegram menu with underscores. `/codex-runtime` already appears to Telegram users as `/codex_runtime`, but selecting that command could fail to dispatch correctly because `codex_runtime` was not registered as an alias. This follows the existing `/reload-skills` and `/reload_skills` convention instead of adding broader command normalization.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/commands.py`: registered `codex_runtime` as an alias for `/codex-runtime`.
- `tests/hermes_cli/test_commands.py`: added coverage for resolving the alias and for Telegram exposing `/codex_runtime` rather than the hyphenated form.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_commands.py::TestResolveCommand tests/hermes_cli/test_commands.py::TestTelegramBotCommands`.
2. Start the Telegram gateway so Hermes refreshes the bot command menu via `set_my_commands`.
3. In Telegram, type `/codex` and confirm `/codex_runtime` appears, then select it and confirm it dispatches to the `/codex-runtime` handler.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests passed:

```text
scripts/run_tests.sh tests/hermes_cli/test_commands.py::TestResolveCommand tests/hermes_cli/test_commands.py::TestTelegramBotCommands
11 passed
```
