### PR TITLE
fix(web): use Node.js for sync-assets instead of Unix rm/cp

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync-assets": "rm -rf public/fonts public/ds-assets && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets",
+    "sync-assets": "node scripts/sync-assets.js",
     "predev": "npm run sync-assets",
     "prebuild": "npm run sync-assets",
     "dev": "vite",

--- a/web/scripts/sync-assets.js
+++ b/web/scripts/sync-assets.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Cross-platform sync-assets: replaces `rm -rf public/fonts public/ds-assets && cp -r ...`
+// Works on Windows (CMD/PowerShell), macOS, and Linux without Unix utilities.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(__dirname, "..");
+
+const targets = ["fonts", "ds-assets"];
+const destDir = path.join(webRoot, "public");
+
+for (const target of targets) {
+  const dest = path.join(destDir, target);
+  // Remove existing directory (recursive, works cross-platform)
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true, force: true });
+  }
+}
+
+// Copy from node_modules
+const srcPkg = "@nous-research/ui";
+const srcFonts = path.join(webRoot, "node_modules", srcPkg, "dist", "fonts");
+const srcAssets = path.join(webRoot, "node_modules", srcPkg, "dist", "assets");
+const destFonts = path.join(destDir, "fonts");
+const destAssets = path.join(destDir, "ds-assets");
+
+if (fs.existsSync(srcFonts)) {
+  fs.cpSync(srcFonts, destFonts, { recursive: true });
+}
+if (fs.existsSync(srcAssets)) {
+  fs.cpSync(srcAssets, destAssets, { recursive: true });
+}


### PR DESCRIPTION
Salvage of #25090 by @ms-alan (pander).

Web UI build failed on Windows CMD/PowerShell because `npm run sync-assets` invoked Unix `rm -rf … && cp -r …` directly in package.json. Replaces the shell incantation with a tiny Node.js script using built-in `fs.rmSync` + `fs.cpSync` (recursive, cross-platform, no new deps).

## Changes
- web/package.json: `sync-assets` now runs `node scripts/sync-assets.js`
- web/scripts/sync-assets.js (new): 34-line ESM script, idempotent delete-then-copy

## Validation
- E2E on Linux/Node 22: `npm install && npm run sync-assets` copies fonts (14 files) + ds-assets (1 file) into web/public/. Second run is idempotent. `npm run prebuild` hook works.
- `fs.cpSync` requires Node 16.7+ — already required by Vite 7.

Closes #25073.
