### PR TITLE
fix(cron): log and redact on secrets-redaction failure

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -956,8 +956,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             from agent.redact import redact_sensitive_text
             stdout = redact_sensitive_text(stdout)
             stderr = redact_sensitive_text(stderr)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to redact sensitive text from output: %s", e)
+            stdout = "[REDACTED - redaction failed]"
+            stderr = "[REDACTED - redaction failed]"
 
         if result.returncode != 0:
             parts = [f"Script exited with code {result.returncode}"]


### PR DESCRIPTION
## What does this PR do?

Fixes a silent exception swallow in `_run_job_script()` where a failure in `redact_sensitive_text()` would leave `stdout`/`stderr` unredacted, potentially leaking API keys, tokens, or other secrets into cron job delivery messages and logs.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`cron/scheduler.py`** — `_run_job_script()` redaction block:
- Replace bare `except Exception: pass` with `except Exception as e`
- Add `logger.warning()` to surface the failure with exception details
- Replace both `stdout` and `stderr` with `'[REDACTED - redaction failed]'` to prevent secrets from leaking when redaction is unavailable

## Root Cause

```python
# Before — silent failure, secrets leak
try:
    from agent.redact import redact_sensitive_text
    stdout = redact_sensitive_text(stdout)
    stderr = redact_sensitive_text(stderr)
except Exception:
    pass  # stdout/stderr left unredacted
```

```python
# After — logged + safe fallback
except Exception as e:
    logger.warning("Failed to redact sensitive text from output: %s", e)
    stdout = "[REDACTED - redaction failed]"
    stderr = "[REDACTED - redaction failed]"
```

## How to Test

```python
# Patch redact to raise, verify output is replaced
from unittest.mock import patch
with patch('agent.redact.redact_sensitive_text', side_effect=RuntimeError('test')):
    # run a cron script job — stdout/stderr should be '[REDACTED - redaction failed]'
```

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Minimal, focused change