### PR TITLE
feat(url_safety): add allow_benchmark_ips to exempt RFC 2544 benchmark range 198.18.0.0/15

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,16 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_API_KEY", raising=False)
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
+    # Reset URL-safety benchmark-IP cache so that tests can reliably toggle
+    # HERMES_ALLOW_BENCHMARK_IPS via setenv/delenv without the module-level
+    # cache from a previous test leaking into the current one.
+    try:
+        from tools.url_safety import _reset_allow_private_cache
+
+        _reset_allow_private_cache()
+    except Exception:
+        pass
+
 
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -159,25 +159,32 @@ class TestIsSafeUrl:
             # 100.0.0.1 is a global IP, not in CGNAT range
             assert is_safe_url("http://legit-host.example/") is True
 
-    def test_benchmark_ip_blocked_for_non_allowlisted_host(self):
+    def test_benchmark_ip_blocked_for_non_allowlisted_host(self, monkeypatch):
+        """198.18.x.x is blocked for non-trusted hostnames by default."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
             assert is_safe_url("https://example.com/file.jpg") is False
 
     def test_qq_multimedia_hostname_allowed_with_benchmark_ip(self):
+        """multimedia.nt.qq.com.cn bypasses IP-level blocking via allow_private_ip."""
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is True
 
-    def test_qq_multimedia_hostname_exception_is_exact_match(self):
+    def test_qq_multimedia_hostname_exception_is_exact_match(self, monkeypatch):
+        """Subdomains of multimedia.nt.qq.com.cn are NOT exempted."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
             assert is_safe_url("https://sub.multimedia.nt.qq.com.cn/download?id=123") is False
 
