### PR TITLE
fix(gateway): improve vision enrichment format for non-vision models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14227,22 +14227,23 @@ class GatewayRunner:
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
                     enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
-                        f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
+                        f"📷 The user sent an image. Here's what I can see:\n"
+                        f"{description}\n"
+                        f"(If you need a closer look, use vision_analyze with "
+                        f"image_url: {path})"
                     )
                 else:
                     enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
+                        "📷 The user sent an image but I couldn't quite see it "
+                        "this time. You can try looking at it yourself "
+                        f"with vision_analyze using image_url: {path}"
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
-                    f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
+                    f"📷 The user sent an image but something went wrong when I "
+                    f"tried to look at it. You can try examining it yourself "
+                    f"with vision_analyze using image_url: {path}"
                 )
 
         # Combine: vision descriptions first, then the user's original text


### PR DESCRIPTION
## Problem
When a user sends an image via Telegram, the vision analysis is generated by `_enrich_message_with_vision` but the model (especially non-vision models like MiniMax M2.7) may not effectively use the enriched description. The model responds with "I cannot see any image attached" despite the analysis being completed successfully.

## Root Cause
The enriched text format used `[brackets]` and `~` characters that could confuse models into treating the vision description as metadata/system notes rather than user message content.

## Fix
Changed the enriched text format in `_enrich_message_with_vision` (`gateway/run.py`) from bracket-heavy format to a more natural conversational format with 📷 emoji prefix and regular punctuation.

## Tests
- All 3 tests in `tests/gateway/test_vision_memory_leak.py` pass
- All 31 tests in `tests/agent/test_image_routing.py` pass

Closes #25900
