### PR TITLE
fix: use AGENT_BROWSER_ARGS (not CHROME_FLAGS) for Chrome sandbox bypass

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1873,7 +1873,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1892,8 +1892,8 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
 
         # Use temp files for stdout/stderr instead of pipes.


### PR DESCRIPTION
## Problem

`_run_browser_command` injects `--no-sandbox` via the `AGENT_BROWSER_CHROME_FLAGS` env var. This env var name is incorrect — agent-browser reads `AGENT_BROWSER_ARGS`, not `AGENT_BROWSER_CHROME_FLAGS`.

The consequence: on any system with AppArmor userns restrictions (Ubuntu 23.10+, Docker, etc.), the `--no-sandbox` injection silently does nothing, and every Chrome launch fails with:

```
FATAL: No usable sandbox! If you are running on Ubuntu 23.10+...
```

## Root Cause

agent-browser's `--help` documents:

```
--args <args>   Browser launch args, comma or newline separated (or AGENT_BROWSER_ARGS)
```

Not `AGENT_BROWSER_CHROME_FLAGS`. The format is also comma-separated, not space-separated.

## Fix

Two changes:
1. `AGENT_BROWSER_CHROME_FLAGS` → `AGENT_BROWSER_ARGS`
2. `"--no-sandbox --disable-dev-shm-usage"` → `"--no-sandbox,--disable-dev-shm-usage"`

## Verification

Tested on Ubuntu with `/proc/sys/kernel/apparmor_restrict_unprivileged_userns=1`. Before this fix, the env var was silently ignored. After, Chrome launches successfully.