-    def test_qq_multimedia_hostname_exception_requires_https(self):
+    def test_qq_multimedia_hostname_exception_requires_https(self, monkeypatch):
+        """HTTP variant of multimedia.nt.qq.com.cn is NOT exempted."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
@@ -593,3 +600,29 @@ class TestBenchmarkIpIntegration:
             (2, 1, 6, "", ("140.82.121.4", 0)),  # github.com real IP
         ]):
             assert is_safe_url("https://github.com/") is True
+
+    def test_allow_benchmark_does_not_bypass_private_ssrf(self, monkeypatch):
+        """allow_benchmark=true must NOT open access to private IPs (10.x, 192.168.x, etc.).
+        This was the logic bug reported in review: benchmark and private-IP toggles are
+        independent. Regression test for https://github.com/NousResearch/hermes-agent/pull/26064."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "false")
+        cfg = {"security": {"allow_benchmark_ips": True, "allow_private_urls": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            # Private IP must still be blocked even when benchmark toggle is on
+            for ip in ["10.0.0.1", "192.168.1.1", "172.16.0.1"]:
+                with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", (ip, 0))]):
+                    assert is_safe_url(f"https://{ip}/") is False, f"{ip} should still be blocked"
+
+    def test_allow_benchmark_only_affects_benchmark_range(self, monkeypatch):
+        """CGNAT (100.64.x.x) and link-local (169.254.x.x) remain blocked even with
+        allow_benchmark_ips=true — they are in _is_blocked_ip but outside _BENCHMARK_NETWORK."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        cfg = {"security": {"allow_benchmark_ips": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            # CGNAT — blocked (in _is_blocked_ip but not in _BENCHMARK_NETWORK)
+            with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("100.64.0.1", 0))]):
+                assert is_safe_url("https://cgnat.example/") is False
+            # Link-local — blocked
+            with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("169.254.169.254", 0))]):
+                assert is_safe_url("https://linklocal.example/") is False

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -8,6 +8,7 @@ from tools.url_safety import (
     is_always_blocked_url,
     _is_blocked_ip,
     _global_allow_private_urls,
+    _global_allow_benchmark_ips,
     _reset_allow_private_cache,
 )
 
@@ -474,3 +475,121 @@ class TestIsAlwaysBlockedUrl:
         """security.allow_private_urls can NOT unblock cloud metadata."""
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
         assert is_always_blocked_url("http://169.254.169.254/") is True
+
+
+class TestGlobalAllowBenchmarkIps:
+    """Tests for the security.allow_benchmark_ips config toggle."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """Reset both toggle caches before and after each test."""
+        _reset_allow_private_cache()
+        yield
+        _reset_allow_private_cache()
+
+    def test_default_is_false(self, monkeypatch):
+        """Toggle defaults to False when no env var or config is set."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
+        with patch("hermes_cli.config.read_raw_config", side_effect=Exception("no config")):
+            assert _global_allow_benchmark_ips() is False
+
+    def test_env_var_true(self, monkeypatch):
+        """HERMES_ALLOW_BENCHMARK_IPS=true enables the toggle."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        assert _global_allow_benchmark_ips() is True
+
+    def test_env_var_1(self, monkeypatch):
+        """HERMES_ALLOW_BENCHMARK_IPS=1 enables the toggle."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "1")
+        assert _global_allow_benchmark_ips() is True
+
+    def test_env_var_yes(self, monkeypatch):
+        """HERMES_ALLOW_BENCHMARK_IPS=yes enables the toggle."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "yes")
+        assert _global_allow_benchmark_ips() is True
+
+    def test_env_var_false(self, monkeypatch):
+        """HERMES_ALLOW_BENCHMARK_IPS=false keeps it disabled."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "false")
+        assert _global_allow_benchmark_ips() is False
+
+    def test_config_security_section(self, monkeypatch):
+        """security.allow_benchmark_ips in config enables the toggle."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
+        cfg = {"security": {"allow_benchmark_ips": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _global_allow_benchmark_ips() is True
+
+    def test_env_var_overrides_config(self, monkeypatch):
+        """Env var takes priority over config."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "false")
+        cfg = {"security": {"allow_benchmark_ips": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _global_allow_benchmark_ips() is False
+
+    def test_result_is_cached(self, monkeypatch):
+        """Second call uses cached result, doesn't re-read config."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        assert _global_allow_benchmark_ips() is True
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "false")
+        assert _global_allow_benchmark_ips() is True  # still cached
+
+
+class TestBenchmarkIpIntegration:
+    """Integration tests: is_safe_url respects the benchmark-IP toggle."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        _reset_allow_private_cache()
+        yield
+        _reset_allow_private_cache()
+
+    def test_benchmark_ip_blocked_by_default(self, monkeypatch):
+        """198.18.x.x is blocked when allow_benchmark_ips is off."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
+        with patch("hermes_cli.config.read_raw_config", return_value={"security": {}}):
+            with patch("socket.getaddrinfo", return_value=[
+                (2, 1, 6, "", ("198.18.0.23", 0)),
+            ]):
+                assert is_safe_url("https://github.com/robots.txt") is False
+
+    def test_benchmark_ip_allowed_when_toggle_on(self, monkeypatch):
+        """198.18.x.x passes is_safe_url when allow_benchmark_ips is enabled."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.23", 0)),
+        ]):
+            assert is_safe_url("https://github.com/robots.txt") is True
+
+    def test_benchmark_ip_allowed_via_config(self, monkeypatch):
+        """allow_benchmark_ips via config.yaml also works."""
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
+        cfg = {"security": {"allow_benchmark_ips": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            with patch("socket.getaddrinfo", return_value=[
+                (2, 1, 6, "", ("198.18.255.255", 0)),
+            ]):
+                assert is_safe_url("https://pypi.org/") is True
+
+    def test_private_toggle_allows_benchmark_ip_too(self, monkeypatch):
+        """When allow_private_urls=true, _is_blocked_ip is never called (short-circuit),
+        so benchmark IPs pass as a side-effect.  This is fine — users who set
+        allow_private_urls=true have already opted out of SSRF protection for
+        all private ranges.  The dedicated allow_benchmark_ips toggle is the
+        correct choice for DNS-fake-IP environments without disabling SSRF entirely."""
+        monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+        monkeypatch.delenv("HERMES_ALLOW_BENCHMARK_IPS", raising=False)
+        cfg = {"security": {"allow_benchmark_ips": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            with patch("socket.getaddrinfo", return_value=[
+                (2, 1, 6, "", ("198.18.0.23", 0)),
+            ]):
+                assert is_safe_url("https://example.com/") is True
+
+    def test_public_url_still_allowed_with_toggle_on(self, monkeypatch):
+        """Benchmark toggle doesn't break normal public URLs."""
+        monkeypatch.setenv("HERMES_ALLOW_BENCHMARK_IPS", "true")
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("140.82.121.4", 0)),  # github.com real IP
+        ]):
+            assert is_safe_url("https://github.com/") is True

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -359,12 +359,18 @@ def is_safe_url(url: str) -> bool:
                 )
                 return False
 
