### PR TITLE
fix(terminal): clear container config when backend is local

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -497,6 +497,19 @@ def load_cli_config() -> Dict[str, Any]:
     if effective_backend == "local":
         terminal_config["cwd"] = os.getcwd()
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        # Remove container-specific config keys so stale Docker/Modal/etc.
+        # settings from a previous config do not leak via env vars.
+        for _ck in (
+            "docker_image", "docker_forward_env", "docker_volumes",
+            "docker_env", "docker_mount_cwd_to_workspace",
+            "docker_run_as_host_user", "docker_extra_args",
+            "singularity_image", "modal_image", "modal_mode",
+            "daytona_image", "vercel_runtime",
+            "container_cpu", "container_memory", "container_disk",
+            "container_persistent",
+        ):
+            terminal_config.pop(_ck, None)
+            defaults.get("terminal", {}).pop(_ck, None)
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -465,8 +465,28 @@ if _config_path.exists():
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }
+            # When the terminal backend is local, skip container-specific
+            # config keys so stale Docker/Modal/etc. settings from a previous
+            # config do not leak through env vars into the terminal tool.
+            _container_only_keys = {
+                "docker_image", "docker_forward_env", "docker_volumes",
+                "docker_env", "docker_mount_cwd_to_workspace",
+                "docker_run_as_host_user", "docker_extra_args",
+                "singularity_image", "modal_image", "modal_mode",
+                "daytona_image", "vercel_runtime",
+                "container_cpu", "container_memory", "container_disk",
+                "container_persistent",
+            }
+            _backend = str(_terminal_cfg.get("backend", "local")).strip().lower()
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
+                    # Skip container-only keys when running locally.
+                    if _backend == "local" and _cfg_key in _container_only_keys:
+                        # Explicitly clear any previously-set env var so a
+                        # stale Docker config from an earlier gateway process
+                        # does not persist.
+                        os.environ.pop(_env_var, None)
+                        continue
                     _val = _terminal_cfg[_cfg_key]
                     # Skip cwd placeholder values (".", "auto", "cwd") — the
                     # gateway resolves these to Path.home() later (line ~255).


### PR DESCRIPTION
## Problem

Issue #25402: When switching `terminal.backend` from Docker to local, stale Docker-related config keys (docker_image, docker_volumes, etc.) in config.yaml were still bridged to environment variables by the config bridge.

## Fix

When `backend: local` is set, explicitly remove container-specific config keys from both the terminal config and the environment variables. Applied in both:
- `gateway/run.py` (gateway config bridge)
- `cli.py` (CLI config bridge)

## Changed files
- `gateway/run.py` — skip container-only keys when backend is local, clear stale env vars
- `cli.py` — remove container-only config keys from terminal config when backend is local
