### PR TITLE
fix(compression): use getattr for _custom_providers in feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3250,7 +3250,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
-                custom_providers=self._custom_providers,
+                custom_providers=getattr(self, "_custom_providers", []),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -205,6 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -258,6 +260,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
     )
 
 


### PR DESCRIPTION
## Summary

The auxiliary compression model's context-length probe at `run_agent.py:3253`
(added in #25494) reads `self._custom_providers` directly.  Every other agent
attribute read in the same function uses `getattr(self, ..., <default>)` so
the feasibility check is robust against AIAgent instances that did not go
through full `__init__` (test stubs constructed with `AIAgent.__new__`, lazy
gateway init, etc.).  The direct attribute access raises `AttributeError` in
those cases, which is silently swallowed by the broad `except Exception` at
the bottom of the function — so the entire feasibility check no-ops without
warning.

## The bug

`tests/run_agent/test_compression_feasibility.py` constructs minimal agents
with `AIAgent.__new__(AIAgent)` and hand-set attributes.  After #25494
landed, eight tests fail on clean `origin/main`:

| Test | Failure |
|------|---------|
| `test_rejects_aux_below_minimum_context` | DID NOT RAISE |
| `test_auto_corrects_threshold_when_aux_context_below_threshold` | `assert 0 == 1` |
| `test_just_below_threshold_auto_corrects` | `assert 0 == 1` |
| `test_warning_stored_for_gateway_replay` | `assert 0 == 1` |
| `test_feasibility_check_ignores_invalid_context_length` | Called 0 times |
| `test_run_conversation_clears_warning_after_replay` | `assert None is not None` |
| `test_feasibility_check_passes_config_context_length` | Called 0 times |
| `test_init_feasibility_check_uses_aux_context_override_from_config` | expected call kwargs mismatch |

Six of these fail because the AttributeError short-circuits the function.
Two real-`__init__` tests (`test_feasibility_check_passes_config_context_length`
and `test_init_feasibility_check_uses_aux_context_override_from_config`) fail
for a different reason — their `assert_called_once_with` assertions were not
updated when the new `custom_providers=` kwarg was added at the call site.

## The fix

1. `run_agent.py:3253` — switch the call site to
   `getattr(self, "_custom_providers", [])`, matching the surrounding
   defensive pattern (e.g. `getattr(self, "_aux_compression_context_length_config", None)`,
   `getattr(self, "provider", "")` in the same function).  Production behaviour
   on a fully-initialised AIAgent is unchanged because `__init__` still sets
   `self._custom_providers = _custom_providers` on line 2209.

2. `tests/run_agent/test_compression_feasibility.py` — add the new
   `custom_providers=[]` kwarg to the three `assert_called_once_with`
   assertions that exercise the path through `get_model_context_length`.

## Test plan

- [x] Focused regression test: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_compression_feasibility.py -v` — `16 passed` (was `8 passed, 8 failed` on clean `origin/main`).
- [x] Adjacent suite: `tests/run_agent/` excluding `test_provider_parity.py` / `test_background_review.py` / `test_switch_model_context.py` (those have separate baseline failures unrelated to this fix) — `1265 passed, 9 skipped`.
- [x] Regression guard: reverted the `getattr` change alone — 6 tests fail with the "Called 0 times" / "DID NOT RAISE" / silent-no-op symptoms; restoring it brings them back to green.  Reverted the test assertion updates alone — only the two `assert_called_once_with` tests fail with the kwarg mismatch.  Both pieces are needed.

## Related

- #25494 — the merge commit that introduced the new `custom_providers=self._custom_providers` call site (originally PR #25359 by @PaTTeeL).