### PR TITLE
fix(qqbot): support Windows local media sends

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import uuid
 from abc import ABC, abstractmethod
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 from utils import normalize_proxy_url
 
@@ -251,6 +251,44 @@ def _split_host_port(value: str) -> tuple[str, int | None]:
         if maybe_port.isdigit():
             return host.lower().rstrip("."), int(maybe_port)
     return raw.lower().strip("[]").rstrip("."), None
+
+
+def _normalize_file_image_url(url: str) -> str:
+    """Normalize ``file://`` image URLs for downstream local-file senders.
+
+    POSIX paths stay as ``file:///tmp/x.png``. Windows drive-letter forms are
+    normalized to ``file://C:/path/to/x.png`` so callers that strip the
+    ``file://`` prefix do not end up with a bogus leading slash.
+    """
+    if not url.lower().startswith("file://"):
+        return url
+    raw_path = unquote(url[7:]).replace("\\", "/")
+    if re.match(r"^/[A-Za-z]:/", raw_path):
+        raw_path = raw_path[1:]
+    if re.match(r"^[A-Za-z]:/", raw_path):
+        return f"file://{raw_path}"
+    return f"file://{raw_path}"
+
+
+def _is_extractable_image_url(url: str) -> bool:
+    lower = url.lower()
+    if lower.startswith("file://"):
+        return lower.split("?", 1)[0].endswith(
+            (".png", ".jpg", ".jpeg", ".gif", ".webp")
+        )
+    return any(
+        lower.endswith(ext) or ext in lower
+        for ext in (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            "fal.media",
+            "fal-cdn",
+            "replicate.delivery",
+        )
+    )
 
 
 def _no_proxy_entries() -> list[str]:
