### PR TITLE
fix(cli): read agent.clarify_timeout in CLI clarify callback

### DIFF
--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -23,7 +23,14 @@ def clarify_callback(cli, question, choices):
     """
     from cli import CLI_CONFIG
 
-    timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
+    # Prefer the unified `agent.clarify_timeout` key (also used by the
+    # gateway) so a single config change applies everywhere.  Fall back
+    # to the CLI-specific `clarify.timeout` key, then to 120s.
+    agent_timeout = CLI_CONFIG.get("agent", {}).get("clarify_timeout")
+    if agent_timeout is not None:
+        timeout = int(agent_timeout)
+    else:
+        timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
     response_queue = queue.Queue()
     is_open_ended = not choices
 


### PR DESCRIPTION
## Summary

The CLI clarify callback in `hermes_cli/callbacks.py` only read the `clarify.timeout` config key (default 120s), ignoring the unified `agent.clarify_timeout` key that the gateway uses (default 600s). Users who set `agent.clarify_timeout` in `~/.hermes/config.yaml` saw their gateway sessions respect the new value, but CLI/TUI sessions still timed out after 120s.

## Changes

- **`hermes_cli/callbacks.py`**: Check `agent.clarify_timeout` first, fall back to `clarify.timeout`, then to the 120s hardcoded default.

## Root Cause

Two independent config keys governed clarify timeout in different code paths:
- `agent.clarify_timeout` → read by `tools/clarify_gateway.py:get_clarify_timeout()` (gateway)
- `clarify.timeout` → read by `hermes_cli/callbacks.py:clarify_callback()` (CLI/TUI)

The docs only mention `agent.clarify_timeout`, so users had no way to know a second key existed.

## Testing

- Existing `tests/tools/test_clarify_gateway.py` passes (15/15).
- Manual verification: setting `agent.clarify_timeout: 300` now correctly applies to CLI sessions.

Fixes #25859