### PR TITLE
fix: strip OSC-8 hyperlink sequences in ChatConsole

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2061,6 +2061,13 @@ class ChatConsole:
     that expects a console.print() interface.
     """
 
+    # OSC-8 terminal hyperlink escape sequences.  Rich emits these for
+    # ``[link=URL]text[/link]`` markup.  prompt_toolkit's ANSI() renderer
+    # does not understand OSC-8 — it strips the ``\x1b]`` / ``\x1b\\``
+    # delimiters but leaves the URL params visible as garbage text.
+    # Strip them here so hyperlinks degrade gracefully to plain text.
+    _OSC_8_RE = re.compile(r'\x1b\]8;[^\x07\x1b]*?(?:\x07|\x1b\\)')
+
     def __init__(self):
         from io import StringIO
         self._buffer = StringIO()
@@ -2078,6 +2085,8 @@ class ChatConsole:
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
         output = self._buffer.getvalue()
+        # Strip OSC-8 hyperlink sequences before routing through prompt_toolkit
+        output = self._OSC_8_RE.sub('', output)
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 


### PR DESCRIPTION
## Problem

When using `/clear`, `/reset`, or `/new` in the interactive CLI, the welcome banner renders raw OSC-8 hyperlink escape sequences as visible garbage text.

## Root Cause

1. Rich's `[link=URL]text[/link]` markup generates OSC-8 terminal hyperlink sequences
2. `ChatConsole.print()` captures Rich output and routes through `_cprint` -> `prompt_toolkit.ANSI()`
3. prompt_toolkit's `ANSI()` renderer strips the `]` / `\` delimiters but leaves URL params visible

## Fix

Add a targeted OSC-8-only regex strip in `ChatConsole.print()` before routing through `_cprint`:

```python
_OSC_8_RE = re.compile(r'\]8;[^]*?(?:|\)')

# In print():
output = self._OSC_8_RE.sub('', output)
```

This is lighter than `strip_ansi()` which would also remove SGR color codes we want to keep.

Fixes #25939