### PR TITLE
feat: automatic Chrome fallback when CDP override endpoint fails

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -678,6 +678,73 @@ def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Di
     return target
 
 
+def _cdp_override_fallback_reason(
+    session_info: Dict[str, Any],
+    command: str,
+    result: Dict[str, Any],
+) -> Optional[str]:
+    """Return the user-visible reason a CDP-override result needs Chrome fallback.
+
+    ``None`` means no fallback should run.  The returned string is copied into
+    the fallback result so CLI/TUI/gateway users can see when Hermes silently
+    switched from the CDP override engine to Chrome for reliability.
+    """
+    # Only trigger fallback for CDP override sessions.
+    features = session_info.get("features", {})
+    if not isinstance(features, dict) or not features.get("cdp_override"):
+        return None
+
+    # Only retry commands where Chrome can meaningfully produce a different
+    # result. Session-management commands are tied to the original engine.
+    _FALLBACK_ELIGIBLE = {"open", "snapshot", "screenshot", "eval", "click",
+                          "fill", "scroll", "back", "press", "console", "errors"}
+    if command not in _FALLBACK_ELIGIBLE:
+        return None
+
+    # Explicit failure — the CDP engine couldn't handle this operation.
+    if not result.get("success"):
+        error = str(result.get("error") or "command failed").strip()
+        return f"CDP override {command!r} failed ({error}); retried with Chrome."
+
+    return None
+
+
+def _needs_cdp_override_fallback(
+    session_info: Dict[str, Any],
+    command: str,
+    result: Dict[str, Any],
+) -> bool:
+    """Check if a CDP-override result should trigger an automatic Chrome fallback."""
+    return _cdp_override_fallback_reason(session_info, command, result) is not None
+
+
+def _annotate_cdp_fallback(result: Dict[str, Any], reason: str) -> Dict[str, Any]:
+    """Add a user-visible Chrome fallback warning to a CDP override result."""
+    warning = (
+        "⚠ CDP override fallback: Chrome was used for this browser action. "
+        f"{reason}"
+    )
+    annotated = dict(result)
+    annotated["fallback_warning"] = warning
+    annotated["browser_engine"] = "chrome"
+    annotated["browser_engine_fallback"] = {
+        "from": "cdp_override",
+        "to": "chrome",
+        "reason": reason,
+    }
+    data = annotated.get("data")
+    if isinstance(data, dict):
+        data = dict(data)
+        data.setdefault("fallback_warning", warning)
+        data.setdefault("browser_engine", "chrome")
+        data.setdefault(
+            "browser_engine_fallback",
+            {"from": "cdp_override", "to": "chrome", "reason": reason},
+        )
+        annotated["data"] = data
+    return annotated
+
+
 def _run_chrome_fallback_command(
     task_id: str,
     command: str,
@@ -748,6 +815,33 @@ def _run_chrome_fallback_command(
 
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
+
+    # Inject --no-sandbox when needed (issue #15765):
+    # - Running as root: Chromium always refuses to start without it
+    # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
+    #   are restricted, causing Chromium to exit with "No usable sandbox"
+    #   even for non-root users running under systemd or containers.
+    if "AGENT_BROWSER_ARGS" not in browser_env:
+        _needs_sandbox_bypass = False
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            _needs_sandbox_bypass = True
+            logger.debug("browser fallback: running as root — injecting --no-sandbox")
+        else:
+            _userns_restrict = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+            try:
+                with open(_userns_restrict, encoding="utf-8") as _f:
+                    if _f.read().strip() == "1":
+                        _needs_sandbox_bypass = True
+                        logger.debug(
+                            "browser fallback: AppArmor userns restrictions detected — "
+                            "injecting --no-sandbox"
+                        )
+            except OSError:
+                pass
+        if _needs_sandbox_bypass:
+            browser_env["AGENT_BROWSER_ARGS"] = (
+                "--no-sandbox,--disable-dev-shm-usage"
+            )
 
     def _run_tmp(cmd: str, cmd_args: List[str]) -> Dict[str, Any]:
         full = base_args + [cmd] + cmd_args
@@ -1873,7 +1967,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1892,8 +1986,8 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
 
         # Use temp files for stdout/stderr instead of pipes.
@@ -2046,6 +2140,23 @@ def _run_browser_command(
         else:
             fallback_result = _run_chrome_fallback_command(task_id, command, args, timeout)
         return _annotate_lightpanda_fallback(fallback_result, fallback_reason)
+
+    # --- CDP override automatic Chrome fallback ---
+    # If the session uses a user-supplied CDP endpoint (e.g. Obscura) that
+    # fails on an operation, retry with Chrome.
+    cdp_fallback_reason = _cdp_override_fallback_reason(session_info, command, result)
+    if cdp_fallback_reason:
+        logger.info(
+            "CDP override fallback: retrying '%s' with Chrome (task=%s): %s",
+            command,
+            task_id,
+            cdp_fallback_reason,
+        )
+        if command == "screenshot":
+            fallback_result = _chrome_fallback_screenshot(task_id, args or [], timeout)
+        else:
+            fallback_result = _run_chrome_fallback_command(task_id, command, args, timeout)
+        return _annotate_cdp_fallback(fallback_result, cdp_fallback_reason)
 
     return result
 


### PR DESCRIPTION
## Summary

Extends the existing Lightpanda→Chrome fallback pattern to CDP override mode. When a user-supplied CDP endpoint (Obscura, Lightpanda-as-a-service, etc.) can't handle an operation, Hermes automatically retries with a local Chrome session.

## Motivation

The Lightpanda fallback (#issue) already handles the case where `engine: lightpanda` produces broken results. CDP override mode (`browser.cdp_url`) has the same class of problem — alternative engines may lack `Page.captureScreenshot` or other CDP methods — but there's no automatic recovery. Users see errors instead of results.

This is already a known gap:
- `h4ckf0r0day/obscura#121` — `Page.captureScreenshot` not implemented
- `h4ckf0r0day/obscura#15445` — Hermes Obscura integration request

## How It Works

Same architecture as the Lightpanda fallback (same `_run_chrome_fallback_command` helper is reused):

1. `_cdp_override_fallback_reason()` — detects CDP engine failures on eligible commands
2. In `_run_browser_command` — after the Lightpanda fallback block, same logic for CDP override
3. Creates a temporary Chrome session, navigates to the current URL, retries the command
4. Annotates result with `{from: "cdp_override", to: "chrome"}` metadata

Only triggers for CDP override sessions (`features.cdp_override: true`). Only for commands Chrome can meaningfully retry (not session management). Any `success: false` triggers fallback.

## Changes

| Change | Lines |
|--------|-------|
| New functions: `_cdp_override_fallback_reason`, `_needs_cdp_override_fallback`, `_annotate_cdp_fallback` | 67 |
| Fallback block in `_run_browser_command` | 17 |
| Sandbox bypass in `_run_chrome_fallback_command` | 27 |
| Fix `AGENT_BROWSER_CHROME_FLAGS` → `AGENT_BROWSER_ARGS` (in both paths) | 6 |

The sandbox bypass in the fallback path and the env var fix are needed for Chrome to work on Ubuntu 23.10+ systems with AppArmor userns restrictions.

## Testing

End-to-end verified: navigation via Obscura CDP → screenshot fails → Chrome fallback → screenshot saved. Fallback metadata visible in both tool results and agent logs.