### PR TITLE
fix(dashboard): resolve chat TUI argv off event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3319,6 +3319,7 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
 # drops AND the publisher has disconnected.
 _event_channels: dict[str, set] = {}
 _event_lock = asyncio.Lock()
+_chat_argv_lock = asyncio.Lock()
 
 
 def _resolve_chat_argv(
@@ -3364,6 +3365,28 @@ def _resolve_chat_argv(
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
 
     return list(argv), str(cwd) if cwd else None, env
+
+
+async def _resolve_chat_argv_async(
+    resume: Optional[str] = None,
+    sidecar_url: Optional[str] = None,
+) -> tuple[list[str], Optional[str], Optional[dict]]:
+    """Resolve chat argv without blocking the dashboard event loop.
+
+    ``_resolve_chat_argv`` may run ``npm install`` / ``npm run build`` through
+    ``_make_tui_argv``.  Keep that synchronous work off the WebSocket event
+    loop so reverse proxies and existing dashboard connections can continue
+    to exchange keepalives while the TUI launch command is prepared.  The
+    async lock preserves the previous one-build-at-a-time behavior when
+    multiple browser tabs connect at once without occupying worker threads
+    while queued connections wait.
+    """
+    async with _chat_argv_lock:
+        return await asyncio.to_thread(
+            _resolve_chat_argv,
+            resume=resume,
+            sidecar_url=sidecar_url,
+        )
 
 
 def _build_sidecar_url(channel: str) -> Optional[str]:
@@ -3438,7 +3461,7 @@ async def pty_ws(ws: WebSocket) -> None:
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        argv, cwd, env = await _resolve_chat_argv_async(resume=resume, sidecar_url=sidecar_url)
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,6 +51,7 @@ AUTHOR_MAP = {
     "me@promplate.dev": "CNSeniorious000",
     "yichengqiao21@gmail.com": "YarrowQiao",
     "erhanyasarx@gmail.com": "erhnysr",
+    "draihan@student.ubc.ca": "0xdany",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "anadi.jaggia@gmail.com": "Jaggia",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.web_server and related config utilities."""
 
+import asyncio
 import os
 import json
 import tempfile
@@ -2141,6 +2142,60 @@ class TestPtyWebSocket:
             with self.client.websocket_connect(self._url(token="wrong")):
                 pass
         assert exc.value.code == 4401
+
+    def test_resolve_chat_argv_async_uses_worker_thread(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_resolve(resume=None, sidecar_url=None):
+            captured["resume"] = resume
+            captured["sidecar_url"] = sidecar_url
+            return (["node", "dist/entry.js"], "/tmp/ui-tui", {"NODE_ENV": "production"})
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            captured["thread_fn"] = fn
+            captured["thread_args"] = args
+            captured["thread_kwargs"] = kwargs
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+        monkeypatch.setattr(self.ws_module.asyncio, "to_thread", fake_to_thread)
+
+        argv, cwd, env = asyncio.run(
+            self.ws_module._resolve_chat_argv_async(
+                resume="sess-42",
+                sidecar_url="ws://127.0.0.1:9119/api/pub?channel=abc",
+            )
+        )
+
+        assert callable(captured["thread_fn"])
+        assert captured["thread_args"] == ()
+        assert captured["thread_kwargs"] == {
+            "resume": "sess-42",
+            "sidecar_url": "ws://127.0.0.1:9119/api/pub?channel=abc",
+        }
+        assert argv == ["node", "dist/entry.js"]
+        assert cwd == "/tmp/ui-tui"
+        assert env == {"NODE_ENV": "production"}
+        assert captured["resume"] == "sess-42"
+        assert captured["sidecar_url"] == "ws://127.0.0.1:9119/api/pub?channel=abc"
+
+    def test_pty_ws_resolves_argv_through_async_wrapper(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_resolve_async(resume=None, sidecar_url=None):
+            captured["resume"] = resume
+            captured["sidecar_url"] = sidecar_url
+            return (["/bin/sh", "-c", "printf async-resolve-ok"], None, None)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv_async", fake_resolve_async)
+
+        with self.client.websocket_connect(self._url(resume="sess-99")) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured["resume"] == "sess-99"
 
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Dashboard chat now resolves its TUI launch command off the FastAPI/WebSocket event loop. The resolver can run `npm install` / `npm run build` through `_make_tui_argv()`, and doing that synchronously in `/api/pty` can block proxy keepalives and other dashboard WebSocket work long enough for reverse-proxy deployments to drop the chat connection.

This keeps the current TUI build policy intact: normal production launches still run the correctness-first `npm run build` path, while `HERMES_TUI_DIR` remains the prebuilt/no-build path for distros and containers. The change only moves the potentially slow resolver work to a worker thread for the dashboard chat path.

I initially looked at skipping no-op TUI rebuilds, but `main` intentionally simplified that logic in `c6ca11618` to avoid fragile mtime-based staleness checks:

1. `HERMES_TUI_DIR` set: use prebuilt `dist/entry.js`, no build.
2. `--dev`: run TypeScript sources directly, no production build.
3. Normal path: always `npm run build` for correctness.

This PR does not reintroduce bundle staleness caching. It addresses the dashboard-specific failure mode instead: blocking work inside the WebSocket handler's event loop.

## Related Issue

Fixes #25351

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: add `_resolve_chat_argv_async()` and call it from the `/api/pty` WebSocket handler.
- `hermes_cli/web_server.py`: run the synchronous resolver via `asyncio.to_thread()` so the dashboard event loop stays responsive while Node/npm work completes.
- `hermes_cli/web_server.py`: serialize resolver calls with an `asyncio.Lock` before dispatching to the worker thread. This preserves one-build-at-a-time behavior when multiple chat tabs connect, without occupying default threadpool workers while queued connections wait.
- `tests/hermes_cli/test_web_server.py`: add coverage that the resolver is dispatched through the async wrapper and that `/api/pty` uses that wrapper.

## How to Test

1. Confirm formatting:
   - `git diff --check`
2. Run focused regression coverage:
   - `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_resolve_chat_argv_async_uses_worker_thread tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pty_ws_resolves_argv_through_async_wrapper -q`
3. Run the broader dashboard/TUI launcher slice:
   - `uv run --with pytest --with pytest-xdist --with ptyprocess pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_tui_npm_install.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation results:

| Check | Result |
| --- | --- |
| `git diff --check` | pass |
| `uv run --with pytest --with pytest-xdist pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_resolve_chat_argv_async_uses_worker_thread tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pty_ws_resolves_argv_through_async_wrapper -q` | `2 passed` |
| `uv run --with pytest --with pytest-xdist --with ptyprocess pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_tui_npm_install.py -q` | `156 passed` |

`SystemExit` behavior is preserved: if `_make_tui_argv()` exits because Node/npm is unavailable or the TUI build fails, `asyncio.to_thread()` propagates that back to the WebSocket handler and the existing error response path still runs.
