### PR TITLE
fix(discord): tighten channel controls

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -77,21 +77,33 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
     # Platforms that don't support direct channel enumeration get session-based
-    # discovery automatically.  Skip infrastructure entries that aren't messaging
-    # platforms — everything else falls through to _build_from_sessions().
+    # discovery automatically, but only for platforms that are connected in this
+    # gateway process.  Historical session origins for disabled/decommissioned
+    # platforms (for example Marco's Slack fallback after the Discord cutover)
+    # must not be resurrected into the active send target directory.
     _SKIP_SESSION_DISCOVERY = frozenset({"local", "api_server", "webhook"})
+    adapter_platform_names = {getattr(platform, "value", str(platform)) for platform in adapters}
     for plat in Platform:
         plat_name = plat.value
-        if plat_name in _SKIP_SESSION_DISCOVERY or plat_name in platforms:
+        if (
+            plat_name in _SKIP_SESSION_DISCOVERY
+            or plat_name in platforms
+            or plat_name not in adapter_platform_names
+        ):
             continue
         platforms[plat_name] = _build_from_sessions(plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
-    # Platform.__members__, so the loop above misses them).
+    # Platform.__members__, so the loop above misses them).  Same connected-only
+    # rule: don't expose stale session targets for plugins that are not loaded.
     try:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
-            if entry.name not in _SKIP_SESSION_DISCOVERY and entry.name not in platforms:
+            if (
+                entry.name not in _SKIP_SESSION_DISCOVERY
+                and entry.name not in platforms
+                and entry.name in adapter_platform_names
+            ):
                 platforms[entry.name] = _build_from_sessions(entry.name)
     except Exception:
         pass

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -919,6 +919,10 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                if "text_batch_delay_seconds" in discord_cfg and not os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS"):
+                    os.environ["HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS"] = str(discord_cfg["text_batch_delay_seconds"])
+                if "text_batch_split_delay_seconds" in discord_cfg and not os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS"):
+                    os.environ["HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS"] = str(discord_cfg["text_batch_split_delay_seconds"])
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -560,9 +560,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
-        # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        # Text batching: merge rapid successive messages (Telegram-style).
+        # Keep the delay short for Discord: transport batching should smooth
+        # rapid split replies, not add noticeable latency to every tiny message.
+        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.2"))
+        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "1.0"))
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -17,6 +17,7 @@ from gateway.channel_directory import (
     _build_slack,
     DIRECTORY_PATH,
 )
+from gateway.config import Platform
 
 
 def _write_directory(tmp_path, platforms):
@@ -69,6 +70,23 @@ class TestBuildChannelDirectoryWrites:
             result = load_directory()
 
         assert result == previous
+
+    def test_does_not_resurrect_disabled_platforms_from_session_history(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "old_slack": {"origin": {"platform": "slack", "chat_id": "C01", "chat_name": "legacy-slack"}},
+            "active_telegram": {"origin": {"platform": "telegram", "chat_id": "123", "chat_name": "Active Chat"}},
+        }))
+        cache_file = tmp_path / "channel_directory.json"
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            directory = asyncio.run(build_channel_directory({Platform.TELEGRAM: object()}))
+
+        assert "telegram" in directory["platforms"]
+        assert "slack" not in directory["platforms"]
+        assert directory["platforms"]["telegram"][0]["id"] == "123"
 
 
 class TestResolveChannelName:

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -77,6 +77,14 @@ class FakeThread:
 def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    for env_name in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_AUTO_THREAD",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
@@ -110,7 +118,7 @@ async def test_ignored_channel_blocks_message(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "500")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
-    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
@@ -140,7 +148,7 @@ async def test_non_ignored_channel_processes_normally(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "500,600")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
-    message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=700), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
@@ -155,7 +163,7 @@ async def test_ignored_channels_csv_parsing(adapter, monkeypatch):
 
     for ch_id in (500, 600, 700):
         adapter.handle_message.reset_mock()
-        message = make_message(channel=FakeTextChannel(channel_id=ch_id), content="hello")
+        message = make_message(channel=FakeTextChannel(channel_id=ch_id), content="please inspect port 443")
         await adapter._handle_message(message)
         adapter.handle_message.assert_not_awaited()
 
@@ -167,7 +175,7 @@ async def test_ignored_channels_empty_string_ignores_nothing(adapter, monkeypatc
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
-    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
@@ -214,7 +222,7 @@ async def test_no_thread_channel_skips_auto_thread(adapter, monkeypatch):
 
     adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
 
-    message = make_message(channel=FakeTextChannel(channel_id=800), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=800), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter._auto_create_thread.assert_not_awaited()
@@ -235,7 +243,7 @@ async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
     fake_thread = FakeThread(channel_id=999, name="auto-thread")
     adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
 
-    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter._auto_create_thread.assert_awaited_once()
@@ -258,7 +266,7 @@ async def test_no_thread_channels_csv_parsing(adapter, monkeypatch):
     for ch_id in (800, 900):
         adapter._auto_create_thread.reset_mock()
         adapter.handle_message.reset_mock()
-        message = make_message(channel=FakeTextChannel(channel_id=ch_id), content="hello")
+        message = make_message(channel=FakeTextChannel(channel_id=ch_id), content="please inspect port 443")
         await adapter._handle_message(message)
         adapter._auto_create_thread.assert_not_awaited()
 
@@ -274,7 +282,7 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
 
     adapter._auto_create_thread = AsyncMock()
 
-    message = make_message(channel=FakeTextChannel(channel_id=800), content="hello")
+    message = make_message(channel=FakeTextChannel(channel_id=800), content="please inspect port 443")
     await adapter._handle_message(message)
 
     adapter._auto_create_thread.assert_not_awaited()
@@ -324,6 +332,28 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
 
 
+def test_config_bridges_discord_text_batch_delays(monkeypatch, tmp_path):
+    """gateway/config.py bridges Discord text batch latency knobs to env vars."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "text_batch_delay_seconds": 0.15,
+            "text_batch_split_delay_seconds": 0.75,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "")
+    monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS") == "0.15"
+    assert os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS") == "0.75"
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml
@@ -331,10 +361,12 @@ def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     config_file.write_text(yaml.dump({
         "discord": {
             "ignored_channels": ["111"],
+            "text_batch_delay_seconds": 0.15,
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "999")
+    monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.4")
 
     from gateway.config import load_gateway_config
     load_gateway_config()
@@ -342,3 +374,4 @@ def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     import os
     # Env var should NOT be overwritten
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "999"
+    assert os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS") == "0.4"


### PR DESCRIPTION
## Summary
- Tightens channel-directory behavior so disabled/decommissioned session-derived platforms are not resurrected unless the platform is connected in the current gateway process.
- Lowers Discord text batching default latency while preserving env/config override behavior.
- Bridges `discord.text_batch_delay_seconds` and `discord.text_batch_split_delay_seconds` config keys into env vars without overriding existing env values.
- Adds focused gateway tests for channel directory and Discord channel-control behavior.

## Verification
- `python -m py_compile gateway/channel_directory.py gateway/config.py gateway/platforms/discord.py`
- `git diff origin/main...HEAD --check`
- secret/dangerous-code scans clean
- `python -m pytest tests/gateway/test_channel_directory.py tests/gateway/test_discord_channel_controls.py -q` → 49 passed
- Vex clean-branch PR review: PASS

## Notes
- Clean branch is based on current `origin/main`.
- This PR is intentionally independent from token optimization PR #25953.
