### PR TITLE
feat(email): add EMAIL_ACCOUNT env var for separate IMAP/SMTP login (#25849)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -9,7 +9,8 @@ Environment variables:
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
-    EMAIL_ADDRESS       — Email address for the agent
+    EMAIL_ADDRESS       — Display email address for the agent (From header)
+    EMAIL_ACCOUNT       — IMAP/SMTP login account name (defaults to EMAIL_ADDRESS if not set)
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
@@ -249,6 +250,7 @@ class EmailAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.EMAIL)
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
+        self._account = os.getenv("EMAIL_ACCOUNT", "") or self._address
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
@@ -298,7 +300,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            imap.login(self._account, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -318,7 +320,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._account, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -367,7 +369,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                imap.login(self._account, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -551,7 +553,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._account, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -673,7 +675,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._account, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -752,7 +754,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._account, self._password)
             smtp.send_message(msg)
         finally:
             try:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1206,5 +1206,68 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         mock_imap.xatom.assert_called_once()
 
 
+class TestEmailAccountEnvVar(unittest.TestCase):
+    """Verify EMAIL_ACCOUNT is used for IMAP/SMTP login while EMAIL_ADDRESS is used for display."""
+
+    def _make_adapter(self, env_overrides: dict):
+        """Create an EmailAdapter with custom env vars."""
+        from gateway.config import PlatformConfig
+        defaults = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        defaults.update(env_overrides)
+        with patch.dict(os.environ, defaults):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_account_defaults_to_address(self):
+        """When EMAIL_ACCOUNT is not set, self._account should equal self._address."""
+        adapter = self._make_adapter({})
+        self.assertEqual(adapter._account, adapter._address)
+
+    def test_account_separate_from_address(self):
+        """When EMAIL_ACCOUNT is set, self._account should be the account and self._address the display address."""
+        adapter = self._make_adapter({"EMAIL_ACCOUNT": "login@other.com"})
+        self.assertEqual(adapter._account, "login@other.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+        self.assertNotEqual(adapter._account, adapter._address)
+
+    def test_account_used_for_imap_login(self):
+        """IMAP login should use self._account instead of self._address."""
+        adapter = self._make_adapter({"EMAIL_ACCOUNT": "login@other.com"})
+        mock_imap = MagicMock()
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            with patch("gateway.platforms.email._send_imap_id"):
+                adapter._fetch_new_messages()
+        # Verify login was called with the account, not the address
+        login_calls = [c for c in mock_imap.login.call_args_list]
+        self.assertTrue(login_calls)
+        self.assertEqual(login_calls[0][0][0], "login@other.com")
+        self.assertNotEqual(login_calls[0][0][0], "hermes@test.com")
+
+    def test_address_used_for_from_header(self):
+        """msg['From'] should use self._address for the display address."""
+        adapter = self._make_adapter({"EMAIL_ACCOUNT": "login@other.com"})
+        with patch("smtplib.SMTP") as mock_smtp:
+            adapter._send_email("user@test.com", "Hello")
+        # Verify From header uses display address
+        call_msg = mock_smtp.return_value.send_message.call_args[0][0]
+        self.assertEqual(call_msg["From"], "hermes@test.com")
+
+    def test_address_domain_in_message_id(self):
+        """Message-ID domain should come from EMAIL_ADDRESS, not EMAIL_ACCOUNT."""
+        adapter = self._make_adapter({"EMAIL_ACCOUNT": "login@other.com"})
+        with patch("smtplib.SMTP") as mock_smtp:
+            adapter._send_email("user@test.com", "Hello")
+        call_msg = mock_smtp.return_value.send_message.call_args[0][0]
+        msg_id = call_msg["Message-ID"]
+        self.assertIn("@test.com", msg_id)
+        self.assertNotIn("@other.com", msg_id)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1373,6 +1373,7 @@ async def _send_email(extra, chat_id, message):
     from email.utils import formatdate
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
+    account = os.getenv("EMAIL_ACCOUNT", "") or address
     password = os.getenv("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
     try:
@@ -1392,7 +1393,7 @@ async def _send_email(extra, chat_id, message):
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=ssl.create_default_context())
-        server.login(address, password)
+        server.login(account, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}


### PR DESCRIPTION
## Summary
Closes #25849

Add `EMAIL_ACCOUNT` environment variable to separate IMAP/SMTP login credentials from the display email address. When not set, falls back to `EMAIL_ADDRESS` for backward compatibility.

## Changes
- **`gateway/platforms/email.py`**: Added `self._account` property; all IMAP/SMTP `login()` calls use `EMAIL_ACCOUNT` (fallback: `EMAIL_ADDRESS`); `From` header and Message-ID domain remain on `EMAIL_ADDRESS`
- **`tools/send_message_tool.py`**: `_send_email()` uses `EMAIL_ACCOUNT` for SMTP login
- **`tests/gateway/test_email.py`**: 5 new tests covering account/address separation, login routing, and fallback behavior

## Proof
```
tests/gateway/test_email.py  65 passed in 3.53s
```
