### PR TITLE
fix(aux): surface Nous auth-unavailable warning in auxiliary client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1456,8 +1456,21 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
+        logger.warning(
+            "Auxiliary Nous client unavailable: no Nous authentication found "
+            "(run: hermes auth)."
+        )
         _mark_provider_unhealthy("nous", ttl=60)
         return None, None
+    if runtime is None and nous:
+        # Runtime credential mint failed but stored Nous auth is still present.
+        # Falls back to the raw stored token below; surface a debug line so
+        # operators investigating expired/invalid sessions have a breadcrumb,
+        # without blocking the fallback path the rest of this function relies on.
+        logger.debug(
+            "Auxiliary Nous: runtime credential mint failed; falling back to "
+            "stored auth.json token."
+        )
     global auxiliary_is_nous
     auxiliary_is_nous = True
     logger.debug("Auxiliary client: Nous Portal")


### PR DESCRIPTION
Salvages the useful piece of #23881 by @0xharryriddle onto current `main`.

## What changed

When the auxiliary client's Nous fallback path is taken (no stored auth, or runtime credential mint failed), only `debug`-level lines were logged, so the next provider in the chain takes over silently. This promotes the no-auth path to a warning that points operators at `hermes auth`, and adds a debug breadcrumb on the rarer mint-failed-but-stored-auth-still-present path while preserving the existing fallback to the raw stored token.

## What was dropped from #23881

- The `hermes_cli/goals.py` changes (reason-determination + pause-message rewrite). The goal-pause auto-trigger only fires when a judge call returns non-JSON content (`parse_failed=True`). When the auxiliary client is `None`, `judge_goal` returns `parse_failed=False`, which resets `consecutive_parse_failures` — the pause path is unreachable, so the reason string the contributor added never surfaces in the pause message. The original symptom in the linked thread was almost certainly a judge model returning empty/unparseable content (e.g. user configured `deepseek/deepseek-v4-pro` on Nous, which isn't a valid Portal model), not an auth-resolution failure.
- The contributor's second-branch `return None, None` was also dropped because it broke `test_try_nous_uses_pool_entry` — when the pool has an entry but `_resolve_nous_runtime_api` fails, the existing code legitimately falls back to the raw pool token. Kept the warning intent, dropped the early-return so the fallback still works.

## Validation

| | Before | After |
|---|---|---|
| `tests/agent/test_auxiliary_client.py` | 319 pass / 1 pre-existing fail (codex wrapper, unrelated) | 319 pass / 1 pre-existing fail (codex wrapper, unrelated) |

Original PR #23881 to be closed with credit.

Refs #23876