### PR TITLE
fix(browser): rename AGENT_BROWSER_CHROME_FLAGS to AGENT_BROWSER_ARGS

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1873,7 +1873,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1892,7 +1892,7 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
+                browser_env["AGENT_BROWSER_ARGS"] = (
                     "--no-sandbox --disable-dev-shm-usage"
                 )
 


### PR DESCRIPTION
## Summary

The sandbox-bypass injection in `_run_browser_command` wrote `AGENT_BROWSER_CHROME_FLAGS`, but `agent-browser` (the Rust binary) reads `AGENT_BROWSER_ARGS`. This made the `--no-sandbox` workaround for root/AppArmor-restricted systems a silent no-op (see #23496 for full repro).

## Fix

Rename the env var from `AGENT_BROWSER_CHROME_FLAGS` to `AGENT_BROWSER_ARGS` in both the guard check and the assignment. No other code in the repo references `AGENT_BROWSER_CHROME_FLAGS`, so this is a complete fix.

## Verification

- `grep -r AGENT_BROWSER_CHROME_FLAGS` returns no results post-fix.
- `grep -r AGENT_BROWSER_ARGS` confirms the var is used consistently.
- The detection logic (root via `os.geteuid()`, AppArmor via `/proc/sys/kernel/apparmor_restrict_unprivileged_userns`) is unchanged — only the env var name it writes is corrected.

Fixes #23496