### PR TITLE
fix(run_agent): defensive .get() in AIAgent.chat() to avoid KeyError on final_response

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -15577,7 +15577,7 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        return result.get("final_response") or result.get("response") or ""
 
     def _run_codex_app_server_turn(
         self,


### PR DESCRIPTION
## Summary

`AIAgent.chat()` calls `run_conversation()` and reads `result["final_response"]` directly. When `run_conversation()` returns a result dict that does not contain that key, the one-shot path (`hermes -z`) crashes with an unhandled `KeyError` and the user sees an empty stdout.

This patch swaps the direct dict access for a chained `.get()` so the chat method degrades gracefully instead of crashing.

## Repro

Hit on a custom OpenAI-compatible provider configured under the new top-level `providers:` config:

```yaml
# ~/.hermes/config.yaml
providers:
  github-models:
    base_url: https://models.github.ai/inference
    key_env: GITHUB_TOKEN
    api_mode: openai
```

```bash
hermes --provider 'custom:github-models' \
       --model 'openai/gpt-4.1-mini' \
       -z 'reply with one word: pong'
```

The same prompt against the same endpoint via raw `curl` returns a normal OpenAI-shape completion. Hermes crashes:

```
File "hermes_cli/oneshot.py", line 336, in _run_agent
    return agent.chat(prompt) or ""
File "run_agent.py", line 15580, in chat
    return result["final_response"]
KeyError: 'final_response'
```

Same shape of crash with another `custom:*` provider (Groq via `https://api.groq.com/openai/v1`), so it does not appear endpoint-specific.

## What this PR does (and doesn't)

It is **defensive only**. One line:

```python
-        return result["final_response"]
+        return result.get("final_response") or result.get("response") or ""
```

`response` is used as a secondary fallback because several streaming-completion code paths elsewhere in `run_agent.py` set that key.

It does **not** fix the root cause — there is a code path inside `run_conversation()` that returns a dict without setting `final_response` on the `custom:*` route. A follow-up should trace the early returns in `run_conversation()` (there are several `return {...}` sites near lines 12500–14310) to find the responsible branch and ensure `final_response` is always present in the result. Happy to do that as a separate PR if a maintainer can confirm the desired contract.

## Risk

Minimal. The only behavioral change is: where Hermes used to throw `KeyError` and dump a traceback to stderr, it now returns `""` to the caller. The existing call site already does `agent.chat(prompt) or ""`, so callers handling an empty string are strictly better off than with a traceback.

## Test plan

- [x] Reproduced KeyError with `custom:github-models` provider before the patch
- [x] Confirmed no crash with the patch applied
- [ ] Maintainers may want a regression test under `tests/` — happy to add one if desired (would need a fake/mocked transport since this only manifests on certain provider paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
