### PR TITLE
fix(telegram): re-trigger typing indicator after sending messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1663,7 +1663,17 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
-            
+
+            # Re-trigger typing indicator after sending a message.
+            # Telegram clears the typing state when a new message is delivered,
+            # so without this the "...typing" bubble disappears mid-response
+            # (especially noticeable when the agent sends intermediate progress
+            # messages like "Checking:" before running tools).
+            try:
+                await self.send_typing(chat_id, metadata=metadata)
+            except Exception:
+                pass  # Typing failures are non-fatal
+
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,


### PR DESCRIPTION
## Problem
Telegram clears the typing indicator when a new message is delivered. When the agent sends intermediate progress messages (like "Checking:"), the "...typing" bubble disappears immediately and doesn't return until the next keepalive tick (up to 2s later). This makes Hermes appear unresponsive during multi-tool operations.

## Root Cause
The `_keep_typing` loop refreshes every 2 seconds, but when `send()` delivers a message, Telegram clears the typing state instantly. There's no immediate re-trigger, so the typing bubble stays dead until the next keepalive tick.

## Fix
Call `send_typing()` immediately after successful message delivery in `telegram.py:send()`. This restarts the typing indicator without waiting for the next keepalive tick, keeping the "...typing" bubble visible throughout the agent's response.

## Testing
- Verified the fix follows the existing `send_typing()` pattern
- Typing failures are caught and ignored (non-fatal), consistent with existing behavior
- No changes to the keepalive loop needed

Fixes #25836
