### PR TITLE
fix(cli): strip OSC-8 hyperlink sequences in ChatConsole before _cprint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2052,6 +2052,14 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
     return message, deduped
 
 
+# OSC-8 terminal hyperlink sequences.  Rich emits these for ``[link=URL]``
+# markup, but prompt_toolkit's ANSI parser strips only the ``\x1b]`` / ``\x1b\\``
+# delimiters and leaves the URL parameters visible as garbage text.
+# A targeted strip keeps SGR colors intact while removing the invisible
+# hyperlink metadata that ChatConsole's _cprint path cannot handle.
+_OSC_8_RE = re.compile(r"\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)")
+
+
 class ChatConsole:
     """Rich Console adapter for prompt_toolkit's patch_stdout context.
 
@@ -2078,6 +2086,7 @@ class ChatConsole:
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
         output = self._buffer.getvalue()
+        output = _OSC_8_RE.sub("", output)
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -133,3 +133,39 @@ def test_build_welcome_banner_title_falls_back_when_no_tag():
     raw = buf.getvalue()
     assert "Hermes Agent v" in raw, "Version label missing from title"
     assert "\x1b]8;" not in raw, "OSC-8 hyperlink should not be emitted without a tag"
+
+def test_chatconsole_strips_osc8_hyperlinks():
+    """ChatConsole.print() must strip OSC-8 hyperlink sequences that Rich emits
+    for ``[link=URL]`` markup.  prompt_toolkit's ANSI parser removes the
+    ``\x1b]`` / ``\x1b\\`` delimiters but leaves the URL parameters
+    visible, producing garbage text in the welcome banner after /clear.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/25939
+    """
+    from cli import _OSC_8_RE, ChatConsole, _cprint
+
+    # -- regex unit tests --
+    # BEL-terminated OSC-8
+    assert _OSC_8_RE.sub("", "\x1b]8;;https://example.com\x07click\x1b]8;;\x07") == "click"
+    # ST-terminated OSC-8 (\x1b\\)
+    assert _OSC_8_RE.sub("", "\x1b]8;id=1;https://example.com\x1b\\click\x1b]8;;\x1b\\") == "click"
+    # SGR color codes must survive
+    sgr = "\x1b[1;32mHello\x1b[0m"
+    assert _OSC_8_RE.sub("", sgr) == sgr
+
+    # -- integration: ChatConsole strips OSC-8 before _cprint --
+    captured = []
+    import cli as cli_mod
+    original_cprint = cli_mod._cprint
+    cli_mod._cprint = captured.append
+    try:
+        console = ChatConsole()
+        from rich.text import Text
+        # Rich ``[link=URL]text[/link]`` becomes an OSC-8 wrapped string
+        t = Text("v0.13.0", style="link=https://example.com")
+        console.print(t)
+        rendered = "\n".join(captured)
+        assert "\x1b]8;" not in rendered, f"OSC-8 leaked into _cprint: {rendered!r}"
+        assert "v0.13.0" in rendered, "Version label lost during OSC-8 strip"
+    finally:
+        cli_mod._cprint = original_cprint


### PR DESCRIPTION
## What does this PR do?

`ChatConsole.print()` passes Rich-rendered output through `_cprint` → prompt_toolkit's `ANSI()` parser. When the welcome banner contains `[link=URL]` markup (for the version title), Rich emits OSC-8 hyperlink escape sequences. prompt_toolkit strips the `\x1b]` / `\x1b\\` delimiters but leaves the URL and parameter content visible as garbage text.

This only affects banner re-rendering via `/clear`, `/reset`, `/new` — not initial startup (which writes directly to stdout through Rich's `Console`).


### Root Cause

Two rendering paths exist for the welcome banner:

1. **Initial startup** — `build_welcome_banner(console=self.console, ...)` renders through Rich's `Console` directly to stdout. Terminal natively handles OSC-8 hyperlinks.

2. **`/clear`/`/reset`/`/new`** — creates a `ChatConsole()` wrapper. `ChatConsole.print()` captures Rich output as a string, then calls `_cprint(line)` for each line. `_cprint` routes text through `prompt_toolkit.formatted_text.ANSI()`, which does NOT understand OSC-8.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Analyzed:** `ChatConsole.print()` (callers: 2 — banner re-render, skill hub), `_cprint` (callers: 20+ throughout cli.py)
- **Blast radius:** LOW — change is scoped to `ChatConsole.print()` output sanitization, no upstream callers affected
- **Related patterns:** `tools/ansi_strip.py` already has full ANSI stripping (including OSC-8) but strips ALL ANSI including SGR colors. A targeted OSC-8-only strip is needed here.

## Regression Coverage

- `test_chatconsole_strips_osc8_hyperlinks` — tests both the regex (BEL/ST terminators, SGR preservation) and the integration path (Rich `[link=URL]` → ChatConsole → `_cprint` receives clean text)