### PR TITLE
fix(agent): stop auth refresh loops from blocking fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7421,6 +7421,22 @@ class AIAgent:
         if effective_reason == FailoverReason.auth:
             refreshed = pool.try_refresh_current()
             if refreshed is not None:
+                refreshed_id = getattr(refreshed, "id", None)
+                if refreshed_id is not None:
+                    refresh_counts = getattr(self, "_auth_pool_refresh_counts", {})
+                    refresh_key = (self.provider, refreshed_id)
+                    refresh_counts[refresh_key] = refresh_counts.get(refresh_key, 0) + 1
+                    self._auth_pool_refresh_counts = refresh_counts
+                    # A token refresh can still leave us pinned to the same dead
+                    # credential if the upstream keeps rejecting it. Let fallback
+                    # activate instead of looping forever on the same entry.
+                    if refresh_counts[refresh_key] > 2:
+                        logger.warning(
+                            "Credential auth failure persists after %s refreshes for pool entry %s; allowing fallback",
+                            refresh_counts[refresh_key] - 1,
+                            refreshed_id,
+                        )
+                        return False, has_retried_429
                 logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
                 self._swap_credential(refreshed)
                 return True, has_retried_429
@@ -12593,6 +12609,7 @@ class AIAgent:
             retry_count = 0
             max_retries = self._api_max_retries
             primary_recovery_attempted = False
+            self._auth_pool_refresh_counts = {}
             max_compression_attempts = 3
             codex_auth_retry_attempted=False
             anthropic_auth_retry_attempted=False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2935,6 +2935,59 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after remint"
 
+    def test_persistent_401_same_pool_entry_triggers_fallback(self, agent):
+        """Repeated same-entry auth refreshes must not block fallback activation."""
+        self._setup_agent(agent)
+        agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent._fallback_index = 0
+        agent._fallback_activated = False
+
+        class _UnauthorizedError(RuntimeError):
+            def __init__(self):
+                super().__init__("Error code: 401 - unauthorized")
+                self.status_code = 401
+
+        refreshed_entry = SimpleNamespace(label="primary", id="abc")
+
+        class _Pool:
+            def try_refresh_current(self):
+                return refreshed_entry
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                return None
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+        agent.client.chat.completions.create.side_effect = [
+            _UnauthorizedError(),
+            _UnauthorizedError(),
+            _UnauthorizedError(),
+            _mock_response(content="Fallback answer.", finish_reason="stop"),
+        ]
+
+        fallback_called = {"called": 0}
+
+        def _mock_fallback():
+            fallback_called["called"] += 1
+            agent._fallback_index = 1
+            agent._fallback_activated = True
+            agent.model = "anthropic/claude-sonnet-4"
+            agent.provider = "openrouter"
+            return True
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert fallback_called["called"] == 1
+        assert result["completed"] is True
+        assert result["final_response"] == "Fallback answer."
+        assert agent._swap_credential.call_count == 2
+
     def test_context_compression_triggered(self, agent):
         """When compressor says should_compress, compression runs."""
         self._setup_agent(agent)
@@ -3757,6 +3810,36 @@ class TestCredentialPoolRecovery:
 
         assert recovered is False
         agent._swap_credential.assert_not_called()
+
+    def test_recover_with_pool_401_same_entry_refreshes_stop_after_two(self, agent):
+        """Repeated auth refreshes for the same entry must eventually fall through."""
+
+        refreshed_entry = SimpleNamespace(label="primary", id="abc")
+
+        class _Pool:
+            def try_refresh_current(self):
+                return refreshed_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        first = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+        second = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+        third = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert first == (True, False)
+        assert second == (True, False)
+        assert third == (False, False)
+        assert agent._swap_credential.call_count == 2
 
     def test_extract_api_error_context_uses_reset_timestamp_and_reason(self, agent):
         response = SimpleNamespace(headers={})


### PR DESCRIPTION
## Summary
- cap same-entry credential-pool auth refresh recoveries so persistent 401s can fall through to fallback
- reset the per-entry auth refresh tracker for each API request block
- add regressions for helper-level recovery and run_conversation fallback activation

## Testing
- python3 -m pytest -o addopts='' tests/run_agent/test_run_agent.py -q -k "same_pool_entry or recover_with_pool_401"
- uv run --frozen ruff check run_agent.py tests/run_agent/test_run_agent.py
- git diff --check

Fixes #26080