### PR TITLE
feat(kanban): AION 中文工厂驾驶舱与归档状态 / AION cockpit archive status

### DIFF
--- a/docs/hermes-aion-archive-mechanism-v0.1.md
+++ b/docs/hermes-aion-archive-mechanism-v0.1.md
@@ -1,0 +1,193 @@
+# AION × Hermes 归档机制 v0.1
+
+> 目标：让项目越来越多以后，AION 仍能被 AI 高效调用、低 token 检索、精确追溯。Hermes 原生归档负责“移出活跃视图”；AION 归档负责“可审计、可召回、可汇总”。
+
+## 1. Hermes 现有归档能力盘点
+
+Hermes 已有多类归档/清理机制：
+
+| 类型 | Hermes 机制 | 特点 | AION 使用方式 |
+| --- | --- | --- | --- |
+| Kanban task archive | task 状态变为 `archived`；默认不显示，可通过 include archived 查看 | 不删除数据库记录，只移出默认看板 | 用作“移出主战场”，不是最终档案 |
+| Kanban board archive | 删除 board 默认移动到 `boards/_archived/`，可恢复 | 项目级看板归档 | 用作项目看板冷归档 |
+| Kanban gc | 清理 archived task workspace、旧 events、旧 logs | 偏存储清理 | 只能在确认 AION 档案已入账后使用 |
+| Session export/prune | `hermes sessions export` / `sessions prune` | 导出 JSONL、清理旧会话 | 只做会话备份/清理，不能当任务正本 |
+| Profile export/import | `hermes profile export`，不包含 `.env`/`auth.json` |  profile 备份，排除凭据 | 用作 GM/007/审计环境备份，不存 secret |
+| Skill curator archive | 技能移动到 `.archive/`，可 restore | 可恢复，不直接删除 | 用作过期技能归档，不等于项目档案 |
+| Cron local output | cron 输出默认保存本地文件 | 可查调度结果 | 只存摘要索引，不把长输出塞进看板 |
+
+结论：Hermes 原生归档偏“收纳/隐藏/恢复”，AION 还需要一层“任务正本索引 + 精准摘要 + 证据链”。
+
+## 2. AION 归档原则
+
+1. **GitHub 仍是正本**：issue、PR、commit、CI、review、comment 是最终证据。
+2. **Factory Report 是账本**：保存健康、吞吐、证据索引、完成趋势。
+3. **Hermes Kanban 是作战视图**：显示当前状态，不承载长历史。
+4. **归档不是删除**：主战场减负，但必须可恢复、可检索、可追溯。
+5. **AI 优先读取短索引**：默认读取精简 JSON/Markdown 索引；只有需要时再打开长文、PR、日志。
+6. **禁止归档未闭环任务**：缺 GitHub evidence、缺审计、缺 ledger 的任务不能归档为“已完成”。
+7. **高风险单独留痕**：涉及 production/payment/credits/webhook/DB/customer data/legal 的任务必须保留授权证据链接。
+
+## 3. AION 档案层级
+
+建议采用四层结构：
+
+```text
+Level 0: Live 看板
+  当前活跃任务，只放短字段。
+
+Level 1: Index 索引
+  AI 默认读取；每条任务 10-20 行以内。
+
+Level 2: Packet 完成包
+  单任务完整收口：目标、范围、PR、测试、审计、风险、AAR。
+
+Level 3: Evidence 原始证据
+  GitHub issue/PR/comment/CI/log/report/截图链接，不复制长内容。
+```
+
+## 4. 推荐目录结构
+
+在 AION governance repo 中建议新增：
+
+```text
+factory/archive/
+  index.json
+  index.md
+  projects/
+    <project_id>/
+      project-index.json
+      project-index.md
+      tasks/
+        <task_id>.json
+        <task_id>.md
+      prs/
+        pr-<number>.json
+        pr-<number>.md
+      aar/
+        <date>-<task_id>-aar.md
+```
+
+其中：
+
+- `index.json`：机器优先读取。
+- `index.md`：人类快速查看。
+- `task_id.json`：短、结构化、AI 友好。
+- `task_id.md`：完成包，可读版本。
+- 不把大日志全文塞进去，只保存链接和摘要。
+
+## 5. 单任务归档字段
+
+```yaml
+archive_packet:
+  schema_version: aion.archive.v0.1
+  project_id:
+  task_id:
+  title_cn:
+  status: completed | archived | blocked | superseded | abandoned
+  owner:
+  auditor:
+  risk_level: L0 | L1 | L2 | L3 | L4
+  monarch_required: true | false
+  github:
+    repo:
+    issue:
+    pr:
+    head_sha:
+    merge_commit:
+    ci_runs:
+    review_comments:
+  evidence:
+    status: present | missing
+    links:
+    summary:
+  audit:
+    verdict: pass | fail | fallback | retrospective | pending
+    auditor:
+    comment_url:
+  factory_report:
+    report_url:
+    evidence_index_path:
+  kanban:
+    board:
+    card_id:
+    final_state:
+    archived_at:
+  aar:
+    what_was_expected:
+    what_happened:
+    lessons:
+    followups:
+  retrieval:
+    keywords:
+    one_line_summary:
+    token_budget: short
+```
+
+## 6. 归档门槛
+
+任务从 `已完成` 进入 `已归档` 前必须满足：
+
+- ✅ 有 GitHub 正本链接。
+- ✅ 有 PR/commit/CI/review/comment 等 evidence。
+- ✅ 有审计或 GM2 low-risk verdict。
+- ✅ 有 completion packet。
+- ✅ 有 AAR/经验教训，哪怕很短。
+- ✅ 已写入 AION archive index。
+
+不满足时：
+
+- 缺 evidence：停在 `待补证据`。
+- 缺审计：停在 `待审计`。
+- 高风险缺授权：停在 `待君主拍板`。
+- 缺 completion packet：停在 `待入档`。
+
+## 7. 看板归档规则
+
+Hermes Kanban 中的 `archived` 只表示“移出主战场”，不等于 AION 归档完成。
+
+推荐状态：
+
+```text
+已完成 → 待入档 → 已归档
+```
+
+v0.1 如果不新增列，可以用卡片字段：
+
+```yaml
+evidence_status: present
+archive_status: pending | indexed | archived
+```
+
+## 8. AI 检索策略
+
+AI 调用时按顺序读取：
+
+1. `factory/archive/index.json`：找项目、任务、PR。
+2. `project-index.json`：找项目内相关任务。
+3. `<task_id>.json`：读取短结构化事实。
+4. 必要时才打开 `<task_id>.md`。
+5. 最后才访问 GitHub PR/issue/log 原文。
+
+这样避免每次把长 PR、长日志、长会话塞进上下文。
+
+## 9. PR / 完成任务入档要求
+
+所有完成 PR 必须能整理入档：
+
+- PR 标题中英文双语。
+- PR body 含验收、测试、风险、回滚/恢复、审计请求。
+- merge 后生成或更新 archive packet。
+- Factory Report evidence index 加一条短索引。
+- Kanban card 最终状态改为 `已归档` 前必须能反查 archive packet。
+
+## 10. v0.1 实施建议
+
+本次 Hermes AION Kanban PR 先做：
+
+1. 文档定义归档机制。
+2. Kanban AION payload 增加 `archive_status` 概念。
+3. 卡片显示“是否已入档”。
+4. 测试覆盖：没有 evidence/audit/archive packet 的任务不能显示为真正归档完成。
+
+后续 AION governance repo 再落地真实 `factory/archive/` schema、checker、fixtures、Factory Report 入口。

