### PR TITLE
fix(install): restrict ~/.hermes/.env to owner-only permissions (0600)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1422,6 +1422,9 @@ copy_config_templates() {
     else
         log_info "~/.hermes/.env already exists, keeping it"
     fi
+    # Always ensure restrictive permissions (0600) to protect API keys
+    chmod 0600 "$HERMES_HOME/.env" 2>/dev/null || true
+    log_success "Restricted ~/.hermes/.env to owner-only (0600)"
     configure_browser_env_from_system_browser
 
     # Create config.yaml at ~/.hermes/config.yaml (top level, easy to find)


### PR DESCRIPTION
## Problem
The install script creates `~/.hermes/.env` with default permissions (0644 or 0664), making API keys and secrets group/world-readable.

## Fix
Added `chmod 0600` after `.env` creation in `copy_config_templates()` in `scripts/install.sh`.

## Changed file
- `scripts/install.sh` — 1 line added
