### PR TITLE
feat(email): optional HTML signature via EMAIL_SIGNATURE_HTML_FILE

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -13,6 +13,9 @@ Environment variables:
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    EMAIL_SIGNATURE_HTML_FILE — Optional path to an HTML file appended to
+        outbound messages as a multipart/alternative HTML part.  When unset,
+        outbound messages are plain-text-only (unchanged default).
 """
 
 import asyncio
@@ -546,7 +549,36 @@ class EmailAdapter(BasePlatformAdapter):
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
-        msg.attach(MIMEText(body, "plain", "utf-8"))
+        # Optional HTML signature.
+        # When EMAIL_SIGNATURE_HTML_FILE points to a readable HTML file, the
+        # body is wrapped as multipart/alternative: a text/plain part with the
+        # raw body (unchanged for clients that prefer plain) and a text/html
+        # part that wraps the body (HTML-escaped, line-breaks converted to
+        # <br/>) followed by the signature HTML.  Without the env var, the
+        # adapter falls back to the original text/plain-only behaviour.
+        _sig_path = os.getenv("EMAIL_SIGNATURE_HTML_FILE", "").strip()
+        _sig_html = ""
+        if _sig_path:
+            try:
+                with open(_sig_path, "r", encoding="utf-8") as _f:
+                    _sig_html = _f.read()
+            except Exception as _e:
+                logger.warning("[Email] Failed to read signature %s: %s", _sig_path, _e)
+
+        if _sig_html:
+            import html as _html_mod
+            alt = MIMEMultipart("alternative")
+            alt.attach(MIMEText(body, "plain", "utf-8"))
+            _body_html = _html_mod.escape(body).replace("\n", "<br/>\n")
+            _html_doc = (
+                "<!DOCTYPE html><html><body style=\"font-family:Arial,Helvetica,sans-serif;"
+                "font-size:14px;color:#222;line-height:1.5;\">"
+                f"<div>{_body_html}</div>{_sig_html}</body></html>"
+            )
+            alt.attach(MIMEText(_html_doc, "html", "utf-8"))
+            msg.attach(alt)
+        else:
+            msg.attach(MIMEText(body, "plain", "utf-8"))
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1206,5 +1206,120 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         mock_imap.xatom.assert_called_once()
 
 
+class TestHtmlSignature(unittest.TestCase):
+    """Verify the optional HTML signature support in _send_email."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "993",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "587",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def _sent_message(self, mock_smtp):
+        """Return the MIME message object passed to smtplib.SMTP.send_message."""
+        mock_server = MagicMock()
+        mock_smtp.return_value = mock_server
+        return mock_server
+
+    def test_no_signature_stays_plain_text(self):
+        """Without EMAIL_SIGNATURE_HTML_FILE, behaviour is unchanged (plain only)."""
+        adapter = self._make_adapter()
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("EMAIL_SIGNATURE_HTML_FILE", None)
+            with patch("smtplib.SMTP") as mock_smtp:
+                server = self._sent_message(mock_smtp)
+                adapter._send_email("user@test.com", "Plain body.", None)
+
+        sent = server.send_message.call_args[0][0]
+        # Top-level MIME structure: MIMEMultipart() with one text/plain leaf
+        payload = sent.get_payload()
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0].get_content_type(), "text/plain")
+        self.assertIn("Plain body.", payload[0].get_payload(decode=True).decode("utf-8"))
+
+    def test_signature_produces_multipart_alternative(self):
+        """When the env var points to a readable HTML file, build a
+        multipart/alternative with text/plain (raw body) + text/html
+        (HTML-escaped body + signature)."""
+        import tempfile
+
+        adapter = self._make_adapter()
+        sig_html = (
+            '<table><tr><td style="color:#FD7D00">'
+            "Signature with brand color"
+            "</td></tr></table>"
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".html", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(sig_html)
+            sig_path = f.name
+
+        try:
+            with patch.dict(
+                os.environ, {"EMAIL_SIGNATURE_HTML_FILE": sig_path}, clear=False
+            ):
+                with patch("smtplib.SMTP") as mock_smtp:
+                    server = self._sent_message(mock_smtp)
+                    adapter._send_email(
+                        "user@test.com",
+                        "Hello & welcome.\nSecond line.",
+                        None,
+                    )
+
+            sent = server.send_message.call_args[0][0]
+            # Should have a multipart/alternative inside the outer multipart
+            alt = next(
+                p for p in sent.walk() if p.get_content_type() == "multipart/alternative"
+            )
+            parts = alt.get_payload()
+            self.assertEqual(len(parts), 2)
+            self.assertEqual(parts[0].get_content_type(), "text/plain")
+            self.assertEqual(parts[1].get_content_type(), "text/html")
+
+            plain = parts[0].get_payload(decode=True).decode("utf-8")
+            html = parts[1].get_payload(decode=True).decode("utf-8")
+
+            # Plain part keeps the body verbatim
+            self.assertIn("Hello & welcome.", plain)
+
+            # HTML part: body is HTML-escaped, newlines become <br/>, and
+            # the signature HTML is concatenated as-is
+            self.assertIn("Hello &amp; welcome.", html)
+            self.assertIn("<br/>", html)
+            self.assertIn("color:#FD7D00", html)
+        finally:
+            os.unlink(sig_path)
+
+    def test_signature_file_missing_falls_back_to_plain(self):
+        """A missing or unreadable signature file must not crash the send;
+        adapter falls back to plain-text-only."""
+        adapter = self._make_adapter()
+
+        with patch.dict(
+            os.environ,
+            {"EMAIL_SIGNATURE_HTML_FILE": "/nonexistent/signature.html"},
+            clear=False,
+        ):
+            with patch("smtplib.SMTP") as mock_smtp:
+                server = self._sent_message(mock_smtp)
+                adapter._send_email("user@test.com", "Body.", None)
+
+        sent = server.send_message.call_args[0][0]
+        payload = sent.get_payload()
+        # Falls back to plain (single text/plain part, no alternative)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0].get_content_type(), "text/plain")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Add optional HTML-signature support to the email adapter.

Operators deploying Hermes as a branded mailbox (persona, brand, on-call account) commonly want a styled signature on every outbound reply — without injecting "always append this HTML to your replies" into the agent's system prompt.  Today, `EmailAdapter._send_email` always attaches a single `text/plain` part, so the only way to get a signature is to teach the LLM about it, which is fragile and bloats every prompt.

This PR adds a single env-var, `EMAIL_SIGNATURE_HTML_FILE`.  When set to a readable HTML file, the adapter sends `multipart/alternative` with:
1. `text/plain` — the body unchanged (so clients that opt for plain still see exactly what the agent wrote)
2. `text/html` — the body HTML-escaped with newlines converted to `<br/>`, followed by the signature HTML, wrapped in a minimal HTML document

When the env-var is unset, behaviour is identical to before — single `text/plain` part, no change.  A misconfigured path (env-var set but file missing) logs a warning and falls back to plain-only, so a typo never blocks an outbound message.

## Related Issue

Fixes #<!-- no existing issue — I can file one to capture the use-case if you'd prefer -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/email.py` module docstring: add `EMAIL_SIGNATURE_HTML_FILE` to the documented env-var list with a one-line description and explicit mention that the default (env-var unset) is unchanged.
- `gateway/platforms/email.py` `_send_email`: branch on `EMAIL_SIGNATURE_HTML_FILE`.  When set and readable, build `multipart/alternative` with `text/plain` (raw body) + `text/html` (escaped body + `<br/>` line-breaks + signature).  When unset/unreadable, attach the existing single `text/plain` part.
- `tests/gateway/test_email.py`: new `TestHtmlSignature` class with 3 cases (no signature → plain-only; signature → multipart/alternative with escaped body and signature concatenation; missing signature file → warning + plain fallback).

## How to Test

```bash
pytest tests/gateway/test_email.py::TestHtmlSignature -v
pytest tests/gateway/test_email.py -q   # all 60 existing tests still pass
```

End-to-end reproduction:

```bash
cat > /tmp/sig.html <<'HTML'
<table><tr><td style="font-family:monospace;background:#06171E;color:#fff;
padding:12px;border-radius:6px;">— Hermes Agent</td></tr></table>
HTML

EMAIL_SIGNATURE_HTML_FILE=/tmp/sig.html hermes gateway run
# send Hermes a message, observe the reply renders as styled HTML in
# Gmail / Outlook / Apple Mail, while plain-text clients still see the
# raw body.
```

## Checklist

- [x] I've read the Contributing Guide.
- [x] Conventional Commits format (`feat(email): …`).
- [x] No duplicate PR — searched for `signature`, `email html`, `multipart` open PRs.
- [x] Only the email adapter is touched.
- [x] I've run `pytest tests/gateway/test_email.py -q` and all 63 tests pass (60 existing + 3 new).
- [x] I've added tests for the new feature: happy path + no-config (no regression) + missing-file (graceful fallback).
- [x] Platform: Ubuntu 24.04 LTS, Python 3.13, Hetzner SMTP relay.

### Documentation & Housekeeping

- [x] Module docstring updated with the new env var.
- [ ] I've updated `cli-config.yaml.example` — N/A, this is an env-only knob (matches existing `EMAIL_POLL_INTERVAL` / `EMAIL_ALLOWED_USERS` style).
- [x] No architecture change.
- [x] Cross-platform: pure Python `email.mime` + `html.escape`, no OS-specific code.
- [x] No tool schema change.

## Screenshots / Logs

Outbound MIME structure with the env-var set (Python `email.message.Message.walk()`):
```
multipart/mixed
└── multipart/alternative
    ├── text/plain   (raw body)
    └── text/html    (escaped body + signature)
```

Outbound MIME structure with the env-var unset (unchanged from current behaviour):
```
multipart/mixed
└── text/plain
```
