### PR TITLE
fix(model_metadata): treat .local mDNS hostnames as local endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -313,6 +313,13 @@ _CONTAINER_LOCAL_SUFFIXES = (
     ".containers.internal",
     ".lima.internal",
 )
+# mDNS / Bonjour link-local hostnames. RFC 6762 reserves the ``.local``
+# special-use TLD for multicast DNS — any name under it is, by definition,
+# only resolvable on the same broadcast domain. Matching here lets users
+# point Hermes at a self-hosted backend by Bonjour name (``macmini.local``,
+# ``my-mac.local``) and still get the timeout auto-bumps that loopback,
+# RFC-1918, and Tailscale peers already receive.
+_MDNS_LOCAL_SUFFIXES = (".local",)
 
 
 def _normalize_base_url(base_url: str) -> str:
@@ -408,6 +415,7 @@ def is_local_endpoint(base_url: str) -> bool:
 
     Recognises loopback (``localhost``, ``127.0.0.0/8``, ``::1``),
     container-internal DNS names (``host.docker.internal`` et al.),
+    mDNS / Bonjour link-local hostnames (``*.local``, RFC 6762),
     RFC-1918 private ranges (``10/8``, ``172.16/12``, ``192.168/16``),
     link-local, and Tailscale CGNAT (``100.64.0.0/10``). Tailscale CGNAT
     is included so remote-but-trusted Ollama boxes reached over a
@@ -426,6 +434,9 @@ def is_local_endpoint(base_url: str) -> bool:
         return True
     # Docker / Podman / Lima internal DNS names (e.g. host.docker.internal)
     if any(host.endswith(suffix) for suffix in _CONTAINER_LOCAL_SUFFIXES):
+        return True
+    # mDNS / Bonjour link-local names (e.g. macmini.local) — RFC 6762.
+    if any(host.endswith(suffix) for suffix in _MDNS_LOCAL_SUFFIXES):
         return True
     # RFC-1918 private ranges, link-local, and Tailscale CGNAT
     try:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -103,9 +103,20 @@ class TestIsLocalEndpoint:
         "https://openrouter.ai/api",
         "https://api.anthropic.com",
         "https://evil.docker.internal.example.com",
+        "https://macmini.local.example.com",
     ])
     def test_remote_endpoints(self, url):
         assert is_local_endpoint(url) is False
+
+    @pytest.mark.parametrize("url", [
+        "http://macmini.local:8000/v1",       # bare bonjour name
+        "http://my-mac.local",                # no port, no path
+        "http://nas.local:11434",             # ollama on a Bonjour-named NAS
+        "https://workstation.local:443/v1",   # https + standard port + path
+    ])
+    def test_mdns_local_names(self, url):
+        """mDNS / Bonjour ``*.local`` hostnames are link-local by RFC 6762."""
+        assert is_local_endpoint(url) is True
 
     @pytest.mark.parametrize("url", [
         "http://100.64.0.0:11434",            # lower bound of CGNAT block


### PR DESCRIPTION
is_local_endpoint() gates several timeout auto-bumps — the streaming stale-stream detector (run_agent.py:8539), the non-stream stale-call detector (run_agent.py:3461), and the httpx stream read timeout (run_agent.py:7942) — on whether the configured base_url points to a local-network machine. Hostnames under the mDNS / Bonjour ``.local`` TLD were not recognised, so a self-hosted backend reached at e.g. ``macmini.local:8000`` was treated as a remote provider and got the default 300s stale-stream threshold instead of the auto-disable that loopback, RFC-1918, and Tailscale peers already receive.

The user-visible symptom is that any streaming chat completion whose prefill takes longer than 300s — large context against a local model — fires the "No response from provider for 300s, reconnecting..." warning and tears the connection down, then loops because the reconnect restarts prefill from scratch and never reaches first-token before the next 300s cycle.

Add ``.local`` to a new ``_MDNS_LOCAL_SUFFIXES`` constant alongside the existing container suffixes. ``.local`` is an IETF-reserved special-use TLD per RFC 6762 ("Multicast DNS") and resolves only on the local broadcast domain by definition, so matching it as "local" is correct without a config opt-in.

A new TestIsLocalEndpoint::test_mdns_local_names parametrised case covers bare ``.local`` names with and without ports / paths / https. The existing remote-endpoints case is extended with ``macmini.local.example.com`` to lock in suffix-anchored matching (``.local`` in the middle of a hostname must not match).

## Related Issue

No tracking issue filed — this PR is self-contained, with the diagnosis above and the fix in one place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: add `_MDNS_LOCAL_SUFFIXES = (".local",)` constant; extend `is_local_endpoint()` with a suffix check that catches mDNS / Bonjour link-local hostnames; update docstring to advertise the new category.
- `tests/agent/test_local_stream_timeout.py`: add `TestIsLocalEndpoint::test_mdns_local_names` parametrised case covering `*.local` with and without ports / paths / https; extend `test_remote_endpoints` with `macmini.local.example.com` to lock in suffix-anchored matching (so a hostname containing `.local` in the middle is not misclassified as local).

## How to Test

1. Run the targeted unit tests:
   ```
   pytest tests/agent/test_local_stream_timeout.py -q
   ```
   The new `test_mdns_local_names` case passes; the existing `test_remote_endpoints`, `test_classic_local_addresses`, `test_container_dns_names`, `test_tailscale_cgnat_is_local`, and `test_near_but_not_cgnat_is_remote` continue to pass (regression check).
2. End-to-end repro of the original symptom: point Hermes at any local OpenAI-compatible backend addressed by Bonjour name, e.g. set `base_url: http://macmini.local:8000/v1` in `~/.hermes/config.yaml`, and send a streaming chat with a context large enough that prefill exceeds 300 seconds (~150K tokens against a local large model is reliable). Before the fix: the "No response from provider for 300s, reconnecting…" warning fires and loops indefinitely. After the fix: the connection is held open while prefill runs, and tokens stream normally once decode begins.
3. Negative check: confirm an unrelated remote endpoint with `.local` mid-hostname (the `macmini.local.example.com` case in the tests) is still classified as remote, so the suffix match doesn't false-positive on real public domains.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(model_metadata): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — single commit, two files, +22 lines
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `is_local_endpoint` docstring updated to list `*.local` as a recognised category; no user-facing docs needed (internal helper).
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; `.local` matches automatically without any config opt-in).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — mDNS / Bonjour `.local` resolution exists on macOS, Linux (Avahi), and Windows; the host-string suffix check itself is OS-agnostic.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

Before (loops every 300s, never produces a token):

```
⚠️ No response from provider for 300s (model: <name>, context: ~150,000 tokens). Reconnecting...
⚠️ No response from provider for 300s (model: <name>, context: ~150,000 tokens). Reconnecting...
⚠️ No response from provider for 300s (model: <name>, context: ~150,000 tokens). Reconnecting...
…
```

After (`is_local_endpoint("http://macmini.local:8000/v1")` now returns `True`, the stale-stream detector is auto-disabled per the existing logic at `run_agent.py:8539-8541`):

```
DEBUG agent: Local provider detected (http://macmini.local:8000/v1) — stale stream timeout disabled
```

Stream stays open for the full prefill duration; tokens arrive once decode begins.
