### PR TITLE
fix(model_tools): log MCP async cleanup failures instead of silently swallowing

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -135,8 +135,8 @@ def _run_async(coro):
                         worker_loop.run_until_complete(
                             asyncio.gather(*pending, return_exceptions=True)
                         )
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning("MCP async cleanup failed: %s", e)
                 worker_loop.close()
 
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)


### PR DESCRIPTION
## What does this PR do?

Fixes a silent exception swallow in `_run_async_in_thread()` where a failure during MCP worker thread cleanup would go completely unnoticed, potentially masking thread leaks in long-running agent sessions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`model_tools.py`** — `_run_async_in_thread()` cleanup block:
- Replace bare `except Exception: pass` with `except Exception as e`
- Add `logger.warning()` to surface cleanup failures
- `worker_loop.close()` still runs unconditionally after the warning

## Root Cause

```python
# Before — silent failure, thread leak masked
finally:
    try:
        pending = asyncio.all_tasks(worker_loop)
        for t in pending:
            t.cancel()
        if pending:
            worker_loop.run_until_complete(
                asyncio.gather(*pending, return_exceptions=True)
            )
    except Exception:
        pass  # thread leak invisible
    worker_loop.close()
```

```python
# After — failure is logged
    except Exception as e:
        logger.warning("MCP async cleanup failed: %s", e)
    worker_loop.close()
```

## Impact

In long-running agent sessions with MCP server reconnection cycles, cleanup failures can cause thread accumulation. With bare `except: pass`, these failures were completely invisible — no log entry, no diagnostic.

## How to Test

```python
from unittest.mock import patch
import asyncio

with patch('asyncio.gather', side_effect=RuntimeError('cleanup error')):
    # trigger MCP tool call — warning should appear in logs
```

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Minimal, focused change