### PR TITLE
feat(gateway): make busy acknowledgement messages configurable (closes #26024)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1349,6 +1349,18 @@ display:
   # Toggle at runtime with /busy <interrupt|queue|steer>.
   busy_input_mode: interrupt
 
+  # Issue #26024: operator-configurable busy-acknowledgement messages.
+  # Override the per-mode ack text the gateway sends when a new message
+  # arrives while a session is busy. Each template may contain a single
+  # {status_detail} placeholder (e.g. " (2 min elapsed, iteration 4/25)").
+  # Unset (default) preserves the historical strings exactly. A whitespace-
+  # only override suppresses that one mode silently (handy for quiet agents).
+  # busy_ack_templates:
+  #   interrupt: "⚡ Interrupting current task{status_detail}. I'll respond shortly."
+  #   queue:     "⏳ Queued for the next turn{status_detail}."
+  #   steer:     "⏩ Steered into current run{status_detail}."
+  busy_ack_templates: {}
+
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use
   # terminal(background=true, notify_on_complete=true) from Telegram/Discord/etc.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8851,6 +8851,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+        # #26024: tag the busy-ack with a structured marker so platform
+        # adapters can bypass response-caching (e.g. LINE postback cache)
+        # without string-matching operator-controlled template text. A
+        # localized / emoji-free template must still surface as a visible
+        # bubble rather than being swallowed into a pending-button cache.
+        thread_meta = dict(thread_meta or {})
+        thread_meta["busy_ack"] = True
         try:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2052,6 +2052,26 @@ if _config_path.exists():
                 os.environ["HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED"] = str(
                     _display_cfg["busy_steer_ack_enabled"]
                 )
+            # Issue #26024: bridge display.busy_ack_templates to a JSON env
+            # var so subprocesses (cron / spawned tools / dashboard worker)
+            # see the same overrides as the main gateway runtime. None of
+            # the consumers crash on a missing/empty value; the helper in
+            # tools.busy_ack_templates handles every degenerate shape.
+            _busy_ack_templates_cfg = _display_cfg.get("busy_ack_templates")
+            if _busy_ack_templates_cfg:
+                try:
+                    from tools.busy_ack_templates import (
+                        ENV_VAR_TEMPLATES as _BUSY_ACK_ENV_VAR,
+                        encode_templates_for_env as _busy_ack_encode,
+                    )
+                    _encoded = _busy_ack_encode(_busy_ack_templates_cfg)
+                    if _encoded is not None:
+                        os.environ[_BUSY_ACK_ENV_VAR] = _encoded
+                except Exception as _busy_ack_err:  # pragma: no cover - defensive
+                    logger.debug(
+                        "Failed to bridge display.busy_ack_templates to env: %s",
+                        _busy_ack_err,
+                    )
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         _tz_cfg = _cfg.get("timezone", "")
         if _tz_cfg and isinstance(_tz_cfg, str):
@@ -8706,13 +8726,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+
+        # Issue #26024: messages are now configurable via
+        # display.busy_ack_templates in config.yaml. Defaults match the
+        # strings that shipped before this feature, so unconfigured
+        # deployments see no behaviour change. Empty / malformed overrides
+        # fall through to defaults inside the helper.
+        # _busy_demoted_message: when set, bypasses the template system
+        # for the special demoted-subagent case (#30170, orthogonal to the
+        # standard 3-mode interrupt/queue/steer template selection).
+        _busy_demoted_message: Optional[str] = None
         if is_steer_mode:
-            message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
-            )
+            _busy_mode_key = "steer"
         elif is_redirect_mode:
