### PR TITLE
fix: add deepseek/deepseek-v4-flash to Nous Portal curated model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -176,6 +176,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "x-ai/grok-4.3",
         "nvidia/nemotron-3-super-120b-a12b",
         "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-11T16:41:16Z",
+  "updated_at": "2026-05-15T05:38:00Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -215,6 +215,9 @@
         },
         {
           "id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash"
         }
       ]
     }


### PR DESCRIPTION
## Summary

`deepseek/deepseek-v4-flash` is a free-tier model on the Nous Portal but was missing from `_PROVIDER_MODELS["nous"]`. This meant:

1. It never appeared in the `/model` TUI picker
2. It was absent from the `model-catalog.json` manifest published to hermes-agent.nousresearch.com
3. Free-tier users who configure it manually (it works via API) couldn't select or discover it from the picker

## Changes

- `hermes_cli/models.py`: Added `"deepseek/deepseek-v4-flash"` to the `nous` provider's curated model list
- `website/static/api/model-catalog.json`: Rebuilt via `scripts/build_model_catalog.py` so the deployed catalog reflects the change

## Verification

The free-tier models from Nous Portal's `/api/nous/recommended-models` endpoint are:
- ✅ `stepfun/step-3.5-flash` (was already in list)
- ✅ `deepseek/deepseek-v4-flash` (now added)
- ✅ `google/gemini-3-flash-preview` (was already in list)

## Notes

The curated catalog (model-catalog.json) is built from `_PROVIDER_MODELS` via `scripts/build_model_catalog.py`. The runtime fetcher at `https://hermes-agent.nousresearch.com/docs/api/model-catalog.json` will pick this up after the next docs deployment.