### PR TITLE
[codex] Add Codex runtime home migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,90 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+<!-- BEGIN HERMES CODEX CODING DISCIPLINE -->
+## Codex Coding Discipline
+
+Apply these rules whenever Codex writes, fixes, refactors, reviews, or explains
+code in this repo. They adapt the `karpathy-coding` skill for a tool-using
+Codex runtime: use the terminal, inspect the codebase, edit files directly, and
+verify real behavior where practical.
+
+Core tension: trade a little speed for fewer rewrites. For obvious one-liners,
+typos, and simple explanation questions, skip the ceremony and answer directly.
+
+### Pre-flight
+
+Before changing code, know what "done" looks like in verifiable terms:
+
+| Vague request | Verifiable criterion |
+|---|---|
+| "fix the login bug" | Correct password logs in; wrong password is rejected. |
+| "make it faster" | The target operation stays under an agreed threshold. |
+| "add validation" | Named invalid inputs raise the expected error or response. |
+
+If the done condition is unclear and a wrong guess would cause a rewrite, ask a
+short clarifying question before editing. If there are multiple plausible
+interpretations, name them and ask the user to choose.
+
+State load-bearing assumptions early, either in an update or in the final
+answer. Examples: Python version, persistence behavior, whether a setting is
+CLI-only or also gateway-visible, or whether a plugin change may touch core.
+
+### Implementation Rules
+
+- Prefer the smallest change that satisfies today's request.
+- Match surrounding style exactly; avoid drive-by formatting, renames, and
+  unrelated refactors.
+- Do not add abstractions, optional parameters, config keys, logging, or broad
+  error handling unless the task needs them now.
+- Every changed line should trace back to the user's request or to verification
+  required by that request.
+- Use structured parsers and existing helpers instead of ad hoc string handling
+  when the codebase already has the right tool.
+- Keep comments rare and useful: explain non-obvious decisions, not what each
+  line does.
+
+For non-trivial tasks, work from a short plan with explicit checks:
+
+```text
+Plan:
+1. Change X -> verify with test Y or command Z.
+2. Update affected surface A -> verify behavior B.
+```
+
+### Delegation Contract
+
+Use subagents only when the user explicitly asks for delegation, parallel
+agents, or subagent work. Delegation is for bounded side work that can progress
+in parallel with the main path; do the immediate blocking investigation or edit
+locally.
+
+When delegating:
+
+- Give each subagent a concrete, self-contained task.
+- Assign clear ownership of files, modules, or read-only questions.
+- Tell workers they are not alone in the codebase and must not revert or
+  overwrite unrelated edits.
+- Do not duplicate work between the parent and subagents.
+- Prefer disjoint write sets for parallel workers.
+- Continue useful non-overlapping work locally while subagents run.
+- Review returned changes before integrating or reporting them.
+
+For Hermes runtime delegation specifically, also follow the
+`delegate_task` constraints in the **Delegation (`delegate_task`)** section
+below: leaf/orchestrator roles, concurrency caps, and the fact that
+`delegate_task` is synchronous and not durable.
+
+### Verification
+
+Run the narrowest meaningful verification first: targeted pytest, typecheck,
+lint, or an executable reproduction. Broaden only when the change touches shared
+contracts, cross-module behavior, CLI/gateway surfaces, or user-facing flows.
+
+If verification is impossible or too expensive for the current turn, say exactly
+what was not run and why. Do not imply unrun tests passed.
+<!-- END HERMES CODEX CODING DISCIPLINE -->
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.

