### PR TITLE
fix(gateway): transcribe audio attachments in background tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10432,22 +10432,32 @@ class GatewayRunner:
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
-            # Enrich the prompt with image descriptions so the background
-            # agent can see user-attached images (same as the main flow).
+            # Enrich the prompt with media context so the background agent
+            # sees the same user input the foreground path would surface.
             enriched_prompt = prompt
             if media_urls:
                 image_paths = []
+                audio_paths = []
                 for i, path in enumerate(media_urls):
                     mtype = media_types[i] if i < len(media_types) else ""
                     if mtype.startswith("image/"):
                         image_paths.append(path)
+                    if mtype.startswith("audio/"):
+                        audio_paths.append(path)
                 if image_paths:
                     try:
                         enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                            enriched_prompt, image_paths,
                         )
                     except Exception as e:
                         logger.warning("Background task vision enrichment failed: %s", e)
+                if audio_paths:
+                    try:
+                        enriched_prompt = await self._enrich_message_with_transcription(
+                            enriched_prompt, audio_paths,
+                        )
+                    except Exception as e:
+                        logger.warning("Background task transcription enrichment failed: %s", e)
 
             def run_sync():
                 agent = AIAgent(

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -269,6 +269,73 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_audio_attachments_are_transcribed_into_background_prompt(self, monkeypatch):
+        """Background tasks should get the same audio/STT prompt enrichment as foreground turns."""
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value="prompt [AUDIO]"
+        )
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        captured = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+
+            def _run_conversation(*, user_message, task_id=None):
+                captured["user_message"] = user_message
+                return {"final_response": "done", "messages": []}
+
+            mock_agent_instance.run_conversation.side_effect = _run_conversation
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task(
+                "prompt",
+                source,
+                "bg_test",
+                media_urls=["/tmp/voice.ogg"],
+                media_types=["audio/ogg"],
+            )
+
+        runner._enrich_message_with_transcription.assert_awaited_once_with(
+            "prompt",
+            ["/tmp/voice.ogg"],
+        )
+        assert captured["user_message"] == "prompt [AUDIO]"
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_telegram_dm_topic_completion_preserves_reply_anchor_metadata(self, monkeypatch):
         """Background completion metadata must let Telegram send thread id plus reply id."""
         from gateway import run as gateway_run


### PR DESCRIPTION
## What does this PR do?

This PR addresses a functional disparity between foreground and background task execution. In the current implementation, voice/audio attachments sent via `/background` commands were being forwarded as metadata but ignored during prompt assembly. Unlike the standard gateway flow, the background path lacked the Speech-to-Text (STT) enrichment step.

This fix ensures that background agents receive the full context of audio attachments by integrating `_enrich_message_with_transcription()` into the background task lifecycle.

## Related Issue

Fixes # <!-- Add issue number here -->

## Type of Change

- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [x] ✅ **Tests** (adding or improving test coverage)

## Changes Made

### `gateway/run.py`
- Refactored `_run_background_task()` to explicitly handle `audio/*` mime-types.
- Integrated `_enrich_message_with_transcription()` into the background prompt assembly flow.
- Ensured that audio transcription parity is maintained with the main `_enrich_message_with_transcription` logic used in line 6854.

### `tests/gateway/test_background_command.py`
- Added a regression test: `audio_attachments_are_transcribed_into_background_prompt`.
- The test verifies that:
  1. Media URLs with audio types are correctly identified.
  2. The transcription helper is invoked.
  3. The enriched prompt is successfully passed to `run_conversation()`.

## How to Test


```powershell
# Run the specific regression test
pytest tests/gateway/test_background_command.py -k audio_attachments_are_transcribed_into_background_prompt -n0 -v