### PR TITLE
feat: add cron test-run and profile sidecars

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -246,7 +246,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """
     global _skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands = {}
+    new_commands: Dict[str, Dict[str, Any]] = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
@@ -291,7 +291,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    new_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
@@ -301,6 +301,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     continue
     except Exception:
         pass
+
+    # Preserve object identity: cli.py imports this dict once at process start
+    # and dispatches skill slash commands through that reference.  Rebinding the
+    # module global here leaves running CLI processes with a stale command map.
+    _skill_commands.clear()
+    _skill_commands.update(new_commands)
     return _skill_commands
 
 

--- a/cli.py
+++ b/cli.py
@@ -4200,6 +4200,12 @@ class HermesCLI:
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
             )
+            # This is the foreground interactive CLI agent for the current
+            # cmux surface. AIAgent itself defaults this off because background
+            # tasks/subagents inherit CMUX_* env vars and must not steal the
+            # focused-surface session mapping.
+            self.agent._publish_cmux_surface_sidecar = True
+            self.agent._write_current_session_sidecar()
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref
             _active_agent_ref = self.agent

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -166,7 +166,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("search", "browse", "inspect", "install")),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
-               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
+               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "test-run", "remove")),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -13,6 +13,8 @@ from typing import Iterable, List, Optional
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from cron.jobs import get_job, save_job_output
+from cron.scheduler import run_job
 from hermes_cli.colors import Colors, color
 
 
@@ -253,6 +255,24 @@ def cron_edit(args):
     return 0
 
 
+def cron_test_run(job_id: str) -> int:
+    job = get_job(job_id)
+    if not job:
+        print(color(f"Job not found: {job_id}", Colors.RED))
+        return 1
+
+    success, output, _final_response, error = run_job(job)
+    output_path = save_job_output(job_id, output)
+    status = "success" if success else "failure"
+
+    print(color(f"Test run {status}: {job_id}", Colors.GREEN if success else Colors.RED))
+    print(f"  Output: {output_path}")
+    print(f"  Output length: {len(output)}")
+    if error:
+        print(f"  Error: {error}")
+    return 0 if success else 1
+
+
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
     result = _cron_api(action=action, job_id=job_id)
     if not result.get("success"):
@@ -298,6 +318,9 @@ def cron_command(args):
 
     if subcmd == "run":
         return _job_action("run", args.job_id, "Triggered")
+
+    if subcmd == "test-run":
+        return cron_test_run(args.job_id)
 
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10088,6 +10088,11 @@ def main():
     cron_run.add_argument("job_id", help="Job ID to trigger")
     _add_accept_hooks_flag(cron_run)
 
+    cron_test_run = cron_subparsers.add_parser(
+        "test-run", help="Run one job immediately and save local output"
+    )
+    cron_test_run.add_argument("job_id", help="Job ID to test")
+
     cron_remove = cron_subparsers.add_parser(
         "remove", aliases=["rm", "delete"], help="Remove a scheduled job"
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -116,6 +116,18 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # The flag is stripped from sys.argv so argparse never sees it.
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
+def _is_mcp_sync_local_profile_flag(argv: list[str], index: int, arg: str) -> bool:
+    """Return True when --profile belongs to `hermes mcp sync`, not HERMES_HOME."""
+    if arg != "--profile" and not arg.startswith("--profile="):
+        return False
+    try:
+        mcp_index = argv.index("mcp")
+        sync_index = argv.index("sync", mcp_index + 1)
+    except ValueError:
+        return False
+    return index > sync_index
+
+
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before module imports."""
     argv = sys.argv[1:]
@@ -124,6 +136,8 @@ def _apply_profile_override() -> None:
 
     # 1. Check for explicit -p / --profile flag
     for i, arg in enumerate(argv):
+        if _is_mcp_sync_local_profile_flag(argv, i, arg):
+            continue
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
             profile_name = argv[i + 1]
             consume = 2
