### PR TITLE
fix(gateway): resolve user plugin platforms after discover_plugins()

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -448,7 +448,12 @@ class GatewayConfig:
     """
     # Platform configurations
     platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
-    
+
+    # Raw platform entries whose names couldn't be resolved to a Platform
+    # member at parse time (plugin not yet imported). Flushed into ``platforms``
+    # by ``resolve_pending_platforms()`` after discover_plugins() runs.
+    _pending_platforms: Dict[str, Any] = field(default_factory=dict)
+
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
     reset_by_type: Dict[str, SessionResetPolicy] = field(default_factory=dict)
@@ -584,12 +589,16 @@ class GatewayConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GatewayConfig":
         platforms = {}
+        pending_platforms = {}
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:
                 platform = Platform(platform_name)
                 platforms[platform] = PlatformConfig.from_dict(platform_data)
             except ValueError:
-                pass  # Skip unknown platforms
+                # Platform name unknown at parse time — plugin not yet loaded.
+                # Stash raw data; resolve_pending_platforms() flushes these
+                # after discover_plugins() registers the Platform pseudo-member.
+                pending_platforms[platform_name] = platform_data
         
         reset_by_type = {}
         for type_name, policy_data in data.get("reset_by_type", {}).items():
@@ -634,6 +643,7 @@ class GatewayConfig:
 
         return cls(
             platforms=platforms,
+            _pending_platforms=pending_platforms,
             default_reset_policy=default_policy,
             reset_by_type=reset_by_type,
             reset_by_platform=reset_by_platform,
@@ -648,6 +658,26 @@ class GatewayConfig:
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
         )
+
+    def resolve_pending_platforms(self) -> None:
+        """Retry Platform() resolution for names that failed at parse time.
+
+        Call this after discover_plugins() has run so that user-installed
+        platform plugins (which register Platform pseudo-members via
+        platform_registry at import time) are now resolvable.
+        """
+        if not self._pending_platforms:
+            return
+        resolved = []
+        for platform_name, platform_data in self._pending_platforms.items():
+            try:
+                platform = Platform(platform_name)
+                self.platforms[platform] = PlatformConfig.from_dict(platform_data)
+                resolved.append(platform_name)
+            except ValueError:
+                pass  # Still unknown — plugin didn't register it
+        for name in resolved:
+            del self._pending_platforms[name]
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
         """Return the effective unauthorized-DM behavior for a platform."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3410,6 +3410,12 @@ class GatewayRunner:
                 "plugin discovery failed at gateway startup", exc_info=True,
             )
 
+        # Flush any platform names that failed to resolve at config-parse time
+        # (before plugins were loaded). Now that discover_plugins() has run,
+        # user platform plugins have registered their Platform pseudo-members
+        # and Platform._missing_ will resolve them correctly.
+        self.config.resolve_pending_platforms()
+
         # Register declarative shell hooks from cli-config.yaml.  Gateway
         # has no TTY, so consent has to come from one of the three opt-in
         # channels (--accept-hooks on launch, HERMES_ACCEPT_HOOKS env var,


### PR DESCRIPTION
GatewayConfig.from_dict() calls Platform(name) for each entry in platforms: in config.yaml. Platform._missing_ checks platform_registry, but user plugins haven't been imported yet at that point — discover_plugins() runs later in GatewayRunner.run(). Any platform name that raises ValueError is silently dropped and never retried.

Fix:
- GatewayConfig gains a _pending_platforms field (Dict[str, Any]) to stash raw config data for names that fail Platform() at parse time.
- GatewayConfig.resolve_pending_platforms() retries resolution and flushes successfully resolved entries into self.platforms.
- GatewayRunner.run() calls resolve_pending_platforms() immediately after discover_plugins() so user platform plugins are live first.

Tested with user-installed platform plugin, kind=platform in ~/.hermes/plugins/).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

