### PR TITLE
fix: recognize gateway launchd wrappers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1446,6 +1446,14 @@ def run_doctor(args):
                 "Authorization": f"Bearer {key}",
                 "User-Agent": _HERMES_USER_AGENT,
             }
+            # Gemini's native API does not accept OpenAI-style Bearer auth for
+            # the models endpoint. Use the documented API-key header so doctor
+            # does not report valid GOOGLE_API_KEY/GEMINI_API_KEY values as invalid.
+            if pname.lower() == "gemini":
+                headers = {
+                    "x-goog-api-key": key,
+                    "User-Agent": _HERMES_USER_AGENT,
+                }
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
             r = httpx.get(url, headers=headers, timeout=10)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -2836,7 +2837,61 @@ def launchd_plist_is_current() -> bool:
 
     installed = plist_path.read_text(encoding="utf-8")
     expected = generate_launchd_plist()
-    return _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected)
+    if _normalize_launchd_plist_for_comparison(installed) == _normalize_launchd_plist_for_comparison(expected):
+        return True
+    return _launchd_custom_wrapper_is_current(installed)
+
+
+def _launchd_custom_wrapper_is_current(installed: str) -> bool:
+    """Accept a profile-local launchd wrapper that delegates to the current gateway.
+
+    Some production profiles intentionally use a small wrapper script as the
+    launchd ProgramArguments entry so secrets can be loaded from an external
+    store before `hermes gateway run --replace` starts. Treat that as current
+    when the wrapper lives under the active profile and still delegates to the
+    current Hermes checkout/profile rather than overwriting it with the vanilla
+    generated plist on the next status/start check.
+    """
+    try:
+        data = plistlib.loads(installed.encode("utf-8"))
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+
+    prog_args = data.get("ProgramArguments")
+    if not isinstance(prog_args, list) or len(prog_args) != 1 or not isinstance(prog_args[0], str):
+        return False
+
+    hermes_home = get_hermes_home().resolve()
+    wrapper = Path(prog_args[0])
+    try:
+        wrapper_resolved = wrapper.resolve()
+    except OSError:
+        return False
+    scripts_dir = hermes_home / "scripts"
+    if scripts_dir not in wrapper_resolved.parents:
+        return False
+    if not wrapper_resolved.is_file():
+        return False
+
+    env = data.get("EnvironmentVariables") or {}
+    if isinstance(env, dict) and env.get("HERMES_HOME") not in {None, str(hermes_home)}:
+        return False
+    working_dir = data.get("WorkingDirectory")
+    if working_dir and str(Path(str(working_dir)).resolve()) != str(PROJECT_ROOT):
+        return False
+
+    try:
+        wrapper_text = wrapper_resolved.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    required_fragments = ["hermes_cli.main", "gateway", "run", "--replace"]
+    profile_arg = _profile_arg(hermes_home)
+    if profile_arg:
+        required_fragments.extend(profile_arg.split())
+    return all(fragment in wrapper_text for fragment in required_fragments)
 
 
 def refresh_launchd_plist_if_needed() -> bool:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -224,6 +224,73 @@ class TestLaunchdPlistCurrentness:
 
         assert gateway_cli.launchd_plist_is_current() is True
 
+    def test_launchd_plist_is_current_accepts_profile_local_wrapper(self, tmp_path, monkeypatch):
+        """Profile-local launchd wrappers are current when they delegate to gateway run.
+
+        Production profiles may use a wrapper script to load external secrets
+        before starting the standard gateway. Status/start checks should not
+        treat those wrappers as stale and overwrite them with the vanilla plist.
+        """
+        hermes_home = tmp_path / "profile"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        wrapper = scripts_dir / "run-gateway-with-1password-env.sh"
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            "exec /venv/bin/python -m hermes_cli.main gateway run --replace\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(
+            f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+  <key>Label</key><string>ai.hermes.gateway-test</string>
+  <key>ProgramArguments</key><array><string>{wrapper}</string></array>
+  <key>WorkingDirectory</key><string>{gateway_cli.PROJECT_ROOT}</string>
+  <key>EnvironmentVariables</key><dict><key>HERMES_HOME</key><string>{hermes_home}</string></dict>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_is_current_rejects_wrapper_not_delegating_to_gateway(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "profile"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        wrapper = scripts_dir / "run-gateway-with-1password-env.sh"
+        wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        wrapper.chmod(0o755)
+
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(
+            f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+  <key>ProgramArguments</key><array><string>{wrapper}</string></array>
+  <key>WorkingDirectory</key><string>{gateway_cli.PROJECT_ROOT}</string>
+  <key>EnvironmentVariables</key><dict><key>HERMES_HOME</key><string>{hermes_home}</string></dict>
+</dict>
+</plist>
+""",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
 
 # ---------------------------------------------------------------------------
 # cmd_update — macOS launchd detection


### PR DESCRIPTION
## Summary
- use Gemini's native x-goog-api-key header for doctor model connectivity checks
- treat profile-local launchd wrapper scripts as current when they delegate to the active Hermes gateway run command
- add regression coverage for accepted and rejected launchd wrapper scripts

## Test Plan
- python -m pytest tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_doctor.py -q