### PR TITLE
feat(cli,gateway): add /advisor command for on-demand second-opinion from a stronger model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7653,6 +7653,8 @@ class HermesCLI:
             self._handle_agents_command()
         elif canonical == "background":
             self._handle_background_command(cmd_original)
+        elif canonical == "advisor":
+            self._handle_advisor_command(cmd_original)
         elif canonical == "queue":
             # Extract prompt after "/queue " or "/q "
             parts = cmd_original.split(None, 1)
@@ -7961,6 +7963,174 @@ class HermesCLI:
                     self._invalidate(min_interval=0)
 
         thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
+
+    _ADVISOR_DEFAULT_MODEL = "claude-opus-4-7"
+    _ADVISOR_SYSTEM_PROMPT = (
+        "You are an expert advisor reviewing a conversation between a user and an AI assistant. "
+        "Your role is to provide a high-quality second opinion, critique, or improvement on the "
+        "assistant's most recent response. Be direct and concise. "
+        "If the assistant's answer was correct and thorough, confirm it and note any small gaps. "
+        "If you can do better, provide the improved answer. "
+        "Do not simply repeat what was said."
+    )
+
+    def _handle_advisor_command(self, cmd: str) -> None:
+        """Handle /advisor [model] [question] -- ask a stronger model to review the conversation.
+
+        Usage:
+          /advisor                     -- review the last exchange with the default advisor model
+          /advisor opus                -- same, explicitly using opus
+          /advisor claude-opus-4-7     -- same, full model name
+          /advisor What is a qubit?    -- override the question sent to the advisor
+
+        The advisor sees the full conversation history (read-only) and posts its
+        response as a background panel, without affecting the active session.
+        """
+        parts = cmd.strip().split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+
+        # Detect if the first word looks like a model name or known alias.
+        advisor_model = self._ADVISOR_DEFAULT_MODEL
+        question_override = ""
+        if raw_args:
+            first_word = raw_args.split()[0]
+            # Treat it as a model hint if it contains a model keyword or looks
+            # like an API model ID.
+            _model_keywords = {"opus", "sonnet", "haiku", "claude", "gpt", "gemini", "llama",
+                               "mixtral", "qwen", "mistral", "grok", "deepseek"}
+            _is_model_hint = (
+                any(kw in first_word.lower() for kw in _model_keywords)
+                or "-" in first_word
+            )
+            if _is_model_hint:
+                advisor_model = first_word
+                question_override = raw_args.split(None, 1)[1].strip() if " " in raw_args else ""
+            else:
+                question_override = raw_args
+
+        # Resolve credentials for the advisor model. Use the same provider as
+        # the current session so the user does not need a separate credential.
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start advisor: no valid credentials.")
+            return
+
+        # Snapshot conversation history for the advisor (read-only copy).
+        history_snapshot: list[dict] = []
+        if self.agent is not None and hasattr(self.agent, "messages"):
+            try:
+                import copy
+                history_snapshot = copy.deepcopy(self.agent.messages)
+            except Exception:
+                pass
+
+        if not history_snapshot:
+            _cprint("  No conversation history yet -- start a conversation first, then call /advisor.")
+            return
+
+        # Build the question sent to the advisor.
+        if question_override:
+            advisor_question = question_override
+        else:
+            advisor_question = (
+                "Please review the conversation above. "
+                "Provide a second opinion or improvement on the assistant's most recent response."
+            )
+
+        task_id = f"advisor_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        _cprint(f"  Consulting advisor ({advisor_model}) on this conversation ...")
+        _cprint(f"  Task ID: {task_id}  (results appear here when ready)\n")
+
+        turn_route = self._resolve_turn_agent_config(advisor_question)
+
+        def run_advisor():
+            set_sudo_password_callback(self._sudo_password_callback)
+            set_approval_callback(self._approval_callback)
+            try:
+                set_secret_capture_callback(self._secret_capture_callback)
+            except Exception:
+                pass
+            try:
+                adv_agent = AIAgent(
+                    model=advisor_model,
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    max_iterations=10,
+                    enabled_toolsets=[],  # advisor is read-only, no tools
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=task_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                )
+                adv_agent._print_fn = lambda *_a, **_kw: None
+
+                result = adv_agent.run_conversation(
+                    user_message=advisor_question,
+                    system_message=self._ADVISOR_SYSTEM_PROMPT,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                ChatConsole().print(f"[#B8860B]{'=' * 50}[/]")
+                _cprint(f"  Advisor ({advisor_model}) -- second opinion")
+                ChatConsole().print(f"[#B8860B]{'=' * 50}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        _resp_color = _skin.get_color("response_border", "#B8860B")
+                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                    except Exception:
+                        _resp_color = "#B8860B"
+                        _resp_text = "#FFF8DC"
+
+                    ChatConsole().print(Panel(
+                        _render_final_assistant_content(response, mode=self.final_response_markdown),
+                        title=f"[{_resp_color} bold]Advisor ({advisor_model})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                    ))
+                else:
+                    _cprint("  (Advisor returned no response)")
+
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  Advisor failed: {e}")
+            finally:
+                try:
+                    set_sudo_password_callback(None)
+                    set_approval_callback(None)
+                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
+                self._background_tasks.pop(task_id, None)
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_advisor, daemon=True, name=f"advisor-{task_id}")
         self._background_tasks[task_id] = thread
         thread.start()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6542,6 +6542,9 @@ class GatewayRunner:
         if canonical == "background":
             return await self._handle_background_command(event)
 
+        if canonical == "advisor":
+            return await self._handle_advisor_command(event)
+
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
             # Strip the prefix so downstream treats it as a normal user
@@ -10543,6 +10546,176 @@ class GatewayRunner:
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # /advisor command -- gateway (async) implementation
+    # ------------------------------------------------------------------
+
+    _ADVISOR_DEFAULT_MODEL = "claude-opus-4-7"
+    _ADVISOR_SYSTEM_PROMPT = (
+        "You are an expert advisor reviewing a conversation between a user and an AI assistant. "
+        "Your role is to provide a high-quality second opinion, critique, or improvement on the "
+        "assistant's most recent response. Be direct and concise. "
+        "If the assistant's answer was correct and thorough, confirm it and note any small gaps. "
+        "If you can do better, provide the improved answer. "
+        "Do not simply repeat what was said."
+    )
+
+    async def _handle_advisor_command(self, event: "MessageEvent") -> str:
+        """Handle /advisor [model] [question] -- consult a stronger model for a second opinion.
+
+        Usage:
+          /advisor                     review last exchange with the default advisor model
+          /advisor opus                same, explicitly using opus
+          /advisor claude-opus-4-7     same, full model name
+          /advisor What is a qubit?    custom question sent to the advisor
+
+        The advisor receives the full conversation history read-only and responds
+        directly to the chat without modifying the active session context.
+        """
+        raw_args = event.get_command_args().strip()
+
+        advisor_model = self._ADVISOR_DEFAULT_MODEL
+        question_override = ""
+        if raw_args:
+            first_word = raw_args.split()[0]
+            _model_keywords = {"opus", "sonnet", "haiku", "claude", "gpt", "gemini", "llama",
+                               "mixtral", "qwen", "mistral", "grok", "deepseek"}
+            _is_model_hint = (
+                any(kw in first_word.lower() for kw in _model_keywords)
+                or "-" in first_word
+            )
+            if _is_model_hint:
+                advisor_model = first_word
+                question_override = raw_args.split(None, 1)[1].strip() if " " in raw_args else ""
+            else:
+                question_override = raw_args
+
+        source = event.source
+        task_id = f"advisor_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        event_message_id = self._reply_anchor_for_event(event)
+
+        _task = asyncio.create_task(
+            self._run_advisor_task(
+                advisor_model=advisor_model,
+                question_override=question_override,
+                source=source,
+                task_id=task_id,
+                event_message_id=event_message_id,
+            )
+        )
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        return f"Consulting advisor ({advisor_model}) ... (task {task_id})"
+
+    async def _run_advisor_task(
+        self,
+        advisor_model: str,
+        question_override: str,
+        source: "SessionSource",
+        task_id: str,
+        event_message_id: Optional[str] = None,
+    ) -> None:
+        """Execute the advisor agent and deliver the result to the chat."""
+        from run_agent import AIAgent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in advisor task %s", source.platform, task_id)
+            return
+
+        _thread_metadata = self._thread_metadata_for_source(source, event_message_id)
+
+        try:
+            user_config = _load_gateway_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                user_config=user_config,
+            )
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    f"Advisor task {task_id} failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            # Snapshot the active session history, if one exists.
+            history_snapshot: list[dict] = []
+            try:
+                session_key = self._session_key_for_source(source)
+                cached = self._agent_cache.get(session_key)
+                if cached:
+                    cached_agent = cached[0]
+                    raw_msgs = getattr(cached_agent, "messages", None)
+                    if raw_msgs:
+                        import copy
+                        history_snapshot = copy.deepcopy(raw_msgs)
+            except Exception:
+                pass
+
+            if not history_snapshot:
+                await adapter.send(
+                    source.chat_id,
+                    "No conversation history found for this session. Start a conversation first.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            advisor_question = question_override or (
+                "Please review the conversation above. "
+                "Provide a second opinion or improvement on the assistant's most recent response."
+            )
+
+            adv_agent = AIAgent(
+                model=advisor_model,
+                api_key=runtime_kwargs.get("api_key"),
+                base_url=runtime_kwargs.get("base_url"),
+                provider=runtime_kwargs.get("provider"),
+                api_mode=runtime_kwargs.get("api_mode"),
+                max_iterations=10,
+                enabled_toolsets=[],  # advisor is read-only, no tools
+                quiet_mode=True,
+                verbose_logging=False,
+                session_id=task_id,
+                platform=source.platform,
+                session_db=self._session_db,
+            )
+            adv_agent._print_fn = lambda *_a, **_kw: None  # type: ignore[method-assign]
+
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: adv_agent.run_conversation(
+                    user_message=advisor_question,
+                    system_message=self._ADVISOR_SYSTEM_PROMPT,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                ),
+            )
+
+            response = (result or {}).get("final_response", "")
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+
+            header = f"**Advisor ({advisor_model})**\n\n"
+            await adapter.send(
+                chat_id=source.chat_id,
+                content=header + (response or "(No response generated)"),
+                metadata=_thread_metadata,
+            )
+
+        except Exception as e:
+            logger.exception("Advisor task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"Advisor task {task_id} failed: {e}",
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -96,6 +96,13 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
+    CommandDef(
+        "advisor",
+        "Ask a stronger advisor model for a second opinion on the current conversation",
+        "Session",
+        aliases=("consult",),
+        args_hint="[model] [question]",
+    ),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",

--- a/tests/cli/test_advisor_command.py
+++ b/tests/cli/test_advisor_command.py
@@ -1,0 +1,240 @@
+"""Unit tests for the /advisor command (CLI + gateway dispatch).
+
+These tests verify:
+- CommandDef registration (name, aliases, args_hint)
+- Model/question parsing from raw args
+- Guard against empty conversation history
+- Background thread is spawned for valid input
+- Gateway handler returns the consulting ack string
+"""
+from __future__ import annotations
+
+import threading
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cli(history: list | None = None):
+    """Return a minimal HermesCLI-like stub for testing _handle_advisor_command."""
+    cli = MagicMock()
+    cli._ADVISOR_DEFAULT_MODEL = "claude-opus-4-7"
+    cli._ADVISOR_SYSTEM_PROMPT = "You are an expert advisor..."
+    cli._ensure_runtime_credentials.return_value = True
+    cli._resolve_turn_agent_config.return_value = {
+        "model": "claude-opus-4-7",
+        "runtime": {
+            "api_key": "sk-test",
+            "base_url": None,
+            "provider": "anthropic",
+            "api_mode": None,
+        },
+    }
+    cli.final_response_markdown = "markdown"
+    cli.bell_on_complete = False
+    cli._app = None
+    cli._background_tasks = {}
+    cli._spinner_text = ""
+    cli._agent_running = False
+    cli._session_db = None
+
+    # Attach a fake agent with messages
+    fake_agent = MagicMock()
+    fake_agent.messages = history if history is not None else [
+        {"role": "user", "content": "What is a neural network?"},
+        {"role": "assistant", "content": "A neural network is..."},
+    ]
+    cli.agent = fake_agent
+
+    return cli
+
+
+# ---------------------------------------------------------------------------
+# CommandDef registration
+# ---------------------------------------------------------------------------
+
+class TestAdvisorCommandDef(unittest.TestCase):
+
+    def test_advisor_in_registry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names = {c.name for c in COMMAND_REGISTRY}
+        self.assertIn("advisor", names)
+
+    def test_advisor_aliases(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "advisor")
+        self.assertIn("consult", cmd.aliases)
+
+    def test_advisor_args_hint(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "advisor")
+        self.assertIsNotNone(cmd.args_hint)
+
+    def test_resolve_consult_alias(self):
+        from hermes_cli.commands import resolve_command
+        cmd = resolve_command("consult")
+        self.assertIsNotNone(cmd)
+        self.assertEqual(cmd.name, "advisor")
+
+    def test_no_em_dash_in_description(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+        cmd = next(c for c in COMMAND_REGISTRY if c.name == "advisor")
+        self.assertNotIn("\u2014", cmd.description)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing (model hint detection)
+# ---------------------------------------------------------------------------
+
+class TestAdvisorArgParsing(unittest.TestCase):
+
+    def _parse(self, raw_args: str):
+        """Exercise the argument-parsing logic from _handle_advisor_command."""
+        advisor_model = "claude-opus-4-7"
+        question_override = ""
+        if raw_args:
+            first_word = raw_args.split()[0]
+            _model_keywords = {"opus", "sonnet", "haiku", "claude", "gpt", "gemini", "llama",
+                               "mixtral", "qwen", "mistral", "grok", "deepseek"}
+            _is_model_hint = (
+                any(kw in first_word.lower() for kw in _model_keywords)
+                or "-" in first_word
+            )
+            if _is_model_hint:
+                advisor_model = first_word
+                question_override = raw_args.split(None, 1)[1].strip() if " " in raw_args else ""
+            else:
+                question_override = raw_args
+        return advisor_model, question_override
+
+    def test_no_args_uses_default_model(self):
+        model, q = self._parse("")
+        self.assertEqual(model, "claude-opus-4-7")
+        self.assertEqual(q, "")
+
+    def test_opus_shorthand(self):
+        model, q = self._parse("opus")
+        self.assertEqual(model, "opus")
+        self.assertEqual(q, "")
+
+    def test_full_model_id(self):
+        model, q = self._parse("claude-opus-4-7")
+        self.assertEqual(model, "claude-opus-4-7")
+        self.assertEqual(q, "")
+
+    def test_model_with_question(self):
+        model, q = self._parse("opus What is a qubit?")
+        self.assertEqual(model, "opus")
+        self.assertEqual(q, "What is a qubit?")
+
+    def test_plain_question_no_model(self):
+        model, q = self._parse("Is the last answer correct?")
+        self.assertEqual(model, "claude-opus-4-7")
+        self.assertEqual(q, "Is the last answer correct?")
+
+    def test_sonnet_detected(self):
+        model, q = self._parse("sonnet")
+        self.assertEqual(model, "sonnet")
+
+    def test_hyphen_in_first_word_treated_as_model(self):
+        model, q = self._parse("gpt-4o What's new?")
+        self.assertEqual(model, "gpt-4o")
+        self.assertEqual(q, "What's new?")
+
+
+# ---------------------------------------------------------------------------
+# _handle_advisor_command behaviour
+# ---------------------------------------------------------------------------
+
+class TestHandleAdvisorCommand(unittest.TestCase):
+
+    def _invoke(self, cli, cmd: str):
+        """Call the real method on the stub."""
+        from cli import HermesCLI
+        return HermesCLI._handle_advisor_command(cli, cmd)
+
+    def test_no_history_prints_and_returns(self):
+        """When agent.messages is empty, should print a hint and not spawn a thread."""
+        cli = _make_cli(history=[])
+        self._invoke(cli, "/advisor")
+        # No thread should have been appended to _background_tasks
+        self.assertEqual(len(cli._background_tasks), 0)
+
+    def test_no_credentials_returns_early(self):
+        cli = _make_cli()
+        cli._ensure_runtime_credentials.return_value = False
+        self._invoke(cli, "/advisor")
+        self.assertEqual(len(cli._background_tasks), 0)
+
+    def test_spawns_thread_with_history(self):
+        cli = _make_cli()
+        self._invoke(cli, "/advisor")
+        self.assertEqual(len(cli._background_tasks), 1)
+        task_id, thread = next(iter(cli._background_tasks.items()))
+        self.assertIsInstance(thread, threading.Thread)
+        self.assertTrue(thread.daemon)
+
+    def test_custom_model_passed(self):
+        cli = _make_cli()
+        # Patch AIAgent so we can inspect what model was passed.
+        with patch("cli.AIAgent") as MockAgent:
+            MockAgent.return_value.run_conversation.return_value = {"final_response": "ok"}
+            self._invoke(cli, "/advisor sonnet Is this right?")
+            # Background thread may not have run yet, but _background_tasks was populated.
+            self.assertEqual(len(cli._background_tasks), 1)
+
+
+# ---------------------------------------------------------------------------
+# Gateway: /advisor handler
+# ---------------------------------------------------------------------------
+
+class TestGatewayAdvisorHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def test_returns_ack_string(self):
+        from gateway.run import GatewayRunner
+
+        runner = MagicMock(spec=GatewayRunner)
+        runner._ADVISOR_DEFAULT_MODEL = GatewayRunner._ADVISOR_DEFAULT_MODEL
+        runner._reply_anchor_for_event.return_value = None
+        runner._background_tasks = set()
+
+        event = MagicMock()
+        event.get_command_args.return_value = ""
+        event.source.platform = "discord"
+
+        with patch("asyncio.create_task") as mock_create_task:
+            mock_task = MagicMock()
+            mock_create_task.return_value = mock_task
+
+            result = await GatewayRunner._handle_advisor_command(runner, event)
+
+        self.assertIn("claude-opus-4-7", result)
+        self.assertIn("Consulting advisor", result)
+
+    async def test_custom_model_in_ack(self):
+        from gateway.run import GatewayRunner
+
+        runner = MagicMock(spec=GatewayRunner)
+        runner._ADVISOR_DEFAULT_MODEL = GatewayRunner._ADVISOR_DEFAULT_MODEL
+        runner._reply_anchor_for_event.return_value = None
+        runner._background_tasks = set()
+
+        event = MagicMock()
+        event.get_command_args.return_value = "opus"
+        event.source.platform = "discord"
+
+        with patch("asyncio.create_task") as mock_create_task:
+            mock_task = MagicMock()
+            mock_create_task.return_value = mock_task
+
+            result = await GatewayRunner._handle_advisor_command(runner, event)
+
+        self.assertIn("opus", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

I noticed there is no built-in way to get a quick second opinion from a stronger model without permanently switching the session model or manually copying conversation history. This PR adds `/advisor` (alias: `/consult`), which mirrors the advisor pattern from Claude Code but for the Hermes CLI and gateway surfaces.

## What this does

`/advisor` snapshots the current session's conversation history (read-only deep copy), spawns an isolated `AIAgent` configured with a configurable advisor model (default: `claude-opus-4-7`), and streams the result back without touching the active session context or history.

**CLI**: response renders in a distinct gold-bordered panel as a background task, same pattern as `/background`.  
**Gateway**: advisor response is delivered to the originating chat thread as an async background task.

## Usage

```
/advisor                       review last exchange with default advisor model
/advisor opus                  same, explicit model shorthand
/advisor claude-opus-4-7       same, full model ID
/advisor Is this answer right? ask a custom question
/consult sonnet                alias with a different model
```

Model detection: if the first word contains a known model keyword (`opus`, `sonnet`, `haiku`, `claude`, `gpt`, `gemini`, etc.) or a hyphen, it is treated as a model ID; otherwise the entire string is the question.

## Files changed

| File | Change |
|------|--------|
| `hermes_cli/commands.py` | Register `CommandDef` for `advisor` (alias: `consult`) |
| `cli.py` | `_handle_advisor_command()` + dispatch in `process_command()` |
| `gateway/run.py` | Async `_handle_advisor_command()` + `_run_advisor_task()` + gateway dispatch |
| `tests/cli/test_advisor_command.py` | 18 unit tests (CommandDef, alias resolution, arg parsing, guard conditions, thread spawning, gateway ack) |

## Tests

```
18 passed in 2.98s
```

## Design notes

- The advisor agent has `enabled_toolsets=[]` intentionally -- it should review and respond, not call tools.
- History snapshot is a deep copy so the advisor cannot mutate the active session.
- The command is non-blocking in both CLI (daemon thread) and gateway (asyncio task), matching the `/background` pattern.
- Default advisor model is a class-level constant (`_ADVISOR_DEFAULT_MODEL`) making it easy to change via a future config key without touching dispatch logic.

Happy to receive feedback on naming, the model-detection heuristic, or whether a config key for the default advisor model would be preferred over the current constant.