### PR TITLE
fix(agent): prevent GLM stop-to-length heuristic false positives (#14572)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -578,6 +578,13 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
+
+  # GLM stop-to-length truncation heuristic (#14572).
+  # Ollama-hosted GLM models can misreport truncated responses as
+  # finish_reason='stop'.  When true (default), the agent detects
+  # likely truncations and requests continuation.  Set to false to
+  # disable and treat all stop reasons as genuine.
+  # glm_truncation_heuristic: true
   
   # Enable verbose logging
   verbose: false

--- a/run_agent.py
+++ b/run_agent.py
@@ -2098,6 +2098,18 @@ class AIAgent:
             _api_retries = 3
         self._api_max_retries = _api_retries
 
+        # GLM stop-to-length heuristic opt-out (#14572 / #15463).
+        # Set agent.glm_truncation_heuristic: false in config.yaml to
+        # disable the conservative stop->length reclassification for
+        # Ollama-hosted GLM models.  Defaults to True (heuristic on).
+        _glm_heuristic_raw = _agent_section.get("glm_truncation_heuristic", True)
+        if isinstance(_glm_heuristic_raw, str):
+            self._glm_truncation_heuristic_enabled = (
+                _glm_heuristic_raw.lower() in ("true", "1", "yes")
+            )
+        else:
+            self._glm_truncation_heuristic_enabled = bool(_glm_heuristic_raw)
+
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
         # Configuration via config.yaml (compression section)
@@ -3745,7 +3757,18 @@ class AIAgent:
 
     @staticmethod
     def _has_natural_response_ending(content: str) -> bool:
-        """Heuristic: does visible assistant text look intentionally finished?"""
+        """Heuristic: does visible assistant text look intentionally finished?
+
+        Recognises ASCII/CJK punctuation, emoji, and other common sign-off
+        glyphs as natural endings.  Returns True for characters that are
+        unlikely to appear mid-sentence in a truncated response.
+
+        Extended to cover emoji sign-offs (e.g. 💛 ✨ 🙌) and math/arrow
+        symbols which were previously false-positive triggers for the
+        Ollama/GLM stop-to-length heuristic.
+        """
+        import unicodedata
+
         if not content:
             return False
         stripped = content.rstrip()
@@ -3753,7 +3776,35 @@ class AIAgent:
             return False
         if stripped.endswith("```"):
             return True
-        return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
+        if stripped[-1] in '.!?:)"\']}。！？：）】」』》':
+            return True
+
+        # Strip trailing Unicode combining marks (variation selectors
+        # U+FE0F, zero-width joiners U+200D, etc.) before checking the
+        # last real glyph so emoji + VS16 is recognised as the base emoji.
+        i = len(stripped) - 1
+        while i >= 0 and unicodedata.category(stripped[i]) in ("Mn", "Me", "Cf"):
+            i -= 1
+        if i < 0:
+            return False
+        last_char = stripped[i]
+
+        # Emoji and other Unicode sign-off glyphs.
+        # Use unicodedata categories rather than a hard-coded codepoint
+        # list so we automatically cover new emoji as Python's Unicode
+        # database grows.
+        cat = unicodedata.category(last_char)
+        # So (Other_Symbol): sparkles, rocket, check, cross, stars, etc.
+        # Sk (Modifier_Symbol): VS16 heart variation selector, etc.
+        # Sm (Math_Symbol): arrows, infinity, and similar sign-off glyphs.
+        if cat in ("So", "Sk", "Sm"):
+            return True
+        # Extended_Pictographic range (many emoji have category So but
+        # some are Lo/Lm/Other — this catches the rest).
+        try:
+            return ord(last_char) in range(0x1F000, 0x1FAFF)
+        except TypeError:
+            return False
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""
@@ -3771,7 +3822,17 @@ class AIAgent:
         assistant_message,
         messages: Optional[list] = None,
     ) -> bool:
-        """Detect conservative stop->length misreports for Ollama-hosted GLM models."""
+        """Detect conservative stop->length misreports for Ollama-hosted GLM models.
+
+        Guard rails (to minimise false positives, cf. #14572):
+        - <500 chars visible: almost certainly complete (short replies can't
+          hit meaningful token limits)
+        - heuristic_enabled flag: opt-out via agent.glm_truncation_heuristic
+        """
+        # Config opt-out (#14572).
+        if not getattr(self, "_glm_truncation_heuristic_enabled", True):
+            return False
+
         if finish_reason != "stop" or self.api_mode != "chat_completions":
             return False
         if not self._is_ollama_glm_backend():
@@ -3792,6 +3853,13 @@ class AIAgent:
         if not visible_text:
             return False
         if len(visible_text) < 20 or not re.search(r"\s", visible_text):
+            return False
+
+        # Short-to-medium responses (<500 chars visible) are very unlikely
+        # to be truncated.  Raising this gate from 20 to 500 eliminates the
+        # vast majority of false positives from conversational replies and
+        # emoji sign-offs (#14572).
+        if len(visible_text) < 500:
             return False
 
         return not self._has_natural_response_ending(visible_text)

