### PR TITLE
fix(agent): coerce ephemeral_system_prompt to str before concatenation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11634,7 +11634,17 @@ class AIAgent:
 
             effective_system = self._cached_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+                # ephemeral_system_prompt is typed and documented as str, but
+                # some callers (e.g. multi-model orchestration paths) pass a
+                # dict. Concatenating a non-str with str raises TypeError, so
+                # coerce defensively before use.
+                eph = self.ephemeral_system_prompt
+                if not isinstance(eph, str):
+                    try:
+                        eph = json.dumps(eph)
+                    except (TypeError, ValueError):
+                        eph = str(eph)
+                effective_system = (effective_system + "\n\n" + eph).strip()
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
@@ -12476,7 +12486,17 @@ class AIAgent:
             # stay warm.
             effective_system = active_system_prompt or ""
             if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+                # ephemeral_system_prompt is typed and documented as str, but
+                # some callers (e.g. multi-model orchestration paths) pass a
+                # dict. Concatenating a non-str with str raises TypeError, so
+                # coerce defensively before use.
+                eph = self.ephemeral_system_prompt
+                if not isinstance(eph, str):
+                    try:
+                        eph = json.dumps(eph)
+                    except (TypeError, ValueError):
+                        eph = str(eph)
+                effective_system = (effective_system + "\n\n" + eph).strip()
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
 


### PR DESCRIPTION
## Problem

`ephemeral_system_prompt` is annotated and documented as `str` on `AIAgent`, but some callers — multi-model orchestration code paths — pass a `dict`. Two sites in `AIAgent` concatenate it directly with a `str`:

```python
effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
```

When the value is a `dict`, this raises `TypeError: can only concatenate str (not "dict") to str`.

## Fix

Coerce defensively at both sites: `json.dumps()` the value when it isn't already a `str`, falling back to `str()` if it isn't JSON-serialisable.

`AIAgent` already `isinstance`-guards the same attribute elsewhere, so the non-`str` case is a known occurrence — these two concatenation sites just missed the guard. This makes them consistent.

## Notes

- `json` is already imported at module level.
- Surgical change; syntax-checked locally with `py_compile`.