### PR TITLE
fix(browser): use AGENT_BROWSER_ARGS for sandbox bypass (DGX Spark / AppArmor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,6 +281,13 @@ BROWSER_SESSION_TIMEOUT=300
 # Browser sessions are automatically closed after this period of no activity
 BROWSER_INACTIVITY_TIMEOUT=120
 
+# Extra Chromium launch flags passed to agent-browser, comma- or newline-separated.
+# Hermes auto-injects "--no-sandbox,--disable-dev-shm-usage" when it detects root
+# or AppArmor-restricted unprivileged user namespaces (Ubuntu 23.10+, DGX Spark,
+# many container images), so leave this unset unless you need extra flags.
+# Setting this disables the auto-injection.
+# AGENT_BROWSER_ARGS=--no-sandbox
+
 # Camofox local anti-detection browser (Camoufox-based Firefox).
 # Set CAMOFOX_URL to route the browser tools through a local Camofox server
 # instead of agent-browser/Browserbase. See docs/user-guide/features/browser.md.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
+    "anadi.jaggia@gmail.com": "Jaggia",
     "32201324+simpolism@users.noreply.github.com": "simpolism",
     "simpolism@gmail.com": "simpolism",
     "jake@nousresearch.com": "simpolism",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1873,7 +1873,13 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        # Honour either the legacy AGENT_BROWSER_CHROME_FLAGS (never consumed by
+        # agent-browser itself, but documented in older notes) or the real
+        # AGENT_BROWSER_ARGS — if the user pre-sets either, don't overwrite it.
+        if (
+            "AGENT_BROWSER_ARGS" not in browser_env
+            and "AGENT_BROWSER_CHROME_FLAGS" not in browser_env
+        ):
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1892,8 +1892,8 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
 
         # Use temp files for stdout/stderr instead of pipes.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -135,6 +135,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `CAMOFOX_SESSION_KEY` | Optional Camofox session key used when creating tabs for `CAMOFOX_USER_ID` |
 | `CAMOFOX_ADOPT_EXISTING_TAB` | Set to `true` to reuse an existing Camofox tab before creating a new one |
 | `BROWSER_INACTIVITY_TIMEOUT` | Browser session inactivity timeout in seconds |
+| `AGENT_BROWSER_ARGS` | Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects `--no-sandbox,--disable-dev-shm-usage` when running as root or on AppArmor-restricted unprivileged user namespaces (Ubuntu 23.10+, DGX Spark, many container images); set this manually only to override or add other flags. |
 | `FAL_KEY` | Image generation ([fal.ai](https://fal.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -368,6 +368,13 @@ BROWSERBASE_SESSION_TIMEOUT=600000
 
 # Inactivity timeout before auto-cleanup in seconds (default: 120)
 BROWSER_INACTIVITY_TIMEOUT=120
+
+# Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects
+# `--no-sandbox,--disable-dev-shm-usage` when it detects root or AppArmor-restricted
+# unprivileged user namespaces (Ubuntu 23.10+, DGX Spark, many container images),
+# so most users don't need to set this. Set it manually only if you need a flag
+# Hermes doesn't add automatically; setting it disables the auto-injection.
+AGENT_BROWSER_ARGS=--no-sandbox
 ```
 
 ### Install agent-browser CLI


### PR DESCRIPTION
## Summary
Auto-sandbox-bypass now actually fires on Ubuntu 23.10+, DGX Spark, and any AppArmor-restricted system. Hermes was setting `AGENT_BROWSER_CHROME_FLAGS`, which agent-browser has never read — confirmed empirically: the var appears nowhere in agent-browser's source, while `AGENT_BROWSER_ARGS` is the documented one and is parsed in `daemon.js` via `split(/[,\\n]/)`. Reported in [Discord by Waethorn](https://discord.com/) running on DGX Spark.

Salvaged from #24821 (@Jaggia) with a small follow-up.

## Changes
- `tools/browser_tool.py`: set `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` (was: `AGENT_BROWSER_CHROME_FLAGS` with space-separated value, which agent-browser would have parsed as one bad flag even if it read it). Comma-separated to match the daemon's split regex. [@Jaggia]
- `tools/browser_tool.py`: gate now opts out on either `AGENT_BROWSER_ARGS` OR the legacy `AGENT_BROWSER_CHROME_FLAGS` — so users who already set `AGENT_BROWSER_ARGS` aren't overwritten.
- `.env.example`, `website/docs/user-guide/features/browser.md`, `website/docs/reference/environment-variables.md`: document `AGENT_BROWSER_ARGS` and the auto-injection.
- `scripts/release.py`: AUTHOR_MAP for `anadi.jaggia@gmail.com → Jaggia`.

## Validation
| | Before | After |
|---|---|---|
| Clean env, AppArmor=1 | injects `CHROME_FLAGS` (ignored by agent-browser → Chromium dies "No usable sandbox") | injects `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` |
| User pre-set `AGENT_BROWSER_ARGS=--foo` | clobbered with `CHROME_FLAGS` | preserved |
| User pre-set legacy `AGENT_BROWSER_CHROME_FLAGS` | preserved | preserved |
| Root | injects `CHROME_FLAGS` (ignored) | injects `AGENT_BROWSER_ARGS` |

E2E ran on this AppArmor=1 host through the four scenarios above. Browser test slice: 57 passed, 1 pre-existing skip.

Closes #24821 (salvaged). Closes #24930 (alternate, more invasive).

Co-authored-by: Anadi Jaggia <anadi.jaggia@gmail.com>