### PR TITLE
fix(tirith): support Windows/MSYS auto-install

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -225,6 +225,30 @@ class TestPathExpansion:
 
 
 # ---------------------------------------------------------------------------
+# Platform target detection
+# ---------------------------------------------------------------------------
+
+class TestTargetDetection:
+    @patch("tools.tirith_security.platform.machine", return_value="AMD64")
+    @patch("tools.tirith_security.platform.system", return_value="Windows")
+    def test_detect_target_windows_amd64(self, mock_system, mock_machine):
+        from tools.tirith_security import _detect_target
+        assert _detect_target() == "x86_64-pc-windows-msvc"
+
+    @patch("tools.tirith_security.platform.machine", return_value="x86_64")
+    @patch("tools.tirith_security.platform.system", return_value="MSYS_NT-10.0")
+    def test_detect_target_msys_x86_64(self, mock_system, mock_machine):
+        from tools.tirith_security import _detect_target
+        assert _detect_target() == "x86_64-pc-windows-msvc"
+
+    @patch("tools.tirith_security.platform.machine", return_value="ARM64")
+    @patch("tools.tirith_security.platform.system", return_value="Windows")
+    def test_detect_target_windows_arm64_unsupported(self, mock_system, mock_machine):
+        from tools.tirith_security import _detect_target
+        assert _detect_target() is None
+
+
+# ---------------------------------------------------------------------------
 # Findings cap + summary cap
 # ---------------------------------------------------------------------------
 
@@ -617,6 +641,42 @@ class TestCosignVerification:
         assert reason == "binary_not_in_archive"
         assert mock_checksum.called  # reached SHA-256 step
         assert mock_cosign.called  # cosign was invoked
+
+    @patch("tools.tirith_security.os.chmod")
+    @patch("tools.tirith_security.os.stat")
+    @patch("tools.tirith_security.shutil.move")
+    @patch("tools.tirith_security._extract_release_binary", return_value="/tmp/tirith.exe")
+    @patch("tools.tirith_security._verify_checksum", return_value=True)
+    @patch("tools.tirith_security.shutil.which", return_value=None)
+    @patch("tools.tirith_security._download_file")
+    @patch("tools.tirith_security._hermes_bin_dir", return_value="/hermes/bin")
+    @patch("tools.tirith_security._detect_target", return_value="x86_64-pc-windows-msvc")
+    def test_install_windows_uses_zip_archive_and_exe_dest(
+        self,
+        mock_target,
+        mock_bin_dir,
+        mock_dl,
+        mock_which,
+        mock_checksum,
+        mock_extract,
+        mock_move,
+        mock_stat,
+        mock_chmod,
+    ):
+        """Windows installs should fetch the zip asset and keep the .exe suffix."""
+        from tools.tirith_security import _install_tirith
+
+        mock_stat.return_value = type("Stat", (), {"st_mode": 0o644})()
+
+        path, reason = _install_tirith()
+
+        assert reason == ""
+        assert path == "/hermes/bin/tirith.exe"
+        assert mock_dl.call_args_list[0].args[0].endswith(
+            "/tirith-x86_64-pc-windows-msvc.zip"
+        )
+        mock_extract.assert_called_once()
+        mock_move.assert_called_once_with("/tmp/tirith.exe", "/hermes/bin/tirith.exe")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -33,6 +33,7 @@ import tempfile
 import threading
 import time
 import urllib.request
+import zipfile
 
 from hermes_constants import get_hermes_home
 
@@ -181,6 +182,28 @@ def _hermes_bin_dir() -> str:
     return d
 
 
+def _is_windows_system(system: str | None = None) -> bool:
+    """Return True for native Windows and MSYS/Cygwin-style shells."""
+    name = (system or platform.system()).upper()
+    return name == "WINDOWS" or name.startswith(("MSYS", "MINGW", "CYGWIN"))
+
+
+def _installed_binary_name(system: str | None = None) -> str:
+    """Return the installed tirith filename for the current platform."""
+    return "tirith.exe" if _is_windows_system(system) else "tirith"
+
+
+def _archive_binary_name(archive_name: str) -> str:
+    """Return the executable name contained in a release archive."""
+    return "tirith.exe" if archive_name.endswith(".zip") else "tirith"
+
+
+def _release_archive_name(target: str) -> str:
+    """Return the release archive name for a resolved target triple."""
+    suffix = ".zip" if target.endswith("-pc-windows-msvc") else ".tar.gz"
+    return f"tirith-{target}{suffix}"
+
+
 def _detect_target() -> str | None:
     """Return the Rust target triple for the current platform, or None."""
     system = platform.system()
