### PR TITLE
feat(display): add reasoning_format config option for reasoning output style (#25574)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,7 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "show_reasoning": False,
+    "reasoning_format": "code",
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
     # When true, delete tool-progress / "Still working..." / status bubbles
@@ -54,6 +55,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
 _TIER_HIGH = {
     "tool_progress": "all",
     "show_reasoning": False,
+    "reasoning_format": "code",
     "tool_preview_length": 40,
     "streaming": None,  # follow global
 }
@@ -61,6 +63,7 @@ _TIER_HIGH = {
 _TIER_MEDIUM = {
     "tool_progress": "new",
     "show_reasoning": False,
+    "reasoning_format": "code",
     "tool_preview_length": 40,
     "streaming": None,
 }
@@ -68,6 +71,7 @@ _TIER_MEDIUM = {
 _TIER_LOW = {
     "tool_progress": "off",
     "show_reasoning": False,
+    "reasoning_format": "code",
     "tool_preview_length": 40,
     "streaming": False,
 }
@@ -75,6 +79,7 @@ _TIER_LOW = {
 _TIER_MINIMAL = {
     "tool_progress": "off",
     "show_reasoning": False,
+    "reasoning_format": "code",
     "tool_preview_length": 0,
     "streaming": False,
 }
@@ -194,6 +199,12 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)
+    if setting == "reasoning_format":
+        valid = {"code", "quote", "none"}
+        val = str(value).lower().strip()
+        if val in valid:
+            return val
+        return "code"  # fallback to safe default
     if setting == "cleanup_progress":
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7895,8 +7895,15 @@ class GatewayRunner:
                     "show_reasoning",
                     getattr(self, "_show_reasoning", False),
                 )
+                _reasoning_format = _rds(
+                    _load_gateway_config(),
+                    _platform_config_key(source.platform),
+                    "reasoning_format",
+                    "code",
+                )
             except Exception:
                 _show_reasoning_effective = getattr(self, "_show_reasoning", False)
+                _reasoning_format = "code"
             if _show_reasoning_effective and response:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
@@ -7907,7 +7914,12 @@ class GatewayRunner:
                         display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
                     else:
                         display_reasoning = last_reasoning.strip()
-                    response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                    if _reasoning_format == "none":
+                        pass  # skip reasoning output entirely
+                    elif _reasoning_format == "quote":
+                        response = f"💭 **Reasoning:**\n> {display_reasoning.replace(chr(10), chr(10) + '> ')}\n\n{response}"
+                    else:  # "code" (default)
+                        response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -163,6 +163,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "streaming"),
         ("display", "skin"),
         ("display", "show_reasoning"),
+        ("display", "reasoning_format"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
     ]

--- a/tests/gateway/test_reasoning_format.py
+++ b/tests/gateway/test_reasoning_format.py
@@ -1,0 +1,107 @@
+"""Tests for display.reasoning_format config option (#25574).
+
+Validates that reasoning_format=code|quote|none controls how reasoning
+content is rendered in gateway responses.
+"""
+
+import pytest
+
+from gateway.display_config import (
+    _GLOBAL_DEFAULTS,
+    _normalise,
+    resolve_display_setting,
+)
+
+
+class TestReasoningFormatDefaults:
+    """Default value is 'code' (backward-compatible)."""
+
+    def test_global_default_is_code(self):
+        assert _GLOBAL_DEFAULTS["reasoning_format"] == "code"
+
+    def test_resolve_default_returns_code(self):
+        """No config set anywhere → returns 'code' from global defaults."""
+        result = resolve_display_setting(
+            {},  # user_config
+            "telegram",  # platform_key
+            "reasoning_format",
+            "code",
+        )
+        assert result == "code"
+
+
+class TestReasoningFormatNormalise:
+    """_normalise() validation of reasoning_format values."""
+
+    def test_code_is_accepted(self):
+        assert _normalise("reasoning_format", "code") == "code"
+
+    def test_quote_is_accepted(self):
+        assert _normalise("reasoning_format", "quote") == "quote"
+
+    def test_none_is_accepted(self):
+        assert _normalise("reasoning_format", "none") == "none"
+
+    def test_case_insensitive(self):
+        assert _normalise("reasoning_format", "CODE") == "code"
+        assert _normalise("reasoning_format", "Quote") == "quote"
+        assert _normalise("reasoning_format", "NONE") == "none"
+
+    def test_invalid_value_falls_back_to_code(self):
+        assert _normalise("reasoning_format", "invalid") == "code"
+        assert _normalise("reasoning_format", "markdown") == "code"
+        assert _normalise("reasoning_format", "") == "code"
+
+    def test_boolean_falls_back_to_code(self):
+        assert _normalise("reasoning_format", True) == "code"
+        assert _normalise("reasoning_format", False) == "code"
+
+
+class TestReasoningFormatPerPlatform:
+    """Per-platform overrides work for reasoning_format."""
+
+    def test_platform_override_wins_over_global(self):
+        """display.platforms.telegram.reasoning_format overrides display.reasoning_format."""
+        config = {
+            "display": {
+                "reasoning_format": "code",
+                "platforms": {
+                    "telegram": {"reasoning_format": "quote"},
+                },
+            },
+        }
+        result = resolve_display_setting(config, "telegram", "reasoning_format", "code")
+        assert result == "quote"
+
+    def test_global_setting_works(self):
+        """display.reasoning_format is read when no per-platform override."""
+        config = {
+            "display": {
+                "reasoning_format": "quote",
+            },
+        }
+        result = resolve_display_setting(config, "telegram", "reasoning_format", "code")
+        assert result == "quote"
+
+    def test_invalid_platform_value_falls_back(self):
+        """Invalid value in per-platform override falls back to code."""
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {"reasoning_format": "invalid_option"},
+                },
+            },
+        }
+        result = resolve_display_setting(config, "telegram", "reasoning_format", "code")
+        assert result == "code"
+
+
+class TestReasoningFormatInConfig:
+    """Integration-style: reasoning_format key is present in defaults dicts."""
+
+    def test_key_in_global_defaults(self):
+        assert "reasoning_format" in _GLOBAL_DEFAULTS
+
+    def test_key_in_overrideable_keys(self):
+        from gateway.display_config import OVERRIDEABLE_KEYS
+        assert "reasoning_format" in OVERRIDEABLE_KEYS


### PR DESCRIPTION
## Summary

Adds `display.reasoning_format` config option controlling how reasoning/thinking blocks are rendered in gateway output.

## Changes

- **`gateway/display_config.py`**: Added `"reasoning_format": "code"` to `_GLOBAL_DEFAULTS`, all tier defaults, and validation in `_normalise()` supporting `code`, `quote`, `none` values with fallback to `code`
- **`gateway/run.py`**: Reads `reasoning_format` setting via `resolve_display_setting()`, formats reasoning as code fence (`code`), blockquote (`quote`), or hides it entirely (`none`)
- **`hermes_cli/dump.py`**: Added `("display", "reasoning_format")` to config dump interesting paths
- **`tests/gateway/test_reasoning_format.py`**: 13 tests covering defaults, normalise validation, per-platform overrides, and invalid value fallback

## Design

- Default `code` preserves current behaviour (zero breaking change)
- `show_reasoning: false` takes precedence over `reasoning_format`
- Invalid values fall back to `code`
- CLI terminal rendering deferred to follow-up

Closes #25574