### PR TITLE
fix(slack): emit reactions in free_response_channels

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2228,10 +2228,16 @@ class SlackAdapter(BasePlatformAdapter):
             auto_skill=_auto_skill,
         )
 
-        # Only react when bot is directly addressed (DM or @mention).
-        # In listen-all channels (require_mention=false), reacting to every
-        # casual message would be noisy.
-        _should_react = (is_dm or is_mentioned) and self._reactions_enabled()
+        # React when the bot is directly addressed (DM or @mention), or
+        # when the channel is opt-in free-response (operator has explicitly
+        # said "treat every message here like a DM"). Skipped in plain
+        # listen-all channels (require_mention=false without per-channel
+        # opt-in) where reacting to every casual message would be noisy.
+        _should_react = (
+            is_dm
+            or is_mentioned
+            or channel_id in self._slack_free_response_channels()
+        ) and self._reactions_enabled()
         if _should_react:
             self._reacting_message_ids.add(ts)
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1922,6 +1922,37 @@ class TestReactions:
         adapter._app.client.reactions_remove.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_reactions_added_for_free_response_channel(self, adapter):
+        """Untagged messages in free_response_channels should still get reactions.
+
+        free_response_channels is opt-in per channel — the operator has
+        explicitly said 'treat every message here like a DM'. The
+        noise-avoidance reasoning behind skipping reactions in plain
+        listen-all channels doesn't apply, and without an immediate
+        :eyes: ack the human can't tell a slow agent reply from an
+        ignored message.
+        """
+        adapter.config.extra["free_response_channels"] = ["C_FREE"]
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Tyler"}}
+        })
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C_FREE",
+            "channel_type": "channel",
+            "ts": "1234567890.000005",
+        }
+        await adapter._handle_slack_message(event)
+
+        # Should register for reactions even though it's a non-mention
+        # channel message, because the channel is opt-in free-response.
+        assert "1234567890.000005" in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
     async def test_reactions_disabled_via_env(self, adapter, monkeypatch):
         """SLACK_REACTIONS=false should suppress all reaction lifecycle."""
         monkeypatch.setenv("SLACK_REACTIONS", "false")


### PR DESCRIPTION
## Summary

In channels listed under `slack.free_response_channels`, untagged messages route through the agent (the mention-gate at `gateway/platforms/slack.py:1972` explicitly bypasses `require_mention` for these channels). But the reaction lifecycle at the bottom of `_handle_slack_message` still only fires `:eyes:` → `:white_check_mark:`/`:x:` when the message is a DM or @-mention. The result: in a private one-user free-response channel, the human sees no immediate acknowledgement, and a 30-80s agent response is indistinguishable from "ignored."

This patch extends `_should_react` to also include `channel_id in self._slack_free_response_channels()`.

## Why this is safe

`free_response_channels` is opt-in **per channel**. The operator has already declared "treat every message in this channel like a DM." The original comment justifies the existing skip as noise-avoidance for plain listen-all channels (`require_mention: false` set globally without per-channel opt-in) — that reasoning still applies and is preserved by the patch. Plain listen-all channels without per-channel opt-in are unaffected.

## How it manifests today

A user runs `slack.free_response_channels: [C_PRIVATE]` for a private 1:1 channel with the bot. They send untagged messages. The agent processes and replies, but during the 30-80s reasoning window the user sees zero feedback (`:eyes:` never appears), so they assume the bot is broken and start tagging — which defeats the point of free-response. Confirmed end-to-end against a live install.

## Test plan

- [x] Added `test_reactions_added_for_free_response_channel` to `tests/gateway/test_slack.py::TestReactions` — sends an untagged channel message with `free_response_channels=["C_FREE"]` configured, asserts the message is registered for the reaction lifecycle.
- [x] Existing `test_reactions_skipped_for_non_dm_non_mention` still passes (channels NOT in `free_response_channels` still skip reactions).
- [x] Full Slack suite (`tests/gateway/test_slack*.py`) — 276 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)