### PR TITLE
fix(codex-runtime): avoid duplicate plugin tables

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -242,6 +244,54 @@ def _quote_key(key: str) -> str:
         return key
     escaped = key.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
+
+
+_PLUGIN_TABLE_HEADER_RE = re.compile(
+    r"^\[plugins\."
+    r"(?P<key>\"(?:\\.|[^\"\\])*\"|'[^']*'|[A-Za-z0-9_-]+)"
+    r"\]\s*(?:#.*)?$"
+)
+
+
+def _decode_toml_key(raw_key: str) -> Optional[str]:
+    """Decode one TOML table key segment, returning None on invalid syntax."""
+    if raw_key.startswith(("'", '"')):
+        try:
+            decoded = tomllib.loads(f"key = {raw_key}\n")["key"]
+        except tomllib.TOMLDecodeError:
+            return None
+        return str(decoded)
+    return raw_key
+
+
+def _existing_plugin_table_keys(toml_text: str) -> set[str]:
+    """Return plugin table keys already present outside Hermes' block.
+
+    Codex may keep native plugin entries in ~/.codex/config.toml itself.
+    If Hermes writes the same [plugins."name@marketplace"] table into its
+    managed block, the resulting TOML has a duplicate table and codex refuses
+    to start. This scanner runs after the Hermes block has been stripped, so
+    every match belongs to user/Codex-owned config that must be preserved.
+    """
+    keys: set[str] = set()
+    for line in toml_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("[["):
+            continue
+        match = _PLUGIN_TABLE_HEADER_RE.match(stripped)
+        if not match:
+            continue
+        key = _decode_toml_key(match.group("key"))
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _plugin_config_key(plugin: dict) -> str:
+    """Return the Codex config table key for one plugin/list entry."""
+    name = plugin.get("name") or ""
+    marketplace = plugin.get("marketplace") or "openai-curated"
+    return f"{name}@{marketplace}"
 
 def render_codex_toml_section(
     servers: dict[str, dict],
@@ -537,8 +587,28 @@ def migrate(
         plugins, plugin_err = _query_codex_plugins(codex_home=codex_home)
         if plugin_err:
             report.plugin_query_error = plugin_err
-        for p in plugins:
-            report.migrated_plugins.append(f"{p['name']}@{p['marketplace']}")
+
+    # Read existing codex config if any, strip the prior managed block,
+    # and collect user/Codex-owned plugin tables that must not be duplicated
+    # in the regenerated managed block.
+    without_managed: Optional[str] = None
+    existing_plugin_keys: set[str] = set()
+    if target.exists():
+        try:
+            existing = target.read_text(encoding="utf-8")
+        except Exception as exc:
+            report.errors.append(f"could not read {target}: {exc}")
+            return report
+        without_managed = _strip_existing_managed_block(existing)
+        existing_plugin_keys = _existing_plugin_table_keys(without_managed)
+
+    if existing_plugin_keys:
+        plugins = [
+            plugin for plugin in plugins
+            if _plugin_config_key(plugin) not in existing_plugin_keys
+        ]
+    for plugin in plugins:
+        report.migrated_plugins.append(_plugin_config_key(plugin))
 
     # Track whether we wrote a default permission profile so the report
     # surfaces it to the user.
@@ -562,15 +632,8 @@ def migrate(
         default_permission_profile=default_permission_profile,
     )
 
-    # Read existing codex config if any, strip the prior managed block,
-    # append the new one.
-    if target.exists():
-        try:
-            existing = target.read_text(encoding="utf-8")
-        except Exception as exc:
-            report.errors.append(f"could not read {target}: {exc}")
-            return report
-        without_managed = _strip_existing_managed_block(existing)
+    # Append the new managed block after preserved user/Codex config.
+    if without_managed is not None:
         # Ensure exactly one blank line between user content and managed block
         if without_managed and not without_managed.endswith("\n"):
             without_managed += "\n"

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tomllib
 
 import pytest
 
 from hermes_cli.codex_runtime_plugin_migration import (
+    MIGRATION_END_MARKER,
     MIGRATION_MARKER,
     MigrationReport,
     _format_toml_value,
@@ -360,6 +362,51 @@ class TestMigrate:
         assert "enabled = true" in text
         assert "google-calendar@openai-curated" in report.migrated_plugins
         assert "github@openai-curated" in report.migrated_plugins
+
+    def test_existing_plugin_table_is_not_duplicated_in_managed_block(
+        self, tmp_path, monkeypatch
+    ):
+        """Codex-owned plugin tables outside Hermes' block are preserved.
+
+        Re-migrating the same installed plugin should not add a second
+        [plugins."name@marketplace"] table, because TOML rejects duplicate
+        tables and codex refuses to start with that config.
+        """
+        from hermes_cli import codex_runtime_plugin_migration as crpm
+
+        target = tmp_path / "config.toml"
+        target.write_text(
+            '[plugins."github@openai-curated"]\n'
+            "enabled = false\n\n"
+            f"{MIGRATION_MARKER}\n"
+            '[plugins."github@openai-curated"]\n'
+            "enabled = true\n"
+            f"{MIGRATION_END_MARKER}\n"
+        )
+
+        def fake_query(codex_home=None, timeout=8.0):
+            return [
+                {"name": "github", "marketplace": "openai-curated",
+                 "enabled": True},
+                {"name": "google-calendar", "marketplace": "openai-curated",
+                 "enabled": True},
+            ], None
+        monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
+
+        report = migrate(
+            {},
+            codex_home=tmp_path,
+            discover_plugins=True,
+            default_permission_profile=None,
+            expose_hermes_tools=False,
+        )
+        text = target.read_text()
+
+        assert text.count('[plugins."github@openai-curated"]') == 1
+        assert "enabled = false" in text
+        assert '[plugins."google-calendar@openai-curated"]' in text
+        assert report.migrated_plugins == ["google-calendar@openai-curated"]
+        tomllib.loads(text)
 
     def test_plugin_discovery_skips_unavailable_plugins(self):
         """Plugins where codex reports availability != AVAILABLE should


### PR DESCRIPTION
Fixes #26089

## Summary

This PR makes `hermes codex-runtime migrate` skip native Codex plugin tables that already exist outside Hermes' managed block.

## Root Cause

The migration was idempotent only for Hermes' own managed block. It preserved user/Codex-owned `[plugins."<name>@<marketplace>"]` sections outside the managed block, then rendered the same installed plugins again from `plugin/list`, producing duplicate TOML tables.

## Fix

- Add a small scanner for existing `[plugins."<name>@<marketplace>"]` table headers after the prior Hermes block is stripped.
- Filter discovered `plugin/list` entries whose config key already exists in preserved user/Codex config.
- Report only plugin entries that Hermes actually writes into the regenerated managed block.
- Add a regression test that preserves an existing plugin table, migrates a different plugin, and validates the final TOML with `tomllib`.

## Behavior Change

Codex-owned plugin tables outside the Hermes managed section remain the source of truth for those plugins. Hermes still migrates other discovered native plugins into its managed block.

## Test Plan

- `python -m pytest tests/hermes_cli/test_codex_runtime_plugin_migration.py -o 'addopts=' -q`
  - `57 passed in 1.29s`
- `python -m py_compile hermes_cli/codex_runtime_plugin_migration.py tests/hermes_cli/test_codex_runtime_plugin_migration.py`
- `git diff --check`

## Risk Assessment

Low — the change is scoped to Codex plugin migration rendering. MCP server migration and permissions rendering use the same paths as before, while plugin entries gain a duplicate-table guard before rendering.