### PR TITLE
fix: guard os.chmod(path.parent, 0o700) against system directories

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 def _hermes_home_path() -> Path:
@@ -109,3 +112,52 @@ def get_read_block_error(path: str) -> Optional[str]:
             "Use the skills_list or skill_view tools instead."
         )
     return None
+
+
+# Well-known system directories that must never be chmod'd.
+_UNSAFE_PARENT_DIRS: frozenset[str] = frozenset({
+    "/", "/etc", "/usr", "/var", "/sys", "/proc", "/boot",
+    "/dev", "/bin", "/sbin", "/lib", "/lib64", "/opt", "/root",
+})
+
+
+def safe_chmod_parent(path: Path | str, mode: int = 0o700) -> None:
+    """chmod ``path.parent`` only after verifying it is a sane directory.
+
+    Prevents ``os.chmod(\"/\", 0o700)`` which strips traversal permission
+    from the root inode and bricks the entire host (DNS, networking,
+    journald, Docker, etc.).  See issue #25821.
+
+    Checks (any failure → skip with warning, no exception raised):
+      1. Resolved parent is not ``/`` or a well-known system directory.
+      2. Parent exists and is a directory.
+    """
+    try:
+        parent = Path(path).resolve().parent
+    except Exception:
+        logger.warning("safe_chmod_parent: cannot resolve parent of %r", path)
+        return
+
+    parent_str = str(parent)
+
+    # Check 1: not root or a well-known system directory
+    if parent_str in _UNSAFE_PARENT_DIRS:
+        logger.warning(
+            "safe_chmod_parent: refusing to chmod system directory %s "
+            "(path=%r) — see #25821", parent_str, str(path),
+        )
+        return
+
+    # Check 2: parent exists and is a directory
+    if not parent.is_dir():
+        logger.warning(
+            "safe_chmod_parent: parent %s does not exist or is not a directory "
+            "(path=%r) — skipping chmod", parent_str, str(path),
+        )
+        return
+
+    try:
+        os.chmod(parent, mode)
+    except OSError:
+        # Silently ignore — some filesystems (e.g. Windows mounts) don't support chmod
+        pass

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -490,11 +490,9 @@ def save_credentials(creds: GoogleCredentials) -> Path:
     path = _credentials_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds file.
-    # On Windows this is a no-op (POSIX mode bits aren't enforced); ignore failures.
-    try:
-        os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
+    # Guard against path.parent resolving to / or a system directory (#25821).
+    from agent.file_safety import safe_chmod_parent
+    safe_chmod_parent(path)
     payload = json.dumps(creds.to_dict(), indent=2, sort_keys=True) + "\n"
 
     with _credentials_lock():

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -986,11 +986,9 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     auth_file = _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
-    # No-op on Windows (POSIX mode bits not enforced); ignore failures.
-    try:
-        os.chmod(auth_file.parent, 0o700)
-    except OSError:
-        pass
+    # Guard against path.parent resolving to / or a system directory (#25821).
+    from agent.file_safety import safe_chmod_parent
+    safe_chmod_parent(auth_file)
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
@@ -1569,10 +1567,9 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
 def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     auth_path = _qwen_cli_auth_path()
     auth_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(auth_path.parent, 0o700)
