### PR TITLE
fix(delegate): preserve completed status and interrupt pending children

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1407,7 +1407,6 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
@@ -1416,7 +1415,6 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1456,7 +1454,6 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
-        _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     global auxiliary_is_nous
     auxiliary_is_nous = True

--- a/run_agent.py
+++ b/run_agent.py
@@ -3250,7 +3250,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
-                custom_providers=self._custom_providers,
+                custom_providers=getattr(self, "_custom_providers", None),
             )
 
             # Hard floor: the auxiliary compression model must have at least
@@ -4268,6 +4268,7 @@ class AIAgent:
             except Exception:
                 pass
             review_agent = None
+            review_session_messages = []
             try:
                 with open(os.devnull, "w", encoding="utf-8") as _devnull, \
                      contextlib.redirect_stdout(_devnull), \
@@ -4373,6 +4374,8 @@ class AIAgent:
                     finally:
                         clear_thread_tool_whitelist()
 
+                    review_session_messages = getattr(review_agent, "_session_messages", [])
+
                     # Tear down memory providers while stdout is still
                     # redirected so background thread teardown (Honcho flush,
                     # Hindsight sync, etc.) stays silent.  The finally block
@@ -4394,7 +4397,7 @@ class AIAgent:
                 # re-surface stale "created"/"updated" messages from the prior
                 # conversation as if they just happened (issue #14944).
                 actions = self._summarize_background_review_actions(
-                    getattr(review_agent, "_session_messages", []),
+                    review_session_messages,
                     messages_snapshot,
                 )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "thakoreh@users.noreply.github.com": "thakoreh",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "32201324+simpolism@users.noreply.github.com": "simpolism",

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -10,7 +10,7 @@ def _compressor() -> ContextCompressor:
         return ContextCompressor(
             model="test/model",
             threshold_percent=0.85,
-            protect_first_n=1,
+            protect_first_n=0,
             protect_last_n=1,
             quiet_mode=True,
         )
@@ -31,6 +31,7 @@ def _messages_with_handoff(summary_body: str):
         {"role": "assistant", "content": "new assistant work after resume"},
         {"role": "user", "content": "more new work after resume"},
         {"role": "assistant", "content": "latest tail response"},
+        {"role": "user", "content": "final user turn forcing compression"},
     ]
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -66,6 +66,8 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
+    discord_mod.HTTPException = type("HTTPException", (Exception,), {})
     discord_mod.Interaction = object
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
@@ -325,10 +327,15 @@ def make_fake_guild(guild_id: int = GUILD_ID, name: str = "Test Server"):
 
 
 def make_fake_text_channel(channel_id: int = CHANNEL_ID, name: str = "general", guild=None):
+    async def _empty_history(**_kwargs):
+        if False:
+            yield None
+
     return SimpleNamespace(
         id=channel_id, name=name,
         guild=guild or make_fake_guild(),
         topic=None, type=0,
+        history=_empty_history,
     )
 
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -305,6 +305,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
+    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda: None)
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,19 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_33_profiles_register():
-    """After discovery, the registry must contain exactly 33 distinct profiles."""
+def test_all_34_profiles_register():
+    """After discovery, the registry must contain exactly 34 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 33, f"Expected 33 profiles, got {len(names)}: {names}"
+    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "zai",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -205,6 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -258,6 +260,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
     )
 
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -934,6 +934,14 @@ class TestBuildAssistantMessage:
 class TestAuxiliaryClientProviderPriority:
     """Verify auxiliary client resolution doesn't break for any provider."""
 
