### PR TITLE
fix(agent): keep image tool results from poisoning text-only sessions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9324,6 +9324,46 @@ class AIAgent:
             )
         return transformed
 
+    def _tool_result_content_for_active_model(self, tool_name: str, result: Any) -> Any:
+        """Return the tool message content that is safe for the active model.
+
+        Multimodal tool results normally unwrap to OpenAI-style content parts so
+        vision-capable models can inspect screenshots.  Text-only providers must
+        not receive those image parts, because a rejected tool result becomes
+        part of the canonical history and can make the next user turn fail before
+        the agent has a chance to recover.
+        """
+        if not _is_multimodal_tool_result(result):
+            return result
+
+        content = result.get("content") or []
+        if not self._content_has_image_parts(content):
+            return content
+
+        if self._model_supports_vision():
+            return content
+
+        summary = _multimodal_text_summary(result)
+        if tool_name == "computer_use":
+            return json.dumps({
+                "error": (
+                    "computer_use returned screenshot/image content, but the active "
+                    "model/provider does not support image input. Switch to a "
+                    "vision-capable model for desktop computer use, or use browser "
+                    "tools for browser tasks."
+                ),
+                "text_summary": summary,
+            })
+
+        logger.warning(
+            "Tool %s returned image content for non-vision model %s/%s; "
+            "falling back to text summary",
+            tool_name,
+            self.provider,
+            self.model,
+        )
+        return summary
+
     def _try_shrink_image_parts_in_messages(self, api_messages: list) -> bool:
         """Re-encode all native image parts at a smaller size to recover from
         image-too-large errors (Anthropic 5 MB, unknown other providers).
@@ -11096,14 +11136,10 @@ class AIAgent:
             # rather than a raw Python dict.  The Anthropic adapter already
             # accepts content lists; vision-capable OpenAI-compatible servers
             # (mlx-vlm, GPT-4o, …) accept image_url in tool messages natively.
-            # Text-only servers that reject images are handled by the adaptive
-            # _vision_supported recovery in the API retry loop.
+            # Text-only servers get a string-safe fallback here so a rejected
+            # image tool result never poisons canonical session history.
             # String results pass through unchanged.
-            _tool_content = (
-                function_result["content"]
-                if _is_multimodal_tool_result(function_result)
-                else function_result
-            )
+            _tool_content = self._tool_result_content_for_active_model(name, function_result)
             tool_msg = {
                 "role": "tool",
                 "name": name,
@@ -11518,11 +11554,7 @@ class AIAgent:
 
             # Unwrap _multimodal dicts to an OpenAI-style content list
             # (see parallel path for rationale). String results pass through.
-            _tool_content = (
-                function_result["content"]
-                if _is_multimodal_tool_result(function_result)
-                else function_result
-            )
+            _tool_content = self._tool_result_content_for_active_model(function_name, function_result)
             tool_msg = {
                 "role": "tool",
                 "name": function_name,
@@ -13535,6 +13567,11 @@ class AIAgent:
                         # we don't false-trip on other URL validation
                         # errors. (issue #23570)
                         "image_url'. expected",
+                        # DeepSeek's OpenAI-compatible API reports text-only
+                        # request-body variants as:
+                        # "unknown variant `image_url`, expected `text`".
+                        "unknown variant `image_url`, expected `text`",
+                        "unknown variant image_url, expected text",
                     )
                     _err_lower = _err_body.lower()
                     _looks_like_image_rejection = any(

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -591,6 +591,67 @@ class TestRunAgentMultimodalHelpers:
             for p in cleaned["content"]
         )
 
+    def test_computer_use_image_result_becomes_error_for_text_only_model(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.provider = "deepseek"
+        agent.model = "deepseek-v4-pro"
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "screen captured"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+            "text_summary": "screen captured",
+        }
+
+        with patch.object(agent, "_model_supports_vision", return_value=False):
+            content = agent._tool_result_content_for_active_model("computer_use", result)
+
+        parsed = json.loads(content)
+        assert "computer_use returned screenshot/image content" in parsed["error"]
+        assert parsed["text_summary"] == "screen captured"
+        assert "image_url" not in content
+
+    def test_computer_use_image_result_preserved_for_vision_model(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "screen captured"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+        }
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model("computer_use", result)
+
+        assert content is result["content"]
+        assert any(part.get("type") == "image_url" for part in content)
+
+    def test_other_multimodal_tool_uses_text_summary_for_text_only_model(self):
+        from run_agent import AIAgent
+
+        agent = object.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.model = "text-only"
+        result = {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "analysis text"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+            "text_summary": "analysis summary",
+        }
+
+        with patch.object(agent, "_model_supports_vision", return_value=False):
+            content = agent._tool_result_content_for_active_model("vision_analyze", result)
+
+        assert content == "analysis summary"
+
 
 # ---------------------------------------------------------------------------
 # Universality: does the schema work without Anthropic?


### PR DESCRIPTION
## What does this PR do?

Prevents `computer_use` screenshot results from poisoning text-only model sessions.

When `computer_use` returns a screenshot result while the active model/provider does not support image input, Hermes now stores a clean tool error instead of appending raw `image_url` content to the canonical conversation history. That avoids the repeated 400 loop where every later user turn resends the rejected image message before the agent can recover.

This is intentionally narrower than the existing provider-profile image fallback PRs. It does not try to make a text-only model operate the desktop from an auxiliary vision description; it fails cleanly and tells the model/user to switch to a vision-capable model for desktop computer use.

## Related Issue

Related: #23733

Related but not duplicate:

- #23743 / #23750 cover the registered provider-profile image preprocessing path.
- #24070 routes `computer_use` captures through `auxiliary.vision`; this PR takes the safer text-only behavior for desktop control by returning a tool error instead of giving the main text-only model a generated screenshot description to act on.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: added `_tool_result_content_for_active_model()` so multimodal tool results are adapted before they enter session history.
- `run_agent.py`: converts `computer_use` screenshot results into a clear tool error for text-only active models/providers.
- `run_agent.py`: preserves screenshot/image tool results for vision-capable active models.
- `run_agent.py`: recognizes DeepSeek's exact text-only image rejection wording in adaptive recovery.
- `tests/tools/test_computer_use.py`: covers text-only and vision-capable handling for `computer_use` multimodal results.

## How to Test

1. Use `computer_use` with a text-only OpenAI-compatible provider such as direct DeepSeek.
2. Confirm Hermes records a tool error instead of a raw `image_url` tool result.
3. Continue the same session and confirm later turns do not repeat the same provider-side image deserialization 400.

Targeted tests run locally:

`pytest -q tests/tools/test_computer_use.py::TestRunAgentMultimodalHelpers tests/run_agent/test_vision_aware_preprocessing.py`

Result: `19 passed in 2.89s`

Full suite run locally:

`scripts/run_tests.sh`

Result: failed in `0:11:36` with `62 failed, 22918 passed, 61 skipped, 244 warnings, 19 errors`.

The full-suite failures/errors are broad existing/global areas outside this PR's two touched files. Examples include `tests/cli/test_cli_save_config_value.py`, `tests/agent/lsp/test_client_e2e.py`, `tests/gateway/test_approve_deny_commands.py`, `tests/run_agent/test_compression_feasibility.py`, process/terminal timeout cleanup tests, and `tests/tools/test_browser_supervisor.py` teardown errors from the live-system guard blocking `os.kill(...)` on spawned Chrome PIDs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux targeted unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Support repro showed direct DeepSeek rejecting the post-`computer_use` request with:

`messages[10]: unknown variant image_url, expected text`