-            if not allow_all_private and not allow_private_ip and not allow_benchmark and _is_blocked_ip(ip):
-                logger.warning(
-                    "Blocked request to private/internal address: %s -> %s",
-                    hostname, ip_str,
-                )
-                return False
+            if not allow_all_private and not allow_private_ip and _is_blocked_ip(ip):
+                if allow_benchmark and ip in _BENCHMARK_NETWORK:
+                    logger.debug(
+                        "Allowing benchmark-IP resolution (security.allow_benchmark_ips=true): %s",
+                        hostname,
+                    )
+                else:
+                    logger.warning(
+                        "Blocked request to private/internal address: %s -> %s",
+                        hostname, ip_str,
+                    )
+                    return False
 
         if allow_all_private:
             logger.debug(

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -69,6 +69,13 @@ _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
+# 198.18.0.0/15 (Benchmark Testing Range, RFC 2544) — reserved for benchmark
+# testing of inter-network communications.  Used by DNS-based proxies / fake-IP
+# systems that redirect external domains to this range.  Not covered by
+# ipaddress.is_private or is_global.  Blocked by default; exempted only when
+# ``security.allow_benchmark_ips: true`` in config.yaml.
+_BENCHMARK_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+
 # ---------------------------------------------------------------------------
 # Global toggle: allow private/internal IP resolution
 # ---------------------------------------------------------------------------
@@ -133,6 +140,54 @@ def _reset_allow_private_cache() -> None:
     global _allow_private_resolved, _cached_allow_private
     _allow_private_resolved = False
     _cached_allow_private = False
+    global _allow_benchmark_resolved, _cached_allow_benchmark
+    _allow_benchmark_resolved = False
+    _cached_allow_benchmark = False
+
+
+# Cached after first read so we don't hit the filesystem on every URL check.
+_allow_benchmark_resolved = False
+_cached_allow_benchmark: bool = False
+
+
+def _global_allow_benchmark_ips() -> bool:
+    """Return True when the user has opted into benchmark-IP resolution.
+
+    Checks (in priority order):
+    1. ``HERMES_ALLOW_BENCHMARK_IPS`` env var  (``true``/``1``/``yes``)
+    2. ``security.allow_benchmark_ips`` in config.yaml
+
+    Result is cached for the process lifetime.
+    """
+    global _allow_benchmark_resolved, _cached_allow_benchmark
+    if _allow_benchmark_resolved:
+        return _cached_allow_benchmark
+
+    _allow_benchmark_resolved = True
+    _cached_allow_benchmark = False  # safe default
+
+    # 1. Env var override (highest priority)
+    env_val = os.getenv("HERMES_ALLOW_BENCHMARK_IPS", "").strip().lower()
+    if env_val in {"true", "1", "yes"}:
+        _cached_allow_benchmark = True
+        return _cached_allow_benchmark
+    if env_val in {"false", "0", "no"}:
+        return _cached_allow_benchmark
+
+    # 2. Config file
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        sec = cfg.get("security", {})
+        if isinstance(sec, dict) and is_truthy_value(
+            sec.get("allow_benchmark_ips"), default=False
+        ):
+            _cached_allow_benchmark = True
+            return _cached_allow_benchmark
+    except Exception:
+        pass
+
+    return _cached_allow_benchmark
 
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
@@ -143,6 +198,9 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         return True
     # CGNAT range not covered by is_private
     if ip in _CGNAT_NETWORK:
+        return True
+    # Benchmark range (198.18.0.0/15) — blocked unless user opted in
+    if ip in _BENCHMARK_NETWORK:
         return True
     return False
 
@@ -275,6 +333,7 @@ def is_safe_url(url: str) -> bool:
         allow_all_private = _global_allow_private_urls()
 
         allow_private_ip = _allows_private_ip_resolution(hostname, scheme)
+        allow_benchmark = _global_allow_benchmark_ips()
 
         # Try to resolve and check IP
         try:
@@ -300,7 +359,7 @@ def is_safe_url(url: str) -> bool:
                 )
                 return False
 
-            if not allow_all_private and not allow_private_ip and _is_blocked_ip(ip):
+            if not allow_all_private and not allow_private_ip and not allow_benchmark and _is_blocked_ip(ip):
                 logger.warning(
                     "Blocked request to private/internal address: %s -> %s",
                     hostname, ip_str,
@@ -310,6 +369,11 @@ def is_safe_url(url: str) -> bool:
         if allow_all_private:
             logger.debug(
                 "Allowing private/internal resolution (security.allow_private_urls=true): %s",
+                hostname,
+            )
+        elif allow_benchmark:
+            logger.debug(
+                "Allowing benchmark-IP resolution (security.allow_benchmark_ips=true): %s",
                 hostname,
             )
         elif allow_private_ip:


### PR DESCRIPTION
## Summary

In DNS fake IP environments (common in China),  /  can resolve to IPs in  (RFC 2544 benchmark range). Hermes correctly identifies these as non-private, but had no way to exempt them, causing false positives.

This PR adds an independent `allow_benchmark_ips` toggle to precisely control `198.18.0.0/15` without affecting other reserved ranges or SSRF protection.

## Config
```yaml
security:
  allow_benchmark_ips: false  # default off
```

## Priority
1. `HERMES_ALLOW_BENCHMARK_IPS` env var (highest)
2. `security.allow_benchmark_ips` in config.yaml
3. Default: `false` (benchmarks blocked)

## What is NOT affected
- `allow_private_urls` remains fully independent
- 10.x / 192.168.x / 100.64.0.0/10 / 169.254.0.0/16 / cloud metadata retain full SSRF protection
- 110/110 tests passing