### PR TITLE
Add safe cron test-run command

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -166,7 +166,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("search", "browse", "inspect", "install")),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
-               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
+               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "test-run", "remove")),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -13,6 +13,8 @@ from typing import Iterable, List, Optional
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from cron.jobs import get_job, save_job_output
+from cron.scheduler import run_job
 from hermes_cli.colors import Colors, color
 
 
@@ -253,6 +255,24 @@ def cron_edit(args):
     return 0
 
 
+def cron_test_run(job_id: str) -> int:
+    job = get_job(job_id)
+    if not job:
+        print(color(f"Job not found: {job_id}", Colors.RED))
+        return 1
+
+    success, output, _final_response, error = run_job(job)
+    output_path = save_job_output(job_id, output)
+    status = "success" if success else "failure"
+
+    print(color(f"Test run {status}: {job_id}", Colors.GREEN if success else Colors.RED))
+    print(f"  Output: {output_path}")
+    print(f"  Output length: {len(output)}")
+    if error:
+        print(f"  Error: {error}")
+    return 0 if success else 1
+
+
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
     result = _cron_api(action=action, job_id=job_id)
     if not result.get("success"):
@@ -298,6 +318,9 @@ def cron_command(args):
 
     if subcmd == "run":
         return _job_action("run", args.job_id, "Triggered")
+
+    if subcmd == "test-run":
+        return cron_test_run(args.job_id)
 
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10222,6 +10222,11 @@ def main():
     cron_run.add_argument("job_id", help="Job ID to trigger")
     _add_accept_hooks_flag(cron_run)
 
+    cron_test_run = cron_subparsers.add_parser(
+        "test-run", help="Run one job immediately and save local output"
+    )
+    cron_test_run.add_argument("job_id", help="Job ID to test")
+
     cron_remove = cron_subparsers.add_parser(
         "remove", aliases=["rm", "delete"], help="Remove a scheduled job"
     )

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -194,6 +194,20 @@ class TestCronTestRun:
         monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
         cron_mod.cron_test_run(job["id"])
 
+    def test_missing_job_returns_nonzero_without_running_or_saving(self, tmp_cron_dir, monkeypatch, capsys):
+        def should_not_run(*args, **kwargs):
+            raise AssertionError("missing job must not run or save output")
+
+        monkeypatch.setattr(cron_mod, "run_job", should_not_run)
+        monkeypatch.setattr(cron_mod, "save_job_output", should_not_run)
+
+        rc = cron_mod.cron_test_run("missing-job-id")
+        out = capsys.readouterr().out
+
+        assert rc != 0
+        assert "Job not found" in out
+        assert "missing-job-id" in out
+
     def test_success_stdout_includes_evidence(self, tmp_cron_dir, monkeypatch, capsys):
         """Success path stdout must contain job id, success status, output path, and output length."""
         job = create_job(prompt="check", schedule="every 1h")

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -4,7 +4,10 @@ from argparse import Namespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+import cron.jobs as jobs_mod
+import cron.scheduler as scheduler_mod
+import hermes_cli.cron as cron_mod
+from cron.jobs import create_job, get_job, list_jobs, pause_job
 from hermes_cli.cron import cron_command
 
 
