### PR TITLE
fix(agent): gate single-model probe on known server type

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1161,14 +1161,18 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                                     return int(ctx)
                             break
 
-            # LM Studio / vLLM / llama.cpp: try /v1/models/{model}
-            resp = client.get(f"{server_url}/v1/models/{model}")
-            if resp.status_code == 200:
-                data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
-                if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+            # vLLM / llama.cpp: try /v1/models/{model} for context window.
+            # Skip for unknown server types (e.g. LiteLLM proxy) that gate
+            # this endpoint behind admin auth — the /v1/models list call
+            # below works on all OpenAI-compatible servers.
+            if server_type is not None:
+                resp = client.get(f"{server_url}/v1/models/{model}")
+                if resp.status_code == 200:
+                    data = resp.json()
+                    # vLLM returns max_model_len
+                    ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
+                    if ctx and isinstance(ctx, (int, float)):
+                        return int(ctx)
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -188,7 +188,6 @@ class TestQueryLocalContextLengthModelsList:
         """Finds context length for model in /v1/models list."""
         from agent.model_metadata import _query_local_context_length
 
-        detail_resp = self._make_resp(404, {})
         list_resp = self._make_resp(200, {
             "data": [
                 {"id": "other-model", "max_model_len": 4096},
@@ -199,9 +198,7 @@ class TestQueryLocalContextLengthModelsList:
         call_count = [0]
         def side_effect(url, **kwargs):
             call_count[0] += 1
-            if call_count[0] == 1:
-                return detail_resp  # /v1/models/omnicoder-9b
-            return list_resp  # /v1/models
+            return list_resp  # Only /v1/models is called when server_type is None
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock
@@ -214,12 +211,12 @@ class TestQueryLocalContextLengthModelsList:
             result = _query_local_context_length("omnicoder-9b", "http://localhost:1234")
 
         assert result == 131072
+        assert call_count[0] == 1  # Only the /v1/models list call, detail probe is gated
 
     def test_models_list_model_not_found_returns_none(self):
         """Returns None when model is not in the /v1/models list."""
         from agent.model_metadata import _query_local_context_length
 
-        detail_resp = self._make_resp(404, {})
         list_resp = self._make_resp(200, {
             "data": [{"id": "other-model", "max_model_len": 4096}]
         })
@@ -227,9 +224,7 @@ class TestQueryLocalContextLengthModelsList:
         call_count = [0]
         def side_effect(url, **kwargs):
             call_count[0] += 1
-            if call_count[0] == 1:
-                return detail_resp
-            return list_resp
+            return list_resp  # Only /v1/models when server_type is None
 
         client_mock = MagicMock()
         client_mock.__enter__ = lambda s: client_mock


### PR DESCRIPTION
_query_local_context_length() unconditionally probes /v1/models/{model} which LiteLLM proxies gate behind proxy_admin auth. On unrecognized servers (server_type=None), skip this probe and rely solely on the /v1/models list endpoint which works universally.

Fixes #25848

## What does this PR do?
Gates the `/v1/models/{model}` probe in `_query_local_context_length()`
behind a server-type check, preventing 401 noise on LiteLLM proxies.
When `detect_local_server_type()` returns `None` (unrecognized server),
the admin-gated single-model probe is skipped and context-length
resolution relies solely on the universally-supported `/v1/models`
list endpoint.

## Related Issue
Fixes #25848

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- **`agent/model_metadata.py`:** Added `if server_type is not None:`
  guard at line 1164 before the `/v1/models/{model}` probe. Updated
  comment to document why unknown server types are skipped.
- **`tests/agent/test_model_metadata_local_ctx.py`:** Updated two
  tests (`test_models_list_max_model_len` and
  `test_models_list_model_not_found_returns_none`) to reflect that
  the single-model detail probe is no longer called when
  `detect_local_server_type()` returns `None`. Removed unused
  `detail_resp` variables.

## How to Test
1. Configure a `custom` provider pointing at a LiteLLM proxy
2. Set `model.default` to a LiteLLM-routed model
3. Send a message via `hermes chat`
4. Check LiteLLM logs — no more "Only proxy admin" ERROR lines
5. Verify context-length resolution still works (list endpoint is unchanged)

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/agent/ -k model_metadata -q` — 131 passed, 0 failed
- [ ] I've added tests for my changes (existing tests updated; N/A for new test — the change gates an existing probe, no new logic path added)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (no API change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (Python-level guard, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A
