### PR TITLE
fix(gateway): bridge Codex approvals to messaging platforms

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -601,37 +601,26 @@ class CodexAppServerSession:
             except Exception:
                 logger.exception("approval_callback raised on exec request")
                 return "decline"
+        try:
+            from tools.approval import request_gateway_approval
+
+            choice = request_gateway_approval(
+                command,
+                description,
+                pattern_key="codex:exec",
+                surface="codex_app_server",
+            )
+            return _approval_choice_to_codex_decision(choice)
+        except Exception:
+            logger.exception("gateway approval bridge raised on exec request")
+            return "decline"
         return "decline"  # fail-closed when no callback wired
 
     def _decide_apply_patch_approval(self, params: dict) -> str:
         if self._routing.auto_approve_apply_patch:
             return "accept"
+        command_label, description = self._format_apply_patch_approval(params)
         if self._approval_callback is not None:
-            # FileChangeRequestApprovalParams gives us reason + grantRoot.
-            # The actual changeset lives on the corresponding fileChange
-            # item which the projector has already cached for us — look it
-            # up by item_id so the user sees what's actually changing.
-            reason = params.get("reason")
-            grant_root = params.get("grantRoot")
-            item_id = params.get("itemId") or ""
-            change_summary = self._lookup_pending_file_change(item_id)
-            description_parts = []
-            if reason:
-                description_parts.append(reason)
-            if change_summary:
-                description_parts.append(change_summary)
-            if grant_root:
-                description_parts.append(f"grants write to {grant_root}")
-            description = (
-                "; ".join(description_parts)
-                if description_parts
-                else "Codex requests to apply a patch"
-            )
-            command_label = (
-                f"apply_patch: {change_summary}" if change_summary
-                else f"apply_patch: {reason}" if reason
-                else "apply_patch"
-            )
             try:
                 choice = self._approval_callback(
                     command_label,
@@ -642,7 +631,45 @@ class CodexAppServerSession:
             except Exception:
                 logger.exception("approval_callback raised on apply_patch")
                 return "decline"
+        try:
+            from tools.approval import request_gateway_approval
+
+            choice = request_gateway_approval(
+                command_label,
+                description,
+                pattern_key="codex:apply_patch",
+                surface="codex_app_server",
+            )
+            return _approval_choice_to_codex_decision(choice)
+        except Exception:
+            logger.exception("gateway approval bridge raised on apply_patch")
+            return "decline"
         return "decline"
+
+    def _format_apply_patch_approval(self, params: dict) -> tuple[str, str]:
+        """Return ``(command_label, description)`` for Codex file changes."""
+        reason = params.get("reason")
+        grant_root = params.get("grantRoot")
+        item_id = params.get("itemId") or ""
+        change_summary = self._lookup_pending_file_change(item_id)
+        description_parts = []
+        if reason:
+            description_parts.append(reason)
+        if change_summary:
+            description_parts.append(change_summary)
+        if grant_root:
+            description_parts.append(f"grants write to {grant_root}")
+        description = (
+            "; ".join(description_parts)
+            if description_parts
+            else "Codex requests to apply a patch"
+        )
+        command_label = (
+            f"apply_patch: {change_summary}" if change_summary
+            else f"apply_patch: {reason}" if reason
+            else "apply_patch"
+        )
+        return command_label, description
 
     def _track_pending_file_change(self, note: dict) -> None:
         """Maintain self._pending_file_changes from item/started + item/completed

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -315,6 +315,45 @@ class TestServerRequestRouting:
         s.run_turn("hi", turn_timeout=1.0)
         assert ("req-1", {"decision": "decline"}) in client.responses
 
+    def test_exec_approval_without_callback_uses_gateway_queue(self, monkeypatch):
+        """Gateway sessions have no CLI callback, but Codex approvals must
+        still notify and wait on the gateway approval queue."""
+        from tools import approval
+
+        approval._gateway_queues.clear()
+        approval._gateway_notify_cbs.clear()
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        token = approval.set_current_session_key("agent:main:telegram:dm:1")
+        notified = {}
+
+        def notify(data):
+            notified.update(data)
+            approval.resolve_gateway_approval("agent:main:telegram:dm:1", "once")
+
+        approval.register_gateway_notify("agent:main:telegram:dm:1", notify)
+        try:
+            client = FakeClient()
+            client.queue_server_request(
+                "item/commandExecution/requestApproval", request_id="req-gw-1",
+                command="python migrate.py", cwd="/repo", reason="needs write access",
+            )
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
+            s = make_session(client)
+            s.run_turn("hi", turn_timeout=1.0)
+        finally:
+            approval.unregister_gateway_notify("agent:main:telegram:dm:1")
+            approval.reset_current_session_key(token)
+            approval._gateway_queues.clear()
+            approval._gateway_notify_cbs.clear()
+
+        assert notified["command"] == "python migrate.py"
+        assert notified["pattern_key"] == "codex:exec"
+        assert "Codex requests exec in /repo" in notified["description"]
+        assert ("req-gw-1", {"decision": "accept"}) in client.responses
+
     def test_apply_patch_approval_session_maps_to_session_decision(self):
         client = FakeClient()
         client.queue_server_request(
@@ -336,6 +375,47 @@ class TestServerRequestRouting:
         s = make_session(client, approval_callback=cb)
         s.run_turn("hi", turn_timeout=1.0)
         assert ("req-2", {"decision": "acceptForSession"}) in client.responses
+
+    def test_apply_patch_approval_without_callback_uses_gateway_queue(self, monkeypatch):
+        from tools import approval
+
+        approval._gateway_queues.clear()
+        approval._gateway_notify_cbs.clear()
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        token = approval.set_current_session_key("agent:main:telegram:dm:1")
+        notified = {}
+
+        def notify(data):
+            notified.update(data)
+            approval.resolve_gateway_approval("agent:main:telegram:dm:1", "session")
+
+        approval.register_gateway_notify("agent:main:telegram:dm:1", notify)
+        try:
+            client = FakeClient()
+            client.queue_server_request(
+                "item/fileChange/requestApproval", request_id="req-gw-2",
+                itemId="fc-1",
+                turnId="t1",
+                threadId="th",
+                reason="modify config file",
+                grantRoot="/repo",
+            )
+            client.queue_notification(
+                "turn/completed", threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
+            s = make_session(client)
+            s.run_turn("hi", turn_timeout=1.0)
+        finally:
+            approval.unregister_gateway_notify("agent:main:telegram:dm:1")
+            approval.reset_current_session_key(token)
+            approval._gateway_queues.clear()
+            approval._gateway_notify_cbs.clear()
+
+        assert notified["command"] == "apply_patch: modify config file"
+        assert notified["pattern_key"] == "codex:apply_patch"
+        assert "grants write to /repo" in notified["description"]
+        assert ("req-gw-2", {"decision": "acceptForSession"}) in client.responses
 
     def test_unknown_server_request_replied_with_error(self):
         client = FakeClient()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -551,6 +551,131 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def request_gateway_approval(
+    command: str,
+    description: str,
+    *,
+    pattern_key: str = "external:approval",
+    pattern_keys: Optional[list[str]] = None,
+    surface: str = "gateway",
+) -> str:
+    """Request an arbitrary gateway approval and block for the user's choice.
+
+    This is the gateway analogue of ``prompt_dangerous_approval()`` for
+    callers that already know an operation requires approval, but do not flow
+    through ``check_all_command_guards()``.  The Codex app-server transport is
+    the main user: Codex emits its own exec/apply-patch approval requests, so
+    Hermes must bridge those requests to Telegram/Discord/etc. instead of
+    relying on Hermes' regex detector to rediscover them.
+
+    Returns one of ``once``, ``session``, ``always``, or ``deny``.  Failures,
+    missing gateway context, and timeouts all return ``deny`` (fail closed).
+    """
+    session_key = get_current_session_key(default="")
+    if not session_key or not _is_gateway_approval_context():
+        return "deny"
+
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        return "deny"
+
+    keys = list(pattern_keys or [pattern_key])
+    if pattern_key not in keys:
+        keys.insert(0, pattern_key)
+    approval_data = {
+        "command": command,
+        "pattern_key": pattern_key,
+        "pattern_keys": keys,
+        "description": description,
+    }
+    entry = _ApprovalEntry(approval_data)
+    with _lock:
+        _gateway_queues.setdefault(session_key, []).append(entry)
+
+    _fire_approval_hook(
+        "pre_approval_request",
+        command=command,
+        description=description,
+        pattern_key=pattern_key,
+        pattern_keys=list(keys),
+        session_key=session_key,
+        surface=surface,
+    )
+
+    try:
+        notify_cb(approval_data)
+    except Exception as exc:
+        logger.warning("Gateway approval notify failed: %s", exc)
+        with _lock:
+            queue = _gateway_queues.get(session_key, [])
+            if entry in queue:
+                queue.remove(entry)
+            if not queue:
+                _gateway_queues.pop(session_key, None)
+        _fire_approval_hook(
+            "post_approval_response",
+            command=command,
+            description=description,
+            pattern_key=pattern_key,
+            pattern_keys=list(keys),
+            session_key=session_key,
+            surface=surface,
+            choice="notify_failed",
+        )
+        return "deny"
+
+    timeout = _get_approval_config().get("gateway_timeout", 300)
+    try:
+        timeout = int(timeout)
+    except (ValueError, TypeError):
+        timeout = 300
+
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:  # pragma: no cover
+        touch_activity_if_due = None
+
+    _now = time.monotonic()
+    _deadline = _now + max(timeout, 0)
+    _activity_state = {"last_touch": _now, "start": _now}
+    resolved = False
+    while True:
+        _remaining = _deadline - time.monotonic()
+        if _remaining <= 0:
+            break
+        if entry.event.wait(timeout=min(1.0, _remaining)):
+            resolved = True
+            break
+        if touch_activity_if_due is not None:
+            touch_activity_if_due(_activity_state, "waiting for user approval")
+
+    with _lock:
+        queue = _gateway_queues.get(session_key, [])
+        if entry in queue:
+            queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+    choice = entry.result
+    outcome = "timeout" if not resolved else (choice if choice else "timeout")
+    _fire_approval_hook(
+        "post_approval_response",
+        command=command,
+        description=description,
+        pattern_key=pattern_key,
+        pattern_keys=list(keys),
+        session_key=session_key,
+        surface=surface,
+        choice=outcome,
+    )
+    if not resolved or choice is None:
+        return "deny"
+    if choice in {"once", "session", "always", "deny"}:
+        return choice
+    return "deny"
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:


### PR DESCRIPTION
## Summary

- add a reusable gateway approval helper for operations that already know they need user approval
- bridge Codex app-server exec/apply-patch approval requests into Hermes' existing gateway approval queue
- cover both exec and file-change approvals without a CLI callback, matching Telegram/Discord/etc. gateway sessions

## Verification

- `./venv/bin/python -m pytest tests/agent/transports/test_codex_app_server_session.py -q -n0`
- `./venv/bin/python -m pytest tests/gateway/test_approve_deny_commands.py tests/tools/test_approval_heartbeat.py tests/tools/test_approval_plugin_hooks.py -q -n0`
- `./scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/gateway/test_approve_deny_commands.py tests/tools/test_approval_heartbeat.py tests/tools/test_approval_plugin_hooks.py`