### PR TITLE
fix: add server error (5xx) detection to auxiliary vision fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2064,6 +2064,30 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _is_server_error(exc: Exception) -> bool:
+    """Detect server-side errors (HTTP 5xx) that warrant provider fallback.
+
+    Server errors (502, 503, 504, etc.) are transient — the endpoint is
+    temporarily broken regardless of whether it was explicitly chosen by the
+    user.  This is fundamentally different from payment/rate-limit errors
+    where the ``is_auto`` gate makes sense (explicit provider = hard constraint).
+
+    Returns True for:
+      - HTTP 5xx status codes (500–599)
+      - Common server error text patterns in the exception message
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int) and 500 <= status <= 599:
+        return True
+    err_lower = str(exc).lower()
+    return any(kw in err_lower for kw in (
+        "server error", "internal server error",
+        "bad gateway", "service unavailable", "gateway timeout",
+        "unavailable", "temporarily unavailable",
+        "overloaded", "try again later",
+    ))
+
+
 def _is_auth_error(exc: Exception) -> bool:
     """Detect auth failures that should trigger provider-specific refresh."""
     status = getattr(exc, "status_code", None)
@@ -4380,12 +4404,15 @@ def call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_error(first_err)
         )
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
+        # Exception: server errors (5xx) are transient and warrant fallback
+        # even for explicit providers — the endpoint is broken regardless. (#25822)
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback and (is_auto or _is_server_error(first_err)):
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -4397,6 +4424,8 @@ def call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_server_error(first_err):
+                reason = "server error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -4712,9 +4741,10 @@ async def async_call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_error(first_err)
         )
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback and (is_auto or _is_server_error(first_err)):
             if _is_payment_error(first_err):
                 reason = "payment error"
                 _mark_provider_unhealthy(
@@ -4722,6 +4752,8 @@ async def async_call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_server_error(first_err):
+                reason = "server error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/tests/test_auxiliary_server_error_fallback.py
+++ b/tests/test_auxiliary_server_error_fallback.py
@@ -1,0 +1,129 @@
+"""Tests for _is_server_error() and server-error fallback in auxiliary_client.py.
+
+Issue #25822: HTTP 503 from Gemini should trigger fallback even when the
+provider is explicitly configured (is_auto=False).
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_server_error()
+# ---------------------------------------------------------------------------
+
+def _make_exc(status_code=None, message=""):
+    """Create a mock exception with optional status_code."""
+    exc = Exception(message)
+    if status_code is not None:
+        exc.status_code = status_code
+    return exc
+
+
+class TestIsServerError:
+    """Test the _is_server_error() detector function."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from agent.auxiliary_client import _is_server_error
+        self.is_server_error = _is_server_error
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 599])
+    def test_detects_5xx_status_codes(self, status):
+        assert self.is_server_error(_make_exc(status_code=status))
+
+    @pytest.mark.parametrize("status", [400, 401, 402, 403, 404, 429])
+    def test_rejects_4xx_status_codes(self, status):
+        assert not self.is_server_error(_make_exc(status_code=status))
+
+    @pytest.mark.parametrize("msg", [
+        "server error",
+        "internal server error",
+        "bad gateway",
+        "service unavailable",
+        "gateway timeout",
+        "unavailable",
+        "temporarily unavailable",
+        "overloaded",
+        "try again later",
+        "Server Error: something went wrong",
+        "503 Service Unavailable",
+    ])
+    def test_detects_server_error_strings(self, msg):
+        assert self.is_server_error(_make_exc(message=msg))
+
+    @pytest.mark.parametrize("msg", [
+        "rate limit exceeded",
+        "authentication failed",
+        "connection refused",
+        "invalid request",
+        "payment required",
+        "model not found",
+    ])
+    def test_rejects_non_server_error_strings(self, msg):
+        assert not self.is_server_error(_make_exc(message=msg))
+
+    def test_no_status_code_uses_string_match(self):
+        assert self.is_server_error(_make_exc(message="unavailable"))
+        assert not self.is_server_error(_make_exc(message="something random"))
+
+    def test_gemini_503_real_world(self):
+        """Exact error string from Gemini 503 in production."""
+        exc = _make_exc(
+            status_code=503,
+            message="UNAVAILABLE: This model is currently experiencing high demand.",
+        )
+        assert self.is_server_error(exc)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: fallback triggers on 503 for explicit provider
+# ---------------------------------------------------------------------------
+
+class TestServerErrorFallback:
+    """Verify that server errors bypass the is_auto gate."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from agent import auxiliary_client
+        self.mod = auxiliary_client
+
+    def test_503_triggers_fallback_on_explicit_provider(self):
+        """A 503 should trigger fallback even when is_auto=False."""
+        is_server_error = self.mod._is_server_error
+
+        # Simulate the decision logic
+        first_err = _make_exc(status_code=503, message="Service Unavailable")
+        resolved_provider = "google"  # explicit, NOT "auto"
+
+        should_fallback = (
+            self.mod._is_payment_error(first_err)
+            or self.mod._is_connection_error(first_err)
+            or self.mod._is_rate_limit_error(first_err)
+            or is_server_error(first_err)
+        )
+        is_auto = resolved_provider in {"auto", "", None}
+
+        # The key assertion: should_fallback is True AND
+        # the gate allows server errors through even for explicit providers
+        assert should_fallback is True
+        assert is_auto is False
+        assert should_fallback and (is_auto or is_server_error(first_err))
+
+    def test_402_does_not_bypass_is_auto_gate(self):
+        """A 402 should NOT bypass the is_auto gate for explicit providers."""
+        first_err = _make_exc(status_code=402, message="Payment required")
+        resolved_provider = "google"
+
+        should_fallback = (
+            self.mod._is_payment_error(first_err)
+            or self.mod._is_connection_error(first_err)
+            or self.mod._is_rate_limit_error(first_err)
+            or self.mod._is_server_error(first_err)
+        )
+        is_auto = resolved_provider in {"auto", "", None}
+
+        # Payment error triggers should_fallback but NOT the server-error bypass
+        assert should_fallback is True
+        assert is_auto is False
+        # Without server error, the gate should block
+        assert not (should_fallback and (is_auto or self.mod._is_server_error(first_err)))


### PR DESCRIPTION
## Problem

When `auxiliary.vision.provider` is set to `google` (Gemini) and it returns HTTP 503 (UNAVAILABLE), no fallback is tried even with `fallback_provider` configured. The error propagates directly.

## Root Cause

Two independent issues:
1. **No `_is_server_error()` detector** — 5xx matches none of the existing checks (`_is_payment_error`, `_is_connection_error`, `_is_rate_limit_error`)
2. **`is_auto` gate blocks fallback for explicit providers** — server errors (503) are transient, not a user-config issue

## Fix

- Add `_is_server_error()` detecting HTTP 5xx status codes and common server error strings
- Add server error to `should_fallback` in both sync (`call_llm`) and async (`async_call_llm`) paths
- Bypass `is_auto` gate for server errors — a 503 means the endpoint is broken regardless of whether the user chose it explicitly

## Testing

- 32 tests: all pass
- `_is_server_error()`: 5xx detection, 4xx rejection, string matching, real-world Gemini 503
- Fallback gate: 503 bypasses is_auto, 402 does NOT bypass is_auto

Closes #25822
