### PR TITLE
fix(docker): pre-install WhatsApp bridge node_modules at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,17 @@ COPY --chown=hermes:hermes . .
 RUN cd web && npm run build && \
     cd ../ui-tui && npm run build
 
+# Pre-install scripts/whatsapp-bridge/node_modules at build time.
+# The WhatsApp adapter (gateway/platforms/whatsapp.py:_send_whatsapp) otherwise
+# falls back to running `npm install` at first connect.  When the entrypoint
+# remaps the hermes user via HERMES_UID (the documented way to share host-side
+# ownership for the data volume), the bridge directory remains owned by the
+# original UID 10000 and the new hermes user cannot write into it — the
+# runtime install fails with EACCES and the adapter silently never connects.
+RUN cd scripts/whatsapp-bridge && \
+    npm install --prefer-offline --no-audit && \
+    npm cache clean --force
+
 # ---------- Permissions ----------
 # Make install dir world-readable so any HERMES_UID can read it at runtime.
 # The venv needs to be traversable too.
@@ -100,7 +111,8 @@ RUN cd web && npm run build && \
 # adapters silently fail to load.  See tools/lazy_deps.py.
 USER root
 RUN chmod -R a+rX /opt/hermes && \
-    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules
+    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules \
+        /opt/hermes/scripts/whatsapp-bridge
 # Start as root so the entrypoint can usermod/groupmod + gosu.
 # If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
 


### PR DESCRIPTION
## What does this PR do?

Pre-install `scripts/whatsapp-bridge/node_modules` at Docker build time and chown the directory to the `hermes` user.  Without this, enabling WhatsApp inside a container started with a remapped `HERMES_UID` silently fails to connect.

The WhatsApp adapter (`gateway/platforms/whatsapp.py`, around line 466 in `connect()`) checks for `node_modules` and falls back to `npm install --silent`.  When the entrypoint remaps the hermes user via `HERMES_UID` (the documented way to align with a host-mounted data volume), the bridge directory remains owned by the original UID 10000 and the new hermes user cannot write into it.  The runtime install fails with `EACCES` and the bridge process never starts, so the adapter reports only `Bridge found … failed to connect` with no further detail.  `bridge.log` is empty because the install errors out before the bridge writes its first line.

The fix is the same pattern the Dockerfile already uses for the top-level, `web/`, and `ui-tui/` directories: install at build time and chown.

## Related Issue

Fixes #<!-- create issue or leave blank — happy to file a companion issue describing the silent-failure mode if you'd like -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `Dockerfile`: add `RUN cd scripts/whatsapp-bridge && npm install --prefer-offline --no-audit && npm cache clean --force` after the existing `web` + `ui-tui` build step.
- `Dockerfile`: extend the existing chown line to include `/opt/hermes/scripts/whatsapp-bridge` alongside `ui-tui` and `node_modules`.

## How to Test

1. Build the image with the default UID: `docker build -t hermes-agent:test .`
2. Start it with a remapped UID: `docker run --rm -e HERMES_UID=1000 -e HERMES_GID=1000 -e WHATSAPP_ENABLED=true -e WHATSAPP_ALLOWED_USERS=+15551234567 -v hermes-data:/opt/data hermes-agent:test gateway run` (plus the bot tokens you normally use).
3. Without the patch: gateway logs `[Whatsapp] Bridge found at /opt/hermes/scripts/whatsapp-bridge/bridge.js` followed seconds later by `✗ whatsapp failed to connect`, and `/opt/data/whatsapp/bridge.log` does not exist.
4. With the patch: the same setup logs `✓ whatsapp connected` and `/opt/data/whatsapp/bridge.log` records `🌉 WhatsApp bridge listening on port 3000`.

Image size delta in my measurement: ~10 MB added (Baileys + transitive deps).

## Checklist

- [x] I've read the Contributing Guide.
- [x] Conventional Commits format (`fix(docker): …`).
- [x] No duplicate PR — searched for `whatsapp bridge` and `node_modules` open PRs.
- [x] Only Dockerfile changes, nothing unrelated.
- [x] I've run `pytest tests/ -q` and all tests pass (no Python code changed in this PR, but verified the Dockerfile builds with `docker build`).
- [ ] I've added tests — N/A for a Dockerfile build-time change.
- [x] Platform: Ubuntu 24.04 LTS + Docker 27.x.

### Documentation & Housekeeping

- [x] Inline comment in the `Dockerfile` explains why the pre-install + chown is needed.
- [x] No config keys changed — N/A for `cli-config.yaml.example`.
- [x] No architecture change — N/A for `CONTRIBUTING.md`/`AGENTS.md`.
- [x] Cross-platform: Docker-only change, no impact on macOS / Windows native installs.
- [x] No tool schema change.

## Screenshots / Logs

Without the patch (gateway):
```
INFO gateway.run: Connecting to whatsapp...
INFO gateway.platforms.whatsapp: [Whatsapp] Bridge found at /opt/hermes/scripts/whatsapp-bridge/bridge.js
WARNING gateway.run: ✗ whatsapp failed to connect
```

With the patch (gateway):
```
INFO gateway.run: Connecting to whatsapp...
INFO gateway.platforms.whatsapp: [Whatsapp] Bridge found at /opt/hermes/scripts/whatsapp-bridge/bridge.js
INFO gateway.run: ✓ whatsapp connected
```
