### PR TITLE
fix(models): add deepseek-v4-flash to Nous Portal static fallback list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -176,6 +176,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "x-ai/grok-4.3",
         "nvidia/nemotron-3-super-120b-a12b",
         "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.


### PR DESCRIPTION
The Nous Portal API advertises `deepseek/deepseek-v4-flash` (now free for a limited time per promotional email), but the static fallback model list in `hermes_cli/models.py` only included `deepseek/deepseek-v4-pro`. This meant the model picker (`/model`) didnt show it.

**Change:** Added `"deepseek/deepseek-v4-flash"` to the `_PROVIDER_MODELS["nous"]` list.

The live API already returns this model — this just fixes the static fallback that the CLI model picker uses.