### PR TITLE
feat(send_message): add edit action for in-place message updates (#21859)

### DIFF
--- a/tests/tools/test_send_message_edit.py
+++ b/tests/tools/test_send_message_edit.py
@@ -1,0 +1,176 @@
+"""Tests for the edit action on the send_message tool."""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from tools.send_message_tool import SEND_MESSAGE_SCHEMA, send_message_tool
+from unittest.mock import patch, MagicMock
+
+
+class TestSchema:
+    """Verify the schema accepts the edit action and message_id parameter."""
+
+    def test_schema_accepts_edit_action(self):
+        """Schema should include 'edit' in the action enum."""
+        action_prop = SEND_MESSAGE_SCHEMA["parameters"]["properties"]["action"]
+        assert "edit" in action_prop["enum"], "edit should be a valid action"
+        assert action_prop["enum"] == ["send", "list", "edit"]
+
+    def test_schema_has_message_id(self):
+        """Schema should include message_id property."""
+        props = SEND_MESSAGE_SCHEMA["parameters"]["properties"]
+        assert "message_id" in props, "message_id should be a parameter"
+        assert props["message_id"]["type"] == "string"
+
+    def test_schema_description_mentions_edit(self):
+        """Action description should mention the edit action."""
+        action_prop = SEND_MESSAGE_SCHEMA["parameters"]["properties"]["action"]
+        assert "edit" in action_prop["description"].lower()
+
+
+class TestHandleEdit:
+    """Test the _handle_edit dispatch function."""
+
+    def test_edit_dispatches_to_adapter(self):
+        """_handle_edit should call adapter.edit_message when platform is supported."""
+        args = {
+            "action": "edit",
+            "target": "telegram:-1001234567890",
+            "message": "Updated message",
+            "message_id": "12345",
+        }
+
+        with (
+            patch("tools.send_message_tool._parse_target_ref") as mock_parse,
+            patch("gateway.config.load_gateway_config") as mock_load_cfg,
+            patch("gateway.config.Platform") as mock_platform_cls,
+            patch("tools.interrupt.is_interrupted") as mock_interrupt,
+            patch("model_tools._run_async") as mock_run,
+        ):
+            mock_parse.return_value = ("-1001234567890", None, True)
+            mock_interrupt.return_value = False
+
+            mock_platform = MagicMock()
+            mock_platform.value = "telegram"
+            mock_platform_cls.return_value = mock_platform
+
+            mock_cfg = MagicMock()
+            mock_pconfig = MagicMock()
+            mock_pconfig.enabled = True
+            mock_cfg.platforms = {mock_platform: mock_pconfig}
+            mock_load_cfg.return_value = mock_cfg
+
+            mock_run.return_value = {
+                "success": True,
+                "platform": "telegram",
+                "chat_id": "-1001234567890",
+                "message_id": "12345",
+            }
+
+            result = send_message_tool(args)
+            result_data = json.loads(result)
+
+            assert result_data["success"] is True
+            assert result_data["platform"] == "telegram"
+            assert result_data["message_id"] == "12345"
+            mock_run.assert_called_once()
+
+    def test_edit_returns_error_for_unsupported_platform(self):
+        """_handle_edit should return an error when edit_message is not supported."""
+        args = {
+            "action": "edit",
+            "target": "telegram:-1001234567890",
+            "message": "Updated message",
+            "message_id": "12345",
+        }
+
+        with (
+            patch("tools.send_message_tool._parse_target_ref") as mock_parse,
+            patch("gateway.config.load_gateway_config") as mock_load_cfg,
+            patch("gateway.config.Platform") as mock_platform_cls,
+            patch("tools.interrupt.is_interrupted") as mock_interrupt,
+            patch("model_tools._run_async") as mock_run,
+        ):
+            mock_parse.return_value = ("-1001234567890", None, True)
+            mock_interrupt.return_value = False
+
+            mock_platform = MagicMock()
+            mock_platform.value = "telegram"
+            mock_platform_cls.return_value = mock_platform
+
+            mock_cfg = MagicMock()
+            mock_pconfig = MagicMock()
+            mock_pconfig.enabled = True
+            mock_cfg.platforms = {mock_platform: mock_pconfig}
+            mock_load_cfg.return_value = mock_cfg
+
+            mock_run.return_value = {"error": "Edit not supported on this platform"}
+
+            result = send_message_tool(args)
+            result_data = json.loads(result)
+
+            assert "error" in result_data
+
+    def test_edit_returns_error_when_message_id_missing(self):
+        """_handle_edit should return an error when message_id is missing."""
+        args = {
+            "action": "edit",
+            "target": "telegram:-1001234567890",
+            "message": "Updated message",
+        }
+
+        result = send_message_tool(args)
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+
+    def test_edit_requires_target_and_message(self):
+        """_handle_edit should return an error when target or message is missing."""
+        # Missing target
+        result = send_message_tool({
+            "action": "edit",
+            "target": "",
+            "message": "Updated message",
+            "message_id": "12345",
+        })
+        assert "error" in json.loads(result)
+
+        # Missing message
+        result = send_message_tool({
+            "action": "edit",
+            "target": "telegram:-1001234567890",
+            "message": "",
+            "message_id": "12345",
+        })
+        assert "error" in json.loads(result)
+
+    def test_send_action_still_works(self):
+        """Original send action should still work unchanged."""
+        # The send action should route to _handle_send (not _handle_edit)
+        with patch("tools.send_message_tool._handle_send") as mock_send:
+            mock_send.return_value = json.dumps({
+                "success": True,
+                "platform": "telegram",
+                "chat_id": "-1001234567890",
+                "message_id": "99999",
+            })
+            result = send_message_tool({
+                "action": "send",
+                "target": "telegram:-1001234567890",
+                "message": "Hello world",
+            })
+            result_data = json.loads(result)
+            assert result_data["success"] is True
+            mock_send.assert_called_once()
+
+    def test_list_action_still_works(self):
+        """Original list action should still work unchanged."""
+        with patch("tools.send_message_tool._handle_list") as mock_list:
+            mock_list.return_value = json.dumps({"targets": ["telegram:home"]})
+            result = send_message_tool({"action": "list"})
+            result_data = json.loads(result)
+            assert "targets" in result_data
+            mock_list.assert_called_once()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -130,8 +130,8 @@ SEND_MESSAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["send", "list"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms."
+                "enum": ["send", "list", "edit"],
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'edit' edits an existing message in-place."
             },
             "target": {
                 "type": "string",
@@ -140,6 +140,10 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment."
+            },
+            "message_id": {
+                "type": "string",
+                "description": "ID of the message to edit. Required when action is 'edit'."
             }
         },
         "required": []
