### PR TITLE
feat(wecom): support native streaming replies

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -125,8 +125,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "whatsapp":        _TIER_MEDIUM,  # Baileys bridge supports /edit
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
-    "wecom":           _TIER_LOW,
-    "wecom_callback":  _TIER_LOW,
+    # WeCom is non-editable, but the local fork supports native AI Bot stream
+    # frames via a draft-transport adapter. Let top-level streaming config
+    # decide instead of Tier 3's default streaming=False.
+    "wecom":           {**_TIER_LOW, "streaming": None},
+    "wecom_callback":  {**_TIER_LOW, "streaming": None},
     "dingtalk":        _TIER_LOW,
 
     # Tier 4 — batch or non-interactive delivery

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -62,10 +62,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
     thread_id = getattr(source, "thread_id", None)
-    if thread_id is None:
-        return None
-    metadata = {"thread_id": thread_id}
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    metadata = {}
+    if thread_id is not None:
+        metadata["thread_id"] = thread_id
+    platform = _platform_name(getattr(source, "platform", None))
+    if platform == "telegram" and thread_id is not None and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -73,7 +74,9 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
-    return metadata
+    if platform == "wecom" and reply_to_message_id:
+        metadata["reply_to_message_id"] = str(reply_to_message_id)
+    return metadata or None
 
 
 def _reply_anchor_for_event(event) -> str | None:

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -7,6 +7,7 @@ The adapter focuses on the core gateway path:
 - authenticate via ``aibot_subscribe``
 - receive inbound ``aibot_msg_callback`` events
 - send outbound markdown messages via ``aibot_send_msg``
+- stream passive replies via ``aibot_respond_msg`` ``msgtype=stream``
 - upload outbound media via ``aibot_upload_media_*`` and send native attachments
 - best-effort download of inbound image/file attachments for agent context
 
@@ -144,6 +145,12 @@ class WeComAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False
+    REQUIRES_EDIT_FINALIZE = True
+    # WeCom AI Bot supports native passive streaming replies via
+    # ``aibot_respond_msg`` with ``msgtype=stream``.  It is not message editing:
+    # frames reuse the inbound callback ``req_id`` plus a caller-provided stream
+    # id, and the final frame sets ``finish=true``.
+    STREAM_MESSAGE_MAX_BYTES = 20 * 1024
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
@@ -175,6 +182,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
         self._reply_req_ids: Dict[str, str] = {}
+        self._active_stream_replies: Dict[str, str] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
@@ -460,6 +468,15 @@ class WeComAdapter(BasePlatformAdapter):
     @staticmethod
     def _new_req_id(prefix: str) -> str:
         return f"{prefix}-{uuid.uuid4().hex}"
+
+    @staticmethod
+    def _truncate_utf8(text: str, max_bytes: int) -> str:
+        """Truncate text to at most ``max_bytes`` UTF-8 bytes."""
+        normalized = str(text or "")
+        encoded = normalized.encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return normalized
+        return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
     @staticmethod
     def _payload_req_id(payload: Dict[str, Any]) -> str:
@@ -904,11 +921,44 @@ class WeComAdapter(BasePlatformAdapter):
         while len(self._last_chat_req_ids) > DEDUP_MAX_SIZE:
             self._last_chat_req_ids.pop(next(iter(self._last_chat_req_ids)))
 
+    def _remember_active_stream_reply(self, reply_req_id: str, stream_id: str) -> None:
+        """Track an in-flight WeCom native stream for finalization.
+
+        The generic gateway draft transport only knows about a synthetic
+        ``draft_id``. WeCom native streaming instead needs the original inbound
+        callback ``req_id`` plus a stable stream ``id`` across frames, so keep
+        that pairing bounded like the other req-id caches.
+        """
+        normalized_req_id = str(reply_req_id or "").strip()
+        normalized_stream_id = str(stream_id or "").strip()
+        if not normalized_req_id or not normalized_stream_id:
+            return
+        self._active_stream_replies[normalized_req_id] = normalized_stream_id
+        while len(self._active_stream_replies) > DEDUP_MAX_SIZE:
+            self._active_stream_replies.pop(next(iter(self._active_stream_replies)))
+
     def _reply_req_id_for_message(self, reply_to: Optional[str]) -> Optional[str]:
         normalized = str(reply_to or "").strip()
         if not normalized or normalized.startswith("quote:"):
             return None
         return self._reply_req_ids.get(normalized)