--- a/hermes_cli/codex_runtime_home.py
+++ b/hermes_cli/codex_runtime_home.py
@@ -1,0 +1,41 @@
+"""CODEX_HOME resolution for Hermes' Codex app-server runtime.
+
+Hermes writes runtime-managed Codex config into an isolated directory by
+default so enabling the runtime cannot corrupt the user's global ~/.codex
+config. Users can still opt into a shared Codex home with CODEX_HOME or a
+runtime-specific override with HERMES_CODEX_HOME.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+
+PathLike = Union[str, os.PathLike[str], Path]
+
+
+def default_codex_runtime_home() -> Path:
+    """Return Hermes' isolated default Codex home."""
+    hermes_home = os.getenv("HERMES_HOME", "").strip()
+    base = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    return base / "codex-runtime"
+
+
+def resolve_codex_runtime_home(explicit: Optional[PathLike] = None) -> Path:
+    """Resolve the Codex home used by Hermes' app-server runtime.
+
+    Precedence:
+      1. Explicit caller override.
+      2. HERMES_CODEX_HOME, for runtime-specific isolation.
+      3. CODEX_HOME, for users who intentionally share Codex CLI state.
+      4. <HERMES_HOME or ~/.hermes>/codex-runtime.
+    """
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    for env_name in ("HERMES_CODEX_HOME", "CODEX_HOME"):
+        raw = os.getenv(env_name, "").strip()
+        if raw:
+            return Path(raw).expanduser()
+    return default_codex_runtime_home()

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -1,5 +1,5 @@
 """Migrate Hermes' MCP server config and Codex's installed curated plugins
-to the format Codex expects in ~/.codex/config.toml.
+to the format Codex expects in its app-server runtime config.toml.
 
 When the user enables the codex_app_server runtime, the codex subprocess
 runs its own MCP client and its own plugin runtime (Linear, Atlassian,
@@ -8,15 +8,15 @@ be useful, the user's choices need to be visible to codex too. This
 module:
 
   1. Reads Hermes' YAML and writes equivalent [mcp_servers.<name>]
-     entries to ~/.codex/config.toml.
+     entries to the resolved Codex runtime config.toml.
   2. Queries codex's `plugin/list` for the openai-curated marketplace
      and writes [plugins."<name>@<marketplace>"] entries for any plugin
      the user has installed=true on their codex CLI. (This is what
      OpenClaw calls "migrate native codex plugins" — the YouTube-video-
      worthy bit Pash highlighted: Canva, GitHub, Calendar, Gmail
      pre-configured.)
-  3. Writes a [permissions] default profile so users on this runtime
-     don't get an approval prompt on every write attempt.
+  3. Writes Codex's no-sandbox / never-approve defaults so Hermes-managed
+     Codex sessions inherit the same YOLO posture as Hermes approvals.mode=off.
 
 What translates (MCP servers):
   Hermes mcp_servers.<n>.command/args/env  → codex stdio transport
@@ -28,19 +28,27 @@ What does NOT translate (warned + skipped):
   Hermes-specific keys (sampling, etc.) — codex's MCP client has no
   equivalent. Listed in the per-server skipped[] field of the report.
 
-What's NOT migrated (intentional):
-  AGENTS.md — codex respects this file natively in its cwd. Hermes' own
-  AGENTS.md (project-level) is already in the worktree, so codex picks
-  it up without translation. No code needed.
+AGENTS.md handling:
+  Codex respects AGENTS.md natively in its cwd. Hermes also writes the
+  reusable codex-coding-discipline block into the resolved Codex runtime
+  home so the same operating contract is available as both a Hermes skill
+  template and a Codex instruction file.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
+import shutil
+import tempfile
+import tomllib
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
+
+from hermes_cli.codex_runtime_home import resolve_codex_runtime_home
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +62,10 @@ MIGRATION_END_MARKER = (
     "# end hermes-agent managed section"
 )
 
+_TOML_TABLE_RE = re.compile(r"^\s*\[(?!\[)(?P<name>[^\]]+)\]\s*(?:#.*)?$")
+AGENTS_MARKER = "<!-- BEGIN HERMES CODEX CODING DISCIPLINE -->"
+AGENTS_END_MARKER = "<!-- END HERMES CODEX CODING DISCIPLINE -->"
+
 
 @dataclass
 class MigrationReport:
@@ -65,7 +77,11 @@ class MigrationReport:
     migrated_plugins: list[str] = field(default_factory=list)
     plugin_query_error: Optional[str] = None
     wrote_permissions_default: Optional[str] = None
+    agents_path: Optional[Path] = None
+    wrote_agents_file: bool = False
     errors: list[str] = field(default_factory=list)
+    backup_path: Optional[Path] = None
+    validation_error: Optional[str] = None
     written: bool = False
     dry_run: bool = False
 
@@ -75,6 +91,8 @@ class MigrationReport:
             lines.append(f"(dry run) Would write {self.target_path}")
         elif self.written:
             lines.append(f"Wrote {self.target_path}")
+        if self.backup_path:
+            lines.append(f"Backup: {self.backup_path}")
         if self.migrated:
             lines.append(f"Migrated {len(self.migrated)} MCP server(s):")
             for name in self.migrated:
@@ -98,9 +116,57 @@ class MigrationReport:
                 f"Wrote default_permissions = "
                 f"{self.wrote_permissions_default!r}"
             )
+        if self.wrote_agents_file and self.agents_path:
+            lines.append(f"Wrote Codex AGENTS.md instructions: {self.agents_path}")
         for err in self.errors:
-            lines.append(f"⚠ {err}")
+            lines.append(f"⚠ {redact_secrets(err)}")
         return "\n".join(lines)
+
+
+@dataclass
+class RepairReport:
+    """Outcome of a repair pass for an existing Codex config.toml."""
+
+    target_path: Optional[Path] = None
+    corrections: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    backup_path: Optional[Path] = None
+    written: bool = False
+    dry_run: bool = False
+
+    def summary(self) -> str:
+        lines: list[str] = []
+        if self.dry_run and self.corrections:
+            lines.append(f"(dry run) Would repair {self.target_path}")
+        elif self.written:
+            lines.append(f"Repaired {self.target_path}")
+        else:
+            lines.append(f"No repair needed for {self.target_path}")
+        if self.backup_path:
+            lines.append(f"Backup: {self.backup_path}")
+        if self.corrections:
+            lines.append("Corrections:")
+            for item in self.corrections:
+                lines.append(f"  - {redact_secrets(item)}")
+        for err in self.errors:
+            lines.append(f"⚠ {redact_secrets(err)}")
+        return "\n".join(lines)
+
+
+def redact_secrets(text: Any) -> str:
+    """Redact likely secret values from user-facing logs and reports."""
+    s = str(text)
+    s = re.sub(
+        r'(?i)([A-Za-z0-9_.-]*(?:API_KEY|TOKEN|SECRET|PASSWORD|AUTH|BEARER|KEY)[A-Za-z0-9_.-]*\s*=\s*)"[^"]*"',
+        r'\1"[REDACTED_SECRET]"',
+        s,
+    )
+    s = re.sub(
+        r"(?i)(Bearer\s+)[A-Za-z0-9._~+/=-]+",
+        r"\1[REDACTED_SECRET]",
+        s,
+    )
+    return s
 
 
 # Hermes keys that codex's MCP schema doesn't support — dropped during
@@ -243,43 +309,266 @@ def _quote_key(key: str) -> str:
     escaped = key.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
 
+
+def _codex_home_from_env() -> Path:
+    return resolve_codex_runtime_home()
+
+
+def _is_start_marker(line: str) -> bool:
+    stripped = line.strip()
+    lowered = stripped.lower()
+    return (
+        stripped == MIGRATION_MARKER
+        or "begin hermes-agent managed section" in lowered
+        or "managed by hermes-agent" in lowered
+    )
+
+
+def _is_end_marker(line: str) -> bool:
+    return "end hermes-agent managed section" in line.strip().lower()
+
+
+def _table_name(line: str) -> Optional[str]:
+    match = _TOML_TABLE_RE.match(line)
+    if not match:
+        return None
+    return match.group("name").strip()
+
+
+def _iter_table_blocks(toml_text: str) -> list[tuple[Optional[str], list[str]]]:
+    """Split TOML into root/table blocks without parsing it.
+
+    This deliberately works on invalid TOML so repair can remove duplicate
+    table declarations before handing the text to tomllib.
+    """
+    blocks: list[tuple[Optional[str], list[str]]] = []
+    current_name: Optional[str] = None
+    current_lines: list[str] = []
+    for line in toml_text.splitlines(keepends=True):
+        name = _table_name(line)
+        if name is not None:
+            if current_lines:
+                blocks.append((current_name, current_lines))
+            current_name = name
+            current_lines = [line]
+            continue
+        current_lines.append(line)
+    if current_lines:
+        blocks.append((current_name, current_lines))
+    return blocks
+
+
+def _remove_table_blocks(
+    toml_text: str,
+    table_names: set[str],
+) -> tuple[str, list[str]]:
+    if not table_names:
+        return toml_text, []
+    out: list[str] = []
+    removed: list[str] = []
+    for name, block in _iter_table_blocks(toml_text):
+        if name in table_names:
+            removed.append(f"replaced existing [{name}] table")
+            continue
+        out.extend(block)
+    return "".join(out), removed
+
+
+def _dedupe_known_table_blocks(toml_text: str) -> tuple[str, list[str]]:
+    """Remove duplicate table blocks that commonly break Codex config.
+
+    The first occurrence wins. That is the least surprising repair for a
+    user-edited config, and the next migration pass can regenerate Hermes'
+    managed tables from source config.
+    """
+    prefixes = (
+        "plugins.",
+        "mcp_servers.",
+        "projects.",
+        "features",
+        "features.",
+        "permissions",
+        "permissions.",
+    )
+    seen: set[str] = set()
+    out: list[str] = []
+    corrections: list[str] = []
+    for name, block in _iter_table_blocks(toml_text):
+        should_track = bool(name) and any(
+            name == prefix.rstrip(".") or name.startswith(prefix)
+            for prefix in prefixes
+        )
+        if should_track and name in seen:
+            corrections.append(f"removed duplicate [{name}] table")
+            continue
+        if should_track and name:
+            seen.add(name)
+        out.extend(block)
+    return "".join(out), corrections
+
+
+def _remove_root_key_lines(toml_text: str, key: str) -> tuple[str, list[str]]:
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*=")
+    out: list[str] = []
+    removed = 0
+    in_root = True
+    for line in toml_text.splitlines(keepends=True):
+        if _table_name(line) is not None:
+            in_root = False
+        if in_root and pattern.match(line):
+            removed += 1
+            continue
+        out.append(line)
+    corrections = [f"replaced existing {key} key"] if removed else []
+    return "".join(out), corrections
+
+
+def _set_root_key(toml_text: str, key: str, value: Any) -> str:
+    """Insert a TOML root key before the first table declaration."""
+    line = f"{key} = {_format_toml_value(value)}\n"
+    lines = toml_text.splitlines(keepends=True)
+    first_table = next(
+        (idx for idx, existing in enumerate(lines) if _table_name(existing) is not None),
+        len(lines),
+    )
+    root = lines[:first_table]
+    rest = lines[first_table:]
+    while root and not root[-1].strip():
+        root.pop()
+    if root:
+        root.append(line)
+        root.append("\n")
+    else:
+        root = [line, "\n"]
+    return "".join(root + rest)
+
+
+def _managed_table_names(managed_block: str) -> set[str]:
+    return {
+        name
+        for name, _block in _iter_table_blocks(managed_block)
+        if name is not None
+    }
+
+
+def _validate_toml_text(text: str, path: Path) -> Optional[str]:
+    try:
+        tomllib.loads(text)
+    except Exception as exc:
+        return f"{path}: {exc}"
+    return None
+
+
+def _backup_existing_config(target: Path) -> Optional[Path]:
+    if not target.exists():
+        return None
+    backup_dir = target.parent / "backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    backup = backup_dir / f"config.toml.hermes.{stamp}.bak"
+    shutil.copy2(target, backup)
+    return backup
+
+
+def _atomic_write_validated_toml(
+    target: Path,
+    text: str,
+    *,
+    backup: bool = True,
+) -> Optional[Path]:
+    validation_error = _validate_toml_text(text, target)
+    if validation_error:
+        raise ValueError(validation_error)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    backup_path = _backup_existing_config(target) if backup else None
+    tmp_fd, tmp_path_str = tempfile.mkstemp(
+        prefix=".config.toml.", dir=str(target.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        tmp_validation_error = _validate_toml_text(
+            tmp_path.read_text(encoding="utf-8"),
+            tmp_path,
+        )
+        if tmp_validation_error:
+            raise ValueError(tmp_validation_error)
+        tmp_path.replace(target)
+        return backup_path
+    except Exception:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except Exception:
+            pass
+        raise
+
+
+def _load_codex_agents_block() -> str:
+    """Load the reusable AGENTS.md block shipped by the optional skill."""
+    from hermes_constants import get_optional_skills_dir
+
+    skill_root = (
+        get_optional_skills_dir(Path(__file__).parent.parent / "optional-skills")
+        / "software-development"
+        / "codex-coding-discipline"
+    )
+    template = skill_root / "templates" / "AGENTS.md"
+    return template.read_text(encoding="utf-8").strip() + "\n"
+
+
+def _apply_agents_block(existing: str, block: str) -> tuple[str, str]:
+    """Insert or replace the managed Codex coding discipline AGENTS block."""
+    pattern = re.compile(
+        rf"{re.escape(AGENTS_MARKER)}.*?{re.escape(AGENTS_END_MARKER)}\n?",
+        flags=re.DOTALL,
+    )
+    if pattern.search(existing):
+        return pattern.sub(block, existing), "updated"
+    if not existing.strip():
+        return block, "created"
+    return existing.rstrip() + "\n\n" + block, "appended"
+
+
+def _write_codex_agents_file(codex_home: Path) -> tuple[Path, bool, Optional[str]]:
+    """Install the reusable AGENTS.md block into the Codex runtime home."""
+    target = codex_home / "AGENTS.md"
+    try:
+        block = _load_codex_agents_block()
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        new_text, _action = _apply_agents_block(existing, block)
+        if new_text == existing:
+            return target, False, None
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(new_text, encoding="utf-8")
+        return target, True, None
+    except Exception as exc:
+        return target, False, redact_secrets(str(exc))
+
 def render_codex_toml_section(
     servers: dict[str, dict],
     plugins: Optional[list[dict]] = None,
     default_permission_profile: Optional[str] = None,
 ) -> str:
     """Render the managed [mcp_servers.<n>] / [plugins.<id>] / [permissions]
-    block for ~/.codex/config.toml.
+    block for the resolved Codex runtime config.toml.
 
     Args:
         servers: dict of MCP server name → translated codex inline-table
         plugins: optional list of {name, marketplace, enabled} for native
             Codex plugins to enable. (E.g. the Linear / Atlassian / Asana
             curated plugins, or per-account ChatGPT apps.)
