### PR TITLE
feat(kanban): add claude CLI dispatch bridge for Max-plan session quota

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,55 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _read_dispatch_override(profile_name: str) -> Optional[str]:
+    """Read ``dispatch_command_override`` from the profile's config.yaml.
+
+    Returns the override string if it is a non-empty str, or ``None`` if:
+    - the profile directory does not exist
+    - config.yaml is absent or unreadable
+    - the key is missing, empty, or not a string
+
+    In all error cases we emit a warning to stderr and return ``None`` so
+    ``_default_spawn`` falls back to the default hermes spawn.  We never
+    raise — the dispatcher tick must not crash due to a malformed config.
+    """
+    try:
+        from hermes_cli.profiles import get_profile_dir  # noqa: PLC0415
+        profile_dir = get_profile_dir(profile_name)
+        config_path = profile_dir / "config.yaml"
+        if not config_path.exists():
+            return None
+        import yaml as _yaml  # noqa: PLC0415
+        with config_path.open("r", encoding="utf-8") as _f:
+            raw = _yaml.safe_load(_f) or {}
+        val = raw.get("dispatch_command_override")
+        if val is None:
+            return None
+        if not isinstance(val, str):
+            print(
+                f"[kanban] WARNING: dispatch_command_override in {config_path} "
+                f"must be a string, got {type(val).__name__!r} — ignoring",
+                file=sys.stderr,
+            )
+            return None
+        val = val.strip()
+        if not val:
+            print(
+                f"[kanban] WARNING: dispatch_command_override in {config_path} "
+                "is empty — ignoring",
+                file=sys.stderr,
+            )
+            return None
+        return val
+    except Exception as _exc:
+        print(
+            f"[kanban] WARNING: could not read dispatch_command_override "
+            f"for profile {profile_name!r}: {_exc} — falling back to default spawn",
+            file=sys.stderr,
+        )
+        return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3975,6 +4024,59 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    # ---------------------------------------------------------------------------
+    # dispatch_command_override — if the profile's config.yaml defines this key,
+    # skip the default hermes spawn and run the override command instead.
+    #
+    # The override string may contain the placeholders:
+    #   ${HERMES_KANBAN_TASK}   — substituted with task.id
+    #   ${HERMES_KANBAN_BOARD}  — substituted with the resolved board slug
+    #   ${HERMES_REPO_ROOT}     — defaults to /home/josep/.local/share/hermes-agent
+    #
+    # Safety: if the override value is missing, empty, or not a string, we log
+    # a warning to stderr and fall through to the default spawn — we never crash.
+    # ---------------------------------------------------------------------------
+    _override_cmd = _read_dispatch_override(profile_arg)
+    if _override_cmd is not None:
+        import shlex as _shlex  # noqa: PLC0415
+        import string as _string  # noqa: PLC0415
+        _override_env = dict(env)
+        _override_env.setdefault("HERMES_REPO_ROOT",
+            os.environ.get("HERMES_REPO_ROOT", "/home/josep/.local/share/hermes-agent"))
+        try:
+            expanded = _string.Template(_override_cmd).safe_substitute(_override_env)
+            override_argv = _shlex.split(expanded)
+        except Exception as _exc:
+            print(
+                f"[kanban] WARNING: dispatch_command_override for profile {profile_arg!r} "
+                f"could not be parsed: {_exc} — falling back to default spawn",
+                file=sys.stderr,
+            )
+            override_argv = None
+        if override_argv:
+            log_dir = worker_logs_dir(board=board)
+            log_dir.mkdir(parents=True, exist_ok=True)
+            log_path = log_dir / f"{task.id}.log"
+            _rotate_worker_log(log_path, DEFAULT_LOG_ROTATE_BYTES)
+            log_f = open(log_path, "ab")
+            try:
+                proc = subprocess.Popen(  # noqa: S603
+                    override_argv,
+                    cwd=workspace if os.path.isdir(workspace) else None,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_f,
+                    stderr=subprocess.STDOUT,
+                    env=_override_env,
+                    start_new_session=True,
+                )
+            except FileNotFoundError:
+                log_f.close()
+                raise RuntimeError(
+                    f"dispatch_command_override executable not found: {override_argv[0]!r}. "
+                    "Check the profile's config.yaml dispatch_command_override setting."
+                )
+            return proc.pid
 
     cmd = [
         *_resolve_hermes_argv(),

--- a/scripts/claude_kanban_bridge.py
+++ b/scripts/claude_kanban_bridge.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Claude CLI Kanban Bridge.
+
+Dispatches a single Kanban task by spawning ``claude --print`` as a
+subprocess, then writes the outcome back to the Kanban DB using the
+same ``complete_task`` / ``block_task`` primitives that native Hermes
+workers use.
+
+Why this exists
+---------------
+The Hermes ``anthropic`` provider bills against Anthropic's "extra
+usage" bucket, which requires separate API credits.  The ``claude``
+CLI bills against the chat-session bucket — the same one a logged-in
+claude.ai Max user gets when they open Claude Code.  This bridge lets
+Kanban workers run entirely on Max-plan session quota with zero extra
+billing setup.
+
+Usage
+-----
+    python3 scripts/claude_kanban_bridge.py --task <task-id> [--board <slug>]
+
+Environment variables (all optional, injected by the dispatcher)
+-----------------------------------------------------------------
+HERMES_KANBAN_TASK     Task id (overridden by --task when both present)
+HERMES_KANBAN_BOARD    Board slug (overridden by --board when both present)
+HERMES_KANBAN_DB       Full path to the DB file (board resolution fallback)
+HERMES_REPO_ROOT       Absolute path to the Hermes repo root for artifact
+                       paths.  Defaults to /home/josep/.local/share/hermes-agent.
+
+Collaboration gates (respected by the spawned claude process)
+-------------------------------------------------------------
+  destructive  push  restart  config  billing  security  scope  dirty-stash
+
+The bridge instructs claude to pause at these gates for user confirmation
+before proceeding.  It never applies / pops / drops stashes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TIMEOUT_SECONDS = 600
+_DEFAULT_HERMES_REPO_ROOT = "/home/josep/.local/share/hermes-agent"
+
+# ---------------------------------------------------------------------------
+# Prompt template
+# ---------------------------------------------------------------------------
+
+_PROMPT_TEMPLATE = """\
+# Kanban task {task_id} — {board} board
+
+**Title:** {title}
+
+**Board:** {board}
+
+**Task ID:** {task_id}
+
+## Task body
+
+{body}
+
+---
+
+## Instructions
+
+You are executing this Kanban task as a claude-cli-bridge worker.
+
+1. **Do the work** described above thoroughly.
+2. When finished, emit a concise final summary (3–10 sentences) covering
+   what was done, key decisions made, and any caveats or follow-up items.
+   The summary is the last thing you write — it becomes the task's official
+   completion record in the Kanban board.
+3. **Artifact evidence:** if you produce any files or artifacts, write a
+   copy or reference to them under:
+       ~/.hermes/audits/{audit_ts}-{task_id}/
+   Create that directory if it does not exist.  This gives auditors a
+   timestamped record tied to the task.
+
+## Collaboration gates — ALWAYS pause for user confirmation before:
+
+- **destructive** — deleting / overwriting data or files irreversibly
+- **push** — pushing commits to a remote or publishing a release
+- **restart** — restarting services, containers, or system processes
+- **config** — changing machine-level or account-level configuration
+- **billing** — any action that incurs real-money cost
+- **security** — changing credentials, secrets, or access-control rules
+- **scope** — starting work that is outside the stated task description
+- **dirty-stash** — touching the git stash when the working tree is dirty
+
+## Stash rule — NEVER apply / pop / drop / clear stashes under any
+circumstances.  If the working tree has uncommitted changes that block
+progress, pause and ask the user.
+
+---
+
+Begin working on the task now.
+"""
+
+
+def _build_prompt(
+    task_id: str,
+    board: str,
+    title: str,
+    body: str | None,
+    audit_ts: str,
+) -> str:
+    return _PROMPT_TEMPLATE.format(
+        task_id=task_id,
+        board=board,
+        title=title,
+        body=body.strip() if body and body.strip() else "(no body provided)",
+        audit_ts=audit_ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB helpers — thin wrappers around kanban_db primitives
+# ---------------------------------------------------------------------------
+
+def _connect_board(board: str | None):
+    """Return a live sqlite3 connection to the board's kanban DB."""
+    from hermes_cli import kanban_db as kb  # noqa: PLC0415
+    return kb.connect(board=board)
+
+
+def _fetch_task(conn, task_id: str):
+    from hermes_cli import kanban_db as kb  # noqa: PLC0415
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id!r} not found in the kanban DB")
+    return task
+
+
+def _complete(conn, task_id: str, summary: str, metadata: dict) -> None:
+    from hermes_cli import kanban_db as kb  # noqa: PLC0415
+    kb.complete_task(conn, task_id, summary=summary, metadata=metadata)
+
+
+def _block(conn, task_id: str, reason: str) -> None:
+    from hermes_cli import kanban_db as kb  # noqa: PLC0415
+    kb.block_task(conn, task_id, reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+
+def run(task_id: str, board: str | None, *, timeout: int = _DEFAULT_TIMEOUT_SECONDS) -> int:
+    """Execute the bridge logic.  Returns 0 on success, non-zero on failure."""
+    audit_ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    # --- fetch task ---
+    with contextlib.closing(_connect_board(board)) as conn:
+        task = _fetch_task(conn, task_id)
+
+    effective_board = board or os.environ.get("HERMES_KANBAN_BOARD", "default")
+    prompt = _build_prompt(
+        task_id=task_id,
+        board=effective_board,
+        title=task.title,
+        body=task.body,
+        audit_ts=audit_ts,
+    )
+
+    # --- invoke claude CLI ---
+    claude_bin = _find_claude()
+    cmd = [claude_bin, "--print", "--output-format", "text"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        _log_error(f"claude subprocess timed out after {timeout}s for task {task_id}")
+        stderr_bytes = exc.stderr
+        if isinstance(stderr_bytes, bytes):
+            stderr_snippet = stderr_bytes.decode("utf-8", errors="replace")[:500]
+        else:
+            stderr_snippet = (stderr_bytes or "")[:500]
+        with contextlib.closing(_connect_board(board)) as conn:
+            _block(
+                conn,
+                task_id,
+                reason=(
+                    f"bridge-error: claude subprocess timed out after {timeout}s. "
+                    f"stderr: {stderr_snippet}"
+                ),
+            )
+        return 1
+    except FileNotFoundError:
+        _log_error("'claude' CLI not found on PATH. Install Claude Code to use this bridge.")
+        with contextlib.closing(_connect_board(board)) as conn:
+            _block(
+                conn,
+                task_id,
+                reason="bridge-error: 'claude' CLI not found on PATH",
+            )
+        return 1
+
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
+
+    if result.returncode != 0:
+        _log_error(
+            f"claude exited with code {result.returncode} for task {task_id}. "
+            f"stderr: {stderr[:500]}"
+        )
+        with contextlib.closing(_connect_board(board)) as conn:
+            _block(
+                conn,
+                task_id,
+                reason=(
+                    f"bridge-error: claude exited with code {result.returncode}. "
+                    f"stderr: {stderr[:500]}"
+                ),
+            )
+        return result.returncode
+
+    # --- success path ---
+    summary = stdout.strip()
+    metadata = {
+        "executor": "claude-cli-bridge",
+        "claude_exit_code": result.returncode,
+        "audit_dir": str(
+            Path.home() / ".hermes" / "audits" / f"{audit_ts}-{task_id}"
+        ),
+        "board": effective_board,
+    }
+
+    with contextlib.closing(_connect_board(board)) as conn:
+        _complete(conn, task_id, summary=summary, metadata=metadata)
+
+    _log_info(f"Task {task_id} completed successfully via claude-cli-bridge.")
+    return 0
+
+
+def _find_claude() -> str:
+    """Return the path to the ``claude`` CLI, or raise FileNotFoundError."""
+    import shutil  # noqa: PLC0415
+    path = shutil.which("claude")
+    if path:
+        return path
+    raise FileNotFoundError("'claude' not found on PATH")
+
+
+def _log_info(msg: str) -> None:
+    print(f"[claude-kanban-bridge] INFO: {msg}", file=sys.stderr)
+
+
+def _log_error(msg: str) -> None:
+    print(f"[claude-kanban-bridge] ERROR: {msg}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Dispatch a Kanban task via the claude CLI subprocess bridge.",
+    )
+    parser.add_argument(
+        "--task",
+        default=os.environ.get("HERMES_KANBAN_TASK", ""),
+        help="Kanban task id (e.g. t_abc123). Also read from HERMES_KANBAN_TASK env.",
+    )
+    parser.add_argument(
+        "--board",
+        default=os.environ.get("HERMES_KANBAN_BOARD", None),
+        help="Board slug. Also read from HERMES_KANBAN_BOARD env.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(os.environ.get("HERMES_BRIDGE_TIMEOUT", str(_DEFAULT_TIMEOUT_SECONDS))),
+        help=f"Max seconds to wait for claude (default {_DEFAULT_TIMEOUT_SECONDS}).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.task:
+        print(
+            "error: --task / HERMES_KANBAN_TASK is required",
+            file=sys.stderr,
+        )
+        return 2
+    return run(args.task, args.board or None, timeout=args.timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hermes_cli/test_claude_kanban_bridge.py
+++ b/tests/hermes_cli/test_claude_kanban_bridge.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/claude_kanban_bridge.py.
+
+All tests mock the subprocess boundary — the real `claude` CLI is never invoked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a fresh kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def ready_task(kanban_home):
+    """Return a task-id for a ready task assigned to claude-code-bridge."""
+    from hermes_cli import kanban_db as kb
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Run integration smoke tests",
+            body="Execute the smoke test suite and report failures.",
+            assignee="claude-code-bridge",
+        )
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_bridge(task_id, board=None, argv=None, monkeypatch=None):
+    """Import and call the bridge's main() function in-process."""
+    import importlib.util, os
+    spec = importlib.util.spec_from_file_location(
+        "claude_kanban_bridge",
+        "scripts/claude_kanban_bridge.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    extra = []
+    if board:
+        extra = ["--board", board]
+    return mod.main(["--task", task_id] + extra)
+
+
+# ---------------------------------------------------------------------------
+# test_bridge_completes_task_on_claude_success
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_completes_task_on_claude_success(
+    kanban_home, ready_task, monkeypatch
+):
+    """Mock claude returning exit 0 with a summary; task must end in 'done'."""
+    from hermes_cli import kanban_db as kb
+
+    fake_output = "Smoke tests passed: 42 tests, 0 failures. All green."
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = fake_output
+    fake_result.stderr = ""
+
+    with patch("subprocess.run", return_value=fake_result) as mock_run,          patch("shutil.which", return_value="/usr/local/bin/claude"):
+        rc = _run_bridge(ready_task)
+
+    assert rc == 0, f"Expected exit 0, got {rc}"
+    mock_run.assert_called_once()
+
+    # Verify the task transitioned to 'done' with the right summary/metadata.
+    with kb.connect() as conn:
+        task = kb.get_task(conn, ready_task)
+        assert task.status == "done", f"Expected done, got {task.status}"
+        summary = kb.latest_summary(conn, ready_task)
+        assert summary == fake_output.strip(), f"Summary mismatch: {summary!r}"
+
+        # Check metadata stored on the run.
+        from hermes_cli.kanban_db import list_runs
+        runs = list_runs(conn, ready_task)
+        # complete_task creates a run with outcome='completed' (not 'done')
+        done_run = next((r for r in runs if r.outcome in ("done", "completed")), None)
+        assert done_run is not None, "No completed run found"
+        meta = done_run.metadata or {}
+        assert meta.get("executor") == "claude-cli-bridge"
+        assert meta.get("claude_exit_code") == 0
+
+
+# ---------------------------------------------------------------------------
+# test_bridge_blocks_task_on_claude_failure
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_blocks_task_on_claude_failure(
+    kanban_home, ready_task, monkeypatch
+):
+    """Mock claude returning exit 1; task must end in 'blocked' with bridge-error reason."""
+    from hermes_cli import kanban_db as kb
+
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stdout = ""
+    fake_result.stderr = "Error: some internal claude error"
+
+    with patch("subprocess.run", return_value=fake_result),          patch("shutil.which", return_value="/usr/local/bin/claude"):
+        rc = _run_bridge(ready_task)
+
+    assert rc != 0, f"Expected non-zero exit, got {rc}"
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, ready_task)
+        assert task.status == "blocked", f"Expected blocked, got {task.status}"
+        # Verify the run records a bridge-error reason.
+        from hermes_cli.kanban_db import list_runs
+        runs = list_runs(conn, ready_task)
+        blocked_run = next(
+            (r for r in runs if r.outcome == "blocked"), None
+        )
+        assert blocked_run is not None, "No 'blocked' run found"
+        assert blocked_run.summary is not None
+        assert "bridge-error" in blocked_run.summary
+        assert "exit code" in blocked_run.summary.lower() or "returncode" in blocked_run.summary.lower() or "1" in blocked_run.summary
+
+
+# ---------------------------------------------------------------------------
+# test_bridge_blocks_task_on_subprocess_timeout
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_blocks_task_on_subprocess_timeout(
+    kanban_home, ready_task, monkeypatch
+):
+    """Mock subprocess.run raising TimeoutExpired; task must end in 'blocked'."""
+    from hermes_cli import kanban_db as kb
+
+    def _raise_timeout(*args, **kwargs):
+        exc = subprocess.TimeoutExpired(cmd="claude", timeout=600)
+        exc.stdout = None
+        exc.stderr = b"partial output before timeout"
+        raise exc
+
+    with patch("subprocess.run", side_effect=_raise_timeout),          patch("shutil.which", return_value="/usr/local/bin/claude"):
+        rc = _run_bridge(ready_task)
+
+    assert rc != 0, f"Expected non-zero exit, got {rc}"
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, ready_task)
+        assert task.status == "blocked", f"Expected blocked, got {task.status}"
+        from hermes_cli.kanban_db import list_runs
+        runs = list_runs(conn, ready_task)
+        blocked_run = next(
+            (r for r in runs if r.outcome == "blocked"), None
+        )
+        assert blocked_run is not None
+        assert "bridge-error" in (blocked_run.summary or "")
+        assert "timed out" in (blocked_run.summary or "").lower()

--- a/tests/hermes_cli/test_spawn_dispatch_override.py
+++ b/tests/hermes_cli/test_spawn_dispatch_override.py
@@ -1,0 +1,209 @@
+"""Tests for `_default_spawn` dispatch_command_override behaviour.
+
+All tests mock the subprocess boundary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a fresh kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def profile_dir(tmp_path, monkeypatch):
+    """Return the path to a synthetic profiles root and patch get_profile_dir."""
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+
+    from hermes_cli import profiles as _profiles_mod
+
+    def _fake_get_profile_dir(name):
+        canon = _profiles_mod.normalize_profile_name(name)
+        if canon == "default":
+            return tmp_path / ".hermes"
+        return profiles / canon
+
+    monkeypatch.setattr(_profiles_mod, "get_profile_dir", _fake_get_profile_dir)
+    monkeypatch.setattr(_profiles_mod, "profile_exists", lambda name: True)
+    return profiles
+
+
+def _make_task(task_id="t_override_test", assignee="claude-code-bridge"):
+    return kb.Task(
+        id=task_id,
+        title="Override test task",
+        body="Test body",
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+
+def _write_profile_config(profile_dir, profile_name, config_text):
+    """Write a config.yaml under profiles/<name>/."""
+    pdir = profile_dir / profile_name
+    pdir.mkdir(exist_ok=True)
+    (pdir / "config.yaml").write_text(config_text, encoding="utf-8")
+    return pdir
+
+
+# ---------------------------------------------------------------------------
+# test_spawn_override_used_when_present
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_override_used_when_present(kanban_home, profile_dir):
+    """When a profile defines dispatch_command_override, that command is run."""
+    _write_profile_config(
+        profile_dir,
+        "claude-code-bridge",
+        'dispatch_command_override: "echo hello --task t_override_test"\n',
+    )
+
+    task = _make_task()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.pid = 9999
+
+    with patch("subprocess.Popen", _FakePopen):
+        pid = kb._default_spawn(task, "/tmp/ws")
+
+    assert pid == 9999, "Should return the override process PID"
+    assert captured.get("cmd") is not None, "Popen was not called"
+    cmd_str = " ".join(captured["cmd"])
+    # The override command must be used, NOT the hermes default
+    assert "echo" in cmd_str, f"Expected 'echo' in cmd, got: {cmd_str!r}"
+    assert "hermes" not in cmd_str.lower() or "echo" in cmd_str,         f"Default hermes spawn must not run when override is set"
+
+
+# ---------------------------------------------------------------------------
+# test_spawn_override_falls_back_when_malformed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_value,label", [
+    ("", "empty string"),
+    ("   ", "whitespace only"),
+])
+def test_spawn_override_falls_back_when_malformed(
+    kanban_home, profile_dir, bad_value, label, capsys
+):
+    """Empty/whitespace override value causes fallback to default spawn + warning."""
+    import yaml
+    config_content = yaml.dump({"dispatch_command_override": bad_value})
+    _write_profile_config(profile_dir, "claude-code-bridge", config_content)
+
+    task = _make_task()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.pid = 7777
+
+    with patch("subprocess.Popen", _FakePopen):
+        pid = kb._default_spawn(task, "/tmp/ws")
+
+    # Should fall back to default hermes spawn
+    assert pid == 7777
+    cmd_str = " ".join(captured.get("cmd", []))
+    assert "hermes" in cmd_str or "hermes_cli" in cmd_str or "-p" in cmd_str,         f"Expected default hermes spawn but got: {cmd_str!r}"
+
+    out = capsys.readouterr()
+    # A warning must be emitted to stderr
+    assert "WARNING" in out.err or "ignoring" in out.err.lower() or "empty" in out.err.lower(),         f"Expected warning in stderr for {label!r}, got: {out.err!r}"
+
+
+def test_spawn_override_falls_back_when_none(kanban_home, profile_dir):
+    """If dispatch_command_override is null/None in YAML, use default spawn silently."""
+    import yaml
+    config_content = yaml.dump({"dispatch_command_override": None})
+    _write_profile_config(profile_dir, "claude-code-bridge", config_content)
+
+    task = _make_task()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.pid = 5555
+
+    with patch("subprocess.Popen", _FakePopen):
+        pid = kb._default_spawn(task, "/tmp/ws")
+
+    # None → key missing → default spawn
+    assert pid == 5555
+    cmd_str = " ".join(captured.get("cmd", []))
+    assert "hermes" in cmd_str or "-p" in cmd_str or "hermes_cli" in cmd_str,         f"Expected default hermes spawn but got: {cmd_str!r}"
+
+
+# ---------------------------------------------------------------------------
+# test_spawn_override_interpolates_env_vars
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_override_interpolates_env_vars(kanban_home, profile_dir, monkeypatch):
+    """${HERMES_KANBAN_TASK} and ${HERMES_KANBAN_BOARD} are interpolated in the command."""
+    monkeypatch.setenv("HERMES_REPO_ROOT", "/opt/hermes")
+    _write_profile_config(
+        profile_dir,
+        "claude-code-bridge",
+        'dispatch_command_override: "python3 ${HERMES_REPO_ROOT}/scripts/claude_kanban_bridge.py --task ${HERMES_KANBAN_TASK} --board ${HERMES_KANBAN_BOARD}"\n',
+    )
+
+    task = _make_task(task_id="t_interp_123")
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env", {})
+            self.pid = 8888
+
+    with patch("subprocess.Popen", _FakePopen):
+        pid = kb._default_spawn(task, "/tmp/ws")
+
+    assert pid == 8888
+    cmd = captured.get("cmd", [])
+    cmd_str = " ".join(cmd)
+
+    # HERMES_REPO_ROOT must be substituted
+    assert "/opt/hermes" in cmd_str,         f"Expected /opt/hermes in cmd: {cmd_str!r}"
+    # Task id must be substituted
+    assert "t_interp_123" in cmd_str,         f"Expected task id in cmd: {cmd_str!r}"
+    # No leftover placeholder tokens
+    assert "${HERMES_KANBAN_TASK}" not in cmd_str,         f"Unresolved placeholder in cmd: {cmd_str!r}"
+    assert "${HERMES_REPO_ROOT}" not in cmd_str,         f"Unresolved placeholder in cmd: {cmd_str!r}"


### PR DESCRIPTION
## Summary
Adds a `dispatch_command_override` mechanism in `_default_spawn` that lets a profile's `config.yaml` replace the default hermes-spawn command with an arbitrary subprocess. The bundled `claude-code-bridge` profile uses this to invoke `scripts/claude_kanban_bridge.py`, which pipes the Kanban task prompt into `claude --print` (Claude Code CLI) and writes the result back to the DB via `complete_task`/`block_task`.

This unblocks Max-plan users whose **session bucket** has abundant quota (`claude.ai/settings/usage`) but who have no `api.anthropic.com` **extra-usage** credits configured — the same bucket the `claude` CLI itself uses.

## What changes
- `scripts/claude_kanban_bridge.py` (new, 230 lines) — subprocess wrapper around `claude --print` with in-process kanban_db read/write
- `hermes_cli/kanban_db.py` (+102 lines) — `_read_dispatch_override(profile_name)` helper + override branch in `_default_spawn`. Falls back to default spawn if override is malformed/empty/None
- Tests in `tests/hermes_cli/test_claude_kanban_bridge.py` and `tests/hermes_cli/test_spawn_dispatch_override.py` — mock subprocess boundary; no live claude calls

## Wire-up after merge
1. Create `~/.hermes/profiles/claude-code-bridge/` with `dispatch_command_override: "python3 ${HERMES_REPO_ROOT}/scripts/claude_kanban_bridge.py --task ${HERMES_KANBAN_TASK} --board ${HERMES_KANBAN_BOARD}"`
2. Optional: routing rule `labels: [claude-bridge] → assignee: claude-code-bridge`
3. Restart gateway

## Test plan
- [x] 8/8 tests in the two new test files, mocked subprocess
- [x] `HERMES_REPO_ROOT` env var resolution + fallback to `/home/josep/.local/share/hermes-agent`
- [x] Malformed override values fall back to default spawn with logged warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)