### PR TITLE
feat: send empty placeholder draft for instant visual feedback in topic mode

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -376,6 +376,18 @@ class GatewayStreamConsumer:
                 "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
                 self.chat_id, self._draft_id,
             )
+            # Send an empty placeholder draft immediately so the user sees
+            # visual feedback before any token arrives.  Non-fatal — the
+            # normal _send_draft_frame path retries when deltas flow.
+            try:
+                await self.adapter.send_draft(
+                    chat_id=self.chat_id,
+                    draft_id=self._draft_id,
+                    content=" ",
+                    metadata=self.metadata,
+                )
+            except Exception:
+                pass
 
         try:
             while True:


### PR DESCRIPTION
## Problem

In Telegram topic mode (and similar threaded platforms), when the agent starts processing a user message, there is no immediate visual feedback — the user sees nothing until the first token arrives. This causes two issues:

1. **No real-time feedback** — the user cannot tell if the agent has started working or if their message was dropped
2. **Message drift** — without a draft "anchor", the agent's response can appear at the wrong position in the conversation, drifting up or down in the dialog

## Solution

Send an empty placeholder draft (single space) immediately when the stream consumer starts, before any tokens arrive. This is best-effort — if the draft send fails (e.g. platform doesn't support drafts), the error is silently caught and the normal streaming path continues unaffected.

## Changes

`gateway/stream_consumer.py` — 12 lines added in the native-draft transport path

## Benefits

- ✅ **Instant visual feedback** — user sees a "typing" bubble or draft appear immediately
- ✅ **Message anchor** — prevents response drift in threaded/topic conversations
- ✅ **Graceful degradation** — non-fatal if platform/draft mechanism unavailable
- ✅ **Minimal change** — single location, no config changes, no breaking changes