### PR TITLE
fix(cron): cap job toolsets by config

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -55,12 +55,47 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _normalize_toolset_names(raw: object) -> list[str]:
+    """Return a stable, non-empty list of toolset names from persisted job data."""
+    if not raw:
+        return []
+    items = raw if isinstance(raw, (list, tuple, set)) else [raw]
+    names: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        name = str(item).strip()
+        if name and name not in seen:
+            names.append(name)
+            seen.add(name)
+    return names
+
+
+def _configured_disabled_toolsets(cfg: dict) -> set[str]:
+    agent_cfg = (cfg or {}).get("agent") if isinstance(cfg, dict) else {}
+    if not isinstance(agent_cfg, dict):
+        return set()
+    return set(_normalize_toolset_names(agent_cfg.get("disabled_toolsets")))
+
+
+def _log_dropped_job_toolsets(job: dict, dropped: list[str]) -> None:
+    if not dropped:
+        return
+    logger.warning(
+        "Cron job '%s' requested toolsets %s but they are denied by cron "
+        "platform config or agent.disabled_toolsets; dropping them.",
+        job.get("name") or job.get("id") or "<unnamed>",
+        dropped,
+    )
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
     Precedence:
-    1. Per-job ``enabled_toolsets`` (set via ``cronjob`` tool on create/update).
-       Keeps the agent's job-scoped toolset override intact — #6130.
+    1. Per-job ``enabled_toolsets`` narrows the cron platform toolsets, but it
+       cannot re-enable toolsets denied by ``platform_toolsets.cron`` or
+       ``agent.disabled_toolsets``. This keeps job-level scoping useful without
+       creating a confused-deputy bypass for cron-created agents.
     2. Per-platform ``hermes tools`` config for the ``cron`` platform.
        Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``)
        so users can gate cron toolsets globally without recreating every job.
