### PR TITLE
test: unblock post-25957 shared CI

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -66,6 +66,9 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
+    discord_mod.MessageType = SimpleNamespace(default=0, reply=19)
+    discord_mod.Object = lambda *, id: SimpleNamespace(id=id)
     discord_mod.Interaction = object
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -61,6 +61,8 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
     )
     if model:
         kwargs["model"] = model
+    elif provider == "nous":
+        kwargs["model"] = "gpt-5"
     base_url="https://openrouter.ai/api/v1",
     api_key="test-key",
     base_url="https://openrouter.ai/api/v1",


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining shared CI failures after #25957.

There are two small test-isolation fixes here:

1. Discord e2e mock surface: history backfill now catches `discord.Forbidden` and uses `discord.MessageType` / `discord.Object`, but the e2e mock still exposed those as generic `MagicMock` attributes. That made the expected fallback path crash with `TypeError: catching classes that do not inherit from BaseException is not allowed`.
2. Nous provider parity helper: a few provider-parity tests instantiate the Nous Portal path without passing a model. After the minimum-context guard, that empty model resolves to a 15K fallback context and fails before the tests reach the provider-format assertions. The helper now uses `gpt-5` for Nous parity tests, matching what those tests assert against later anyway.

## Related Issue

Follow-up to #25957 and latest `main` Tests run `25895188143`. Does not close a separate issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/e2e/conftest.py`
  - Adds `discord.Forbidden` as an exception class in the e2e Discord mock.
  - Adds deterministic `discord.MessageType.default` / `reply` values for history-context filtering.
  - Adds a minimal `discord.Object(id=...)` mock for cached-history `after=` support.
- `tests/run_agent/test_provider_parity.py`
  - Makes the shared test helper pass `gpt-5` for Nous provider tests when a model is not provided explicitly.

## How to Test

1. Reproduce the failed latest-main e2e nodes from run `25895188143`.
2. Run the failed provider-parity nodes from PR CI.
3. Run the focused Discord e2e file.
4. Run the full e2e suite plus provider-parity file.

Validation run locally with `scripts/run_tests.sh`:

```bash
./scripts/run_tests.sh -n 0 tests/e2e/test_discord_adapter.py -q --tb=short
# 6 passed

./scripts/run_tests.sh -n 0 \
  tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal \
  tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags \
  tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format \
  tests/e2e/test_discord_adapter.py \
  -q --tb=short
# 9 passed

./scripts/run_tests.sh -n 0 tests/run_agent/test_provider_parity.py tests/e2e -q --tb=short
# 149 passed, 7 skipped

git diff --check origin/main...HEAD
/home/w0lf/hermes-agent/venv/bin/python -m compileall -q tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
/home/w0lf/hermes-agent/venv/bin/python -m ruff check tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
# All checks passed
```

## Validation Status

- [x] Reproduced current-main e2e failure: `4 failed, 2 passed` in `tests/e2e/test_discord_adapter.py`.
- [x] Focused Discord e2e after fix: `6 passed in 2.65s`.
- [x] Newly failed provider-parity nodes plus Discord e2e after fix: `9 passed in 5.03s`.
- [x] Full e2e suite plus provider parity after fix: `149 passed, 7 skipped in 74.56s`.
- [x] `git diff --check origin/main...HEAD` passed.
- [x] `python -m compileall -q tests/e2e/conftest.py tests/run_agent/test_provider_parity.py` passed.
- [x] `python -m ruff check tests/e2e/conftest.py tests/run_agent/test_provider_parity.py` passed.
- [ ] Full `pytest tests/ -q` is not claimed here. This is intentionally a narrow CI unblocker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.11 venv via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, test fixture/helper only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — test-only changes, no runtime platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
FAILED tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_mention_then_command - TypeError: catching classes that do not inherit from BaseException is not allowed
FAILED tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_nickname_mention_then_command - TypeError: catching classes that do not inherit from BaseException is not allowed
FAILED tests/e2e/test_discord_adapter.py::TestAutoThreadingPreservesCommand::test_command_detected_after_auto_thread - TypeError: catching classes that do not inherit from BaseException is not allowed
FAILED tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_text_before_command_not_detected - TypeError: catching classes that do not inherit from BaseException is not allowed

FAILED tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal - ValueError: Model  has a context window of 15,000 tokens
FAILED tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags - ValueError: Model  has a context window of 15,000 tokens
FAILED tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format - ValueError: Model  has a context window of 15,000 tokens

149 passed, 7 skipped in 74.56s
All checks passed!
```
