### PR TITLE
Protect sensitive local auth files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -91,9 +91,50 @@ def is_write_denied(path: str) -> bool:
 
 
 def get_read_block_error(path: str) -> Optional[str]:
-    """Return an error message when a read targets internal Hermes cache files."""
+    """Return an error message when a read targets sensitive local state."""
     resolved = Path(path).expanduser().resolve()
     hermes_home = _hermes_home_path().resolve()
+
+    sensitive_exact = {
+        hermes_home / ".env",
+        hermes_home / "auth.json",
+        hermes_home / "config.yaml",
+        hermes_home / "state.db",
+        hermes_home / "state.db-shm",
+        hermes_home / "state.db-wal",
+    }
+    sensitive_names = {
+        ".env",
+        "auth.json",
+        "id_rsa",
+        "id_ed25519",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+    }
+    if resolved in sensitive_exact or resolved.name in sensitive_names:
+        return (
+            f"Access denied: {path} may contain credentials, tokens, or "
+            "private Hermes state. Ask the user to inspect it manually instead."
+        )
+
+    sensitive_dirs = [
+        hermes_home / ".codex",
+        hermes_home / "sessions",
+        hermes_home / "cron",
+        hermes_home / "memories",
+        Path.home() / ".codex",
+    ]
+    for blocked in sensitive_dirs:
+        try:
+            resolved.relative_to(blocked.resolve())
+        except (ValueError, OSError):
+            continue
+        return (
+            f"Access denied: {path} is private agent/user state and cannot be "
+            "read directly by tools."
+        )
+
     blocked_dirs = [
         hermes_home / "skills" / ".hub" / "index-cache",
         hermes_home / "skills" / ".hub",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -127,6 +127,34 @@ class TestSafeCommand:
         assert desc is None
 
 
+class TestSensitiveLocalStateReadPatterns:
+    def test_cat_auth_json_requires_approval(self):
+        is_dangerous, key, desc = detect_dangerous_command("cat /opt/data/auth.json")
+        assert is_dangerous is True
+        assert key is not None
+        assert "sensitive" in desc.lower()
+
+    def test_tar_codex_dir_requires_approval(self):
+        is_dangerous, key, desc = detect_dangerous_command("tar -czf out.tgz ~/.codex")
+        assert is_dangerous is True
+        assert key is not None
+        assert "sensitive" in desc.lower()
+
+    def test_upload_hermes_data_requires_approval(self):
+        is_dangerous, key, desc = detect_dangerous_command(
+            "gh release upload v1 hermes-data/auth.json"
+        )
+        assert is_dangerous is True
+        assert key is not None
+        assert "upload" in desc.lower()
+
+    def test_ls_regular_tmp_is_safe(self):
+        is_dangerous, key, desc = detect_dangerous_command("ls -la /tmp")
+        assert is_dangerous is False
+        assert key is None
+        assert desc is None
+
+
 def _clear_session(key):
     """Replace for removed clear_session() — directly clear internal state."""
     approval_module._session_approved.pop(key, None)

--- a/tests/tools/test_file_read_safety.py
+++ b/tests/tools/test_file_read_safety.py
@@ -1,0 +1,39 @@
+"""Tests for read blocking of sensitive local Hermes state."""
+
+from pathlib import Path
+
+from agent.file_safety import get_read_block_error
+
+
+def test_hermes_env_is_blocked(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    target = hermes_home / ".env"
+    target.write_text("TOKEN=secret\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert get_read_block_error(str(target)) is not None
+
+
+def test_hermes_sessions_are_blocked(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    target = hermes_home / "sessions" / "session.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("{}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert get_read_block_error(str(target)) is not None
+
+
+def test_regular_workspace_file_is_allowed(tmp_path: Path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    target = tmp_path / "workspace" / "notes.txt"
+    target.parent.mkdir()
+    target.write_text("hello")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert get_read_block_error(str(target)) is None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -303,6 +303,8 @@ def _sudo_stdin_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
+    (r'\b(cat|less|more|head|tail|sed|awk|grep|rg|ripgrep|find|ls|tar|zip)\b.*(auth\.json\b|\.codex\b|/opt/data/(auth\.json|sessions|cron|memories|state\.db)|hermes-data\b)', "read or package sensitive Hermes/Codex files"),
+    (r'\b(curl|wget|scp|rsync|rclone|gh|git)\b.*(@|--data|--data-binary|-d\s|upload|release\s+upload|push\b).*(auth\.json\b|\.codex\b|/opt/data/(auth\.json|sessions|cron|memories|state\.db)|hermes-data\b)', "possible upload of sensitive Hermes/Codex files"),
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),


### PR DESCRIPTION
## Summary
- block reads of local auth/config/session files that may contain tokens or private state
- require approval before commands read/package or upload Hermes/Codex sensitive paths
- add regression coverage for file-read safety and approval detection

## Tests
- 
