### PR TITLE
fix(fallback): forward custom_providers to fallback model context-length detection

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8901,6 +8901,7 @@ class AIAgent:
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
                     config_context_length=getattr(self, "_config_context_length", None),
+                    custom_providers=self._custom_providers,
                 )
                 self.context_compressor.update_model(
                     model=self.model,


### PR DESCRIPTION
This is a sibling fix to the auxiliary compression fix (PR #25494). The same root cause: get_model_context_length() is called without custom_providers, so per-model context_length overrides in custom_providers are silently skipped. The fallback activation path (_try_activate_fallback) had the same missing parameter.

When the agent switches to a fallback provider, _try_activate_fallback() probes the fallback model's context window via get_model_context_length(). Without custom_providers, it skips step 0b and falls through to models.dev, which may return a different value than what the user configured (e.g. 204800 from models.dev vs 196608 from custom_providers for NVIDIA NIM minimax-m2.7). This can cause the fallback model to run with an incorrect context window, leading to truncated messages or failed API requests.

Fix: added custom_providers=self._custom_providers to the get_model_context_length() call in _try_activate_fallback(), matching what the main model and auxiliary compression paths already do.

Changes: 1 line in run_agent.py

Related to #25494 (same root cause, different call site).