### PR TITLE
feat(gateway): make auto-TTS markdown strip overridable via prepare_tts_text() hook

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2011,6 +2011,13 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
+    def prepare_tts_text(self, text: str) -> str:
+        """Prepare text for TTS. Override to filter tool output, code, etc.
+
+        Default strips markdown formatting and truncates to 4000 chars.
+        """
+        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+
     async def play_tts(
         self,
         chat_id: str,
@@ -3125,7 +3132,7 @@ class BasePlatformAdapter(ABC):
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                            speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
                             tts_result_str = await asyncio.to_thread(


### PR DESCRIPTION
## What

Extracts the inlined markdown-strip-and-truncate at the auto-TTS site in `BasePlatformAdapter._process_message_background` into an overridable method:

```python
def prepare_tts_text(self, text: str) -> str:
    """Prepare text for TTS. Override to filter tool output, code, etc.

    Default strips markdown formatting and truncates to 4000 chars.
    """
    return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
```

…and replaces the call site:

```diff
-speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+speech_text = self.prepare_tts_text(text_content)
```

That's the entire change. 8 lines added, 1 removed, one file.

## Why

The default implementation is **byte-identical** to the previous inline expression, so this is a zero-behaviour-change refactor for every existing adapter (Telegram, Discord, Slack, Matrix, IRC, Mattermost, BlueBubbles, Feishu, DingTalk, WeCom, WhatsApp, Signal, etc.). They all continue to get exactly the same TTS text they got before.

**The hook unblocks voice-first platform adapters.** What works for text-bubble platforms is wrong for read-aloud platforms:

- A Telegram bot reply containing `Run \`pip install foo\` then visit https://docs.example.com/install#step-2` looks fine in the chat bubble.
- A LiveKit voice agent speaking that same reply has to read it out as `Run backtick pip install foo backtick then visit h-t-t-p-s colon slash slash docs dot example dot com slash install hash step dash two`. Markdown sigils get stripped, but URLs, file paths, fenced code blocks, and `MEDIA:` tags are spoken character-by-character.

A voice-output adapter wants to drop those spans before TTS synthesis, while keeping the full text in the data-channel transcript for clients that render visually.

**Today, without this hook, voice adapters have two options, both worse:**

1. Duplicate the auto-TTS pipeline inside their own `handle_response` override — which means re-implementing `extract_media`, `extract_images`, `extract_local_files`, attachment routing, the auto-TTS gate, error handling, and the auto-TTS playback ordering from `_process_message_background`. ~80 lines of fragile copy-paste that goes stale every time someone touches the base flow.
2. Live with TTS reading URLs and code blocks aloud.

A 7-line overridable method removes the dilemma without affecting any existing adapter.

## Example consumer

[kortexa-ai/hermes-livekit](https://github.com/kortexa-ai/hermes-livekit) — a LiveKit WebRTC voice gateway plugin for hermes-agent, installable via pip into an existing hermes install:

```bash
pip install git+https://github.com/kortexa-ai/hermes-livekit.git
hermes plugins enable livekit
```

It registers as a platform plugin via the `hermes_agent.plugins` entry-point group (zero core edits required to load it) and overrides `prepare_tts_text()` to additionally strip:

- Fenced code blocks (` ``` ... ``` `)
- Inline code (`` `...` ``)
- URLs (`https?://...`)
- File paths (`/x/y`, `~/x`, `C:\x`)
- `MEDIA:<path>` tags
- Collapses repeated whitespace

…before TTS synthesis. The full original response still reaches connected LiveKit clients via the data channel for visual rendering.

That override is **the only piece of the LiveKit platform implementation** that can't be done entirely from within a plugin against the existing `register_platform()` hook surface. Every other LiveKit-specific behaviour (env-driven auto-enable, connected-status check, cron home-channel, allowed-users gate, platform prompt hint, interactive setup) maps cleanly onto an existing kwarg on `register_platform()`. This one hook is the missing piece.

## Relation to #3894

#3894 ([feat(gateway): add LiveKit WebRTC voice platform support](https://github.com/NousResearch/hermes-agent/pull/3894)) bundles this same hook change together with the full LiveKit platform adapter. This PR carves the generic hook out so it can be reviewed and merged independently — the hook is useful to any future voice-output platform adapter (LiveKit, Twilio Voice, telephony bridges, etc.), and shouldn't be coupled to LiveKit-specific review concerns.

## Risk

Approximately zero. The default returns exactly the same string as the previous inline expression. Existing tests for the auto-TTS path do not need updates (verified manually — the call site is unreachable from anywhere except the auto-TTS branch, and behaviour at that branch is unchanged for non-overriding adapters).

## Testing

Verified end-to-end against the consumer plugin: real LiveKit server → STT (qwen3-asr) → agent loop → TTS (qwen3-tts) → audio published back to the room → captured WAV transcribes to the agent's reply word-for-word.

The override in `hermes_livekit/adapter.py` activates only when running against a hermes-agent build that has this hook in `base.py`; on stock upstream `main` today, the override is dead code and TTS falls back to the inline default — TTS still works, just speaks URLs aloud. This PR makes the override live for any installation that wants voice-friendly TTS prep.