### PR TITLE
chore(release): add lowercase bartok9 noreply email to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -821,6 +821,7 @@ AUTHOR_MAP = {
     "danieldliu@tencent.com": "danieldliu",
     "loongzhao@tencent.com": "loongzhao",
     "Bartok9@users.noreply.github.com": "Bartok9",
+    "bartok9@users.noreply.github.com": "Bartok9",  # lowercase form (older commits)
     "LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "kshitijk4poor@users.noreply.github.com": "kshitijk4poor",
     "mbelleau@Michels-MacBook-Pro.local": "malaiwah",


### PR DESCRIPTION
## Summary

Adds the lowercase noreply form `bartok9@users.noreply.github.com` to `scripts/release.py` AUTHOR_MAP so the contributor-attribution gate stops failing on PRs that contain older commits from this account.

## Context

Older commits from `Bartok9` used the lowercase noreply email form (`bartok9@users.noreply.github.com`). AUTHOR_MAP currently has the canonical capital-B form (`Bartok9@users.noreply.github.com`) but the gate's email comparison is case-sensitive, so those older commits fail the check.

This affects e.g. **#23061** (rebased earlier tonight; one of the cherry-picked commits carries that older author shape).

## Change

One line added next to the existing canonical entry:

```python
"bartok9@users.noreply.github.com": "Bartok9",  # lowercase form (older commits)
```

## Test plan

- Diff is one line; no other file touched.
- After merge, `check-attribution` on #23061 will pick up the new mapping on next rebase or push and resolve to ✅.

🎻