### PR TITLE
fix(oneshot): infer provider from profile model defaults

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -242,6 +242,10 @@ def _run_agent(
         cfg_model = model_cfg.get("default") or model_cfg.get("model") or ""
 
     env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
+    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+    cfg_provider = ""
+    if isinstance(model_cfg, dict):
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
     effective_model = (model or "").strip() or env_model or cfg_model
 
     # Resolve effective provider: explicit arg → (auto-detect from model if
@@ -254,36 +258,26 @@ def _run_agent(
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
     explicit_base_url_from_alias: Optional[str] = None
-    if effective_provider is None and (model or env_model):
-        # Only auto-detect when the model was explicitly requested via arg or
-        # env var (not when it came from config — that's the "use my defaults"
-        # path and the configured provider is already correct).
-        explicit_model = (model or "").strip() or env_model
-        if explicit_model:
-            # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
-            # These map a user-defined alias to (model, provider, base_url) for
-            # endpoints not in any catalog (local servers, custom proxies, etc.).
-            try:
-                from hermes_cli import model_switch as _ms
-                _ms._ensure_direct_aliases()
-                direct = _ms.DIRECT_ALIASES.get(explicit_model.strip().lower())
-            except Exception:
-                direct = None
-            if direct is not None:
-                effective_model = direct.model
-                effective_provider = direct.provider
-                if direct.base_url:
-                    explicit_base_url_from_alias = direct.base_url.rstrip("/")
-            else:
-                cfg_provider = ""
-                if isinstance(model_cfg, dict):
-                    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-                current_provider = (
-                    cfg_provider
-                    or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
-                    or "auto"
-                )
-                detected = detect_provider_for_model(explicit_model, current_provider)
+    if effective_provider is None and effective_model:
+        # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
+        # These map a user-defined alias to (model, provider, base_url) for
+        # endpoints not in any catalog (local servers, custom proxies, etc.).
+        try:
+            from hermes_cli import model_switch as _ms
+            _ms._ensure_direct_aliases()
+            direct = _ms.DIRECT_ALIASES.get(effective_model.strip().lower())
+        except Exception:
+            direct = None
+        if direct is not None:
+            effective_model = direct.model
+            effective_provider = direct.provider
+            if direct.base_url:
+                explicit_base_url_from_alias = direct.base_url.rstrip("/")
+        else:
+            current_provider = cfg_provider or env_provider or "auto"
+            should_detect_provider = bool(model or env_model) or not (cfg_provider or env_provider)
+            if should_detect_provider:
+                detected = detect_provider_for_model(effective_model, current_provider)
                 if detected:
                     effective_provider, effective_model = detected
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -485,6 +485,86 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def test_oneshot_detects_provider_for_config_model_when_profile_omits_provider(monkeypatch):
+    """Profile-backed oneshot should infer provider from config model defaults."""
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["agent_kwargs"] = kwargs
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def chat(self, prompt):
+            captured["prompt"] = prompt
+            return "ok"
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    def fake_resolve_runtime_provider(**kwargs):
+        captured["runtime_call"] = kwargs
+        return {
+            "api_key": "k",
+            "base_url": "u",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_state",
+        mod("hermes_state", SessionDB=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "moonshotai/kimi-k2.6"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod(
+            "hermes_cli.models",
+            detect_provider_for_model=lambda model_name, current_provider: (
+                "openrouter",
+                "moonshotai/kimi-k2.6",
+            )
+            if model_name == "moonshotai/kimi-k2.6" and current_provider == "auto"
+            else None,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=fake_resolve_runtime_provider,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    assert _run_agent("hello from profile") == "ok"
+    assert captured["runtime_call"]["requested"] == "openrouter"
+    assert captured["runtime_call"]["target_model"] == "moonshotai/kimi-k2.6"
+    assert captured["agent_kwargs"]["provider"] == "openrouter"
+    assert captured["agent_kwargs"]["model"] == "moonshotai/kimi-k2.6"
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
Fixes #25965

## Summary
- infer oneshot provider from the profile-configured model when no provider override is set
- keep direct alias resolution working for config-derived default models
- add a regression test covering profile-backed `hermes -z` provider inference

## Testing
- `uv run --frozen --extra dev python -m pytest -o addopts='' tests/hermes_cli/test_tui_resume_flow.py -k 'oneshot_wires_session_db_for_recall or oneshot_detects_provider_for_config_model_when_profile_omits_provider'`
- `uv run --frozen --extra dev ruff check hermes_cli/oneshot.py tests/hermes_cli/test_tui_resume_flow.py`
- `git diff --check`

## Attribution
- Recent company PRs #26030, #25675, and #25672 all share a failing GitHub `test` check; this PR is locally green and treats that lane as `preexisting_unrelated` baseline noise.