@@ -11097,6 +11111,41 @@ Examples:
 
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")
+
+    mcp_sync_p = mcp_sub.add_parser(
+        "sync",
+        help="Sync shared MCP server definitions into profile configs",
+    )
+    mcp_sync_p.add_argument(
+        "--shared",
+        help="Shared MCP YAML path (default: ~/.hermes/shared/mcp_servers.yaml)",
+    )
+    mcp_sync_p.add_argument(
+        "--profile",
+        action="append",
+        default=[],
+        help="Target profile name; repeatable. Supports 'default'.",
+    )
+    mcp_sync_p.add_argument(
+        "--all",
+        action="store_true",
+        help="Target default and all named profiles",
+    )
+    mcp_sync_p.add_argument(
+        "--servers",
+        action="append",
+        help="Comma-separated shared server names to sync; repeatable",
+    )
+    mcp_sync_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show changes without writing profile configs",
+    )
+    mcp_sync_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite conflicting same-name MCP entries",
+    )
 
     mcp_cfg_p = mcp_sub.add_parser(
         "configure", aliases=["config"], help="Toggle tool selection"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7578,28 +7578,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         current_branch = result.stdout.strip()
 
-        # Always update against main
+        # ``hermes update`` mutates the installed source checkout.  Never switch
+        # branches from inside the updater: this checkout may be shared by
+        # multiple live Hermes sessions, so a hidden checkout changes the code
+        # under every session, not just the caller that asked for an update.
         branch = "main"
-
-        # If user is on a non-main branch or detached HEAD, switch to main
-        if current_branch != "main":
+        if current_branch != branch:
             label = (
                 "detached HEAD"
                 if current_branch == "HEAD"
                 else f"branch '{current_branch}'"
             )
-            print(f"  ⚠ Currently on {label} — switching to main for update...")
-            # Stash before checkout so uncommitted work isn't lost
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-            subprocess.run(
-                git_cmd + ["checkout", "main"],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-                check=True,
+            print(f"✗ Refusing to update while on {label}.")
+            print(
+                "  hermes update changes the installed checkout; switching "
+                "branches here would affect all running Hermes sessions."
             )
-        else:
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+            print("  Switch explicitly when you are ready, then run hermes update:")
+            print(f"  git -C {PROJECT_ROOT} checkout main && hermes update")
+            print(
+                "  For feature work, use hermes -w or a separate git worktree "
+                "so updates do not disturb active branches."
+            )
+            sys.exit(1)
+
+        auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
         prompt_for_restore = (
             auto_stash_ref is not None

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,11 +9,16 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
+import copy
 import logging
 import os
 import re
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import yaml
 
 from hermes_cli.config import (
     cfg_get,
@@ -24,7 +29,7 @@ from hermes_cli.config import (
     get_hermes_home,  # noqa: F401 — used by test mocks
 )
 from hermes_cli.colors import Colors, color
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_default_hermes_root
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +130,173 @@ def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
             raise ValueError(f"Invalid --env variable name '{key}'")
         parsed[key] = value
     return parsed
+
+
+@dataclass
+class McpSyncPlan:
+    """Pure merge result for syncing shared MCP servers into one profile."""
+
+    merged_servers: Dict[str, dict]
+    added: List[str] = field(default_factory=list)
+    updated: List[str] = field(default_factory=list)
+    skipped: List[str] = field(default_factory=list)
+    conflicts: List[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.added or self.updated)
+
+
+@dataclass(frozen=True)
+class McpSyncTarget:
+    """A profile config targeted by ``hermes mcp sync``."""
+
+    name: str
+    config_path: Path
+
+
+def _default_shared_mcp_path() -> Path:
+    """Return the profile-root shared MCP YAML path."""
+    return get_default_hermes_root() / "shared" / "mcp_servers.yaml"
+
+
+def _load_yaml_mapping(path: Path) -> dict:
+    """Load a YAML file that must contain a mapping."""
+    path = Path(path).expanduser()
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Shared MCP file not found: {path}")
+
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML file must contain a mapping: {path}")
+    return data
+
+
+def _load_shared_mcp_servers(path: Path) -> Dict[str, dict]:
+    """Load shared MCP server definitions from a YAML file.
+
+    Accepts either a wrapped shape::
+
+        mcp_servers:
+          name: {...}
+
+    or a raw ``{name: config}`` mapping.
+    """
+    data = _load_yaml_mapping(path)
+    raw_servers = data.get("mcp_servers", data)
+    if not isinstance(raw_servers, dict):
+        raise ValueError("Shared MCP file must contain a mapping of server names to configs")
+
+    servers: Dict[str, dict] = {}
+    for name, cfg in raw_servers.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Shared MCP server names must be non-empty strings")
+        if not isinstance(cfg, dict):
+            raise ValueError(f"Shared MCP server '{name}' must be a mapping")
+        servers[name] = copy.deepcopy(cfg)
+    return servers
+
+
+def _read_config_file(path: Path) -> dict:
+    """Read a profile config file as raw YAML, returning {} when absent/empty."""
+    path = Path(path).expanduser()
+    if not path.exists():
+        return {}
+    data = _load_yaml_mapping(path)
+    return data
+
+
+def _write_config_file(path: Path, config: dict) -> None:
+    """Write a profile config file atomically."""
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(Path(path).expanduser(), config, sort_keys=False)
+
+
+def _parse_selected_server_names(raw_servers: Optional[List[str]]) -> Optional[Set[str]]:
+    """Parse repeated/comma-separated ``--servers`` values."""
+    if not raw_servers:
+        return None
+
+    selected: Set[str] = set()
+    for raw in raw_servers:
+        for item in str(raw or "").split(","):
+            name = item.strip()
+            if name:
+                selected.add(name)
+    return selected
+
+
+def _plan_mcp_sync(
+    target_servers: Dict[str, dict],
+    shared_servers: Dict[str, dict],
+    selected_names: Optional[Set[str]],
+    *,
+    force: bool,
+) -> McpSyncPlan:
+    """Plan a deterministic MCP-server merge without filesystem side effects."""
+    merged = copy.deepcopy(target_servers or {})
+    plan = McpSyncPlan(merged_servers=merged)
+
+    for name in sorted(shared_servers):
+        if selected_names is not None and name not in selected_names:
+            continue
+
+        shared_cfg = copy.deepcopy(shared_servers[name])
+        if name not in merged:
+            merged[name] = shared_cfg
+            plan.added.append(name)
+        elif merged[name] == shared_cfg:
+            plan.skipped.append(name)
+        elif force:
+            merged[name] = shared_cfg
+            plan.updated.append(name)
+        else:
+            plan.conflicts.append(name)
+
+    return plan
+
+
+def _resolve_mcp_sync_targets(profile_names: List[str], all_profiles: bool) -> List[McpSyncTarget]:
+    """Resolve ``hermes mcp sync`` target profiles to config paths."""
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        list_profiles,
+        normalize_profile_name,
+        profile_exists,
+        validate_profile_name,
+    )
+
+    if all_profiles and profile_names:
+        raise ValueError("Use either --all or --profile, not both")
+    if all_profiles:
+        return [
+            McpSyncTarget(name=profile.name, config_path=Path(profile.path) / "config.yaml")
+            for profile in list_profiles()
+        ]
+    if not profile_names:
+        raise ValueError("Specify --profile NAME or --all")
+
+    targets: List[McpSyncTarget] = []
+    seen: Set[str] = set()
+    for raw_name in profile_names:
+        name = normalize_profile_name(raw_name)
+        validate_profile_name(name)
+        if name != "default" and not profile_exists(name):
+            raise FileNotFoundError(
+                f"Profile '{name}' does not exist. Create it with: hermes profile create {name}"
+            )
+        if name in seen:
+            continue
+        seen.add(name)
+        targets.append(McpSyncTarget(name=name, config_path=get_profile_dir(name) / "config.yaml"))
+    return targets
+
+
+def _format_names(names: List[str]) -> str:
+    return ", ".join(names) if names else "-"
 
 
 def _apply_mcp_preset(
@@ -588,6 +760,92 @@ def _interpolate_value(value: str) -> str:
     return re.sub(r"\$\{(\w+)\}", _replace, value)
 
 
+# ─── hermes mcp sync ──────────────────────────────────────────────────────────
+
+def cmd_mcp_sync(args):
+    """Sync shared MCP server definitions into one or more profile configs."""
+    shared_path = Path(getattr(args, "shared", None) or _default_shared_mcp_path()).expanduser()
+    dry_run = bool(getattr(args, "dry_run", False))
+    force = bool(getattr(args, "force", False))
+    profile_names = list(getattr(args, "profile", None) or [])
+    all_profiles = bool(getattr(args, "all", False))
+
+    try:
+        shared_servers = _load_shared_mcp_servers(shared_path)
+        selected_names = _parse_selected_server_names(getattr(args, "servers", None))
+        if selected_names:
+            missing = sorted(selected_names - set(shared_servers))
+            if missing:
+                _error(f"Unknown shared MCP server(s): {', '.join(missing)}")
+                _info(f"Available in {shared_path}: {', '.join(sorted(shared_servers)) or '(none)'}")
+                return
+        targets = _resolve_mcp_sync_targets(profile_names, all_profiles)
+    except FileNotFoundError as exc:
+        _error(str(exc))
+        if str(exc).startswith("Shared MCP file not found"):
+            _info("Create it with: mkdir -p ~/.hermes/shared && $EDITOR ~/.hermes/shared/mcp_servers.yaml")
+        return
+    except ValueError as exc:
+        _error(str(exc))
+        return
+
+    if dry_run:
+        print(color("  DRY RUN — no files will be changed", Colors.YELLOW))
+    print(color(f"  Shared MCP file: {shared_path}", Colors.CYAN))
+
+    any_changes = False
+    any_conflicts = False
+    for target in targets:
+        try:
+            config = _read_config_file(target.config_path)
+        except ValueError as exc:
+            _error(f"{target.name}: {exc}")
+            continue
+
+        current_servers = config.get("mcp_servers")
+        if not isinstance(current_servers, dict):
+            current_servers = {}
+
+        plan = _plan_mcp_sync(
+            target_servers=current_servers,
+            shared_servers=shared_servers,
+            selected_names=selected_names,
+            force=force,
+        )
+        any_changes = any_changes or plan.changed
+        any_conflicts = any_conflicts or bool(plan.conflicts)
+
+        print()
+        print(color(f"  Profile: {target.name}", Colors.CYAN))
+        _info(f"Config: {target.config_path}")
+        _info(f"Added: {_format_names(plan.added)}")
+        _info(f"Updated: {_format_names(plan.updated)}")
+        _info(f"Skipped: {_format_names(plan.skipped)}")
+        if plan.conflicts:
+            _warning(f"Conflicts: {_format_names(plan.conflicts)}")
+            _info("Use --force to replace conflicting same-name entries")
+        else:
+            _info("Conflicts: -")
+
+        if dry_run or not plan.changed:
+            continue
+
+        config["mcp_servers"] = plan.merged_servers
+        _write_config_file(target.config_path, config)
+        _success(f"Synced {target.name}")
+
+    print()
+    if dry_run:
+        _info("Dry run complete.")
+    elif any_changes:
+        _success("MCP sync complete.")
+        _info("Run /reload-mcp in active sessions or restart affected gateways.")
+    elif any_conflicts:
+        _warning("No changes written because all differences were conflicts.")
+    else:
+        _info("No MCP sync changes needed.")
+
+
 # ─── hermes mcp login ────────────────────────────────────────────────────────
 
 def cmd_mcp_login(args):
@@ -762,6 +1020,7 @@ def mcp_command(args):
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
         "test": cmd_mcp_test,
+        "sync": cmd_mcp_sync,
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,
@@ -781,6 +1040,7 @@ def mcp_command(args):
         _info("hermes mcp remove <name>                      Remove a server")
         _info("hermes mcp list                               List servers")
         _info("hermes mcp test <name>                        Test connection")
+        _info("hermes mcp sync --all --dry-run               Sync shared MCPs into profiles")
         _info("hermes mcp configure <name>                   Toggle tools")
         _info("hermes mcp login <name>                       Re-authenticate OAuth")
         print()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1911,6 +1911,10 @@ class AIAgent:
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+        # Foreground CLI code opts this in after constructing the main agent.
+        # Background tasks/subagents inherit cmux env vars, so defaulting this
+        # on here would let them steal the focused-surface mapping.
+        self._publish_cmux_surface_sidecar = False
         self._write_current_session_sidecar()
 
         # Track conversation messages for session logging
@@ -5199,6 +5203,19 @@ class AIAgent:
         content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
 
+    def _safe_sidecar_key(self, value: str) -> str:
+        """Return a filesystem-safe sidecar key without allowing path escape."""
+        key = re.sub(r"[^A-Za-z0-9_.:-]", "_", (value or "").strip())
+        return key[:200]
+
+    def _current_tty_name(self) -> str:
+        try:
+            if sys.stdin is not None and sys.stdin.isatty():
+                return os.ttyname(sys.stdin.fileno())
+        except Exception:
+            pass
+        return ""
+
     def _write_current_session_sidecar(self) -> None:
         try:
             hermes_home = get_hermes_home()
@@ -5207,33 +5224,33 @@ class AIAgent:
                 "session_id": self.session_id,
                 "pid": os.getpid(),
                 "cwd": os.getcwd(),
+                "platform": self.platform,
                 "updated_at": updated_at,
                 "session_json": str(self.session_log_file),
             }
             atomic_json_write(hermes_home / "current-session.json", payload)
 
-            surface_id = os.getenv("CMUX_SURFACE_ID", "").strip()
-            if self.platform == "cli" and not self.quiet_mode and surface_id:
-                safe_surface_id = re.sub(r"[^A-Za-z0-9._-]", "_", surface_id)
-                if safe_surface_id:
-                    tty = ""
-                    try:
-                        if os.isatty(0):
-                            tty = os.ttyname(0)
-                    except Exception:
-                        tty = ""
-                    cmux_payload = {
-                        **payload,
-                        "cmux": {
-                            "workspace_id": os.getenv("CMUX_WORKSPACE_ID", ""),
-                            "surface_id": surface_id,
-                            "socket_path": os.getenv("CMUX_SOCKET_PATH", ""),
-                            "tty": tty,
-                        },
+            surface_id = (os.environ.get("CMUX_SURFACE_ID") or "").strip()
+            if (
+                getattr(self, "_publish_cmux_surface_sidecar", False)
+                and (self.platform or "") == "cli"
+                and surface_id
+            ):
+                sidecar_key = self._safe_sidecar_key(surface_id)
+                if sidecar_key:
+                    surface_dir = hermes_home / "current-sessions" / "by-cmux-surface"
+                    surface_dir.mkdir(parents=True, exist_ok=True)
+                    surface_payload = dict(payload)
+                    surface_payload["cmux"] = {
+                        "workspace_id": os.environ.get("CMUX_WORKSPACE_ID", ""),
+                        "surface_id": surface_id,
+                        "socket_path": os.environ.get("CMUX_SOCKET_PATH", ""),
+                        "tty": self._current_tty_name(),
                     }
-                    sidecar_dir = hermes_home / "current-sessions" / "by-cmux-surface"
-                    sidecar_dir.mkdir(parents=True, exist_ok=True)
-                    atomic_json_write(sidecar_dir / f"{safe_surface_id}.json", cmux_payload)
+                    atomic_json_write(
+                        surface_dir / f"{sidecar_key}.json",
+                        surface_payload,
+                    )
         except Exception as e:
             logger.debug("Could not write current-session sidecar: %s", e)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1911,7 +1911,8 @@ class AIAgent:
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
-        
+        self._write_current_session_sidecar()
+
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
         self._memory_write_origin = "assistant_tool"
@@ -5197,6 +5198,20 @@ class AIAgent:
         content = re.sub(r'\n+(<think>)', r'\n\1', content)
         content = re.sub(r'(</think>)\n+', r'\1\n', content)
         return content.strip()
+
+    def _write_current_session_sidecar(self) -> None:
+        try:
+            atomic_json_write(
+                get_hermes_home() / "current-session.json",
+                {
+                    "session_id": self.session_id,
+                    "pid": os.getpid(),
+                    "cwd": os.getcwd(),
+                    "updated_at": datetime.now().isoformat(),
+                },
+            )
+        except Exception as e:
+            logger.debug("Could not write current-session sidecar: %s", e)
 
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
         """
@@ -10432,6 +10447,7 @@ class AIAgent:
                     pass
                 # Update session_log_file to point to the new session's JSON file
                 self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+                self._write_current_session_sidecar()
                 self._session_db_created = False
                 self._session_db.create_session(
                     session_id=self.session_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5201,15 +5201,39 @@ class AIAgent:
 
     def _write_current_session_sidecar(self) -> None:
         try:
-            atomic_json_write(
-                get_hermes_home() / "current-session.json",
-                {
-                    "session_id": self.session_id,
-                    "pid": os.getpid(),
-                    "cwd": os.getcwd(),
-                    "updated_at": datetime.now().isoformat(),
-                },
-            )
+            hermes_home = get_hermes_home()
+            updated_at = datetime.now().isoformat()
+            payload = {
+                "session_id": self.session_id,
+                "pid": os.getpid(),
+                "cwd": os.getcwd(),
+                "updated_at": updated_at,
+                "session_json": str(self.session_log_file),
+            }
+            atomic_json_write(hermes_home / "current-session.json", payload)
+
+            surface_id = os.getenv("CMUX_SURFACE_ID", "").strip()
+            if self.platform == "cli" and not self.quiet_mode and surface_id:
+                safe_surface_id = re.sub(r"[^A-Za-z0-9._-]", "_", surface_id)
+                if safe_surface_id:
+                    tty = ""
+                    try:
+                        if os.isatty(0):
+                            tty = os.ttyname(0)
+                    except Exception:
+                        tty = ""
+                    cmux_payload = {
+                        **payload,
+                        "cmux": {
+                            "workspace_id": os.getenv("CMUX_WORKSPACE_ID", ""),
+                            "surface_id": surface_id,
+                            "socket_path": os.getenv("CMUX_SOCKET_PATH", ""),
+                            "tty": tty,
+                        },
+                    }
+                    sidecar_dir = hermes_home / "current-sessions" / "by-cmux-surface"
+                    sidecar_dir.mkdir(parents=True, exist_ok=True)
+                    atomic_json_write(sidecar_dir / f"{safe_surface_id}.json", cmux_payload)
         except Exception as e:
             logger.debug("Could not write current-session sidecar: %s", e)
 

--- a/tests/agent/test_skill_commands_reload.py
+++ b/tests/agent/test_skill_commands_reload.py
@@ -137,6 +137,27 @@ class TestReloadSkillsHelper:
         assert result["added"] == []
         assert result["removed"] == []
 
+    def test_reload_preserves_command_map_object_for_cli_references(self, hermes_home):
+        """The CLI imports a module-level command map at startup.
+
+        Reloading skills must update that existing dict in place so a running
+        CLI process can see newly installed slash skills without restart.
+        """
+        import agent.skill_commands as skill_commands
+
+        command_map = skill_commands.get_skill_commands()
+        assert command_map is skill_commands._skill_commands
+        assert command_map == {}
+
+        _write_skill(hermes_home / "skills", "demo", "newly installed skill")
+        result = skill_commands.reload_skills()
+
+        assert result["added"] == [
+            {"name": "demo", "description": "newly installed skill"}
+        ]
+        assert command_map is skill_commands._skill_commands
+        assert "/demo" in command_map
+
     def test_does_not_invalidate_prompt_cache_snapshot(self, hermes_home):
         """reload_skills must NOT delete the skills prompt-cache snapshot.
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,4 +1,4 @@
-"""Tests for cmd_update — branch fallback when remote branch doesn't exist."""
+"""Tests for cmd_update branch safety and update flow."""
 
 import subprocess
 from types import SimpleNamespace
@@ -39,36 +39,35 @@ def mock_args():
     return SimpleNamespace()
 
 
-class TestCmdUpdateBranchFallback:
-    """cmd_update falls back to main when current branch has no remote counterpart."""
+class TestCmdUpdateBranchSafety:
+    """cmd_update refuses to switch the installed checkout between branches."""
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_update_falls_back_to_main_when_branch_not_on_remote(
+    def test_update_refuses_non_main_branch_without_switching(
         self, mock_run, _mock_which, mock_args, capsys
     ):
         mock_run.side_effect = _make_run_side_effect(
             branch="fix/stoicneko", verify_ok=False, commit_count="3"
         )
 
-        cmd_update(mock_args)
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(mock_args)
+
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "Refusing to update while on branch 'fix/stoicneko'" in captured.out
+        assert "would affect all running Hermes sessions" in captured.out
 
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
-
-        # rev-list should use origin/main, not origin/fix/stoicneko
-        rev_list_cmds = [c for c in commands if "rev-list" in c]
-        assert len(rev_list_cmds) == 1
-        assert "origin/main" in rev_list_cmds[0]
-        assert "origin/fix/stoicneko" not in rev_list_cmds[0]
-
-        # pull should use main, not fix/stoicneko
-        pull_cmds = [c for c in commands if "pull" in c]
-        assert len(pull_cmds) == 1
-        assert "main" in pull_cmds[0]
+        assert not any("checkout" in c for c in commands)
+        assert not any("pull" in c for c in commands)
+        assert not any("rev-list" in c for c in commands)
+        assert not any("status --porcelain" in c for c in commands)
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_update_uses_current_branch_when_on_remote(
+    def test_update_uses_main_when_on_main(
         self, mock_run, _mock_which, mock_args, capsys
     ):
         mock_run.side_effect = _make_run_side_effect(
@@ -76,7 +75,6 @@ class TestCmdUpdateBranchFallback:
         )
 
         cmd_update(mock_args)
-
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
 
         rev_list_cmds = [c for c in commands if "rev-list" in c]
@@ -85,6 +83,7 @@ class TestCmdUpdateBranchFallback:
 
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 1
+        assert "main" in pull_cmds[0]
         assert "main" in pull_cmds[0]
 
     @patch("shutil.which", return_value=None)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -4,7 +4,10 @@ from argparse import Namespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+import cron.jobs as jobs_mod
+import cron.scheduler as scheduler_mod
+import hermes_cli.cron as cron_mod
+from cron.jobs import create_job, get_job, list_jobs, pause_job
 from hermes_cli.cron import cron_command
 
 
@@ -105,3 +108,132 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+
+def _block_unsafe_paths(monkeypatch):
+    """Patch every helper the test-run command must NEVER call."""
+
+    def boom(name):
+        def _raise(*args, **kwargs):
+            raise AssertionError(f"test-run must not call {name}; got args={args} kwargs={kwargs}")
+        return _raise
+
+    monkeypatch.setattr(scheduler_mod, "tick", boom("scheduler.tick"))
+    monkeypatch.setattr(scheduler_mod, "_deliver_result", boom("scheduler._deliver_result"))
+    monkeypatch.setattr(jobs_mod, "mark_job_run", boom("jobs.mark_job_run"))
+    monkeypatch.setattr(jobs_mod, "advance_next_run", boom("jobs.advance_next_run"))
+    monkeypatch.setattr(jobs_mod, "update_job", boom("jobs.update_job"))
+    monkeypatch.setattr(jobs_mod, "get_due_jobs", boom("jobs.get_due_jobs"))
+    monkeypatch.setattr(cron_mod, "_cron_api", boom("hermes_cli.cron._cron_api"))
+
+
+class TestCronTestRun:
+    """Phase 1 failing tests: `hermes cron test-run <job_id>` safe one-job verification."""
+
+    def test_routes_to_cron_test_run(self, tmp_cron_dir, monkeypatch):
+        """cron_command must dispatch 'test-run' to a new cron_test_run function."""
+        calls = []
+
+        def fake(job_id):
+            calls.append(job_id)
+            return 0
+
+        monkeypatch.setattr(cron_mod, "cron_test_run", fake)
+        cron_command(Namespace(cron_command="test-run", job_id="abc123"))
+        assert calls == ["abc123"]
+
+    def test_calls_get_job_once(self, tmp_cron_dir, monkeypatch):
+        """The new command must look up exactly one job via get_job."""
+        job = create_job(prompt="check", schedule="every 1h")
+        seen = []
+
+        def recorder(job_id):
+            seen.append(job_id)
+            return job
+
+        monkeypatch.setattr(cron_mod, "get_job", recorder)
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+        assert seen == [job["id"]]
+
+    def test_calls_run_job_once_with_fetched_job(self, tmp_cron_dir, monkeypatch):
+        """run_job must be called exactly once with the job dict from get_job."""
+        job = create_job(prompt="check", schedule="every 1h")
+        runs = []
+
+        def recorder(j):
+            runs.append(j)
+            return (True, "out", "final", None)
+
+        monkeypatch.setattr(cron_mod, "run_job", recorder)
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+        assert len(runs) == 1
+        assert runs[0]["id"] == job["id"]
+
+    def test_saves_output_once(self, tmp_cron_dir, monkeypatch):
+        """save_job_output must be called exactly once with (job_id, output)."""
+        job = create_job(prompt="check", schedule="every 1h")
+        saves = []
+
+        def recorder(jid, out):
+            saves.append((jid, out))
+            return "/tmp/saved.md"
+
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "OUTPUT_BODY", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", recorder)
+        cron_mod.cron_test_run(job["id"])
+        assert saves == [(job["id"], "OUTPUT_BODY")]
+
+    def test_never_calls_unsafe_paths(self, tmp_cron_dir, monkeypatch):
+        """test-run must not touch tick, delivery, run marking, schedule advancement, due lookup, or the queued cron API."""
+        job = create_job(prompt="check", schedule="every 1h")
+        _block_unsafe_paths(monkeypatch)
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+
+    def test_success_stdout_includes_evidence(self, tmp_cron_dir, monkeypatch, capsys):
+        """Success path stdout must contain job id, success status, output path, and output length."""
+        job = create_job(prompt="check", schedule="every 1h")
+        output_body = "Hello world, this is the output."
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, output_body, "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/cron/output/abc.md")
+        rc = cron_mod.cron_test_run(job["id"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert job["id"] in out
+        assert "success" in out.lower()
+        assert "/tmp/cron/output/abc.md" in out
+        assert str(len(output_body)) in out
+
+    def test_failure_returns_nonzero_and_prints_error(self, tmp_cron_dir, monkeypatch, capsys):
+        """Failure path must return non-zero, still save output, and print path + length + error text."""
+        job = create_job(prompt="check", schedule="every 1h")
+        partial = "Partial output before failure"
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (False, partial, "", "boom: model errored"))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/cron/output/fail.md")
+        rc = cron_mod.cron_test_run(job["id"])
+        out = capsys.readouterr().out
+        assert rc != 0
+        assert job["id"] in out
+        assert "/tmp/cron/output/fail.md" in out
+        assert str(len(partial)) in out
+        assert "boom: model errored" in out
+
+    def test_preserves_paused_state_and_last_run(self, tmp_cron_dir, monkeypatch):
+        """A paused job must remain paused and its last_run timestamp must not change."""
+        job = create_job(prompt="check", schedule="every 1h")
+        pause_job(job["id"])
+        before = get_job(job["id"])
+        assert before["state"] == "paused"
+        last_run_before = before.get("last_run")
+
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+
+        after = get_job(job["id"])
+        assert after["state"] == "paused"
+        assert after.get("last_run") == last_run_before

--- a/tests/hermes_cli/test_mcp_sync.py
+++ b/tests/hermes_cli/test_mcp_sync.py
@@ -1,0 +1,440 @@
+"""Tests for ``hermes mcp sync`` shared profile MCP configuration."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+
+class TestSharedMcpServerLoading:
+    def test_load_shared_mcp_servers_accepts_wrapped_mcp_servers(self, tmp_path):
+        shared = tmp_path / "mcp_servers.yaml"
+        shared.write_text("""
+mcp_servers:
+  prism:
+    command: prism-mcp
+""")
+
+        from hermes_cli.mcp_config import _load_shared_mcp_servers
+
+        assert _load_shared_mcp_servers(shared) == {"prism": {"command": "prism-mcp"}}
+
+    def test_load_shared_mcp_servers_accepts_raw_mapping(self, tmp_path):
+        shared = tmp_path / "mcp_servers.yaml"
+        shared.write_text("""
+prism:
+  command: prism-mcp
+""")
+
+        from hermes_cli.mcp_config import _load_shared_mcp_servers
+
+        assert _load_shared_mcp_servers(shared) == {"prism": {"command": "prism-mcp"}}
+
+    def test_load_shared_mcp_servers_rejects_non_mapping_server_entry(self, tmp_path):
+        shared = tmp_path / "mcp_servers.yaml"
+        shared.write_text("mcp_servers:\n  prism: nope\n")
+
+        from hermes_cli.mcp_config import _load_shared_mcp_servers
+
+        with pytest.raises(ValueError, match="prism"):
+            _load_shared_mcp_servers(shared)
+
+    def test_load_shared_mcp_servers_reports_missing_file(self, tmp_path):
+        from hermes_cli.mcp_config import _load_shared_mcp_servers
+
+        with pytest.raises(FileNotFoundError, match="Shared MCP file not found"):
+            _load_shared_mcp_servers(tmp_path / "missing.yaml")
+
+
+class TestMcpSyncPlanning:
+    def test_plan_mcp_sync_adds_missing_server(self):
+        from hermes_cli.mcp_config import _plan_mcp_sync
+
+        plan = _plan_mcp_sync(
+            target_servers={},
+            shared_servers={"prism": {"command": "prism-mcp"}},
+            selected_names=None,
+            force=False,
+        )
+
+        assert plan.merged_servers == {"prism": {"command": "prism-mcp"}}
+        assert plan.added == ["prism"]
+        assert plan.changed is True
+
+    def test_plan_mcp_sync_skips_identical_server(self):
+        from hermes_cli.mcp_config import _plan_mcp_sync
+
+        cfg = {"command": "prism-mcp"}
+        plan = _plan_mcp_sync(
+            target_servers={"prism": cfg},
+            shared_servers={"prism": cfg},
+            selected_names=None,
+            force=False,
+        )
+
+        assert plan.skipped == ["prism"]
+        assert plan.changed is False
+
+    def test_plan_mcp_sync_conflicts_without_force(self):
+        from hermes_cli.mcp_config import _plan_mcp_sync
+
+        plan = _plan_mcp_sync(
+            target_servers={"prism": {"command": "old"}},
+            shared_servers={"prism": {"command": "new"}},
+            selected_names=None,
+            force=False,
+        )
+
+        assert plan.conflicts == ["prism"]
+        assert plan.merged_servers["prism"] == {"command": "old"}
+        assert plan.changed is False
+
+    def test_plan_mcp_sync_replaces_conflict_with_force(self):
+        from hermes_cli.mcp_config import _plan_mcp_sync
+
+        plan = _plan_mcp_sync(
+            target_servers={"prism": {"command": "old"}},
+            shared_servers={"prism": {"command": "new"}},
+            selected_names=None,
+            force=True,
+        )
+
+        assert plan.updated == ["prism"]
+        assert plan.merged_servers["prism"] == {"command": "new"}
+        assert plan.changed is True
+
+    def test_plan_mcp_sync_respects_selected_names(self):
+        from hermes_cli.mcp_config import _plan_mcp_sync
+
+        plan = _plan_mcp_sync(
+            target_servers={},
+            shared_servers={"prism": {"command": "p"}, "qmd": {"url": "u"}},
+            selected_names={"qmd"},
+            force=False,
+        )
+
+        assert plan.added == ["qmd"]
+        assert "prism" not in plan.merged_servers
+
+
+class TestMcpSyncTargetResolution:
+    def test_resolve_sync_targets_explicit_profiles(self, monkeypatch, tmp_path):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        (tmp_path / "main").mkdir()
+        (tmp_path / "therapy").mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir", lambda name: tmp_path / name
+        )
+
+        targets = _resolve_mcp_sync_targets(
+            profile_names=["main", "therapy"], all_profiles=False
+        )
+
+        assert [t.name for t in targets] == ["main", "therapy"]
+        assert [t.config_path for t in targets] == [
+            tmp_path / "main" / "config.yaml",
+            tmp_path / "therapy" / "config.yaml",
+        ]
+
+    def test_resolve_sync_targets_all_profiles(self, monkeypatch, tmp_path):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [
+                SimpleNamespace(name="default", path=tmp_path / "default"),
+                SimpleNamespace(name="main", path=tmp_path / "main"),
+            ],
+        )
+
+        targets = _resolve_mcp_sync_targets(profile_names=[], all_profiles=True)
+
+        assert [t.name for t in targets] == ["default", "main"]
+        assert [t.config_path for t in targets] == [
+            tmp_path / "default" / "config.yaml",
+            tmp_path / "main" / "config.yaml",
+        ]
+
+    def test_resolve_sync_targets_rejects_all_plus_explicit_profile(self):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        with pytest.raises(ValueError, match="either --all or --profile"):
+            _resolve_mcp_sync_targets(profile_names=["main"], all_profiles=True)
+
+    def test_resolve_sync_targets_rejects_invalid_profile_name(self):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            _resolve_mcp_sync_targets(profile_names=["../escape"], all_profiles=False)
+
+    def test_resolve_sync_targets_rejects_missing_named_profile(self, monkeypatch, tmp_path):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir", lambda name: tmp_path / name
+        )
+
+        with pytest.raises(FileNotFoundError, match="Profile 'missing' does not exist"):
+            _resolve_mcp_sync_targets(profile_names=["missing"], all_profiles=False)
+
+        assert not (tmp_path / "missing" / "config.yaml").exists()
+
+    def test_resolve_sync_targets_requires_a_target(self):
+        from hermes_cli.mcp_config import _resolve_mcp_sync_targets
+
+        with pytest.raises(ValueError, match="Specify --profile"):
+            _resolve_mcp_sync_targets(profile_names=[], all_profiles=False)
+
+
+class TestMcpSyncCommand:
+    def test_cmd_mcp_sync_dry_run_does_not_write(self, tmp_path, monkeypatch, capsys):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text("mcp_servers:\n  prism:\n    command: prism-mcp\n")
+        profile = tmp_path / "main"
+        profile.mkdir()
+        config_path = profile / "config.yaml"
+        config_path.write_text("model:\n  default: gpt-5.5\n")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            lambda profile_names, all_profiles: [
+                SimpleNamespace(name="main", config_path=config_path)
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["main"],
+            all=False,
+            servers=None,
+            dry_run=True,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "prism" in out
+        assert "mcp_servers" not in config_path.read_text()
+
+    def test_cmd_mcp_sync_writes_config_preserving_other_sections(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text("mcp_servers:\n  prism:\n    command: prism-mcp\n")
+        profile = tmp_path / "main"
+        profile.mkdir()
+        config_path = profile / "config.yaml"
+        config_path.write_text("model:\n  default: gpt-5.5\n")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            lambda profile_names, all_profiles: [
+                SimpleNamespace(name="main", config_path=config_path)
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["main"],
+            all=False,
+            servers=None,
+            dry_run=False,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        out = capsys.readouterr().out
+        written = yaml.safe_load(config_path.read_text())
+        assert "Synced" in out
+        assert written["model"] == {"default": "gpt-5.5"}
+        assert written["mcp_servers"] == {"prism": {"command": "prism-mcp"}}
+
+    def test_cmd_mcp_sync_reports_conflict_without_force(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text("mcp_servers:\n  prism:\n    command: new\n")
+        profile = tmp_path / "main"
+        profile.mkdir()
+        config_path = profile / "config.yaml"
+        config_path.write_text("mcp_servers:\n  prism:\n    command: old\n")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            lambda profile_names, all_profiles: [
+                SimpleNamespace(name="main", config_path=config_path)
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["main"],
+            all=False,
+            servers=None,
+            dry_run=False,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        out = capsys.readouterr().out
+        written = yaml.safe_load(config_path.read_text())
+        assert "conflict" in out.lower()
+        assert written["mcp_servers"]["prism"] == {"command": "old"}
+
+    def test_cmd_mcp_sync_selected_servers_only(self, tmp_path, monkeypatch):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text(
+            "mcp_servers:\n  prism:\n    command: p\n  qmd:\n    url: http://localhost/sse\n"
+        )
+        profile = tmp_path / "main"
+        profile.mkdir()
+        config_path = profile / "config.yaml"
+        config_path.write_text("{}\n")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            lambda profile_names, all_profiles: [
+                SimpleNamespace(name="main", config_path=config_path)
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["main"],
+            all=False,
+            servers=["qmd"],
+            dry_run=False,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        written = yaml.safe_load(config_path.read_text())
+        assert written["mcp_servers"] == {"qmd": {"url": "http://localhost/sse"}}
+
+    def test_cmd_mcp_sync_unknown_selected_server_errors(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text("mcp_servers:\n  prism:\n    command: p\n")
+        profile = tmp_path / "main"
+        profile.mkdir()
+        config_path = profile / "config.yaml"
+        config_path.write_text("{}\n")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            lambda profile_names, all_profiles: [
+                SimpleNamespace(name="main", config_path=config_path)
+            ],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["main"],
+            all=False,
+            servers=["missing"],
+            dry_run=False,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        out = capsys.readouterr().out
+        assert "Unknown shared MCP server" in out
+        assert yaml.safe_load(config_path.read_text()) == {}
+
+    def test_cmd_mcp_sync_missing_profile_does_not_show_shared_file_hint(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        shared = tmp_path / "shared.yaml"
+        shared.write_text("mcp_servers:\n  prism:\n    command: p\n")
+
+        def raise_missing_profile(profile_names, all_profiles):
+            raise FileNotFoundError("Profile 'missing' does not exist")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._resolve_mcp_sync_targets",
+            raise_missing_profile,
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_sync
+
+        args = SimpleNamespace(
+            shared=str(shared),
+            profile=["missing"],
+            all=False,
+            servers=None,
+            dry_run=False,
+            force=False,
+        )
+        cmd_mcp_sync(args)
+
+        out = capsys.readouterr().out
+        assert "Profile 'missing' does not exist" in out
+        assert "mkdir -p ~/.hermes/shared" not in out
+
+
+def test_mcp_dispatcher_routes_sync(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.mcp_config.cmd_mcp_sync",
+        lambda args: calls.append(args.mcp_action),
+    )
+
+    from hermes_cli.mcp_config import mcp_command
+
+    mcp_command(SimpleNamespace(mcp_action="sync"))
+
+    assert calls == ["sync"]
+
+
+def test_cli_mcp_sync_profile_flag_is_not_consumed_by_global_profile_override(tmp_path):
+    """`mcp sync --profile` is a local flag, not the global profile override."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    shared = tmp_path / "shared.yaml"
+    shared.write_text("mcp_servers:\n  demo:\n    command: demo-mcp\n")
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["NO_COLOR"] = "1"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "mcp",
+            "sync",
+            "--shared",
+            str(shared),
+            "--profile",
+            "default",
+            "--dry-run",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0
+    assert "Profile: default" in combined
+    assert "Specify --profile NAME or --all" not in combined

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -512,57 +512,65 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Non-main branch → auto-checkout main
+# Non-main branch → fail safe, no implicit checkout
 # ---------------------------------------------------------------------------
 
-def test_cmd_update_switches_to_main_from_feature_branch(monkeypatch, tmp_path, capsys):
-    """When on a feature branch, update checks out main before pulling."""
+def test_cmd_update_refuses_feature_branch_without_checkout(monkeypatch, tmp_path, capsys):
+    """When on a feature branch, update fails instead of checking out main."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="fix/something")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit) as exc:
+        hermes_main.cmd_update(SimpleNamespace())
 
-    checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
-    assert len(checkout_calls) == 1
+    assert exc.value.code == 1
+    assert not any("checkout" in c for c in recorded)
+    assert not any("pull" in c for c in recorded)
 
     out = capsys.readouterr().out
     assert "fix/something" in out
-    assert "switching to main" in out
+    assert "Refusing to update" in out
+    assert "would affect all running Hermes sessions" in out
 
 
-def test_cmd_update_switches_to_main_from_detached_head(monkeypatch, tmp_path, capsys):
-    """When in detached HEAD state, update checks out main before pulling."""
+def test_cmd_update_refuses_detached_head_without_checkout(monkeypatch, tmp_path, capsys):
+    """When in detached HEAD state, update fails instead of checking out main."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit) as exc:
+        hermes_main.cmd_update(SimpleNamespace())
 
-    checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
-    assert len(checkout_calls) == 1
+    assert exc.value.code == 1
+    assert not any("checkout" in c for c in recorded)
+    assert not any("pull" in c for c in recorded)
 
     out = capsys.readouterr().out
     assert "detached HEAD" in out
+    assert "Refusing to update" in out
 
 
-def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatch, tmp_path, capsys):
-    """When on a feature branch with no updates, stash is restored and branch switched back."""
+def test_cmd_update_does_not_stash_or_restore_when_refusing_non_main(monkeypatch, tmp_path, capsys):
+    """Non-main safety check happens before stashing local changes."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
-    # Enable stash so it returns a ref
+    stash_calls = []
     monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
+        hermes_main,
+        "_stash_local_changes_if_needed",
+        lambda *a, **kw: stash_calls.append(1) or "abc123deadbeef",
     )
     restore_calls = []
     monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
+        hermes_main,
+        "_restore_stashed_changes",
         lambda *a, **kw: restore_calls.append(1) or True,
     )
 
@@ -571,17 +579,16 @@ def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatc
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit) as exc:
+        hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash should have been restored
-    assert len(restore_calls) == 1
-
-    # Should have checked out back to the original branch
-    checkout_back = [c for c in recorded if "checkout" in c and "fix/something" in c]
-    assert len(checkout_back) == 1
+    assert exc.value.code == 1
+    assert stash_calls == []
+    assert restore_calls == []
+    assert not any("checkout" in c for c in recorded)
 
     out = capsys.readouterr().out
-    assert "Already up to date" in out
+    assert "Refusing to update" in out
 
 
 def test_cmd_update_no_checkout_when_already_on_main(monkeypatch, tmp_path):

--- a/tests/run_agent/test_session_sidecars.py
+++ b/tests/run_agent/test_session_sidecars.py
@@ -1,0 +1,90 @@
+"""Session sidecar behavior for external cmux prompt enhancers."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*, quiet_mode: bool = True, platform: str = "cli") -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=quiet_mode,
+            platform=platform,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_cmux_surface_sidecar_is_opt_in_for_foreground_cli(monkeypatch):
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "workspace-abc")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "surface-123")
+    monkeypatch.setenv("CMUX_SOCKET_PATH", "/tmp/cmux-test.sock")
+
+    agent = _make_agent(quiet_mode=True, platform="cli")
+    agent._publish_cmux_surface_sidecar = True
+    agent._write_current_session_sidecar()
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    sidecar = hermes_home / "current-sessions" / "by-cmux-surface" / "surface-123.json"
+    assert sidecar.exists()
+
+    payload = json.loads(sidecar.read_text())
+    assert payload["session_id"] == agent.session_id
+    assert payload["pid"] == os.getpid()
+    assert payload["session_json"] == str(hermes_home / "sessions" / f"session_{agent.session_id}.json")
+    assert payload["cmux"] == {
+        "workspace_id": "workspace-abc",
+        "surface_id": "surface-123",
+        "socket_path": "/tmp/cmux-test.sock",
+        "tty": "",
+    }
+
+
+def test_cmux_surface_sidecar_not_written_until_foreground_cli_opts_in(monkeypatch):
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "workspace-abc")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "surface-background")
+
+    _make_agent(quiet_mode=True, platform="cli")
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    sidecar = hermes_home / "current-sessions" / "by-cmux-surface" / "surface-background.json"
+    assert not sidecar.exists()
+
+
+def test_cmux_surface_sidecar_key_cannot_escape_directory(monkeypatch):
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "workspace-abc")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "../surface-bad")
+
+    agent = _make_agent(quiet_mode=True, platform="cli")
+    agent._publish_cmux_surface_sidecar = True
+    agent._write_current_session_sidecar()
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    escaped = hermes_home / "current-sessions" / "surface-bad.json"
+    sidecar = hermes_home / "current-sessions" / "by-cmux-surface" / ".._surface-bad.json"
+    assert not escaped.exists()
+    assert sidecar.exists()
+    assert json.loads(sidecar.read_text())["session_id"] == agent.session_id

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -228,6 +228,38 @@ mcp_my_api_list_items_v2
 
 Keep this in mind when writing `include` / `exclude` filters — use the **original** MCP tool name (with hyphens/dots), not the sanitized version.
 
