### PR TITLE
fix(cron): log channel name resolution failures instead of silently swallowing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -439,8 +439,11 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                         thread_id = parsed_thread_id
                 else:
                     chat_id = resolved
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Failed to resolve channel name for platform_key=%r chat_id=%r: %s",
+                platform_key, chat_id, e,
+            )
 
         return {
             "platform": platform_name,


### PR DESCRIPTION
## What does this PR do?

Fixes a silent exception swallow in `_resolve_deliver_target()` where a failure in `resolve_channel_name()` would go completely unnoticed, leaving cron jobs silently delivering to wrong or nonexistent targets.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`cron/scheduler.py`** — `_resolve_deliver_target()` channel resolution block:
- Replace bare `except Exception: pass` with `except Exception as e`
- Add `logger.warning()` with platform_key, chat_id, and exception details
- Fallback behavior (using raw chat_id) is preserved

## Root Cause

```python
# Before — silent failure, wrong delivery target
try:
    from gateway.channel_directory import resolve_channel_name
    resolved = resolve_channel_name(platform_key, chat_id)
    if resolved:
        ...
except Exception:
    pass  # raw chat_id used silently, no indication of failure
```

```python
# After — failure is logged with context
except Exception as e:
    logger.warning(
        "Failed to resolve channel name for platform_key=%r chat_id=%r: %s",
        platform_key, chat_id, e,
    )
```

## Impact

When `resolve_channel_name()` fails (gateway not loaded, import error, network issue), cron job output is delivered using the raw `chat_id` string without any log entry. In headless cron environments this means misconfigured deliveries are completely invisible.

## How to Test

```python
from unittest.mock import patch
with patch('gateway.channel_directory.resolve_channel_name', side_effect=RuntimeError('test')):
    # trigger cron delivery — warning should appear in logs
```

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Minimal, focused change