### PR TITLE
fix(gateway): publish compression tip before reusing session history

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1812,6 +1812,92 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _advance_session_entry_to_compression_tip(
+        self,
+        source: SessionSource,
+        session_entry,
+    ):
+        """Advance a route/session entry to the latest compression child.
+
+        Gateway route state can lag behind the canonical session chain when a
+        prior turn compressed into a child session. Follow the compression tip
+        before loading transcript history so the next turn cannot pair a child
+        session id with a parent-sized transcript.
+        """
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or session_entry is None:
+            return session_entry
+
+        current_session_id = str(getattr(session_entry, "session_id", "") or "")
+        if not current_session_id:
+            return session_entry
+
+        try:
+            tip_session_id = str(
+                session_db.get_compression_tip(current_session_id) or current_session_id
+            )
+        except Exception:
+            logger.debug("Failed to resolve compression tip", exc_info=True)
+            return session_entry
+
+        if not tip_session_id or tip_session_id == current_session_id:
+            return session_entry
+
+        logger.info(
+            "Advancing session route to compression tip: %s -> %s",
+            current_session_id,
+            tip_session_id,
+        )
+        session_entry.session_id = tip_session_id
+        try:
+            self.session_store._save()
+        except Exception:
+            logger.debug("Failed to persist session route tip advance", exc_info=True)
+
+        if self._is_telegram_topic_lane(source):
+            try:
+                self._record_telegram_topic_binding(source, session_entry)
+            except Exception:
+                logger.debug("Failed to rebind Telegram topic to compression tip", exc_info=True)
+
+        self._evict_cached_agent_if_session_mismatch(
+            getattr(session_entry, "session_key", ""),
+            tip_session_id,
+        )
+        return session_entry
+
+    def _publish_compression_split(
+        self,
+        source: SessionSource,
+        session_key: str,
+        old_session_id: str,
+        new_session_id: str,
+    ) -> None:
+        """Publish a compression-driven session split to gateway route state."""
+        if not session_key:
+            return
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return
+
+        try:
+            entry = self.session_store._entries.get(session_key)
+        except Exception:
+            entry = None
+        if entry is None:
+            return
+
+        entry.session_id = new_session_id
+        try:
+            self.session_store._save()
+        except Exception:
+            logger.debug("Failed to persist compression split route update", exc_info=True)
+
+        if self._is_telegram_topic_lane(source):
+            try:
+                self._record_telegram_topic_binding(source, entry)
+            except Exception:
+                logger.debug("Failed to publish Telegram topic compression split", exc_info=True)
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -7061,6 +7147,10 @@ class GatewayRunner:
                     self._record_telegram_topic_binding(source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+        session_entry = self._advance_session_entry_to_compression_tip(
+            source,
+            session_entry,
+        )
         if getattr(session_entry, "was_auto_reset", False):
             # Treat auto-reset as a full conversation boundary — drop every
             # session-scoped transient state so the fresh session does not
@@ -13849,6 +13939,70 @@ class GatewayRunner:
             with _lock:
                 self._agent_cache.pop(session_key, None)
 
+    def _evict_cached_agent_if_session_mismatch(
+        self,
+        session_key: str,
+        expected_session_id: str,
+    ) -> bool:
+        """Drop a cached agent when it points at a different session id."""
+        _lock = getattr(self, "_agent_cache_lock", None)
+        if not _lock or not session_key or not expected_session_id:
+            return False
+
+        with _lock:
+            cached = self._agent_cache.get(session_key)
+            if not cached:
+                return False
+            agent = cached[0]
+            cached_session_id = str(getattr(agent, "session_id", "") or "")
+            if not cached_session_id or cached_session_id == expected_session_id:
+                return False
+            logger.warning(
+                "Evicting cached agent for %s due to session mismatch: cached=%s canonical=%s",
+                session_key,
+                cached_session_id,
+                expected_session_id,
+            )
+            self._agent_cache.pop(session_key, None)
+            return True
+
+    def _get_cached_agent_for_turn(
+        self,
+        session_key: str,
+        signature: str,
+        session_id: str,
+        interrupt_depth: int,
+    ):
+        """Return a reusable cached agent only when session identity matches."""
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if not _cache_lock or _cache is None or not session_key:
+            return None
+
+        with _cache_lock:
+            cached = _cache.get(session_key)
+            if not cached or cached[1] != signature:
+                return None
+            agent = cached[0]
+            cached_session_id = str(getattr(agent, "session_id", "") or "")
+            if session_id and cached_session_id and cached_session_id != session_id:
+                logger.warning(
+                    "Cached agent session mismatch for %s: cached=%s canonical=%s",
+                    session_key,
+                    cached_session_id,
+                    session_id,
+                )
+                _cache.pop(session_key, None)
+                return None
+            if hasattr(_cache, "move_to_end"):
+                try:
+                    _cache.move_to_end(session_key)
+                except KeyError:
+                    pass
+            self._init_cached_agent_for_turn(agent, interrupt_depth)
+            logger.debug("Reusing cached agent for session %s", session_key)
+            return agent
+
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
@@ -15049,22 +15203,12 @@ class GatewayRunner:
                 cache_keys=self._extract_cache_busting_config(user_config),
             )
             agent = None
