### PR TITLE
fix(cli): keep API-only user prefixes out of transcripts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10602,17 +10602,24 @@ class HermesCLI:
                 except Exception:
                     pass
                 agent_message = _voice_prefix + message if _voice_prefix else message
-                # Prepend pending model switch note so the model knows about the switch
+                persist_user_message = message if _voice_prefix else None
+                # Prepend pending model switch note so the model knows about the switch.
+                # The note is API-call-local only: persist the clean user text so
+                # session transcripts, /resume history, exports, and search do not
+                # present runtime metadata as something the user actually said.
                 _msn = getattr(self, '_pending_model_switch_note', None)
                 if _msn:
                     agent_message = _msn + "\n\n" + agent_message
+                    persist_user_message = message
                     self._pending_model_switch_note = None
                 # Prepend pending /reload-skills note so the model sees which
                 # skills were added/removed before handling this turn. Same
-                # one-shot queue pattern as the model-switch note above.
+                # one-shot queue pattern as the model-switch note above; also
+                # API-call-local for transcript cleanliness.
                 _srn = getattr(self, '_pending_skills_reload_note', None)
                 if _srn:
                     agent_message = _srn + "\n\n" + agent_message
+                    persist_user_message = message
                     self._pending_skills_reload_note = None
                 try:
                     result = self.agent.run_conversation(
@@ -10620,7 +10627,7 @@ class HermesCLI:
                         conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
                         stream_callback=stream_callback,
                         task_id=self.session_id,
-                        persist_user_message=message if _voice_prefix else None,
+                        persist_user_message=persist_user_message,
                     )
                 except Exception as exc:
                     logging.error("run_conversation raised: %s", exc, exc_info=True)

--- a/tests/cli/test_cli_api_only_user_prefixes.py
+++ b/tests/cli/test_cli_api_only_user_prefixes.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import queue
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.calls = []
+        self.session_id = "sess-test"
+        self.max_iterations = 90
+
+    def run_conversation(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": kwargs["user_message"]},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "completed": True,
+            "api_calls": 1,
+        }
+
+    def switch_model(self, **kwargs):
+        return None
+
+
+def _make_cli():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    cli.model = "old-model"
+    cli.provider = "old-provider"
+    cli.requested_provider = "old-provider"
+    cli.api_key = ""
+    cli.base_url = ""
+    cli.api_mode = "chat_completions"
+    cli._explicit_api_key = ""
+    cli._explicit_base_url = ""
+    cli._voice_mode = False
+    cli._pending_model_switch_note = None
+    cli._pending_skills_reload_note = None
+    cli._sudo_password_callback = lambda: ""
+    cli._approval_callback = lambda *a, **k: "approve_once"
+    cli._secret_capture_callback = lambda *a, **k: {}
+    cli._interrupt_queue = queue.Queue()
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._prompt_start_time = None
+    cli._prompt_duration = 0.0
+    cli._voice_tts = False
+    cli._voice_tts_done = None
+    cli._voice_continuous = False
+    cli._voice_recording = False
+    cli._last_turn_interrupted = False
+    cli._ensure_runtime_credentials = lambda: True
+    cli._resolve_turn_agent_config = lambda user_message: {
+        "signature": "test-route",
+        "model": cli.model,
+        "runtime": {
+            "provider": cli.provider,
+            "api_key": cli.api_key,
+            "base_url": cli.base_url,
+            "api_mode": cli.api_mode,
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+        "request_overrides": None,
+    }
+    cli._active_agent_route_signature = "test-route"
+    cli.session_id = "sess-test"
+    cli.conversation_history = [{"role": "assistant", "content": "prior"}]
+    cli._flush_stream = lambda: None
+    cli._reset_stream_state = lambda: None
+    cli._safe_print = lambda *a, **k: None
+    cli._invalidate = lambda *a, **k: None
+    cli._pending_title = None
+    cli._session_db = None
+    cli.show_reasoning = False
+    cli.final_response_markdown = "raw"
+    cli.bell_on_complete = False
+    cli._stream_started = False
+    cli._stream_box_opened = False
+    cli._reasoning_shown_this_turn = False
+    cli._stream_context_scrubber = None
+    cli._stream_think_scrubber = None
+    return cli
+
+
+class ImmediateThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self._alive = False
+        self.ident = 1
+
+    def start(self):
+        self._alive = True
+        try:
+            if self._target:
+                self._target(*self._args, **self._kwargs)
+        finally:
+            self._alive = False
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        return None
+
+
+def _patch_chat_runtime(monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "set_sudo_password_callback", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod, "set_approval_callback", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod, "set_secret_capture_callback", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod.logging, "error", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda *a, **k: None)
+
+
+def test_apply_model_switch_result_marks_next_turn_as_api_only(monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod, "save_config_value", lambda *a, **k: None)
+
+    cli = _make_cli()
+    result = ModelSwitchResult(
+        success=True,
+        new_model="gpt-5.5",
+        target_provider="custom:pixel",
+        provider_changed=True,
+        api_key="",
+        base_url="",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="pixel",
+        model_info=None,
+        error_message="",
+    )
+
+    cli_mod.HermesCLI._apply_model_switch_result(cli, result, False)
+
+    assert "switched from old-model to gpt-5.5" in cli._pending_model_switch_note
+
+
+def test_chat_persists_clean_user_message_when_model_switch_note_is_prepended(monkeypatch):
+    import cli as cli_mod
+
+    _patch_chat_runtime(monkeypatch)
+    monkeypatch.setattr(cli_mod.ChatConsole, "print", lambda *a, **k: None)
+
+    cli = _make_cli()
+    cli._pending_model_switch_note = "[Note: model was just switched from a to b.]"
+
+    cli_mod.HermesCLI.chat(cli, "继续任务")
+
+    call = cli.agent.calls[-1]
+    assert call["user_message"].startswith("[Note: model was just switched")
+    assert call["persist_user_message"] == "继续任务"
+
+
+def test_chat_persists_clean_user_message_when_skills_reload_note_is_prepended(monkeypatch):
+    import cli as cli_mod
+
+    _patch_chat_runtime(monkeypatch)
+    monkeypatch.setattr(cli_mod.ChatConsole, "print", lambda *a, **k: None)
+
+    cli = _make_cli()
+    cli._pending_skills_reload_note = "[Skills reloaded: added foo]"
+
+    cli_mod.HermesCLI.chat(cli, "继续任务")
+
+    call = cli.agent.calls[-1]
+    assert call["user_message"].startswith("[Skills reloaded")
+    assert call["persist_user_message"] == "继续任务"


### PR DESCRIPTION
## Summary

Fixes a transcript hygiene issue in the CLI path: runtime-only user-message prefixes injected for model context are now kept out of persisted session transcripts.

Specifically:

- `/model` switch notes are still prepended to the next API call so the model sees the runtime change.
- `/reload-skills` notes are still prepended to the next API call so the model sees skill changes.
- Both paths now pass the clean user text via `persist_user_message`, matching the existing voice-mode pattern.

This prevents session history, `/resume`, exports, search, titles/previews, and transcript viewers from treating runtime metadata as something the user actually typed.

## Test Plan

- `venv/bin/python -m pytest tests/cli/test_cli_api_only_user_prefixes.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride -q -o addopts=`
- `python3 -m py_compile cli.py run_agent.py`

## Notes

This is intentionally a minimal fix for the clear CLI API-only prefix paths. A larger follow-up could model runtime/internal notices structurally as `session_meta`/internal events rather than text prefixes.
