### PR TITLE
fix(clarify): remove awaiting_text filter from get_pending_for_session so text-intercept works on platforms without buttons

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -58,19 +58,29 @@ class TestClarifyPrimitive:
         assert pending.clarify_id == "id2"
 
     def test_button_choice_does_not_auto_await(self):
-        """Multi-choice clarify should NOT be in text-capture mode initially."""
+        """Multi-choice clarify: awaiting_text=False but get_pending_for_session
+        still returns the entry so the gateway text-intercept can handle it
+        on platforms without native button support (Discord, Slack, etc.)."""
         from tools import clarify_gateway as cm
 
         entry = cm.register("id3", "sk3", "Pick", ["X", "Y"])
         assert entry.awaiting_text is False
-        assert cm.get_pending_for_session("sk3") is None
+        # get_pending_for_session now returns ANY pending clarify regardless
+        # of awaiting_text, so text-intercept works on Discord/Slack/WhatsApp.
+        pending = cm.get_pending_for_session("sk3")
+        assert pending is not None
+        assert pending.clarify_id == "id3"
 
     def test_other_button_flips_to_text_mode(self):
-        """mark_awaiting_text makes get_pending_for_session find the entry."""
+        """mark_awaiting_text makes get_pending_for_session ... still works,
+        but now get_pending_for_session also returns entries before marking."""
         from tools import clarify_gateway as cm
 
         cm.register("id4", "sk4", "Pick", ["X", "Y"])
-        assert cm.get_pending_for_session("sk4") is None
+        # Note: with the fix, get_pending_for_session now returns the entry
+        # even before mark_awaiting_text (so text-intercept works on
+        # platforms without button support). The awaiting_text flag still
+        # correctly tracks whether the entry is in text-capture mode.
 
         flipped = cm.mark_awaiting_text("id4")
         assert flipped is True
@@ -184,9 +194,11 @@ class TestGatewayTextIntercept:
     def setup_method(self):
         _clear_clarify_state()
 
-    def test_get_pending_for_session_returns_oldest_text_awaiting(self):
+    def test_get_pending_for_session_returns_oldest_entry(self):
         """When two clarifies are pending, get_pending_for_session returns the
-        first that is awaiting_text (the older one if both)."""
+        oldest entry regardless of awaiting_text state. This ensures the
+        text-intercept works even for choice-based clarifies on platforms
+        without native button support (Discord, Slack, WhatsApp)."""
         from tools import clarify_gateway as cm
 
         # Older multi-choice (not awaiting text)
@@ -195,9 +207,9 @@ class TestGatewayTextIntercept:
         cm.register("second", "sk", "Q2?", None)
 
         pending = cm.get_pending_for_session("sk")
-        # The newer one is awaiting text; the older isn't.
+        # With the fix, returns oldest entry regardless of awaiting_text
         assert pending is not None
-        assert pending.clarify_id == "second"
+        assert pending.clarify_id == "first"
 
         # Now flip the first to text mode too.  Both are awaiting text,
         # FIFO returns the older one.

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -175,8 +175,7 @@ def get_pending_for_session(session_key: str) -> Optional[_ClarifyEntry]:
             entry = _entries.get(cid)
             if entry is None:
                 continue
-            if entry.awaiting_text:
-                return entry
+            return entry
         return None
 
 


### PR DESCRIPTION
## Problem

When the agent calls `clarify` with multiple choices on platforms that don't support native buttons (Discord, Slack, WhatsApp, etc.), the clarify hangs indefinitely with `⏳ Still working...` messages until the 10-minute timeout.

## Root Cause

`tools/clarify_gateway.py:get_pending_for_session()` filters entries by `awaiting_text=True`. Choice-based clarifies are registered with `awaiting_text=False` (because the button path handles them on Telegram). On Discord, the base `send_clarify` renders choices as a numbered text list, but the user's reply (`"1"`, `"Option A"`) is never intercepted — the function returns `None` and the agent stays blocked on `wait_for_response()`.

## Fix

Removed the `awaiting_text` filter from `get_pending_for_session()`. It now returns the oldest pending clarify entry regardless of its text-capture mode.

## Safety

- **Telegram (with buttons)**: Button callbacks resolve via `resolve_gateway_clarify()` directly, removing the entry from `_entries` before the text-intercept runs. No double-resolution.
- **Discord (text only)**: The text-intercept can now find and resolve choice-based clarifies. Same path as open-ended clarifies.
- **`awaiting_text` flag preserved**: Still used correctly for tracking "Other" button state. Just no longer gates retrieval.

## PoC

```bash
# Fresh Docker environment
docker run --rm ghcr.io/caixa-git/poc-clarify

# Or locally
cd /tmp/fork-hermes
python3 -m pytest tests/tools/test_clarify_gateway.py -v
```

PoC output confirms:
- ✅ Bug reproduced: `get_pending_for_session()` returned None for choice-based clarify
- ✅ Fix verified: entry found after fix
- ✅ 41/41 clarify-related tests pass
- ✅ Full flow (register → resolve → wait) works correctly