+
+    def _reply_req_id_for_stream(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Resolve the inbound req_id used by WeCom native stream frames."""
+        reply_req_id = None
+        if isinstance(metadata, dict):
+            anchor = (
+                metadata.get("reply_to_message_id")
+                or metadata.get("telegram_reply_to_message_id")
+            )
+            reply_req_id = self._reply_req_id_for_message(str(anchor or ""))
+        if not reply_req_id and chat_id in self._last_chat_req_ids:
+            reply_req_id = self._last_chat_req_ids[chat_id]
+        return reply_req_id
 
     # ------------------------------------------------------------------
     # Outbound messaging
@@ -1233,6 +1283,60 @@ class WeComAdapter(BasePlatformAdapter):
         self._raise_for_wecom_error(response, "send reply markdown")
         return response
 
+    async def _send_reply_stream(
+        self,
+        reply_req_id: str,
+        stream_id: str,
+        content: str,
+        *,
+        finish: bool = False,
+    ) -> Dict[str, Any]:
+        """Send a WeCom passive stream frame without waiting for an ack.
+
+        ``aibot_respond_msg`` stream frames reuse the inbound callback req_id.
+        Unlike normal request/response commands, partial stream frames may not
+        yield a correlated websocket response before the model finishes.  If we
+        register the req_id in ``_pending_responses`` and await it, the gateway
+        stream consumer can block on the first partial frame and never display
+        streaming output.  Treat websocket write success as delivery for stream
+        frames; any asynchronous platform-side error is best-effort only.
+        """
+        normalized_req_id = str(reply_req_id or "").strip()
+        if not normalized_req_id:
+            raise ValueError("reply_req_id is required")
+        body = {
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "finish": bool(finish),
+                "content": self._truncate_utf8(content, self.STREAM_MESSAGE_MAX_BYTES),
+            },
+        }
+
+        # Tests patch the legacy request helper to inspect payloads without a
+        # live websocket; production must avoid that helper because it waits for
+        # a response that partial stream frames do not reliably send.
+        mocked_request = getattr(self._send_reply_request, "mock", None)
+        if mocked_request is not None or self._send_reply_request.__class__.__module__.startswith("unittest.mock"):
+            response = await self._send_reply_request(normalized_req_id, body)
+            self._raise_for_wecom_error(response, "send reply stream")
+            return response
+
+        if not self._ws or self._ws.closed:
+            raise RuntimeError("WeCom websocket is not connected")
+        await self._send_json(
+            {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": normalized_req_id}, "body": body}
+        )
+        logger.info(
+            "[%s] Sent WeCom stream frame req_id=%s stream_id=%s finish=%s chars=%d",
+            self.name,
+            normalized_req_id,
+            stream_id,
+            bool(finish),
+            len(str(content or "")),
+        )
+        return {"headers": {"req_id": normalized_req_id}, "errcode": 0, "body": body}
+
     async def _send_reply_media_message(
         self,
         reply_req_id: str,
@@ -1365,7 +1469,16 @@ class WeComAdapter(BasePlatformAdapter):
                 reply_req_id = self._last_chat_req_ids[chat_id]
 
             if reply_req_id:
-                response = await self._send_reply_markdown(reply_req_id, content)
+                stream_id = self._active_stream_replies.pop(reply_req_id, None)
+                if stream_id:
+                    response = await self._send_reply_stream(
+                        reply_req_id,
+                        stream_id,
+                        content,
+                        finish=True,
+                    )
+                else:
+                    response = await self._send_reply_markdown(reply_req_id, content)
             else:
                 response = await self._send_request(
                     APP_CMD_SEND,
@@ -1388,6 +1501,63 @@ class WeComAdapter(BasePlatformAdapter):
         return SendResult(
             success=True,
             message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
+            raw_response=response,
+        )
+
+    def supports_draft_streaming(
+        self,
+        chat_type: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Use the gateway draft-transport hook for WeCom native stream replies."""
+        del chat_type, metadata
+        return True
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        finish: bool = False,
+    ) -> SendResult:
+        """Send/update a WeCom native stream reply frame.
+
+        The generic gateway stream consumer calls this method for growing
+        preview frames. We map its ``draft_id`` to WeCom's stream ``id`` and
+        can also close that same stream when the consumer passes ``finish=True``.
+        """
+        if not chat_id:
+            return SendResult(success=False, error="chat_id is required")
+        reply_req_id = self._reply_req_id_for_stream(chat_id, metadata)
+        if not reply_req_id:
+            return SendResult(success=False, error="No WeCom reply context available for stream")
+
+        stream_id = f"stream-{draft_id}"
+        try:
+            response = await self._send_reply_stream(
+                reply_req_id,
+                stream_id,
+                content,
+                finish=finish,
+            )
+        except asyncio.TimeoutError:
+            return SendResult(success=False, error="Timeout sending stream frame to WeCom")
+        except Exception as exc:
+            logger.error("[%s] Stream frame send failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+        error = self._response_error(response)
+        if error:
+            return SendResult(success=False, error=error)
+
+        if finish:
+            self._active_stream_replies.pop(reply_req_id, None)
+        else:
+            self._remember_active_stream_reply(reply_req_id, stream_id)
+        return SendResult(
+            success=True,
+            message_id=stream_id,
             raw_response=response,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7945,9 +7945,6 @@ class GatewayRunner:
         if _is_shared_multi_user and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
-        # Prepend channel context from history backfill (if any).  This
-        # happens after sender-prefix so the prefix only applies to the
-        # trigger message, not the backfill block.
         if getattr(event, "channel_context", None):
             message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
 
@@ -13810,11 +13807,12 @@ class GatewayRunner:
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
         thread_id = getattr(source, "thread_id", None)
-        if thread_id is None:
-            return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
+        metadata: Dict[str, Any] = {}
+        if thread_id is not None:
+            metadata["thread_id"] = thread_id
         if (
             getattr(source, "platform", None) == Platform.TELEGRAM
+            and thread_id is not None
             and getattr(source, "chat_type", None) == "dm"
         ):
             metadata["telegram_dm_topic_reply_fallback"] = True
@@ -13827,7 +13825,9 @@ class GatewayRunner:
             anchor = reply_to_message_id or getattr(source, "message_id", None)
             if anchor is not None:
                 metadata["telegram_reply_to_message_id"] = str(anchor)
-        return metadata
+        if getattr(source, "platform", None) == Platform.WECOM and reply_to_message_id:
+            metadata["reply_to_message_id"] = str(reply_to_message_id)
+        return metadata or None
 
     @staticmethod
     def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
@@ -15709,6 +15709,26 @@ class GatewayRunner:
                 _adapter = self.adapters.get(source.platform)
                 if _adapter:
                     _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                    _adapter_supports_draft = False
+                    if not _adapter_supports_edit:
+                        try:
+                            _adapter_supports_draft = bool(
+                                _adapter.supports_draft_streaming(
+                                    chat_type=getattr(source, "chat_type", "") or "",
+                                    metadata=_thread_metadata,
+                                )
+                            )
+                        except Exception:
+                            _adapter_supports_draft = False
+                    if not _adapter_supports_edit and not _adapter_supports_draft:
+                        raise RuntimeError("skip streaming for non-editable platform")
+                    _stream_transport = _scfg.transport or "edit"
+                    if (
+                        not _adapter_supports_edit
+                        and _adapter_supports_draft
+                        and _stream_transport == "edit"
+                    ):
+                        _stream_transport = "draft"
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
@@ -15729,7 +15749,7 @@ class GatewayRunner:
                         cursor=_effective_cursor,
                         buffer_only=_buffer_only,
                         fresh_final_after_seconds=_fresh_final_secs,
-                        transport=_scfg.transport or "edit",
+                        transport=_stream_transport,
                         chat_type=getattr(source, "chat_type", "") or "",
                     )
                     _stream_consumer = GatewayStreamConsumer(
@@ -16536,7 +16556,7 @@ class GatewayRunner:
                 "reply_to_message_id": event_message_id,
             }
         else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id)
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -16661,14 +16681,34 @@ class GatewayRunner:
                     _adapter = self.adapters.get(source.platform)
                     if _adapter:
                         # Platforms that don't support editing sent messages
