### PR TITLE
feat(gateway): HERMES_SUPPRESS_SHUTDOWN_NOTIFY env-var gate in _notify_active_sessions_of_shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2738,7 +2738,22 @@ class GatewayRunner:
         Called at the very start of stop() — adapters are still connected so
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
+
+        Set the ``HERMES_SUPPRESS_SHUTDOWN_NOTIFY`` environment variable to a
+        truthy value (``"true"``, ``"1"``, ``"yes"`` — case-insensitive) to
+        skip all outbound notifications.  Useful for single-machine deployments
+        (e.g. Fly.io) where every ``fly deploy`` emits a SIGTERM and the
+        resulting broadcast is noise for operator-only installs.  The default
+        when the variable is absent is to send notifications (i.e. previous
+        behaviour is preserved).
         """
+        import os as _os
+        if _os.getenv("HERMES_SUPPRESS_SHUTDOWN_NOTIFY", "").lower() in ("1", "true", "yes"):
+            logger.debug(
+                "HERMES_SUPPRESS_SHUTDOWN_NOTIFY is set — skipping shutdown notifications"
+            )
+            return
+
         active = self._snapshot_running_agents()
 
         action = "restarting" if self._restart_requested else "shutting down"

--- a/tests/gateway/test_shutdown_notify_env_gate.py
+++ b/tests/gateway/test_shutdown_notify_env_gate.py
@@ -1,0 +1,73 @@
+"""Tests for the HERMES_SUPPRESS_SHUTDOWN_NOTIFY env-var gate.
+
+When HERMES_SUPPRESS_SHUTDOWN_NOTIFY is set to a truthy value the gateway must
+skip all outbound Telegram/messaging broadcasts on shutdown — the function
+body still runs to completion (other code may reference the symbol) but no
+adapter.send() call is made.
+
+When the env var is absent or set to a falsy value ("false", "0", "no") the
+function proceeds normally and sends notifications to active sessions.
+
+Motivation: single-machine Fly.io apps emit SIGTERM on every ``fly deploy``
+which, without this gate, broadcasts "Gateway shutting down" to every active
+chat on every deploy.  Operators who only use Hermes as a scripted tool (no
+interactive Telegram DMs) receive pure noise.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import SendResult
+from gateway.session import build_session_key
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "env_value",
+    ["true", "True", "TRUE", "1", "yes", "Yes", "YES"],
+)
+async def test_shutdown_notify_suppressed_when_env_truthy(env_value, monkeypatch):
+    """When HERMES_SUPPRESS_SHUTDOWN_NOTIFY is a truthy value, no message is sent."""
+    monkeypatch.setenv("HERMES_SUPPRESS_SHUTDOWN_NOTIFY", env_value)
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="111")
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner._cache_session_source(session_key, source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "env_value",
+    [None, "false", "False", "FALSE", "0", "no", "No", "NO"],
+)
+async def test_shutdown_notify_fires_when_env_falsy(env_value, monkeypatch):
+    """When HERMES_SUPPRESS_SHUTDOWN_NOTIFY is absent or falsy, messages are sent."""
+    if env_value is None:
+        monkeypatch.delenv("HERMES_SUPPRESS_SHUTDOWN_NOTIFY", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_SUPPRESS_SHUTDOWN_NOTIFY", env_value)
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="222")
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner._cache_session_source(session_key, source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    call_args = adapter.send.call_args
+    assert "222" == call_args[0][0]
+    assert "shutting down" in call_args[0][1].lower() or "⚠️" in call_args[0][1]


### PR DESCRIPTION
## Motivation

On single-machine deployments (Fly.io, systemd single-unit, Docker Compose), every routine
restart emits a SIGTERM.  That fires `_notify_active_sessions_of_shutdown()` and broadcasts
`⚠️ Gateway shutting down — Your current task will be interrupted.` to every active chat.

For operator-only installs (scripted automation, no interactive user DMs) this is pure noise
on every `fly deploy` / service restart — users who are not actively chatting with the gateway
receive an out-of-context interruption notice with no actionable information.

## Current workaround

[AutomationOS](https://github.com/OwenHolt04/AutomationOS) (a personal automation runner
built on hermes-agent) works around this today with a build-time Python regex injection
in `hermes/Dockerfile` that monkey-patches the function after installation:

```python
# hermes/Dockerfile — OT-88 patch
RUN python3 <<PYEOF
import re, sys, pathlib
p = pathlib.Path("/usr/local/lib/hermes-agent/gateway/run.py")
src = p.read_text()
# ... regex inserts env-gated early return after the docstring ...
PYEOF
```

This works but is brittle: any upstream refactor of the function signature/docstring silently
breaks the patch (the regex fails to match and the build exits 1). Every upstream version
bump requires re-validating the regex against the new source. A native env-var check in the
function itself is the right long-term fix.

## Proposed API

Set `HERMES_SUPPRESS_SHUTDOWN_NOTIFY` in the environment (e.g. via `fly secrets set` or
`docker run -e`):

| Value | Behaviour |
|-------|-----------|
| absent / `"false"` / `"0"` / `"no"` | Default — notifications sent (unchanged) |
| `"true"` / `"1"` / `"yes"` (case-insensitive) | Early return — no sends, DEBUG log |

The default-absent value is **falsy** (sends notifications), which preserves existing
behaviour for all current users. Operators who want to suppress must explicitly opt in.

## Implementation

`gateway/run.py` — at the top of `_notify_active_sessions_of_shutdown`, before the
`_snapshot_running_agents()` call:

```python
import os as _os
if _os.getenv("HERMES_SUPPRESS_SHUTDOWN_NOTIFY", "").lower() in ("1", "true", "yes"):
    logger.debug(
        "HERMES_SUPPRESS_SHUTDOWN_NOTIFY is set — skipping shutdown notifications"
    )
    return
```

The `os` import is local to avoid polluting the module namespace with an import that only
fires on this code path.

## Tests

New file: `tests/gateway/test_shutdown_notify_env_gate.py` — 15 parametrised tests:

- 7 truthy variants (`"true"`, `"True"`, `"TRUE"`, `"1"`, `"yes"`, `"Yes"`, `"YES"`) —
  `adapter.send` must **not** be called
- 8 falsy variants (absent, `"false"`, `"False"`, `"FALSE"`, `"0"`, `"no"`, `"No"`, `"NO"`)
  — `adapter.send` **must** be called with the correct chat_id and message

All 34 pre-existing gateway shutdown and restart-notification tests continue to pass.

## Notes on default

The default (env var absent → send notifications) is intentionally conservative. An
alternative would be to default to suppressed on the theory that most production operators
do not want the noise — but that would be a breaking change for interactive users. Happy to
discuss if upstream prefers a different default.
