### PR TITLE
fix(cli): batch resize history replay (salvage #25007)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1473,6 +1473,7 @@ def _replay_output_history() -> None:
         return
     _OUTPUT_HISTORY_REPLAYING = True
     try:
+        rendered_lines = []
         for entry in tuple(_OUTPUT_HISTORY):
             if callable(entry):
                 try:
@@ -1483,8 +1484,15 @@ def _replay_output_history() -> None:
                     lines = lines.splitlines()
             else:
                 lines = [entry]
-            for line in lines:
-                _pt_print(_PT_ANSI(str(line)))
+            rendered_lines.extend(str(line) for line in lines)
+        if rendered_lines:
+            # Replay after resize can contain hundreds of history lines. A
+            # per-line prompt_toolkit print forces one synchronous terminal I/O
+            # and redraw cycle per line, which users perceive as a waterfall of
+            # old output. Keep the existing history contents unchanged, but
+            # emit the replay as one ANSI payload so resize recovery does a
+            # single prompt_toolkit print/redraw.
+            _pt_print(_PT_ANSI("\n".join(rendered_lines)))
     except Exception:
         pass
     finally:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -69,6 +69,8 @@ AUTHOR_MAP = {
     "datapod.k@gmail.com": "dandacompany",
     "treydong.zh@gmail.com": "TreyDong",
     "kyanam.preetham@gmail.com": "pkyanam",
+    "zhizhong.xu@shopee.com": "1000Delta",
+    "30397170+1000Delta@users.noreply.github.com": "1000Delta",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "147827411+EloquentBrush@users.noreply.github.com": "AhmetArif0",
     "97489706+purzbeats@users.noreply.github.com": "purzbeats",

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -258,8 +258,23 @@ def test_replay_output_history_rerenders_callable_entries(monkeypatch):
     cli._replay_output_history()
 
     assert widths_seen == ["called"]
-    assert printed == ["top border", "body"]
+    assert printed == ["top border\nbody"]
     assert list(cli._OUTPUT_HISTORY) == [_render_current_width]
+
+
+def test_replay_output_history_batches_rendered_lines_into_one_print(monkeypatch):
+    cli._configure_output_history(True, 10)
+    cli._record_output_history("first line")
+    cli._record_output_history("second line")
+    cli._record_output_history_entry(lambda: ["third line", "fourth line"])
+    printed = []
+
+    monkeypatch.setattr(cli, "_pt_print", lambda value: printed.append(value))
+    monkeypatch.setattr(cli, "_PT_ANSI", lambda text: text)
+
+    cli._replay_output_history()
+
+    assert printed == ["first line\nsecond line\nthird line\nfourth line"]
 
 
 def test_suspend_output_history_blocks_recording():


### PR DESCRIPTION
Salvage of #25007 by @1000Delta.

## Summary
Batch `_replay_output_history()` output into a single ANSI payload instead of one prompt_toolkit print per history line, so resize/redraw recovery in the classic CLI no longer visibly waterfalls old output.

## Changes
- cli.py: `_replay_output_history()` renders all lines, joins with `\n`, prints once.
- tests/cli/test_cprint_bg_thread.py: expectations updated to one batched print + coverage for batching rendered output-history.
- scripts/release.py: AUTHOR_MAP entry for @1000Delta.

## Validation
`scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/cli/test_resume_display.py` — 49/49 pass.

Original PR: #25007. Author @1000Delta credited via cherry-pick (`Xu Zhizhong <zhizhong.xu@shopee.com>`).

Closes #25007.