-            _cache_lock = getattr(self, "_agent_cache_lock", None)
-            _cache = getattr(self, "_agent_cache", None)
-            if _cache_lock and _cache is not None:
-                with _cache_lock:
-                    cached = _cache.get(session_key)
-                    if cached and cached[1] == _sig:
-                        agent = cached[0]
-                        # Refresh LRU order so the cap enforcement evicts
-                        # truly-oldest entries, not the one we just used.
-                        if hasattr(_cache, "move_to_end"):
-                            try:
-                                _cache.move_to_end(session_key)
-                            except KeyError:
-                                pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+            agent = self._get_cached_agent_for_turn(
+                session_key,
+                _sig,
+                session_id,
+                _interrupt_depth,
+            )
 
             if agent is None:
                 # Config changed or first message — create fresh agent
@@ -15610,10 +15754,12 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                self._publish_compression_split(
+                    source,
+                    session_key,
+                    session_id,
+                    agent.session_id,
+                )
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -338,6 +338,26 @@ class TestAgentCacheLifecycle:
         assert cached[1] == sig
         assert cached[0] is agent1  # same instance
 
+    def test_cached_agent_session_mismatch_is_evicted(self):
+        """Cached agents must not be reused across compression-driven session switches."""
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        cached_agent = MagicMock()
+        cached_agent.session_id = "parent-session"
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (cached_agent, "sig123")
+
+        reused = runner._get_cached_agent_for_turn(
+            session_key,
+            "sig123",
+            "child-session",
+            0,
+        )
+
+        assert reused is None
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+
     def test_cache_miss_on_model_change(self):
         """Model change produces different signature → cache miss."""
         from run_agent import AIAgent

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -267,6 +267,97 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
 
 
 @pytest.mark.asyncio
+async def test_topic_lane_follows_compression_tip_before_loading_history_and_rebinds_split(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="compressed-root",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.end_session("compressed-root", "compression")
+    session_db.create_session(
+        session_id="compressed-child",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="compressed-root",
+    )
+    session_db.append_message("compressed-child", "user", "already compact")
+    # Pre-create the next compression child so the test can verify rebinding
+    # after the mocked turn returns a new session id.
+    session_db.create_session(
+        session_id="compressed-grandchild",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="compressed-child",
+    )
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=build_session_key(_make_source(thread_id="17585")),
+        session_id="compressed-root",
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False: SessionEntry(
+        session_key=topic_key,
+        session_id="compressed-root",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=source,
+    )
+    seen = {}
+
+    def _load_transcript(session_id):
+        seen["loaded_session_id"] = session_id
+        return [{"role": "user", "content": "already compact"}]
+
+    runner.session_store.load_transcript.side_effect = _load_transcript
+
+    async def fake_run_agent(*args, **kwargs):
+        seen["run_session_id"] = kwargs.get("session_id")
+        return {
+            "success": True,
+            "final_response": "continued",
+            "session_id": "compressed-grandchild",
+            "messages": [],
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue", thread_id="17585"))
+
+    assert result == "continued"
+    assert seen["loaded_session_id"] == "compressed-child"
+    assert seen["run_session_id"] == "compressed-child"
+    runner._publish_compression_split(
+        topic_source,
+        topic_key,
+        "compressed-child",
+        "compressed-grandchild",
+    )
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988",
+        thread_id="17585",
+    )
+    assert binding["session_id"] == "compressed-grandchild"
+
+
+@pytest.mark.asyncio
 async def test_telegram_group_prompt_is_not_topic_lobby_even_when_dm_topic_mode_enabled(
     tmp_path, monkeypatch
 ):
@@ -1048,7 +1139,4 @@ async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
         ).fetchall()
     }
     assert tables == set()
-
-
-
 


### PR DESCRIPTION
Fixes #25921.

## Summary
- follow the latest compression continuation before loading gateway transcript history and rebind Telegram topic lanes to that tip
- publish compression-driven session splits back into gateway route state instead of leaving stale parent session ids behind
- refuse cached-agent reuse when the cached agent session id no longer matches the canonical route session id

## Testing
- `python3 -m pytest -o addopts='' tests/gateway/test_telegram_topic_mode.py tests/gateway/test_agent_cache.py -q`
- `uv run --frozen ruff check gateway/run.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_agent_cache.py`
- `git diff --check`

## Attribution
- Local proof: `.paperclip_artifacts/quality-gate/proof-67cdc6216c7662ff6dd76313c0c8ff0c67b9f0be.json`
- Recent company PRs `#26081`, `#26068`, and `#26059` share the same red `Tests / test` and `Tests / e2e` failures while attribution, lint, nix, and supply-chain checks stay green, so any repeat of those lanes should be treated as `preexisting_unrelated` baseline noise unless this diff shows a new signature.
