### PR TITLE
fix(run_agent): recover first object from concatenated tool_call args (#25333)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -783,6 +783,13 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     "invalid tool call arguments".  This function applies common repairs;
     if all fail it returns ``"{}"`` so the request succeeds (better than
     crashing the session).  All repairs are logged at WARNING level.
+
+    ``gemini-3-flash-preview`` (and any provider whose streaming tool-call
+    accumulator merges parallel tool-call argument deltas into one buffer)
+    occasionally emits two complete JSON objects back-to-back with no
+    delimiter -- ``{...}{...}``.  The first object is recoverable via
+    ``raw_decode``; the trailing-object is dropped with a clear log line
+    so the caller can investigate (see #25333).
     """
     raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
 
@@ -810,6 +817,30 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 tool_name,
             )
         return reserialised
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    # Repair pass 0.5: concatenated top-level JSON objects (gemini-3-flash-
+    # preview parallel tool-call accumulator merges multiple tool_call args
+    # into one field with no delimiter -- see #25333). ``raw_decode`` parses
+    # the first complete JSON value and reports where it ended; any
+    # non-whitespace content after that boundary is the concatenation
+    # signature. Recover the first object so at least one tool call lands
+    # instead of dropping both.
+    try:
+        decoder = json.JSONDecoder()
+        first_obj, end_idx = decoder.raw_decode(raw_stripped, idx=0)
+        trailing = raw_stripped[end_idx:].lstrip()
+        if trailing:
+            reserialised = json.dumps(first_obj, separators=(",", ":"))
+            logger.warning(
+                "Recovered first object from concatenated tool_call arguments "
+                "for %s -- kept first object, dropped %d trailing chars (likely "
+                "the streaming tool-call accumulator merged parallel calls; "
+                "see #25333). Dropped tail starts: %s",
+                tool_name, len(trailing), trailing[:60],
+            )
+            return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -141,3 +141,76 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    # -- Stage 0.5: concatenated top-level JSON objects (#25333) --
+    # gemini-3-flash-preview occasionally emits parallel tool-call args
+    # merged into one buffer as `}{` with no delimiter. raw_decode parses
+    # the first complete object; we keep that and drop the trailing
+    # concatenation with a clear log line so at least one tool call lands.
+
+    def test_two_concatenated_objects_keeps_first(self):
+        """Real-world repro from yantrikos/yantrikdb-hermes-plugin#5:
+        gemini-3-flash-preview emitted two complete ``yantrikdb_relate``
+        argument objects back-to-back with no delimiter."""
+        raw = (
+            '{"entity": "Don Bowman", "relationship": "ceo_of", "target": "Agilicus"}'
+            '{"entity": "Don Bowman", "relationship": "works_at", "target": "Agilicus"}'
+        )
+        result = _repair_tool_call_arguments(raw, "yantrikdb_relate")
+        parsed = json.loads(result)
+        # First object preserved, second dropped (caller can still see the
+        # warning log line and act on it if needed).
+        assert parsed == {
+            "entity": "Don Bowman",
+            "relationship": "ceo_of",
+            "target": "Agilicus",
+        }
+
+    def test_concatenated_objects_with_braces_inside_strings(self):
+        """The boundary detector must not be confused by `}{` characters
+        that appear *inside* a JSON string value."""
+        raw = (
+            '{"snippet": "if (cfg) { run(); }", "ok": true}'
+            '{"snippet": "second call", "ok": false}'
+        )
+        result = _repair_tool_call_arguments(raw, "t")
+        parsed = json.loads(result)
+        assert parsed["snippet"] == "if (cfg) { run(); }"
+        assert parsed["ok"] is True
+
+    def test_three_concatenated_objects_keeps_only_first(self):
+        """When the model glues N>2 objects, still only the first is
+        recovered. The remaining N-1 are dropped (with a warning) — a
+        higher-fidelity recovery is a fix for the streaming accumulator,
+        not this repair pass."""
+        raw = '{"i": 1}{"i": 2}{"i": 3}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"i": 1}
+
+    def test_first_object_invalid_then_trailing_object_still_falls_back(self):
+        """If the first object is itself malformed, raw_decode fails and
+        the trailing-object pass shouldn't claim to recover anything.
+        We expect the existing brace-counting heuristic to take over (or
+        the final {} fallback if all repair stages fail)."""
+        raw = '{"a": 1,}{"b": 2}'
+        result = _repair_tool_call_arguments(raw, "t")
+        # The downstream trailing-comma + raw_decode flow recovers {"a":1}
+        # from the leading object. Either {"a": 1} or {} is acceptable here;
+        # what we MUST NOT do is silently emit invalid JSON.
+        parsed = json.loads(result)
+        assert parsed in ({}, {"a": 1})
+
+    def test_concatenated_at_array_top_level(self):
+        """raw_decode works equally well for top-level arrays, though
+        tool_call args are usually objects. Cover the case for safety."""
+        raw = '[1, 2, 3][4, 5]'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == [1, 2, 3]
+
+    def test_single_object_with_trailing_whitespace_is_not_treated_as_concatenation(self):
+        """The raw_decode pass should not log a warning or drop content when
+        the only trailing content is whitespace — that's a normal valid
+        input, handled by the strict=False pass above."""
+        raw = '{"key": "value"}   \n\t'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"key": "value"}
+


### PR DESCRIPTION
## Summary

`gemini-3-flash-preview` occasionally emits two parallel tool-call argument deltas merged into one streaming buffer with no delimiter, producing inputs like:

```
{"entity": "X", "relationship": "works_at", "target": "Y"}{"entity": "X", "relationship": "ceo_of", "target": "Y"}
```

The existing `_repair_tool_call_arguments` cascade (strict=False → trailing-comma strip → brace-balance heuristic → control-char escape) doesn't handle this shape:

- `strict=False` `json.loads` fails on the extra data ("Extra data: line 1 column N")
- The brace counts are already balanced (2 `{` and 2 `}`), so the brace-balance heuristic is a no-op
- Input falls through to the `{}` fallback — **both tool calls are dropped**

This PR adds a repair pass that uses `json.JSONDecoder.raw_decode()` to extract the first complete top-level JSON value. If anything non-whitespace follows the parsed boundary, we log a warning naming #25333 and return the first object. At least one of the two parallel tool calls then lands instead of both being dropped.

`raw_decode` respects JSON string semantics, so the boundary detector is not fooled by `}{` characters appearing inside string values (test `test_concatenated_objects_with_braces_inside_strings` covers this).

## Relationship to PR #24676

This is the **parser-side** counterpart to the streaming-accumulator fix in #24676. That PR fixes the upstream cause (the accumulator shouldn't merge parallel deltas in the first place); this PR makes the parser graceful when the upstream cause does slip through. The two are complementary; both can land independently.

## Test Plan

- 7 new test cases in `tests/run_agent/test_repair_tool_call_arguments.py` covering:
  - Two concatenated objects → keep first (the exact repro from #25333)
  - Three+ concatenated objects → keep only first
  - Braces inside string values (`{"snippet": "if (cfg) { run(); }"}`) → no false-positive boundary
  - Trailing whitespace only → no false positive
  - Top-level arrays → also handled
  - Malformed first object → graceful fallback (doesn't claim a bad recovery)
- All 27 cases pass: `python -m pytest tests/run_agent/test_repair_tool_call_arguments.py -p no:xdist -o addopts= -v`

## Reproducer

The bug surfaced in [yantrikos/yantrikdb-hermes-plugin#5](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/5), filed as #25333 here. With `model=gemini-3-flash-preview` and the message "import the builtin memories into yantrikdb", Hermes logs:

```
2026-05-13 21:01:30,386 WARNING run_agent: Unrepairable tool_call arguments for yantrikdb_relate — replaced with empty object (was: {"entity": "Don Bowman", "relationship": "ceo_of", "target": "Agilicus"}{"entity)
```

The trailing `{"entity` is the start of a second `yantrikdb_relate` call. With this patch the first call now lands cleanly; the second is dropped with a clear log line so operators can investigate further. Closing #24676 will additionally fix the upstream merge so neither call is ever dropped.

Refs:
- Closes #25333
- Related: #24676
