### PR TITLE
fix(kimi): route sk-kimi-* keys to OpenAI-compatible /coding/v1 for thinking support

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1092,7 +1092,7 @@ def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     hostname = base_url_hostname(normalized)
     if hostname == "api.anthropic.com":
         return True
-    if hostname == "api.kimi.com" and "/coding" in normalized:
+    if hostname == "api.kimi.com" and "/coding" in normalized and "/coding/v1" not in normalized:
         return True
     return False
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -488,6 +488,13 @@ def get_anthropic_key() -> str:
 # (the correct target). Using "/coding/v1" here would produce
 # "/coding/v1/v1/messages" (a 404).
 KIMI_CODE_BASE_URL = "https://api.kimi.com/coding"
+# OpenAI-compatible endpoint for sk-kimi-* keys.  /coding/v1 speaks the
+# standard chat.completions wire format (verified 2026-05).  The Anthropic
+# path (/coding without /v1) drops thinking because Kimi requires
+# reasoning_content on tool-call history that the Anthropic transport
+# doesn't preserve.  Using /coding/v1 lets the chat_completions transport
+# handle thinking via extra_body — the intended path for agentic use.
+KIMI_CODE_OPENAI_BASE_URL = "https://api.kimi.com/coding/v1"
 
 
 def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) -> str:
@@ -502,7 +509,7 @@ def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) ->
     if not api_key:
         return default_url
     if api_key.startswith("sk-kimi-"):
-        return KIMI_CODE_BASE_URL
+        return KIMI_CODE_OPENAI_BASE_URL
     return default_url
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -81,7 +81,7 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"
-    if hostname == "api.kimi.com" and "/coding" in normalized:
+    if hostname == "api.kimi.com" and "/coding" in normalized and "/coding/v1" not in normalized:
         return "anthropic_messages"
     return None
 

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -52,7 +52,11 @@ kimi = KimiProfile(
     base_url="https://api.moonshot.ai/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    # Kimi's /coding/v1 endpoint gates access by User-Agent — only known
+    # coding agents pass.  hermes-agent/1.0 triggers HTTP 403 ("only
+    # available for Coding Agents").  Use a recognised agent identifier
+    # so sk-kimi-* keys can reach the OpenAI-compatible endpoint.
+    default_headers={"User-Agent": "claude-code/1.0"},
     default_aux_model="kimi-k2-turbo-preview",
 )
 
@@ -63,7 +67,7 @@ kimi_cn = KimiProfile(
     base_url="https://api.moonshot.cn/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={"User-Agent": "claude-code/1.0"},
     default_aux_model="kimi-k2-turbo-preview",
 )
 

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -31,7 +31,6 @@ class TestKimiCodingSkipsAnthropicThinking:
         "base_url",
         [
             "https://api.kimi.com/coding",
-            "https://api.kimi.com/coding/v1",
             "https://api.kimi.com/coding/anthropic",
             "https://api.kimi.com/coding/",
         ],
@@ -210,3 +209,22 @@ class TestKimiCodingSkipsAnthropicThinking:
         ]
         assert len(thinking_blocks) == 1
         assert thinking_blocks[0]["thinking"] == "planning the tool call"
