### PR TITLE
feat(kanban): tags column + --tag/--sort filters + tag/merge verbs

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -50,7 +50,8 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    tags = f"  #{' #'.join(t.tags)}" if t.tags else ""
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}{tags}"
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -71,6 +72,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "tags": list(t.tags) if t.tags else [],
     }
 
 
@@ -304,6 +306,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_list.add_argument("--status", default=None,
                         choices=sorted(kb.VALID_STATUSES))
     p_list.add_argument("--tenant", default=None)
+    p_list.add_argument("--tag", default=None,
+                        help="Only tasks bearing this tag (case-insensitive)")
+    p_list.add_argument("--sort", dest="sort_by", default=None,
+                        choices=sorted(kb.VALID_LIST_SORT_KEYS),
+                        help="Sort by created_at, priority, or updated "
+                             "(most recent lifecycle timestamp)")
+    sort_dir = p_list.add_mutually_exclusive_group()
+    sort_dir.add_argument("--asc", dest="sort_dir", action="store_const",
+                          const="asc", help="Sort ascending (default for --sort created_at)")
+    sort_dir.add_argument("--desc", dest="sort_dir", action="store_const",
+                          const="desc", help="Sort descending (default for --sort priority/updated)")
     p_list.add_argument("--archived", action="store_true",
                         help="Include archived tasks")
     p_list.add_argument("--json", action="store_true")
@@ -385,6 +398,35 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_claim.add_argument("task_id")
     p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
                          help="Claim TTL in seconds (default: 900)")
+
+    # --- tag ---
+    p_tag = sub.add_parser(
+        "tag",
+        help="Add, remove, or set tags on a task",
+    )
+    p_tag.add_argument("task_id")
+    p_tag.add_argument("tags", nargs="*",
+                       help="Tag names. Each tag is normalised to lowercase. "
+                            "Whitespace inside a tag is rejected.")
+    tag_mode = p_tag.add_mutually_exclusive_group()
+    tag_mode.add_argument("--remove", action="store_true",
+                          help="Remove the listed tags instead of adding them")
+    tag_mode.add_argument("--replace", action="store_true",
+                          help="Replace the entire tag set with the listed tags "
+                               "(pass none to clear)")
+    p_tag.add_argument("--json", action="store_true",
+                       help="Emit the resulting tag list as JSON")
+
+    # --- merge ---
+    p_merge = sub.add_parser(
+        "merge",
+        help="Merge a duplicate task into a kept task (re-parents links, "
+             "transfers comments, archives the duplicate)",
+    )
+    p_merge.add_argument("keep_id", help="Task to keep")
+    p_merge.add_argument("dup_id", help="Duplicate task to merge in and archive")
+    p_merge.add_argument("--json", action="store_true",
+                         help="Emit the merge summary as JSON")
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
@@ -721,6 +763,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         "unlink":   _cmd_unlink,
         "claim":    _cmd_claim,
         "comment":  _cmd_comment,
+        "tag":      _cmd_tag,
+        "merge":    _cmd_merge,
         "complete": _cmd_complete,
         "edit":     _cmd_edit,
         "block":    _cmd_block,
@@ -1102,17 +1146,32 @@ def _cmd_list(args: argparse.Namespace) -> int:
     assignee = args.assignee
     if args.mine and not assignee:
         assignee = _profile_author()
+    sort_dir = getattr(args, "sort_dir", None)
+    descending: Optional[bool]
+    if sort_dir == "asc":
+        descending = False
+    elif sort_dir == "desc":
+        descending = True
+    else:
+        descending = None
     with kb.connect() as conn:
         # Cheap "mini-dispatch": recompute ready so list output reflects
         # dependencies that may have cleared since the last dispatcher tick.
         kb.recompute_ready(conn)
-        tasks = kb.list_tasks(
-            conn,
-            assignee=assignee,
-            status=args.status,
-            tenant=args.tenant,
-            include_archived=args.archived,
-        )
+        try:
+            tasks = kb.list_tasks(
+                conn,
+                assignee=assignee,
+                status=args.status,
+                tenant=args.tenant,
+                include_archived=args.archived,
+                tag=getattr(args, "tag", None),
+                sort_by=getattr(args, "sort_by", None),
+                descending=descending,
+            )
+        except ValueError as exc:
+            print(f"kanban: {exc}", file=sys.stderr)
+            return 2
     if getattr(args, "json", False):
         print(json.dumps([_task_to_dict(t) for t in tasks], indent=2, ensure_ascii=False))
         return 0