@@ -1960,6 +1998,8 @@ class BasePlatformAdapter(ABC):
         """
         images = []
         cleaned = content
+        extracted_markdown: list[str] = []
+        extracted_html: list[str] = []
         
         # Match markdown images: ![alt](url)
         md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
@@ -1967,24 +2007,28 @@ class BasePlatformAdapter(ABC):
             alt_text = match.group(1)
             url = match.group(2)
             # Only extract URLs that look like actual images
-            if any(url.lower().endswith(ext) or ext in url.lower() for ext in
-                   ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
+            if _is_extractable_image_url(url):
                 images.append((url, alt_text))
-        
-        # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
-        html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
-        for match in re.finditer(html_pattern, content):
-            url = match.group(1)
-            images.append((url, ""))
-        
+                extracted_markdown.append(match.group(0))
+
+        # Match HTML img tags with quoted or unquoted src values and tolerate
+        # additional attributes before/after src.
+        html_pattern = re.compile(
+            r'<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|\'([^\']+)\'|([^>\s]+))[^>]*>\s*(?:</img>)?',
+            re.IGNORECASE,
+        )
+        for match in html_pattern.finditer(content):
+            raw_url = match.group(1) or match.group(2) or match.group(3) or ""
+            normalized = _normalize_file_image_url(raw_url) if raw_url.lower().startswith("file://") else raw_url
+            if not _is_extractable_image_url(normalized):
+                continue
+            images.append((normalized, ""))
+            extracted_html.append(match.group(0))
+
         # Remove only the matched image tags from content (not all markdown images)
         if images:
-            extracted_urls = {url for url, _ in images}
-            def _remove_if_extracted(match):
-                url = match.group(2) if match.lastindex >= 2 else match.group(1)
-                return '' if url in extracted_urls else match.group(0)
-            cleaned = re.sub(md_pattern, _remove_if_extracted, cleaned)
-            cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned)
+            for raw in extracted_markdown + extracted_html:
+                cleaned = cleaned.replace(raw, "")
             # Clean up leftover blank lines
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
@@ -2170,8 +2214,14 @@ class BasePlatformAdapter(ABC):
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
         # (?:~/|/)    anchors to absolute or home-relative paths
-        path_re = re.compile(
+        posix_path_re = re.compile(
             r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            re.IGNORECASE,
+        )
+        windows_path_re = re.compile(
+            r'(?<![\w/:.-])[A-Za-z]:(?:\\|/)(?:[^<>:"|?*\r\n]+(?:\\|/))*[^<>:"|?*\r\n]+\.(?:'
+            + ext_part
+            + r')\b',
             re.IGNORECASE,
         )
 
@@ -2185,19 +2235,23 @@ class BasePlatformAdapter(ABC):
         def _in_code(pos: int) -> bool:
             return any(s <= pos < e for s, e in code_spans)
 
-        found: list = []  # (raw_match_text, expanded_path)
-        for match in path_re.finditer(content):
+        found: list = []  # (start_pos, raw_match_text, expanded_path)
+        all_matches = []
+        for path_re in (posix_path_re, windows_path_re):
+            all_matches.extend(path_re.finditer(content))
+
+        for match in sorted(all_matches, key=lambda m: m.start()):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
             expanded = os.path.expanduser(raw)
             if os.path.isfile(expanded):
-                found.append((raw, expanded))
+                found.append((match.start(), raw, expanded))
 
         # Deduplicate by expanded path, preserving discovery order
         seen: set = set()
         unique: list = []
-        for raw, expanded in found:
+        for _start, raw, expanded in found:
             if expanded not in seen:
                 seen.add(expanded)
                 unique.append((raw, expanded))

--- a/gateway/platforms/qqbot/__init__.py
+++ b/gateway/platforms/qqbot/__init__.py
@@ -19,6 +19,7 @@ from .adapter import (  # noqa: F401
     QQAdapter,
     QQCloseError,
     check_qq_requirements,
+    get_active_adapter,
     _coerce_list,
     _ssrf_redirect_guard,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "QQAdapter",
     "QQCloseError",
     "check_qq_requirements",
+    "get_active_adapter",
     "_coerce_list",
     "_ssrf_redirect_guard",
     # onboard

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,7 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, ClassVar, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 try:
@@ -160,6 +160,17 @@ class QQAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
+    _active_instance: ClassVar[Optional["QQAdapter"]] = None
+
+    @classmethod
+    def get_active(cls) -> Optional["QQAdapter"]:
+        """Return the currently connected adapter instance, if any."""
+        return cls._active_instance
+
+    @classmethod
+    def set_active(cls, adapter: Optional["QQAdapter"]) -> None:
+        """Track the live adapter so helper tools can reuse native media sends."""
+        cls._active_instance = adapter
 
     @property
     def _log_tag(self) -> str:
@@ -321,6 +332,7 @@ class QQAdapter(BasePlatformAdapter):
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             self._mark_connected()
+            QQAdapter.set_active(self)
             logger.info("[%s] Connected", self._log_tag)
             return True
         except Exception as exc:
@@ -335,6 +347,8 @@ class QQAdapter(BasePlatformAdapter):
         """Close all connections and stop listeners."""
         self._running = False
         self._mark_disconnected()
+        if QQAdapter._active_instance is self:
+            QQAdapter.set_active(None)
 
         if self._listen_task:
             self._listen_task.cancel()
@@ -645,6 +659,7 @@ class QQAdapter(BasePlatformAdapter):
             gateway_url = await self._get_gateway_url()
             await self._open_ws(gateway_url)
             self._mark_connected()
+            QQAdapter.set_active(self)
             logger.info("[%s] Reconnected", self._log_tag)
             return True
         except Exception as exc:
@@ -2711,7 +2726,6 @@ class QQAdapter(BasePlatformAdapter):
             reply_to,
             file_name=file_name,
         )
-
     async def _send_media(
             self,
             chat_id: str,
@@ -3069,3 +3083,8 @@ class QQAdapter(BasePlatformAdapter):
             return True
         self._seen_messages[msg_id] = now
         return False
+
+
+def get_active_adapter() -> Optional["QQAdapter"]:
+    """Delegate to ``QQAdapter.get_active()`` for tool-side reuse."""
+    return QQAdapter.get_active()

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -104,6 +104,16 @@ class TestBasicDetection:
         paths, _ = _extract("File at /tmp/my-screenshot-2024.png done")
         assert paths == ["/tmp/my-screenshot-2024.png"]
 
+    def test_windows_backslash_path(self):
+        paths, cleaned = _extract(r"Saved to C:\Users\Test User\shot.png now")
+        assert paths == [r"C:\Users\Test User\shot.png"]
+        assert r"C:\Users\Test User\shot.png" not in cleaned
+
+    def test_windows_forwardslash_path(self):
+        paths, cleaned = _extract("Saved to C:/Users/Test User/shot.png now")
+        assert paths == ["C:/Users/Test User/shot.png"]
+        assert "C:/Users/Test User/shot.png" not in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Non-existent files are skipped
@@ -153,6 +163,10 @@ class TestURLRejection:
     def test_file_url_not_matched(self):
         paths, _ = _extract("Open file:///home/user/doc.png in browser")
         # file:// has :// before /home so lookbehind blocks it
+        assert paths == []
+
+    def test_windows_file_url_not_matched(self):
+        paths, _ = _extract("Open file://C:/Users/Test/shot.png in browser")
         assert paths == []
 
 
@@ -278,10 +292,11 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
-        assert paths == []
+    def test_windows_path_is_matched(self):
+        """Windows-style absolute media paths should be detected."""
+        paths, cleaned = _extract("See C:\\Users\\test\\image.png")
+        assert paths == [r"C:\Users\test\image.png"]
+        assert r"C:\Users\test\image.png" not in cleaned
 
     def test_relative_path_not_matched(self):
         """Relative paths like ./image.png should not match."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -238,6 +238,18 @@ class TestExtractImages:
         images, _ = BasePlatformAdapter.extract_images(content)
         assert images == []
 