@@ -105,3 +108,132 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+
+def _block_unsafe_paths(monkeypatch):
+    """Patch every helper the test-run command must NEVER call."""
+
+    def boom(name):
+        def _raise(*args, **kwargs):
+            raise AssertionError(f"test-run must not call {name}; got args={args} kwargs={kwargs}")
+        return _raise
+
+    monkeypatch.setattr(scheduler_mod, "tick", boom("scheduler.tick"))
+    monkeypatch.setattr(scheduler_mod, "_deliver_result", boom("scheduler._deliver_result"))
+    monkeypatch.setattr(jobs_mod, "mark_job_run", boom("jobs.mark_job_run"))
+    monkeypatch.setattr(jobs_mod, "advance_next_run", boom("jobs.advance_next_run"))
+    monkeypatch.setattr(jobs_mod, "update_job", boom("jobs.update_job"))
+    monkeypatch.setattr(jobs_mod, "get_due_jobs", boom("jobs.get_due_jobs"))
+    monkeypatch.setattr(cron_mod, "_cron_api", boom("hermes_cli.cron._cron_api"))
+
+
+class TestCronTestRun:
+    """Phase 1 failing tests: `hermes cron test-run <job_id>` safe one-job verification."""
+
+    def test_routes_to_cron_test_run(self, tmp_cron_dir, monkeypatch):
+        """cron_command must dispatch 'test-run' to a new cron_test_run function."""
+        calls = []
+
+        def fake(job_id):
+            calls.append(job_id)
+            return 0
+
+        monkeypatch.setattr(cron_mod, "cron_test_run", fake)
+        cron_command(Namespace(cron_command="test-run", job_id="abc123"))
+        assert calls == ["abc123"]
+
+    def test_calls_get_job_once(self, tmp_cron_dir, monkeypatch):
+        """The new command must look up exactly one job via get_job."""
+        job = create_job(prompt="check", schedule="every 1h")
+        seen = []
+
+        def recorder(job_id):
+            seen.append(job_id)
+            return job
+
+        monkeypatch.setattr(cron_mod, "get_job", recorder)
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+        assert seen == [job["id"]]
+
+    def test_calls_run_job_once_with_fetched_job(self, tmp_cron_dir, monkeypatch):
+        """run_job must be called exactly once with the job dict from get_job."""
+        job = create_job(prompt="check", schedule="every 1h")
+        runs = []
+
+        def recorder(j):
+            runs.append(j)
+            return (True, "out", "final", None)
+
+        monkeypatch.setattr(cron_mod, "run_job", recorder)
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+        assert len(runs) == 1
+        assert runs[0]["id"] == job["id"]
+
+    def test_saves_output_once(self, tmp_cron_dir, monkeypatch):
+        """save_job_output must be called exactly once with (job_id, output)."""
+        job = create_job(prompt="check", schedule="every 1h")
+        saves = []
+
+        def recorder(jid, out):
+            saves.append((jid, out))
+            return "/tmp/saved.md"
+
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "OUTPUT_BODY", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", recorder)
+        cron_mod.cron_test_run(job["id"])
+        assert saves == [(job["id"], "OUTPUT_BODY")]
+
+    def test_never_calls_unsafe_paths(self, tmp_cron_dir, monkeypatch):
+        """test-run must not touch tick, delivery, run marking, schedule advancement, due lookup, or the queued cron API."""
+        job = create_job(prompt="check", schedule="every 1h")
+        _block_unsafe_paths(monkeypatch)
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+
+    def test_success_stdout_includes_evidence(self, tmp_cron_dir, monkeypatch, capsys):
+        """Success path stdout must contain job id, success status, output path, and output length."""
+        job = create_job(prompt="check", schedule="every 1h")
+        output_body = "Hello world, this is the output."
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, output_body, "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/cron/output/abc.md")
+        rc = cron_mod.cron_test_run(job["id"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert job["id"] in out
+        assert "success" in out.lower()
+        assert "/tmp/cron/output/abc.md" in out
+        assert str(len(output_body)) in out
+
+    def test_failure_returns_nonzero_and_prints_error(self, tmp_cron_dir, monkeypatch, capsys):
+        """Failure path must return non-zero, still save output, and print path + length + error text."""
+        job = create_job(prompt="check", schedule="every 1h")
+        partial = "Partial output before failure"
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (False, partial, "", "boom: model errored"))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/cron/output/fail.md")
+        rc = cron_mod.cron_test_run(job["id"])
+        out = capsys.readouterr().out
+        assert rc != 0
+        assert job["id"] in out
+        assert "/tmp/cron/output/fail.md" in out
+        assert str(len(partial)) in out
+        assert "boom: model errored" in out
+
+    def test_preserves_paused_state_and_last_run(self, tmp_cron_dir, monkeypatch):
+        """A paused job must remain paused and its last_run timestamp must not change."""
+        job = create_job(prompt="check", schedule="every 1h")
+        pause_job(job["id"])
+        before = get_job(job["id"])
+        assert before["state"] == "paused"
+        last_run_before = before.get("last_run")
+
+        monkeypatch.setattr(cron_mod, "run_job", lambda j: (True, "out", "final", None))
+        monkeypatch.setattr(cron_mod, "save_job_output", lambda jid, out: "/tmp/x.md")
+        cron_mod.cron_test_run(job["id"])
+
+        after = get_job(job["id"])
+        assert after["state"] == "paused"
+        assert after.get("last_run") == last_run_before


### PR DESCRIPTION
## Summary
- Add a focused `hermes cron test-run <job_id>` command that runs one scheduled job immediately and saves local output.
- Preserve paused job state and avoid scheduler-wide tick, due-job scanning, schedule advancement, and delivery mutation.
- Add command-boundary tests, including missing-job behavior and unsafe-path tripwires.

Fixes #1010
Fixes #1011
Fixes #1012

## Test plan
- [x] `pytest tests/hermes_cli/test_cron.py -x -v` (12 passed)
- [x] `pytest tests/cron/test_scheduler.py -x -v` (121 passed)
- [x] Disposable local proof passed with paused no-agent local job and scheduler/delivery tripwires

🤖 Generated with [Claude Code](https://claude.com/claude-code)