### PR TITLE
fix: invalidate update-check cache inputs

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -275,6 +275,36 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _git_rev_parse(repo_dir: Path, rev: str) -> Optional[str]:
+    """Resolve a git revision to a full hash, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", rev],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            parsed = result.stdout.strip()
+            if parsed:
+                return parsed
+    except Exception:
+        pass
+    return None
+
+
+def _local_git_cache_rev(repo_dir: Path) -> Optional[str]:
+    """Return a cache key component for local update-check inputs."""
+    head = _git_rev_parse(repo_dir, "HEAD")
+    if not head:
+        return None
+
+    # The update result depends on both HEAD and the fetched upstream ref. If an
+    # external process updates origin/main while HEAD stays fixed, a HEAD-only
+    # cache key can falsely keep reporting "Up to date" until the TTL expires.
+    upstream = _git_rev_parse(repo_dir, "refs/remotes/origin/main") or "unknown"
+    return f"git:{repo_dir}:HEAD={head}:origin/main={upstream}"
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
@@ -396,6 +426,7 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -411,23 +442,8 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text(encoding="utf-8"))
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
     if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
+        cache_rev = f"embedded:{embedded_rev}"
     else:
         # Prefer the running code's location over the profile-scoped path.
         # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
@@ -439,13 +455,45 @@ def check_for_updates() -> Optional[int]:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
-            behind = None
+            repo_dir = None
+            cache_rev = None
         else:
-            behind = _check_via_local_git(repo_dir)
+            cache_rev = _local_git_cache_rev(repo_dir)
+
+    # Read cache — invalidate if the embedded rev/local git fingerprint OR
+    # installed version has changed since the last check. Older cache files did
+    # not include a local git fingerprint, so do not trust them for git
+    # checkouts; otherwise an already-updated checkout can keep reporting a
+    # stale "N commits behind" result until the TTL expires.
+    now = time.time()
+    try:
+        cache_key_available = repo_dir is None or cache_rev is not None
+        if cache_file.exists() and cache_key_available:
+            cached = json.loads(cache_file.read_text(encoding="utf-8"))
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == cache_rev
+                and cached.get("ver") == VERSION
+            ):
+                return cached.get("behind")
+    except Exception:
+        pass
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+    elif repo_dir is None:
+        behind = None
+    else:
+        behind = _check_via_local_git(repo_dir)
+        # ``_check_via_local_git`` fetches before counting. If that fetch advances
+        # ``origin/main``, persisting the pre-fetch fingerprint forces the next
+        # invocation to miss cache immediately. Recompute before writing so the
+        # cache represents the refs that produced ``behind``.
+        cache_rev = _local_git_cache_rev(repo_dir)
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({"ts": now, "behind": behind, "rev": cache_rev, "ver": VERSION}),
             encoding="utf-8",
         )
     except Exception:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -204,6 +204,36 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _git_rev_parse(repo_dir: Path, rev: str) -> Optional[str]:
+    """Resolve a git revision to a full hash, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", rev],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            parsed = result.stdout.strip()
+            if parsed:
+                return parsed
+    except Exception:
+        pass
+    return None
+
+
+def _local_git_cache_rev(repo_dir: Path) -> Optional[str]:
+    """Return a cache key component for local update-check inputs."""
+    head = _git_rev_parse(repo_dir, "HEAD")
+    if not head:
+        return None
+
+    # The update result depends on both HEAD and the fetched upstream ref. If an
+    # external process updates origin/main while HEAD stays fixed, a HEAD-only
+    # cache key can falsely keep reporting "Up to date" until the TTL expires.
+    upstream = _git_rev_parse(repo_dir, "refs/remotes/origin/main") or "unknown"
+    return f"git:{repo_dir}:HEAD={head}:origin/main={upstream}"
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
@@ -287,6 +317,7 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -297,28 +328,14 @@ def check_for_updates() -> Optional[int]:
     # (web_server.py); mirror that here so the banner/TUI surfaces agree.
     try:
         from hermes_cli.config import detect_install_method, get_project_root
+
         if detect_install_method(get_project_root()) == "docker":
             return None
     except Exception:
         pass
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text(encoding="utf-8"))
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
     if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
+        cache_rev = f"embedded:{embedded_rev}"
     else:
         # Prefer the running code's location over the profile-scoped path.
         # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
@@ -330,13 +347,45 @@ def check_for_updates() -> Optional[int]:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
-            behind = None
+            repo_dir = None
+            cache_rev = None
         else:
-            behind = _check_via_local_git(repo_dir)
+            cache_rev = _local_git_cache_rev(repo_dir)
+
+    # Read cache — invalidate if the embedded rev/local git fingerprint OR
+    # installed version has changed since the last check. Older cache files did
+    # not include a local git fingerprint, so do not trust them for git
+    # checkouts; otherwise an already-updated checkout can keep reporting a
+    # stale "N commits behind" result until the TTL expires.
+    now = time.time()
+    try:
+        cache_key_available = repo_dir is None or cache_rev is not None
+        if cache_file.exists() and cache_key_available:
+            cached = json.loads(cache_file.read_text(encoding="utf-8"))
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == cache_rev
+                and cached.get("ver") == VERSION
+            ):
+                return cached.get("behind")
+    except Exception:
+        pass
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+    elif repo_dir is None:
+        behind = None
+    else:
+        behind = _check_via_local_git(repo_dir)
+        # ``_check_via_local_git`` fetches before counting. If that fetch advances
+        # ``origin/main``, persisting the pre-fetch fingerprint forces the next
+        # invocation to miss cache immediately. Recompute before writing so the
+        # cache represents the refs that produced ``behind``.
+        cache_rev = _local_git_cache_rev(repo_dir)
 
     try:
         cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
+            json.dumps({"ts": now, "behind": behind, "rev": cache_rev, "ver": VERSION}),
             encoding="utf-8",
         )
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -1,40 +1,95 @@
 """Tests for the update check mechanism in hermes_cli.banner."""
 
 import json
-import os
 import threading
 import time
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
-
+def _fake_checkout(tmp_path):
+    repo_dir = tmp_path / "hermes-agent"
+    (repo_dir / "hermes_cli").mkdir(parents=True)
+    (repo_dir / "hermes_cli" / "banner.py").touch()
+    (repo_dir / ".git").mkdir()
+    return repo_dir
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    """When cache inputs match, check_for_updates returns cached value without fetch."""
+    import hermes_cli.banner as banner
     from hermes_cli import __version__
 
-    # Create a fake git repo and fresh cache
-    repo_dir = tmp_path / "hermes-agent"
-    repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
-
+    repo_dir = _fake_checkout(tmp_path)
+    cache_rev = f"git:{repo_dir}:HEAD=head-sha:origin/main=upstream-sha"
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "rev": cache_rev, "ver": __version__})
+    )
 
+    monkeypatch.setattr(banner, "__file__", str(repo_dir / "hermes_cli" / "banner.py"))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "HEAD":
+            return MagicMock(returncode=0, stdout="head-sha\n")
+        if cmd[:3] == ["git", "rev-parse", "--verify"] and cmd[3] == "refs/remotes/origin/main":
+            return MagicMock(returncode=0, stdout="upstream-sha\n")
+        raise AssertionError(f"unexpected git command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run) as mock_run:
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 2  # HEAD + origin/main cache-key probes only
 
 
+def test_check_for_updates_writes_post_fetch_fingerprint_then_hits_cache(tmp_path, monkeypatch):
+    """If fetch moves origin/main, cache the post-fetch ref for the next invocation."""
+    import hermes_cli.banner as banner
+    from hermes_cli import __version__
 
+    repo_dir = _fake_checkout(tmp_path)
+    cache_file = tmp_path / ".update_check"
 
+    monkeypatch.setattr(banner, "__file__", str(repo_dir / "hermes_cli" / "banner.py"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    refs = {"HEAD": "head-sha", "refs/remotes/origin/main": "old-upstream-sha"}
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(tuple(cmd))
+        if cmd[:3] == ["git", "rev-parse", "--verify"]:
+            rev = cmd[3]
+            return MagicMock(returncode=0, stdout=f"{refs[rev]}\n")
+        if cmd[:2] == ["git", "remote"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            refs["refs/remotes/origin/main"] = "new-upstream-sha"
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="1\n")
+        raise AssertionError(f"unexpected git command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        assert banner.check_for_updates() == 1
+
+    cached = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert cached["behind"] == 1
+    assert cached["ver"] == __version__
+    assert cached["rev"] == f"git:{repo_dir}:HEAD=head-sha:origin/main=new-upstream-sha"
+    assert any(call[:3] == ("git", "fetch", "origin") for call in calls)
+
+    calls.clear()
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        assert banner.check_for_updates() == 1
+
+    assert calls == [
+        ("git", "rev-parse", "--verify", "HEAD"),
+        ("git", "rev-parse", "--verify", "refs/remotes/origin/main"),
+    ]
 
 
 def test_prefetch_non_blocking():
@@ -56,7 +111,3 @@ def test_prefetch_non_blocking():
         # Wait for the background thread to finish
         banner._update_check_done.wait(timeout=5)
         assert banner._update_result == 5
-
-
-
-


### PR DESCRIPTION
## Why change

The CLI update banner caches the behind-count for several hours. For local git checkouts, the cached value depended only on time and the optional embedded revision, so it could keep showing stale update status after either checked-out `HEAD` or fetched `origin/main` changed.

## Files changed

- `hermes_cli/banner.py`: key local-git cache entries by `HEAD` and `refs/remotes/origin/main`, retain current `(rev, ver)` and Docker behavior, and recompute the fingerprint after fetch before writing the cache.
- `tests/hermes_cli/test_update_check.py`: cover matching-input cache hits and the fetch-moves-ref → post-fetch cache write → subsequent cache-hit sequence.

## Verification run

- focused update-check tests — **3 passed**
- Ruff — passed
- Python compile checks — passed
- `git diff --check` — passed

## Risk level

Low. Localized CLI banner cache invalidation only; no provider, gateway, auth, or runtime service changes.