### PR TITLE
fix(codex_app_server): seed Hermes context on first turn

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -196,6 +196,7 @@ class CodexAppServerSession:
         # to surface a real summary in the approval prompt (quirk #4).
         self._pending_file_changes: dict[str, str] = {}
         self._closed = False
+        self._seed_context_sent = False
 
     # ---------- lifecycle ----------
 
@@ -329,6 +330,7 @@ class CodexAppServerSession:
         self,
         user_input: str,
         *,
+        seed_context: str = "",
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
@@ -365,6 +367,14 @@ class CodexAppServerSession:
         self._interrupt_event.clear()
         projector = CodexEventProjector()
 
+        input_text = user_input
+        if seed_context and not self._seed_context_sent:
+            input_text = (
+                f"{seed_context}\n\n"
+                "[CURRENT USER MESSAGE]\n"
+                f"{user_input}"
+            )
+
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
         try:
@@ -372,10 +382,12 @@ class CodexAppServerSession:
                 "turn/start",
                 {
                     "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": user_input}],
+                    "input": [{"type": "text", "text": input_text}],
                 },
                 timeout=10,
             )
+            if seed_context and not self._seed_context_sent:
+                self._seed_context_sent = True
         except CodexAppServerError as exc:
             # Classify auth/refresh failures so the user gets a clear
             # `codex login` pointer instead of a raw RPC error string.

