### PR TITLE
fix(gateway): give launchd_restart drain wait a +5s cleanup tail buffer

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3099,9 +3099,15 @@ def launchd_restart():
             except (ProcessLookupError, PermissionError, OSError):
                 pid = None
             if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+                # CLI deadline must exceed the gateway's own drain budget by
+                # the cleanup tail (adapter disconnect / SessionDB close /
+                # atexit) so a drain that uses its full budget still gets
+                # reported as a clean exit. The systemd path applies the
+                # same +5s buffer in _graceful_restart_via_sigusr1.
+                cli_deadline = drain_timeout + 5
+                exited = _wait_for_gateway_exit(timeout=cli_deadline, force_after=None)
                 if not exited:
-                    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
+                    print(f"⚠ Gateway drain timed out after {cli_deadline:.0f}s — forcing launchd restart")
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -580,6 +580,38 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
+    def test_launchd_restart_cli_deadline_exceeds_gateway_drain_budget(self, monkeypatch):
+        """CLI deadline must exceed gateway drain budget so a drain that uses
+        its full budget still has time for cleanup tail (adapter disconnect /
+        SessionDB close / atexit) without false-firing the timeout warning.
+        Mirrors the +5s buffer applied on the systemd path. Regression for
+        #25966 — equal deadlines false-fire on every full-budget drain."""
+        wait_calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 60.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+
+        def fake_wait_for_gateway_exit(timeout, force_after=None):
+            wait_calls.append({"timeout": timeout, "force_after": force_after})
+            return True
+
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", fake_wait_for_gateway_exit)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **kw: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert len(wait_calls) == 1
+        assert wait_calls[0]["timeout"] > 60.0, (
+            f"CLI timeout {wait_calls[0]['timeout']} must exceed drain budget "
+            "to cover gateway cleanup tail; got equal deadlines."
+        )
+
     def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
## Summary

`hermes gateway restart` on launchd false-fires the *"Gateway PID N still running after 60.0s — restart may fail"* warning on **clean** shutdowns, then SIGKILLs the gateway mid-cleanup. Sessions that shut down gracefully end up tagged auto-resumable on the next boot.

## The bug

`launchd_restart()` waits on the gateway exit with the same deadline the gateway uses for its own drain budget:

```python
exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
if not exited:
    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
```

`drain_timeout` defaults to **60 s** (`HERMES_RESTART_DRAIN_TIMEOUT` / `agent.restart_drain_timeout`). The gateway's own drain budget is also **60 s** plus ~1.2–15 s of cleanup tail (adapter disconnect, `SessionDB.close`, `atexit`, final exit).

When the drain runs close to its full budget the CLI deadline lapses before the cleanup tail completes. The CLI prints the false alarm and then runs `launchctl kickstart -k` against a gateway that was already exiting cleanly, so `.clean_shutdown` is never written and the next gateway boot logs:

```
INFO gateway.run: Marked 1 in-flight session(s) as resumable from previous run
INFO gateway.run: Scheduled auto-resume for 1 restart-interrupted session(s)
```

## The fix

The systemd path already does the right thing at the equivalent site:

```python
if _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
    ...
print(f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
      "forcing a service restart...")
```

Mirror that buffer on the launchd path so the CLI deadline exceeds the gateway's drain budget by enough to cover the observed cleanup tail. `launchctl kickstart -k` remains the correct escalation when the gateway is genuinely stuck — only the boundary changes.

## Test plan

- [x] Added `test_launchd_restart_cli_deadline_exceeds_gateway_drain_budget` asserting the `timeout` arg passed to `_wait_for_gateway_exit` is strictly greater than the configured `drain_timeout`.
- [x] Confirmed regression guard: reverting the `+5` makes the new test fail with `assert 60.0 > 60.0`; restoring it passes.
- [x] `tests/hermes_cli/test_gateway_service.py` and `tests/hermes_cli/test_gateway.py` — pre-existing systemd-only failures on macOS (`UserSystemdUnavailableError` — no user D-Bus session) reproduce on clean `origin/main fe83c4001` and are unrelated to this change. Zero touched-code failures.

## Related

- Refs #25966.
- Orthogonal to #17292, which fixes the analogous deadline on the `restart-all` / stop-then-start paths in `_gateway_command_inner` (different call sites; no overlap).

> Sibling code paths that may need the same fix: `_wait_for_gateway_exit(timeout=10.0, force_after=5.0)` calls inside `_gateway_command_inner` (around L5102 / L5238 / L5308). PR #17292 already updates two such sites; the remaining ones use the 10 s default rather than `drain_timeout`. Intentionally left out of this PR's scope to avoid colliding with #17292 — happy to widen once that PR's direction is settled.