-        default_permission_profile: when set, write `[permissions] default`
-            so the user doesn't get an approval prompt on every write
-            attempt. Common values: "workspace-write", "read-only",
-            "full-access".
+        default_permission_profile: deprecated for this renderer. Root-level
+            TOML keys must be written before the first table, so migrate()
+            writes default_permissions separately.
     """
     out = [MIGRATION_MARKER]
-    if not servers and not plugins and not default_permission_profile:
-        out.append("# (no MCP servers, plugins, or permissions configured by Hermes)")
+    if not servers and not plugins:
+        out.append("# (no MCP servers or plugins configured by Hermes)")
         out.append(MIGRATION_END_MARKER)
         return "\n".join(out) + "\n"
-
-    if default_permission_profile:
-        # Codex's config schema: `default_permissions` is a top-level
-        # string referencing a profile name. Built-in profile names start
-        # with ":" (":workspace-write", ":read-only", ":full-access"). The
-        # [permissions] table is for *user-defined* named profiles with
-        # structured fields — not what we want.
-        normalized = (
-            default_permission_profile
-            if default_permission_profile.startswith(":")
-            else f":{default_permission_profile}"
-        )
-        out.append("")
-        out.append(f"default_permissions = {_format_toml_value(normalized)}")
 
     if servers:
         for name in sorted(servers.keys()):
@@ -323,12 +612,12 @@ def _strip_existing_managed_block(toml_text: str) -> str:
     saw_end_marker = False
     for line in lines:
         line_stripped_nl = line.rstrip("\n")
-        if line_stripped_nl == MIGRATION_MARKER:
+        if _is_start_marker(line_stripped_nl):
             in_managed = True
             saw_end_marker = False
             continue
         if in_managed:
-            if line_stripped_nl == MIGRATION_END_MARKER:
+            if _is_end_marker(line_stripped_nl):
                 in_managed = False
                 saw_end_marker = True
                 continue
@@ -476,37 +765,49 @@ def migrate(
     codex_home: Optional[Path] = None,
     dry_run: bool = False,
     discover_plugins: bool = True,
-    default_permission_profile: Optional[str] = ":workspace",
+    default_permission_profile: Optional[str] = ":danger-no-sandbox",
+    default_approval_policy: Optional[str] = "never",
+    default_sandbox_mode: Optional[str] = "danger-full-access",
     expose_hermes_tools: bool = True,
+    install_agents_instructions: bool = True,
 ) -> MigrationReport:
     """Translate Hermes mcp_servers config + Codex curated plugins into
-    ~/.codex/config.toml.
+    Hermes' Codex runtime config.toml.
 
     Args:
         hermes_config: full ~/.hermes/config.yaml dict
-        codex_home: override CODEX_HOME (defaults to ~/.codex)
+        codex_home: override runtime Codex home. Defaults to
+            HERMES_CODEX_HOME, CODEX_HOME, or ~/.hermes/codex-runtime.
         dry_run: skip the actual write; report what would happen
         discover_plugins: when True (default), query `plugin/list` against
             the live codex CLI to migrate any installed curated plugins
             into [plugins."<name>@<marketplace>"] entries. Set False to
             skip the subprocess spawn (for tests or restricted environments).
-        default_permission_profile: when set (default ":workspace"), write
+        default_permission_profile: when set (default ":danger-no-sandbox"), write
             top-level `default_permissions = "<name>"` so users on this
-            runtime don't get an approval prompt on every write attempt.
+            runtime get full filesystem access without approval prompts.
             Built-in codex profile names are ":workspace", ":read-only",
             ":danger-no-sandbox" (note the leading ":"). Also accepts a
             user-defined profile name (no leading ":") that the user has
             configured in their own [permissions.<name>] table. Set None
             to leave permissions unset and let codex use its compiled-in
             default (which is read-only).
+        default_approval_policy: when set (default "never"), write
+            `approval_policy = "<value>"` at the TOML root.
+        default_sandbox_mode: when set (default "danger-full-access"), write
+            `sandbox_mode = "<value>"` at the TOML root.
         expose_hermes_tools: when True (default), register Hermes' own
             tool surface (web_search, browser_*, delegate_task, vision,
-            memory, skills, etc.) as an MCP server in ~/.codex/config.toml
+            memory, skills, etc.) as an MCP server in the runtime config.toml
             so the codex subprocess can call back into Hermes for tools
             codex doesn't have built in. Set False to opt out.