--- a/docs/hermes-aion-kanban-integration-v0.1.md
+++ b/docs/hermes-aion-kanban-integration-v0.1.md
@@ -17,6 +17,20 @@ Hermes 原生 Web Kanban 不重造、不替代 GitHub、不替代 AION Factory R
 | refresh | 刷新战报 | 只读刷新当前聚合状态。 |
 | nudge dispatcher | 催动调度器 | v0.1 只读模式禁用；Phase 3 才允许门禁化启用。 |
 
+### 1.1 Hermes 原生调用机制理解
+
+Hermes Kanban 背后不是普通页面列表，而是一套“任务队列 + 调度器 + 多 Profile Worker”的调用机制：
+
+- 任务、评论、运行记录、状态变化都写入 SQLite Kanban 数据库。
+- 人和脚本可以通过 `hermes kanban ...`、Dashboard、slash command 操作。
+- AI Worker 不靠 shell 调 `hermes kanban`，而是通过 `kanban_*` 工具读写任务，例如 `kanban_show`、`kanban_comment`、`kanban_complete`、`kanban_block`。
+- Dispatcher 默认跑在 Hermes Gateway 里，每轮扫描 ready 任务，按 assignee/profile 拉起对应 Hermes profile。
+- Worker 被拉起后会拿到当前 task、board、workspace、run_id、claim_lock 等环境变量。
+- 每个 Worker 必须用 `kanban_complete` 或 `kanban_block` 收尾；否则会被视为 crash / timeout / gave_up。
+- Dashboard API 是薄封装，读写最终还是走同一套 `kanban_db`，并通过 task_events / WebSocket 做实时更新。
+
+因此 AION v0.1 只在 Dashboard 读层增加中文解释和总控摘要，不改变原生调度器、worker、claim、complete/block 的生命周期真相。
+
 ## 2. 三个数据源的职责
 
 ### 2.1 GitHub：任务正本
@@ -82,6 +96,23 @@ Kanban 顶部摘要应读取或复用 Factory Report 的关键指标：
 - 通过拖拽或 nudge dispatcher 让 v0.1 产生执行/写回副作用。
 
 ## 4. 页面结构
+
+### 4.0 中文更新简报
+
+顶部必须先给君主一段大白话中文简报，原则是“短、准、能判断是否要拍板”：
+
+```text
+过去一段时间发生了什么？
+做了哪些工作？
+AION 无人值守工厂是否正常运作？
+运作过程中出现了哪些问题？
+有没有 AAR / 复盘？
+现在正在做什么？
+未来计划做什么？
+现有 AION 已经能实现哪些功能？
+```
+
+这段简报只放结论，不堆长细节；详细任务、负责人、证据、审计、AAR、归档状态全部交给 Kanban 卡片和详情页展示。
 
 ### 4.1 顶部君主摘要条
 