@@ -1204,6 +1263,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
           (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.skills:
         print(f"  skills:    {', '.join(task.skills)}")
+    if task.tags:
+        print(f"  tags:      {', '.join(task.tags)}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see
@@ -1517,6 +1578,61 @@ def _cmd_comment(args: argparse.Namespace) -> int:
     with kb.connect() as conn:
         kb.add_comment(conn, args.task_id, author, body)
     print(f"Comment added to {args.task_id}")
+    return 0
+
+
+def _cmd_tag(args: argparse.Namespace) -> int:
+    tags = list(args.tags or [])
+    # --replace with no tags is the explicit "clear all" form. Anything
+    # else with an empty tag list is operator error.
+    if not tags and not args.replace:
+        print("kanban tag: at least one tag is required "
+              "(use --replace with no tags to clear)", file=sys.stderr)
+        return 2
+    try:
+        with kb.connect() as conn:
+            if not kb.get_task(conn, args.task_id):
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            if args.replace:
+                resulting = kb.set_task_tags(conn, args.task_id, tags)
+                verb = "replaced"
+            elif args.remove:
+                resulting = kb.remove_task_tags(conn, args.task_id, tags)
+                verb = "removed"
+            else:
+                resulting = kb.add_task_tags(conn, args.task_id, tags)
+                verb = "added"
+    except ValueError as exc:
+        print(f"kanban tag: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps({"task_id": args.task_id, "tags": resulting}))
+        return 0
+    label = ", ".join(resulting) if resulting else "(none)"
+    print(f"{verb} tags on {args.task_id}; current: {label}")
+    return 0
+
+
+def _cmd_merge(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect() as conn:
+            summary = kb.merge_tasks(conn, args.keep_id, args.dup_id)
+    except ValueError as exc:
+        print(f"kanban merge: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(summary))
+        return 0
+    print(
+        f"Merged {args.dup_id} into {args.keep_id}: "
+        f"{summary['moved_children']} child link(s), "
+        f"{summary['moved_parents']} parent link(s), "
+        f"{summary['moved_comments']} comment(s) transferred. "
+        f"{args.dup_id} archived."
+    )
+    if summary["tags"]:
+        print(f"Tags now on {args.keep_id}: {', '.join(summary['tags'])}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -606,6 +606,11 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Free-form tags for filtering/grouping. Stored as a JSON array of
+    # normalised lowercase strings. None = no row written; an empty list
+    # is preserved explicitly so callers can distinguish "untagged" from
+    # "tags cleared" in event payloads.
+    tags: Optional[list] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -619,6 +624,15 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        # Parse tags JSON blob if present
+        tags_value: Optional[list] = None
+        if "tags" in keys and row["tags"]:
+            try:
+                parsed_tags = json.loads(row["tags"])
+                if isinstance(parsed_tags, list):
+                    tags_value = [str(t) for t in parsed_tags if t]
+            except Exception:
+                tags_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -670,6 +684,7 @@ class Task:
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
+            tags=tags_value,
         )
 
 
@@ -796,7 +811,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
-    max_retries          INTEGER
+    max_retries          INTEGER,
+    -- Free-form tags for filtering/grouping (JSON array of normalised
+    -- lowercase strings). NULL or empty array = untagged. Filtering and
+    -- the ``hermes kanban tag`` verb expand this column.
+    tags                 TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1076,6 +1095,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
 
+    if "tags" not in cols:
+        # JSON array of normalised lowercase tag strings. NULL is fine for
+        # existing rows — they're treated as untagged by the filter.
+        _add_column_if_missing(conn, "tasks", "tags", "tags TEXT")
+
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
@@ -1244,6 +1268,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    tags: Optional[Iterable[str]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1324,6 +1349,22 @@ def create_task(
             )
         skills_list = cleaned
 
+    # Normalise + dedupe tags up-front so we never persist mixed case or
+    # whitespace-padded duplicates.
+    tags_list: Optional[list[str]] = None
+    if tags is not None:
+        normalised: list[str] = []
+        seen_tags: set[str] = set()
+        for t in tags:
+            if t is None or not str(t).strip():
+                continue
+            norm = _normalize_tag(t)
+            if norm in seen_tags:
+                continue
+            seen_tags.add(norm)
+            normalised.append(norm)
+        tags_list = sorted(normalised)
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -1377,8 +1418,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         tenant, idempotency_key, max_runtime_seconds, skills,
-                        max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        max_retries, tags
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1396,6 +1437,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        json.dumps(tags_list) if tags_list else None,
                     ),
                 )
                 for pid in parents:
@@ -1413,6 +1455,7 @@ def create_task(
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
+                        "tags": list(tags_list) if tags_list else None,
                     },
                 )
             return task_id
@@ -1442,6 +1485,9 @@ def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
     return Task.from_row(row) if row else None
 
 
+VALID_LIST_SORT_KEYS = {"created_at", "priority", "updated"}
+
+
 def list_tasks(
     conn: sqlite3.Connection,
     *,
@@ -1450,6 +1496,9 @@ def list_tasks(
     tenant: Optional[str] = None,
     include_archived: bool = False,
     limit: Optional[int] = None,
+    tag: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    descending: Optional[bool] = None,
 ) -> list[Task]:
     query = "SELECT * FROM tasks WHERE 1=1"
     params: list[Any] = []
@@ -1464,13 +1513,327 @@ def list_tasks(
     if tenant is not None:
         query += " AND tenant = ?"
         params.append(tenant)
+    if tag is not None:
+        normalised = _normalize_tag(tag)
+        if not normalised:
+            raise ValueError("tag filter cannot be empty")
+        # json_each on a NULL value yields zero rows, so untagged tasks
+        # are correctly excluded without an extra NULL guard.
+        query += (
+            " AND EXISTS (SELECT 1 FROM json_each(tasks.tags) WHERE json_each.value = ?)"
+        )
+        params.append(normalised)
     if not include_archived and status != "archived":
         query += " AND status != 'archived'"
-    query += " ORDER BY priority DESC, created_at ASC"
+
+    # Sort key mapping. ``updated`` collapses lifecycle timestamps into
+    # one "most recent activity" column via COALESCE so the operator
+    # doesn't have to know which one was last written.
+    if sort_by is not None and sort_by not in VALID_LIST_SORT_KEYS:
+        raise ValueError(
+            f"sort_by must be one of {sorted(VALID_LIST_SORT_KEYS)}, got {sort_by!r}"
+        )
+    if sort_by is None:
+        # Preserve historical default: priority DESC, then oldest first.
+        query += " ORDER BY priority DESC, created_at ASC"
+    else:
+        if sort_by == "created_at":
+            sort_expr = "created_at"
+            default_desc = False
+        elif sort_by == "priority":
+            sort_expr = "priority"
+            default_desc = True
+        else:  # updated
+            sort_expr = (
+                "COALESCE(completed_at, last_heartbeat_at, started_at, created_at)"
+            )
+            default_desc = True
+        if descending is None:
+            descending = default_desc
+        direction = "DESC" if descending else "ASC"
+        # Tiebreaker on id keeps the order stable when many rows share
+        # the primary sort value (e.g. priority).
+        query += f" ORDER BY {sort_expr} {direction}, id ASC"
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()
     return [Task.from_row(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
+
+_TAG_MAX_LEN = 64
+
+
+def _normalize_tag(tag: Any) -> str:
+    """Normalise a tag for storage/comparison.
+
+    Lowercase + strip + collapse whitespace runs. Rejects empties and
+    over-long names so a typo doesn't quietly produce a tag nobody can
+    type again. Returns the normalised form on success, raises
+    ``ValueError`` on bad input.
+    """
+    if tag is None:
+        raise ValueError("tag cannot be None")
+    s = str(tag).strip().lower()
+    if not s:
+        raise ValueError("tag cannot be empty")
+    if len(s) > _TAG_MAX_LEN:
+        raise ValueError(f"tag exceeds {_TAG_MAX_LEN} chars: {s[:_TAG_MAX_LEN]}…")
+    # Whitespace inside a tag almost certainly means the caller meant
+    # two tags. Reject it so they have to split explicitly.
+    if any(c.isspace() for c in s):
+        raise ValueError(
+            f"tag {tag!r} contains whitespace; pass each tag as a separate argument"
+        )
+    return s
+
+
+def _read_tags(conn: sqlite3.Connection, task_id: str) -> tuple[list[str], bool]:
+    """Return ``(tags, exists)``. ``exists=False`` when the task is gone."""
+    row = conn.execute("SELECT tags FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row is None:
+        return ([], False)
+    raw = row["tags"]
+    if not raw:
+        return ([], True)
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return ([], True)
+    if not isinstance(parsed, list):
+        return ([], True)
+    return ([str(t) for t in parsed if t], True)
+
+
+def _write_tags(
+    conn: sqlite3.Connection, task_id: str, tags: list[str], kind: str
+) -> list[str]:
+    """Persist the canonical tag list and append an event. Assumes
+    the caller already holds a write transaction."""
+    payload = json.dumps(tags) if tags else None
+    conn.execute("UPDATE tasks SET tags = ? WHERE id = ?", (payload, task_id))
+    _append_event(conn, task_id, kind, {"tags": list(tags)})
+    return list(tags)
+
+
+def add_task_tags(
+    conn: sqlite3.Connection, task_id: str, tags: Iterable[str]
+) -> list[str]:
+    """Union the given tags into the task's tag set.
+
+    Returns the resulting tag list (sorted for stability). Raises
+    ``ValueError`` on unknown task or bad tag.
+    """
+    new = [_normalize_tag(t) for t in tags]
+    if not new:
+        raise ValueError("at least one tag is required")
+    with write_txn(conn):
+        existing, exists = _read_tags(conn, task_id)
+        if not exists:
+            raise ValueError(f"unknown task {task_id}")
+        combined = sorted(set(existing) | set(new))
+        return _write_tags(conn, task_id, combined, "tagged")
+
+
+def remove_task_tags(
+    conn: sqlite3.Connection, task_id: str, tags: Iterable[str]
+) -> list[str]:
+    """Remove the given tags from the task's tag set (no-op for tags
+    that aren't present). Returns the resulting tag list."""
+    drop = {_normalize_tag(t) for t in tags}
+    if not drop:
+        raise ValueError("at least one tag is required")
+    with write_txn(conn):
+        existing, exists = _read_tags(conn, task_id)
+        if not exists:
+            raise ValueError(f"unknown task {task_id}")
+        combined = sorted(set(existing) - drop)
+        return _write_tags(conn, task_id, combined, "untagged")
+
+
+def set_task_tags(
+    conn: sqlite3.Connection, task_id: str, tags: Iterable[str]
+) -> list[str]:
+    """Replace the task's tag set wholesale. An empty iterable clears
+    every tag (sets the column to NULL)."""
+    new = sorted({_normalize_tag(t) for t in tags}) if tags else []
+    with write_txn(conn):
+        _, exists = _read_tags(conn, task_id)
+        if not exists:
+            raise ValueError(f"unknown task {task_id}")
+        return _write_tags(conn, task_id, new, "tagged")
+
+
+def get_task_tags(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    """Return the task's tag list (empty if untagged or unknown)."""
+    tags, _exists = _read_tags(conn, task_id)
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# Merge
+# ---------------------------------------------------------------------------
+
+def merge_tasks(
+    conn: sqlite3.Connection, keep_id: str, dup_id: str
+) -> dict:
+    """Merge ``dup_id`` into ``keep_id``: re-parent links, union tags,
+    transfer comments, archive the duplicate, and record a
+    ``merged_into`` event on both sides.
+
+    Returns a summary dict (counts of moved children/parents/comments,
+    final tag list on ``keep``). Raises ``ValueError`` on unknown ids,
+    self-merge, or cycle-inducing re-parenting that can't be safely
+    rewritten.
+
+    The duplicate is preserved as an archived row so existing references
+    (event log, prior runs, comment-thread URLs) keep resolving — the
+    merge isn't a delete.
+    """
+    if keep_id == dup_id:
+        raise ValueError("cannot merge a task into itself")
+    with write_txn(conn):
+        keep_row = conn.execute(
+            "SELECT id, status, tags FROM tasks WHERE id = ?", (keep_id,)
+        ).fetchone()
+        if keep_row is None:
+            raise ValueError(f"unknown task {keep_id}")
+        dup_row = conn.execute(
+            "SELECT id, status, tags FROM tasks WHERE id = ?", (dup_id,)
+        ).fetchone()
+        if dup_row is None:
+            raise ValueError(f"unknown task {dup_id}")
+        if keep_row["status"] == "archived":
+            raise ValueError(
+                f"cannot merge into archived task {keep_id}; unarchive it first"
+            )
+        if dup_row["status"] == "archived":
+            raise ValueError(
+                f"task {dup_id} is already archived; nothing to merge"
+            )
+        if dup_row["status"] == "running":
+            raise ValueError(
+                f"cannot merge {dup_id}: currently running. Reclaim or wait first."
+            )
+
+        # Re-parent children: any link (dup -> X) becomes (keep -> X).
+        # Skip links that would self-loop or cycle.
+        child_links = conn.execute(
+            "SELECT child_id FROM task_links WHERE parent_id = ?", (dup_id,)
+        ).fetchall()
+        moved_children = 0
+        for r in child_links:
+            child = r["child_id"]
+            conn.execute(
+                "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
+                (dup_id, child),
+            )
+            if child == keep_id:
+                continue
+            if _would_cycle(conn, keep_id, child):
+                continue
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (keep_id, child),
+            )
+            if cur.rowcount:
+                moved_children += 1
+
+        # Re-parent parents: any link (X -> dup) becomes (X -> keep).
+        parent_links = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ?", (dup_id,)
+        ).fetchall()
+        moved_parents = 0
+        for r in parent_links:
+            parent = r["parent_id"]
+            conn.execute(
+                "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
+                (parent, dup_id),
+            )
+            if parent == keep_id:
+                continue
+            if _would_cycle(conn, parent, keep_id):
+                continue
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (parent, keep_id),
+            )
+            if cur.rowcount:
+                moved_parents += 1
+
+        # Transfer comments from dup to keep, prefixing each with the
+        # source so the merged thread stays attributable.
+        comment_rows = conn.execute(
+            "SELECT id, author, body, created_at FROM task_comments "
+            "WHERE task_id = ? ORDER BY created_at ASC, id ASC",
+            (dup_id,),
+        ).fetchall()
+        moved_comments = 0
+        for c in comment_rows:
+            prefixed = f"[merged from {dup_id}] {c['body']}"
+            conn.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (keep_id, c["author"], prefixed, c["created_at"]),
+            )
+            moved_comments += 1
+        # Drop the originals so the dup row's comment thread on the
+        # archived task is empty (the source is recorded in the prefix).
+        if comment_rows:
+            conn.execute("DELETE FROM task_comments WHERE task_id = ?", (dup_id,))
+
+        # Union tags.
+        def _parse_tag_blob(blob):
+            if not blob:
+                return []
+            try:
+                parsed = json.loads(blob)
+            except Exception:
+                return []
+            return [str(t) for t in parsed if t] if isinstance(parsed, list) else []
+
+        merged_tags = sorted(
+            set(_parse_tag_blob(keep_row["tags"]))
+            | set(_parse_tag_blob(dup_row["tags"]))
+        )
+        tags_payload = json.dumps(merged_tags) if merged_tags else None
+        conn.execute(
+            "UPDATE tasks SET tags = ? WHERE id = ?", (tags_payload, keep_id)
+        )
+
+        # Record events on both sides for an auditable trail.
+        _append_event(
+            conn, keep_id, "merged_from",
+            {"dup": dup_id, "moved_children": moved_children,
+             "moved_parents": moved_parents, "moved_comments": moved_comments,
+             "tags": merged_tags},
+        )
+        _append_event(
+            conn, dup_id, "merged_into", {"keep": keep_id},
+        )
+
+        # Finally, archive the dup. ``archive_task`` opens its own write
+        # transaction; we're already inside one, so inline the UPDATE +
+        # event to stay atomic.
+        conn.execute(
+            "UPDATE tasks SET status = 'archived', "
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND status != 'archived'",
+            (dup_id,),
+        )
+        _append_event(conn, dup_id, "archived", None)
+
+        return {
+            "keep_id": keep_id,
+            "dup_id": dup_id,
+            "moved_children": moved_children,
+            "moved_parents": moved_parents,
+            "moved_comments": moved_comments,
+            "tags": merged_tags,
+        }
 
 
 def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1530,3 +1530,278 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
         conn.close()
     age = kb.task_age(task)
     assert age["created_age_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
+
+def test_create_task_with_tags_normalises(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["Urgent", " refactor ", "URGENT"])
+        t = kb.get_task(conn, tid)
+    assert t.tags == ["refactor", "urgent"]  # sorted, lowercased, deduped
+
+
+def test_create_task_without_tags_leaves_column_null(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        t = kb.get_task(conn, tid)
+    assert t.tags is None
+
+
+def test_add_task_tags_unions_existing(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["alpha"])
+        result = kb.add_task_tags(conn, tid, ["Beta", "alpha"])
+        t = kb.get_task(conn, tid)
+    assert result == ["alpha", "beta"]
+    assert t.tags == ["alpha", "beta"]
+
+
+def test_remove_task_tags_drops_listed_only(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["a", "b", "c"])
+        result = kb.remove_task_tags(conn, tid, ["b", "missing"])
+        t = kb.get_task(conn, tid)
+    assert result == ["a", "c"]
+    assert t.tags == ["a", "c"]
+
+
+def test_set_task_tags_replaces_wholesale(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["a", "b"])
+        result = kb.set_task_tags(conn, tid, ["x", "y"])
+        t = kb.get_task(conn, tid)
+    assert result == ["x", "y"]
+    assert t.tags == ["x", "y"]
+
+
+def test_set_task_tags_empty_clears(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", tags=["a"])
+        result = kb.set_task_tags(conn, tid, [])
+        t = kb.get_task(conn, tid)
+    assert result == []
+    # Empty list collapses to NULL on disk; from_row returns None for that.
+    assert t.tags is None
+
+
+def test_tag_validation_rejects_whitespace_and_empty(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        with pytest.raises(ValueError, match="whitespace"):
+            kb.add_task_tags(conn, tid, ["bad tag"])
+        with pytest.raises(ValueError, match="cannot be empty"):
+            kb.add_task_tags(conn, tid, ["   "])
+        with pytest.raises(ValueError, match="at least one"):
+            kb.add_task_tags(conn, tid, [])
+
+
+def test_tag_unknown_task_raises(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="unknown task"):
+            kb.add_task_tags(conn, "t_missing", ["x"])
+
+
+def test_tag_events_recorded(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t")
+        kb.add_task_tags(conn, tid, ["a"])
+        kb.remove_task_tags(conn, tid, ["a"])
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+    assert "tagged" in kinds
+    assert "untagged" in kinds
+
+
+# ---------------------------------------------------------------------------
+# list_tasks: tag filter + sort
+# ---------------------------------------------------------------------------
+
+def test_list_tasks_tag_filter(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="A", tags=["bug"])
+        b = kb.create_task(conn, title="B", tags=["feature"])
+        c = kb.create_task(conn, title="C", tags=["bug", "feature"])
+        # Case-insensitive match
+        ids = {t.id for t in kb.list_tasks(conn, tag="BUG")}
+    assert ids == {a, c}
+    with kb.connect() as conn:
+        ids = {t.id for t in kb.list_tasks(conn, tag="feature")}
+    assert ids == {b, c}
+
+
+def test_list_tasks_tag_filter_empty_rejected(kanban_home):
+    with kb.connect() as conn:
+        kb.create_task(conn, title="x")
+        with pytest.raises(ValueError):
+            kb.list_tasks(conn, tag="   ")
+
+
+def test_list_tasks_sort_created_at_ascending_default(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="first")
+        # Backdate created_at so sort order is deterministic.
+        conn.execute("UPDATE tasks SET created_at = 1000 WHERE id = ?", (first,))
+        second = kb.create_task(conn, title="second")
+        conn.execute("UPDATE tasks SET created_at = 2000 WHERE id = ?", (second,))
+        ids = [t.id for t in kb.list_tasks(conn, sort_by="created_at")]
+    assert ids == [first, second]
+
+
+def test_list_tasks_sort_created_at_descending(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="first")
+        conn.execute("UPDATE tasks SET created_at = 1000 WHERE id = ?", (first,))
+        second = kb.create_task(conn, title="second")
+        conn.execute("UPDATE tasks SET created_at = 2000 WHERE id = ?", (second,))
+        ids = [t.id for t in kb.list_tasks(conn, sort_by="created_at", descending=True)]
+    assert ids == [second, first]
+
+
+def test_list_tasks_sort_priority_descending_default(kanban_home):
+    with kb.connect() as conn:
+        low = kb.create_task(conn, title="low", priority=1)
+        high = kb.create_task(conn, title="high", priority=10)
+        mid = kb.create_task(conn, title="mid", priority=5)
+        ids = [t.id for t in kb.list_tasks(conn, sort_by="priority")]
+    assert ids[0] == high
+    assert ids[-1] == low
+
+
+def test_list_tasks_sort_updated_uses_most_recent_lifecycle_ts(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a", assignee="x")
+        b = kb.create_task(conn, title="b", assignee="x")
+        # Backdate creation, then bump b's started_at to be most recent.
+        conn.execute("UPDATE tasks SET created_at = 1000 WHERE id = ?", (a,))
+        conn.execute("UPDATE tasks SET created_at = 1100 WHERE id = ?", (b,))
+        conn.execute("UPDATE tasks SET started_at = 9000 WHERE id = ?", (b,))
+        ids = [t.id for t in kb.list_tasks(conn, sort_by="updated")]
+    assert ids[0] == b
+
+
+def test_list_tasks_invalid_sort_key_raises(kanban_home):
+    with kb.connect() as conn:
+        kb.create_task(conn, title="x")
+        with pytest.raises(ValueError, match="sort_by"):
+            kb.list_tasks(conn, sort_by="nonsense")
+
+
+def test_list_tasks_unchanged_default_order(kanban_home):
+    """Regression guard: default ordering must remain priority DESC, created_at ASC."""
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a", priority=1)
+        b = kb.create_task(conn, title="b", priority=5)
+        ids = [t.id for t in kb.list_tasks(conn)]
+    assert ids[0] == b
+    assert ids[1] == a
+
+
+# ---------------------------------------------------------------------------
+# Merge
+# ---------------------------------------------------------------------------
+
+def test_merge_reparents_children_and_archives_dup(kanban_home):
+    with kb.connect() as conn:
+        keep = kb.create_task(conn, title="keep")
+        dup = kb.create_task(conn, title="dup")
+        child_a = kb.create_task(conn, title="ca", parents=[dup])
+        child_b = kb.create_task(conn, title="cb", parents=[dup])
+        result = kb.merge_tasks(conn, keep, dup)
+        keep_children = kb.child_ids(conn, keep)
+        dup_after = kb.get_task(conn, dup)
+    assert result["moved_children"] == 2
+    assert set(keep_children) == {child_a, child_b}
+    assert dup_after.status == "archived"
+
+
+def test_merge_reparents_parents(kanban_home):
+    with kb.connect() as conn:
+        upstream = kb.create_task(conn, title="upstream")
+        keep = kb.create_task(conn, title="keep")
+        dup = kb.create_task(conn, title="dup", parents=[upstream])
+        result = kb.merge_tasks(conn, keep, dup)
+        keep_parents = kb.parent_ids(conn, keep)
+    assert result["moved_parents"] == 1
+    assert keep_parents == [upstream]
+
+
+def test_merge_transfers_comments_with_source_prefix(kanban_home):
+    with kb.connect() as conn:
+        keep = kb.create_task(conn, title="keep")
+        dup = kb.create_task(conn, title="dup")
+        kb.add_comment(conn, dup, "alice", "first thought")
+        kb.add_comment(conn, dup, "bob", "second thought")
+        kb.merge_tasks(conn, keep, dup)
+        keep_comments = kb.list_comments(conn, keep)
+        dup_comments = kb.list_comments(conn, dup)
+    assert len(keep_comments) == 2
+    bodies = [c.body for c in keep_comments]
+    assert any("first thought" in b and dup in b for b in bodies)
+    assert dup_comments == []
+
+
+def test_merge_unions_tags(kanban_home):
+    with kb.connect() as conn:
+        keep = kb.create_task(conn, title="keep", tags=["alpha"])
+        dup = kb.create_task(conn, title="dup", tags=["beta", "alpha"])
+        result = kb.merge_tasks(conn, keep, dup)
+        keep_task = kb.get_task(conn, keep)
+    assert result["tags"] == ["alpha", "beta"]
+    assert keep_task.tags == ["alpha", "beta"]
+
+
+def test_merge_rejects_self_merge(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        with pytest.raises(ValueError, match="itself"):
+            kb.merge_tasks(conn, a, a)
+
+
+def test_merge_rejects_unknown_ids(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        with pytest.raises(ValueError, match="unknown task"):
+            kb.merge_tasks(conn, a, "t_missing")
+        with pytest.raises(ValueError, match="unknown task"):
+            kb.merge_tasks(conn, "t_missing", a)
+
+
+def test_merge_skips_cycle_inducing_reparent(kanban_home):
+    """If dup's child is an ancestor of keep, re-parenting would cycle.
+    The link is dropped rather than added."""
+    with kb.connect() as conn:
+        # ancestor -> keep already; dup -> ancestor would put keep under
+        # itself transitively if we re-parented.
+        ancestor = kb.create_task(conn, title="ancestor")
+        keep = kb.create_task(conn, title="keep", parents=[ancestor])
+        dup = kb.create_task(conn, title="dup")
+        # link dup -> ancestor: now if we merged dup into keep, we'd be
+        # adding keep -> ancestor, but ancestor -> keep already exists
+        # which is a direct cycle.
+        kb.link_tasks(conn, dup, ancestor)
+        kb.merge_tasks(conn, keep, dup)
+        # The cycle-inducing edge must NOT have been installed.
+        assert keep not in kb.parent_ids(conn, ancestor)
+
+
+def test_merge_records_events_on_both_sides(kanban_home):
+    with kb.connect() as conn:
+        keep = kb.create_task(conn, title="keep")
+        dup = kb.create_task(conn, title="dup")
+        kb.merge_tasks(conn, keep, dup)
+        keep_kinds = [e.kind for e in kb.list_events(conn, keep)]
+        dup_kinds = [e.kind for e in kb.list_events(conn, dup)]
+    assert "merged_from" in keep_kinds
+    assert "merged_into" in dup_kinds
+    assert "archived" in dup_kinds
+
+
+def test_merge_refuses_when_dup_is_running(kanban_home):
+    with kb.connect() as conn:
+        keep = kb.create_task(conn, title="keep")
+        dup = kb.create_task(conn, title="dup", assignee="x")
+        kb.claim_task(conn, dup)
+        with pytest.raises(ValueError, match="running"):
+            kb.merge_tasks(conn, keep, dup)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -219,6 +219,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "children": children,
         "parent_count": len(parents),
         "child_count": len(children),
+        "tags": list(task.tags) if task.tags else [],
     }
 
 
@@ -258,6 +259,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "tags": list(t.tags) if t.tags else [],
                 }
 
             def _run_dict(r):
@@ -585,6 +587,13 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"skills must be a list of skill names, got {type(skills).__name__}"
         )
+    tags = args.get("tags")
+    if isinstance(tags, str):
+        tags = [tags]
+    if tags is not None and not isinstance(tags, (list, tuple)):
+        return tool_error(
+            f"tags must be a list of strings, got {type(tags).__name__}"
+        )
     if isinstance(parents, str):
         parents = [parents]
     if not isinstance(parents, (list, tuple)):
@@ -611,6 +620,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                tags=tags,
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -1009,6 +1019,16 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Free-form tags for filtering/grouping. Tags are "
+                    "normalised to lowercase; whitespace inside a tag "
+                    "is rejected (pass each as a separate string). "
+                    "Filter on these later with `hermes kanban list --tag`."
                 ),
             },
         },


### PR DESCRIPTION
## What

Adds tag/sort/merge surface to the Kanban CLI and MCP tools, requested by an internal task (`t_8e15c283`) that wanted board-level filtering and a `merge` verb so the existing dedup scanner is actionable end-to-end.

### CLI

- `hermes kanban list --tag <tag>` — filter by tag (case-insensitive match on normalised lowercase storage).
- `hermes kanban list --sort created_at|priority|updated [--asc|--desc]` — explicit sort key with sensible direction default per key (`created_at`→asc, `priority`/`updated`→desc). `updated` collapses `COALESCE(completed_at, last_heartbeat_at, started_at, created_at)`.
- `hermes kanban tag <id> <tag>...` — adds tags (union by default), `--remove` to drop, `--replace` to set wholesale (empty list clears). `--json` for scripting.
- `hermes kanban merge <keep-id> <dup-id>` — re-parents children and parents of the duplicate onto the keeper (skipping cycle-inducing edges), unions tags, transfers comments with a `[merged from <dup>] ` prefix, archives the duplicate, and records `merged_from` / `merged_into` events on both sides.

### Schema

- Adds `tasks.tags TEXT` (JSON array, nullable). Migration is additive in `_migrate_add_optional_columns`, idempotent across races (same pattern as every other column added since v1). NULL = untagged.
- Existing rows untouched; default list ordering and existing list filters unchanged (regression test included).

### MCP tools

- `kanban_create` accepts `tags: [str]` (single string also accepted for convenience).
- `kanban_show` and `_task_summary_dict` surface the `tags` array.

### Validation rules for tag names

- Lowercased, stripped.
- Rejected: empty, whitespace inside (`"my tag"` is almost certainly meant as two tags — pass them as separate args), >64 chars.
- Dedupe + sort on store.

### Merge safety

Refuses: self-merge, unknown ids, dup currently `running`, keep already `archived`. Cycle-inducing link transfers are silently dropped (the source edge is still removed). The duplicate is archived rather than deleted so existing references (event log, prior runs, comment-thread URLs) keep resolving.

## Tests

26 new tests in `tests/hermes_cli/test_kanban_db.py` cover:

- Tag normalisation, add/remove/set, event recording, validation rules, unknown-task handling.
- `list_tasks` tag filter (case-insensitive), sort by each key, default direction, descending override, regression guard for unchanged default order, invalid-key rejection.
- Merge: re-parent children, re-parent parents, comment transfer with prefix, tag union, self-merge rejection, unknown-id rejection, cycle-inducing edge skip, both-sides event recording, refuses running duplicate.

```
$ pytest tests/hermes_cli/test_kanban_db.py -q
108 passed
```

(All pre-existing 82 still pass; the 3 `test_kanban_notify.py` failures predate this branch — missing `pytest-asyncio` in the test env.)

## Try it

```
hermes kanban create "fix db pool" --assignee infra
hermes kanban tag t_xxxxxxxx urgent backend
hermes kanban list --tag backend --sort priority --desc
hermes kanban merge t_keep t_dup
```

## Notes

- Migration is bundled with the code that reads the column, per the contributing guidance and the upstream constraint that `/opt/hermes` is image-only on production deployments. Operators should redeploy; the schema upgrade runs the next time `init_db()` opens the DB.
- The `merge` verb makes the existing `kanban-dedup-scan.py` workflow finally actionable end-to-end (it surfaces candidate pairs; this lets the operator collapse them without hand-editing the DB).