--- a/run_agent.py
+++ b/run_agent.py
@@ -12266,6 +12266,7 @@ class AIAgent:
         if self.api_mode == "codex_app_server":
             return self._run_codex_app_server_turn(
                 user_message=user_message,
+                system_message=system_message,
                 original_user_message=original_user_message,
                 messages=messages,
                 effective_task_id=effective_task_id,
@@ -15716,10 +15717,83 @@ class AIAgent:
         result = self.run_conversation(message, stream_callback=stream_callback)
         return result["final_response"]
 
+    @staticmethod
+    def _coerce_codex_app_server_content_to_text(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            pieces: List[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    pieces.append(part)
+                    continue
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "text":
+                    text = part.get("text")
+                    if isinstance(text, str):
+                        pieces.append(text)
+            return "\n".join(piece for piece in pieces if piece)
+        if isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return text
+            alt = content.get("content")
+            if isinstance(alt, str):
+                return alt
+        return str(content)
+
+    def _build_codex_app_server_seed_context(
+        self,
+        messages: List[Dict[str, Any]],
+        system_message: str = "",
+    ) -> str:
+        """Serialize Hermes-assembled context for the first Codex app-server turn.
+
+        The Codex subprocess owns its own thread state after startup, so we only
+        need to seed the pre-existing Hermes context once: system prompt, SOUL,
+        injected memory/context files, and any conversation history that
+        existed before the current user message was appended.
+        """
+        if not messages:
+            return ""
+
+        seed_messages = list(messages)
+        if seed_messages and seed_messages[-1].get("role") == "user":
+            seed_messages = seed_messages[:-1]
+
+        rendered: List[str] = []
+        custom_system_message = str(system_message or "").strip()
+        if custom_system_message:
+            rendered.append(f"[SYSTEM]\n{custom_system_message}")
+        system_prompt = str(getattr(self, "_cached_system_prompt", "") or "").strip()
+        if system_prompt and system_prompt != custom_system_message:
+            rendered.append(f"[HERMES_SYSTEM_PROMPT]\n{system_prompt}")
+        for msg in seed_messages:
+            role = str(msg.get("role") or "unknown").upper()
+            text = self._coerce_codex_app_server_content_to_text(
+                msg.get("content")
+            ).strip()
+            if not text:
+                continue
+            rendered.append(f"[{role}]\n{text}")
+
+        if not rendered:
+            return ""
+
+        return (
+            "Hermes session context. Preserve this identity, instructions, and "
+            "conversation state when answering in the Codex runtime.\n\n"
+            + "\n\n".join(rendered)
+        )
+
     def _run_codex_app_server_turn(
         self,
         *,
         user_message: str,
+        system_message: str,
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
@@ -15755,9 +15829,16 @@ class AIAgent:
         # NOTE: the user message is ALREADY appended to messages by the
         # standard run_conversation() flow (line ~11823) before the early
         # return reaches us. Do NOT append again — that would duplicate.
+        seed_context = self._build_codex_app_server_seed_context(
+            messages,
+            system_message=system_message,
+        )
 
         try:
-            turn = self._codex_session.run_turn(user_input=user_message)
+            turn = self._codex_session.run_turn(
+                user_input=user_message,
+                seed_context=seed_context,
+            )
         except Exception as exc:
             logger.exception("codex app-server turn failed")
             # Crash → unconditionally drop the session so the next turn

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -186,6 +186,50 @@ class TestRunTurn:
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
 
+    def test_seed_context_only_applies_to_first_turn(self):
+        client = FakeClient()
+        s = make_session(client)
+
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "first"},
+            threadId="t",
+            turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s.run_turn(
+            "hello",
+            seed_context="[SYSTEM]\nBe Hermes",
+            turn_timeout=2.0,
+        )
+
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m2", "text": "second"},
+            threadId="t",
+            turnId="tu2",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu2", "status": "completed", "error": None},
+        )
+        s.run_turn(
+            "again",
+            seed_context="[SYSTEM]\nBe Hermes",
+            turn_timeout=2.0,
+        )
+
+        turn_starts = [params for (method, params) in client.requests if method == "turn/start"]
+        assert len(turn_starts) == 2
+        assert "[SYSTEM]\nBe Hermes" in turn_starts[0]["input"][0]["text"]
+        assert "[CURRENT USER MESSAGE]\nhello" in turn_starts[0]["input"][0]["text"]
+        assert turn_starts[1]["input"][0]["text"] == "again"
+
     def test_tool_iteration_counter_ticks(self):
         client = FakeClient()
         # Two completed exec items + one final agent message

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -130,6 +130,42 @@ class TestRunConversationCodexPath:
         )
         assert user_count == 1, f"user message appeared {user_count}× in {result['messages']}"
 
+    def test_seed_context_includes_system_and_prior_history(self, monkeypatch):
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured["user_input"] = user_input
+            captured["seed_context"] = kwargs.get("seed_context", "")
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-ctx",
+                thread_id="thread-stub-ctx",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-ctx"
+        )
+
+        agent = _make_codex_agent()
+        history = [
+            {"role": "user", "content": "earlier user"},
+            {"role": "assistant", "content": "earlier assistant"},
+        ]
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation(
+                "current turn",
+                system_message="SOUL: Stay in persona.",
+                conversation_history=history,
+            )
+
+        assert captured["user_input"] == "current turn"
+        assert "[SYSTEM]\nSOUL: Stay in persona." in captured["seed_context"]
+        assert "[USER]\nearlier user" in captured["seed_context"]
+        assert "[ASSISTANT]\nearlier assistant" in captured["seed_context"]
+        assert "current turn" not in captured["seed_context"]
+
     def test_background_review_NOT_invoked_below_threshold(self, fake_session):
         """A single turn shouldn't trigger background review — counters
         haven't reached the nudge interval (default 10)."""


### PR DESCRIPTION
Fixes #26035.

## Summary
- seed Codex app-server sessions with the current Hermes system/SOUL context on the first turn
- preserve prior text conversation history in that first-turn seed without duplicating the current user message
- add regression coverage for first-turn-only seeding and run_conversation() context projection

## Local proof
- `python3 -m pytest -o addopts= tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py -q`\n- `uv run --frozen ruff check run_agent.py agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py`\n- `git diff --check`\n\n## CI attribution\n- recent company PRs `#26068`, `#26059`, and `#26038` all show `e2e` failures, so that lane appears to be preexisting shared baseline noise rather than candidate-specific\n- the broader `test` lane is mixed across those PRs and is not claimed as baseline for this change