@@ -72,18 +107,40 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     get cron WITHOUT ``moa`` by default (issue reported by Norbert —
     surprise $4.63 run).
     """
-    per_job = job.get("enabled_toolsets")
-    if per_job:
-        return per_job
+    per_job = _normalize_toolset_names(job.get("enabled_toolsets"))
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        platform_toolsets = sorted(_get_platform_tools(cfg or {}, "cron"))
     except Exception as exc:
+        if per_job:
+            logger.warning(
+                "Cron platform toolset resolution failed; using per-job "
+                "toolsets with agent.disabled_toolsets fallback: %s",
+                exc,
+            )
+            disabled = _configured_disabled_toolsets(cfg or {})
+            filtered = [name for name in per_job if name not in disabled]
+            _log_dropped_job_toolsets(
+                job,
+                [name for name in per_job if name in disabled],
+            )
+            return filtered
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",
             exc,
         )
         return None
+
+    if per_job:
+        allowed = set(platform_toolsets)
+        filtered = [name for name in per_job if name in allowed]
+        _log_dropped_job_toolsets(
+            job,
+            [name for name in per_job if name not in allowed],
+        )
+        return filtered
+
+    return platform_toolsets
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,16 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _build_job_prompt,
+    _deliver_result,
+    _resolve_cron_enabled_toolsets,
+    _resolve_delivery_target,
+    _resolve_origin,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -941,6 +950,63 @@ class TestRunJobSessionPersistence:
             ),
         ]
 
+    def test_resolve_cron_enabled_toolsets_intersects_per_job_with_platform_tools(self):
+        job = {
+            "id": "denylist-job",
+            "name": "denylist test",
+            "enabled_toolsets": ["web", "terminal", "file", "web"],
+        }
+
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value={"web", "file"},
+        ):
+            result = _resolve_cron_enabled_toolsets(job, {})
+
+        assert result == ["web", "file"]
+
+    def test_resolve_cron_enabled_toolsets_honors_agent_disabled_toolsets(self):
+        job = {
+            "id": "disabled-job",
+            "enabled_toolsets": ["web", "terminal", "file"],
+        }
+        cfg = {"agent": {"disabled_toolsets": ["terminal"]}}
+
+        result = _resolve_cron_enabled_toolsets(job, cfg)
+
+        assert "web" in result
+        assert "file" in result
+        assert "terminal" not in result
+
+    def test_resolve_cron_enabled_toolsets_returns_empty_when_override_fully_denied(self):
+        job = {
+            "id": "fully-denied-job",
+            "enabled_toolsets": ["terminal", "code_execution"],
+        }
+
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value={"web"},
+        ):
+            result = _resolve_cron_enabled_toolsets(job, {})
+
+        assert result == []
+
+    def test_resolve_cron_enabled_toolsets_fallback_still_honors_disabled_config(self):
+        job = {
+            "id": "fallback-job",
+            "enabled_toolsets": ["terminal", "web"],
+        }
+        cfg = {"agent": {"disabled_toolsets": ["terminal"]}}
+
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            side_effect=RuntimeError("config unavailable"),
+        ):
+            result = _resolve_cron_enabled_toolsets(job, cfg)
+
+        assert result == ["web"]
+
     def test_run_job_passes_enabled_toolsets_to_agent(self, tmp_path):
         job = {
             "id": "toolset-job",
@@ -950,7 +1016,11 @@ class TestRunJobSessionPersistence:
         }
         fake_db, patches = self._make_run_job_patches(tmp_path)
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patch("run_agent.AIAgent") as mock_agent_cls:
+             patch("run_agent.AIAgent") as mock_agent_cls, \
+             patch(
+                 "hermes_cli.tools_config._get_platform_tools",
+                 return_value={"web", "terminal", "file"},
+             ):
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
@@ -990,9 +1060,9 @@ class TestRunJobSessionPersistence:
         # run cannot accidentally spin up frontier models.
         assert "moa" not in kwargs["enabled_toolsets"]
 
-    def test_run_job_per_job_toolsets_win_over_platform_config(self, tmp_path):
-        """Per-job enabled_toolsets (via cronjob tool) always take precedence
-        over the platform-level ``hermes tools`` config."""
+    def test_run_job_per_job_toolsets_are_capped_by_platform_config(self, tmp_path):
+        """Per-job enabled_toolsets can narrow cron tools but cannot widen
+        past the platform-level ``hermes tools`` config."""
         job = {
             "id": "override-job",
             "name": "test",
@@ -1000,8 +1070,8 @@ class TestRunJobSessionPersistence:
             "enabled_toolsets": ["terminal"],
         }
         fake_db, patches = self._make_run_job_patches(tmp_path)
-        # Even if the user has ``hermes tools`` configured to enable web+file
-        # for cron, the per-job override wins.
+        # If the user has ``hermes tools`` configured to enable only web+file
+        # for cron, a per-job request cannot re-enable terminal.
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
              patch("run_agent.AIAgent") as mock_agent_cls, \
              patch(
@@ -1014,7 +1084,7 @@ class TestRunJobSessionPersistence:
             run_job(job)
 
         kwargs = mock_agent_cls.call_args.kwargs
-        assert kwargs["enabled_toolsets"] == ["terminal"]
+        assert kwargs["enabled_toolsets"] == []
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).


### PR DESCRIPTION
## Summary
- cap per-job cron enabled_toolsets to the cron platform toolsets, so a job can narrow its tools but cannot widen past config
- keep agent.disabled_toolsets enforced even for persisted job-level overrides
- normalize persisted toolset entries before resolving them, avoiding duplicates/blank entries from hand-edited jobs

Fixes #25752

## Tests
- python3 -m ruff check cron/scheduler.py tests/cron/test_scheduler.py
- python3 -m pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_resolve_cron_enabled_toolsets_intersects_per_job_with_platform_tools tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_resolve_cron_enabled_toolsets_honors_agent_disabled_toolsets tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_resolve_cron_enabled_toolsets_returns_empty_when_override_fully_denied tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_resolve_cron_enabled_toolsets_fallback_still_honors_disabled_config tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_passes_enabled_toolsets_to_agent tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_per_job_toolsets_are_capped_by_platform_config -q
- HOME=/tmp/hermes-cron-test-home python3 -m pytest tests/cron/test_scheduler.py -q

Note: scripts/run_tests.sh could not run locally because this checkout has no .venv or venv; the equivalent pytest commands above passed.