### PR TITLE
fix(cli): fall back to SelectSelector when kqueue can't watch stdin on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13401,6 +13401,30 @@ class HermesCLI:
             self._print_exit_summary()
             return
 
+        # On macOS with uv-managed Python, kqueue's selector cannot register
+        # fd 0, raising OSError(EINVAL) from kqueue.control() when prompt_toolkit
+        # calls loop.add_reader (#6393). Probe kqueue and, if it can't watch
+        # stdin, switch to a SelectSelector-backed event loop policy.
+        if sys.platform == "darwin":
+            try:
+                import selectors as _selectors
+                if hasattr(_selectors, "KqueueSelector"):
+                    _kq = _selectors.KqueueSelector()
+                    try:
+                        _kq.register(0, _selectors.EVENT_READ)
+                        _kq.unregister(0)
+                    finally:
+                        _kq.close()
+            except (OSError, ValueError, KeyError):
+                import asyncio as _aio_probe
+                import selectors as _selectors
+
+                class _SelectEventLoopPolicy(_aio_probe.DefaultEventLoopPolicy):
+                    def new_event_loop(self):
+                        return _aio_probe.SelectorEventLoop(_selectors.SelectSelector())
+
+                _aio_probe.set_event_loop_policy(_SelectEventLoopPolicy())
+
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():
@@ -13421,12 +13445,20 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
             # and I/O errors from broken stdout during interrupt (#13710).
-            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
+            _errno = getattr(_stdin_err, "errno", None) if isinstance(_stdin_err, OSError) else None
+            _msg = str(_stdin_err)
+            if _errno == errno.EIO:
                 pass  # suppress broken-stdout I/O errors on interrupt (#13710)
-            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            elif (
+                _errno in (errno.EINVAL, errno.EBADF)
+                or "is not registered" in _msg
+                or "Bad file descriptor" in _msg
+                or "Invalid argument" in _msg
+            ):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
-                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS)\n"
+                    "where kqueue cannot register fd 0.\n"
                     "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
                 )
             else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "oleksii.lisikh@gmail.com": "olisikh",
+    "jeremy@geocaching.com": "outdoorsea",
     "leone.parise@gmail.com": "leoneparise",
     "mr@shu.io": "mrshu",
     "buraysandro9@gmail.com": "ygd58",


### PR DESCRIPTION
Salvage of #20948 by @outdoorsea onto current main.

## Summary
Prevents the `OSError: [Errno 22] Invalid argument` startup crash that hits uv-managed cPython 3.11 on macOS (issue #5884). Probes `KqueueSelector.register(0, EVENT_READ)` at CLI startup; on failure, installs an event-loop policy that returns a `SelectorEventLoop(SelectSelector())` so prompt_toolkit's `add_reader(0, …)` works. Also widens the existing `except (KeyError, OSError)` net to match `EINVAL` / `EBADF` / "Invalid argument" so any future leak hits the friendly "reinstall Python via pyenv/Homebrew" message instead of a raw traceback.

## Changes
- `cli.py`: kqueue probe + SelectSelector fallback before `app.run()`; widened post-`app.run()` except. Gated on `sys.platform == 'darwin'`, no-op on Linux/Windows and on Homebrew/pyenv/system Python.
- `scripts/release.py`: AUTHOR_MAP entry for `jeremy@geocaching.com` → `outdoorsea`.

## Validation
- Cherry-picked cleanly onto current main.
- `py_compile cli.py` ok.
- Lands next to the existing `#6393` `os.fstat(0)` stdin pre-check.

## Fan-out
~15 sibling PRs (#19501, #21660, #20482, #18363, #11253, #12111, #11866, #8796, #13251, #9996, #15720, #8843, #15706, etc.) target the same crash but only widen the except. This PR is the only one that actually prevents the failure. They'll be closed pointing here.

Closes #5884
Supersedes #20482, #21660, #19501, #18363, #11253, #12111, #11866, #8796, #13251, #9996, #15720, #8843, #15706