--- a/docs/hermes-aion-kanban-integration-v0.1.md
+++ b/docs/hermes-aion-kanban-integration-v0.1.md
@@ -1,0 +1,161 @@
+# Hermes × AION Kanban 集成方案 v0.1
+
+> English: Hermes native Kanban becomes the Chinese operational cockpit for the AION factory. GitHub remains the source of truth; Factory Report remains the ledger/health report; Discord remains the activity trace.
+
+## 1. 定位
+
+Hermes 原生 Web Kanban 不重造、不替代 GitHub、不替代 AION Factory Report。本方案只把 Hermes 已有概念翻译并映射为 AION 工厂语义：
+
+| Hermes 原生概念 | AION 中文语义 | 说明 |
+| --- | --- | --- |
+| board | 项目看板 / 作战面板 | 一个 board 对应一个项目或工厂作战视图。 |
+| lane / column | AION 状态列 | 见 state model 文档。 |
+| card / task | 作战卡片 | 展示 GitHub 正本、负责人、审计、风险、证据。 |
+| assignee / profile | 负责人 / 角色 | GM1、GM2、007、13爷、八府巡按、Cursor、Hermes、外部执行器、君主。 |
+| tenant | 项目 | 用于按 AION 子项目过滤。 |
+| archive | 已归档 | 完成并过冷却期后移出主战场。 |
+| refresh | 刷新战报 | 只读刷新当前聚合状态。 |
+| nudge dispatcher | 催动调度器 | v0.1 只读模式禁用；Phase 3 才允许门禁化启用。 |
+
+## 2. 三个数据源的职责
+
+### 2.1 GitHub：任务正本
+
+GitHub 是最终可信来源。Kanban 只展示，不把卡片本身当作完成依据。
+
+必须优先展示：
+
+- issue：任务正本
+- PR：变更正本
+- commit：提交证据
+- check run / CI：验证证据
+- review / audit comment：审计证据
+- evidence link：可点击的 GitHub 证据链接
+
+规则：没有 GitHub issue / PR / commit / CI / review evidence 的任务，不得显示为真正完成，只能显示为 `待补证据 / Evidence Missing` 或 `待审计`。
+
+### 2.2 Discord：实时活动线
+
+Discord 不是最终正本，只用于最近活动摘要：
+
+- GM / 13爷派发
+- 007 接单
+- 八府巡按审计开始 / 完成
+- 阻塞报告
+- 完成报告
+- 君主拍板记录
+- 调度器被催动
+
+v0.1 中 Discord trace 可以来自任务评论或外部同步写入的摘要字段。结论仍以 GitHub evidence 为准。
+
+### 2.3 AION Factory Report：账本与健康报告
+
+Factory Report 继续做长期账本和健康报告；Hermes Kanban 是一屏驾驶舱。
+
+Kanban 顶部摘要应读取或复用 Factory Report 的关键指标：
+
+- 总体状态
+- 无人值守成熟度
+- 总体评分
+- 当前瓶颈
+- 正在推进 / 待审计 / 阻塞 / 待君主 / 今日完成
+
+## 3. v0.1 范围：只读集成
+
+本版本目标是把 Hermes 原生 Kanban 改造成 AION 中文作战驾驶舱的第一版。
+
+允许：
+
+- 读取 Hermes Kanban task 数据。
+- 从卡片正文、结果、评论中抽取 GitHub evidence link。
+- 聚合 AION 状态列与君主摘要条。
+- 展示 Discord/评论活动摘要。
+- 展示风险等级、证据状态、下一关口、是否需君主。
+- 中文化主要列名、按钮和卡片字段。
+
+不允许：
+
+- 自动改 GitHub。
+- 自动关闭 issue。
+- 自动 merge PR。
+- 自动触发 production、payment、credits、webhook、external execution。
+- 通过拖拽或 nudge dispatcher 让 v0.1 产生执行/写回副作用。
+
+## 4. 页面结构
+
+### 4.1 顶部君主摘要条
+
+页面顶部显示：
+
+```text
+AION 帝国工厂驾驶舱
+总体状态：运转中 / 部分阻塞 / 等君主拍板
+无人值守成熟度：半自动 / 可审计自动 / 不可完全无人化
+总体评分：xx / 100
+当前瓶颈：GM2 / 007 / 八府巡按 / 外部依赖 / 君主
+正在推进：xx
+待审计：xx
+阻塞：xx
+待君主：xx
+今日完成：xx
+```
+
+### 4.2 主看板
+
+默认按状态列展示，也必须支持按角色、项目、风险、阻塞、待审计、君主待决过滤。
+
+### 4.3 卡片
+
+卡片只展示短字段；长文本放详情页。
+
+示例：
+
+```text
+#266 L1 prepare-only 修复包
+负责人：13爷 ｜ 审计：八府巡按
+风险：L1 ｜ 证据：PR #267
+下一关口：八府巡按 formal verdict
+等待：21h ｜ 是否需要君主：否 ｜ 是否允许 merge：否
+留痕：007 已提交，等待审计
+```
+
+## 5. 后续阶段
+
+### Phase 1：只读集成（本 PR）
+
+只展示，不反写。
+
+### Phase 2：受控写回
+
+允许低风险 comment 写回：dispatcher tick、ACK、blocked、audit requested。禁止 close / merge / production / payment / webhook / external execution。
+
+### Phase 3：门禁化自动推进
+
+L0/L1 自动推进，L2 自动推进但必须审计，L3 prepare-only，L4 进入君主列。
+
+## 6. 验收证据
+
+v0.1 PR 至少提供：
+
+- 3 个真实 GitHub issue / PR 映射样例。
+- 1 个待审计任务。
+- 1 个阻塞任务。
+- 1 个待君主拍板任务。
+- 1 个已完成/归档任务。
+- 测试输出。
+- 截图或 API JSON 证据。
+
+## 7. 归档机制
+
+Hermes 原生 archive 只表示“移出默认看板/主战场”，不是 AION 的最终档案。AION 归档必须同时满足：
+
+- GitHub 正本链接存在。
+- evidence、审计、completion packet、AAR 已齐全。
+- 已写入 AION archive index 或 Factory Report evidence index。
+- Kanban 卡片能反查 archive packet。
+
+详细机制见：`docs/hermes-aion-archive-mechanism-v0.1.md`。
+
+## 8. 安全边界
+
+v0.1 是只读驾驶舱。任何真实财务后果、真实法律后果、production、payment、credits、webhook、secret、DB mutation、customer data、irreversible operation、high-risk merge 都不得由普通调度器直接推进，必须进入 `待君主拍板`。

