### PR TITLE
fix(cli): preserve ANSI styling in resize replay history (salvage #24292)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1415,9 +1415,6 @@ _OUTPUT_HISTORY_REPLAYING = False
 _OUTPUT_HISTORY_SUPPRESSED = False
 _OUTPUT_HISTORY_MAX_LINES = 200
 _OUTPUT_HISTORY = deque(maxlen=_OUTPUT_HISTORY_MAX_LINES)
-_ANSI_CONTROL_RE = re.compile(
-    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
-)
 
 
 def _coerce_output_history_limit(value) -> int:
@@ -1459,10 +1456,10 @@ def _record_output_history_entry(entry) -> None:
 def _record_output_history(text: str) -> None:
     if not _OUTPUT_HISTORY_ENABLED or _OUTPUT_HISTORY_REPLAYING or _OUTPUT_HISTORY_SUPPRESSED:
         return
-    clean = _ANSI_CONTROL_RE.sub("", str(text)).replace("\r", "").rstrip("\n")
-    if not clean:
+    normalized = str(text).replace("\r", "").rstrip("\n")
+    if not normalized:
         return
-    for line in clean.splitlines():
+    for line in normalized.splitlines():
         _record_output_history_entry(line)
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -146,6 +146,7 @@ AUTHOR_MAP = {
     "sandrohub013@gmail.com": "SandroHub013",
     "maciekczech@users.noreply.github.com": "maciekczech",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
+    "cine.dreamer.one@gmail.com": "LeonSGP43",
     "zjtan1@gmail.com": "zeejaytan",
     "asslaenn5@gmail.com": "Aslaaen",
     "trae.anderson17@icloud.com": "Tkander1715",

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -215,13 +215,15 @@ def test_cprint_swallows_prompt_toolkit_import_error(monkeypatch):
     assert direct_prints == ["fallback2"]
 
 
-def test_output_history_strips_ansi_and_keeps_recent_lines():
+def test_output_history_preserves_ansi_and_keeps_recent_lines():
     cli._configure_output_history(True, 10)
 
     for idx in range(12):
         cli._record_output_history(f"\x1b[31mline-{idx}\x1b[0m")
 
-    assert list(cli._OUTPUT_HISTORY) == [f"line-{idx}" for idx in range(2, 12)]
+    assert list(cli._OUTPUT_HISTORY) == [
+        f"\x1b[31mline-{idx}\x1b[0m" for idx in range(2, 12)
+    ]
 
 
 def test_replay_output_history_does_not_record_replayed_lines(monkeypatch):
@@ -275,6 +277,16 @@ def test_replay_output_history_batches_rendered_lines_into_one_print(monkeypatch
     cli._replay_output_history()
 
     assert printed == ["first line\nsecond line\nthird line\nfourth line"]
+
+
+def test_chat_console_records_rich_ansi_for_resize_replay(monkeypatch):
+    cli._configure_output_history(True, 10)
+    monkeypatch.setattr(cli, "_pt_print", lambda *_args, **_kwargs: None)
+
+    cli.ChatConsole().print("[bold red]Hello[/]")
+
+    assert cli._OUTPUT_HISTORY
+    assert any("\x1b[" in line for line in cli._OUTPUT_HISTORY)
 
 
 def test_suspend_output_history_blocks_recording():


### PR DESCRIPTION
Salvage of #24292 by @LeonSGP43.

## Summary
`_record_output_history()` was stripping ANSI escape sequences before storing entries, so when `/redraw` or Ctrl+L triggered `_replay_output_history()`, all colors and styling came back as plain text. Now the history retains the original ANSI payload and `_PT_ANSI(...)` renders it correctly on replay.

## Changes
- cli.py: drop `_ANSI_CONTROL_RE` and the strip in `_record_output_history`; store the raw normalized text.
- tests/cli/test_cprint_bg_thread.py: rename `test_output_history_strips_ansi_…` to `test_output_history_preserves_ansi_…` and assert ANSI is kept; add `test_chat_console_records_rich_ansi_for_resize_replay` covering the Rich → ANSI path.
- scripts/release.py: AUTHOR_MAP entry for @LeonSGP43's commit email.

## Validation
`scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/cli/test_resume_display.py` — 50/50 pass (including the batched-replay test from #25972 alongside the new ANSI-preservation assertions).

Original PR: #24292. Contributor authorship preserved via cherry-pick (`LeonSGP43 <cine.dreamer.one@gmail.com>`).

Closes #24292.