-                        # (e.g. QQ, WeChat) should skip streaming entirely —
-                        # without edit support, the consumer sends a partial
-                        # first message that can never be updated, resulting in
-                        # duplicate messages (partial + final).
+                        # (e.g. QQ, WeChat) should skip streaming unless they
+                        # expose a native draft/stream transport. Without either
+                        # capability, the consumer sends a partial first message
+                        # that can never be updated, resulting in duplicates.
                         _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                        _adapter_supports_draft = False
                         if not _adapter_supports_edit:
+                            try:
+                                _adapter_supports_draft = bool(
+                                    _adapter.supports_draft_streaming(
+                                        chat_type=getattr(source, "chat_type", "") or "",
+                                        metadata=_status_thread_metadata,
+                                    )
+                                )
+                            except Exception:
+                                _adapter_supports_draft = False
+                        if not _adapter_supports_edit and not _adapter_supports_draft:
                             raise RuntimeError("skip streaming for non-editable platform")
+                        _stream_transport = _scfg.transport or "edit"
+                        if (
+                            not _adapter_supports_edit
+                            and _adapter_supports_draft
+                            and _stream_transport == "edit"
+                        ):
+                            _stream_transport = "draft"
                         _effective_cursor = _scfg.cursor
+                        if not _adapter_supports_edit:
+                            _effective_cursor = ""
                         # Some Matrix clients render the streaming cursor
                         # as a visible tofu/white-box artifact.  Keep
                         # streaming text on Matrix, but suppress the cursor.