+        install_agents_instructions: when True (default), install the
+            reusable Codex coding-discipline AGENTS.md block into the resolved
+            Codex runtime home. The same block is shipped as the
+            codex-coding-discipline optional Hermes skill template.
     """
     report = MigrationReport(dry_run=dry_run)
-    codex_home = codex_home or Path.home() / ".codex"
+    codex_home = codex_home or _codex_home_from_env()
     target = codex_home / "config.toml"
     report.target_path = target
 
@@ -536,7 +837,7 @@ def migrate(
     if discover_plugins and not dry_run:
         plugins, plugin_err = _query_codex_plugins(codex_home=codex_home)
         if plugin_err:
-            report.plugin_query_error = plugin_err
+            report.plugin_query_error = redact_secrets(plugin_err)
         for p in plugins:
             report.migrated_plugins.append(f"{p['name']}@{p['marketplace']}")
 
@@ -558,19 +859,39 @@ def migrate(
 
     # Build the new managed block
     managed_block = render_codex_toml_section(
-        translated, plugins=plugins,
-        default_permission_profile=default_permission_profile,
+        translated,
+        plugins=plugins,
+        default_permission_profile=None,
     )
+    managed_table_names = _managed_table_names(managed_block)
 
     # Read existing codex config if any, strip the prior managed block,
-    # append the new one.
+    # remove any user/outdated tables Hermes is about to manage, append the
+    # new managed table block, then write root-level defaults before the
+    # first table so TOML semantics stay correct.
     if target.exists():
         try:
             existing = target.read_text(encoding="utf-8")
         except Exception as exc:
-            report.errors.append(f"could not read {target}: {exc}")
+            report.errors.append(redact_secrets(f"could not read {target}: {exc}"))
             return report
         without_managed = _strip_existing_managed_block(existing)
+        without_managed, dedupe_corrections = _dedupe_known_table_blocks(
+            without_managed
+        )
+        if dedupe_corrections:
+            logger.info(
+                "repaired duplicate Codex config tables during migration: %s",
+                ", ".join(dedupe_corrections),
+            )
+        without_managed, replaced_tables = _remove_table_blocks(
+            without_managed, managed_table_names
+        )
+        if replaced_tables:
+            logger.info(
+                "replaced Codex config tables during migration: %s",
+                ", ".join(replaced_tables),
+            )
         # Ensure exactly one blank line between user content and managed block
         if without_managed and not without_managed.endswith("\n"):
             without_managed += "\n"
@@ -582,33 +903,79 @@ def migrate(
     else:
         new_text = managed_block
 
+    if default_permission_profile:
+        normalized = (
+            default_permission_profile
+            if default_permission_profile.startswith(":")
+            else f":{default_permission_profile}"
+        )
+        new_text, _ = _remove_root_key_lines(new_text, "default_permissions")
+        new_text = _set_root_key(new_text, "default_permissions", normalized)
+    if default_sandbox_mode:
+        new_text, _ = _remove_root_key_lines(new_text, "sandbox_mode")
+        new_text = _set_root_key(new_text, "sandbox_mode", default_sandbox_mode)
+    if default_approval_policy:
+        new_text, _ = _remove_root_key_lines(new_text, "approval_policy")
+        new_text = _set_root_key(new_text, "approval_policy", default_approval_policy)
+
     if dry_run:
         return report
 
     try:
-        codex_home.mkdir(parents=True, exist_ok=True)
-        # Atomic write: write to a temp file in the same directory then
-        # rename. Same-directory rename is atomic on POSIX and ReplaceFile
-        # on Windows. Avoids leaving a half-written config.toml that
-        # codex would refuse to load if we crash mid-write.
-        import tempfile
-        tmp_fd, tmp_path_str = tempfile.mkstemp(
-            prefix=".config.toml.", dir=str(codex_home)
-        )
-        tmp_path = Path(tmp_path_str)
-        try:
-            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-                fh.write(new_text)
-            tmp_path.replace(target)
-        except Exception:
-            # Clean up the temp file if the rename didn't happen.
-            try:
-                if tmp_path.exists():
-                    tmp_path.unlink()
-            except Exception:
-                pass
-            raise
+        report.backup_path = _atomic_write_validated_toml(target, new_text)
         report.written = True
     except Exception as exc:
-        report.errors.append(f"could not write {target}: {exc}")
+        report.validation_error = redact_secrets(str(exc))
+        report.errors.append(redact_secrets(f"could not write {target}: {exc}"))
+        return report
+
+    if install_agents_instructions:
+        agents_path, wrote_agents, agents_error = _write_codex_agents_file(codex_home)
+        report.agents_path = agents_path
+        report.wrote_agents_file = wrote_agents
+        if agents_error:
+            report.errors.append(
+                f"could not write Codex AGENTS.md instructions at {agents_path}: {agents_error}"
+            )
+    return report
+
+
+def repair_config(
+    *,
+    codex_home: Optional[Path] = None,
+    dry_run: bool = False,
+) -> RepairReport:
+    """Repair common Codex config.toml duplicate-table failures."""
+    codex_home = codex_home or _codex_home_from_env()
+    target = codex_home / "config.toml"
+    report = RepairReport(target_path=target, dry_run=dry_run)
+    if not target.exists():
+        report.errors.append(f"{target} does not exist")
+        return report
+
+    try:
+        original = target.read_text(encoding="utf-8")
+    except Exception as exc:
+        report.errors.append(redact_secrets(f"could not read {target}: {exc}"))
+        return report
+
+    repaired, corrections = _dedupe_known_table_blocks(original)
+    report.corrections.extend(corrections)
+
+    validation_error = _validate_toml_text(repaired, target)
+    if validation_error:
+        report.errors.append(redact_secrets(validation_error))
+        return report
+
+    if repaired == original:
+        return report
+
+    if dry_run:
+        return report
+
+    try:
+        report.backup_path = _atomic_write_validated_toml(target, repaired)
+        report.written = True
+    except Exception as exc:
+        report.errors.append(redact_secrets(f"could not write {target}: {exc}"))
     return report

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -172,6 +172,53 @@ def apply(
                 codex_version=None,
             )
 
+    msg_lines = [
+        f"openai_runtime: {current} → {new_value}",
+    ]
+    mig_report = None
+    if new_value == "codex_app_server":
+        ok, ver = _check_binary_cached()
+        if ok:
+            msg_lines.append(f"codex CLI: {ver}")
+        # Auto-migrate Hermes' MCP servers + Codex's installed curated
+        # plugins into ~/.codex/config.toml so the spawned codex subprocess
+        # sees the same tool surface AND can call back into Hermes for
+        # browser/web/delegate_task/vision/memory tools (#7 fix).
+        # If migration cannot leave Codex with a valid config.toml, do not
+        # persist the runtime switch. That avoids trapping the user in a
+        # codex_app_server startup loop.
+        try:
+            from hermes_cli.codex_runtime_plugin_migration import migrate
+            mig_report = migrate(config)
+        except Exception as exc:
+            logger.exception("codex app-server config migration failed")
+            return CodexRuntimeStatus(
+                success=False,
+                new_value=None,
+                old_value=current,
+                message=(
+                    "Cannot enable codex_app_server runtime: "
+                    f"Codex config migration failed: {exc}\n"
+                    "Runtime setting was not changed. Use `/codex-runtime auto` "
+                    "to stay on the default runtime, then run "
+                    "`hermes codex-runtime repair-config` if needed."
+                ),
+            )
+        if mig_report.validation_error or not mig_report.written:
+            return CodexRuntimeStatus(
+                success=False,
+                new_value=None,
+                old_value=current,
+                message=(
+                    "Cannot enable codex_app_server runtime: Hermes could not "
+                    "write a valid Codex config.toml.\n"
+                    + "\n".join(f"  - {err}" for err in mig_report.errors)
+                    + "\nRuntime setting was not changed. Use `/codex-runtime auto` "
+                    "to stay on the default runtime, then run "
+                    "`hermes codex-runtime repair-config`."
+                ),
+            )
+
     set_runtime(config, new_value)
     if persist_callback is not None:
         try:
@@ -185,21 +232,8 @@ def apply(
                 message=f"updated config in memory but persist failed: {exc}",
             )
 
-    msg_lines = [
-        f"openai_runtime: {current} → {new_value}",
-    ]
     if new_value == "codex_app_server":
-        ok, ver = _check_binary_cached()
-        if ok:
-            msg_lines.append(f"codex CLI: {ver}")
-        # Auto-migrate Hermes' MCP servers + Codex's installed curated
-        # plugins into ~/.codex/config.toml so the spawned codex subprocess
-        # sees the same tool surface AND can call back into Hermes for
-        # browser/web/delegate_task/vision/memory tools (#7 fix).
-        # Failures are non-fatal — the runtime change still proceeds.
-        try:
-            from hermes_cli.codex_runtime_plugin_migration import migrate
-            mig_report = migrate(config)
+        if mig_report is not None:
             # Tools/MCP servers (excluding the hermes-tools callback,
             # which is internal plumbing — surface separately).
             user_servers = [
@@ -228,6 +262,16 @@ def apply(
                     f"Default sandbox: {mig_report.wrote_permissions_default} "
                     f"(no approval prompt on every write)"
                 )
+            if mig_report.agents_path:
+                status = (
+                    "installed"
+                    if mig_report.wrote_agents_file
+                    else "already present"
+                )
+                msg_lines.append(
+                    f"Codex AGENTS.md discipline block {status}: "
+                    f"{mig_report.agents_path}"
+                )
             if "hermes-tools" in mig_report.migrated:
                 msg_lines.append(
                     "Hermes tool callback registered: codex can now use "
@@ -241,10 +285,8 @@ def apply(
                     "agent loop context.)"
                 )
             msg_lines.append(f"  (config: {mig_report.target_path})")
-            for err in mig_report.errors:
-                msg_lines.append(f"⚠ MCP migration: {err}")
-        except Exception as exc:
-            msg_lines.append(f"⚠ MCP migration skipped: {exc}")
+            if mig_report.backup_path:
+                msg_lines.append(f"  (backup: {mig_report.backup_path})")
         msg_lines.append(
             "OpenAI/Codex turns now run through `codex app-server` "
             "(terminal/file ops/patching inside Codex; "

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -223,8 +223,14 @@ def _build_command_lookup() -> dict[str, CommandDef]:
     lookup: dict[str, CommandDef] = {}
     for cmd in COMMAND_REGISTRY:
         lookup[cmd.name] = cmd
+        underscored_name = cmd.name.replace("-", "_")
+        if underscored_name != cmd.name:
+            lookup[underscored_name] = cmd
         for alias in cmd.aliases:
             lookup[alias] = cmd
+            underscored_alias = alias.replace("-", "_")
+            if underscored_alias != alias:
+                lookup[underscored_alias] = cmd
     return lookup
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9353,6 +9353,30 @@ def cmd_logs(args):
     )
 
 
+def cmd_codex_runtime(args):
+    """Codex app-server runtime maintenance commands."""
+    action = getattr(args, "codex_runtime_action", None)
+    if action == "repair-config":
+        from pathlib import Path
+
+        from hermes_cli.codex_runtime_plugin_migration import repair_config
+
+        codex_home_raw = getattr(args, "codex_home", None)
+        codex_home = Path(codex_home_raw).expanduser() if codex_home_raw else None
+        report = repair_config(
+            codex_home=codex_home,
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+        print(report.summary())
+        if report.errors:
+            sys.exit(1)
+        return
+    print(
+        "Usage: hermes codex-runtime repair-config "
+        "[--codex-home PATH] [--dry-run]"
+    )
+
+
 def _build_provider_choices() -> list[str]:
     """Build the --provider choices list from CANONICAL_PROVIDERS + 'auto'."""
     try:
@@ -9380,7 +9404,7 @@ def _build_provider_choices() -> list[str]:
 # to parse.
 _BUILTIN_SUBCOMMANDS = frozenset(
     {
-        "acp", "auth", "backup", "checkpoints", "claw", "completion",
+        "acp", "auth", "backup", "checkpoints", "claw", "codex-runtime", "completion",
         "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
@@ -9543,6 +9567,36 @@ def main():
         help="Disable TLS verification for Nous login (testing only)",
     )
     model_parser.set_defaults(func=cmd_model)
+
+    # =========================================================================
+    # codex-runtime command — repair Codex app-server integration state
+    # =========================================================================
+    codex_runtime_parser = subparsers.add_parser(
+        "codex-runtime",
+        help="Manage Codex app-server runtime integration",
+    )
+    codex_runtime_sub = codex_runtime_parser.add_subparsers(
+        dest="codex_runtime_action"
+    )
+    codex_repair = codex_runtime_sub.add_parser(
+        "repair-config",
+        help="Repair duplicate tables in Codex config.toml",
+    )
+    codex_repair.add_argument(
+        "--codex-home",
+        metavar="PATH",
+        help=(
+            "Codex home to repair (default: HERMES_CODEX_HOME, CODEX_HOME, "
+            "or ~/.hermes/codex-runtime)"
+        ),
+    )
+    codex_repair.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report changes without writing config.toml",
+    )
+    codex_runtime_parser.set_defaults(func=cmd_codex_runtime)
+    codex_repair.set_defaults(func=cmd_codex_runtime)
 
     # =========================================================================
     # fallback command — manage the fallback provider chain

--- a/optional-skills/software-development/codex-coding-discipline/SKILL.md
+++ b/optional-skills/software-development/codex-coding-discipline/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: codex-coding-discipline
+description: Apply disciplined coding and delegation rules.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [codex, coding, delegation, agents, AGENTS.md]
+    category: software-development
+    related_skills: [codex, hermes-agent]
+---
+
+# Codex Coding Discipline Skill
+
+Use this skill to apply disciplined coding, scoped delegation, and explicit
+verification rules to software work. It does not replace project-specific
+architecture notes; it supplies a reusable operating contract that can also be
+installed into `AGENTS.md` for Codex and other agent runtimes.
+
+## When to Use
+
+- Writing, fixing, refactoring, extending, or reviewing code
+- Translating a Hermes skill habit into persistent workspace instructions
+- Preparing a repo for Codex app-server or Codex CLI work
+- Coordinating subagents or parallel coding workers
+
+Skip the full workflow for obvious one-line fixes, typo corrections, and simple
+code explanation questions.
+
+## Prerequisites
+
+- Hermes skill install: `hermes skills install official/software-development/codex-coding-discipline`
+- Workspace install: a writable `AGENTS.md` in the target repo, or permission
+  to create one
+
+## How to Run
+
+For a Hermes session, install or preload this skill and follow the procedure
+below.
+
+For Codex or repo-wide instructions, install the included `AGENTS.md` block:
+
+```bash
+python optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py AGENTS.md
+```
+
+From an installed skill directory, run the same script under
+`~/.hermes/skills/software-development/codex-coding-discipline/scripts/`.
+
+To print the block without writing:
+
+```bash
+python optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py --print
+```
+
+## Quick Reference
+
+- Define "done" as a verifiable outcome before editing.
+- State load-bearing assumptions early.
+- Prefer the smallest change that solves today's request.
+- Keep edits surgical and traceable to the task.
+- Delegate only bounded side work when delegation is explicitly requested.
+- Verify with the narrowest meaningful command first.
+
+## Procedure
+
+1. Convert the request into one or more concrete done criteria.
+2. Identify assumptions that would force a rewrite if wrong; ask only about
+   blocking ambiguity.
+3. Inspect the relevant code before editing.
+4. Make the minimum change that satisfies the criteria.
+5. If subagents are explicitly requested, assign disjoint ownership and concrete
+   outputs before they start.
+6. Run targeted verification, then broaden only if the touched surface warrants
+   it.
+7. Report what changed and what verification did or did not run.
+
+## Pitfalls
+
+- Do not silently choose between multiple valid interpretations.
+- Do not add abstractions for one-off code.
+- Do not bundle unrelated refactors with a bug fix.
+- Do not spawn subagents for immediate blocking work.
+- Do not claim tests passed unless they were run.
+
+## Verification
+
+For the skill package itself:
+
+```bash
+python optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py --print >/tmp/codex-discipline.md
+python optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py /tmp/AGENTS.md
+python optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py --check /tmp/AGENTS.md
+```

--- a/optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py
+++ b/optional-skills/software-development/codex-coding-discipline/scripts/install_agents_block.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Install the Codex coding discipline block into an AGENTS.md file."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+START = "<!-- BEGIN HERMES CODEX CODING DISCIPLINE -->"
+END = "<!-- END HERMES CODEX CODING DISCIPLINE -->"
+
+
+def _skill_dir() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_block() -> str:
+    path = _skill_dir() / "templates" / "AGENTS.md"
+    return path.read_text(encoding="utf-8").strip() + "\n"
+
+
+def apply_block(existing: str, block: str) -> tuple[str, str]:
+    pattern = re.compile(
+        rf"{re.escape(START)}.*?{re.escape(END)}\n?",
+        flags=re.DOTALL,
+    )
+    if pattern.search(existing):
+        return pattern.sub(block, existing), "updated"
+
+    if not existing.strip():
+        return block, "created"
+
+    separator = "\n\n" if existing.endswith("\n") else "\n\n"
+    return existing.rstrip() + separator + block, "appended"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install Hermes' Codex coding discipline into AGENTS.md."
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default="AGENTS.md",
+        help="AGENTS.md path to update, default: ./AGENTS.md",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        dest="print_block",
+        help="Print the reusable AGENTS.md block instead of writing.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 0 if the target already contains the managed block.",
+    )
+    args = parser.parse_args(argv)
+
+    block = load_block()
+    target = Path(args.target)
+
+    if args.print_block:
+        sys.stdout.write(block)
+        return 0
+
+    existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    if args.check:
+        return 0 if START in existing and END in existing else 1
+
+    new_text, action = apply_block(existing, block)
+    target.write_text(new_text, encoding="utf-8")
+    print(f"{action}: {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/software-development/codex-coding-discipline/templates/AGENTS.md
+++ b/optional-skills/software-development/codex-coding-discipline/templates/AGENTS.md
@@ -1,0 +1,78 @@
+<!-- BEGIN HERMES CODEX CODING DISCIPLINE -->
+## Codex Coding Discipline
+
+Apply these rules whenever Codex writes, fixes, refactors, reviews, or explains
+code. They adapt the `karpathy-coding` discipline for a tool-using Codex
+runtime: inspect the codebase first, edit files directly, and verify real
+behavior where practical.
+
+Core tension: trade a little speed for fewer rewrites. For obvious one-liners,
+typos, and simple explanation questions, skip the ceremony and answer directly.
+
+### Pre-flight
+
+Before changing code, know what "done" looks like in verifiable terms:
+
+| Vague request | Verifiable criterion |
+|---|---|
+| "fix the login bug" | Correct password logs in; wrong password is rejected. |
+| "make it faster" | The target operation stays under an agreed threshold. |
+| "add validation" | Named invalid inputs raise the expected error or response. |
+
+If the done condition is unclear and a wrong guess would cause a rewrite, ask a
+short clarifying question before editing. If there are multiple plausible
+interpretations, name them and ask the user to choose.
+
+State load-bearing assumptions early. Examples: runtime version, persistence
+behavior, whether a setting is local-only or cross-surface, and whether a plugin
+change may touch core.
+
+### Implementation Rules
+
+- Prefer the smallest change that satisfies today's request.
+- Match surrounding style exactly; avoid drive-by formatting, renames, and
+  unrelated refactors.
+- Do not add abstractions, optional parameters, config keys, logging, or broad
+  error handling unless the task needs them now.
+- Every changed line should trace back to the user's request or to verification
+  required by that request.
+- Use structured parsers and existing helpers instead of ad hoc string handling
+  when the codebase already has the right tool.
+- Keep comments rare and useful: explain non-obvious decisions, not what each
+  line does.
+
+For non-trivial tasks, work from a short plan with explicit checks:
+
+```text
+Plan:
+1. Change X -> verify with test Y or command Z.
+2. Update affected surface A -> verify behavior B.
+```
+
+### Delegation Contract
+
+Use subagents only when the user explicitly asks for delegation, parallel
+agents, or subagent work. Delegation is for bounded side work that can progress
+in parallel with the main path; do the immediate blocking investigation or edit
+locally.
+
+When delegating:
+
+- Give each subagent a concrete, self-contained task.
+- Assign clear ownership of files, modules, or read-only questions.
+- Tell workers they are not alone in the codebase and must not revert or
+  overwrite unrelated edits.
+- Do not duplicate work between the parent and subagents.
+- Prefer disjoint write sets for parallel workers.
+- Continue useful non-overlapping work locally while subagents run.
+- Review returned changes before integrating or reporting them.
+
+### Verification
+
+Run the narrowest meaningful verification first: targeted test, typecheck,
+lint, or an executable reproduction. Broaden only when the change touches shared
+contracts, cross-module behavior, CLI/gateway surfaces, or user-facing flows.
+
+If verification is impossible or too expensive for the current turn, say exactly
+what was not run and why. Do not imply unrun tests passed.
+<!-- END HERMES CODEX CODING DISCIPLINE -->

--- a/run_agent.py
+++ b/run_agent.py
@@ -1498,7 +1498,7 @@ class AIAgent:
         # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
         # (which creates a new AIAgent per message) won't duplicate handlers.
         from hermes_logging import setup_logging, setup_verbose_logging
-        setup_logging(hermes_home=_hermes_home)
+        setup_logging(hermes_home=get_hermes_home())
 
         if self.verbose_logging:
             setup_verbose_logging()
@@ -15700,6 +15700,9 @@ class AIAgent:
         # shutdown (see _cleanup hook).
         if not hasattr(self, "_codex_session") or self._codex_session is None:
             cwd = getattr(self, "session_cwd", None) or os.getcwd()
+            from hermes_cli.codex_runtime_home import resolve_codex_runtime_home
+
+            codex_home = str(resolve_codex_runtime_home())
             # Approval callback: defer to Hermes' standard prompt flow if a
             # CLI thread has installed one. Gateway / cron contexts get the
             # codex-side fail-closed default.
@@ -15710,6 +15713,7 @@ class AIAgent:
                 approval_callback = None
             self._codex_session = CodexAppServerSession(
                 cwd=cwd,
+                codex_home=codex_home,
                 approval_callback=approval_callback,
             )
 
@@ -15721,6 +15725,11 @@ class AIAgent:
             turn = self._codex_session.run_turn(user_input=user_message)
         except Exception as exc:
             logger.exception("codex app-server turn failed")
+            # Avoid retrying the same broken app-server path indefinitely in
+            # this cached agent. The persisted config is left alone so the
+            # user stays in control; `/codex-runtime auto` is still the
+            # explicit permanent rollback.
+            self.api_mode = "codex_responses"
             # Crash → unconditionally drop the session so the next turn
             # respawns from scratch instead of reusing a dead client.
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,8 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
     "HERMES_HOME_MODE",
+    "HERMES_CODEX_HOME",
+    "CODEX_HOME",
     # Kanban path/board pins must never leak from a developer shell or
     # dispatched worker into tests; otherwise tests can write fake tasks to
     # the real ~/.hermes/kanban.db instead of the per-test HERMES_HOME.

--- a/tests/hermes_cli/test_codex_runtime_home.py
+++ b/tests/hermes_cli/test_codex_runtime_home.py
@@ -1,0 +1,31 @@
+"""Tests for Hermes' isolated Codex runtime home resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hermes_cli.codex_runtime_home import resolve_codex_runtime_home
+
+
+def test_defaults_to_hermes_isolated_codex_home(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_CODEX_HOME", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+
+    assert resolve_codex_runtime_home() == hermes_home / "codex-runtime"
+
+
+def test_hermes_codex_home_overrides_global_codex_home(monkeypatch, tmp_path):
+    hermes_codex_home = tmp_path / "runtime-codex"
+    global_codex_home = tmp_path / "global-codex"
+    monkeypatch.setenv("HERMES_CODEX_HOME", str(hermes_codex_home))
+    monkeypatch.setenv("CODEX_HOME", str(global_codex_home))
+
+    assert resolve_codex_runtime_home() == hermes_codex_home
+
+
+def test_explicit_path_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_CODEX_HOME", str(tmp_path / "env-codex"))
+
+    assert resolve_codex_runtime_home(Path("~/explicit-codex")).name == "explicit-codex"

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
 
 from hermes_cli.codex_runtime_plugin_migration import (
+    AGENTS_END_MARKER,
+    AGENTS_MARKER,
     MIGRATION_MARKER,
     MigrationReport,
+    _apply_agents_block,
     _format_toml_value,
     _strip_existing_managed_block,
     _translate_one_server,
+    _write_codex_agents_file,
     migrate,
+    redact_secrets,
+    repair_config,
     render_codex_toml_section,
 )
 
@@ -307,6 +314,21 @@ class TestStripExistingManagedBlock:
 # ---- end-to-end migrate(, expose_hermes_tools=False) ----
 
 class TestMigrate:
+    def test_default_target_is_hermes_isolated_codex_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_CODEX_HOME", raising=False)
+        monkeypatch.delenv("CODEX_HOME", raising=False)
+
+        report = migrate({"mcp_servers": {"x": {"command": "y"}}},
+                         discover_plugins=False,
+                         expose_hermes_tools=False,
+                         default_permission_profile=None)
+
+        assert report.target_path == hermes_home / "codex-runtime" / "config.toml"
+        assert report.written
+        assert report.target_path.exists()
+
     def test_no_servers_no_plugins_no_perms_writes_placeholder(self, tmp_path):
         report = migrate({}, codex_home=tmp_path,
                          discover_plugins=False,
@@ -326,8 +348,10 @@ class TestMigrate:
         # Codex's schema: top-level `default_permissions` keying a built-in
         # profile name (prefixed with ":"). NOT a [permissions] section
         # (which is for *user-defined* profiles with structured fields).
-        assert 'default_permissions = ":workspace"' in text
-        assert report.wrote_permissions_default == ":workspace"
+        assert 'default_permissions = ":danger-no-sandbox"' in text
+        assert 'approval_policy = "never"' in text
+        assert 'sandbox_mode = "danger-full-access"' in text
+        assert report.wrote_permissions_default == ":danger-no-sandbox"
 
     def test_explicit_none_permissions_skips_block(self, tmp_path):
         report = migrate({"mcp_servers": {"x": {"command": "y"}}},
@@ -513,6 +537,50 @@ class TestMigrate:
         assert "[mcp_servers.hermes-tools]" not in text
         assert "hermes_tools_mcp_server" not in text
 
+    def test_migration_installs_codex_agents_instructions(self, tmp_path):
+        report = migrate({}, codex_home=tmp_path,
+                         discover_plugins=False,
+                         default_permission_profile=None,
+                         expose_hermes_tools=False)
+
+        agents = tmp_path / "AGENTS.md"
+        assert report.agents_path == agents
+        assert report.wrote_agents_file is True
+        text = agents.read_text(encoding="utf-8")
+        assert AGENTS_MARKER in text
+        assert AGENTS_END_MARKER in text
+        assert "Delegation Contract" in text
+
+    def test_migration_can_skip_codex_agents_instructions(self, tmp_path):
+        report = migrate({}, codex_home=tmp_path,
+                         discover_plugins=False,
+                         default_permission_profile=None,
+                         expose_hermes_tools=False,
+                         install_agents_instructions=False)
+
+        assert report.agents_path is None
+        assert not (tmp_path / "AGENTS.md").exists()
+
+    def test_agents_block_replaces_existing_managed_block(self, tmp_path):
+        first_path, first_wrote, first_error = _write_codex_agents_file(tmp_path)
+        second_path, second_wrote, second_error = _write_codex_agents_file(tmp_path)
+
+        assert first_path == second_path == tmp_path / "AGENTS.md"
+        assert first_wrote is True
+        assert second_wrote is False
+        assert first_error is None
+        assert second_error is None
+        text = first_path.read_text(encoding="utf-8")
+        assert text.count(AGENTS_MARKER) == 1
+
+    def test_apply_agents_block_preserves_user_content(self):
+        block = f"{AGENTS_MARKER}\nmanaged\n{AGENTS_END_MARKER}\n"
+        new_text, action = _apply_agents_block("Keep me.\n", block)
+
+        assert action == "appended"
+        assert new_text.startswith("Keep me.")
+        assert block in new_text
+
     def test_dry_run_doesnt_write(self, tmp_path):
         report = migrate({"mcp_servers": {"x": {"command": "y"}}},
                          codex_home=tmp_path, dry_run=True, expose_hermes_tools=False)
@@ -604,6 +672,85 @@ class TestMigrate:
         # And our managed block is still there with the new content
         assert "[mcp_servers.hermes-mcp]" in final
 
+    def test_existing_plugin_table_is_replaced_not_duplicated(self, tmp_path, monkeypatch):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'model = "gpt-5.5"\n\n'
+            '[plugins."github@openai-curated"]\n'
+            "enabled = true\n"
+        )
+        monkeypatch.setattr(crpm, "_query_codex_plugins",
+                            lambda codex_home=None, timeout=8.0: (
+                                [{"name": "github", "marketplace": "openai-curated", "enabled": True}],
+                                None,
+                            ))
+
+        report = migrate({}, codex_home=tmp_path, discover_plugins=True,
+                         default_permission_profile=None, expose_hermes_tools=False)
+
+        assert report.written
+        text = target.read_text()
+        assert text.count('[plugins."github@openai-curated"]') == 1
+        tomllib.loads(text)
+
+    def test_existing_hermes_tools_table_is_replaced_not_duplicated(self, tmp_path):
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "[mcp_servers.hermes-tools]\n"
+            'command = "old-python"\n'
+        )
+
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         default_permission_profile=None, expose_hermes_tools=True)
+
+        assert report.written
+        text = target.read_text()
+        assert text.count("[mcp_servers.hermes-tools]") == 1
+        assert "hermes_tools_mcp_server" in text
+        tomllib.loads(text)
+
+    def test_old_managed_section_variant_is_replaced_cleanly(self, tmp_path):
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'model = "gpt-5.5"\n\n'
+            "# begin hermes-agent managed section\n"
+            "[mcp_servers.old]\n"
+            'command = "old"\n'
+            "# end hermes-agent managed section\n"
+        )
+
+        migrate({"mcp_servers": {"new": {"command": "newcmd"}}},
+                codex_home=tmp_path, discover_plugins=False,
+                default_permission_profile=None, expose_hermes_tools=False)
+
+        text = target.read_text()
+        assert "mcp_servers.old" not in text
+        assert "[mcp_servers.new]" in text
+        assert text.count("managed") == 2
+        tomllib.loads(text)
+
+    def test_invalid_generated_toml_does_not_overwrite_original(self, tmp_path, monkeypatch):
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        target = tmp_path / "config.toml"
+        original = 'model = "gpt-5.5"\n'
+        target.write_text(original)
+        monkeypatch.setattr(
+            crpm,
+            "render_codex_toml_section",
+            lambda *a, **kw: "[mcp_servers.broken]\ncommand = \n",
+        )
+
+        report = migrate({"mcp_servers": {"broken": {"command": "x"}}},
+                         codex_home=tmp_path, discover_plugins=False,
+                         default_permission_profile=None, expose_hermes_tools=False)
+
+        assert not report.written
+        assert report.validation_error
+        assert target.read_text() == original
+
     def test_skipped_keys_reported(self, tmp_path):
         report = migrate({
             "mcp_servers": {
@@ -635,3 +782,49 @@ class TestMigrate:
         assert "Migrated 2 MCP server(s)" in summary
         assert "- a" in summary
         assert "- b" in summary
+
+
+class TestRepairConfig:
+    def test_repair_duplicate_plugin_table(self, tmp_path):
+        target = tmp_path / "config.toml"
+        target.write_text(
+            'model = "gpt-5.5"\n\n'
+            '[plugins."github@openai-curated"]\n'
+            "enabled = true\n\n"
+            '[plugins."github@openai-curated"]\n'
+            "enabled = true\n"
+        )
+
+        report = repair_config(codex_home=tmp_path)
+
+        assert report.written
+        assert report.backup_path and report.backup_path.exists()
+        assert any("github@openai-curated" in c for c in report.corrections)
+        text = target.read_text()
+        assert text.count('[plugins."github@openai-curated"]') == 1
+        tomllib.loads(text)
+
+    def test_repair_duplicate_features_table(self, tmp_path):
+        target = tmp_path / "config.toml"
+        target.write_text(
+            "[features]\n"
+            "experimental = true\n\n"
+            "[features]\n"
+            "experimental = true\n"
+        )
+
+        report = repair_config(codex_home=tmp_path)
+
+        assert report.written
+        assert any("[features]" in c for c in report.corrections)
+        text = target.read_text()
+        assert text.count("[features]") == 1
+        tomllib.loads(text)
+
+    def test_redacts_secret_values_in_reports(self):
+        text = redact_secrets(
+            'env = { AGENTMAIL_API_KEY = "real-secret", Authorization = "Bearer abc123" }'
+        )
+        assert "real-secret" not in text
+        assert "abc123" not in text
+        assert "[REDACTED_SECRET]" in text

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -115,7 +115,17 @@ class TestApply:
             persisted.update(c)
 
         with patch.object(crs, "check_codex_binary_ok",
-                          return_value=(True, "0.130.0")):
+                          return_value=(True, "0.130.0")), \
+             patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = ["hermes-tools"]
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = ":danger-no-sandbox"
+            mig.return_value.errors = []
+            mig.return_value.validation_error = None
+            mig.return_value.written = True
+            mig.return_value.backup_path = None
+            mig.return_value.target_path = "/fake/.codex/config.toml"
             r = crs.apply(cfg, "codex_app_server", persist_callback=persist)
         assert r.success
         assert r.new_value == "codex_app_server"
@@ -163,8 +173,11 @@ class TestApply:
             mig.return_value.migrated = ["filesystem", "hermes-tools"]
             mig.return_value.migrated_plugins = []
             mig.return_value.plugin_query_error = None
-            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.wrote_permissions_default = ":danger-no-sandbox"
             mig.return_value.errors = []
+            mig.return_value.validation_error = None
+            mig.return_value.written = True
+            mig.return_value.backup_path = None
             mig.return_value.target_path = "/fake/.codex/config.toml"
             r = crs.apply(cfg, "codex_app_server")
         assert r.success
@@ -173,7 +186,7 @@ class TestApply:
         assert "Migrated 1 MCP server" in r.message
         assert "filesystem" in r.message
         # Permissions default surfaces
-        assert "Default sandbox: :workspace" in r.message
+        assert "Default sandbox: :danger-no-sandbox" in r.message
         # Hermes tool callback announcement
         assert "via MCP" in r.message
 
@@ -188,19 +201,38 @@ class TestApply:
         assert r.success
         assert not mig.called  # disabling does not migrate
 
-    def test_migration_failure_does_not_block_enable(self):
-        """If MCP migration raises, the runtime change still proceeds —
-        users can manually re-run migration later."""
+    def test_migration_failure_blocks_enable(self):
+        """If MCP migration raises, keep the prior runtime to avoid an
+        app-server startup loop."""
         cfg = {"mcp_servers": {"x": {"command": "y"}}}
         with patch.object(crs, "check_codex_binary_ok",
                           return_value=(True, "0.130.0")), \
              patch("hermes_cli.codex_runtime_plugin_migration.migrate",
                    side_effect=RuntimeError("disk full")):
             r = crs.apply(cfg, "codex_app_server")
-        assert r.success  # change still applied
-        assert r.new_value == "codex_app_server"
-        assert "MCP migration skipped" in r.message
+        assert not r.success
+        assert r.new_value is None
+        assert cfg.get("model", {}).get("openai_runtime") in (None, "")
+        assert "Runtime setting was not changed" in r.message
         assert "disk full" in r.message
+
+    def test_invalid_migration_report_blocks_enable(self):
+        cfg = {"mcp_servers": {"x": {"command": "y"}}}
+        with patch.object(crs, "check_codex_binary_ok",
+                          return_value=(True, "0.130.0")), \
+             patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = []
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = None
+            mig.return_value.errors = ["could not write config.toml"]
+            mig.return_value.validation_error = "duplicate key"
+            mig.return_value.written = False
+            r = crs.apply(cfg, "codex_app_server")
+
+        assert not r.success
+        assert cfg.get("model", {}).get("openai_runtime") in (None, "")
+        assert "repair-config" in r.message
 
     def test_binary_check_cached_within_apply(self):
         """check_codex_binary_ok is invoked at most once per apply() call.
@@ -213,7 +245,16 @@ class TestApply:
         cfg = {}
         with patch.object(crs, "check_codex_binary_ok",
                           return_value=(True, "0.130.0")) as bin_check, \
-             patch("hermes_cli.codex_runtime_plugin_migration.migrate"):
+             patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = []
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = None
+            mig.return_value.errors = []
+            mig.return_value.validation_error = None
+            mig.return_value.written = True
+            mig.return_value.backup_path = None
+            mig.return_value.target_path = "/fake/.codex/config.toml"
             r = crs.apply(cfg, "codex_app_server")
         assert r.success
         assert bin_check.call_count == 1, (

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -109,6 +109,10 @@ class TestResolveCommand:
         assert resolve_command("reload_mcp").name == "reload-mcp"
         assert resolve_command("tasks").name == "agents"
 
+    def test_telegram_underscore_form_resolves_to_hyphenated_command(self):
+        assert resolve_command("codex_runtime").name == "codex-runtime"
+        assert resolve_command("/codex_runtime").name == "codex-runtime"
+
     def test_topic_is_gateway_command(self):
         topic = resolve_command("topic")
         assert topic is not None

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -232,6 +232,35 @@ class TestRunConversationCodexPath:
             agent.run_conversation("hi")
         assert not client_mock.chat.completions.create.called
 
+    def test_session_uses_isolated_codex_home(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                thread_id="th",
+                turn_id="t",
+            )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_CODEX_HOME", raising=False)
+        monkeypatch.delenv("CODEX_HOME", raising=False)
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "ensure_started",
+                            lambda self: "th")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["codex_home"] == str(hermes_home / "codex-runtime")
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background
@@ -320,6 +349,7 @@ class TestErrorHandling:
         assert result["partial"] is True
         assert "subprocess died" in result["error"]
         assert "codex-runtime auto" in result["final_response"]
+        assert agent.api_mode == "codex_responses"
 
     def test_interrupted_turn_marked_partial(self, monkeypatch):
         def interrupted_turn(self, user_input, **kwargs):

--- a/tests/skills/test_codex_coding_discipline_skill.py
+++ b/tests/skills/test_codex_coding_discipline_skill.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "optional-skills" / "software-development" / "codex-coding-discipline"
+SCRIPT = SKILL_DIR / "scripts" / "install_agents_block.py"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("install_agents_block", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_description_meets_listing_standard():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    line = next(line for line in text.splitlines() if line.startswith("description: "))
+    description = line.split(":", 1)[1].strip()
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_agents_installer_creates_and_checks_block(tmp_path):
+    installer = _load_script()
+    target = tmp_path / "AGENTS.md"
+
+    assert installer.main([str(target)]) == 0
+    text = target.read_text(encoding="utf-8")
+    assert installer.START in text
+    assert installer.END in text
+    assert "Delegation Contract" in text
+    assert installer.main(["--check", str(target)]) == 0
+
+
+def test_agents_installer_is_idempotent(tmp_path):
+    installer = _load_script()
+    target = tmp_path / "AGENTS.md"
+
+    assert installer.main([str(target)]) == 0
+    assert installer.main([str(target)]) == 0
+
+    text = target.read_text(encoding="utf-8")
+    assert text.count(installer.START) == 1

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -517,7 +517,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_HUMAN_DELAY_MIN_MS` | Custom delay range minimum (ms) |
 | `HERMES_HUMAN_DELAY_MAX_MS` | Custom delay range maximum (ms) |
 | `HERMES_QUIET` | Suppress non-essential output (`true`/`false`) |
-| `CODEX_HOME` | When [Codex app-server runtime](../user-guide/features/codex-app-server-runtime) is enabled, override the directory Codex CLI reads its config + auth from (default: `~/.codex`). Hermes' migration writes the managed block to `<CODEX_HOME>/config.toml`. |
+| `HERMES_CODEX_HOME` | Codex app-server runtime home used by Hermes. Overrides `CODEX_HOME` for this runtime only. Default: `<HERMES_HOME>/codex-runtime` or `~/.hermes/codex-runtime`. |
+| `CODEX_HOME` | Shared Codex CLI home. Hermes respects it when `HERMES_CODEX_HOME` is unset; otherwise Hermes uses its isolated runtime home to avoid modifying global `~/.codex/config.toml`. |
 | `HERMES_KANBAN_TASK` | Set by the kanban dispatcher when spawning a worker (task UUID). Workers and the spawned `hermes-tools` MCP subprocess inherit it so kanban tools gate correctly. Don't set manually. |
 | `HERMES_API_TIMEOUT` | LLM API call timeout in seconds (default: `1800`) |
 | `HERMES_API_CALL_STALE_TIMEOUT` | Non-streaming stale-call timeout in seconds (default: `300`). Auto-disabled for local providers when left unset. Also configurable via `providers.<id>.stale_timeout_seconds` or `providers.<id>.models.<model>.stale_timeout_seconds` in `config.yaml`. |

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -31,7 +31,7 @@ These ship with `codex app-server` itself — no Hermes involvement, no MCP, no 
 - **`view_image`** — load a local image file into the conversation so the model can see it.
 - **`web_search`** — codex has its own built-in web search when configured. Hermes also exposes `web_search` (Firecrawl-backed) via the callback below; the model picks whichever it prefers.
 
-So **anything you'd do via terminal — read/write/search/find/run — codex does natively**. The sandbox profile (`:workspace` by default when you enable the runtime) controls what's writable.
+So **anything you'd do via terminal — read/write/search/find/run — codex does natively**. The sandbox profile (`:danger-no-sandbox` by default when you enable the runtime) controls what's writable.
 
 ### 2. Native Codex plugins (auto-migrated from your `codex plugin` install)
 
@@ -51,7 +51,7 @@ What's NOT migrated:
 - Plugins you haven't installed yet — install them in Codex first.
 - ChatGPT app marketplace entries (`app/list`) — these are already enabled inside codex by virtue of your account auth.
 
-### 3. Hermes tool callback (MCP server, registered in `~/.codex/config.toml`)
+### 3. Hermes tool callback (MCP server, registered in the runtime `config.toml`)
 
 Hermes registers itself as an MCP server so codex can call back for tools codex doesn't ship with. Available via the callback:
 
@@ -79,7 +79,7 @@ These four Hermes tools require the running AIAgent context (mid-loop state) to 
 
 **Works on this runtime.** Goals persist in `state_meta` keyed by session id, the continuation prompt feeds back as a normal user message through `run_conversation()`, and codex executes the next turn natively. The goal judge runs via the auxiliary client (configured via `auxiliary.goal_judge` in config.yaml), independent of which runtime is active. The judge's "blocked, needs user input" verdict is a clean escape if codex stalls on approvals.
 
-**One thing to be aware of:** each continuation prompt is a fresh codex turn, which means codex re-evaluates command approval policy from scratch. If you're doing a long-running goal with lots of writes, expect more approval prompts than you'd see on a single in-session task. Set `default_permissions = ":workspace"` (which Hermes does automatically when you enable the runtime) so simple workspace writes don't require prompting.
+**One thing to be aware of:** each continuation prompt is a fresh codex turn, which means codex re-evaluates command approval policy from scratch. Hermes writes `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and `default_permissions = ":danger-no-sandbox"` when you enable the runtime, so Codex turns run without sandbox approval prompts unless you change the Codex config.
 
 ### Kanban (multi-agent worktree dispatch)
 
@@ -135,18 +135,18 @@ The kanban tools are gated by `HERMES_KANBAN_TASK` env var the dispatcher sets �
    npm i -g @openai/codex
    codex --version   # 0.130.0 or newer
    ```
-2. **Codex OAuth login.** The codex subprocess reads `~/.codex/auth.json`. Two ways to populate it:
+2. **Codex OAuth login.** The codex subprocess reads `<runtime-codex-home>/auth.json`. By default Hermes uses `~/.hermes/codex-runtime` so it cannot corrupt global `~/.codex/config.toml`:
    ```bash
-   codex login                  # writes tokens to ~/.codex/auth.json
+   CODEX_HOME=~/.hermes/codex-runtime codex login
    ```
-   Hermes' own `hermes auth login codex` writes to `~/.hermes/auth.json` — that's a separate session. **Run `codex login` separately** if you haven't.
+   Hermes' own `hermes auth login codex` writes to `~/.hermes/auth.json` — that's a separate session. **Run `codex login` separately** for the runtime home if you haven't.
 
 3. **(Optional) Install the Codex plugins you want.** When you enable the runtime, Hermes auto-migrates whichever curated plugins you've already installed via Codex CLI:
    ```bash
    codex plugin marketplace add openai-curated
    # then via codex's TUI, install Linear / GitHub / Gmail / etc.
    ```
-   Hermes will discover them and write `[plugins."<name>@openai-curated"]` entries to `~/.codex/config.toml` automatically.
+   Hermes will discover them and write `[plugins."<name>@openai-curated"]` entries to the runtime `config.toml` automatically.
 
 ## Enabling
 
@@ -159,10 +159,10 @@ In a Hermes session:
 That command:
 - Verifies the `codex` CLI is installed (blocks with an install hint if not).
 - Persists `model.openai_runtime: codex_app_server` to your config.yaml.
-- Migrates user MCP servers from `~/.hermes/config.yaml` to `~/.codex/config.toml`.
+- Migrates user MCP servers from `~/.hermes/config.yaml` to the isolated Codex runtime `config.toml`.
 - **Discovers and migrates installed native Codex plugins** (Linear, GitHub, Gmail, Calendar, Canva, etc.) by querying Codex's `plugin/list` RPC.
 - **Registers Hermes' own tools as an MCP server** so the codex subprocess can call back for tools codex doesn't ship with.
-- **Writes `default_permissions = ":workspace"`** so the sandbox allows writes within the workspace without prompting for every operation.
+- **Writes `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and `default_permissions = ":danger-no-sandbox"`** so the runtime has full filesystem access without prompting for every operation.
 - Tells you what was migrated. Takes effect on the **next** session — the current cached agent keeps the prior runtime so prompt caches stay valid.
 
 Synonyms: `/codex-runtime on`, `/codex-runtime off`, `/codex-runtime auto`.
@@ -229,13 +229,15 @@ For `apply_patch` (file edit) approvals, Hermes shows a summary of what changed 
 
 Codex has three built-in permission profiles:
 - `:read-only` — no writes; every shell command requires approval
-- `:workspace` — writes within the current workspace allowed without prompts (Hermes' default when you enable the runtime)
-- `:danger-no-sandbox` — no sandbox at all (don't use this unless you understand it)
+- `:workspace` — writes within the current workspace allowed without prompts
+- `:danger-no-sandbox` — no sandbox at all (Hermes' default when you enable the runtime)
 
-You can override the default in `~/.codex/config.toml` outside Hermes' managed block:
+You can override the default in the runtime `config.toml` outside Hermes' managed block:
 
 ```toml
 default_permissions = ":read-only"
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
 ```
 
 (Hermes will preserve your override on re-migration as long as it lives outside the `# managed by hermes-agent` markers.)
@@ -269,13 +271,15 @@ auxiliary:
 
 The self-improvement review fork inherits the main runtime via `_current_main_runtime()` and Hermes downgrades it from `codex_app_server` to `codex_responses` automatically (so the fork can actually call `memory` and `skill_manage` — Hermes' own agent-loop tools). That fork still uses your subscription auth unless you've routed aux tasks elsewhere.
 
-## Editing `~/.codex/config.toml` safely
+## Editing Runtime `config.toml` Safely
 
 Hermes wraps everything it manages between two marker comments:
 
 ```toml
 # managed by hermes-agent — `hermes codex-runtime migrate` regenerates this section
-default_permissions = ":workspace"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+default_permissions = ":danger-no-sandbox"
 [mcp_servers.filesystem]
 ...
 [plugins."github@openai-curated"]
@@ -286,7 +290,7 @@ default_permissions = ":workspace"
 Anything **outside** that block is yours. Re-running migration (via `/codex-runtime codex_app_server` or whenever you toggle the runtime on) replaces the managed block in place but preserves user content above and below it verbatim. This means you can:
 
 - Add your own MCP servers Hermes doesn't know about
-- Override `default_permissions` to `:read-only` if you prefer to be prompted
+- Override `approval_policy`, `sandbox_mode`, or `default_permissions` if you prefer to be prompted
 - Configure codex-only options (model, providers, otel, etc.)
 - Add user-defined permission profiles in `[permissions.<name>]` tables
 
@@ -294,25 +298,23 @@ Anything you add **inside** the managed block will get clobbered on the next mig
 
 ## Multi-profile / multi-tenant setups
 
-By default, Hermes points the codex subprocess at `~/.codex/` regardless of which Hermes profile is active. This means `hermes -p work` and `hermes -p personal` share the same Codex auth, plugins, and config. For most users this is the right behavior — it matches what running `codex` CLI directly would do.
+By default, Hermes points the codex subprocess at `~/.hermes/codex-runtime` (or `<HERMES_HOME>/codex-runtime` when profile-scoped). This keeps Hermes' managed `config.toml` away from global `~/.codex/config.toml`.
 
-If you want per-profile Codex isolation (separate auth, separate installed plugins, separate config), set `CODEX_HOME` explicitly per profile. The cleanest way is to point at a directory under your `HERMES_HOME`:
+If you want a different runtime directory, set `HERMES_CODEX_HOME` explicitly per profile. If you intentionally want to share your normal Codex CLI state, set `CODEX_HOME` and leave `HERMES_CODEX_HOME` unset:
 
 ```bash
 # Inside the work profile, you might wrap hermes:
-CODEX_HOME=~/.hermes/profiles/work/codex hermes chat
+HERMES_CODEX_HOME=~/.hermes/profiles/work/codex hermes chat
 ```
 
-You'll need to re-run `codex login` once with that `CODEX_HOME` set so the OAuth tokens land in the profile-scoped location. After that, `hermes -p work` will operate on isolated Codex state.
-
-We don't auto-scope this because moving an existing user's `~/.codex/` would silently invalidate their Codex CLI auth — anyone who already ran `codex login` would have to re-authenticate. Opt-in feels safer than surprising users.
+You'll need to re-run `codex login` once with that runtime home set so the OAuth tokens land in the profile-scoped location. After that, `hermes -p work` will operate on isolated Codex state.
 
 ## HOME environment variable passthrough
 
 Hermes does NOT rewrite `HOME` when spawning the codex app-server subprocess (we use `os.environ.copy()` and only overlay `CODEX_HOME` and `RUST_LOG`). This means:
 
 - Commands codex runs via its `shell` tool see the real user `HOME` and find `~/.gitconfig`, `~/.gh/`, `~/.aws/`, `~/.npmrc`, etc. correctly.
-- Codex's internal state stays isolated through `CODEX_HOME` (which points at `~/.codex/` by default).
+- Codex's internal state stays isolated through `CODEX_HOME` in the subprocess, resolved from `HERMES_CODEX_HOME`, `CODEX_HOME`, or `~/.hermes/codex-runtime`.
 
 This matches the boundary OpenClaw arrived at after some early experimentation: isolate Codex's state, leave the user's home alone. (Cf. openclaw/openclaw#81562.)
 
@@ -347,7 +349,7 @@ What's NOT migrated:
 
 ## Hermes tool callback (the new MCP server)
 
-Codex's built-in toolset covers shell/file ops/patches but doesn't have web search, browser automation, vision, image generation, etc. To keep those usable in a codex turn, Hermes registers itself as an MCP server in `~/.codex/config.toml`:
+Codex's built-in toolset covers shell/file ops/patches but doesn't have web search, browser automation, vision, image generation, etc. To keep those usable in a codex turn, Hermes registers itself as an MCP server in the runtime `config.toml`:
 
 ```toml
 [mcp_servers.hermes-tools]
@@ -372,7 +374,7 @@ Switch back at any time:
 /codex-runtime auto
 ```
 
-Effective on the next session. The Codex managed block stays in `~/.codex/config.toml` so you can re-enable later without losing config — or remove it manually if you prefer.
+Effective on the next session. The Codex managed block stays in the runtime `config.toml` so you can re-enable later without losing config — or remove it manually if you prefer.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Resolve the Codex app-server runtime home/config path through a dedicated helper.
- Expand migration/repair behavior for Codex config, plugin entries, permissions defaults, backups, validation, and AGENTS.md instruction installation.
- Add the optional codex-coding-discipline skill, tests, and docs updates for the runtime flow.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_codex_runtime_home.py tests/hermes_cli/test_codex_runtime_plugin_migration.py tests/hermes_cli/test_codex_runtime_switch.py tests/hermes_cli/test_commands.py tests/run_agent/test_codex_app_server_integration.py tests/skills/test_codex_coding_discipline_skill.py`