--- a/docs/hermes-aion-kanban-state-model-v0.1.md
+++ b/docs/hermes-aion-kanban-state-model-v0.1.md
@@ -1,0 +1,165 @@
+# Hermes × AION Kanban 状态模型 v0.1
+
+> English: State model for the AION Chinese cockpit layer on top of Hermes native Kanban.
+
+## 1. 状态列
+
+| AION 状态列 | Hermes 基础状态 | 中文定义 | 完成/流转规则 |
+| --- | --- | --- | --- |
+| 待定性 | triage | 原始想法、子议题、未拆解需求 | 需要 GM/13爷补目标、边界、证据要求。 |
+| 待派工 | todo | 已明确目标，但还没有负责人 | 需要指定 owner / assignee。 |
+| 待开工 | ready | 已派给角色，等待调度器 tick 或 worker ACK | v0.1 只展示，不自动催动。 |
+| 执行中 | running | 007 / GM / Cursor / 13爷等正在处理 | 需要持续留痕。 |
+| 待审计 | derived waiting_audit | 执行者声称完成，但没有八府巡按 formal verdict | 有完成声称但缺审计或缺 evidence 时进入。 |
+| 阻塞 | blocked | 缺依赖、CI 失败、证据不足、权限不足、任务定义不清 | 必须显示阻塞原因和下一关口。 |
+| 待君主拍板 | derived needs_monarch | 涉及真实外部影响或高风险 merge | 不能由普通调度器直接推过。 |
+| 已完成 | done | 已有证据、已审计、已写回、可归档 | 没有 GitHub evidence 或 audit verdict 时不得进入真正完成。 |
+| 已归档 | archived | 完成超过冷却期后移出主战场 | 保留查询能力。 |
+
+## 2. 最小卡片字段
+
+```yaml
+task_id:
+title_cn:
+repo:
+issue:
+pr:
+owner:
+auditor:
+risk_level:
+state:
+monarch_required:
+merge_allowed_now:
+evidence_status:
+latest_evidence:
+discord_trace:
+next_gate:
+age_hours:
+sla_status:
+```
+
+字段含义：
+
+- `task_id`：Hermes task id 或 AION task id。
+- `title_cn`：中文标题优先。
+- `repo`：GitHub 仓库。
+- `issue`：GitHub issue 链接或编号。
+- `pr`：GitHub PR 链接或编号。
+- `owner`：负责人，如 007、13爷、GM2、Cursor。
+- `auditor`：审计角色，默认八府巡按。
+- `risk_level`：L0-L4。
+- `state`：AION 状态列。
+- `monarch_required`：是否需要君主拍板。
+- `merge_allowed_now`：当前是否允许 merge；v0.1 只展示，不执行。
+- `evidence_status`：`present` / `missing`。
+- `latest_evidence`：最新 GitHub evidence link。
+- `discord_trace`：最近 Discord/评论活动摘要。
+- `next_gate`：下一关口。
+- `age_hours`：等待时长。
+- `sla_status`：`ok` / `watch` / `overdue`。
+
+## 3. 风险等级
+
+| 等级 | 定义 | Kanban 行为 |
+| --- | --- | --- |
+| L0 | 纯信息 / 只读 | 可自动展示，可进入只读状态流。 |
+| L1 | 文档 / prepare-only / 低风险 | 可自动推进到待审计，但 v0.1 不写回。 |
+| L2 | 可自动执行，但需要留痕 | 必须显示证据和审计关口。 |
+| L3 | 准备包可以做，真实执行需审计 | prepare-only 可走，真实执行前阻断。 |
+| L4 | 必须君主拍板 | 进入待君主拍板列。 |
+
+以下关键词/语义出现时，v0.1 默认标为高风险或待君主拍板候选：
+
+- production deployment
+- prod smoke
+- payment
+- credits
+- webhook
+- external executor
+- secret / token
+- DB mutation
+- customer data
+- irreversible operation
+- merge high-risk PR
+
+注意：AION 总治理仍按“真实财务后果 / 真实法律后果 / 真实外部副作用”判断最终 Monarch gate；Kanban v0.1 为防误推，可以保守展示到 `待君主拍板`。
+
+## 4. 完成判定
+
+不得仅因 worker 声称完成就显示为真正完成。
+
+真正完成至少需要：
+
+1. GitHub evidence link 存在：issue / PR / commit / CI / review。
+2. 审计或验收证据存在：八府巡按 formal verdict、CI PASS、GM2 low-risk verdict 等。
+3. 已写回正本或账本：GitHub comment / Factory Report evidence index。
+
+缺任一项时：
+
+- 缺 evidence：`待补证据 / Evidence Missing`。
+- 缺 audit：`待审计`。
+- 高风险缺君主授权：`待君主拍板`。
+
+## 5. 阻塞判定
+
+进入 `阻塞` 的常见原因：
+
+- CI failed。
+- 权限不足。
+- Command Approval gate 拦截。
+- GitHub evidence 缺失。
+- 任务定义不清。
+- 外部依赖未就绪。
+
+卡片必须显示 `next_gate`，避免只显示“blocked”但不知道谁该动。
+
+## 6. 归档规则
+
+建议：
+
+- 已完成且 evidence/audit/ledger 齐全后进入 `已完成`。
+- 冷却期后可归档；默认建议 24-72 小时。
+- 已归档任务不显示在主战场，但可通过归档过滤查看。
+
+## 7. 归档状态
+
+AION 不把 Hermes 原生 `archived` 等同于最终归档完成。推荐增加卡片字段：
+
+```yaml
+archive_status: none | pending | indexed | archived
+archive_packet:
+```
+
+含义：
+
+- `none`：还没进入归档流程。
+- `pending`：任务完成但还缺入档包、AAR、证据索引或审计链接。
+- `indexed`：已写入 AION archive index / Factory Report evidence index，但仍保留在主战场冷却。
+- `archived`：已完成、已审计、已入档，可从主战场移出。
+
+详细机制见：`docs/hermes-aion-archive-mechanism-v0.1.md`。
+
+## 8. v0.1 只读门禁
+
+v0.1 中这些 UI 动作必须禁用或只显示提示：
+
+- 拖拽改状态。
+- 批量改状态。
+- 新建任务并写回。
+- Nudge Dispatcher / 催动调度器。
+- close issue。
+- merge PR。
+- production / payment / webhook / external executor。
+
+## 8. 审计验收清单
+
+- 中文为主，英文仅技术辅助。
+- GitHub evidence 可点击。
+- Discord trace/评论摘要可见。
+- 执行完成、待审计、审计通过、已归档可区分。
+- 待君主拍板单独成列。
+- 当前瓶颈角色可见。
+- 阻塞原因和下一关口可见。
+- 风险等级可见。
+- 缺证据不得显示为真正完成。
+- 高风险任务不得被调度器误推进。

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1015,6 +1015,7 @@
     return h("div", { className: "hermes-kanban-aion-summary" },
       h("div", { className: "hermes-kanban-aion-title" }, summary.title || "AION 帝国工厂驾驶舱"),
       h("div", { className: "hermes-kanban-aion-phase" }, summary.phase || "Phase 1 只读集成"),
+      h("div", { className: "hermes-kanban-aion-brief" }, summary.briefing_cn || "中文简报：详细任务状态请看下方 Kanban 卡片。"),
       h("div", { className: "hermes-kanban-aion-grid" },
         h("div", null, h("span", null, "总体状态"), h("strong", null, summary.overall_status || "未知")),
         h("div", null, h("span", null, "无人值守成熟度"), h("strong", null, summary.unattended_maturity || "半自动")),

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -57,22 +57,26 @@
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
-    triage: "Triage",
-    todo: "Todo",
-    ready: "Ready",
-    running: "In Progress",
-    blocked: "Blocked",
-    done: "Done",
-    archived: "Archived",
+    triage: "待定性",
+    todo: "待派工",
+    ready: "待开工",
+    running: "执行中",
+    waiting_audit: "待审计",
+    blocked: "阻塞",
+    needs_monarch: "待君主拍板",
+    done: "已完成",
+    archived: "已归档",
   };
   const FALLBACK_COLUMN_HELP = {
-    triage: "Raw ideas — a specifier will flesh out the spec",
-    todo: "Waiting on dependencies or unassigned",
-    ready: "Assigned and waiting for a dispatcher tick",
-    running: "Claimed by a worker — in-flight",
-    blocked: "Worker asked for human input",
-    done: "Completed",
-    archived: "Archived",
+    triage: "原始想法、子议题、未拆解需求",
+    todo: "已明确目标，但还没有负责人",
+    ready: "已派给角色，等待调度器 tick 或 worker ACK",
+    running: "007 / GM / Cursor / 13爷等正在处理",
+    waiting_audit: "执行者声称完成，但还没有八府巡按 formal verdict",
+    blocked: "缺依赖、CI 失败、证据不足、权限不足或定义不清",
+    needs_monarch: "涉及真实外部影响或高风险合并，必须君主拍板",
+    done: "已有证据、已审计、已写回，可归档",
+    archived: "完成后移出主战场，保留查询能力",
   };
   const FALLBACK_DESTRUCTIVE = {
     done: "Mark this task as done? The worker's claim is released and dependent children become ready.",
@@ -115,8 +119,10 @@
     todo: "hermes-kanban-dot-todo",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
+    waiting_audit: "hermes-kanban-dot-ready",
     blocked: "hermes-kanban-dot-blocked",
     done: "hermes-kanban-dot-done",
+    needs_monarch: "hermes-kanban-dot-blocked",
     archived: "hermes-kanban-dot-archived",
   };
 
@@ -474,6 +480,7 @@
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
       const qs = new URLSearchParams();
+      qs.set("aion", "true");
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
@@ -594,7 +601,8 @@
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
         if (q) {
-          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
+          const aionHay = t.aion ? `${t.aion.state || ""} ${t.aion.risk_level || ""} ${t.aion.evidence_status || ""} ${t.aion.next_gate || ""} ${t.aion.discord_trace || ""}` : "";
+          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""} ${aionHay}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
         }
         return true;