+    def setup_method(self):
+        from agent.auxiliary_client import _reset_aux_unhealthy_cache
+        _reset_aux_unhealthy_cache()
+
+    def teardown_method(self):
+        from agent.auxiliary_client import _reset_aux_unhealthy_cache
+        _reset_aux_unhealthy_cache()
+
     def test_openrouter_always_wins(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         from agent.auxiliary_client import get_text_auxiliary_client

--- a/tests/tools/test_delegate_interrupt_status.py
+++ b/tests/tools/test_delegate_interrupt_status.py
@@ -1,0 +1,109 @@
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+from tools import delegate_tool
+
+
+class _StubParent:
+    def __init__(self, interrupted=False):
+        self._interrupt_requested = interrupted
+        self._delegate_depth = 0
+        self._delegate_spinner = None
+        self._memory_manager = None
+        self.session_id = "parent-session"
+
+
+class _StubChild:
+    def __init__(self, result=None):
+        self.result = result or {"completed": True, "final_response": "", "api_calls": 1}
+        self.tool_progress_callback = None
+        self._delegate_saved_tool_names = []
+        self._delegate_role = "leaf"
+        self._credential_pool = None
+        self.subagent_id = "child-1"
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.interrupt_called = False
+        self.interrupt_event = threading.Event()
+
+    def run_conversation(self, user_message, task_id=None):
+        return self.result
+
+    def get_activity_summary(self):
+        return {"api_call_count": self.result.get("api_calls", 0)}
+
+    def interrupt(self):
+        self.interrupt_called = True
+        self.interrupt_event.set()
+
+    def close(self):
+        pass
+
+
+def test_completed_child_with_empty_response_is_completed(monkeypatch):
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 5)
+    child = _StubChild({"completed": True, "final_response": "", "api_calls": 1})
+
+    result = delegate_tool._run_single_child(
+        task_index=0,
+        goal="empty but completed",
+        child=child,
+        parent_agent=_StubParent(),
+    )
+
+    assert result["status"] == "completed"
+    assert result["exit_reason"] == "completed"
+    assert result["summary"] == ""
+    assert "error" not in result
+
+
+def test_batch_parent_interrupt_signals_pending_children(monkeypatch):
+    children = [_StubChild(), _StubChild()]
+
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {"max_iterations": 3})
+    monkeypatch.setattr(delegate_tool, "_get_max_spawn_depth", lambda: 2)
+    monkeypatch.setattr(delegate_tool, "_get_max_concurrent_children", lambda: 3)
+    monkeypatch.setattr(
+        delegate_tool,
+        "_resolve_delegation_credentials",
+        lambda cfg, parent: {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+
+    def fake_build_child_agent(task_index, **kwargs):
+        return children[task_index]
+
+    def fake_run_single_child(task_index, goal, child, parent_agent):
+        child.interrupt_event.wait(timeout=1)
+        return {
+            "task_index": task_index,
+            "status": "interrupted" if child.interrupt_called else "failed",
+            "summary": None,
+            "api_calls": 0,
+            "duration_seconds": 0,
+            "_child_role": "leaf",
+        }
+
+    monkeypatch.setattr(delegate_tool, "_build_child_agent", fake_build_child_agent)
+    monkeypatch.setattr(delegate_tool, "_run_single_child", fake_run_single_child)
+
+    payload = delegate_tool.delegate_task(
+        tasks=[{"goal": "a"}, {"goal": "b"}],
+        parent_agent=_StubParent(interrupted=True),
+    )
+    data = json.loads(payload)
+
+    assert [child.interrupt_called for child in children] == [True, True]
+    assert [entry["status"] for entry in data["results"]] == ["interrupted", "interrupted"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1619,10 +1619,14 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif completed:
+            # The child loop is authoritative: a normal completion can
+            # legitimately produce an empty final response (for example when
+            # the child only wrote files or intentionally stayed silent).
+            status = "completed"
         elif summary:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
+            # Defensive fallback for older result payloads that predate the
+            # explicit completed flag but still returned usable output.
             status = "completed"
         else:
             status = "failed"
@@ -2118,6 +2122,25 @@ def delegate_task(
                     # interrupt signal; we just can't wait forever.
                     for f in pending:
                         idx = futures[f]
+                        child = _child_by_index.get(idx)
+                        if not f.done():
+                            # Fabricating an interrupted result is not enough:
+                            # the worker thread may still be inside the child
+                            # agent loop making API calls. Signal the child so
+                            # it exits at the next interrupt boundary.
+                            try:
+                                interrupt = getattr(child, "interrupt", None)
+                                if callable(interrupt):
+                                    interrupt()
+                                elif child is not None and hasattr(child, "_interrupt_requested"):
+                                    child._interrupt_requested = True
+                            except Exception:
+                                logger.debug(
+                                    "Failed to interrupt pending subagent %s",
+                                    idx,
+                                    exc_info=True,
+                                )
+                            f.cancel()
                         if f.done():
                             try:
                                 entry = f.result()
@@ -2130,7 +2153,7 @@ def delegate_task(
                                     "api_calls": 0,
                                     "duration_seconds": 0,
                                     "_child_role": getattr(
-                                        _child_by_index.get(idx), "_delegate_role", None
+                                        child, "_delegate_role", None
                                     ),
                                 }
                         else:
@@ -2141,9 +2164,7 @@ def delegate_task(
                                 "error": "Parent agent interrupted — child did not finish in time",
                                 "api_calls": 0,
                                 "duration_seconds": 0,
-                                "_child_role": getattr(
-                                    _child_by_index.get(idx), "_delegate_role", None
-                                ),
+                                "_child_role": getattr(child, "_delegate_role", None),
                             }
                         results.append(entry)
                         completed_count += 1


### PR DESCRIPTION
## Summary
- Preserve `completed` status for child agents that finish normally with an empty `final_response`
- Signal pending batch children with `child.interrupt()` when the parent is interrupted
- Add regression tests for both delegate_task failure modes

Fixes #25819

## Test Plan
- `python -m pytest tests/tools/test_delegate_interrupt_status.py -q`
- `python -m pytest tests/tools/test_delegate_interrupt_status.py tests/tools/test_delegate_subagent_timeout_diagnostic.py tests/tools/test_delegate_composite_toolsets.py -q`