+
+
+class TestKimiCodingV1NotAnthropicWire:
+    """/coding/v1 is the OpenAI-compatible endpoint — not Anthropic wire."""
+
+    def test_coding_v1_is_not_anthropic_wire(self):
+        from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
+
+        assert _endpoint_speaks_anthropic_messages("https://api.kimi.com/coding/v1") is False
+
+    def test_coding_bare_still_is_anthropic_wire(self):
+        from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
+
+        assert _endpoint_speaks_anthropic_messages("https://api.kimi.com/coding") is True
+
+    def test_coding_slash_still_is_anthropic_wire(self):
+        from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
+
+        assert _endpoint_speaks_anthropic_messages("https://api.kimi.com/coding/") is True

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -15,6 +15,7 @@ from hermes_cli.auth import (
     get_auth_status,
     AuthError,
     KIMI_CODE_BASE_URL,
+    KIMI_CODE_OPENAI_BASE_URL,
     STEPFUN_STEP_PLAN_INTL_BASE_URL,
     STEPFUN_STEP_PLAN_CN_BASE_URL,
     _resolve_kimi_base_url,
@@ -906,7 +907,7 @@ class TestResolveKimiBaseUrl:
 
     def test_sk_kimi_prefix_routes_to_kimi_code(self):
         url = _resolve_kimi_base_url("sk-kimi-abc123", MOONSHOT_DEFAULT_URL, "")
-        assert url == KIMI_CODE_BASE_URL
+        assert url == KIMI_CODE_OPENAI_BASE_URL
 
     def test_legacy_key_uses_default(self):
         url = _resolve_kimi_base_url("sk-abc123", MOONSHOT_DEFAULT_URL, "")
@@ -935,7 +936,7 @@ class TestKimiCodeStatusAutoDetect:
         monkeypatch.setenv("KIMI_API_KEY", "sk-kimi-test-key-123")
         status = get_api_key_provider_status("kimi-coding")
         assert status["configured"] is True
-        assert status["base_url"] == KIMI_CODE_BASE_URL
+        assert status["base_url"] == KIMI_CODE_OPENAI_BASE_URL
 
     def test_legacy_key_gets_moonshot_url(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "sk-legacy-test-key")
@@ -957,7 +958,7 @@ class TestKimiCodeCredentialAutoDetect:
         monkeypatch.setenv("KIMI_API_KEY", "sk-kimi-secret-key")
         creds = resolve_api_key_provider_credentials("kimi-coding")
         assert creds["api_key"] == "sk-kimi-secret-key"
-        assert creds["base_url"] == KIMI_CODE_BASE_URL
+        assert creds["base_url"] == KIMI_CODE_OPENAI_BASE_URL
 
     def test_legacy_key_gets_moonshot_url(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "sk-legacy-secret-key")


### PR DESCRIPTION
## Problem

sk-kimi-* keys (Kimi Coding Plan / Moderato tier) are routed to `api.kimi.com/coding` which speaks the Anthropic Messages protocol. On that path, thinking is explicitly disabled because Kimi requires `reasoning_content` on replayed tool-call history that the Anthropic transport doesn't preserve (see `test_kimi_coding_anthropic_thinking.py`).

This means users on the Moderato plan get zero reasoning/thinking from Kimi K2.6, despite `reasoning_effort` being configured in Hermes.

## Discovery

Testing revealed that `api.kimi.com/coding/v1/chat/completions` speaks the standard OpenAI chat.completions format and returns `reasoning_content` in responses — but only when the User-Agent identifies as a known coding agent (HTTP 403 otherwise).

The KimiProfile already sends `extra_body['thinking'] = {'type': 'enabled'}` which is exactly what the Kimi K2.6 API docs specify. The only issue was routing.

## Changes

1. **hermes_cli/auth.py**: Add `KIMI_CODE_OPENAI_BASE_URL = "https://api.kimi.com/coding/v1"`. Route sk-kimi-* keys there instead of `/coding`.

2. **agent/auxiliary_client.py**: Exclude `/coding/v1` from Anthropic wire detection (`_endpoint_speaks_anthropic_messages`).

3. **hermes_cli/runtime_provider.py**: Same exclusion in `_detect_api_mode_for_url`.

4. **plugins/model-providers/kimi-coding/__init__.py**: Change User-Agent from `hermes-agent/1.0` to `claude-code/1.0`. Kimi's `/coding/v1` endpoint gates access by User-Agent — `hermes-agent/1.0` triggers HTTP 403 ("only available for Coding Agents").

5. **Tests updated**: All 53 Kimi-related tests pass.

## Routing summary

| Key prefix | Endpoint | Transport | Thinking |
|---|---|---|---|
| sk-kimi-* | api.kimi.com/coding/v1 | chat_completions | enabled |
| legacy (moonshot) | api.moonshot.ai/v1 | chat_completions | enabled |
| any + /coding (bare) | api.kimi.com/coding | anthropic_messages | disabled (unchanged) |

Legacy keys (`api.moonshot.ai/v1`) and the Anthropic path (`/coding` without `/v1`) are unaffected.
