### PR TITLE
feat(web): add chat input speech dictation

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18,6 +18,7 @@ import os
 import secrets
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -50,7 +51,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+    from fastapi import FastAPI, File, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
@@ -62,7 +63,7 @@ except ImportError:
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tool.dashboard", prompt=False)
-        from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+        from fastapi import FastAPI, File, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
         from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
         from fastapi.staticfiles import StaticFiles
@@ -244,6 +245,82 @@ async def auth_middleware(request: Request, call_next):
                 content={"detail": "Unauthorized"},
             )
     return await call_next(request)
+
+
+_AUDIO_SUFFIX_BY_CONTENT_TYPE = {
+    "audio/aac": ".aac",
+    "audio/flac": ".flac",
+    "audio/m4a": ".m4a",
+    "audio/mp4": ".mp4",
+    "audio/mpeg": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/webm": ".webm",
+    "video/webm": ".webm",
+}
+
+
+def _upload_audio_suffix(file: UploadFile) -> str:
+    """Best-effort suffix for uploaded dashboard STT audio."""
+    name_suffix = Path(file.filename or "").suffix.lower()
+    if name_suffix in {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}:
+        return name_suffix
+    content_type = (file.content_type or "").split(";", 1)[0].strip().lower()
+    return _AUDIO_SUFFIX_BY_CONTENT_TYPE.get(content_type, ".webm")
+
+
+@app.post("/api/stt/transcribe")
+async def transcribe_dashboard_audio(file: UploadFile = File(...)):
+    """Transcribe browser-recorded chat input audio using Hermes' built-in STT stack.
+
+    The dashboard records with the browser MediaRecorder API, posts the blob here,
+    and this endpoint delegates to the same provider selection used for gateway
+    voice-message transcription: local faster-whisper, Groq/OpenAI/Mistral/etc.
+    based on ``stt`` config and available credentials.
+    """
+    from tools.transcription_tools import MAX_FILE_SIZE, transcribe_audio
+    from tools.voice_mode import is_whisper_hallucination
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="No audio data received")
+    if len(data) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="Audio file is too large")
+
+    suffix = _upload_audio_suffix(file)
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+
+        result = transcribe_audio(tmp_path)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _log.warning("dashboard STT transcription failed: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}") from exc
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    if not result.get("success"):
+        raise HTTPException(status_code=500, detail=result.get("error") or "Transcription failed")
+
+    transcript = str(result.get("transcript") or "").strip()
+    if transcript and is_whisper_hallucination(transcript):
+        transcript = ""
+
+    return {
+        "ok": True,
+        "text": transcript,
+        "provider": result.get("provider"),
+        "model": result.get("model"),
+        "note": "Uses Hermes built-in STT provider selection from the stt config.",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ youtube = [
   "youtube-transcript-api==1.2.4",
 ]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
-web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0"]
+web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0", "python-multipart==0.0.22"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git@c20c85256e5a45ad31edf8b7276e9c5ee1995a30",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git@30517b667f18a3dfb7ef33fb56cf686d5820ba2b",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,70 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_stt_transcribe_uses_existing_transcription_stack(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+        import tools.voice_mode as voice_mode
+
+        observed = {}
+
+        def fake_transcribe_audio(path):
+            observed["path"] = path
+            observed["suffix"] = Path(path).suffix
+            observed["exists_during_call"] = Path(path).exists()
+            return {
+                "success": True,
+                "transcript": " build the thing ",
+                "provider": "test-provider",
+                "model": "test-model",
+            }
+
+        monkeypatch.setattr(transcription_tools, "transcribe_audio", fake_transcribe_audio)
+        monkeypatch.setattr(voice_mode, "is_whisper_hallucination", lambda text: False)
+
+        resp = self.client.post(
+            "/api/stt/transcribe",
+            files={"file": ("clip.webm", b"not-real-audio", "audio/webm;codecs=opus")},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "text": "build the thing",
+            "provider": "test-provider",
+            "model": "test-model",
+            "note": "Uses Hermes built-in STT provider selection from the stt config.",
+        }
+        assert observed == {"path": observed["path"], "suffix": ".webm", "exists_during_call": True}
+        assert not Path(observed["path"]).exists()
+
+    def test_stt_transcribe_filters_whisper_hallucination(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+        import tools.voice_mode as voice_mode
+
+        monkeypatch.setattr(
+            transcription_tools,
+            "transcribe_audio",
+            lambda _path: {"success": True, "transcript": "Thank you for watching.", "provider": "local", "model": "whisper"},
+        )
+        monkeypatch.setattr(voice_mode, "is_whisper_hallucination", lambda text: True)
+
+        resp = self.client.post(
+            "/api/stt/transcribe",
+            files={"file": ("clip.ogg", b"not-real-audio", "audio/ogg")},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["text"] == ""
+
+    def test_stt_transcribe_rejects_empty_upload(self):
+        resp = self.client.post(
+            "/api/stt/transcribe",
+            files={"file": ("empty.webm", b"", "audio/webm")},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "No audio data received"
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,15 @@ export const api = {
     fetchJSON<SessionLatestDescendantResponse>(
       `/api/sessions/${encodeURIComponent(id)}/latest-descendant`,
     ),
+  transcribeAudio: (audio: Blob) => {
+    const form = new FormData();
+    const ext = audio.type.includes("ogg") ? "ogg" : audio.type.includes("wav") ? "wav" : "webm";
+    form.set("file", audio, `chat-input.${ext}`);
+    return fetchJSON<SpeechToTextResponse>("/api/stt/transcribe", {
+      method: "POST",
+      body: form,
+    });
+  },
   deleteSession: (id: string) =>
     fetchJSON<{ ok: boolean }>(`/api/sessions/${encodeURIComponent(id)}`, {
       method: "DELETE",
@@ -403,6 +412,14 @@ export interface SessionLatestDescendantResponse {
   session_id: string;
   path: string[];
   changed: boolean;
+}
+
+export interface SpeechToTextResponse {
+  ok: boolean;
+  text: string;
+  provider?: string | null;
+  model?: string | null;
+  note?: string;
 }
 
 export interface PaginatedSessions {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,8 +25,9 @@ import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { Copy, Loader2, Mic, PanelRight, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { PointerEvent } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
 
@@ -56,6 +57,14 @@ function generateChannelId(): string {
     return crypto.randomUUID();
   }
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function preferredRecorderMimeType(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined;
+  for (const mime of ["audio/webm;codecs=opus", "audio/webm", "audio/ogg;codecs=opus", "audio/ogg"]) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return undefined;
 }
 
 // Colors for the terminal body.  Matches the dashboard's dark teal canvas
@@ -121,7 +130,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       : null,
   );
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+  const [speechState, setSpeechState] = useState<"idle" | "recording" | "transcribing">("idle");
+  const [speechError, setSpeechError] = useState<string | null>(null);
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<BlobPart[]>([]);
+  const pointerHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerHoldActiveRef = useRef(false);
+  const pendingSpeechStopRef = useRef(false);
+  const suppressNextMicClickRef = useRef(false);
   // Raw state for the mobile side-sheet + a derived value that force-
   // closes whenever the chat tab isn't active.  The *derived* value is
   // what side-effects (body-scroll lock, keydown listener, portal render)
@@ -264,6 +282,160 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     termRef.current?.focus();
   };
 
+  const stopMediaTracks = useCallback(() => {
+    mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    mediaStreamRef.current = null;
+  }, []);
+
+  const insertTranscriptIntoInput = useCallback((text: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      setSpeechError("Chat session is not connected; transcription was not inserted.");
+      return;
+    }
+    ws.send(text);
+    termRef.current?.focus();
+  }, []);
+
+  const startSpeechRecording = useCallback(async () => {
+    if (speechState !== "idle") return;
+    if (typeof MediaRecorder === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      setSpeechError("Browser speech recording is not supported here.");
+      return;
+    }
+
+    setSpeechError(null);
+    setSpeechState("recording");
+    pendingSpeechStopRef.current = false;
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mimeType = preferredRecorderMimeType();
+      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      audioChunksRef.current = [];
+      mediaStreamRef.current = stream;
+      mediaRecorderRef.current = recorder;
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) audioChunksRef.current.push(event.data);
+      };
+
+      recorder.onerror = () => {
+        setSpeechError("Speech recording failed.");
+        setSpeechState("idle");
+        stopMediaTracks();
+      };
+
+      recorder.onstop = async () => {
+        setSpeechState("transcribing");
+        stopMediaTracks();
+        const chunks = audioChunksRef.current;
+        audioChunksRef.current = [];
+        mediaRecorderRef.current = null;
+
+        if (chunks.length === 0) {
+          setSpeechState("idle");
+          return;
+        }
+
+        try {
+          const blob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+          const result = await api.transcribeAudio(blob);
+          const text = result.text.trim();
+          if (text) insertTranscriptIntoInput(text);
+        } catch (error) {
+          setSpeechError(error instanceof Error ? error.message : "Speech transcription failed.");
+        } finally {
+          setSpeechState("idle");
+        }
+      };
+
+      recorder.start();
+      if (pendingSpeechStopRef.current) {
+        pendingSpeechStopRef.current = false;
+        setSpeechState("transcribing");
+        recorder.stop();
+      }
+    } catch (error) {
+      setSpeechError(error instanceof Error ? error.message : "Microphone permission was denied.");
+      setSpeechState("idle");
+      stopMediaTracks();
+    }
+  }, [insertTranscriptIntoInput, speechState, stopMediaTracks]);
+
+  const stopSpeechRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state === "inactive") {
+      if (speechState === "recording") {
+        pendingSpeechStopRef.current = true;
+        setSpeechState("transcribing");
+        return;
+      }
+      setSpeechState("idle");
+      stopMediaTracks();
+      return;
+    }
+    pendingSpeechStopRef.current = false;
+    setSpeechState("transcribing");
+    recorder.stop();
+  }, [speechState, stopMediaTracks]);
+
+  const toggleSpeechRecording = useCallback(() => {
+    if (speechState === "recording") {
+      stopSpeechRecording();
+    } else if (speechState === "idle") {
+      void startSpeechRecording();
+    }
+  }, [speechState, startSpeechRecording, stopSpeechRecording]);
+
+  const handleMicPointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0 || speechState !== "idle") return;
+    pointerHoldActiveRef.current = false;
+    pointerHoldTimerRef.current = setTimeout(() => {
+      pointerHoldActiveRef.current = true;
+      suppressNextMicClickRef.current = true;
+      void startSpeechRecording();
+    }, 300);
+  };
+
+  const handleMicPointerEnd = () => {
+    if (pointerHoldTimerRef.current) {
+      clearTimeout(pointerHoldTimerRef.current);
+      pointerHoldTimerRef.current = null;
+    }
+    if (pointerHoldActiveRef.current) {
+      pointerHoldActiveRef.current = false;
+      stopSpeechRecording();
+    }
+  };
+
+  const handleMicClick = () => {
+    if (suppressNextMicClickRef.current) {
+      suppressNextMicClickRef.current = false;
+      return;
+    }
+    toggleSpeechRecording();
+  };
+
+  useEffect(() => {
+    if (!isActive) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === "m") {
+        event.preventDefault();
+        toggleSpeechRecording();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => document.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [isActive, toggleSpeechRecording]);
+
+  useEffect(() => () => {
+    if (pointerHoldTimerRef.current) clearTimeout(pointerHoldTimerRef.current);
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== "inactive") recorder.stop();
+    stopMediaTracks();
+  }, [stopMediaTracks]);
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -333,7 +505,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // original keydown event's activation. Log to aid debugging.
           console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
         });
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -806,6 +978,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         </div>
       )}
 
