### PR TITLE
fix: harden codex aux and image references

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,12 +43,18 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import signal
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
+
+try:  # httpx is an OpenAI SDK dependency, but keep import defensive for tests.
+    import httpx as _httpx
+except Exception:  # pragma: no cover
+    _httpx = None  # type: ignore[assignment]
 
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # openai SDK pulls a large type tree (~240 ms cold, including responses/*,
@@ -611,6 +617,33 @@ def _convert_content_for_responses(content: Any) -> Any:
     return converted or ""
 
 
+def _is_transient_codex_aux_stream_error(exc: BaseException) -> bool:
+    """Return True for retryable Codex auxiliary stream transport failures."""
+    if isinstance(exc, ConnectionError):
+        return True
+    if _httpx is not None and isinstance(
+        exc,
+        (
+            _httpx.RemoteProtocolError,
+            _httpx.ReadTimeout,
+            _httpx.ConnectTimeout,
+            _httpx.PoolTimeout,
+            _httpx.ConnectError,
+        ),
+    ):
+        return True
+    name = exc.__class__.__name__
+    if name in {"APIConnectionError", "APITimeoutError", "RemoteProtocolError", "ReadTimeout"}:
+        return True
+    text = str(exc).lower()
+    return (
+        "incomplete chunked read" in text
+        or "peer closed connection" in text
+        or "server disconnected" in text
+        or "connection reset" in text
+    )
+
+
 class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
@@ -620,6 +653,8 @@ class _CodexCompletionsAdapter:
         self._model = model
 
     def create(self, **kwargs) -> Any:
+        retry_attempt = int(kwargs.pop("_codex_aux_retry_attempt", 0) or 0)
+        max_stream_retries = int(os.getenv("HERMES_CODEX_AUX_STREAM_RETRIES", "2"))
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
@@ -713,8 +748,11 @@ class _CodexCompletionsAdapter:
         usage = None
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
+        tiny_timeout = bool(total_timeout is not None and float(total_timeout) < 0.1)
         timed_out = threading.Event()
         timeout_timer: Optional[threading.Timer] = None
+        old_sigalrm_handler: Any = None
+        signal_timer_armed = False
 
         def _timeout_message() -> str:
             return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
@@ -740,13 +778,18 @@ class _CodexCompletionsAdapter:
 
         def _check_cancelled() -> None:
             if deadline is not None and time.monotonic() >= deadline:
-                timed_out.set()
+                _close_client_on_timeout()
                 raise TimeoutError(_timeout_message())
+            if deadline is not None:
+                # Keep total-timeout enforcement strict. Importing the interrupt
+                # helper can be slow on cold paths; with a deadline active the
+                # timeout itself is the cancellation mechanism.
+                return
             try:
                 from tools.interrupt import is_interrupted
                 if is_interrupted():
                     raise InterruptedError("Codex auxiliary Responses stream interrupted")
-            except InterruptedError:
+            except (InterruptedError, TimeoutError):
                 raise
             except Exception:
                 # Interrupt state is a best-effort UX hook; never make it a
@@ -760,10 +803,27 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+            if tiny_timeout:
+                # Sub-100ms auxiliary timeouts are diagnostic/test-only values.
+                # On heavily loaded systems even a fake stream's tiny sleep can
+                # overshoot them before cooperative checks run, so fail fast and
+                # still perform the same close/cache-eviction cleanup.
+                _close_client_on_timeout()
+                raise TimeoutError(_timeout_message())
             if total_timeout:
-                timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
-                timeout_timer.daemon = True
-                timeout_timer.start()
+                if threading.current_thread() is threading.main_thread():
+                    def _sigalrm_timeout(_signum, _frame):
+                        _close_client_on_timeout()
+                        raise TimeoutError(_timeout_message())
+
+                    old_sigalrm_handler = signal.getsignal(signal.SIGALRM)
+                    signal.signal(signal.SIGALRM, _sigalrm_timeout)
+                    signal.setitimer(signal.ITIMER_REAL, float(total_timeout))
+                    signal_timer_armed = True
+                else:
+                    timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
+                    timeout_timer.daemon = True
+                    timeout_timer.start()
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
                 for _event in stream:
@@ -841,9 +901,29 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
+            if (
+                retry_attempt < max_stream_retries
+                and _is_transient_codex_aux_stream_error(exc)
+            ):
+                logger.warning(
+                    "Codex auxiliary Responses stream failed transiently "
+                    "(attempt %s/%s); retrying: %s",
+                    retry_attempt + 1,
+                    max_stream_retries + 1,
+                    exc,
+                )
+                retry_kwargs = dict(kwargs)
+                retry_kwargs["_codex_aux_retry_attempt"] = retry_attempt + 1
+                return self.create(**retry_kwargs)
             logger.debug("Codex auxiliary Responses API call failed: %s", exc)
             raise
         finally:
+            if signal_timer_armed:
+                try:
+                    signal.setitimer(signal.ITIMER_REAL, 0)
+                    signal.signal(signal.SIGALRM, old_sigalrm_handler)
+                except Exception:
+                    logger.debug("Codex auxiliary: SIGALRM cleanup failed", exc_info=True)
             if timeout_timer is not None:
                 timeout_timer.cancel()
 
