### PR TITLE
fix(doctor): use ?key= query auth for Gemini connectivity probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1448,6 +1448,13 @@ def run_doctor(args):
             }
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
+            # Google Gemini's native v1beta surface uses ?key= query auth, not
+            # Bearer headers. Without this, Bearer always returns 401 even for
+            # a valid key, producing a false "invalid API key" verdict.
+            if "generativelanguage.googleapis.com" in (url or ""):
+                sep = "&" if "?" in url else "?"
+                url = f"{url}{sep}key={key}"
+                headers.pop("Authorization", None)
             r = httpx.get(url, headers=headers, timeout=10)
             if (
                 pname == "Alibaba/DashScope"


### PR DESCRIPTION
## Problem

`hermes doctor` always reports `gemini (invalid API key)` — even for keys that work perfectly against the Gemini API — because the connectivity probe sends the key as a `Bearer` Authorization header:

```
GET https://generativelanguage.googleapis.com/v1beta/models
Authorization: Bearer AIza...
```

Google's native v1beta surface does not accept Bearer auth on this endpoint; it requires `?key=<value>` query auth. The result is a hard 401, and the probe interprets that as "invalid API key" — a false positive that's misleading users into thinking their valid key is broken.

Verified locally: same key returns 200 with `?key=`, 401 with Bearer.

## Fix

When the probe URL targets `generativelanguage.googleapis.com`, append `?key=<value>` and drop the `Authorization` header. All other providers are unchanged.

## Test plan

- `hermes doctor` against a valid `GEMINI_API_KEY` / `GOOGLE_API_KEY` → now shows ✓
- Same key, invalidated → still shows ✗ (`HTTP 400` from Google's API-key validation path)
- Other providers in `_probe_apikey_provider` (DeepSeek, GLM, Kimi, etc.) unaffected — gated on URL host.