@@ -154,6 +158,9 @@ def send_message_tool(args, **kw):
     if action == "list":
         return _handle_list()
 
+    if action == "edit":
+        return _handle_edit(args)
+
     return _handle_send(args)
 
 
@@ -164,6 +171,111 @@ def _handle_list():
         return json.dumps({"targets": format_directory_for_display()})
     except Exception as e:
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
+
+
+def _handle_edit(args):
+    """Edit a previously sent message in-place."""
+    target = args.get("target", "")
+    message = args.get("message", "")
+    message_id = args.get("message_id", "")
+    if not target or not message or not message_id:
+        return tool_error("'target', 'message', and 'message_id' are required when action='edit'")
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    chat_id = None
+
+    if target_ref:
+        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+    else:
+        is_explicit = False
+
+    if target_ref and not is_explicit:
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(platform_name, target_ref)
+            if resolved:
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+            else:
+                return json.dumps({
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Use send_message(action='list') to see available targets."
+                })
+        except Exception:
+            return json.dumps({
+                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                f"Try using a numeric channel ID instead."
+            })
+
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return tool_error("Interrupted")
+
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+    except Exception as e:
+        return json.dumps(_error(f"Failed to load gateway config: {e}"))
+
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        return tool_error(f"Unknown platform: {platform_name}")
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        if platform_name == "weixin":
+            wx_token = os.getenv("WEIXIN_TOKEN", "").strip()
+            wx_account = os.getenv("WEIXIN_ACCOUNT_ID", "").strip()
+            if wx_token and wx_account:
+                from gateway.config import PlatformConfig
+                pconfig = PlatformConfig(
+                    enabled=True,
+                    token=wx_token,
+                    extra={
+                        "account_id": wx_account,
+                        "base_url": os.getenv("WEIXIN_BASE_URL", "").strip(),
+                        "cdn_base_url": os.getenv("WEIXIN_CDN_BASE_URL", "").strip(),
+                    },
+                )
+            else:
+                return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+        else:
+            return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+
+    if not chat_id:
+        home = config.get_home_channel(platform)
+        if not home and platform_name == "weixin":
+            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+            if wx_home:
+                from gateway.config import HomeChannel
+                home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+        if home:
+            chat_id = home.chat_id
+        else:
+            return json.dumps({
+                "error": f"No home channel set for {platform_name} to determine where to send the message. "
+                f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
+                f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
+            })
+
+    try:
+        from model_tools import _run_async
+        result = _run_async(
+            _edit_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                message_id,
+                message,
+            )
+        )
+        if isinstance(result, dict) and "error" in result:
+            result["error"] = _sanitize_error_text(result["error"])
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps(_error(f"Edit failed: {e}"))
 
 
 def _handle_send(args):
@@ -523,6 +635,31 @@ async def _send_via_adapter(
             f"register a standalone_sender_fn on its PlatformEntry."
         )
     }
+
+
+async def _edit_to_platform(
+    platform,
+    pconfig,
+    chat_id: str,
+    message_id: str,
+    message: str,
+):
+    """Edit a message on the target platform."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    adapter = BasePlatformAdapter.get_adapter(platform, pconfig)
+    if adapter is None:
+        return _error(f"No adapter available for {platform.value}")
+
+    result = await adapter.edit_message(chat_id, message_id, message)
+    if result.success:
+        return {
+            "success": True,
+            "platform": platform.value,
+            "chat_id": chat_id,
+            "message_id": result.message_id or message_id,
+        }
+    return _error(result.error or "Edit not supported on this platform")
 
 
 async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):


### PR DESCRIPTION
## Summary
Closes #21859

Add `"edit"` action to the `send_message` tool, enabling agents to update previously sent messages in-place.

## Changes
- **`tools/send_message_tool.py`**: Added `"edit"` to action enum, `message_id` parameter, `_handle_edit()` dispatch function, and `_edit_to_platform()` async handler
- **`tests/tools/test_send_message_edit.py`**: 9 tests covering schema validation, dispatch routing, error handling, and backward compatibility

## Design Notes
- All 8 platform adapters already have `edit_message()` implemented
- Base adapter returns `success=False` for unsupported platforms
- Follows the same dispatch pattern as `_handle_send()` and `_handle_list()`

## Proof
```
tests/tools/test_send_message_edit.py  9 passed in 3.01s
```
