### PR TITLE
fix(todo): filter completed and cancelled items when hydrating todos

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5876,10 +5876,18 @@ class AIAgent:
                 continue
         
         if last_todo_response:
+            # Filter out completed/cancelled items when restoring from history,
+            # matching the logic in format_for_injection() -- these are intentionally
+            # excluded from context compression and should not be resurrected when
+            # the next turn hydrates the store from conversation history.
+            active_items = [
+                item for item in last_todo_response
+                if item.get("status") in ("pending", "in_progress")
+            ]
             # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
+            self._todo_store.write(active_items, merge=False)
             if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+                self._vprint(f"{self.log_prefix}📋 Restored {len(active_items)} todo item(s) from history ({len(last_todo_response) - len(active_items)} filtered)")
         _set_interrupt(False)
 
     @property

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -208,6 +208,8 @@ AUTHOR_MAP = {
     "formulahendry@gmail.com": "formulahendry",
     "93757150+bogerman1@users.noreply.github.com": "bogerman1",
     "132852777+rob-maron@users.noreply.github.com": "rob-maron",
+    "924358746@qq.com": "johnhom1024",
+    "charles@doublerebel.com": "doublerebel",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -942,6 +942,49 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
 
+    def test_filters_completed_and_cancelled(self, agent):
+        """Completed/cancelled items must not be resurrected (issue #7597)."""
+        todos = [
+            {"id": "1", "content": "still pending", "status": "pending"},
+            {"id": "2", "content": "in progress", "status": "in_progress"},
+            {"id": "3", "content": "done", "status": "completed"},
+            {"id": "4", "content": "nope", "status": "cancelled"},
+        ]
+        history = [
+            {"role": "user", "content": "plan"},
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "c1",
+            },
+        ]
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+        restored = agent._todo_store.read()
+        restored_ids = {item["id"] for item in restored}
+        assert restored_ids == {"1", "2"}
+        assert len(restored) == 2
+
+    def test_filter_log_message(self, agent, capsys):
+        """Log message should report filtered count."""
+        todos = [
+            {"id": "1", "content": "active", "status": "pending"},
+            {"id": "2", "content": "done", "status": "completed"},
+        ]
+        history = [
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "c1",
+            },
+        ]
+        agent.quiet_mode = False
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+        captured = capsys.readouterr()
+        assert "1 todo item(s) from history" in captured.out
+        assert "1 filtered" in captured.out
+
 
 class TestBuildSystemPrompt:
     def test_always_has_identity(self, agent):


### PR DESCRIPTION
## What does this PR do?

Adopts the narrow fix from #7595 so `_hydrate_todo_store()` only restores active todo items from conversation history.

Previously, hydration replayed every item from the last todo tool response, including `completed` and `cancelled` items. That disagreed with `TodoStore.format_for_injection()`, which intentionally omits completed/cancelled items from context injection. After context compression or a fresh agent turn, cancelled work could therefore reappear as active state.

This PR preserves only `pending` and `in_progress` items during hydration and logs how many inactive items were filtered.

Credit/provenance:

* Original upstream fix: #7595 by @johnhom1024
* Adopted commit: b12f1a9dc08fddd280ce93b222c81d772a0225d6

## Related Issue

Addresses #7597 and #7599.

Note: both issues are currently closed upstream, but current `origin/main` still restores inactive todo items from `_hydrate_todo_store()`. This PR applies the closed-but-unmerged fix path and adds regression coverage.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

* `run_agent.py`
  * Filters hydrated todo items to `pending` / `in_progress` before writing them into the todo store.
  * Keeps hydration aligned with `TodoStore.format_for_injection()` so completed/cancelled work is not resurrected.
  * Reports the filtered count in verbose restore output.
* `tests/run_agent/test_run_agent.py`
  * Adds coverage that completed and cancelled items are filtered during hydration.
  * Adds coverage for the restored/filtered count message.
* `scripts/release.py`
  * Adds `AUTHOR_MAP` entries for the adopted upstream author and this branch author so the contributor attribution check can pass.

## How to Test

Reproduction on current `origin/main`:

1. Ensure `_hydrate_todo_store()` receives a todo tool response containing mixed statuses:
   * `pending`
   * `in_progress`
   * `completed`
   * `cancelled`
2. Call `_hydrate_todo_store(history)`.
3. Observe current `origin/main` writes all four items back to the todo store.

Fixed behavior on this branch:

1. Run:

   ```bash
   scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestHydrateTodoStore -q
   ```
2. Confirm only `pending` and `in_progress` items are restored.
3. Confirm the restore message reports the filtered inactive count.

Security review:

* Reviewed diff against `origin/main`.
* No new shell, filesystem, network, credential, or path handling.
* Existing history JSON parsing trust boundary is not expanded.
* New verbose logging reports counts only, not todo contents.
* Verdict: no security blockers.

Full-suite local note:

* I ran the full test suite locally via the repository runner, equivalent to the PR-template `pytest tests/ -q` check:

  ```bash
  ulimit -n 4096 && scripts/run_tests.sh tests/
  ```

* Result: `94 failed, 22771 passed, 90 skipped, 2 errors` on macOS/darwin-arm64. The failures were broad and outside this PR's touched files, concentrated in existing LSP/client e2e, provider/auxiliary/compression, CLI setup/config/gateway/update/completion, process/terminal/live-system-guard/zombie cleanup, file-tool state/staleness guards, plugin/kanban discovery, browser/TTS/code-execution timeout, and TUI gateway goal-command tests. The two collection errors were in `tests/hermes_cli/test_web_oauth_dispatch.py` and `tests/plugins/test_kanban_dashboard_plugin.py`.
* Focused tests for this change passed: `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestHydrateTodoStore tests/tools/test_todo_tool.py -q` -> `18 passed`.
* E2E suite passed separately: `python -m pytest tests/e2e/ -v --tb=short` -> `56 passed, 7 skipped`.

## Checklist

### Code

- [X] I've read the [Contributing Guide](<https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md>)
- [X] My commit messages follow [Conventional Commits](<https://www.conventionalcommits.org/>) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](<https://github.com/NousResearch/hermes-agent/pulls>) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: macOS / darwin-arm64 local worktree

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](<https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility>) — no OS-specific behavior changed
- [X] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

N/A — no UI screenshots or log excerpts are needed for this non-visual state-hydration fix.

