### PR TITLE
Fix ACP start events for polished tools

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -1123,7 +1123,6 @@ def build_tool_start(
         )
 
     # Generic fallback
-    import json
     try:
         args_text = json.dumps(arguments, indent=2, default=str)
     except (TypeError, ValueError):

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -207,6 +207,16 @@ class TestBuildToolStart:
         assert result.content is None
         assert result.raw_input is None
 
+    def test_build_tool_start_for_browser_navigate(self):
+        """browser_navigate should emit a polished start event."""
+        args = {"url": "https://x.com"}
+        result = build_tool_start("tc-browser-start", "browser_navigate", args)
+        assert isinstance(result, ToolCallStart)
+        assert result.title == "navigate: https://x.com"
+        assert result.kind == "fetch"
+        assert result.content[0].content.text == '{\n  "url": "https://x.com"\n}'
+        assert result.raw_input is None
+
     def test_build_tool_start_for_search(self):
         """search_files should include pattern in content."""
         args = {"pattern": "TODO", "target": "content"}


### PR DESCRIPTION
## Summary

Fix ACP `build_tool_start()` for polished tools such as `browser_navigate`.

The function already imports `json` at module scope, but it also had a local `import json` in the generic fallback branch. Python treats that as a local binding for the entire function, so earlier branches that call `json.dumps()` before the fallback can raise `UnboundLocalError`.

## Impact

When a polished tool start event failed, ACP live clients could miss the `tool_call` start update and only receive the later `tool_call_update`. For `browser_navigate`, that means clients lose the polished title like `navigate: https://x.com` and may fall back to a generic title.

## Changes

- Remove the redundant local `import json` from the generic fallback.
- Add a regression test for `browser_navigate` start event formatting.

## Validation

- `venv/bin/python -m pytest tests/acp/test_tools.py -q`