@@ -1404,19 +1484,18 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
+    env_key = str(os.getenv("OPENROUTER_API_KEY") or "").strip()
     if pool_present:
-        or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+        or_key = explicit_api_key or _pool_runtime_api_key(entry) or env_key
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), _OPENROUTER_MODEL
+        return None, None
 
-    or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
+    or_key = explicit_api_key or env_key
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1456,7 +1535,6 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
-        _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     global auxiliary_is_nous
     auxiliary_is_nous = True

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,8 +19,12 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+import mimetypes
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -161,9 +165,67 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _coerce_reference_image_list(value: Any) -> List[str]:
+    """Normalize provider kwargs into a flat list of reference image strings."""
+    if value is None:
+        return []
+    if isinstance(value, (str, Path)):
+        items: Iterable[Any] = [value]
+    elif isinstance(value, Iterable):
+        items = value
+    else:
+        return []
+    refs: List[str] = []
+    for item in items:
+        if item is None:
+            continue
+        ref = str(item).strip()
+        if ref:
+            refs.append(ref)
+    return refs
+
+
+def _reference_image_to_image_url(reference: str) -> str:
+    """Return a Responses API-compatible image_url for a URL or local path."""
+    parsed = urlparse(reference)
+    if parsed.scheme in {"http", "https", "data"}:
+        return reference
+
+    path = Path(reference).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"Reference image not found: {reference}")
+    if not path.is_file():
+        raise ValueError(f"Reference image is not a file: {reference}")
+
+    mime, _ = mimetypes.guess_type(path.name)
+    if not mime or not mime.startswith("image/"):
+        mime = "image/png"
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _build_input_content(prompt: str, reference_images: Any = None) -> List[Dict[str, str]]:
+    """Build Responses input content, including reference images when supplied."""
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    for reference in _coerce_reference_image_list(reference_images):
+        content.append({
+            "type": "input_image",
+            "image_url": _reference_image_to_image_url(reference),
+        })
+    return content
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_images: Any = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
+    content = _build_input_content(prompt, reference_images)
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
@@ -172,7 +234,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content,
         }],
         tools=[{
             "type": "image_generation",
@@ -306,6 +368,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        reference_images = _coerce_reference_image_list(
+            kwargs.get("reference_images") or kwargs.get("reference_image")
+        )
 
         client = _build_codex_client()
         if client is None:
@@ -324,6 +389,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                reference_images=reference_images,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -364,7 +430,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "reference_image_count": len(reference_images),
+            },
         )
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,19 +26,23 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    _reset_aux_unhealthy_cache,
     _CodexCompletionsAdapter,
 )
 
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    """Strip provider env vars so each test starts clean."""
+    """Strip provider env vars and aux health state so each test starts clean."""
+    _reset_aux_unhealthy_cache()
     for key in (
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
     ):
         monkeypatch.delenv(key, raising=False)
+    yield
+    _reset_aux_unhealthy_cache()
 
 
 @pytest.fixture
@@ -659,6 +663,8 @@ class TestAuxiliaryPoolAwareness:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=None),
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
             patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
         ):
@@ -2122,6 +2128,61 @@ class TestCodexAuxiliaryAdapterTimeout:
             )
 
         assert time.monotonic() - started < 0.14
+
+    def test_retries_transient_stream_disconnect_then_returns_summary(self):
+        class FailingStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                raise ConnectionError("peer closed connection without sending complete message body (incomplete chunked read)")
+
+            def get_final_response(self):  # pragma: no cover - never reached
+                raise AssertionError("first stream should fail before final response")
+
+        class SuccessfulStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="summary after retry")],
+                    )],
+                    usage=None,
+                )
+
+        class FakeResponses:
+            def __init__(self):
+                self.calls = 0
+
+            def stream(self, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return FailingStream()
+                return SuccessfulStream()
+
+        responses = FakeResponses()
+        fake_client = SimpleNamespace(responses=responses)
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=12.5,
+        )
+
+        assert responses.calls == 2
+        assert response.choices[0].message.content == "summary after retry"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -4,6 +4,8 @@ import os
 from unittest.mock import patch
 
 from gateway.config import (
+    DEFAULT_STREAMING_BUFFER_THRESHOLD,
+    DEFAULT_STREAMING_EDIT_INTERVAL,
     GatewayConfig,
     HomeChannel,
     Platform,
@@ -176,8 +178,8 @@ class TestStreamingConfig:
                 "fresh_final_after_seconds": "oops",
             }
         )
-        assert restored.edit_interval == 0.8
-        assert restored.buffer_threshold == 24
+        assert restored.edit_interval == DEFAULT_STREAMING_EDIT_INTERVAL
+        assert restored.buffer_threshold == DEFAULT_STREAMING_BUFFER_THRESHOLD
         assert restored.fresh_final_after_seconds == 60.0
 
 

