### PR TITLE
fix(gateway,image-routing): stop cross-routing docs as images + transcode uncommon formats

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -171,12 +171,93 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     # BMP: "BM"
     if raw.startswith(b"BM"):
         return "image/bmp"
-    # HEIC/HEIF: ftypheic / ftypheix / ftypmif1 / ftypmsf1 etc.
-    if len(raw) >= 12 and raw[4:8] == b"ftyp" and raw[8:12] in {
-        b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1", b"heim", b"heis",
-    }:
-        return "image/heic"
+    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12
+    if len(raw) >= 12 and raw[4:8] == b"ftyp":
+        brand = raw[8:12]
+        if brand in {b"avif", b"avis"}:
+            return "image/avif"
+        if brand in {
+            b"heic", b"heix", b"hevc", b"hevx",
+            b"mif1", b"msf1", b"heim", b"heis",
+        }:
+            return "image/heic"
+    # TIFF: II*\0 (little-endian) or MM\0* (big-endian)
+    if raw[:4] in {b"II*\x00", b"MM\x00*"}:
+        return "image/tiff"
+    # ICO: 00 00 01 00 (reserved=0, type=1=icon)
+    if raw[:4] == b"\x00\x00\x01\x00":
+        return "image/x-icon"
+    # SVG: text-based, look for an <svg tag near the start (skip BOM/whitespace)
+    head = raw[:512].lstrip().lower()
+    if head.startswith(b"<?xml") or head.startswith(b"<svg"):
+        if b"<svg" in head:
+            return "image/svg+xml"
     return None
+
+
+# Formats every major vision provider (Anthropic, OpenAI, Gemini, Bedrock)
+# accepts natively. Anything outside this set has to be transcoded to PNG
+# before we declare media_type, otherwise the provider returns HTTP 400
+# ("Could not process image" / "Unsupported image media type") and the
+# whole turn fails with no salvage path.
+#
+# Discord (and a few other chat platforms) freely accept attachments in
+# formats outside this set -- AVIF screenshots from Chromium, HEIC from
+# iPhones, TIFF from scanners, BMP from old Windows tools, ICO/SVG -- so
+# users do hit this in practice.
+_UNIVERSALLY_SUPPORTED_MIMES = frozenset({
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+})
+
+
+def _transcode_to_png(raw: bytes) -> Optional[bytes]:
+    """Decode arbitrary image bytes with Pillow and re-encode as PNG.
+
+    Returns None if Pillow isn't installed or can't decode the input
+    (rare formats, corrupted bytes, missing optional decoder plugin for
+    HEIC/AVIF). Caller falls back to skipping the image so the rest of
+    the turn still works.
+
+    HEIC/HEIF and AVIF need optional Pillow plugins; we try to register
+    them on demand and swallow ImportError so a missing plugin just
+    looks like 'Pillow can't decode this' rather than crashing.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        logger.info(
+            "image_routing: Pillow not installed; cannot transcode "
+            "non-standard image format to PNG. Install with `pip install Pillow` "
+            "(and `pillow-heif` / `pillow-avif-plugin` for those formats)."
+        )
+        return None
+    # Optional plugin registration. Silent on failure: an unsupported
+    # format will just fall through to Image.open raising below.
+    try:
+        import pillow_heif  # type: ignore
+        pillow_heif.register_heif_opener()
+    except Exception:
+        pass
+    try:
+        import pillow_avif  # type: ignore  # noqa: F401  -- registers AVIF on import
+    except Exception:
+        pass
+    try:
+        from io import BytesIO
+        with Image.open(BytesIO(raw)) as im:
+            # Pick an output mode PNG can serialise. Anything other than
+            # the standard set gets normalised to RGBA so transparency is
+            # preserved where the source had it.
+            if im.mode not in {"RGB", "RGBA", "L", "LA", "P"}:
+                im = im.convert("RGBA")
+            buf = BytesIO()
+            im.save(buf, format="PNG", optimize=False)
+            return buf.getvalue()
+    except Exception as exc:
+        logger.info(
+            "image_routing: Pillow could not transcode image to PNG -- %s", exc
+        )
+        return None
 
 
 def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
@@ -208,21 +289,46 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
 def _file_to_data_url(path: Path) -> Optional[str]:
     """Encode a local image as a base64 data URL at its native size.
 
