### PR TITLE
feat(hooks): add agent:response hook event for post-turn logging/mirroring

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -14,6 +14,7 @@ Events:
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
+  - agent:response      -- Agent response fully assembled (full text + metadata)
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7935,6 +7935,25 @@ class GatewayRunner:
                 **hook_ctx,
                 "response": (response or "")[:500],
             })
+
+            # Emit agent:response hook — fires after the response is fully
+            # assembled (including footer, reasoning, etc.) but before it
+            # is returned to the platform adapter for delivery.  Unlike
+            # agent:end (which truncates response to 500 chars), this event
+            # carries the full response text so downstream consumers (audit
+            # logs, cross-bot mirroring, analytics) receive complete data.
+            # (#26109)
+            await self.hooks.emit("agent:response", {
+                **hook_ctx,
+                "response": response or "",
+                "model": agent_result.get("model", ""),
+                "turn_id": session_entry.session_id,
+                "timestamp": datetime.now().isoformat(),
+                "token_usage": {
+                    "prompt_tokens": agent_result.get("last_prompt_tokens", 0),
+                    "context_length": agent_result.get("context_length"),
+                },
+            })
             
             # Check for pending process watchers (check_interval on background processes)
             try:

--- a/tests/gateway/test_agent_response_hook.py
+++ b/tests/gateway/test_agent_response_hook.py
@@ -1,0 +1,152 @@
+"""Tests for the agent:response hook event (#26109)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.hooks import HookRegistry
+
+
+class TestAgentResponseHookEvent:
+    """Verify that the agent:response event is emitted with the correct
+    payload fields after agent processing completes."""
+
+    @pytest.mark.asyncio
+    async def test_emit_agent_response_hook(self):
+        """HookRegistry should dispatch agent:response to subscribed handlers."""
+        received = []
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [
+            lambda event_type, ctx: received.append((event_type, ctx))
+        ]
+
+        ctx = {
+            "platform": "telegram",
+            "user_id": "u123",
+            "chat_id": "c456",
+            "session_id": "s789",
+            "message": "hello",
+            "response": "Hi there!",
+            "model": "claude-sonnet-4",
+            "turn_id": "s789",
+            "timestamp": "2026-05-15T12:00:00",
+            "token_usage": {"prompt_tokens": 100, "context_length": 128000},
+        }
+        await reg.emit("agent:response", ctx)
+
+        assert len(received) == 1
+        assert received[0][0] == "agent:response"
+        assert received[0][1]["response"] == "Hi there!"
+        assert received[0][1]["model"] == "claude-sonnet-4"
+        assert received[0][1]["turn_id"] == "s789"
+        assert received[0][1]["token_usage"]["prompt_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_agent_response_full_text_not_truncated(self):
+        """agent:response should carry the FULL response text (unlike
+        agent:end which truncates to 500 chars)."""
+        received = []
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [
+            lambda event_type, ctx: received.append(ctx)
+        ]
+
+        long_response = "x" * 2000
+        ctx = {"response": long_response}
+        await reg.emit("agent:response", ctx)
+
+        assert len(received) == 1
+        assert len(received[0]["response"]) == 2000
+
+    @pytest.mark.asyncio
+    async def test_agent_response_async_handler(self):
+        """agent:response should work with async handlers."""
+        received = []
+
+        async def async_handler(event_type, ctx):
+            received.append((event_type, ctx))
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [async_handler]
+
+        ctx = {"response": "test", "platform": "discord"}
+        await reg.emit("agent:response", ctx)
+
+        assert len(received) == 1
+        assert received[0][1]["platform"] == "discord"
+
+    @pytest.mark.asyncio
+    async def test_agent_response_handler_error_does_not_block(self):
+        """Errors in agent:response handlers should not block other handlers
+        or the main pipeline."""
+        results = []
+
+        def bad_handler(event_type, ctx):
+            raise RuntimeError("handler crashed")
+
+        def good_handler(event_type, ctx):
+            results.append("ok")
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [bad_handler, good_handler]
+
+        await reg.emit("agent:response", {"response": "test"})
+        assert results == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_agent_response_payload_fields(self):
+        """Verify all required fields from issue #26109 are present."""
+        received = []
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [
+            lambda event_type, ctx: received.append(ctx)
+        ]
+
+        ctx = {
+            "platform": "telegram",
+            "user_id": "user_abc",
+            "chat_id": "-1001234567890",
+            "session_id": "sess_xyz",
+            "message": "What is 2+2?",
+            "response": "2+2 equals 4.",
+            "model": "gpt-4o",
+            "turn_id": "sess_xyz",
+            "timestamp": "2026-05-15T10:30:00",
+            "token_usage": {
+                "prompt_tokens": 150,
+                "context_length": 128000,
+            },
+        }
+        await reg.emit("agent:response", ctx)
+
+        assert len(received) == 1
+        payload = received[0]
+        # Required fields from #26109
+        assert "response" in payload
+        assert "platform" in payload
+        assert "chat_id" in payload
+        assert "turn_id" in payload
+        assert "timestamp" in payload
+        assert "user_id" in payload
+        assert "model" in payload
+        assert "token_usage" in payload
+
+    @pytest.mark.asyncio
+    async def test_agent_response_via_emit_collect(self):
+        """emit_collect should capture return values from agent:response handlers."""
+        def handler(event_type, ctx):
+            return {"logged": True, "chat": ctx.get("chat_id")}
+
+        reg = HookRegistry()
+        reg._handlers["agent:response"] = [handler]
+
+        results = await reg.emit_collect(
+            "agent:response",
+            {"response": "test", "chat_id": "c1"},
+        )
+        assert len(results) == 1
+        assert results[0] == {"logged": True, "chat": "c1"}