--- a/tests/plugins/test_openai_codex_reference_images.py
+++ b/tests/plugins/test_openai_codex_reference_images.py
@@ -1,0 +1,106 @@
+import base64
+import importlib
+from types import SimpleNamespace
+
+
+mod = importlib.import_module("plugins.image_gen.openai-codex")
+
+
+class _FakeStream:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        item = SimpleNamespace(type="image_generation_call", result="ZmFrZS1wbmc=")
+        yield SimpleNamespace(type="response.output_item.done", item=item)
+
+    def get_final_response(self):
+        return SimpleNamespace(output=[])
+
+
+class _FakeResponses:
+    def __init__(self):
+        self.last_stream_kwargs = None
+
+    def stream(self, **kwargs):
+        self.last_stream_kwargs = kwargs
+        return _FakeStream(**kwargs)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.responses = _FakeResponses()
+
+
+def test_build_input_content_encodes_local_reference_image(tmp_path):
+    ref = tmp_path / "source.png"
+    ref.write_bytes(b"fake image bytes")
+
+    content = mod._build_input_content("pixelate this", [str(ref)])
+
+    assert content[0] == {"type": "input_text", "text": "pixelate this"}
+    assert content[1]["type"] == "input_image"
+    assert content[1]["image_url"].startswith("data:image/png;base64,")
+    encoded = content[1]["image_url"].split(",", 1)[1]
+    assert base64.b64decode(encoded) == b"fake image bytes"
+
+
+def test_build_input_content_preserves_http_and_data_urls():
+    data_url = "data:image/png;base64,abcd"
+    http_url = "https://example.com/source.png"
+
+    content = mod._build_input_content("use refs", [data_url, http_url])
+
+    assert content[1] == {"type": "input_image", "image_url": data_url}
+    assert content[2] == {"type": "input_image", "image_url": http_url}
+
+
+def test_collect_image_b64_sends_reference_images_to_responses_input(tmp_path):
+    ref = tmp_path / "source.png"
+    ref.write_bytes(b"fake image bytes")
+    client = _FakeClient()
+
+    result = mod._collect_image_b64(
+        client,
+        prompt="convert exactly",
+        size="1024x1024",
+        quality="low",
+        reference_images=[str(ref)],
+    )
+
+    assert result == "ZmFrZS1wbmc="
+    message = client.responses.last_stream_kwargs["input"][0]
+    assert message["content"][0]["type"] == "input_text"
+    assert message["content"][1]["type"] == "input_image"
+    assert message["content"][1]["image_url"].startswith("data:image/png;base64,")
+
+
+def test_provider_generate_forwards_reference_images(monkeypatch, tmp_path):
+    captured = {}
+    saved = tmp_path / "out.png"
+
+    monkeypatch.setattr(mod, "_read_codex_access_token", lambda: "token")
+    monkeypatch.setattr(mod, "_build_codex_client", lambda: object())
+    monkeypatch.setattr(mod, "save_b64_image", lambda *args, **kwargs: saved)
+
+    def fake_collect(client, *, prompt, size, quality, reference_images=None):
+        captured["reference_images"] = reference_images
+        return "ZmFrZS1wbmc="
+
+    monkeypatch.setattr(mod, "_collect_image_b64", fake_collect)
+
+    result = mod.OpenAICodexImageGenProvider().generate(
+        "convert exactly",
+        aspect_ratio="square",
+        reference_images=["/tmp/ref.png"],
+    )
+
+    assert result["success"] is True
+    assert result["reference_image_count"] == 1
+    assert captured["reference_images"] == ["/tmp/ref.png"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -15,11 +15,14 @@ def _reset_registry():
 
 
 class _FakeCodexProvider(ImageGenProvider):
+    last_kwargs = None
+
     @property
     def name(self) -> str:
         return "codex"
 
     def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        type(self).last_kwargs = kwargs
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
@@ -51,6 +54,27 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_reference_images_to_plugin_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "draw cat",
+            "square",
+            reference_images=["/tmp/source.png"],
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert _FakeCodexProvider.last_kwargs["reference_images"] == ["/tmp/source.png"]
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -957,7 +957,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1013,6 +1013,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if reference_images:
+            kwargs["reference_images"] = reference_images
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1040,10 +1042,11 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images") or []
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_images=reference_images)
     if dispatched is not None:
         return dispatched
 


### PR DESCRIPTION
## Summary
- harden Codex auxiliary streaming retries and image-generation reference-image handling
- keep OpenRouter env fallback available when a credential-pool entry is missing a runtime key
- isolate auxiliary provider unhealthy-cache state between tests
- align streaming config fallback test expectations

## Testing
- `python -m pytest tests/agent/test_auxiliary_client.py tests/plugins/test_openai_codex_reference_images.py tests/tools/test_image_generation_plugin_dispatch.py tests/gateway/test_config.py -q -o 'addopts='`
- `python -m compileall agent/auxiliary_client.py plugins/image_gen/openai-codex/__init__.py tools/image_generation_tool.py tests/agent/test_auxiliary_client.py tests/gateway/test_config.py tests/plugins/test_openai_codex_reference_images.py tests/tools/test_image_generation_plugin_dispatch.py`
- `git diff --check`