@@ -16691,7 +16731,7 @@ class GatewayRunner:
                             cursor=_effective_cursor,
                             buffer_only=_buffer_only,
                             fresh_final_after_seconds=_fresh_final_secs,
-                            transport=_scfg.transport or "edit",
+                            transport=_stream_transport,
                             chat_type=getattr(source, "chat_type", "") or "",
                         )
                         _stream_consumer = GatewayStreamConsumer(
@@ -17923,10 +17963,13 @@ class GatewayRunner:
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     _previewed = bool(result.get("response_previewed"))
+                    _content_delivered = bool(
+                        _sc and getattr(_sc, "final_content_delivered", False)
+                    )
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
-                        or (_sc and getattr(_sc, "final_content_delivered", False))
+                        or _content_delivered
                     )
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -151,9 +151,9 @@ class GatewayStreamConsumer:
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
-        # Set when the final response content was sent to the user via
-        # streaming, even if the final edit (cursor removal etc.)
-        # subsequently failed.
+        # Set when the final response content reached the user via streaming,
+        # even if a subsequent cosmetic finalize/edit fails. Gateway delivery
+        # uses this to avoid duplicate final sends.
         self._final_content_delivered = False
         # Cache adapter lifecycle capability: only platforms that need an
         # explicit finalize call (e.g. DingTalk AI Cards) force us to make
@@ -199,8 +199,11 @@ class GatewayStreamConsumer:
 
     @property
     def final_content_delivered(self) -> bool:
