### PR TITLE
fix(vision): add minimax providers to media tool result whitelist (#25900)

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -55,6 +55,15 @@ class TestSupportsMediaInToolResults:
     def test_gemini_2_no(self):
         assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
 
+    def test_minimax_native_yes(self):
+        assert _supports_media_in_tool_results("minimax", "minimax-m2.7") is True
+
+    def test_minimax_cn_yes(self):
+        assert _supports_media_in_tool_results("minimax-cn", "minimax-m2.7") is True
+
+    def test_minimax_oauth_yes(self):
+        assert _supports_media_in_tool_results("minimax-oauth", "minimax-m2.7-highspeed") is True
+
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
@@ -211,3 +220,25 @@ class TestHandleVisionAnalyzeFastPath:
 
         assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
             "Fast path fired for unknown provider; should have fallen through"
+
+
+    def test_minimax_provider_uses_fast_path(self, tmp_path, monkeypatch):
+        """MiniMax with anthropic_messages api_mode → fast path returns multimodal."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("minimax", "minimax-m2.7")
+        try:
+            with patch(
+                "agent.image_routing.decide_image_input_mode",
+                return_value="native",
+            ):
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                result = asyncio.get_event_loop().run_until_complete(coro)
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, dict), \
+            f"Expected multimodal envelope, got {type(result).__name__}: {str(result)[:200]}"
+        assert result.get("_multimodal") is True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -452,8 +452,8 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in _AGGREGATORS:
         return True
 
-    # Native Anthropic
-    if p in {"anthropic", "claude", "anthropic-direct"}:
+    # Native Anthropic (and MiniMax which uses anthropic_messages api_mode)
+    if p in {"anthropic", "claude", "anthropic-direct", "minimax", "minimax-cn", "minimax-oauth"}:
         return True
 
     # OpenAI Chat Completions and Responses


### PR DESCRIPTION
## Summary

Adds `"minimax"`, `"minimax-cn"`, and `"minimax-oauth"` to the `_supports_media_in_tool_results()` whitelist so MiniMax users benefit from the native vision fast path.

## Root Cause

In `tools/vision_tools.py`, function `_supports_media_in_tool_results()` has a hardcoded set of providers that support image content inside tool-result messages. MiniMax uses `api_mode="anthropic_messages"` (confirming to the Anthropic Messages API spec) which supports multimodal tool results. But `"minimax"`, `"minimax-cn"`, `"minimax-oauth"` were missing from the whitelist.

This caused `_handle_vision_analyze()` to skip the native fast path and fall through to the legacy text path, which returns JSON instead of pixels.

## Fix

**1 line change** in `tools/vision_tools.py` L456 — added the three MiniMax provider names to the existing anthropic provider set.

## Proof

All 22 tests pass, including the 4 new tests added:

- `test_minimax_native_yes` — `_supports_media_in_tool_results("minimax", ...)` → `True`
- `test_minimax_cn_yes` — `_supports_media_in_tool_results("minimax-cn", ...)` → `True`
- `test_minimax_oauth_yes` — `_supports_media_in_tool_results("minimax-oauth", ...)` → `True`
- `test_minimax_provider_uses_fast_path` — `_handle_vision_analyze` with minimax returns multimodal envelope

```
============================= 22 passed in 5.59s ==============================
```

## Provider Configuration

From `plugins/model-providers/minimax/__init__.py`:

| Provider | api_mode | base_url |
|---|---|---|
| minimax | anthropic_messages | https://api.minimax.io/anthropic |
| minimax-cn | anthropic_messages | https://api.minimaxi.com/anthropic |
| minimax-oauth | anthropic_messages | https://api.minimax.io/anthropic |

All three use `anthropic_messages` — the same message format that Anthropic's native provider uses, which natively supports image content in tool results.
