### PR TITLE
fix(cli): preserve --toolsets across self-relaunch

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -132,7 +132,8 @@ def build_top_level_parser():
             "Applies to -z/--oneshot and --tui. Also settable via HERMES_INFERENCE_PROVIDER env var."
         ),
     )
-    parser.add_argument(
+    _inherited_flag(
+        parser,
         "-t",
         "--toolsets",
         default=None,
@@ -246,7 +247,8 @@ def build_top_level_parser():
         chat_parser,
         "-m", "--model", help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
-    chat_parser.add_argument(
+    _inherited_flag(
+        chat_parser,
         "-t", "--toolsets", help="Comma-separated toolsets to enable"
     )
     _inherited_flag(

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -70,6 +70,14 @@ class TestExtractInheritedFlags:
         argv = ["-s", "foo", "-s", "bar", "--tui"]
         assert relaunch_mod._extract_inherited_flags(argv) == ["-s", "foo", "-s", "bar", "--tui"]
 
+    def test_preserves_toolsets_with_value(self):
+        argv = ["--toolsets", "web,terminal", "--tui", "sessions", "browse"]
+        assert relaunch_mod._extract_inherited_flags(argv) == [
+            "--toolsets",
+            "web,terminal",
+            "--tui",
+        ]
+
 
 class TestInheritedFlagTable:
     """Sanity-check the argparse-introspected table that drives extraction."""
@@ -80,6 +88,7 @@ class TestInheritedFlagTable:
         for short, long_ in [
             ("-p", "--profile"),
             ("-m", "--model"),
+            ("-t", "--toolsets"),
             ("-s", "--skills"),
         ]:
             assert table[short] == table[long_], f"{short}/{long_} disagree"
@@ -91,7 +100,7 @@ class TestInheritedFlagTable:
 
     def test_value_flags_take_value(self):
         table = dict(relaunch_mod._INHERITED_FLAGS_TABLE)
-        for flag in ["--profile", "--model", "--provider", "--skills"]:
+        for flag in ["--profile", "--model", "--provider", "--toolsets", "--skills"]:
             assert table[flag] is True, f"{flag} should take a value"
 
     def test_excluded_flags_are_not_inherited(self):
@@ -128,6 +137,18 @@ class TestBuildRelaunchArgv:
         assert "sessions" not in argv
         assert "browse" not in argv
 
+    def test_preserves_toolsets_across_relaunch(self, monkeypatch):
+        monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: "/usr/bin/hermes")
+        original = ["--toolsets", "web,terminal", "sessions", "browse"]
+        argv = relaunch_mod.build_relaunch_argv(["--resume", "abc"], original_argv=original)
+        assert argv == [
+            "/usr/bin/hermes",
+            "--toolsets",
+            "web,terminal",
+            "--resume",
+            "abc",
+        ]
+
     def test_can_disable_preserve(self, monkeypatch):
         monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: "/usr/bin/hermes")
         original = ["--tui", "chat"]
@@ -146,6 +167,7 @@ class TestRelaunch:
             calls.append((path, argv))
             raise SystemExit(0)
 
+        monkeypatch.setattr(relaunch_mod.sys, "platform", "linux")
         monkeypatch.setattr(relaunch_mod.os, "execvp", fake_execvp)
         monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: "/usr/bin/hermes")
 


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI relaunch bug where invocation-scoped `--toolsets` was silently dropped when Hermes restarted itself, such as after selecting a session from `hermes sessions browse`.

The relaunch path only preserves flags marked with `inherit_on_relaunch`. `--toolsets` was not marked that way in the top-level parser or the `chat` subparser, so resumed sessions could come back with the default tool surface instead of the user-requested restricted toolsets.

This change marks `--toolsets` as inherited in both parser locations and adds regression coverage for extraction, relaunch argv construction, and the existing POSIX exec test behavior on Windows hosts.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Marked `-t/--toolsets` as relaunch-inherited in `hermes_cli/_parser.py`
- Added regression coverage for `--toolsets` extraction and relaunch argv preservation in `tests/hermes_cli/test_relaunch.py`
- Stabilized `test_calls_execvp` by forcing POSIX platform semantics inside the test so it passes on Windows runners too

## How to Test

1. Reproduce before the fix:
   Run `hermes --toolsets web,terminal sessions browse`, select a session, and observe that the resumed process drops the `--toolsets` restriction.
2. Verify parser/relaunch behavior:
   Run `pytest tests/hermes_cli/test_relaunch.py -q`
3. Confirm expected result:
   Test suite passes, including the new `--toolsets` regression coverage, with Windows still skipping the POSIX-only `.py argv0` test as expected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
27 passed, 1 skipped in 3.69s