-    Size limits are NOT enforced here — the agent retry loop
+    Size limits are NOT enforced here -- the agent retry loop
     (``run_agent._try_shrink_image_parts_in_messages``) shrinks on the
     provider's first rejection. Keeping this simple means providers that
     accept large images (OpenAI 49 MB+, Gemini 100 MB) don't pay a silent
     quality tax just because one other provider is stricter.
 
-    Returns None only if the file can't be read (missing, permission
-    denied, etc.); the caller reports those paths in ``skipped``.
+    Format compatibility IS handled here: if the sniffed MIME isn't one
+    of ``_UNIVERSALLY_SUPPORTED_MIMES`` (i.e. it's something like AVIF,
+    HEIC, BMP, TIFF, ICO, or SVG that some providers reject outright),
+    we transcode to PNG with Pillow before declaring media_type. This
+    fixes the user-visible "Could not process image" HTTP 400 from
+    Anthropic on Discord-attached AVIF/HEIC/BMP files.
+
+    Returns None if the file can't be read OR if the format isn't
+    universally supported AND Pillow can't transcode it (Pillow missing,
+    HEIC/AVIF plugin missing, corrupt bytes). The caller reports those
+    paths in ``skipped`` and the rest of the turn proceeds.
     """
     try:
         raw = path.read_bytes()
     except Exception as exc:
-        logger.warning("image_routing: failed to read %s — %s", path, exc)
+        logger.warning("image_routing: failed to read %s -- %s", path, exc)
         return None
     mime = _guess_mime(path, raw=raw)
+    if mime not in _UNIVERSALLY_SUPPORTED_MIMES:
+        transcoded = _transcode_to_png(raw)
+        if transcoded is None:
+            logger.warning(
+                "image_routing: %s is %s which is not accepted by all major "
+                "vision providers and Pillow could not transcode it to PNG; "
+                "skipping this attachment.",
+                path, mime,
+            )
+            return None
+        logger.info(
+            "image_routing: transcoded %s (%s) -> image/png for provider compatibility",
+            path.name, mime,
+        )
+        raw = transcoded
+        mime = "image/png"
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6814,10 +6814,22 @@ class GatewayRunner:
             audio_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
+                # When a per-attachment MIME is known, trust it. Only fall
+                # back to the message-level type (PHOTO / VOICE / AUDIO)
+                # when the per-attachment slot is empty/unknown -- otherwise
+                # a document or other non-image attachment uploaded alongside
+                # an image gets mis-routed as an image (sent to the vision
+                # provider as bogus base64) and the whole turn 400s with
+                # "Could not process image".
+                if mtype.startswith("image/"):
                     image_paths.append(path)
-                if mtype.startswith("audio/") or event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+                elif mtype.startswith("audio/"):
                     audio_paths.append(path)
+                elif not mtype:
+                    if event.message_type == MessageType.PHOTO:
+                        image_paths.append(path)
+                    elif event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+                        audio_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -284,3 +284,121 @@ class TestLargeImageHandling:
         assert len(parts) == 2
         assert parts[0]["type"] == "text"
         assert parts[1]["type"] == "image_url"
+
+
+# --- Format compatibility (transcode-to-PNG for non-universal formats) ------
+
+
+class TestFormatCompatibility:
+    """Some image formats Discord (and other chat platforms) accept aren't
+    accepted by every major vision provider. Anthropic for example returns
+    HTTP 400 'Could not process image' for AVIF/HEIC/BMP/TIFF/ICO/SVG.
+
+    We transcode anything outside the universal-safe set (PNG/JPEG/GIF/WEBP)
+    to PNG with Pillow before declaring media_type so the provider call
+    actually succeeds. Regression coverage for the user-reported Discord
+    'Could not process image' HTTP 400.
+    """
+
+    def test_avif_sniffed_correctly(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+        # Minimal ftyp box with major brand 'avif'
+        avif_header = b"\x00\x00\x00\x20ftypavif\x00\x00\x00\x00"
+        assert _sniff_mime_from_bytes(avif_header) == "image/avif"
+
+    def test_tiff_sniffed_both_endians(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+        assert _sniff_mime_from_bytes(b"II*\x00" + b"\x00" * 16) == "image/tiff"
+        assert _sniff_mime_from_bytes(b"MM\x00*" + b"\x00" * 16) == "image/tiff"
+
+    def test_ico_sniffed_correctly(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+        assert _sniff_mime_from_bytes(b"\x00\x00\x01\x00" + b"\x00" * 16) == "image/x-icon"
+
+    def test_svg_sniffed_correctly(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+        assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"
+        assert _sniff_mime_from_bytes(b'<?xml version="1.0"?><svg/>') == "image/svg+xml"
+
+    def test_bmp_transcoded_to_png(self, tmp_path: Path):
+        """BMP file should land as image/png in the data URL, not image/bmp,
+        because not every provider (Anthropic in particular) accepts BMP.
+        """
+        from PIL import Image
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "scan.bmp"
+        Image.new("RGB", (4, 4), (255, 0, 0)).save(img_path, format="BMP")
+        url = _file_to_data_url(img_path)
+        assert url is not None
+        assert url.startswith("data:image/png;base64,"), (
+            f"BMP must be transcoded to PNG for cross-provider compatibility, got: {url[:60]}"
+        )
+
+    def test_tiff_transcoded_to_png(self, tmp_path: Path):
+        from PIL import Image
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "scan.tiff"
+        Image.new("RGB", (4, 4), (0, 255, 0)).save(img_path, format="TIFF")
+        url = _file_to_data_url(img_path)
+        assert url is not None
+        assert url.startswith("data:image/png;base64,")
+
+    def test_png_passes_through_no_transcode(self, tmp_path: Path):
+        """Universal-safe formats must NOT be re-encoded -- preserves bytes."""
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "ok.png"
+        img_path.write_bytes(_png_bytes())
+        url = _file_to_data_url(img_path)
+        assert url is not None
+        assert url.startswith("data:image/png;base64,")
+        # The data segment should be exactly the b64 of the original bytes,
+        # i.e. transcoding was correctly skipped.
+        import base64
+        b64 = url.split(",", 1)[1]
+        assert base64.b64decode(b64) == _png_bytes()
+
+    def test_jpeg_passes_through_no_transcode(self, tmp_path: Path):
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "ok.jpg"
+        # Tiny but real JPEG
+        img_path.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9")
+        url = _file_to_data_url(img_path)
+        assert url is not None
+        assert url.startswith("data:image/jpeg;base64,")
+
+    def test_transcode_failure_is_skipped_not_crashed(self, tmp_path: Path):
+        """If Pillow can't decode (corrupted bytes labeled as a rare format),
+        return None so the caller adds the path to ``skipped`` rather than
+        sending broken data to the provider.
+        """
+        from agent.image_routing import _file_to_data_url
+
+        # AVIF magic prefix but nonsense payload Pillow can't decode
+        img_path = tmp_path / "corrupt.avif"
+        img_path.write_bytes(b"\x00\x00\x00\x20ftypavif" + b"\x00" * 32)
+        url = _file_to_data_url(img_path)
+        assert url is None
+
+    def test_unsupported_format_skipped_in_native_parts(self, tmp_path: Path):
+        """End-to-end: a file whose format we can't decode at all should
+        show up in `skipped` from `build_native_content_parts`, not crash
+        and not silently send broken bytes.
+        """
+        from agent.image_routing import build_native_content_parts
+
+        # AVIF magic prefix but nonsense payload
+        bad = tmp_path / "broken.avif"
+        bad.write_bytes(b"\x00\x00\x00\x20ftypavif" + b"\x00" * 32)
+        # And one good PNG alongside
+        good = tmp_path / "good.png"
+        good.write_bytes(_png_bytes())
+
+        parts, skipped = build_native_content_parts("look", [str(bad), str(good)])
+        assert str(bad) in skipped
+        # Good image still attached; rest of turn proceeds.
+        image_parts = [p for p in parts if p.get("type") == "image_url"]
+        assert len(image_parts) == 1

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -324,7 +324,7 @@ class TestFormatCompatibility:
         """BMP file should land as image/png in the data URL, not image/bmp,
         because not every provider (Anthropic in particular) accepts BMP.
         """
-        from PIL import Image
+        Image = pytest.importorskip("PIL.Image", reason="Pillow not installed; transcode is best-effort")
         from agent.image_routing import _file_to_data_url
 
         img_path = tmp_path / "scan.bmp"
@@ -336,7 +336,7 @@ class TestFormatCompatibility:
         )
 
     def test_tiff_transcoded_to_png(self, tmp_path: Path):
-        from PIL import Image
+        Image = pytest.importorskip("PIL.Image", reason="Pillow not installed; transcode is best-effort")
         from agent.image_routing import _file_to_data_url
 
         img_path = tmp_path / "scan.tiff"

--- a/tests/gateway/test_mixed_attachment_routing.py
+++ b/tests/gateway/test_mixed_attachment_routing.py
@@ -1,0 +1,193 @@
+"""Tests for media-routing in ``GatewayRunner._prepare_inbound_message_text``.
+
+Regression coverage for the user-reported bug where uploading images
+alongside a non-image attachment (e.g. an .md document) on Discord
+caused the whole turn to fail with HTTP 400 "Could not process image"
+from Anthropic.
+
+Root cause: the routing loop in ``gateway/run.py`` used
+``mtype.startswith("image/") OR event.message_type == PHOTO`` to decide
+whether to attach a media URL as a vision image. When Discord set the
+message-level type to PHOTO (because at least one attachment was an
+image), every other attachment in the same message -- including
+documents -- got routed as an image and base64'd into a vision content
+part, which Anthropic then rejected with a generic 400.
+
+Fix: trust the per-attachment MIME when it's known; only fall back to
+the message-level type when the per-attachment slot is empty/unknown.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "anthropic/claude-sonnet-4"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda: "native"
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-mixed",
+        chat_type="thread",
+        user_name="user-mixed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_image_plus_document_only_image_routed_as_image():
+    """When a message carries one PNG + one MD document, only the PNG
+    should land in the native-image buffer. The MD must NOT be base64'd
+    into a vision content part -- that's the bug Anthropic returns 400
+    for ("Could not process image").
+    """
+    runner = _make_runner()
+    source = _source()
+
+    event = MessageEvent(
+        text="here are some images and the meeting notes",
+        # Discord sets PHOTO at the message level whenever ANY attachment
+        # is an image; the per-attachment MIME is the authoritative signal.
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/scan.png", "/tmp/transcript.md"],
+        media_types=["image/png", "text/markdown"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    pending = runner._consume_pending_native_image_paths(build_session_key(source))
+    assert pending == ["/tmp/scan.png"], (
+        f"Only the image should be routed as a native image; got: {pending}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_images_plus_document_only_images_routed():
+    """Variant of the user-reported failure: 3 PNGs + 1 MD upload should
+    route exactly 3 images, not 4.
+    """
+    runner = _make_runner()
+    source = _source()
+
+    event = MessageEvent(
+        text="three pngs and a transcript",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=[
+            "/tmp/raw.png", "/tmp/realsrgan.png", "/tmp/rrn.png",
+            "/tmp/Weekly_Video_pipeline_sync.md",
+        ],
+        media_types=["image/png", "image/png", "image/png", "text/markdown"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    pending = runner._consume_pending_native_image_paths(build_session_key(source))
+    assert pending == ["/tmp/raw.png", "/tmp/realsrgan.png", "/tmp/rrn.png"], (
+        f"Document must not be routed as a 4th image; got: {pending}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_mime_falls_back_to_message_type_for_image():
+    """Backward compatibility: legacy adapters that set message_type=PHOTO
+    but leave media_types empty (or with blank strings) still get their
+    media routed as images. This keeps existing platforms working.
+    """
+    runner = _make_runner()
+    source = _source()
+
+    event = MessageEvent(
+        text="legacy adapter, no per-attachment MIME",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/legacy.png"],
+        media_types=[""],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert runner._consume_pending_native_image_paths(
+        build_session_key(source)
+    ) == ["/tmp/legacy.png"]
+
+
+@pytest.mark.asyncio
+async def test_document_only_message_routes_nothing_as_image():
+    """A message with only a non-image attachment (and no PHOTO type)
+    should not route anything as an image.
+    """
+    runner = _make_runner()
+    source = _source()
+
+    event = MessageEvent(
+        text="just a doc",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/tmp/report.pdf"],
+        media_types=["application/pdf"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == []
+
+
+@pytest.mark.asyncio
+async def test_audio_alongside_image_not_cross_routed():
+    """Audio attachments alongside an image must not get routed as an
+    image even if message_type happens to be PHOTO (symmetric to the
+    document case).
+    """
+    runner = _make_runner()
+    source = _source()
+
+    event = MessageEvent(
+        text="image + voice note",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/photo.jpg", "/tmp/voice.ogg"],
+        media_types=["image/jpeg", "audio/ogg"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    pending = runner._consume_pending_native_image_paths(build_session_key(source))
+    assert pending == ["/tmp/photo.jpg"], (
+        f"Audio must not be routed as an image; got: {pending}"
+    )


### PR DESCRIPTION
## What does this PR do?

Hey, second time contributing here so be gentle.

I was hitting `HTTP 400: Could not process image` from Anthropic on Discord with no obvious cause. The first time it happened my own previous PR (#25745) seemed to cover it -- but then it kept happening, so I dug deeper and it turned out there were actually two different things happening that both surface as the same generic provider error.

I tried fixing both since they share the same user-visible symptom (and the same error message). Happy to split into two PRs if you'd rather review them separately.

### The actual bug that hit me

In `gateway/run.py`, the loop that routes per-attachment media looked like:

```python
if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
    image_paths.append(path)
```

The Discord adapter sets the message-level type to `PHOTO` whenever any one attachment is an image. So if I upload `3 PNGs + 1 .md transcript`, the loop sweeps the `.md` into `image_paths` too, the gateway base64s it as a vision content part, and Anthropic 400s the whole turn.

I confirmed this in the gateway log: `Image routing: native (model supports vision). 4 image(s) will be attached inline.` -- but only 3 PNGs were ever cached. The 4th was the document.

Fix: trust the per-attachment MIME when it's known, only fall back to the message-level type when the per-attachment slot is empty (legacy adapters that don't populate `media_types` still work).

### The smaller one (format compatibility)

Anthropic / OpenAI / Gemini only natively accept PNG / JPEG / GIF / WEBP. But Discord lets people upload AVIF (Chromium screenshots), HEIC (iPhone photos), BMP, TIFF, ICO, SVG. Those also produce the same generic 400. Pillow is already used elsewhere in the codebase as a soft dep, so this transcodes anything outside the universal set to PNG before declaring `media_type`. Falls through cleanly if Pillow / pillow-heif / pillow-avif-plugin isn't installed (image is skipped with a logged warning rather than crashing the turn).

## Related Issue

Fixes #25935

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py` -- per-attachment MIME is now authoritative in `_prepare_inbound_message_text`. Message-level `PHOTO` / `VOICE` / `AUDIO` is only consulted when the per-attachment MIME slot is empty.
- `agent/image_routing.py`:
  - `_sniff_mime_from_bytes` extended to recognise AVIF, TIFF (both endians), ICO, SVG (was previously PNG / JPEG / GIF / WEBP / BMP / HEIC)
  - New `_UNIVERSALLY_SUPPORTED_MIMES` set listing the formats accepted by every major provider
  - New `_transcode_to_png` helper using Pillow + optional `pillow-heif` and `pillow-avif-plugin`
  - `_file_to_data_url` now transcodes anything outside the safe set to PNG before encoding
  - If transcoding fails (Pillow missing, plugin missing, corrupt bytes) the image is added to `skipped` rather than sent broken
- `tests/gateway/test_mixed_attachment_routing.py` -- new file, 5 tests covering: image + document, multi-image + document (the exact failure I hit), unknown-MIME backward compatibility, document-only no-route, image + audio no-cross-route
- `tests/agent/test_image_routing.py` -- 10 new tests for sniffing AVIF/TIFF/ICO/SVG, BMP→PNG and TIFF→PNG transcode end-to-end, PNG/JPEG pass-through (bytes preserved), corrupted-input handled gracefully

## Testing

Locally:
- 48/48 pass across the image-related test files (`tests/agent/test_image_routing.py`, `tests/gateway/test_mixed_attachment_routing.py`, `tests/gateway/test_native_image_buffer_isolation.py`)
- 118/118 pass across all image-related test files including pre-existing ones
- Verified the new routing test fails on the old code (real regression guard)
- End-to-end with my running Hermes gateway: original failure reproduces on old binary, no longer reproduces after restart with the patch

What I sent through manually after restarting the gateway:
- 3 PNGs + 1 `.md` transcript in one Discord message -> Anthropic accepts, turn completes (previously 400)
- A BMP saved as `.jpg` (Discord MIME-lying scenario) -> transcoded to PNG, accepted
- A `.webp` that's actually PNG bytes (the original #25745 scenario) -> still works
- Plain PNG / JPEG -> pass through with byte-identical payload (no needless re-encode)

## Notes for reviewers

- Pillow is kept a soft dependency. `pillow-heif` and `pillow-avif-plugin` are even softer (lazy-registered, swallowed on ImportError). If none are installed, behaviour matches today's: the unsupported image gets reported in `skipped` and the rest of the turn proceeds, rather than the turn dying with a 400.
- I tried to keep the routing change minimal -- it's 22 lines with comments explaining why, no signature changes, no behaviour change for messages where per-attachment MIME wasn't set.
- The format-compat change touches `_file_to_data_url` which is the single funnel for native image attachment, so it should also cover non-Discord platforms if they hit similar formats.

Happy to take feedback, trim things, or split this into two PRs if it'd be easier to review one at a time.
