### PR TITLE
Fix Docker /update fallback for mounted source repo

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12526,7 +12526,12 @@ class GatewayRunner:
         git_dir = project_root / '.git'
 
         if not git_dir.exists():
-            return t("gateway.update.not_git_repo")
+            # Docker images do not include /opt/hermes/.git. The update
+            # implementation below already knows how to use the mounted
+            # source checkout, so let /update pass the same fallback repo.
+            alt_git = Path("/opt/data/_hermes_repo/.git")
+            if not alt_git.exists():
+                return t("gateway.update.not_git_repo")
 
         hermes_cmd = _resolve_hermes_bin()
         if not hermes_cmd:
@@ -16845,3 +16850,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## What does this PR do?
Fixes Docker gateway `/update` when the image does not contain `/opt/hermes/.git` but the mounted source checkout exists at `/opt/data/_hermes_repo/.git`.

## Root cause
Docker images do not include git metadata under `/opt/hermes`, but `hermes update --gateway` already supports falling back to `/opt/data/_hermes_repo`. The gateway command handler returned `not_git_repo` before that fallback could run.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Updated `gateway/run.py` so the gateway update pre-check accepts the Docker mounted repo fallback.
- Preserved the existing `not_git_repo` behavior when neither repo path exists.

## How to Test
1. Run Hermes from a Docker image where `/opt/hermes/.git` is absent.
2. Ensure `/opt/data/_hermes_repo/.git` exists.
3. Trigger `/update` and verify the command reaches `hermes update --gateway` instead of returning `not_git_repo`.

## Checklist
- [x] My PR contains only changes related to this fix.
- [x] I've considered Docker/Linux deployment impact.
- [ ] Full test suite not run; change is a narrow gateway pre-check fix validated against a live Docker deployment.