+      {speechError && (
+        <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs tracking-wide">
+          Speech-to-text: {speechError}
+        </div>
+      )}
+
       <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
           className={cn(
@@ -821,6 +999,51 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             ref={hostRef}
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
+
+          <Button
+            ghost
+            onPointerDown={handleMicPointerDown}
+            onPointerUp={handleMicPointerEnd}
+            onPointerCancel={handleMicPointerEnd}
+            onPointerLeave={handleMicPointerEnd}
+            onClick={handleMicClick}
+            disabled={speechState === "transcribing"}
+            title="Dictate into the chat input. Click to toggle, hold to speak, or press Ctrl+Shift+M. Uses Hermes built-in STT config."
+            aria-label={
+              speechState === "recording"
+                ? "Stop speech-to-text recording"
+                : "Start speech-to-text recording"
+            }
+            aria-pressed={speechState === "recording"}
+            className={cn(
+              "absolute z-10",
+              "rounded border border-current/30",
+              "bg-black/20 backdrop-blur-sm",
+              "opacity-70 hover:opacity-100 hover:border-current/60",
+              "transition-opacity duration-150 normal-case font-normal tracking-normal",
+              "bottom-2 left-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
+              "lg:bottom-4 lg:left-4",
+              speechState === "recording" && "border-red-300/80 text-red-200 opacity-100",
+            )}
+            style={{ color: speechState === "recording" ? undefined : TERMINAL_THEME.foreground }}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {speechState === "transcribing" ? (
+                <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+              ) : speechState === "recording" ? (
+                <Square className="h-3 w-3 shrink-0" />
+              ) : (
+                <Mic className="h-3 w-3 shrink-0" />
+              )}
+              <span className="hidden min-[400px]:inline tracking-wide">
+                {speechState === "transcribing"
+                  ? "transcribing"
+                  : speechState === "recording"
+                    ? "stop dictation"
+                    : "dictate"}
+              </span>
+            </span>
+          </Button>
 
           <Button
             ghost


### PR DESCRIPTION
## Summary
- add a dashboard STT upload endpoint that reuses Hermes' built-in transcription stack and filters common Whisper hallucinations
- add a chat input mic control with click-to-toggle, press-and-hold-to-speak, and Ctrl/Cmd+Shift+M hotkey behavior
- insert transcribed text into the existing PTY chat input for review/editing instead of auto-sending

## Tests
- python -m pytest tests/hermes_cli/test_web_server.py -q
- npm run build (web)
- npx eslint src/pages/ChatPage.tsx src/lib/api.ts (0 errors, 1 pre-existing exhaustive-deps warning on resumeParam)

Note: full npm run lint still fails on pre-existing lint issues outside this change (OAuthProvidersCard, Toast, i18n, Analytics/Config/Env/Logs/Models/Plugins/Sessions pages, themes).