### PR TITLE
fix(voice): remove per-tool-call beep in CLI voice mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9367,7 +9367,7 @@ class HermesCLI:
 
         Updates the TUI spinner widget so the user can see what the agent
         is doing during tool execution (fills the gap between thinking
-        spinner and next response).  Also plays audio cue in voice mode.
+        spinner and next response).
 
         On tool.started, records a monotonic timestamp so get_spinner_text()
         can show a live elapsed timer (the TUI poll loop already invalidates
@@ -9445,20 +9445,6 @@ class HermesCLI:
                 function_args if function_args is not None else {}
             )
             self._invalidate()
-
-        if not self._voice_mode:
-            return
-        if not function_name or function_name.startswith("_"):
-            return
-        try:
-            from tools.voice_mode import play_beep
-            threading.Thread(
-                target=play_beep,
-                kwargs={"frequency": 1200, "duration": 0.06, "count": 1},
-                daemon=True,
-            ).start()
-        except Exception:
-            pass
 
     def _on_tool_start(self, tool_call_id: str, function_name: str, function_args: dict):
         """Capture local before-state for write-capable tools."""


### PR DESCRIPTION
## Summary
Voice mode no longer dings on every tool call.

## Changes
- `cli.py`: drop the 1.2 kHz `play_beep` thread spawn at the bottom of `_on_tool_progress` (the `tool.started` path).
- Docstring trimmed to match.

## Why
The spinner already shows tool activity visually; the per-tool tone was unwanted noise. Especially painful on WSL2 — every beep also pokes Windows Terminal's bell notification, so it shows up as a system 'ding' on every tool call.

Record start/stop beeps (gated by `voice.beep_enabled`) are unaffected.

## Test plan
`scripts/run_tests.sh tests/cli/test_tool_progress_scrollback.py tests/tools/test_voice_cli_integration.py` — 96/96 passing. No test asserted the per-tool beep.