### PR DESCRIPTION
## Summary

Adds a new gateway hook event `agent:response` that fires after the assistant response is fully assembled but before it is returned to the platform adapter for delivery.

Closes #26109

## Problem

There is no plugin hook that fires when the gateway has finalized an assistant response and is about to send it. The existing `agent:end` hook truncates response text to 500 chars, making it unsuitable for downstream logging, cross-bot mirroring, or audit trails.

## Solution

Added `agent:response` as a new hook event in `gateway/run.py`, emitted right after `agent:end`. It carries:

| Field | Description |
|---|---|
| `response` | Full response text (not truncated) |
| `platform` | telegram / discord / slack / ... |
| `user_id` | Sender user ID |
| `chat_id` | Chat/room ID |
| `session_id` | Session identifier |
| `model` | Resolved model name |
| `turn_id` | Session ID for correlation |
| `timestamp` | ISO format timestamp |
| `token_usage` | `{prompt_tokens, context_length}` |

## Usage

Users create a hook in `~/.hermes/hooks/my-hook/`:

```yaml
# HOOK.yaml
name: cross-bot-logger
events: ["agent:response"]
```

```python
# handler.py
def handle(event_type, context):
    with open("/shared/cross-bot.jsonl", "a") as f:
        f.write(json.dumps({
            "actor": "my-bot",
            "response": context["response"],
            "platform": context["platform"],
            "chat_id": context["chat_id"],
            "timestamp": context["timestamp"],
        }) + "\n")
```

## Files Changed

- `gateway/run.py` — emit `agent:response` after `agent:end`
- `gateway/hooks.py` — documented new event in docstring
- `tests/gateway/test_agent_response_hook.py` — 6 new tests

## Test Results

```
27 passed in 4.32s (existing test_hooks.py + new test_agent_response_hook.py)
```

## Design Decisions

- Fires **after** `agent:end` and after all response post-processing (footer, reasoning), so consumers always see the final text
- Uses the same `HookRegistry.emit()` path — errors are caught and logged without blocking the pipeline
- No breaking changes to existing hooks or API