### PR TITLE
fix(cron): log grace period computation failures instead of silently swallowing

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -367,8 +367,8 @@ def _compute_grace_seconds(schedule: dict) -> int:
             period_seconds = int((second - first).total_seconds())
             grace = period_seconds // 2
             return max(MIN_GRACE, min(grace, MAX_GRACE))
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to compute grace seconds for cron expr %r: %s", schedule.get("expr"), e)
 
     return MIN_GRACE
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent exception swallow in `_compute_grace_seconds()` where a croniter parse failure would silently fall back to `MIN_GRACE` (120s), causing long-period cron jobs to be skipped with no diagnostic.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`cron/jobs.py`** — `_compute_grace_seconds()` cron branch:
- Replace bare `except Exception: pass` with `except Exception as e`
- Add `logger.warning()` with the cron expression and exception details
- `MIN_GRACE` fallback is preserved

## Root Cause

```python
# Before — silent failure, wrong grace period
if kind == "cron" and HAS_CRONITER:
    try:
        ...
        grace = period_seconds // 2
        return max(MIN_GRACE, min(grace, MAX_GRACE))
    except Exception:
        pass  # falls through to MIN_GRACE silently
return MIN_GRACE
```

```python
# After — failure is logged
    except Exception as e:
        logger.warning(
            "Failed to compute grace seconds for cron expr %r: %s",
            schedule.get("expr"), e
        )
return MIN_GRACE
```

## Impact

For long-period jobs like `0 */6 * * *` (every 6 hours), the correct grace period is ~3 hours. When croniter fails silently, the grace period drops to 120s — meaning the job may be skipped entirely on small time drifts with no log entry explaining why.

## How to Test

```python
from unittest.mock import patch
from cron.jobs import _compute_grace_seconds

with patch('cron.jobs.croniter', side_effect=Exception('parse error')):
    result = _compute_grace_seconds({'kind': 'cron', 'expr': '0 */6 * * *'})
    assert result == 120  # MIN_GRACE fallback
    # warning should appear in logs
```

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Minimal, focused change