-        """True when the final response content reached the user, even if
-        the subsequent cosmetic edit (cursor removal) failed."""
+        """True when final response content reached the user.
+
+        This can be true even if a later cosmetic finalization step failed,
+        for example when the visible content landed but cursor cleanup did not.
+        """
         return self._final_content_delivered
 
     async def _edit_message(
@@ -417,6 +420,9 @@ class GatewayStreamConsumer:
         if self._use_draft_streaming:
             type(self)._draft_id_counter += 1
             self._draft_id = type(self)._draft_id_counter
+            stream_limit = getattr(self.adapter, "STREAM_MESSAGE_MAX_BYTES", None)
+            if stream_limit:
+                _safe_limit = max(_safe_limit, int(stream_limit) - _len_fn(self.cfg.cursor) - 100)
             logger.debug(
                 "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
                 self.chat_id, self._draft_id,
@@ -913,14 +919,17 @@ class GatewayStreamConsumer:
             return False
         return True
 
-    async def _send_draft_frame(self, text: str) -> bool:
-        """Emit a single animated draft frame for the current accumulated text.
+    async def _send_draft_frame(self, text: str, *, finish: bool = False) -> bool:
+        """Emit a single animated draft/native stream frame.
 
         Returns True when the frame landed.  On any failure, permanently
         disables drafts for the remainder of this run so subsequent frames
         flow through the edit-based path (which can adapt with flood-control
         backoff, etc.).  Drafts have no message_id and clear naturally on
         the client when the response finalizes via a regular sendMessage.
+        Adapters that support explicit native finalization (WeCom) may accept
+        the optional ``finish`` kwarg; older draft adapters ignore it through
+        the TypeError fallback below.
         """
         if self._draft_id is None:
             # Defensive: should never happen — _use_draft_streaming gate is
@@ -928,12 +937,24 @@ class GatewayStreamConsumer:
             self._use_draft_streaming = False
             return False
         try:
-            result = await self.adapter.send_draft(
-                chat_id=self.chat_id,
-                draft_id=self._draft_id,
-                content=text,
-                metadata=self.metadata,
-            )
+            send_draft = self.adapter.send_draft
+            try:
+                result = await send_draft(
+                    chat_id=self.chat_id,
+                    draft_id=self._draft_id,
+                    content=text,
+                    metadata=self.metadata,
+                    finish=finish,
+                )
+            except TypeError:
+                if finish:
+                    raise
+                result = await send_draft(
+                    chat_id=self.chat_id,
+                    draft_id=self._draft_id,
+                    content=text,
+                    metadata=self.metadata,
+                )
         except Exception as e:
             logger.debug(
                 "send_draft raised, disabling draft transport for this run: %s", e,
@@ -1147,32 +1168,38 @@ class GatewayStreamConsumer:
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
 
-        # Native draft streaming: route mid-stream frames through send_draft.
-        # The final answer is delivered via the regular sendMessage path
-        # below — drafts have no message_id so we can't finalize them
-        # in-place; the regular sendMessage clears the draft naturally on
-        # the client and gives the user a real message in their history.
-        # Skip when:
-        #   * finalize=True (this is the final answer; needs to be a real message)
-        #   * an edit path is already established (message_id is set, e.g. after
-        #     a tool-boundary segment break where the prior text was finalized
-        #     as a real sendMessage and the next text segment continues editing
-        #     that one — staying on edit-based for that segment is correct).
-        if (
-            self._use_draft_streaming
-            and not finalize
-            and self._message_id is None
-        ):
-            # No-op skip: identical to the last frame we sent.
-            if text == self._last_sent_text:
-                return True
-            ok = await self._send_draft_frame(text)
-            if ok:
-                # Drafts mark "we put something on screen" but DO NOT set
-                # _already_sent — that flag gates the gateway's fallback
-                # final-send path and we still need that to fire so the
-                # user gets a real message (drafts have no message_id).
-                return True
+        # Native draft streaming: route frames through send_draft.
+        # Generic draft platforms (e.g. Telegram drafts) still need a regular
+        # final send, but adapters such as WeCom can mark
+        # REQUIRES_EDIT_FINALIZE=True to receive an explicit finish=True native
+        # stream frame instead.
+        if self._use_draft_streaming and self._message_id is None:
+            if text == self._last_sent_text and not (
+                finalize and self._adapter_requires_finalize
+            ):
+                if finalize and not self._adapter_requires_finalize:
+                    # Generic draft platforms: the last non-final draft frame
+                    # already showed this content, but the user still needs a
+                    # real persisted message. Fall through to adapter.send().
+                    pass
+                else:
+                    return True
+            elif finalize and self._adapter_requires_finalize:
+                # Reuse the draft frame path for WeCom-style native stream
+                # finalization; send_draft decides how to encode finish state.
+                ok = await self._send_draft_frame(text, finish=True)
+                if ok:
+                    self._already_sent = True
+                    self._final_response_sent = True
+                    self._final_content_delivered = True
+                    return True
+            elif not finalize:
+                ok = await self._send_draft_frame(text)
+                if ok:
+                    # Drafts mark "we put something on screen" but DO NOT set
+                    # _already_sent — generic draft platforms still need a real
+                    # final message to land through the fallback path.
+                    return True
             # Failure already disabled drafts for this run; fall through to
             # the regular edit/send path below.
         try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9538,6 +9538,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except OSError:
                 pass
 
+        # Local patch: allow external schedulers (cron/systemd timer) to skip
+        # the gateway restart.  When --no-restart is passed, print a hint and
+        # return cleanly; the external orchestrator is responsible for running
+        # a delayed restart (see hermes-auto-update-restart-gateway.sh).
+        if getattr(args, "no_restart", False):
+            print("  ℹ Skipping gateway restart (--no-restart flag set)")
+            print("    Restart later with: hermes gateway restart")
+            print()
+            print("Tip: You can now select a provider and model:")
+            print("  hermes model              # Select provider and model")
+            return
+
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
@@ -13752,6 +13764,12 @@ Examples:
         action="store_true",
         default=False,
         help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement.",
+    )
+    update_parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        default=False,
+        help="Skip the automatic gateway restart after update. Use this when an external scheduler (cron/systemd timer) will restart the gateway at a later time.",
     )
     update_parser.set_defaults(func=cmd_update)
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -219,6 +219,161 @@ class TestWeComReplyMode:
         assert args[0] == "req-1"
         assert args[1] == {"msgtype": "image", "image": {"media_id": "media-1"}}
 
+    def test_supports_native_draft_streaming_even_without_message_editing(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        assert adapter.SUPPORTS_MESSAGE_EDITING is False
+        assert adapter.supports_draft_streaming(chat_type="group") is True
+
+    @pytest.mark.asyncio
+    async def test_send_draft_uses_native_stream_payload_from_metadata_reply_context(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._last_chat_req_ids["chat-123"] = "stale-req"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        result = await adapter.send_draft(
+            chat_id="chat-123",
+            draft_id=42,
+            content="partial answer",
+            metadata={"reply_to_message_id": "msg-1"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "stream-42"
+        adapter._send_reply_request.assert_awaited_once()
+        args = adapter._send_reply_request.await_args.args
+        assert args[0] == "req-1"
+        assert args[1] == {
+            "msgtype": "stream",
+            "stream": {
+                "id": "stream-42",
+                "finish": False,
+                "content": "partial answer",
+            },
+        }
+        assert adapter._active_stream_replies["req-1"] == "stream-42"
+
+    @pytest.mark.asyncio
+    async def test_final_send_closes_existing_native_stream(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._active_stream_replies["req-1"] = "stream-42"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        result = await adapter.send("chat-123", "final answer", reply_to="msg-1")
+
+        assert result.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        args = adapter._send_reply_request.await_args.args
+        assert args[0] == "req-1"
+        assert args[1] == {
+            "msgtype": "stream",
+            "stream": {
+                "id": "stream-42",
+                "finish": True,
+                "content": "final answer",
+            },
+        }
+        assert "req-1" not in adapter._active_stream_replies
+
+    @pytest.mark.asyncio
+    async def test_send_draft_requires_reply_context(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter.send_draft(
+            chat_id="chat-123",
+            draft_id=1,
+            content="partial",
+            metadata=None,
+        )
+
+        assert result.success is False
+        assert "reply context" in (result.error or "")
+
+    def test_truncate_utf8_does_not_split_multibyte_characters(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        text = "你好abc"
+
+        assert WeComAdapter._truncate_utf8(text, 7) == "你好a"
+        assert WeComAdapter._truncate_utf8(text, 6) == "你好"
+
+    def test_thread_metadata_carries_wecom_reply_anchor_without_thread(self):
+        from gateway.platforms.base import _thread_metadata_for_source
+
+        source = SimpleNamespace(
+            platform=Platform.WECOM,
+            chat_type="group",
+            thread_id=None,
+        )
+
+        assert _thread_metadata_for_source(source, "msg-1") == {
+            "reply_to_message_id": "msg-1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_stream_consumer_drives_wecom_native_stream_to_final_frame(self):
+        from gateway.platforms.wecom import WeComAdapter
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+        cfg = StreamConsumerConfig(
+            transport="draft",
+            chat_type="group",
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor="",
+        )
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat-123",
+            cfg,
+            metadata={"reply_to_message_id": "msg-1"},
+            initial_reply_to_id="msg-1",
+        )
+
+        consumer.on_delta("hello ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("world")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        assert consumer.final_response_sent is True
+        assert adapter._active_stream_replies == {}
+        calls = adapter._send_reply_request.await_args_list
+        assert len(calls) >= 2
+        first_payload = calls[0].args[1]
+        final_payload = calls[-1].args[1]
+        assert first_payload["msgtype"] == "stream"
+        assert first_payload["stream"]["finish"] is False
+        assert final_payload == {
+            "msgtype": "stream",
+            "stream": {
+                "id": first_payload["stream"]["id"],
+                "finish": True,
+                "content": "hello world",
+            },
+        }
+
 
 class TestExtractText:
     def test_extracts_plain_text(self):

--- a/tests/gateway/test_wecom_stream_probe.py
+++ b/tests/gateway/test_wecom_stream_probe.py
@@ -1,0 +1,270 @@
+"""End-to-end-ish probes for WeCom gateway native streaming setup."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, StreamingConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.wecom import WeComAdapter
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class RecordingWeComAdapter(WeComAdapter):
+    """WeCom adapter with an in-memory websocket frame recorder."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True))
+        self.frames = []
+        self.normal_sends = []
+        self._ws = SimpleNamespace(closed=False)
+
+    async def _send_json(self, payload):
+        self.frames.append(payload)
+
+    async def send_typing(self, chat_id, metadata=None):
+        return SendResult(success=True)
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.normal_sends.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id=f"normal-{len(self.normal_sends)}")
+
+
+class TestWeComNativeStreamingProbe:
+    def test_runner_builds_wecom_metadata_even_without_thread_id(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.WECOM,
+            chat_id="chat-1",
+            user_id="user-1",
+            chat_type="dm",
+            thread_id=None,
+        )
+
+        assert runner._thread_metadata_for_source(source, "msg-1") == {
+            "reply_to_message_id": "msg-1"
+        }
+
+    @pytest.mark.asyncio
+    async def test_wecom_stream_consumer_emits_partial_and_finish_frames(self):
+        """Probe the exact transport frames expected by the real gateway path."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = RecordingWeComAdapter()
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        cfg = StreamConsumerConfig(
+            transport="draft",
+            chat_type="dm",
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor="",
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=cfg,
+            metadata={"reply_to_message_id": "msg-1"},
+            initial_reply_to_id="msg-1",
+        )
+
+        consumer.on_delta("正在")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("流式输出")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        stream_frames = [f for f in adapter.frames if f.get("cmd") == "aibot_respond_msg"]
+        assert len(stream_frames) >= 2
+        assert all(f["headers"]["req_id"] == "req-1" for f in stream_frames)
+        payloads = [f["body"]["stream"] for f in stream_frames]
+        assert payloads[0]["finish"] is False
+        assert payloads[-1]["finish"] is True
+        assert payloads[-1]["content"] == "正在流式输出"
+        assert {p["id"] for p in payloads} == {payloads[0]["id"]}
+        assert consumer.final_response_sent is True
+
+
+    @pytest.mark.asyncio
+    async def test_wecom_native_stream_uses_stream_limit_for_long_content(self):
+        """Long native streams should not fall into generic markdown chunk sends."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = RecordingWeComAdapter()
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        long_text = "长" * (adapter.MAX_MESSAGE_LENGTH + 500)
+        cfg = StreamConsumerConfig(
+            transport="draft",
+            chat_type="dm",
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor="",
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=cfg,
+            metadata={"reply_to_message_id": "msg-1"},
+            initial_reply_to_id="msg-1",
+        )
+
+        consumer.on_delta(long_text)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        stream_frames = [f for f in adapter.frames if f.get("cmd") == "aibot_respond_msg"]
+        assert adapter.normal_sends == []
+        assert len(stream_frames) >= 2
+        assert stream_frames[0]["body"]["stream"]["finish"] is False
+        assert stream_frames[-1]["body"]["stream"]["finish"] is True
+        assert stream_frames[-1]["body"]["stream"]["content"] == long_text
+        assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_gateway_wecom_stream_setup_uses_native_draft_metadata(self, monkeypatch):
+        """Regression: gateway used to construct no metadata in WeCom DMs.
+
+        The absence of reply_to_message_id meant send_draft() could not resolve
+        the callback req_id, so no native stream frames were produced and only
+        the normal final send reached the user.
+        """
+        import gateway.run as run_mod
+        from gateway.stream_consumer import GatewayStreamConsumer
+
+        adapter = RecordingWeComAdapter()
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        source = SessionSource(
+            platform=Platform.WECOM,
+            chat_id="chat-1",
+            user_id="user-1",
+            chat_type="dm",
+            thread_id=None,
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.WECOM: PlatformConfig(enabled=True)},
+            streaming=StreamingConfig(
+                enabled=True,
+                transport="edit",
+                edit_interval=0.01,
+                buffer_threshold=5,
+                cursor=" ▉",
+            ),
+        )
+        runner.adapters = {Platform.WECOM: adapter}
+        runner._provider_routing = {}
+        runner._reasoning_config = None
+        runner._service_tier = ""
+        runner._agent_cache_lock = None
+        runner._agent_cache = None
+        runner._prefill_messages = []
+        runner._fallback_model = None
+        runner._session_db = None
+        runner._running_agents = {}
+        runner._draining = False
+        runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+        runner._running_generation_by_session = {}
+        runner._session_reasoning_overrides = {}
+        runner._session_model_overrides = {}
+        runner._session_provider_overrides = {}
+        runner._session_workdirs = {}
+        runner._session_reasoning = {}
+        runner._session_service_tier = {}
+        runner._session_toolsets = {}
+        runner._session_ephemeral_system_prompt = {}
+        runner._session_approvals = {}
+        runner._session_model_aliases = {}
+        runner._session_db_lock = None
+        runner._ephemeral_system_prompt = ""
+        runner._pending_session_prompts = {}
+        runner._memory_manager = None
+        runner._user_profile_manager = None
+        runner._context_engine = None
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                self.stream_delta_callback = None
+                self.interim_assistant_callback = None
+                self.tool_progress_callback = None
+                self.step_callback = None
+                self.status_callback = None
+                self.reasoning_config = None
+                self.service_tier = ""
+                self.request_overrides = {}
+                self.context_compressor = SimpleNamespace(last_prompt_tokens=0, context_length=0)
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+
+            def run_conversation(self, *args, **kwargs):
+                import time
+
+                assert self.stream_delta_callback is not None
+                self.stream_delta_callback("正在")
+                time.sleep(0.05)
+                self.stream_delta_callback("流式输出")
+                time.sleep(0.05)
+                return {
+                    "final_response": "正在流式输出",
+                    "messages": [],
+                    "api_calls": 1,
+                    "completed": True,
+                    "interrupted": False,
+                    "partial": False,
+                    "tools": [],
+                }
+
+            def get_activity_summary(self):
+                return {"seconds_since_activity": 0}
+
+        import run_agent as run_agent_mod
+
+        monkeypatch.setattr(run_agent_mod, "AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            run_mod,
+            "_load_gateway_config",
+            lambda: {
+                "display": {"interim_assistant_messages": False},
+                "streaming": {"enabled": True, "transport": "edit"},
+            },
+        )
+        monkeypatch.setattr(GatewayStreamConsumer, "_draft_id_counter", 0)
+        monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+        monkeypatch.setattr(runner, "_resolve_turn_agent_config", lambda *a, **k: {"model": "test", "runtime": {}})
+        monkeypatch.setattr(runner, "_extract_cache_busting_config", lambda *a, **k: {})
+        monkeypatch.setattr(runner, "_agent_config_signature", lambda *a, **k: "sig")
+        monkeypatch.setattr(runner, "_load_service_tier", lambda: None)
+        monkeypatch.setattr(runner, "_resolve_session_reasoning_config", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_is_session_run_current", lambda *a, **k: True)
+        monkeypatch.setattr(runner, "_release_running_agent_state", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_enforce_agent_cache_cap", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_init_cached_agent_for_turn", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_session_saved_history", lambda *a, **k: ([], 0), raising=False)
+
+        result = await runner._run_agent(
+            message="probe",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-1",
+            session_key="agent:main:wecom:dm:chat-1",
+            event_message_id="msg-1",
+        )
+
+        stream_frames = [f for f in adapter.frames if f.get("cmd") == "aibot_respond_msg"]
+        assert result["already_sent"] is True
+        assert len(stream_frames) >= 2
+        assert stream_frames[0]["headers"]["req_id"] == "req-1"
+        assert stream_frames[0]["body"]["stream"]["finish"] is False
+        assert stream_frames[-1]["body"]["stream"]["finish"] is True
+        assert stream_frames[-1]["body"]["stream"]["content"] == "正在流式输出"


### PR DESCRIPTION
## Summary
- add native WeCom AI Bot streaming via `aibot_respond_msg` `msgtype=stream`
- allow non-editable adapters with native draft/stream support to use the gateway stream consumer
- carry WeCom reply metadata in DM replies so stream frames resolve the inbound callback `req_id`
- add focused WeCom stream probe tests for partial and final stream frames

## Test Plan
- `python3.11 -m py_compile gateway/platforms/wecom.py gateway/run.py gateway/stream_consumer.py gateway/display_config.py gateway/platforms/base.py`
- `python3.11 -m pytest tests/gateway/test_wecom.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_wecom_stream_probe.py tests/gateway/test_telegram_thread_fallback.py -q -o 'addopts='`