@@ -191,17 +214,55 @@ def _detect_target() -> str | None:
         plat = "apple-darwin"
     elif system in {"Linux", "Android"}:
         plat = "unknown-linux-gnu"
+    elif _is_windows_system(system):
+        plat = "pc-windows-msvc"
     else:
         return None
 
     if machine in {"x86_64", "amd64"}:
         arch = "x86_64"
     elif machine in {"aarch64", "arm64"}:
+        if plat == "pc-windows-msvc":
+            return None
         arch = "aarch64"
     else:
         return None
 
     return f"{arch}-{plat}"
+
+
+def _extract_release_binary(archive_path: str, archive_name: str, tmpdir: str) -> str | None:
+    """Extract the tirith binary from a release archive into tmpdir."""
+    binary_name = _archive_binary_name(archive_name)
+    extracted_path = os.path.join(tmpdir, binary_name)
+
+    if archive_name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path) as archive:
+            for member in archive.infolist():
+                name = member.filename
+                normalized = name.replace("\\", "/")
+                if ".." in normalized.split("/"):
+                    continue
+                if normalized == binary_name or normalized.endswith(f"/{binary_name}"):
+                    with archive.open(member) as src, open(extracted_path, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    return extracted_path
+        return None
+
+    with tarfile.open(archive_path, "r:gz") as archive:
+        for member in archive.getmembers():
+            name = member.name
+            normalized = name.replace("\\", "/")
+            if ".." in normalized.split("/"):
+                continue
+            if normalized == binary_name or normalized.endswith(f"/{binary_name}"):
+                src = archive.extractfile(member)
+                if src is None:
+                    continue
+                with src, open(extracted_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                return extracted_path
+    return None
 
 
 def _download_file(url: str, dest: str, timeout: int = 10):
@@ -295,7 +356,7 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
                      platform.system(), platform.machine())
         return None, "unsupported_platform"
 
-    archive_name = f"tirith-{target}.tar.gz"
+    archive_name = _release_archive_name(target)
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
 
     tmpdir = tempfile.mkdtemp(prefix="tirith-install-")
@@ -346,21 +407,12 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
         if not _verify_checksum(archive_path, checksums_path, archive_name):
             return None, "checksum_failed"
 
-        with tarfile.open(archive_path, "r:gz") as tar:
-            # Extract only the tirith binary (safety: reject paths with ..)
-            for member in tar.getmembers():
-                if member.name == "tirith" or member.name.endswith("/tirith"):
-                    if ".." in member.name:
-                        continue
-                    member.name = "tirith"
-                    tar.extract(member, tmpdir)
-                    break
-            else:
-                log("tirith binary not found in archive")
-                return None, "binary_not_in_archive"
+        src = _extract_release_binary(archive_path, archive_name, tmpdir)
+        if src is None:
+            log("tirith binary not found in archive")
+            return None, "binary_not_in_archive"
 
-        src = os.path.join(tmpdir, "tirith")
-        dest = os.path.join(_hermes_bin_dir(), "tirith")
+        dest = os.path.join(_hermes_bin_dir(), _archive_binary_name(archive_name))
         try:
             shutil.move(src, dest)
         except OSError:
@@ -441,7 +493,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
         _clear_install_failed()
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = os.path.join(_hermes_bin_dir(), _installed_binary_name())
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
@@ -505,7 +557,7 @@ def _background_install(*, log_failures: bool = True):
             _install_failure_reason = ""
             return
 
-        hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+        hermes_bin = os.path.join(_hermes_bin_dir(), _installed_binary_name())
         if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
             _resolved_path = hermes_bin
             _install_failure_reason = ""
@@ -567,7 +619,7 @@ def ensure_installed(*, log_failures: bool = True):
         _clear_install_failed()
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = os.path.join(_hermes_bin_dir(), _installed_binary_name())
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""


### PR DESCRIPTION
## Summary
- normalize Windows-like shells (`Windows`, `MSYS*`, `MINGW*`, `CYGWIN*`) to the Tirith Windows target triple
- download the Windows release `.zip` asset and preserve the installed `tirith.exe` binary name
- add regression coverage for Windows/MSYS target detection and Windows zip installs

Closes #26044.

## Local proof
- `python3 -m pytest -o addopts='' tests/tools/test_tirith_security.py -q`
- `uv run --frozen ruff check tools/tirith_security.py tests/tools/test_tirith_security.py`
- `git diff --check`

## CI attribution
- Recent company PRs `#26030`, `#26038`, and `#26059` all show failing `e2e` checks; treat that shared red as `preexisting_unrelated` baseline noise rather than candidate-specific fallout.
