### PR TITLE
chore(release): map bartokmagic@proton.me to Bartok9 in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1050,6 +1050,7 @@ AUTHOR_MAP = {
     "37467487+yifengingit@users.noreply.github.com": "yifengingit",  # PR #25589 salvage (AUTOINCREMENT id ordering)
     "89525629+vanthinh6886@users.noreply.github.com": "vanthinh6886",  # PR #25562 salvage (.env 0600 perms)
     "16034932+Arkmusn@users.noreply.github.com": "Arkmusn",  # PR #25559 salvage (approvals.timeout from config)
+    "bartokmagic@proton.me": "Bartok9",  # multiple PRs (Bartok)
 }
 
 


### PR DESCRIPTION
## Summary

Adds the email `bartokmagic@proton.me` to `scripts/release.py` `AUTHOR_MAP` so the contributor-attribution CI gate stops failing on PRs authored from this account.

## Why

Several of my open PRs currently fail the `check-attribution` job (e.g. #11879, #11880, #11877, #24881, #24879, #25533) with the message:

```
⚠️  New contributor email(s) not in AUTHOR_MAP:
  bartokmagic@proton.me (Bartok)
```

The gate's own remediation instructions explicitly tell the author to add the missing mapping to `AUTHOR_MAP`. This PR does exactly that.

## Change

One line added at the bottom of the existing AUTHOR_MAP dict in `scripts/release.py`:

```python
"bartokmagic@proton.me": "Bartok9",  # multiple PRs (Bartok)
```

## Test plan

- Diff is one line added; no other file touched
- After merge, the `check-attribution` gate on every PR authored by `bartokmagic@proton.me` will resolve to ✅ (the gate runs on each push; affected PRs will pick this up on their next rebase or commit)

🎻