--- a/tests/run_agent/test_glm_stop_heuristic.py
+++ b/tests/run_agent/test_glm_stop_heuristic.py
@@ -1,0 +1,278 @@
+"""Tests for the GLM stop-to-length heuristic fix (#14572).
+
+Verifies that:
+1. _has_natural_response_ending() recognizes emoji, Unicode symbols,
+   and math symbols as natural endings (not just ASCII/CJK punctuation)
+2. _should_treat_stop_as_truncated() enforces a 500-char minimum gate
+3. Config opt-out (agent.glm_truncation_heuristic: false) disables the heuristic
+
+Refs: PR #15463, bug #14572.
+"""
+
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirroring test_run_agent.py conventions)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="c1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(
+    content="Hello",
+    finish_reason="stop",
+    tool_calls=None,
+    reasoning=None,
+):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=reasoning,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+def _setup_glm_agent(agent):
+    """Configure the mocked agent for an Ollama/GLM backend."""
+    agent.base_url = "http://localhost:11434/v1"
+    agent._base_url_lower = agent.base_url.lower()
+    agent.model = "glm-5.1:cloud"
+
+
+# ---------------------------------------------------------------------------
+# _has_natural_response_ending — emoji and Unicode symbol detection
+# ---------------------------------------------------------------------------
+
+
+class TestHasNaturalResponseEndingEmoji:
+    """Emoji and Unicode symbol sign-offs should be recognized as natural endings."""
+
+    def test_emoji_heart(self, agent):
+        """💛 is a natural sign-off."""
+        assert agent._has_natural_response_ending("Thanks! 💛") is True
+
+    def test_emoji_sparkles(self, agent):
+        """✨ is a natural sign-off."""
+        assert agent._has_natural_response_ending("Done ✨") is True
+
+    def test_emoji_raised_hands(self, agent):
+        """🙌 is a natural sign-off."""
+        assert agent._has_natural_response_ending("Great work! 🙌") is True
+
+    def test_emoji_rocket(self, agent):
+        """🚀 is a natural sign-off."""
+        assert agent._has_natural_response_ending("Deploying now 🚀") is True
+
+    def test_emoji_check_mark(self, agent):
+        """✅ is a natural sign-off."""
+        assert agent._has_natural_response_ending("All tests pass ✅") is True
+
+    def test_math_symbol_arrow(self, agent):
+        """→ (Sm category) is a natural sign-off."""
+        assert agent._has_natural_response_ending("Therefore the answer is 42 →") is True
+
+    def test_math_symbol_infinity(self, agent):
+        """∞ (Sm category) is a natural sign-off."""
+        assert agent._has_natural_response_ending("Iterate ∞") is True
+
+    def test_other_symbol_warning(self, agent):
+        """⚠ (So category) is a natural sign-off."""
+        assert agent._has_natural_response_ending("Proceed with caution ⚠") is True
+
+    def test_other_symbol_star(self, agent):
+        """★ (So category) is a natural sign-off."""
+        assert agent._has_natural_response_ending("Five stars ★") is True
+
+    def test_still_false_for_no_punctuation_or_symbol(self, agent):
+        """Plain text without punctuation or symbols is not a natural ending."""
+        assert agent._has_natural_response_ending("The answer is 42") is False
+
+    def test_trailing_whitespace_stripped(self, agent):
+        """Trailing whitespace is stripped before checking the last character."""
+        assert agent._has_natural_response_ending("Done ✨   ") is True
+
+    def test_empty_string(self, agent):
+        assert agent._has_natural_response_ending("") is False
+
+    def test_whitespace_only(self, agent):
+        assert agent._has_natural_response_ending("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# _should_treat_stop_as_truncated — 500-char gate
+# ---------------------------------------------------------------------------
+
+
+class TestShouldTreatStopAsTruncated500CharGate:
+    """Responses under 500 chars should be treated as complete, not truncated."""
+
+    def test_short_response_without_punctuation_not_truncated(self, agent):
+        """A 39-char response ending mid-sentence is <500 chars, so not truncated."""
+        _setup_glm_agent(agent)
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search")],
+        )
+        misreported_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+
+        # The heuristic should NOT trigger because the response is <500 chars.
+        assert len(misreported_stop.choices[0].message.content) < 500
+        with patch.object(agent, "_has_natural_response_ending", return_value=False):
+            result = agent._should_treat_stop_as_truncated(
+                finish_reason="stop",
+                assistant_message=misreported_stop.choices[0].message,
+                messages=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}]},
+                    {"role": "tool", "tool_call_id": "c1", "content": "search result"},
+                ],
+            )
+        assert result is False
+
+    def test_long_response_without_punctuation_truncated(self, agent):
+        """A 500+ char response without natural ending IS truncated."""
+        _setup_glm_agent(agent)
+
+        # Build a 510-char response ending mid-sentence
+        long_content = "X" * 509 + " mid-sentence"
+        assert len(long_content) >= 500
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search")],
+        )
+        misreported_stop = _mock_response(
+            content=long_content,
+            finish_reason="stop",
+        )
+
+        with patch.object(agent, "_has_natural_response_ending", return_value=False):
+            result = agent._should_treat_stop_as_truncated(
+                finish_reason="stop",
+                assistant_message=misreported_stop.choices[0].message,
+                messages=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}]},
+                    {"role": "tool", "tool_call_id": "c1", "content": "search result"},
+                ],
+            )
+        assert result is True
+
+    def test_long_response_with_emoji_not_truncated(self, agent):
+        """500+ char response with emoji ending IS complete."""
+        _setup_glm_agent(agent)
+
+        long_content = "X" * 500 + " ✨"
+        misreported_stop = _mock_response(
+            content=long_content,
+            finish_reason="stop",
+        )
+
+        result = agent._should_treat_stop_as_truncated(
+            finish_reason="stop",
+            assistant_message=misreported_stop.choices[0].message,
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "web_search", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "c1", "content": "search result"},
+            ],
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration test: 500-char gate in full conversation loop
+# ---------------------------------------------------------------------------
+
+
+class TestGlmStopHeuristicIntegration:
+    """Full conversation-loop tests for the GLM stop heuristic."""
+
+    def test_short_response_not_continued(self, agent):
+        """Short GLM response <500 chars completes naturally (no continuation)."""
+        _setup_glm_agent(agent)
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search")],
+        )
+        short_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+
+        # Under 500 chars with no terminal punctuation AND no emoji → but gate
+        # still catches this as complete (len < 500).
+        assert len(short_stop.choices[0].message.content) < 500
+
+        agent.client.chat.completions.create.side_effect = [tool_turn, short_stop]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        # Only 2 API calls: tool turn + stop (no continuation)
+        assert result["api_calls"] == 2
+        assert result["final_response"] == "Based on the search results, the best next"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3107,13 +3107,24 @@ class TestRunConversation:
         agent._base_url_lower = agent.base_url.lower()
         agent.model = "glm-5.1:cloud"
 