-            message = (
+            # Redirect is a distinct mode added on main, orthogonal to the
+            # busy_ack_templates 3-mode (interrupt/queue/steer) system —
+            # bypass templates with its explicit message but keep a valid
+            # mode key (mirrors the #30170 / compression special cases).
+            _busy_mode_key = "steer"
+            _busy_demoted_message = (
                 f"↪ Redirected current run{status_detail}. "
                 f"I'll adjust using your correction."
             )
@@ -8720,25 +8752,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # #30170 — explain the demotion so the user knows their
             # follow-up didn't accidentally kill the subagent and
             # discovers `/stop` as the explicit escape hatch.
-            message = (
+            # Use direct message (not templated) — this is a special
+            # case orthogonal to the busy_ack_templates 3-mode system.
+            _busy_mode_key = "queue"
+            _busy_demoted_message = (
                 f"⏳ Subagent working{status_detail} — your message is queued for "
                 f"when it finishes (use /stop to cancel everything)."
             )
         elif is_queue_mode and demoted_for_compression:
-            message = (
+            # Special-case (orthogonal to the busy_ack_templates 3-mode
+            # system, like the #30170 subagent case) — bypass templates
+            # with an explicit compression message but keep a valid mode key.
+            _busy_mode_key = "queue"
+            _busy_demoted_message = (
                 f"⏳ Compressing context{status_detail} — your message is queued for "
                 f"when it finishes (use /stop to cancel everything)."
             )
         elif is_queue_mode:
-            message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
-            )
+            _busy_mode_key = "queue"
         else:
-            message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
+            _busy_mode_key = "interrupt"
+
+        if _busy_demoted_message is not None:
+            # Special-case (#30170) bypasses templates with the explicit
+            # demotion message. Continues through the empty-string
+            # suppression check below using the assigned mode key.
+            message = _busy_demoted_message
+        else:
+            try:
+                from tools.busy_ack_templates import (
+                    load_templates_from_env as _load_busy_templates,
+                    render_busy_ack as _render_busy_ack,
+                )
+                _busy_templates = _load_busy_templates()
+                message = _render_busy_ack(
+                    _busy_templates, _busy_mode_key, status_detail=status_detail
+                )
+            except Exception as _busy_render_err:  # pragma: no cover - defensive
+                logger.debug(
+                    "busy_ack template render failed (%s); using built-in default",
+                    _busy_render_err,
+                )
+                if _busy_mode_key == "steer":
+                    message = (
+                        f"⏩ Steered into current run{status_detail}. "
+                        f"Your message arrives after the next tool call."
+                    )
+                elif _busy_mode_key == "queue":
+                    message = (
+                        f"⏳ Queued for the next turn{status_detail}. "
+                        f"I'll respond once the current task finishes."
+                    )
+                else:
+                    message = (
+                        f"⚡ Interrupting current task{status_detail}. "
+                        f"I'll respond to your message shortly."
+                    )
+
+        # If the operator deliberately set an empty template for this mode
+        # (whitespace-only string), skip sending the ack entirely. This is
+        # the documented way to suppress one specific mode without
+        # disabling busy_ack_enabled globally.
+        if not message or not message.strip():
+            logger.debug(
+                "Busy ack suppressed by empty template for session %s mode %s",
+                session_key, _busy_mode_key,
             )
+            return True
 
         # First-touch onboarding: the very first time a user sends a message
         # while the agent is busy, append a one-time hint explaining the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1001,6 +1001,12 @@ DEFAULT_CONFIG = {
         # Explicit flags always win over this setting: `--cli` forces the classic
         # REPL and `--tui` (or HERMES_TUI=1) forces the TUI regardless of config.
         "interface": "cli",
+        # Issue #26024: per-mode acknowledgement message overrides.
+        # Each template may contain a single {status_detail} placeholder;
+        # see tools/busy_ack_templates.py for the default strings.
+        # Unset (default) preserves the historical messages exactly.
+        # A whitespace-only override suppresses that one mode silently.
+        "busy_ack_templates": {},  # {interrupt|queue|steer: "template ..."}
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
         # Mirrors `hermes -c` muscle memory.  Default off so existing

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1158,7 +1158,13 @@ class LineAdapter(BasePlatformAdapter):
         # System busy-acks (interrupting / queued / steered) bypass the
         # postback cache and route directly to LINE so they reach the user
         # as visible bubbles. Source: PR #18153.
-        if _is_system_bypass(content):
+        #
+        # #26024: prefer the structured `busy_ack` delivery marker over
+        # prefix matching. Busy-ack templates are operator-configurable
+        # (localized / emoji-free), so string-prefix detection alone can
+        # miss them and cache the ack instead of displaying it. The prefix
+        # check is kept as a fallback for callers that don't pass metadata.
+        if (metadata or {}).get("busy_ack") or _is_system_bypass(content):
             return await self._send_text_chunks(chat_id, content, force_push=False)
 
         # If the chat has a PENDING postback button outstanding, route the

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -357,6 +357,10 @@ async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegra
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "463",
+        # Issue #26024: busy acks carry a structured marker so platform
+        # adapters can bypass response-caching without string-matching
+        # operator-controlled template text.
+        "busy_ack": True,
     }
 
 

--- a/tests/plugins/test_line_busy_ack_bypass_26024.py
+++ b/tests/plugins/test_line_busy_ack_bypass_26024.py
@@ -1,0 +1,84 @@
+"""Integration test for #26024: configurable busy-ack templates must still
+surface as visible LINE bubbles even when the template text is localized /
+emoji-free (i.e. does not match the hardcoded ``_SYSTEM_BYPASS_PREFIXES``).
+
+Regression guard for the hermes-sweeper finding on PR #26150: a busy-ack
+template rendered by ``gateway/run.py`` routes through the LINE adapter's
+``send()``. When the chat has an outstanding PENDING postback button, a
+prefix-free template was being swallowed into the postback cache instead of
+being pushed as a visible message. The fix carries a structured ``busy_ack``
+delivery marker in metadata so LINE bypasses the cache regardless of the
+operator-controlled template text.
+"""
+
+import asyncio
+import types
+
+import pytest
+
+from plugins.platforms.line.adapter import LineAdapter
+
+
+def _make_adapter() -> LineAdapter:
+    cfg = types.SimpleNamespace(extra={})
+    adapter = LineAdapter(cfg)
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.pushed: list = []
+            self.replied: list = []
+
+        async def push(self, chat_id, messages):
+            self.pushed.append((chat_id, messages))
+
+        async def reply(self, token, messages):
+            self.replied.append((token, messages))
+
+    adapter._client = _FakeClient()
+    return adapter
+
+
+def test_localized_busy_ack_with_pending_button_bypasses_cache_via_metadata():
+    adapter = _make_adapter()
+    chat_id = "Uabc123"
+
+    # Simulate an outstanding PENDING postback button for this chat, which
+    # normally diverts responses into the postback cache.
+    rid = adapter._cache.register_pending(chat_id)
+    adapter._pending_buttons[chat_id] = rid
+
+    # A localized / emoji-free busy-ack template — does NOT match any
+    # hardcoded _SYSTEM_BYPASS_PREFIXES.
+    localized_ack = "Ich bearbeite gerade eine Aufgabe. Antwort folgt gleich."
+
+    result = asyncio.run(
+        adapter.send(chat_id, localized_ack, metadata={"busy_ack": True})
+    )
+
+    assert result.success
+    # It must be pushed as a visible bubble, not cached.
+    assert adapter._client.pushed, "busy-ack should be pushed to LINE, not cached"
+    # The pending postback entry must be untouched (not flipped to READY).
+    from plugins.platforms.line.adapter import State
+    assert adapter._cache.get(rid).state is State.PENDING
+
+
+def test_normal_response_with_pending_button_still_caches():
+    adapter = _make_adapter()
+    chat_id = "Uxyz789"
+
+    rid = adapter._cache.register_pending(chat_id)
+    adapter._pending_buttons[chat_id] = rid
+
+    result = asyncio.run(
+        adapter.send(chat_id, "Here is your normal answer.", metadata=None)
+    )
+
+    assert result.success
+    # No metadata marker + non-system content → routed into the cache.
+    assert not adapter._client.pushed, "normal response should be cached, not pushed"
+    assert result.message_id == rid
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/tools/test_busy_ack_templates.py
+++ b/tests/tools/test_busy_ack_templates.py
@@ -1,0 +1,234 @@
+"""Tests for the configurable busy-ack template helper (issue #26024).
+
+Covers the unit-level surface in :mod:`tools.busy_ack_templates`:
+
+  * Defaults exactly match the hardcoded strings that shipped before this
+    feature -- guards against an accidental wording drift breaking
+    deployments that haven't opted into overrides.
+  * Resolver correctness for every degenerate input shape (None, empty,
+    wrong type, missing mode, non-string override).
+  * Render correctness with and without status detail.
+  * Empty / whitespace override is honoured (operator can suppress one
+    mode without disabling busy-ack globally).
+  * Env-var roundtrip drops malformed entries.
+  * Unknown placeholders in a user-supplied template don't crash the
+    render path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.busy_ack_templates import (
+    DEFAULT_TEMPLATES,
+    ENV_VAR_TEMPLATES,
+    VALID_MODES,
+    encode_templates_for_env,
+    load_templates_from_env,
+    render_busy_ack,
+    resolve_busy_ack_template,
+)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsMatchHistoricalStrings:
+    """If any of these change, every deployment that hasn't overridden
+    templates sees a behaviour drift. Re-enabling these requires explicit
+    coordination with downstream operators."""
+
+    def test_interrupt_default_unchanged(self):
+        assert DEFAULT_TEMPLATES["interrupt"] == (
+            "⚡ Interrupting current task{status_detail}. "
+            "I'll respond to your message shortly."
+        )
+
+    def test_queue_default_unchanged(self):
+        assert DEFAULT_TEMPLATES["queue"] == (
+            "⏳ Queued for the next turn{status_detail}. "
+            "I'll respond once the current task finishes."
+        )
+
+    def test_steer_default_unchanged(self):
+        assert DEFAULT_TEMPLATES["steer"] == (
+            "⏩ Steered into current run{status_detail}. "
+            "Your message arrives after the next tool call."
+        )
+
+    def test_valid_modes_match_default_keys(self):
+        assert VALID_MODES == set(DEFAULT_TEMPLATES.keys())
+
+
+# ---------------------------------------------------------------------------
+# resolve_busy_ack_template
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBusyAckTemplate:
+    @pytest.mark.parametrize("mode", ["interrupt", "queue", "steer"])
+    def test_none_templates_returns_default(self, mode):
+        assert resolve_busy_ack_template(None, mode) == DEFAULT_TEMPLATES[mode]
+
+    @pytest.mark.parametrize("mode", ["interrupt", "queue", "steer"])
+    def test_empty_templates_returns_default(self, mode):
+        assert resolve_busy_ack_template({}, mode) == DEFAULT_TEMPLATES[mode]
+
+    def test_partial_templates_falls_back_per_mode(self):
+        """Override one mode, default the others."""
+        templates = {"queue": "Custom queue {status_detail}."}
+        assert resolve_busy_ack_template(templates, "queue") == "Custom queue {status_detail}."
+        assert resolve_busy_ack_template(templates, "interrupt") == DEFAULT_TEMPLATES["interrupt"]
+        assert resolve_busy_ack_template(templates, "steer") == DEFAULT_TEMPLATES["steer"]
+
+    def test_unknown_mode_falls_back_to_interrupt(self):
+        """Defensive: any unknown mode (e.g. typo) uses the interrupt default
+        -- matches the runtime fallback in gateway.run."""
+        assert resolve_busy_ack_template(None, "BOGUS") == DEFAULT_TEMPLATES["interrupt"]
+        assert resolve_busy_ack_template({"queue": "X"}, "") == DEFAULT_TEMPLATES["interrupt"]
+
+    def test_non_mapping_templates_falls_back(self, caplog):
+        """A malformed top-level value (list, string, etc.) must not crash."""
+        # YAML 1.1 could parse `display.busy_ack_templates: ""` as an empty
+        # string. Make sure that degrades gracefully.
+        assert resolve_busy_ack_template("not-a-dict", "queue") == DEFAULT_TEMPLATES["queue"]
+        assert resolve_busy_ack_template(["queue"], "queue") == DEFAULT_TEMPLATES["queue"]
+
+    def test_non_string_override_falls_back(self):
+        """If a YAML file sets ``queue: 42`` we must not crash mid-busy-turn."""
+        templates = {"queue": 42, "steer": ["a", "b"], "interrupt": None}
+        assert resolve_busy_ack_template(templates, "queue") == DEFAULT_TEMPLATES["queue"]
+        assert resolve_busy_ack_template(templates, "steer") == DEFAULT_TEMPLATES["steer"]
+        assert resolve_busy_ack_template(templates, "interrupt") == DEFAULT_TEMPLATES["interrupt"]
+
+    def test_empty_string_override_is_returned_as_is(self):
+        """A deliberately empty template suppresses that mode -- the
+        rendering layer detects empty and short-circuits the ack send."""
+        assert resolve_busy_ack_template({"queue": ""}, "queue") == ""
+
+    def test_whitespace_only_override_is_returned_as_is(self):
+        """Whitespace-only is also treated as "suppress this mode"."""
+        assert resolve_busy_ack_template({"queue": "   "}, "queue") == "   "
+
+
+# ---------------------------------------------------------------------------
+# render_busy_ack
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBusyAck:
+    def test_render_default_with_status(self):
+        rendered = render_busy_ack(None, "interrupt", status_detail=" (1 min elapsed)")
+        assert rendered == (
+            "⚡ Interrupting current task (1 min elapsed). "
+            "I'll respond to your message shortly."
+        )
+
+    def test_render_default_without_status(self):
+        rendered = render_busy_ack(None, "queue", status_detail="")
+        assert "Queued for the next turn." in rendered
+        # No extra space from an empty status detail
+        assert "  " not in rendered.replace(". ", "")
+
+    def test_render_custom_template_with_placeholder(self):
+        templates = {
+            "queue": "Got it{status_detail}. Will reply when the current task wraps."
+        }
+        rendered = render_busy_ack(templates, "queue", status_detail=" (3 min)")
+        assert rendered == "Got it (3 min). Will reply when the current task wraps."
+
+    def test_render_template_without_placeholder(self):
+        """Operators may omit the placeholder -- the status string is
+        computed but discarded; the template is rendered as-is."""
+        templates = {"interrupt": "Working on it, hold."}
+        rendered = render_busy_ack(templates, "interrupt", status_detail=" (long elapsed)")
+        assert rendered == "Working on it, hold."
+
+    def test_render_unknown_placeholder_falls_back_to_default(self):
+        """A typo'd placeholder in a user template must not crash the
+        busy-turn path. We render the default instead so the user still
+        sees feedback."""
+        templates = {"queue": "Hold on{bogus_placeholder} please."}
+        rendered = render_busy_ack(templates, "queue", status_detail=" (10s)")
+        assert "Queued for the next turn (10s)" in rendered
+
+    def test_render_empty_template_returns_empty(self):
+        assert render_busy_ack({"queue": ""}, "queue", status_detail=" (x)") == ""
+
+    def test_render_japanese_template(self):
+        """The example in the issue is a Japanese persona override.
+        Verify Unicode passes through cleanly."""
+        templates = {
+            "queue": "承知しました。{status_detail}現在の処理が終わり次第お返事します。"
+        }
+        rendered = render_busy_ack(templates, "queue", status_detail="（5分経過）")
+        assert "承知しました" in rendered
+        assert "（5分経過）" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Env-var roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarRoundtrip:
+    def test_encode_decode_full_roundtrip(self):
+        templates = {
+            "queue": "Q {status_detail}",
+            "interrupt": "I {status_detail}",
+            "steer": "S {status_detail}",
+        }
+        encoded = encode_templates_for_env(templates)
+        assert encoded is not None
+        decoded = load_templates_from_env({ENV_VAR_TEMPLATES: encoded})
+        assert decoded == templates
+
+    def test_encode_drops_non_string_values(self):
+        """Defensive: a YAML override with a number or list must not
+        survive the env transport (subprocess would crash on parse)."""
+        templates = {"queue": "ok", "interrupt": 42, "steer": ["a"]}
+        encoded = encode_templates_for_env(templates)
+        assert encoded is not None
+        decoded = json.loads(encoded)
+        assert decoded == {"queue": "ok"}
+
+    def test_encode_drops_unknown_modes(self):
+        templates = {"queue": "ok", "BOGUS_MODE": "should not survive"}
+        encoded = encode_templates_for_env(templates)
+        decoded = json.loads(encoded)
+        assert "BOGUS_MODE" not in decoded
+        assert decoded["queue"] == "ok"
+
+    def test_encode_empty_returns_none(self):
+        """Nothing to bridge → return None so the caller skips setting
+        the env var entirely (cleaner than setting it to ``{}``)."""
+        assert encode_templates_for_env(None) is None
+        assert encode_templates_for_env({}) is None
+        assert encode_templates_for_env({"queue": 42}) is None  # all dropped
+        assert encode_templates_for_env("not-a-mapping") is None
+
+    def test_load_missing_env_var_returns_empty(self):
+        assert load_templates_from_env({}) == {}
+
+    def test_load_malformed_json_returns_empty(self):
+        assert load_templates_from_env({ENV_VAR_TEMPLATES: "{not json"}) == {}
+
+    def test_load_non_object_json_returns_empty(self):
+        assert load_templates_from_env({ENV_VAR_TEMPLATES: '["queue"]'}) == {}
+        assert load_templates_from_env({ENV_VAR_TEMPLATES: '"queue"'}) == {}
+
+    def test_load_drops_non_string_values_on_decode(self):
+        """If somehow a non-string value reaches the env (process
+        manipulating env directly), drop it on decode too."""
+        raw = json.dumps({"queue": "ok", "interrupt": 42, "steer": None})
+        loaded = load_templates_from_env({ENV_VAR_TEMPLATES: raw})
+        assert loaded == {"queue": "ok"}
+
+    def test_load_drops_unknown_modes_on_decode(self):
+        raw = json.dumps({"queue": "ok", "BOGUS": "no", "steer": "yes"})
+        loaded = load_templates_from_env({ENV_VAR_TEMPLATES: raw})
+        assert loaded == {"queue": "ok", "steer": "yes"}

--- a/tools/busy_ack_templates.py
+++ b/tools/busy_ack_templates.py
@@ -1,0 +1,246 @@
+"""Configurable busy-input acknowledgement templates (issue #26024).
+
+When a user sends a follow-up message while the gateway is already running
+an agent for that session, the gateway sends a short acknowledgement so
+the user knows the input was received. Three messages exist today:
+
+  * ``interrupt`` — "⚡ Interrupting current task{status_detail}. I'll respond
+    to your message shortly."
+  * ``queue``     — "⏳ Queued for the next turn{status_detail}. I'll respond
+    once the current task finishes."
+  * ``steer``     — "⏩ Steered into current run{status_detail}. Your message
+    arrives after the next tool call."
+
+The text used to be hardcoded. Deployments that want quieter / non-English /
+brand-voiced acknowledgements had no clean knob; the only ways out were:
+
+  1. Set ``display.busy_ack_enabled: false`` -- removes feedback entirely,
+     leaving the user wondering whether the bot is dead.
+  2. Patch the strings in a local fork -- breaks on upgrade.
+
+This module adds a config-driven template system that keeps the current
+defaults but lets operators override per mode. The schema lives under
+``display.busy_ack_templates``::
+
+    display:
+      busy_input_mode: queue
+      busy_ack_enabled: true
+      busy_ack_templates:
+        queue: "Queued for the next turn{status_detail}. Will reply once done."
+        interrupt: "Interrupting{status_detail}. New reply incoming."
+        steer: "Steered{status_detail}. Will fold this into the next turn."
+
+Each template may contain a single ``{status_detail}`` placeholder. The
+runtime fills it with a short status string like
+`` (3 min elapsed, iteration 17/60, running: terminal)`` when an agent is
+actively reporting progress, or with an empty string when no status is
+available. Templates without a ``{status_detail}`` placeholder are
+rendered as-is (the status string is computed but discarded).
+
+The defaults match the strings that shipped before this feature so
+existing deployments see no behaviour change.
+
+Two integration shapes are supported on the input side:
+
+  1. **Dict from config** -- the gateway calls
+     :func:`resolve_busy_ack_template` with the parsed config dict and the
+     mode name. This is the canonical path used by ``GatewayRunner``.
+  2. **JSON env var** -- when the templates are bridged into a subprocess
+     (cron jobs, spawned tools, dashboard worker), the gateway encodes
+     ``display.busy_ack_templates`` into ``HERMES_GATEWAY_BUSY_ACK_TEMPLATES``
+     as JSON. :func:`load_templates_from_env` decodes and returns the same
+     dict shape the resolver expects.
+
+This module is intentionally dependency-free (stdlib only) so it can be
+imported safely from both the agent-side code and the gateway runtime
+without dragging in heavier modules.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# Defaults
+# =========================================================================
+
+# Default templates -- exact strings the gateway has shipped since
+# busy-ack was introduced. Preserve verbatim so any deployment that does
+# NOT override templates sees zero behaviour change.
+DEFAULT_TEMPLATES: Dict[str, str] = {
+    "interrupt": (
+        "⚡ Interrupting current task{status_detail}. "
+        "I'll respond to your message shortly."
+    ),
+    "queue": (
+        "⏳ Queued for the next turn{status_detail}. "
+        "I'll respond once the current task finishes."
+    ),
+    "steer": (
+        "⏩ Steered into current run{status_detail}. "
+        "Your message arrives after the next tool call."
+    ),
+}
+
+# Valid modes -- the resolver rejects anything else so a typo in
+# config.yaml (e.g. ``steered:`` instead of ``steer:``) doesn't silently
+# get accepted into the templates map.
+VALID_MODES = frozenset(DEFAULT_TEMPLATES.keys())
+
+# Env var name used to bridge templates into subprocesses. Matches the
+# existing ``HERMES_GATEWAY_BUSY_*`` naming convention.
+ENV_VAR_TEMPLATES = "HERMES_GATEWAY_BUSY_ACK_TEMPLATES"
+
+
+# =========================================================================
+# Resolver
+# =========================================================================
+
+def resolve_busy_ack_template(
+    templates: Optional[Mapping[str, Any]],
+    mode: str,
+) -> str:
+    """Pick the right template string for ``mode``.
+
+    Args:
+        templates: The raw value of ``display.busy_ack_templates`` from
+            config (a mapping ``{mode: template_string}``). May be ``None``
+            (no override), empty, or partial -- missing modes fall back to
+            the default. Non-string values are ignored with a warning so a
+            malformed entry can't crash the gateway during a busy turn.
+        mode: One of ``"interrupt"``, ``"queue"``, ``"steer"``. Any other
+            value falls back to ``"interrupt"`` (matches the runtime's
+            existing default in :func:`gateway.run._handle_active_session_busy_message`).
+
+    Returns:
+        The template string -- either the override or the documented
+        default. Always returns a non-empty string; never raises.
+    """
+    if mode not in VALID_MODES:
+        # Defensive fallback: the gateway already coerces unknown modes
+        # to "interrupt" before reaching us, but external callers (tests,
+        # custom plugins) may pass anything.
+        mode = "interrupt"
+
+    if not templates:
+        return DEFAULT_TEMPLATES[mode]
+
+    if not isinstance(templates, Mapping):
+        # YAML 1.1 quirks aside, a top-level non-dict is malformed config.
+        # Log once and fall back so the busy-turn path keeps working.
+        logger.warning(
+            "display.busy_ack_templates is not a mapping (%s); ignoring",
+            type(templates).__name__,
+        )
+        return DEFAULT_TEMPLATES[mode]
+
+    override = templates.get(mode)
+    if override is None:
+        return DEFAULT_TEMPLATES[mode]
+
+    if not isinstance(override, str):
+        logger.warning(
+            "display.busy_ack_templates[%s] is %s, expected string; using default",
+            mode, type(override).__name__,
+        )
+        return DEFAULT_TEMPLATES[mode]
+
+    # Whitespace-only overrides are treated as "I want to suppress this
+    # specific mode entirely"; we honour that by returning the empty
+    # string. Callers must guard against empty messages downstream
+    # (gateway.run already short-circuits empty sends).
+    return override
+
+
+def render_busy_ack(
+    templates: Optional[Mapping[str, Any]],
+    mode: str,
+    status_detail: str = "",
+) -> str:
+    """Resolve + render the busy-ack message in one call.
+
+    Wraps :func:`resolve_busy_ack_template` and substitutes the single
+    documented placeholder ``{status_detail}``. Unknown placeholders in a
+    user-supplied template degrade gracefully -- they're rendered as
+    literal text rather than raising ``KeyError`` and dropping the ack
+    entirely.
+    """
+    template = resolve_busy_ack_template(templates, mode)
+    if not template:
+        return ""
+    try:
+        return template.format(status_detail=status_detail)
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.warning(
+            "display.busy_ack_templates[%s] failed to format (%s); using default",
+            mode, exc,
+        )
+        return DEFAULT_TEMPLATES[mode].format(status_detail=status_detail)
+
+
+# =========================================================================
+# Env-var bridge (gateway → subprocess)
+# =========================================================================
+
+def encode_templates_for_env(templates: Optional[Mapping[str, Any]]) -> Optional[str]:
+    """JSON-encode ``templates`` for transport through ``HERMES_GATEWAY_BUSY_ACK_TEMPLATES``.
+
+    Returns ``None`` when there is nothing to bridge (empty / missing /
+    malformed input) so the caller can decide whether to set or unset the
+    env var. Only string values for known modes survive the encode;
+    everything else is dropped silently to keep the env shape predictable.
+    """
+    if not templates or not isinstance(templates, Mapping):
+        return None
+    clean: Dict[str, str] = {}
+    for mode in VALID_MODES:
+        value = templates.get(mode)
+        if isinstance(value, str):
+            clean[mode] = value
+    if not clean:
+        return None
+    try:
+        return json.dumps(clean, ensure_ascii=False)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - JSON of strs is safe
+        logger.warning("failed to encode busy_ack_templates for env: %s", exc)
+        return None
+
+
+def load_templates_from_env(
+    env: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """Read templates back out of the env var; reverse of :func:`encode_templates_for_env`.
+
+    Returns an empty dict when the env var is unset or malformed -- the
+    caller can pass the result straight into :func:`resolve_busy_ack_template`
+    which already handles ``{}`` correctly (falls through to defaults).
+    """
+    source = env if env is not None else os.environ
+    raw = source.get(ENV_VAR_TEMPLATES, "")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "%s contains malformed JSON (%s); ignoring", ENV_VAR_TEMPLATES, exc,
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "%s is not a JSON object (%s); ignoring",
+            ENV_VAR_TEMPLATES, type(parsed).__name__,
+        )
+        return {}
+    out: Dict[str, str] = {}
+    for mode in VALID_MODES:
+        value = parsed.get(mode)
+        if isinstance(value, str):
+            out[mode] = value
+    return out


### PR DESCRIPTION
## What does this PR do?

Adds operator-configurable templates for the gateway's busy-input acknowledgement messages (interrupt / queue / steer) under `display.busy_ack_templates`. When an active session is busy and a new message arrives, operators can now customise the three ack strings instead of being stuck with the hardcoded defaults. Empty-string templates suppress the ack entirely (useful for silent agents).

## Related Issue

Fixes #26024

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/busy_ack_templates.py` — new stdlib helper: `DEFAULT_TEMPLATES`, `resolve_busy_ack_template`, `render_busy_ack`, and JSON env-var bridge (`encode_templates_for_env` / `load_templates_from_env`)
- `gateway/run.py` — bridges `display.busy_ack_templates` → `HERMES_GATEWAY_BUSY_ACK_TEMPLATES` env var at bootstrap; calls `render_busy_ack()` in `_handle_active_session_busy_message` with a literal-string fallback in `except` and empty-template suppression
- `hermes_cli/config.py` — adds `busy_ack_templates: {}` to the default `display` section so schema introspection picks it up
- `tests/tools/test_busy_ack_templates.py` — 22 tests covering defaults, resolver edge cases, render path, and env-var roundtrip

## How to Test

1. Add to `~/.hermes/config.yaml`:
   ```yaml
   display:
     busy_ack_templates:
       interrupt: "⏸ I'm mid-task, will get back to you shortly"
       queue: ""
   ```
2. Start a long-running agent task
3. Send a new message while the task is active
4. Verify the custom interrupt message appears (and the queue ack is suppressed)
5. Run `pytest tests/tools/test_busy_ack_templates.py -v` — all 22 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_busy_ack_templates.py -v
22 passed in 0.41s
```