### PR TITLE
fix(security): handle IPv6 scope IDs in URL safety checks to prevent bypass

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -240,9 +240,12 @@ def is_always_blocked_url(url: str) -> bool:
 
         for _family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
+            if '%' in ip_str:
+                ip_str = ip_str.split('%')[0]
             try:
                 resolved = ipaddress.ip_address(ip_str)
             except ValueError:
+                logger.warning("Unparseable IP address %r for hostname %s — skipping address", sockaddr[0], hostname)
                 continue
             if resolved in _ALWAYS_BLOCKED_IPS or any(
                 resolved in net for net in _ALWAYS_BLOCKED_NETWORKS
@@ -311,10 +314,14 @@ def is_safe_url(url: str) -> bool:
 
         for family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
+            if '%' in ip_str:
+                ip_str = ip_str.split('%')[0]
             try:
                 ip = ipaddress.ip_address(ip_str)
             except ValueError:
-                continue
+                # Still unparseable after scope ID strip — fail closed
+                logger.warning("Blocked request — unparseable IP address %r for hostname %s", sockaddr[0], hostname)
+                return False
 
             # Always block cloud metadata IPs and link-local, even with toggle on
             if ip in _ALWAYS_BLOCKED_IPS or any(ip in net for net in _ALWAYS_BLOCKED_NETWORKS):


### PR DESCRIPTION
## What does this PR do?

Fixes a security bypass in `is_always_blocked_url()` and `is_safe_url()` where IPv6 addresses with scope IDs (e.g. `fe80::1%eth0`) caused `ipaddress.ip_address()` to raise `ValueError` and were silently skipped via `continue`.

If ALL resolved addresses for a hostname carry scope IDs, every address is skipped and the URL passes all safety checks — a potential SSRF bypass against link-local or cloud metadata endpoints.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Root Cause

```python
# Before — scope ID causes ValueError, address silently skipped
ip_str = sockaddr[0]  # e.g. "fe80::1%eth0"
try:
    ip = ipaddress.ip_address(ip_str)  # ValueError!
except ValueError:
    continue  # skipped — URL bypasses all checks
```

```python
# After — scope ID stripped, fail closed if still unparseable
ip_str = sockaddr[0]
if '%' in ip_str:
    ip_str = ip_str.split('%')[0]
try:
    ip = ipaddress.ip_address(ip_str)
except ValueError:
    logger.warning("Blocked request — unparseable IP address %r for hostname %s", sockaddr[0], hostname)
    return False
```

## Impact

An attacker controlling DNS for a hostname could return only IPv6 link-local addresses with scope IDs, bypassing cloud metadata endpoint protection.

## Changes Made

**`tools/url_safety.py`** — two occurrences fixed consistently:
- `is_always_blocked_url()`
- `is_safe_url()`

## How to Test

```python
from unittest.mock import patch
import socket
from tools.url_safety import is_safe_url

mock_addr = [(socket.AF_INET6, None, None, None, ('fe80::1%eth0', 0, 0, 0))]
with patch('socket.getaddrinfo', return_value=mock_addr):
    assert is_safe_url('http://evil.example.com/') == False
```

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Both affected functions fixed consistently
- [x] Fail-closed behavior maintained