### PR TITLE
fix(qqbot): fallback to Identify after 3 consecutive Resume failures

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -227,6 +227,7 @@ class QQAdapter(BasePlatformAdapter):
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
+        self._resume_fail_count: int = 0  # consecutive resume failures, fallback to identify at 3
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
 
         # Request/response correlation
@@ -572,11 +573,24 @@ class QQAdapter(BasePlatformAdapter):
                     self._access_token = None
                     self._token_expires_at = 0.0
 
-                # Session invalid → clear session, will re-identify on next Hello
-                if code in {
-                        4006,
-                        4007,
-                        4009,
+                # 4009: QQ Official doc says can RESUME, do NOT clear session
+                # Ref: https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/error-trace/websocket.html
+                if code == 4009:
+                    logger.info(
+                        "[%s] Session timeout (4009), will resume (keeping session_id=%s)",
+                        self._log_tag,
+                        self._session_id,
+                    )
+                elif code in {4006, 4007}:
+                    logger.info(
+                        "[%s] Session invalid (%d), clearing for re-identify",
+                        self._log_tag,
+                        code,
+                    )
+                    self._session_id = None
+                    self._last_seq = None
+                    self._resume_fail_count = 0
+                elif code in {
                         4900,
                         4901,
                         4902,
@@ -593,12 +607,13 @@ class QQAdapter(BasePlatformAdapter):
                         4913,
                 }:
                     logger.info(
-                        "[%s] Session error (%d), clearing session for re-identify",
+                        "[%s] Server error (%d), clearing session for re-identify",
                         self._log_tag,
                         code,
                     )
                     self._session_id = None
                     self._last_seq = None
+                    self._resume_fail_count = 0
 
                 if await self._reconnect(backoff_idx):
                     backoff_idx = 0
@@ -756,9 +771,17 @@ class QQAdapter(BasePlatformAdapter):
                 )
         except Exception as exc:
             logger.error("[%s] Failed to send Resume: %s", self._log_tag, exc)
-            # If resume fails, clear session and fall back to identify on next Hello
-            self._session_id = None
-            self._last_seq = None
+            self._resume_fail_count += 1
+            logger.warning(
+                "[%s] Resume failed (%d/3), will fallback to identify on next failure",
+                self._log_tag,
+                self._resume_fail_count,
+            )
+            if self._resume_fail_count >= 3:
+                logger.warning("[%s] Resume failed 3 times, clearing session for re-identify", self._log_tag)
+                self._session_id = None
+                self._last_seq = None
+                self._resume_fail_count = 0
 
     @staticmethod
     def _create_task(coro):
@@ -832,6 +855,7 @@ class QQAdapter(BasePlatformAdapter):
         """Handle the READY event — store session_id for resume."""
         if isinstance(d, dict):
             self._session_id = d.get("session_id")
+            self._resume_fail_count = 0  # reset counter on successful fresh identify
             logger.info("[%s] Ready, session_id=%s", self._log_tag, self._session_id)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When the QQ Bot WebSocket disconnects and the old session_id expires on the server side, the adapter enters an infinite Resume loop — it never falls back to a fresh Identify handshake, so the bot stays offline indefinitely until manually restarted.

Reported in #22179, and also partially covered by #19648, #19821, #15490.

### Root cause

_send_resume clears session_id+last_seq immediately on any exception, losing the session data needed for subsequent Resume attempts. Combined with close-code handler treating 4009 (session timeout) the same as 4006/4007 (session invalid), the first transient Resume failure triggers a cascade that destroys the session before the server even gets a chance to properly reject it.

## Fix

Three changes:

1. **Resume fail counter** — Track _resume_fail_count. Only clear session after 3 consecutive Resume failures, letting transient network glitches retry. Mirrors the Discord-style gateway pattern that QQ Bot's protocol is based on.

2. **Close-code 4009 / 4006-4007 separation** — Per [QQ Official docs](https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/error-trace/websocket.html), close-code 4009 (session timeout) explicitly supports Resume — the session_id is still valid. Only codes 4006/4007 indicate a truly invalid session that requires fresh Identify.

3. **Reset counter on READY** — Reset _resume_fail_count on successful fresh Identify, so the bot recovers normally after a full re-connect.

## Testing

Existing qqbot test suite (144 tests) passes without changes. The fix is incremental — the fail counter is internal state that only activates on an error path.

Closes #22179