### PR TITLE
fix(ci): add checks: write permissions to resolve blocked fork PRs

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   check-attribution:

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   docs-site-checks:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # needed to post/update PR comments
+  checks: write
+  pull-requests: write # needed to post/update PR comments and checks
 
 concurrency:
   group: lint-${{ github.ref }}

--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  checks: write
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -13,8 +13,9 @@ on:
       - '**/__init__.pth'
 
 permissions:
-  pull-requests: write
   contents: read
+  checks: write
+  pull-requests: write
 
 # Narrow, high-signal scanner. Only fires on critical indicators of supply
 # chain attacks (e.g. the litellm-style payloads). Low-signal heuristics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 # Cancel in-progress runs for the same PR/branch
 concurrency:

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -59,6 +59,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 concurrency:
   group: uv-lockfile-check-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This PR adds explicit `checks: write` (and `pull-requests: write` where appropriate) permissions to all PR-relevant GitHub Actions workflows.

## Problem
PRs opened from forks currently show no CI checks and appear as `BLOCKED`. This was noted on #25968:

> 현재 체크가 없고 BLOCKED 상태입니다. CI/권한 상태를 확인한 뒤 다시 봐야 합니다.

## Root Cause
GitHub runs workflows from fork PRs with a restricted `GITHUB_TOKEN`. Without `checks: write`, jobs cannot report status checks.

## Fix
Updated the following workflows:
- `tests.yml`
- `lint.yml`
- `contributor-check.yml`
- `supply-chain-audit.yml`
- `nix.yml`
- `uv-lockfile-check.yml`
- `docs-site-checks.yml`
- `nix-lockfile-fix.yml`

This is a small infrastructure change that should allow CI to run and report properly on external contributions going forward, including the first-class xAI (Grok) OAuth provider work in #25968.