### PR TITLE
fix(whatsapp): convert E.164 chat_id to JID before sending via bridge

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -625,6 +625,82 @@ class TestSendToPlatformWhatsapp:
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
 
 
+class TestSendWhatsappJidNormalization:
+    """The Baileys bridge expects WhatsApp JIDs (digits@s.whatsapp.net), but
+    _parse_target_ref returns E.164 strings unchanged.  _send_whatsapp must
+    bridge that format gap before POSTing to the bridge."""
+
+    def _post_capture(self):
+        """Return (post_mock, session_ctx_mock) that records the JSON body."""
+        post_resp = MagicMock()
+        post_resp.status = 200
+        post_resp.json = AsyncMock(return_value={"messageId": "wamid.ABC"})
+        post_resp.__aenter__ = AsyncMock(return_value=post_resp)
+        post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        post_mock = MagicMock(return_value=post_resp)
+        session_obj = MagicMock()
+        session_obj.post = post_mock
+        session_obj.__aenter__ = AsyncMock(return_value=session_obj)
+        session_obj.__aexit__ = AsyncMock(return_value=False)
+        return post_mock, session_obj
+
+    def test_e164_target_is_converted_to_jid(self):
+        """+15551234567 -> 15551234567@s.whatsapp.net before HTTP POST."""
+        from tools.send_message_tool import _send_whatsapp
+
+        post_mock, session_obj = self._post_capture()
+        with patch("aiohttp.ClientSession", return_value=session_obj):
+            result = asyncio.run(_send_whatsapp({}, "+15551234567", "hi"))
+
+        assert result["success"] is True
+        _, kwargs = post_mock.call_args
+        assert kwargs["json"]["chatId"] == "15551234567@s.whatsapp.net"
+        # chat_id in the return value is normalized too, so callers can
+        # correlate with the eventual bridge state
+        assert result["chat_id"] == "15551234567@s.whatsapp.net"
+
+    def test_already_formed_jid_passes_through(self):
+        """Targets already in JID form must not be double-normalized."""
+        from tools.send_message_tool import _send_whatsapp
+
+        post_mock, session_obj = self._post_capture()
+        with patch("aiohttp.ClientSession", return_value=session_obj):
+            result = asyncio.run(
+                _send_whatsapp({}, "15551234567@s.whatsapp.net", "hi")
+            )
+
+        assert result["success"] is True
+        _, kwargs = post_mock.call_args
+        assert kwargs["json"]["chatId"] == "15551234567@s.whatsapp.net"
+
+    def test_lid_jid_passes_through(self):
+        """The newer @lid identity format must not be rewritten."""
+        from tools.send_message_tool import _send_whatsapp
+
+        post_mock, session_obj = self._post_capture()
+        with patch("aiohttp.ClientSession", return_value=session_obj):
+            result = asyncio.run(_send_whatsapp({}, "123456789012345@lid", "hi"))
+
+        assert result["success"] is True
+        _, kwargs = post_mock.call_args
+        assert kwargs["json"]["chatId"] == "123456789012345@lid"
+
+    def test_group_jid_passes_through(self):
+        """Group JIDs (digits@g.us) must reach the bridge unchanged."""
+        from tools.send_message_tool import _send_whatsapp
+
+        post_mock, session_obj = self._post_capture()
+        with patch("aiohttp.ClientSession", return_value=session_obj):
+            result = asyncio.run(
+                _send_whatsapp({}, "120363045123456789@g.us", "hi")
+            )
+
+        assert result["success"] is True
+        _, kwargs = post_mock.call_args
+        assert kwargs["json"]["chatId"] == "120363045123456789@g.us"
+
+
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML
     and that plain / markdown messages use MarkdownV2."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1153,6 +1153,18 @@ async def _send_whatsapp(extra, chat_id, message):
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    # Normalize E.164 phone numbers to WhatsApp JID format.
+    # _parse_target_ref accepts "whatsapp:+15551234567" and returns the
+    # E.164 string unchanged (correct for signal-cli, which the parser
+    # comment also covers).  The Baileys bridge, however, calls
+    # sock.sendMessage(chat_id, ...) which expects a JID
+    # ("15551234567@s.whatsapp.net" or similar) and throws
+    # "JID decode failed" on a raw E.164 string.  Convert here so both
+    # raw E.164 and already-formed JIDs (passed through as-is) work.
+    if isinstance(chat_id, str) and chat_id.startswith("+") and "@" not in chat_id:
+        digits = chat_id[1:].strip()
+        if digits.isdigit():
+            chat_id = f"{digits}@s.whatsapp.net"
     try:
         bridge_port = extra.get("bridge_port", 3000)
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## What does this PR do?

