### PR TITLE
fix(guardrails): enable hard_stop_enabled by default

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -70,7 +70,7 @@ class ToolCallGuardrailConfig:
     """
 
     warnings_enabled: bool = True
-    hard_stop_enabled: bool = False
+    hard_stop_enabled: bool = True
     exact_failure_warn_after: int = 2
     exact_failure_block_after: int = 5
     same_tool_failure_warn_after: int = 3

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -742,10 +742,12 @@ DEFAULT_CONFIG = {
 
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
-    # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    # hard stops are enabled by default to prevent infinite retry loops that
+    # waste API tokens (e.g. 90 retries of the same failing command). Users
+    # who prefer unlimited retries can opt out via config.yaml.
     "tool_loop_guardrails": {
         "warnings_enabled": True,
-        "hard_stop_enabled": False,
+        "hard_stop_enabled": True,
         "warn_after": {
             "exact_failure": 2,
             "same_tool_failure": 3,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -33,11 +33,11 @@ def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposi
     assert "☤" not in json.dumps(metadata)
 
 
-def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
+def test_default_config_has_hard_stop_enabled():
     cfg = ToolCallGuardrailConfig()
 
     assert cfg.warnings_enabled is True
-    assert cfg.hard_stop_enabled is False
+    assert cfg.hard_stop_enabled is True
     assert cfg.exact_failure_warn_after == 2
     assert cfg.same_tool_failure_warn_after == 3
     assert cfg.no_progress_warn_after == 2
@@ -74,8 +74,10 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.no_progress_block_after == 8
 
 
-def test_default_repeated_identical_failed_call_warns_without_blocking():
-    controller = ToolCallGuardrailController()
+def test_default_repeated_identical_failed_call_warns_without_hard_stop():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False)
+    )
     args = {"query": "same"}
 
     decisions = []
@@ -147,9 +149,9 @@ def test_file_mutation_lint_error_result_is_not_a_tool_failure():
     assert classify_tool_failure("patch", patch_result) == (False, "")
 
 
-def test_same_tool_varying_args_warns_by_default_without_halting():
+def test_same_tool_varying_args_warns_without_hard_stop():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(same_tool_failure_warn_after=2, same_tool_failure_halt_after=3)
+        ToolCallGuardrailConfig(hard_stop_enabled=False, same_tool_failure_warn_after=2, same_tool_failure_halt_after=3)
     )
 
     first = controller.after_call("terminal", {"command": "cmd-1"}, '{"exit_code":1}', failed=True)
@@ -184,9 +186,9 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     assert third.count == 3
 
 
-def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():
+def test_idempotent_no_progress_warns_without_hard_stop():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(hard_stop_enabled=False, no_progress_warn_after=2, no_progress_block_after=2)
     )
     args = {"path": "/tmp/same.txt"}
     result = "same file contents"


### PR DESCRIPTION
## Problem

`tool_loop_guardrails.hard_stop_enabled` defaults to `false`. Guardrails detect retry loops (same failing command, same tool failure, idempotent no-progress) and inject warning text, but models frequently ignore text guidance and continue retrying until `max_iterations` (90). A single terminal failure loop can consume 90+ API calls doing nothing useful.

## Fix

Change default from `false` → `true` in two locations:
1. `ToolCallGuardrailConfig.hard_stop_enabled` dataclass default
2. `hermes_cli/config.py` default config dict

Users who prefer unlimited retries can opt out via:
```yaml
tool_loop_guardrails:
  hard_stop_enabled: false
```

## Validation

Updated 3 existing tests that assumed `hard_stop_enabled=False` to explicitly pass `hard_stop_enabled=False`. Updated 1 test that asserted the default value. All 13 guardrail tests pass.

Closes #25823
