### PR TITLE
feat(gateway): add .ts/.py/.sh to SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -829,6 +829,9 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".ts": "text/plain",
+    ".py": "text/plain",
+    ".sh": "text/plain",
 }
 
 


### PR DESCRIPTION
## Summary

`SUPPORTED_DOCUMENT_TYPES` already covers plain-text config files (`.ini`, `.cfg`) and structured formats (`.json`, `.yaml`, `.toml`), but not common source-file extensions. Sending a `.ts` / `.py` / `.sh` file to the agent as a document currently requires renaming it to `.txt` first.

This adds `.ts`, `.py`, `.sh` as `text/plain`, consistent with the existing `.ini` / `.cfg` entries.