### PR TITLE
fix(tui): make dashboard sidecar publisher non-blocking at startup

### DIFF
--- a/tests/tui_gateway/test_event_publisher.py
+++ b/tests/tui_gateway/test_event_publisher.py
@@ -1,0 +1,58 @@
+import json
+import threading
+import time
+
+from tui_gateway import event_publisher as publisher
+
+
+class _FakeWS:
+    def __init__(self):
+        self.closed = False
+        self.sent: list[str] = []
+        self.sent_event = threading.Event()
+
+    def send(self, line: str) -> None:
+        self.sent.append(line)
+        self.sent_event.set()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_constructor_does_not_block_on_connect(monkeypatch):
+    gate = threading.Event()
+    ws = _FakeWS()
+
+    def fake_connect(url, open_timeout=None, max_size=None):
+        gate.wait(timeout=1.0)
+        return ws
+
+    monkeypatch.setattr(publisher, "ws_connect", fake_connect)
+
+    start = time.perf_counter()
+    transport = publisher.WsPublisherTransport("ws://example.test/pub")
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.2
+    gate.set()
+    transport.close()
+
+
+def test_write_before_connect_is_buffered_until_background_connect(monkeypatch):
+    gate = threading.Event()
+    ws = _FakeWS()
+
+    def fake_connect(url, open_timeout=None, max_size=None):
+        gate.wait(timeout=1.0)
+        return ws
+
+    monkeypatch.setattr(publisher, "ws_connect", fake_connect)
+
+    transport = publisher.WsPublisherTransport("ws://example.test/pub")
+    assert transport.write({"hello": "world"}) is True
+
+    gate.set()
+    assert ws.sent_event.wait(timeout=1.0)
+    assert json.loads(ws.sent[0]) == {"hello": "world"}
+
+    transport.close()

--- a/tui_gateway/event_publisher.py
+++ b/tui_gateway/event_publisher.py
@@ -23,6 +23,7 @@ import json
 import logging
 import queue
 import threading
+import time
 from typing import Optional
 
 try:
@@ -35,10 +36,11 @@ _log = logging.getLogger(__name__)
 _DRAIN_STOP = object()
 
 _QUEUE_MAX = 256
+_CONNECT_RETRY_DELAYS_S = (0.0, 0.05, 0.1, 0.25, 0.5, 1.0)
 
 
 class WsPublisherTransport:
-    __slots__ = ("_url", "_lock", "_ws", "_dead", "_q", "_worker")
+    __slots__ = ("_url", "_lock", "_ws", "_dead", "_q", "_worker", "_connect_timeout")
 
     def __init__(self, url: str, *, connect_timeout: float = 2.0) -> None:
         self._url = url
@@ -47,27 +49,57 @@ class WsPublisherTransport:
         self._dead = False
         self._q: queue.Queue[object] = queue.Queue(maxsize=_QUEUE_MAX)
         self._worker: Optional[threading.Thread] = None
+        self._connect_timeout = connect_timeout
 
         if ws_connect is None:
             self._dead = True
 
             return
 
-        try:
-            self._ws = ws_connect(url, open_timeout=connect_timeout, max_size=None)
-        except Exception as exc:
-            _log.debug("event publisher connect failed: %s", exc)
-            self._dead = True
-            self._ws = None
-
-            return
-
         self._worker = threading.Thread(
-            target=self._drain,
+            target=self._run,
             name="hermes-ws-pub",
             daemon=True,
         )
         self._worker.start()
+
+    def _run(self) -> None:
+        if not self._connect():
+            self._dead = True
+
+            return
+
+        self._drain()
+
+    def _connect(self) -> bool:
+        attempts = len(_CONNECT_RETRY_DELAYS_S)
+
+        for idx, delay in enumerate(_CONNECT_RETRY_DELAYS_S, start=1):
+            if self._dead:
+                return False
+
+            if delay:
+                time.sleep(delay)
+                if self._dead:
+                    return False
+
+            try:
+                self._ws = ws_connect(
+                    self._url,
+                    open_timeout=self._connect_timeout,
+                    max_size=None,
+                )
+
+                return True
+            except Exception as exc:
+                _log.debug(
+                    "event publisher connect failed (attempt %d/%d): %s",
+                    idx,
+                    attempts,
+                    exc,
+                )
+
+        return False
 
     def _drain(self) -> None:
         while True:
@@ -86,9 +118,10 @@ class WsPublisherTransport:
                 _log.debug("event publisher write failed: %s", exc)
                 self._dead = True
                 self._ws = None
+                return
 
     def write(self, obj: dict) -> bool:
-        if self._dead or self._ws is None or self._worker is None:
+        if self._dead or self._worker is None:
             return False
 
         line = json.dumps(obj, ensure_ascii=False)


### PR DESCRIPTION
## Why this matters

The dashboard chat tab depends on the PTY-side `tui_gateway` coming online fast enough to emit `gateway.ready`.

Before this patch, the dashboard sidecar publisher opened its back-WebSocket synchronously during `WsPublisherTransport(...)` construction. That meant a slow or transiently unavailable `/api/pub` handshake could stall startup *before* the TUI gateway announced readiness.

In practice, this creates exactly the wrong failure mode for an optional telemetry/sidebar path:
- the main stdio path is healthy
- the sidecar path is best-effort
- but the best-effort path could delay or derail primary startup

This patch flips that relationship back to the intended one.

## What changed

### Sidecar connect is now truly best-effort
The publisher no longer performs a blocking WebSocket connect in `__init__`.

Instead:
- construction returns immediately
- connection happens on the background worker
- early writes are queued
- queued events flush once the connection comes up

### Transient startup races are tolerated
A small retry/backoff loop was added for brief dashboard startup timing gaps, where the PTY child is ready slightly before `/api/pub` is fully accepting connections.

### Dead sidecars fail closed
If the sidecar write path dies after connect, the worker now stops draining and marks the publisher dead instead of continuing to pretend the path is usable.

## Behavioral impact

This keeps the startup contract clean:

- primary TUI stdio startup is never gated on the dashboard sidecar
- `gateway.ready` can be emitted promptly even if sidecar connect is slow
- dashboard sidebar events still arrive once the sidecar handshake succeeds
- if the sidecar never comes up, chat still starts normally

## Tests

Added focused regression coverage in `tests/tui_gateway/test_event_publisher.py`:

- `test_constructor_does_not_block_on_connect`
- `test_write_before_connect_is_buffered_until_background_connect`

Validation run:
```text
pytest tests/tui_gateway/test_event_publisher.py -q
2 passed