@@ -608,6 +616,10 @@
 
     // --- actions ------------------------------------------------------------
     const moveTask = useCallback(function (taskId, newStatus) {
+      if (boardData && boardData.readonly) {
+        setError("AION Phase 1 是只读驾驶舱：不允许拖动写回。请以 GitHub 正本为准。");
+        return;
+      }
       const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       const patch = withCompletionSummary({ status: newStatus }, 1, t);
@@ -636,7 +648,7 @@
         setError(tx(t, "moveFailed", "Move failed: ") + (err.message || err));
         loadBoard();
       });
-    }, [loadBoard, board, t]);
+    }, [loadBoard, board, t, boardData]);
 
     const clearSelected = useCallback(function () {
       setSelectedIds(new Set());
@@ -644,6 +656,10 @@
       setFailedIds(new Set());
     }, []);
     const moveSelected = useCallback(function (newStatus) {
+      if (boardData && boardData.readonly) {
+        setError("AION Phase 1 是只读驾驶舱：不允许批量写回。请以 GitHub 正本为准。");
+        return;
+      }
       const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       if (selectedIds.size === 0) return;
@@ -686,9 +702,13 @@
         setFailedIds(new Set(selectedIds));
         loadBoard();
       });
-    }, [selectedIds, loadBoard, board]);
+    }, [selectedIds, loadBoard, board, boardData]);
 
     const createTask = useCallback(function (body) {
+      if (boardData && boardData.readonly) {
+        setError("AION Phase 1 是只读驾驶舱：不允许新建/反写任务。");
+        return Promise.resolve(null);
+      }
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -705,7 +725,7 @@
         loadBoardList();  // refresh counts in the switcher
         return res;
       });
-    }, [loadBoard, loadBoardList, board, t]);
+    }, [loadBoard, loadBoardList, board, t, boardData]);
 
     const toggleSelected = useCallback(function (id, additive) {
       setSelectedIds(function (prev) {
@@ -908,6 +928,15 @@
             return createNewBoard(payload).then(function () { setShowNewBoard(false); });
           },
         }) : null,
+        h(AionCockpitSummary, {
+          summary: boardData && boardData.aion_summary,
+          onQuickSearch: function (label) {
+            if (label === "待审计") setSearch("待审计");
+            else if (label === "阻塞") setSearch("阻塞");
+            else if (label === "待君主") setSearch("君主");
+            else setSearch("");
+          },
+        }),
         h(AttentionStrip, {
           boardData,
           onOpen: setSelectedTaskId,
@@ -920,6 +949,10 @@
           laneByProfile, setLaneByProfile,
           search, setSearch,
           onNudgeDispatch: function () {
+            if (boardData && boardData.readonly) {
+              setError("AION Phase 1 只读集成：催动调度器属于写入/执行动作，本版禁用。");
+              return;
+            }
             SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, board), { method: "POST" })
               .then(loadBoard)
               .catch(function (e) { setError(String(e.message || e)); });
@@ -961,6 +994,40 @@
           assignees: (boardData && boardData.assignees) || [],
           eventTick: taskEventTick[selectedTaskId] || 0,
         }) : null,
+      ),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // AION cockpit summary — Phase 1 read-only commander layer.
+  // -------------------------------------------------------------------------
+
+  function AionCockpitSummary(props) {
+    const summary = props.summary;
+    if (!summary) return null;
+    const items = [
+      ["正在推进", summary.active],
+      ["待审计", summary.waiting_audit],
+      ["阻塞", summary.blocked],
+      ["待君主", summary.needs_monarch],
+      ["今日完成", summary.done_today],
+    ];
+    return h("div", { className: "hermes-kanban-aion-summary" },
+      h("div", { className: "hermes-kanban-aion-title" }, summary.title || "AION 帝国工厂驾驶舱"),
+      h("div", { className: "hermes-kanban-aion-phase" }, summary.phase || "Phase 1 只读集成"),
+      h("div", { className: "hermes-kanban-aion-grid" },
+        h("div", null, h("span", null, "总体状态"), h("strong", null, summary.overall_status || "未知")),
+        h("div", null, h("span", null, "无人值守成熟度"), h("strong", null, summary.unattended_maturity || "半自动")),
+        h("div", null, h("span", null, "总体评分"), h("strong", null, String(summary.score || 0), " / 100")),
+        h("div", null, h("span", null, "当前瓶颈"), h("strong", null, summary.current_bottleneck || "无")),
+      ),
+      h("div", { className: "hermes-kanban-aion-counts" },
+        items.map(function (it) {
+          return h("button", {
+            key: it[0], type: "button", className: "hermes-kanban-aion-chip",
+            onClick: function () { if (props.onQuickSearch) props.onQuickSearch(it[0]); },
+          }, h("span", null, it[0]), h("strong", null, String(it[1] || 0)));
+        }),
       ),
     );
   }