+    def test_html_img_file_url_windows_quoted_is_normalized(self):
+        content = 'Screenshot: <img src="file:///C:/Users/Test User/shot.png">'
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+        assert images == [("file://C:/Users/Test User/shot.png", "")]
+        assert "<img" not in cleaned
+
+    def test_html_img_file_url_windows_unquoted_is_normalized(self):
+        content = "Screenshot: <img src=file://C:\\Users\\Test\\shot.png>"
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+        assert images == [("file://C:/Users/Test/shot.png", "")]
+        assert "<img" not in cleaned
+
     def test_non_image_link_preserved_when_mixed_with_images(self):
         """Regression: non-image markdown links must not be silently removed
         when the response also contains real images."""
@@ -728,4 +740,3 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
-

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -97,6 +97,16 @@ class TestQQAdapterInit:
         adapter = self._make(app_id="a", client_secret="b")
         assert adapter.name == "QQBot"
 
+    def test_active_adapter_helper_round_trips_instance(self):
+        from gateway.platforms.qqbot import QQAdapter, get_active_adapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        QQAdapter.set_active(adapter)
+        try:
+            assert get_active_adapter() is adapter
+        finally:
+            QQAdapter.set_active(None)
+
 
 # ---------------------------------------------------------------------------
 # _coerce_list

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -549,6 +549,47 @@ class TestSendToPlatformChunking:
         helper.assert_not_awaited()
         lightweight.assert_awaited_once()
 
+    def test_qqbot_media_uses_live_adapter_helper(self, tmp_path):
+        image_path = tmp_path / "shot.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+
+        helper = AsyncMock(return_value={"success": True, "platform": "qqbot", "chat_id": "openid-1", "message_id": "msg-1"})
+        with patch("tools.send_message_tool._send_qqbot_via_adapter", helper):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={"app_id": "appid"}),
+                    "openid-1",
+                    "here you go",
+                    media_files=[(str(image_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        helper.assert_awaited_once()
+        call = helper.await_args
+        assert call.args[0] == "openid-1"
+        assert call.args[1] == "here you go"
+        assert call.kwargs["media_files"] == [(str(image_path), False)]
+
+    def test_qqbot_text_only_uses_rest_path(self):
+        media_helper = AsyncMock()
+        rest_helper = AsyncMock(return_value={"success": True, "platform": "qqbot", "chat_id": "openid-1", "message_id": "msg-2"})
+        with patch("tools.send_message_tool._send_qqbot_via_adapter", media_helper), \
+             patch("tools.send_message_tool._send_qqbot", rest_helper):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={"app_id": "appid"}),
+                    "openid-1",
+                    "just text",
+                )
+            )
+
+        assert result["success"] is True
+        media_helper.assert_not_awaited()
+        rest_helper.assert_awaited_once()
+
     def test_send_matrix_via_adapter_sends_document(self, tmp_path):
         file_path = tmp_path / "report.pdf"
         file_path.write_bytes(b"%PDF-1.4 test")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -685,11 +685,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- QQBot: native media attachment support via running gateway adapter ---
