### PR TITLE
fix(feishu): preserve image/attachment context when replying to non-text messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3918,6 +3918,16 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         if normalized.text_content:
             return normalized.text_content
+        # For image messages the text_content is empty but we still have
+        # image_keys -- return a placeholder so reply-to-image context is
+        # not silently lost.  (Fixes #26037.)
+        if getattr(normalized, "image_keys", None):
+            keys_str = ", ".join(normalized.image_keys)
+            return f"[Image: {keys_str}]"
+        # Same idea for file/audio/media attachments.
+        if getattr(normalized, "media_refs", None):
+            names = [getattr(r, "file_name", "") or "attachment" for r in normalized.media_refs]
+            return f"[Attachment: {', '.join(names)}]"
         placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
         return str(placeholder).strip() or None
 


### PR DESCRIPTION
## Summary

Fixes #26037 — When a user replies to an image (or file/audio) message in Feishu, `_fetch_message_text()` returns `None` because `_extract_text_from_raw_content()` only checks `text_content` and `placeholder_text`, both of which are empty for image messages.

## Root Cause

`normalize_feishu_message()` correctly parses image messages and populates `image_keys`, but sets `text_content=''` when the alt text equals `FALLBACK_IMAGE_TEXT`. The downstream `_extract_text_from_raw_content()` method never checks `image_keys`, so the parent context is silently lost.

## Fix

In `_extract_text_from_raw_content()`, after the `text_content` check, add fallback handlers:
- **Image messages**: return `[Image: img_key_xxx]` using `normalized.image_keys`
- **File/audio/media**: return `[Attachment: filename]` using `normalized.media_refs`

This gives the agent enough context to know what the user is replying to and potentially use `vision_analyze` for image content.

## Testing

407 Feishu tests passed, 0 failures.

## Scope

1 file changed (`gateway/platforms/feishu.py`), 10 lines added.