### PR TITLE
fix(cli): wire /whoami slash command in classic CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5421,6 +5421,22 @@ class HermesCLI:
         print(f"  Home:    {display}")
         print()
 
+    def _handle_whoami_command(self):
+        """Display slash-command access for the local CLI surface."""
+        import getpass
+
+        try:
+            user_name = getpass.getuser() or "?"
+        except Exception:
+            user_name = "?"
+
+        print()
+        print("  You:            cli (local terminal)")
+        print(f"  User:           {user_name}")
+        print("  Tier:           unrestricted")
+        print("  Slash commands: all available")
+        print()
+
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
@@ -7418,6 +7434,8 @@ class HermesCLI:
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "whoami":
+            self._handle_whoami_command()
         elif canonical == "profile":
             self._handle_profile_command()
         elif canonical == "tools":

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -402,6 +402,24 @@ class TestHistoryDisplay:
         called_with = mock_handler.call_args.args[0]
         assert called_with.lower().startswith("/sessions")
 
+    def test_whoami_command_is_dispatched_and_prints_cli_access(self, capsys):
+        """/whoami is advertised in classic CLI help and must not fall through.
+
+        Regression test: the command existed in the shared registry, so it
+        appeared in /help and completion, but classic CLI dispatch lacked a
+        matching branch and printed `Unknown command: /whoami`.
+        """
+        cli = _make_cli()
+
+        cli.process_command("/whoami")
+        output = capsys.readouterr().out
+
+        assert "Unknown command" not in output
+        assert "cli (local terminal)" in output
+        assert "Tier:" in output
+        assert "unrestricted" in output
+        assert "Slash commands: all available" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Summary

Classic CLI help and completion surfaced `/whoami` from the shared command registry,
but `HermesCLI.process_command()` had no dispatch branch for it.

This change wires `/whoami` into the classic CLI and adds regression coverage so it
no longer falls through to `Unknown command`.

## What changed

- added a small classic-CLI `/whoami` handler in `cli.py`
- routed `canonical == "whoami"` through the main slash-command dispatcher
- added a regression test in `tests/cli/test_cli_init.py`

## User impact

Before:
- `/whoami` appeared to exist in classic CLI surfaces
- running it printed `Unknown command: /whoami`

After:
- `/whoami` prints local CLI access info as expected

## Testing

Passed:

- `pytest tests/cli/test_cli_init.py -k whoami`

Environment:
- pytest completed successfully with exit code 0
