### PR TITLE
feat(cron): expose structured cron context via adapter send metadata (#26004)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -615,7 +615,13 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    status_hint: str = "ok",
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -686,6 +692,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         "schedule": job.get("schedule"),
         "deliver": job.get("deliver"),
         "origin": origin or None,
+        "status": status_hint,
+        "ran_at": _hermes_now().isoformat(),
     }
     cron_meta = {k: v for k, v in cron_meta_full.items() if v is not None}
 
@@ -1971,7 +1979,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 delivery_error = None
                 if should_deliver:
                     try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                        delivery_error = _deliver_result(
+                            job,
+                            deliver_content,
+                            adapters=adapters,
+                            loop=loop,
+                            status_hint="ok" if success else "error",
+                        )
                     except Exception as de:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -674,13 +674,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     delivery_errors = []
 
+    # Structured side-channel so plugin adapters can recover cron context
+    # without regex-parsing the envelope text. Invariant across targets, so
+    # built once before the loop; only thread_id varies per target.
+    # Filter on `is not None` rather than truthiness so falsy-but-meaningful
+    # values (e.g. an explicitly empty schedule) reach adapters.
+    origin = _resolve_origin(job) or {}
+    cron_meta_full = {
+        "job_id": job.get("id", ""),
+        "job_name": job.get("name") or job.get("id", ""),
+        "schedule": job.get("schedule"),
+        "deliver": job.get("deliver"),
+        "origin": origin or None,
+    }
+    cron_meta = {k: v for k, v in cron_meta_full.items() if v is not None}
+
     for target in targets:
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
-        origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
         if origin_thread and not thread_id:
             logger.warning(
@@ -710,19 +724,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
-
-        # Structured side-channel so plugin adapters can recover cron context
-        # without regex-parsing the envelope text. `thread_id` was the only
-        # existing key; nested under "cron" we expose job_id/job_name/schedule/
-        # deliver/origin. Adapters that ignore unknown keys are unaffected.
-        cron_meta = {
-            "job_id": job.get("id", ""),
-            "job_name": job.get("name") or job.get("id", ""),
-            "schedule": job.get("schedule"),
-            "deliver": job.get("deliver"),
-            "origin": origin or None,
-        }
-        cron_meta = {k: v for k, v in cron_meta.items() if v}
 
         send_metadata: Optional[dict] = None
         if thread_id:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -711,12 +711,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
+        # Structured side-channel so plugin adapters can recover cron context
+        # without regex-parsing the envelope text. `thread_id` was the only
+        # existing key; nested under "cron" we expose job_id/job_name/schedule/
+        # deliver/origin. Adapters that ignore unknown keys are unaffected.
+        cron_meta = {
+            "job_id": job.get("id", ""),
+            "job_name": job.get("name") or job.get("id", ""),
+            "schedule": job.get("schedule"),
+            "deliver": job.get("deliver"),
+            "origin": origin or None,
+        }
+        cron_meta = {k: v for k, v in cron_meta.items() if v}
+
+        send_metadata: Optional[dict] = None
+        if thread_id:
+            send_metadata = {"thread_id": thread_id}
+        if cron_meta:
+            send_metadata = {**(send_metadata or {}), "cron": cron_meta}
+
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -993,12 +993,58 @@ class TestDeliverResultCronMetadata:
         assert "schedule" not in cron_ctx
         # job_id is present (required), job_name falls back to it,
         # deliver and origin are present.
+        # status defaults to "ok"; ran_at is always set (ISO timestamp).
+        ran_at = cron_ctx.pop("ran_at", None)
+        assert isinstance(ran_at, str) and "T" in ran_at
         assert cron_ctx == {
             "job_id": "min-job",
             "job_name": "min-job",
             "deliver": "origin",
             "origin": {"platform": "telegram", "chat_id": "5"},
+            "status": "ok",
         }
+
+    def test_cron_metadata_attached_on_failed_run_with_wrap_disabled(self):
+        """Failed run + wrap_response=false must still surface status=error and full context.
+
+        Regression guard for #26004 step 2: without this, adapters that rely on
+        `metadata["cron"]["status"]` to distinguish success from failure (e.g.
+        for routing failure summaries to a different chat) would always see
+        the default "ok" even when the agent raised.
+        """
+        from gateway.config import Platform
+
+        adapter, loop, fake_run_coro = self._build_adapter_send_mock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "fail-job",
+            "name": "nightly-report",
+            "schedule": "0 3 * * *",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "999"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "Job hit an exception",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+                status_hint="error",
+            )
+
+        cron_ctx = adapter.send.call_args.kwargs["metadata"]["cron"]
+        assert cron_ctx["status"] == "error"
+        assert cron_ctx["job_id"] == "fail-job"
+        assert cron_ctx["job_name"] == "nightly-report"
+        assert cron_ctx["schedule"] == "0 3 * * *"
+        assert "ran_at" in cron_ctx and "T" in cron_ctx["ran_at"]
 
 
 class TestDeliverResultErrorReturns:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -837,6 +837,170 @@ class TestDeliverResultWrapping:
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
 
 
+class TestDeliverResultCronMetadata:
+    """Live adapter sends should receive structured cron context in metadata.
+
+    Without this, plugin adapters have to regex-parse the "Cronjob Response: ..."
+    envelope to recover job_id/job_name, which is brittle and breaks entirely
+    when cron.wrap_response=false. The structured side-channel under
+    metadata["cron"] makes job_id/job_name/schedule/deliver/origin available
+    via the existing metadata kwarg, alongside thread_id.
+    """
+
+    def _build_adapter_send_mock(self):
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        return adapter, loop, fake_run_coro
+
+    def test_live_adapter_send_receives_cron_metadata(self):
+        from gateway.config import Platform
+
+        adapter, loop, fake_run_coro = self._build_adapter_send_mock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "abc123",
+            "name": "daily-summary",
+            "schedule": "0 9 * * *",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "999"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "hello",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once()
+        metadata = adapter.send.call_args.kwargs.get("metadata")
+        assert metadata is not None, "send_metadata should be populated with cron context"
+        assert "cron" in metadata, f"cron context missing: {metadata!r}"
+        cron_ctx = metadata["cron"]
+        assert cron_ctx["job_id"] == "abc123"
+        assert cron_ctx["job_name"] == "daily-summary"
+        assert cron_ctx["schedule"] == "0 9 * * *"
+        assert cron_ctx["deliver"] == "origin"
+        assert cron_ctx["origin"] == {"platform": "telegram", "chat_id": "999"}
+
+    def test_cron_metadata_falls_back_to_job_id_when_name_missing(self):
+        from gateway.config import Platform
+
+        adapter, loop, fake_run_coro = self._build_adapter_send_mock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "noname-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "5"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "hi",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        cron_ctx = adapter.send.call_args.kwargs["metadata"]["cron"]
+        assert cron_ctx["job_name"] == "noname-job"
+
+    def test_cron_metadata_coexists_with_thread_id(self):
+        from gateway.config import Platform
+
+        adapter, loop, fake_run_coro = self._build_adapter_send_mock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "topic-job",
+            "name": "topic-job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "17585",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "hi",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        metadata = adapter.send.call_args.kwargs["metadata"]
+        assert metadata["thread_id"] == "17585"
+        assert metadata["cron"]["job_id"] == "topic-job"
+
+    def test_cron_metadata_omits_empty_fields(self):
+        """Optional fields (schedule, deliver) absent on the job should be omitted."""
+        from gateway.config import Platform
+
+        adapter, loop, fake_run_coro = self._build_adapter_send_mock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "min-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "5"},
+        }  # no name, no schedule
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                job,
+                "hi",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        cron_ctx = adapter.send.call_args.kwargs["metadata"]["cron"]
+        assert "schedule" not in cron_ctx
+        # job_id is present (required), job_name falls back to it,
+        # deliver and origin are present.
+        assert cron_ctx == {
+            "job_id": "min-job",
+            "job_name": "min-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "5"},
+        }
+
+
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2736,11 +2736,15 @@ class TestDeliverResultTimeoutCancelsFuture:
             "configured thread_id 7072 for telegram:226252250 was not found; "
             "delivered without thread_id"
         )
