### PR TITLE
fix: route API-key auxiliary providers through credential pool

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2994,8 +2994,18 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
-        creds = resolve_api_key_provider_credentials(provider)
-        api_key = str(creds.get("api_key", "")).strip()
+        pool_present, pool_entry = _select_pool_entry(provider)
+        if pool_present:
+            api_key = _pool_runtime_api_key(pool_entry)
+            raw_base_url = (
+                _pool_runtime_base_url(pool_entry, pconfig.inference_base_url)
+                or pconfig.inference_base_url
+            )
+            logger.debug("resolve_provider_client: %s via credential pool", provider)
+        else:
+            creds = resolve_api_key_provider_credentials(provider)
+            api_key = str(creds.get("api_key", "")).strip()
+            raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
         # credential can authenticate against endpoints where no built-in
@@ -3011,7 +3021,6 @@ def resolve_provider_client(
                          provider, ", ".join(tried_sources))
             return None, None
 
-        raw_base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         base_url = _to_openai_base_url(raw_base_url)
         # Honour an explicit base_url override from the caller — used when a
         # fallback_model entry (or custom_providers lookup) routes through a

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -276,6 +276,46 @@ class TestAnthropicOAuthFlag:
         assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
 
 
+class TestAPIKeyProviderPoolRouting:
+    def test_explicit_api_key_provider_uses_pool_before_env_resolution(self):
+        class _Entry:
+            access_token = "gemini-pooled-key"
+            base_url = "https://generativelanguage.googleapis.com/v1beta"
+            runtime_api_key = "gemini-pooled-key"
+            runtime_base_url = "https://generativelanguage.googleapis.com/v1beta"
+
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, _Entry())),
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", side_effect=AssertionError("legacy env path should not run")),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock(api_key="gemini-pooled-key", base_url="https://example.invalid/v1")
+
+            client, model = resolve_provider_client("gemini", "gemini-3-flash-preview")
+
+        assert client is not None
+        assert model == "gemini-3-flash-preview"
+        assert getattr(client, "api_key", "") == "gemini-pooled-key"
+
+    def test_explicit_api_key_provider_falls_back_to_env_when_pool_absent(self):
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
+                "api_key": "gemini-env-key",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "source": "GOOGLE_API_KEY",
+            }),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock(api_key="gemini-env-key", base_url="https://example.invalid/v1")
+
+            client, model = resolve_provider_client("gemini", "gemini-3-flash-preview")
+
+        assert client is not None
+        assert model == "gemini-3-flash-preview"
+        assert getattr(client, "api_key", "") == "gemini-env-key"
+
+
 class TestBuildCodexClient:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (


### PR DESCRIPTION
## Summary
- route explicit API-key auxiliary providers through the credential pool before falling back to env/config resolution
- preserve the existing env/config fallback when no pool entry exists
- add regression coverage for explicit Gemini/API-key auxiliary provider routing

## Why
Auxiliary tasks such as context compression can be configured with an explicit API-key provider, for example `auxiliary.compression.provider: gemini`. That path previously resolved credentials via `resolve_api_key_provider_credentials()`, which prefers env vars like `GOOGLE_API_KEY`, bypassing the provider's credential pool and configured pool strategy (`round_robin`, `least_used`, etc.).

As a result, users with multiple Gemini keys in `hermes auth` and `credential_pool_strategies.gemini: round_robin` still sent all compression traffic through a single env key.

## Testing
- `venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `venv/bin/python -m pytest tests/agent/test_auxiliary_client.py::TestAPIKeyProviderPoolRouting tests/agent/test_auxiliary_client.py::TestAnthropicOAuthFlag::test_pool_entry_takes_priority_over_legacy_resolution -q -o 'addopts='`

Note: the broader local run `tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_auxiliary_client.py` has one pre-existing failure in `TestAuxiliaryClientPoisonedCacheEviction::test_codex_timeout_evicts_cached_wrapper`; the focused new regression tests pass.