Make `send_message` work for WhatsApp targets specified in E.164 phone-number form.

`_parse_target_ref` in `tools/send_message_tool.py` accepts a WhatsApp target like `whatsapp:+15551234567`, returns the E.164 string unchanged, and marks it as explicit.  The accompanying comment claims "signal-cli and sms/whatsapp adapters expect E.164 format" — this is correct for signal-cli, but the Baileys-backed bridge in `scripts/whatsapp-bridge/bridge.js` calls `sock.sendMessage(chatId, ...)`, where `chatId` must be a JID (`<digits>@s.whatsapp.net`, `<digits>@lid`, or `<digits>@g.us`).  Calling it with a raw E.164 string raises `JID decode failed` inside Baileys and the bridge returns HTTP 500.

This is reproducible from any agent reply where the recipient is not yet in the directory listing — the agent then falls back to passing the E.164 string straight through.

### Why fix it in `_send_whatsapp` rather than `_parse_target_ref`

I deliberately did not change the parser, because `_PHONE_PLATFORMS` is shared with Signal/SMS where E.164 *is* the correct downstream format.  Normalizing inside `_send_whatsapp` keeps the parser invariant intact and the conversion local to the only adapter that needs JIDs.  Already-formed JIDs (`@s.whatsapp.net`, `@lid`, `@g.us`) pass through unchanged.

## Related Issue

Fixes #<!-- happy to file an issue with the failing reproduction if you'd like -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/send_message_tool.py` `_send_whatsapp`: add a 4-line normalization block before the HTTP POST.  Converts leading-`+` digits-only `chat_id` to `<digits>@s.whatsapp.net`; everything else (including already-formed JIDs) is unchanged.
- `tests/tools/test_send_message_tool.py`: new `TestSendWhatsappJidNormalization` class with 4 cases:
  - `test_e164_target_is_converted_to_jid` — `+15551234567` → `15551234567@s.whatsapp.net` in the bridge POST body and in the return value's `chat_id`.
  - `test_already_formed_jid_passes_through` — `15551234567@s.whatsapp.net` unchanged.
  - `test_lid_jid_passes_through` — `123456789012345@lid` unchanged.
  - `test_group_jid_passes_through` — `120363045123456789@g.us` unchanged.

## How to Test

```bash
pytest tests/tools/test_send_message_tool.py::TestSendWhatsappJidNormalization -v
pytest tests/tools/test_send_message_tool.py -k whatsapp -q
```

End-to-end reproduction (against any running gateway with the Baileys bridge):

```python
from tools.send_message_tool import send_message_tool
# Before the fix: returns {"error": "WhatsApp bridge error (500): ... JID decode failed ..."}
# After the fix:  returns {"success": True, "platform": "whatsapp", "chat_id": "<digits>@s.whatsapp.net", ...}
send_message_tool({
    "action": "send",
    "target": "whatsapp:+15551234567",
    "message": "test",
})
```

## Checklist

- [x] I've read the Contributing Guide.
- [x] Conventional Commits format (`fix(whatsapp): …`).
- [x] No duplicate PR — searched for `JID`, `E.164`, `whatsapp send_message` open PRs.
- [x] Only the WhatsApp send path is touched.
- [x] I've run `pytest tests/tools/test_send_message_tool.py -k whatsapp -q` and all tests pass (existing 6 + new 4).
- [x] I've added tests covering E.164 → JID conversion and three passthrough cases.
- [x] Platform: Ubuntu 24.04 LTS, Python 3.13.

### Documentation & Housekeeping

- [x] Inline comment in `_send_whatsapp` explains the format mismatch and the reason the conversion lives in the adapter (not the parser).
- [x] No config keys changed.
- [x] No architecture change.
- [x] Cross-platform: pure Python string handling, no OS-specific code.
- [x] No tool schema change — the `send_message` schema continues to advertise `whatsapp:<phone-or-jid>` targets.

## Screenshots / Logs

Bridge log line that motivated the fix:
```
{"level":50,"msg":"JID decode failed","input":"+15551234567"}
```
