### PR TITLE
docs: add computer-use-linux community MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ scripts/run_tests.sh
 - 💬 [Discord](https://discord.gg/NousResearch)
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
+- 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
 
 ---


### PR DESCRIPTION
## What does this PR do?

Adds `computer-use-linux` to the README Community section as an external Linux desktop-control MCP server for Hermes users.

## Related Issue

Related to #15876.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Added a community link to `README.md`.

## How to Test

1. Open the README Community section.
2. Confirm the `computer-use-linux` link points to `https://github.com/avifenesh/computer-use-linux`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this documentation update
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux desktop

Docs-only README change; Python tests are not applicable.