+    if platform == Platform.QQBOT and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_qqbot_via_adapter(
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and qqbot; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -697,7 +712,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and qqbot"
         )
 
     last_result = None
@@ -1854,6 +1869,61 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # All endpoints failed — return the most informative error
             return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+    except Exception as e:
+        return _error(f"QQBot send failed: {e}")
+
+
+async def _send_qqbot_via_adapter(chat_id, message, media_files=None):
+    """Send via the live QQBot adapter so local files can use native uploads."""
+    try:
+        from gateway.platforms.qqbot import get_active_adapter
+    except ImportError:
+        return _error("QQBot adapter module not available.")
+
+    adapter = get_active_adapter()
+    if adapter is None:
+        return _error(
+            "QQBot adapter is not running. "
+            "Start the gateway with qqbot platform enabled first."
+        )
+
+    media_files = media_files or []
+
+    try:
+        last_result = None
+        if message.strip():
+            last_result = await adapter.send(chat_id=chat_id, content=message)
+            if not last_result.success:
+                return _error(f"QQBot send failed: {last_result.error}")
+
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                return _error(f"Media file not found: {media_path}")
+
+            ext = os.path.splitext(media_path)[1].lower()
+            if ext in _IMAGE_EXTS:
+                last_result = await adapter.send_image_file(chat_id, media_path)
+            elif ext in _VIDEO_EXTS:
+                last_result = await adapter.send_video(chat_id, media_path)
+            elif ext in _VOICE_EXTS and is_voice:
+                last_result = await adapter.send_voice(chat_id, media_path)
+            elif ext in _AUDIO_EXTS:
+                last_result = await adapter.send_voice(chat_id, media_path)
+            else:
+                last_result = await adapter.send_document(chat_id, media_path)
+
+            if not last_result.success:
+                return _error(f"QQBot media send failed: {last_result.error}")
+
+        if last_result is None:
+            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+        return {
+            "success": True,
+            "platform": "qqbot",
+            "chat_id": chat_id,
+            "message_id": last_result.message_id,
+        }
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the QQBot local-media delivery path for Windows-origin screenshot workflows. `send_message` can now hand QQBot media files to the live gateway adapter, and the gateway path extraction helpers now normalize Windows `file://...` image URLs plus bare absolute Windows media paths so those files are treated as attachments instead of leaked text.

This is adjacent to, but not the same as, the older QQBot live-send PR for `#23825`: this change specifically covers media-only sends and Windows local path extraction for `#26041`.

## Related Issue

Fixes #26041

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- export and track the active QQBot adapter instance across connect/reconnect/disconnect
- route QQBot `send_message` media files through the live adapter's native upload methods
- parse and clean HTML `<img src=...>` `file://` URLs, including Windows drive-letter forms
- detect absolute Windows media paths in `extract_local_files()`
- add regression coverage for QQBot live-adapter routing and Windows local media extraction

## How to Test

1. `uv run --frozen --extra dev --extra messaging python -m pytest -o addopts='' tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py tests/gateway/test_qqbot.py tests/tools/test_send_message_tool.py`
2. `uv run --frozen --extra dev ruff check gateway/platforms/base.py gateway/platforms/qqbot/adapter.py gateway/platforms/qqbot/__init__.py tools/send_message_tool.py tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py tests/gateway/test_qqbot.py tests/tools/test_send_message_tool.py`
3. In a live QQBot session, send a tool result containing `MEDIA:C:\Users\...\shot.png` or `<img src="file:///C:/Users/.../shot.png" />` and confirm the screenshot is uploaded as media instead of left in the text body.

## Notes

- Targeted local proof on commit `83ecdeb65e1515876a0078ccba415a219b0a41c3` is green.
- Recent company Hermes PRs share unrelated GitHub baseline-red lanes; no candidate-specific failure was found locally.