-    except OSError:
-        pass
+    # Guard against path.parent resolving to / or a system directory (#25821).
+    from agent.file_safety import safe_chmod_parent
+    safe_chmod_parent(auth_path)
     # Per-process random temp suffix avoids collisions between concurrent
     # writers and stale leftovers from a crashed prior write.
     tmp_path = auth_path.with_name(f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
@@ -2987,10 +2984,9 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
             path.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                os.chmod(path.parent, 0o700)
-            except OSError:
-                pass
+            # Guard against path.parent resolving to / or a system directory (#25821).
+            from agent.file_safety import safe_chmod_parent
+            safe_chmod_parent(path)
             tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
             # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU
             # window where write_text() + post-write chmod briefly exposed Nous

--- a/tests/test_safe_chmod_parent.py
+++ b/tests/test_safe_chmod_parent.py
@@ -1,0 +1,80 @@
+"""Tests for safe_chmod_parent() in agent/file_safety.py (issue #25821).
+
+Prevents os.chmod("/", 0o700) from bricking the host by blocking chmod on
+root and well-known system directories.
+"""
+import os
+import stat
+import tempfile
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.file_safety import safe_chmod_parent, _UNSAFE_PARENT_DIRS
+
+
+class TestSafeChmodParent:
+
+    def test_normal_directory_gets_chmod(self):
+        """A normal directory should be chmod'd to 0o700."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "sub" / "file.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.touch()
+
+            os.chmod(target.parent, 0o755)
+            safe_chmod_parent(target)
+
+            mode = stat.S_IMODE(os.stat(target.parent).st_mode)
+            assert mode == 0o700
+
+    def test_root_directory_is_skipped(self):
+        """chmod on '/' must be skipped."""
+        target = Path("/.hermes_tokens")
+        original_mode = stat.S_IMODE(os.stat("/").st_mode)
+        safe_chmod_parent(target)
+        new_mode = stat.S_IMODE(os.stat("/").st_mode)
+        assert new_mode == original_mode
+
+    @pytest.mark.parametrize("sys_dir", sorted(_UNSAFE_PARENT_DIRS - {"/"}))
+    def test_system_directories_are_skipped(self, sys_dir):
+        """Well-known system directories must be skipped."""
+        if not os.path.isdir(sys_dir):
+            pytest.skip(f"{sys_dir} not available on this system")
+        target = Path(sys_dir) / ".hermes_test_file"
+        original_mode = stat.S_IMODE(os.stat(sys_dir).st_mode)
+        safe_chmod_parent(target)
+        new_mode = stat.S_IMODE(os.stat(sys_dir).st_mode)
+        assert new_mode == original_mode
+
+    def test_nonexistent_parent_skipped(self):
+        """If parent doesn't exist, skip chmod gracefully."""
+        target = Path("/tmp/nonexistent_dir_xyz987/file.json")
+        safe_chmod_parent(target)  # Should not raise
+
+    def test_oserror_silently_ignored(self):
+        """OSError from chmod (e.g. Windows mounts) should be silently ignored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "file.json"
+            target.touch()
+            with patch("os.chmod", side_effect=OSError("Permission denied")):
+                safe_chmod_parent(target)  # Should not raise
+
+    def test_unsafe_parent_dirs_constant(self):
+        """The blocklist should include all critical system directories."""
+        expected = {"/", "/etc", "/usr", "/var", "/sys", "/proc", "/boot",
+                    "/dev", "/bin", "/sbin", "/lib", "/lib64", "/opt", "/root"}
+        assert expected.issubset(_UNSAFE_PARENT_DIRS)
+
+    def test_nested_directory_works(self):
+        """Deeply nested directories should still be chmod'd."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            deep = Path(tmpdir) / "a" / "b" / "c"
+            deep.mkdir(parents=True, exist_ok=True)
+            target = deep / "file.json"
+            target.touch()
+
+            safe_chmod_parent(target)
+
+            mode = stat.S_IMODE(os.stat(deep).st_mode)
+            assert mode == 0o700

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -174,11 +174,9 @@ def _write_json(path: Path, data: dict) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds.
-    # No-op on Windows (POSIX mode bits aren't enforced); ignore failures.
-    try:
-        os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
+    # Guard against path.parent resolving to / or a system directory (#25821).
+    from agent.file_safety import safe_chmod_parent
+    safe_chmod_parent(path)
     # Per-process random suffix avoids collisions between concurrent
     # writers and stale leftovers from a prior crashed write.
     tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")


### PR DESCRIPTION
## Problem

`os.chmod("/", 0o700)` strips world-traversable permission from the root inode, breaking DNS, networking, journald, Docker, and most system services. This can happen when `path.parent` resolves to `/` (e.g. writing to `/.hermes_tokens`).

## Fix

Add `safe_chmod_parent()` in `agent/file_safety.py` that:
- Blocks chmod on `/` and 13 well-known system directories
- Verifies parent exists and is a directory
- Silently skips on failure (logs warning, no exception raised)

Replace all 5 `os.chmod(path.parent, 0o700)` call sites:
- `agent/google_oauth.py`: Google OAuth credentials path
- `tools/mcp_oauth.py`: MCP OAuth token path
- `hermes_cli/auth.py`: auth store, Qwen CLI tokens, Nous shared store

## Testing

- 19 tests: all pass
- Covers: normal chmod, root skip, 13 system dir skip, nonexistent parent, OSError, nested dirs

Closes #25821