+        # The 500-char gate (#14572) requires >=500 visible chars to trigger
+        # the heuristic.  Pad the mock to a valid-looking long response that
+        # ends mid-sentence without punctuation.
+        _prefix = "Based on the search results, "
+        _filler = "we can see that the data supports this conclusion. " * 10
+        _ending = "the best next"
+        _long_content = _prefix + _filler.strip() + " " + _ending
+        assert len(_long_content.strip()) >= 500, (
+            f"content is {len(_long_content.strip())} chars, need >=500 for 500-char gate"
+        )
+
         tool_turn = _mock_response(
             content="",
             finish_reason="tool_calls",
             tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
         )
         misreported_stop = _mock_response(
-            content="Based on the search results, the best next",
+            content=_long_content,
             finish_reason="stop",
         )
         continued = _mock_response(
@@ -3138,7 +3149,7 @@ class TestRunConversation:
         assert result["api_calls"] == 3
         assert (
             result["final_response"]
-            == "Based on the search results, the best next step is to update the config."
+            == _long_content.rstrip() + " step is to update the config."
         )
 
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]


### PR DESCRIPTION
## Problem
The Ollama/GLM stop-to-length heuristic in `_should_treat_stop_as_truncated()` produces false positives for agents using emoji sign-offs (💛 ✨ 🙌) and short conversational replies, wasting up to 60 turns per user message.

## Fix

Three changes:

1. **`_has_natural_response_ending()`** now recognises emoji and Unicode symbols as natural endings using `unicodedata` categories (So/Sk/Sm) and the Extended_Pictographic codepoint range. Also strips trailing Unicode combining marks (variation selectors, ZWJ) before checking the last real glyph so emoji+VS16 is recognised correctly.

2. **`_should_treat_stop_as_truncated()`** enforces a 500-character minimum gate on visible text. Short replies are almost certainly not truncated and cannot hit meaningful token limits.

3. **Config opt-out**: new `agent.glm_truncation_heuristic` flag (default `true`) lets users disable the heuristic entirely.

## Changes

- `run_agent.py`: Expanded `_has_natural_response_ending()` (+42 lines) and `_should_treat_stop_as_truncated()` (+18 lines) with config opt-out
- `cli-config.yaml.example`: Documented new config flag
- `tests/run_agent/test_glm_stop_heuristic.py`: 17 new tests (emoji/symbol recognition, 500-char gate, integration)
- `tests/run_agent/test_run_agent.py`: Updated existing test for 500-char gate

## Testing

- 17 new tests all pass
- All 325 existing run_agent tests pass (zero regressions)
- Manually verified: emoji sign-offs (💛 ✨ 🙌 🚀 ✅), math symbols (→ ∞), and warning symbols (⚠ ★) correctly classified as natural endings

Closes #14572