@@ -2121,6 +2188,17 @@
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
+          t.aion ? h("div", { className: "hermes-kanban-aion-card" },
+            h("div", null, "负责人：", t.aion.owner || "未指派", " ｜ 审计：", t.aion.auditor || "未进入"),
+            h("div", null, "风险：", t.aion.risk_level || "L1", " ｜ 证据：",
+              t.aion.latest_evidence
+                ? h("a", { href: t.aion.latest_evidence, target: "_blank", rel: "noreferrer", onClick: function (e) { e.stopPropagation(); } }, "GitHub evidence")
+                : "待补证据"),
+            h("div", null, "下一关口：", t.aion.next_gate || "待定"),
+            h("div", null, "等待：", String(t.aion.age_hours || 0), "h ｜ 是否需要君主：", t.aion.monarch_required ? "是" : "否", " ｜ 是否允许 merge：", t.aion.merge_allowed_now ? "是" : "否"),
+            h("div", null, "归档：", t.aion.archive_status || "none"),
+            h("div", { className: "hermes-kanban-aion-trace" }, "留痕：", t.aion.discord_trace || "暂无摘要"),
+          ) : null,
           h("div", { className: "hermes-kanban-card-row hermes-kanban-card-meta" },
             t.assignee
               ? h("span", { className: "hermes-kanban-assignee",

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1511,6 +1511,15 @@
   font-size: 0.76rem;
   color: var(--color-muted-foreground);
 }
+.hermes-kanban-aion-brief {
+  margin-top: 0.55rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.7rem;
+  background: color-mix(in srgb, var(--color-ring) 8%, transparent);
+  color: var(--color-foreground);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
 .hermes-kanban-aion-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1490,3 +1490,84 @@
   font-size: 0.7rem;
   cursor: pointer;
 }
+
+/* ---- AION Chinese cockpit layer -------------------------------------- */
+.hermes-kanban-aion-summary {
+  border: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--color-card) 94%, var(--color-ring) 6%),
+    var(--color-card));
+  box-shadow: 0 10px 24px color-mix(in srgb, black 12%, transparent);
+}
+.hermes-kanban-aion-title {
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+.hermes-kanban-aion-phase {
+  margin-top: 0.25rem;
+  font-size: 0.76rem;
+  color: var(--color-muted-foreground);
+}
+.hermes-kanban-aion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.85rem;
+}
+.hermes-kanban-aion-grid > div,
+.hermes-kanban-aion-chip {
+  border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+  border-radius: 0.65rem;
+  background: color-mix(in srgb, var(--color-background) 72%, transparent);
+  padding: 0.55rem 0.7rem;
+}
+.hermes-kanban-aion-grid span,
+.hermes-kanban-aion-chip span {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--color-muted-foreground);
+}
+.hermes-kanban-aion-grid strong,
+.hermes-kanban-aion-chip strong {
+  display: block;
+  margin-top: 0.1rem;
+  font-size: 1rem;
+}
+.hermes-kanban-aion-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.85rem;
+}
+.hermes-kanban-aion-chip {
+  min-width: 5.8rem;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+}
+.hermes-kanban-aion-chip:hover {
+  border-color: color-mix(in srgb, var(--color-ring) 60%, var(--color-border));
+}
+.hermes-kanban-aion-card {
+  margin-top: 0.45rem;
+  padding: 0.5rem;
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--color-muted) 65%, transparent);
+  color: var(--color-foreground);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+.hermes-kanban-aion-card a {
+  color: var(--color-ring);
+  text-decoration: underline;
+}
+.hermes-kanban-aion-trace {
+  color: var(--color-muted-foreground);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -285,6 +285,12 @@ def _aion_summary(columns: dict[str, list[dict[str, Any]]], now: int) -> dict[st
     else:
         overall = "运转中"
     score = max(0, min(100, 85 - 8 * waiting_audit - 10 * blocked - 12 * needs_monarch))
+    if overall == "运转中":
+        brief = "过去一段时间工厂在正常运转：有任务在推进，暂未发现必须君主拍板的阻塞。详细任务、证据和审计记录请看 Kanban 卡片。"
+    elif overall == "等君主拍板":
+        brief = "过去一段时间工厂有高风险事项进入待君主拍板；低风险任务仍可继续推进。详细风险、证据和停手条件请看 Kanban 卡片。"
+    else:
+        brief = "过去一段时间工厂有部分任务卡住或等待审计；不是全局停摆。详细阻塞原因、负责人和下一关口请看 Kanban 卡片。"
     return {
         "title": "AION 帝国工厂驾驶舱",
         "overall_status": overall,
@@ -297,6 +303,8 @@ def _aion_summary(columns: dict[str, list[dict[str, Any]]], now: int) -> dict[st
         "needs_monarch": needs_monarch,
         "done_today": done_today,
         "current_bottleneck": current_bottleneck,
+        "briefing_cn": brief,
+        "briefing_detail_surface": "Kanban cards carry detailed task state, evidence, audit trail, AAR, and archive status.",
         "phase": "Phase 1 只读集成：展示为主，不反写 GitHub，不自动 merge/close",
     }
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -40,6 +40,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import sqlite3
 import time
 from dataclasses import asdict
@@ -133,8 +134,171 @@ BOARD_COLUMNS: list[str] = [
     "triage", "todo", "ready", "running", "blocked", "done",
 ]
 
+AION_COLUMN_ORDER: list[str] = [
+    "triage", "todo", "ready", "running", "waiting_audit", "blocked",
+    "needs_monarch", "done", "archived",
+]
 
+_GITHUB_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
+    r"(?:issues|pull|commit|actions/runs|checks)/[A-Za-z0-9_./-]+"
+)
+_HIGH_RISK_RE = re.compile(
+    r"production|prod smoke|payment|credits|webhook|external executor|"
+    r"secret|token|db mutation|database|customer data|irreversible|"
+    r"high-risk|merge high-risk|生产|支付|额度|客户数据|数据库|密钥|令牌|"
+    r"外部执行器|不可逆|高风险|正式部署",
+    re.IGNORECASE,
+)
+_AUDIT_RE = re.compile(
+    r"formal verdict|audit pass|审计通过|八府巡按.*(?:PASS|通过)|bafuxunan.*pass",
+    re.IGNORECASE,
+)
+_AUDIT_WAIT_RE = re.compile(
+    r"waiting[_ -]?audit|audit requested|待审计|请求审计|八府巡按|formal audit",
+    re.IGNORECASE,
+)
+_BLOCK_RE = re.compile(r"blocked|阻塞|缺证据|evidence missing|权限不足|ci failed", re.IGNORECASE)
+_RISK_RE = re.compile(r"\b(L[0-4])\b")
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+
+
+def _recent_comments(conn: sqlite3.Connection, task_id: str, limit: int = 6) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT author, body, created_at FROM task_comments "
+        "WHERE task_id = ? ORDER BY created_at DESC, id DESC LIMIT ?",
+        (task_id, limit),
+    ).fetchall()
+    return [{"author": r["author"], "body": r["body"] or "", "created_at": r["created_at"]} for r in rows]
+
+
+def _latest_evidence(text: str) -> Optional[str]:
+    matches = _GITHUB_URL_RE.findall(text or "")
+    return matches[-1] if matches else None
+
+
+def _risk_level(text: str) -> str:
+    explicit = _RISK_RE.search(text or "")
+    if explicit:
+        return explicit.group(1).upper()
+    if _HIGH_RISK_RE.search(text or ""):
+        return "L4"
+    return "L1"
+
+
+def _aion_state(task: kanban_db.Task, text: str, evidence: Optional[str], audit_pass: bool) -> str:
+    if task.status == "archived":
+        return "archived"
+    if _HIGH_RISK_RE.search(text or "") and not audit_pass:
+        return "needs_monarch"
+    if task.status == "blocked" or _BLOCK_RE.search(text or ""):
+        return "blocked"
+    if task.status == "done":
+        return "done" if evidence and audit_pass else "waiting_audit"
+    if _AUDIT_WAIT_RE.search(text or ""):
+        return "waiting_audit"
+    if task.status == "running":
+        return "running"
+    if task.status == "ready":
+        return "ready"
+    if task.status == "triage":
+        return "triage"
+    return "todo"
+
+
+def _aion_fields(task: kanban_db.Task, conn: sqlite3.Connection, now: int) -> dict[str, Any]:
+    comments = _recent_comments(conn, task.id)
+    comment_text = "\n".join(c["body"] for c in comments)
+    text = "\n".join(filter(None, [task.title, task.body, task.result, comment_text]))
+    evidence = _latest_evidence(text)
+    audit_pass = bool(_AUDIT_RE.search(text or ""))
+    risk = _risk_level(text)
+    monarch_required = risk == "L4" or bool(_HIGH_RISK_RE.search(text or ""))
+    state = _aion_state(task, text, evidence, audit_pass)
+    age_hours = round(max(0, now - int(task.created_at or now)) / 3600, 1)
+    discord_comment = next((c for c in comments if re.search(r"discord|君主|007|GM|八府巡按", c["body"], re.I)), None)
+    latest_comment = comments[0] if comments else None
+    trace_source = discord_comment or latest_comment
+    evidence_status = "present" if evidence else "missing"
+    if monarch_required and state != "done":
+        next_gate = "君主拍板 / Monarch decision"
+    elif state == "waiting_audit":
+        next_gate = "八府巡按 formal verdict"
+    elif evidence_status == "missing":
+        next_gate = "补 GitHub evidence link"
+    elif state == "blocked":
+        next_gate = "解除阻塞后重跑"
+    else:
+        next_gate = "可继续调度 / Ready for next dispatcher step"
+    sla_status = "ok"
+    if state in {"waiting_audit", "blocked", "needs_monarch"} and age_hours >= 24:
+        sla_status = "overdue"
+    elif state in {"waiting_audit", "blocked", "needs_monarch"} and age_hours >= 6:
+        sla_status = "watch"
+    archive_status = "none"
+    if state == "archived":
+        archive_status = "archived" if evidence and audit_pass else "pending"
+    elif state == "done":
+        archive_status = "indexed" if evidence and audit_pass else "pending"
+    return {
+        "task_id": task.id,
+        "title_cn": task.title,
+        "repo": None,
+        "issue": None,
+        "pr": evidence if evidence and "/pull/" in evidence else None,
+        "owner": task.assignee or "未指派",
+        "auditor": "八府巡按" if state in {"waiting_audit", "done"} else None,
+        "risk_level": risk,
+        "state": state,
+        "monarch_required": monarch_required,
+        "merge_allowed_now": bool(state == "done" and audit_pass and evidence and not monarch_required),
+        "evidence_status": evidence_status,
+        "latest_evidence": evidence,
+        "discord_trace": (trace_source["body"][:180] if trace_source else "暂无 Discord/评论摘要"),
+        "next_gate": next_gate,
+        "age_hours": age_hours,
+        "sla_status": sla_status,
+        "archive_status": archive_status,
+        "archive_packet": None,
+        "audit_pass": audit_pass,
+    }
+
+
+def _aion_summary(columns: dict[str, list[dict[str, Any]]], now: int) -> dict[str, Any]:
+    counts = {name: len(cards) for name, cards in columns.items()}
+    active = counts.get("ready", 0) + counts.get("running", 0)
+    waiting_audit = counts.get("waiting_audit", 0)
+    blocked = counts.get("blocked", 0)
+    needs_monarch = counts.get("needs_monarch", 0)
+    done_today = 0
+    bottlenecks = {
+        "八府巡按": waiting_audit,
+        "外部依赖": blocked,
+        "君主": needs_monarch,
+        "007/执行者": counts.get("ready", 0) + counts.get("running", 0),
+    }
+    current_bottleneck = max(bottlenecks.items(), key=lambda kv: kv[1])[0] if bottlenecks else "无"
+    if needs_monarch:
+        overall = "等君主拍板"
+    elif blocked or waiting_audit:
+        overall = "部分阻塞"
+    else:
+        overall = "运转中"
+    score = max(0, min(100, 85 - 8 * waiting_audit - 10 * blocked - 12 * needs_monarch))
+    return {
+        "title": "AION 帝国工厂驾驶舱",
+        "overall_status": overall,
+        "unattended_maturity": "可审计自动" if score >= 80 else "半自动",
+        "score": score,
+        "refreshed_at": now,
+        "active": active,
+        "waiting_audit": waiting_audit,
+        "blocked": blocked,
+        "needs_monarch": needs_monarch,
+        "done_today": done_today,
+        "current_bottleneck": current_bottleneck,
+        "phase": "Phase 1 只读集成：展示为主，不反写 GitHub，不自动 merge/close",
+    }
 
 
 def _task_dict(
@@ -343,6 +507,7 @@ def get_board(
     tenant: Optional[str] = Query(None, description="Filter to a single tenant"),
     include_archived: bool = Query(False),
     board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    aion: bool = Query(False, description="Render AION Chinese cockpit read-only view"),
 ):
     """Return the full board grouped by status column.
 
@@ -402,8 +567,10 @@ def get_board(
             "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
         ).fetchone()["m"]
 
-        columns: dict[str, list[dict]] = {c: [] for c in BOARD_COLUMNS}
-        if include_archived:
+        columns: dict[str, list[dict]] = {
+            c: [] for c in (AION_COLUMN_ORDER if aion else BOARD_COLUMNS)
+        }
+        if include_archived and not aion:
             columns["archived"] = []
 
         # Batch-fetch the latest non-null run summary per task in one
@@ -428,7 +595,13 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
+            if aion:
+                aion_meta = _aion_fields(t, conn, int(time.time()))
+                d["aion"] = aion_meta
+                d["readonly"] = True
+                col = aion_meta["state"] if aion_meta["state"] in columns else "todo"
+            else:
+                col = t.status if t.status in columns else "todo"
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks
@@ -450,15 +623,21 @@ def get_board(
             )
         ]
 
-        return {
+        now_ts = int(time.time())
+        response = {
             "columns": [
-                {"name": name, "tasks": columns[name]} for name in columns.keys()
+                {"name": name, "tasks": columns[name], "readonly": bool(aion)} for name in columns.keys()
             ],
             "tenants": tenants,
             "assignees": assignees,
             "latest_event_id": int(latest_event_id),
-            "now": int(time.time()),
+            "now": now_ts,
+            "readonly": bool(aion),
         }
+        if aion:
+            response["aion_mode"] = True
+            response["aion_summary"] = _aion_summary(columns, now_ts)
+        return response
     finally:
         conn.close()
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1794,3 +1794,58 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+def test_aion_readonly_board_maps_factory_cockpit_columns(client):
+    """AION cockpit mode keeps Hermes as read-only source while deriving Chinese lanes."""
+    waiting = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "#266 L1 prepare-only 修复包",
+            "body": "audit requested by 八府巡按 https://github.com/kiddhu/aion-governance/pull/267",
+            "assignee": "gm2",
+        },
+    ).json()["task"]
+    client.patch(f"/api/plugins/kanban/tasks/{waiting['id']}", json={"status": "done", "summary": "claimed done"})
+
+    blocked = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "CI failed blocker", "body": "blocked: ci failed", "assignee": "007"},
+    ).json()["task"]
+    client.patch(f"/api/plugins/kanban/tasks/{blocked['id']}", json={"status": "blocked"})
+
+    monarch = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "L4 production payment webhook", "body": "merge high-risk PR requires Monarch", "assignee": "monarch"},
+    ).json()["task"]
+
+    done = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "L1 docs-only completed",
+            "body": "审计通过 formal verdict https://github.com/kiddhu/aion-governance/pull/283",
+            "assignee": "bafuxunan",
+        },
+    ).json()["task"]
+    client.patch(f"/api/plugins/kanban/tasks/{done['id']}", json={"status": "done", "summary": "audit pass"})
+
+    r = client.get("/api/plugins/kanban/board?aion=true")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["aion_mode"] is True
+    assert data["readonly"] is True
+    names = [c["name"] for c in data["columns"]]
+    for expected in ("waiting_audit", "blocked", "needs_monarch", "done", "archived"):
+        assert expected in names
+
+    by_col = {c["name"]: c["tasks"] for c in data["columns"]}
+    assert any(t["id"] == waiting["id"] and t["aion"]["evidence_status"] == "present" for t in by_col["waiting_audit"])
+    assert any(t["id"] == blocked["id"] for t in by_col["blocked"])
+    assert any(t["id"] == monarch["id"] and t["aion"]["monarch_required"] for t in by_col["needs_monarch"])
+    assert any(t["id"] == done["id"] and t["aion"]["merge_allowed_now"] and t["aion"]["archive_status"] == "indexed" for t in by_col["done"])
+
+    summary = data["aion_summary"]
+    assert summary["title"] == "AION 帝国工厂驾驶舱"
+    assert summary["waiting_audit"] >= 1
+    assert summary["blocked"] >= 1
+    assert summary["needs_monarch"] >= 1
+    assert "只读" in summary["phase"]

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1848,4 +1848,6 @@ def test_aion_readonly_board_maps_factory_cockpit_columns(client):
     assert summary["waiting_audit"] >= 1
     assert summary["blocked"] >= 1
     assert summary["needs_monarch"] >= 1
+    assert summary["briefing_cn"]
+    assert "Kanban" in summary["briefing_detail_surface"]
     assert "只读" in summary["phase"]


### PR DESCRIPTION
## 中文说明

本 PR 增加 AION 中文工厂驾驶舱 v0.1 的只读集成，并补充 AION 自有归档机制：

- 新增 `GET /board?aion=true` 的 AION 视图数据：中文状态列、只读标记、风险、证据、审计、君主门禁、下一关口、SLA、归档状态。
- 新增 AION summary：整体状态、自动化成熟度、当前瓶颈、待审计/阻塞/待君主数量。
- 前端卡片展示 AION 中文摘要与“归档状态”。
- 新增文档：
  - `docs/hermes-aion-kanban-integration-v0.1.md`
  - `docs/hermes-aion-kanban-state-model-v0.1.md`
  - `docs/hermes-aion-archive-mechanism-v0.1.md`
- 明确 Hermes 原生 archive 只表示“移出主战场”；AION 最终归档必须有 GitHub 正本、证据、审计、completion packet、AAR、索引。

## English summary

This PR adds a read-only AION Chinese factory cockpit view for the Hermes Kanban dashboard and documents an AION archive layer optimized for AI retrieval.

- Adds `GET /board?aion=true` derived metadata: Chinese state mapping, read-only flag, risk level, evidence/audit status, Monarch gate, next gate, SLA, and archive status.
- Adds an AION top-level summary with operational status, unattended maturity, bottleneck, audit/blocked/Monarch counts.
- Updates the frontend card rendering to show compact AION metadata and archive status.
- Adds docs for integration, state model, and archive mechanism.
- Clarifies that native Hermes archive means “remove from active board”, while AION final archive requires evidence, audit, completion packet, AAR, and an index entry.

## Safety / 安全边界

- Read-only integration only.
- No production changes.
- No payment/credits/customer-data/webhook/secret/database mutation.
- No PR merge/issue close automation.
- No real financial or legal consequence.

## Tests / 测试

```text
python -m py_compile plugins/kanban/dashboard/plugin_api.py
node --check plugins/kanban/dashboard/dist/index.js
python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q

82 passed in 8.97s
```

## Archive / 入档说明

This PR is archive-ready because it includes:

- structured docs for AION archive policy;
- machine-readable AION fields including `archive_status`;
- test coverage for derived AION view behavior;
- evidence in this PR body and commit history.