+## Shared profile sync
+
+Profiles do not live-inherit MCP configuration. Each profile reads `mcp_servers` from its own `config.yaml`.
+
+To keep common MCP definitions in one place and merge them into selected profiles, create:
+
+```yaml
+# ~/.hermes/shared/mcp_servers.yaml
+mcp_servers:
+  docs:
+    url: "https://mcp.docs.example.com/mcp"
+  filesystem:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+```
+
+Then sync with a dry run first:
+
+```bash
+hermes mcp sync --all --dry-run
+hermes mcp sync --profile main --profile research --servers docs,filesystem
+```
+
+Behavior:
+
+- Only `mcp_servers` entries are merged into target profile configs.
+- Other profile settings are preserved.
+- Existing identical entries are skipped.
+- Existing same-name entries with different config are reported as conflicts and not overwritten unless `--force` is used.
+- `--servers` accepts comma-separated names and can be repeated.
+- After syncing, restart the affected gateway or run `/reload-mcp` / `/reset` in active sessions.
+
 ## OAuth 2.1 authentication
 
 For HTTP servers that require OAuth, set `auth: oauth` on the server entry:

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -91,7 +91,16 @@ Use HTTP servers when:
 
 ## Basic configuration reference
 
-Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
+Hermes reads MCP config from the active profile's `config.yaml` under `mcp_servers`. For the default profile this is `~/.hermes/config.yaml`; for a named profile it is `~/.hermes/profiles/<name>/config.yaml`.
+
+Profiles do not inherit MCP servers from each other. To maintain common MCP servers once and copy them into selected profiles, put shared definitions in `~/.hermes/shared/mcp_servers.yaml` and sync them:
+
+```bash
+hermes mcp sync --all --dry-run
+hermes mcp sync --profile main --profile therapy --servers prism,qmd,shmem
+```
+
+`hermes mcp sync` only merges the selected `mcp_servers` entries. It preserves other profile settings and skips conflicting same-name entries unless you pass `--force`. After syncing, run `/reload-mcp`, `/reset`, or restart affected gateways.
 
 ### Common keys
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -183,6 +183,19 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+### MCP servers in profiles
+
+MCP servers are profile-scoped because each profile has its own `config.yaml`. A server configured in `~/.hermes/config.yaml` is not automatically available in `~/.hermes/profiles/coder/config.yaml`.
+
+For common servers that should be copied into several profiles, keep the canonical definitions in `~/.hermes/shared/mcp_servers.yaml` and sync them explicitly:
+
+```bash
+hermes mcp sync --all --dry-run
+hermes mcp sync --profile coder --servers github,docs
+```
+
+The sync command merges only `mcp_servers` entries and leaves the rest of each profile config alone. Existing same-name profile entries are treated as conflicts and skipped unless `--force` is provided. Restart/reset the affected profile after syncing so its MCP connections are rediscovered.
+
 ## Updating
 
 `hermes update` pulls code once (shared) and syncs new bundled skills to **all** profiles automatically:


### PR DESCRIPTION
## Summary
- Add profile MCP sync command and docs/tests
- Add current-session sidecars, including cmux sidecar publishing from foreground CLI
- Add cron `test-run` safe verification flow
- Make `hermes update` refuse implicit branch switches from non-main/detached HEAD

## Test Plan
- `python -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_yes_flag.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_cron.py tests/hermes_cli/test_mcp_sync.py tests/run_agent/test_session_sidecars.py tests/agent/test_skill_commands_reload.py -q -o 'addopts='`
- `ruff check agent/skill_commands.py cli.py hermes_cli/commands.py hermes_cli/cron.py hermes_cli/main.py hermes_cli/mcp_config.py run_agent.py tests/agent/test_skill_commands_reload.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cron.py tests/hermes_cli/test_mcp_sync.py tests/hermes_cli/test_update_autostash.py tests/run_agent/test_session_sidecars.py`
