### PR TITLE
fix(transport): strip internal scaffolding keys + classify 5xx validation errors as non-retryable

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -213,6 +213,24 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "unsupported model",
 ]
 
+# Request-validation patterns — the request is malformed and will fail
+# identically on every retry. Some OpenAI-compatible gateways (notably
+# codex.nekos.me) return these as 5xx instead of the standard 4xx, which
+# makes the generic "5xx → retryable server_error" rule misfire: the retry
+# loop hammers the same deterministic rejection 3+ times, then the
+# transport-recovery path resets the counter and does it again, producing
+# a request flood. When a 5xx body carries one of these unambiguous
+# request-validation signals, classify as a non-retryable format_error so
+# the loop fails fast and falls back instead of looping.
+_REQUEST_VALIDATION_PATTERNS = [
+    "unknown parameter",
+    "unsupported parameter",
+    "unrecognized request argument",
+    "invalid_request_error",
+    "unknown_parameter",
+    "unsupported_parameter",
+]
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -689,6 +707,23 @@ def _classify_by_status(
         )
 
     if status_code in {500, 502}:
+        # Some OpenAI-compatible gateways return request-validation errors
+        # with a 5xx status (codex.nekos.me returns 502 for unknown/
+        # unsupported parameters). These are deterministic — every retry
+        # gets the identical rejection — so the generic "5xx → retryable
+        # server_error" rule turns one bad request into a retry flood.
+        # Detect the unambiguous request-validation signals (in either the
+        # message text or the structured error code) and fail fast.
+        if (
+            any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
+            or error_code.lower() in {"invalid_request_error", "unknown_parameter",
+                                      "unsupported_parameter"}
+        ):
+            return result_fn(
+                FailoverReason.format_error,
+                retryable=False,
+                should_fallback=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -112,17 +112,33 @@ class ChatCompletionsTransport(ProviderTransport):
     def convert_messages(
         self, messages: list[dict[str, Any]], **kwargs
     ) -> list[dict[str, Any]]:
-        """Messages are already in OpenAI format — sanitize Codex leaks only.
+        """Messages are already in OpenAI format — sanitize internal leaks only.
 
-        Strips Codex Responses API fields (``codex_reasoning_items`` /
-        ``codex_message_items`` on the message, ``call_id``/``response_item_id``
-        on tool_calls) that strict chat-completions providers reject with 400/422.
+        Strips two classes of fields that strict chat-completions backends
+        reject with 400/422 (or, in the case of some OpenAI-compatible
+        gateways, 502):
+
+        1. Codex Responses API fields — ``codex_reasoning_items`` /
+           ``codex_message_items`` on the message, ``call_id`` /
+           ``response_item_id`` on tool_calls.
+        2. Hermes-internal scaffolding markers — any top-level message key
+           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
+           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
+           bookkeeping flags the agent loop attaches to messages; they must
+           never reach the wire. Permissive providers (real OpenAI,
+           Anthropic) silently ignore unknown message keys, but strict
+           gateways reject them — e.g. codex.nekos.me returns
+           ``502 Unknown parameter: 'input[N]._empty_recovery_synthetic'``,
+           which then poisons every subsequent request in the session.
         """
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
             if "codex_reasoning_items" in msg or "codex_message_items" in msg:
+                needs_sanitize = True
+                break
+            if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -145,6 +161,11 @@ class ChatCompletionsTransport(ProviderTransport):
                 continue
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
+            # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
+            # OpenAI's message schema has no ``_``-prefixed fields, so this
+            # is safe and future-proofs against new markers being added.
+            for key in [k for k in msg if isinstance(k, str) and k.startswith("_")]:
+                msg.pop(key, None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -292,6 +292,64 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    # ── 5xx that are actually request-validation errors ──
+    # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
+    # request-validation failures with a 5xx status. These are
+    # deterministic, so they must NOT be retried — otherwise the retry
+    # loop hammers the identical bad request into a flood.
+
+    def test_502_with_unknown_parameter_is_non_retryable(self):
+        e = MockAPIError(
+            "Unknown parameter: 'input[617]._empty_recovery_synthetic'",
+            status_code=502,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": (
+                        "[ObjectParam] [input[617]._empty_recovery_synthetic] "
+                        "[unknown_parameter] Unknown parameter: "
+                        "'input[617]._empty_recovery_synthetic'."
+                    ),
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_502_with_unsupported_parameter_is_non_retryable(self):
+        e = MockAPIError(
+            "Unsupported parameter: logprobs",
+            status_code=502,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Unsupported parameter: logprobs",
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_500_with_invalid_request_error_type_is_non_retryable(self):
+        e = MockAPIError(
+            "bad request",
+            status_code=500,
+            body={"error": {"type": "invalid_request_error", "message": "bad request"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_502_plain_bad_gateway_still_retryable(self):
+        """A genuine 502 with no request-validation signal stays retryable."""
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,38 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
+        """Hermes-internal ``_``-prefixed markers must never reach the wire.
+
+        The empty-response recovery path appends synthetic messages tagged
+        with ``_empty_recovery_synthetic``; permissive providers ignore the
+        unknown key, but strict gateways (codex.nekos.me) reject it with a
+        502, poisoning every later request in the session.
+        """
+        msgs = [
+            {"role": "user", "content": "run the task"},
+            {"role": "assistant", "content": "(empty)", "_empty_recovery_synthetic": True},
+            {"role": "user", "content": "continue", "_empty_recovery_synthetic": True},
+            {"role": "assistant", "content": "done", "_thinking_prefill": True,
+             "_empty_terminal_sentinel": True},
+        ]
+        result = transport.convert_messages(msgs)
+        for m in result:
+            assert not any(k.startswith("_") for k in m), m
+        # Visible content preserved
+        assert result[1]["content"] == "(empty)"
+        assert result[2]["content"] == "continue"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["_empty_recovery_synthetic"] is True
+
+    def test_convert_messages_clean_list_is_identity(self, transport):
+        """A list with no internal/codex keys is returned as-is (no copy)."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert transport.convert_messages(msgs) is msgs
+
 
 class TestChatCompletionsBuildKwargs:
 


### PR DESCRIPTION
## Summary

Two related fixes for a deterministic-error retry flood observed when running against strict OpenAI-compatible gateways. The empty-response recovery path leaks an internal bookkeeping key onto the wire; the error classifier then mistakes the gateway's deterministic rejection for a transient server error and retries it into a flood.

## The bug

The empty-response recovery path in `run_agent.py` appends synthetic messages tagged with `_empty_recovery_synthetic`:

```python
_nudge_msg["_empty_recovery_synthetic"] = True
messages.append(_nudge_msg)
messages.append({"role": "user", "content": "...", "_empty_recovery_synthetic": True})
```

These are internal markers (so `_drop_trailing_empty_response_scaffolding` can later identify and strip them from the persisted transcript). They are **not** meant to reach the API.

`chat_completions`' `convert_messages` sanitizes Codex Responses leak fields (`codex_reasoning_items`, `call_id`, …) but **not** these `_`-prefixed markers. Real OpenAI and Anthropic silently ignore unknown message keys, so the bug stayed hidden there. Strict OpenAI-compatible gateways reject them:

```
502: [ObjectParam] [input[617]._empty_recovery_synthetic]
     [unknown_parameter] Unknown parameter: '_empty_recovery_synthetic'
```

Because the synthetic messages persist in the session, **every** subsequent request in that session carries the poisoned key and fails identically. The error classifier maps `502` → `server_error` → `retryable=True`, so the retry loop burns all 3 attempts, the transport-recovery path resets the counter and burns 3 more — a request flood against a request that can never succeed.

## Fix 1 — `chat_completions` transport (`agent/transports/chat_completions.py`)

`convert_messages` now drops any top-level message key starting with `_` (covers `_empty_recovery_synthetic`, `_empty_terminal_sentinel`, `_thinking_prefill`, and any future internal markers). OpenAI's message schema has no `_`-prefixed fields, so this is safe and future-proof. Deepcopy-on-demand semantics preserved — a clean message list is still returned by identity.

## Fix 2 — error classifier (`agent/error_classifier.py`)

Standard OpenAI returns request-validation failures as `4xx`. Some OpenAI-compatible gateways return them as `5xx` instead. When a `500`/`502` body carries an unambiguous request-validation signal — `unknown parameter` / `unsupported parameter` / `invalid_request_error` in the message text, or `invalid_request_error` / `unknown_parameter` / `unsupported_parameter` as the structured error code — it's now classified as a non-retryable `format_error` so the loop fails fast and falls back instead of flooding. Genuine `502 Bad Gateway` with no such signal stays retryable as before.

Fix 1 is the root cause; Fix 2 is defense-in-depth so any other deterministic `5xx`-as-validation-error can't produce the same flood.

## Tests

- `tests/agent/transports/test_chat_completions.py` — new: internal `_`-prefixed markers stripped; visible content preserved; original list untouched; clean list returned by identity.
- `tests/agent/test_error_classifier.py` — new: `502` + `unknown parameter` → non-retryable `format_error`; `502` + `unsupported parameter`; `500` + `invalid_request_error` error-code; plain `502 Bad Gateway` stays retryable.

All 448 tests in `tests/agent/transports/` + `tests/agent/test_error_classifier.py` + `tests/providers/test_transport_parity.py` pass. (`tests/run_agent/test_provider_parity.py` has 3 pre-existing failures unrelated to this change — they hit the live Nous API and fail on a context-window check; verified failing on pristine `main`.)