-        adapter.send.assert_called_once_with(
-            "226252250",
-            "Hello world",
-            metadata={"thread_id": "7072"},
-        )
+        assert adapter.send.call_count == 1
+        args, kwargs = adapter.send.call_args
+        assert args == ("226252250", "Hello world")
+        metadata = kwargs["metadata"]
+        # thread_id is the load-bearing field for this test — it must survive
+        # alongside the structured cron context added in #26004.
+        assert metadata["thread_id"] == "7072"
+        assert metadata["cron"]["job_id"] == "thread-fallback-job"
+        assert metadata["cron"]["deliver"] == "telegram:226252250:7072"
 
 
 class TestSendMediaTimeoutCancelsFuture:


### PR DESCRIPTION
## What does this PR do?

`cron/scheduler.py`'s `_deliver_result` calls `adapter.send(chat_id, content, metadata=...)` with only `thread_id` in `metadata`. Plugin adapters that want the cron's `job_id`, `job_name`, `schedule`, `deliver`, or `origin` today have to regex-parse the `"Cronjob Response: <name>\n(job_id: <id>)"` envelope — which is brittle and breaks entirely when `cron.wrap_response: false` is configured.

This PR adds those fields under `metadata["cron"]` as a structured side-channel, keeping the existing `metadata["thread_id"]` key. Implements **Step 1 (minimal, fully backwards-compatible)** of #26004. Adapters that ignore unknown metadata keys are unaffected — they already received `{"thread_id": ...}` today and continue to.

## Related Issue

Fixes #26004 (Step 1)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — build `cron_meta = {"job_id", "job_name", "schedule", "deliver", "origin"}` (filtered to non-empty values) from data already in scope in `_deliver_result`, then merge as `send_metadata["cron"] = cron_meta` alongside the existing `thread_id` key. No `run_job` signature change.
- `tests/cron/test_scheduler.py` — `TestDeliverResultCronMetadata` covering populated fields, name fallback to job_id, coexistence with thread_id, omission of empty optional fields (4 cases).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/cron/test_scheduler.py::TestDeliverResultCronMetadata -v`
2. Expected: 4 passed.
3. Adjacent: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/cron/ -v` — 341 passed.
4. Regression guard: revert production hunk — all 4 new tests fail with `TypeError: 'NoneType' object is not subscriptable` on `metadata["cron"]`. Restore — green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (4/4 + 341/341 adjacent)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, side-channel metadata is plugin-facing
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent dict construction
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #26004 — Step 1 (locally-available fields). Step 2 (`response_id` and `session_id`) would require widening `run_job`'s `(success, output, final_response, error)` return tuple — out of scope for a minimal patch. Happy to follow up if the maintainer wants that wired through.

> Audited siblings: `_deliver_result` is the single metadata-build site for cron-originated sends. No widening needed.
