### PR TITLE
fix(auxiliary): fall back to alternative provider on 5xx server errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -38,6 +38,15 @@ Payment / credit exhaustion fallback:
   call_llm() automatically retries with the next available provider in the
   auto-detection chain.  This handles the common case where a user depletes
   their OpenRouter balance but has Codex OAuth or another provider available.
+
+Server error (5xx) fallback:
+  When a resolved provider returns a transient 5xx error (500, 502, 503, 504,
+  etc.), call_llm() automatically retries with the next available provider.
+  Unlike payment/rate-limit errors, server error fallback applies even when
+  the user explicitly configured a provider — 5xx errors are transient and
+  indicate the endpoint is temporarily broken regardless of provider choice.
+  This ensures tasks like vision analysis don't fail when Gemini or other
+  providers experience high demand.  (#25822)
 """
 
 import json
@@ -2060,6 +2069,43 @@ def _is_connection_error(exc: Exception) -> bool:
         "remoteprotocolerror",
         "localprotocolerror",
     )):
+        return True
+    return False
+
+
+def _is_server_error(exc: Exception) -> bool:
+    """Detect transient HTTP 5xx server errors that warrant provider fallback.
+
+    Returns True for 500 (Internal Server Error), 502 (Bad Gateway),
+    503 (Service Unavailable), 504 (Gateway Timeout), and similar server-side
+    failures.  Unlike payment or rate-limit errors, 5xx errors are transient
+    and indicate the endpoint is temporarily broken — falling back to a
+    different provider is always better than surfacing a cryptic error to the
+    user.
+
+    Handles both ``.status_code`` attribute (OpenAI SDK) and common 5xx text
+    patterns in the error message for broader provider compatibility.
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int) and 500 <= status < 600:
+        return True
+    err_lower = str(exc).lower()
+    # Match common 5xx status code patterns in error strings (some providers
+    # embed the code in the message without setting .status_code).
+    if any(kw in err_lower for kw in (
+        "502 bad gateway", "503 service unavailable", "504 gateway timeout",
+        "500 internal server error", "http/50", "http/51", "http/52", "http/53",
+        "520 web server", "521 web server", "522 connection timed out",
+        "523 origin is unreachable", "524 a timeout occurred",
+        "525 ssl handshake", "526 invalid ssl certificate",
+        "527 railgun error", "530",
+        # Gemini-specific text patterns
+        "unavailable", "high demand",
+    )):
+        return True
+    # Match the OpenAI SDK error class names for server errors
+    err_type = type(exc).__name__
+    if any(kw in err_type for kw in ("InternalServerError", "ServiceUnavailable")):
         return True
     return False
 
@@ -4240,6 +4286,7 @@ def call_llm(
                     _is_payment_error(retry_err)
                     or _is_connection_error(retry_err)
                     or _is_auth_error(retry_err)
+                    or _is_server_error(retry_err)
                     or "max_tokens" in retry_err_str
                     or "unsupported_parameter" in retry_err_str
                 ):
@@ -4271,7 +4318,7 @@ def call_llm(
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
-                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
+                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err) or _is_server_error(retry_err)):
                     raise
                 first_err = retry_err
 
@@ -4334,7 +4381,7 @@ def call_llm(
                     return _validate_llm_response(
                         client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
-                    if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
+                    if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err) or _is_server_error(retry_err)):
                         raise
                     recovery_err = retry_err
             if _recover_provider_pool(pool_provider, recovery_err):
@@ -4372,20 +4419,28 @@ def call_llm(
         # and providers the user never configured that got picked up by
         # the auto-detection chain.
         #
-        # ── Rate-limit fallback (#13579) ─────────────────────────────
-        # When the provider returns a 429 rate-limit (not billing), fall
-        # back to an alternative provider instead of exhausting retries
-        # against the same rate-limited endpoint.
+        # ── Payment / connection / rate-limit / server-error fallback ────
+        # When the provider returns a 429 rate-limit (not billing), a
+        # connection error, or a 5xx server error, fall back to an
+        # alternative provider instead of exhausting retries against the
+        # same broken endpoint.
         should_fallback = (
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_error(first_err)
         )
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
+        #
+        # Server errors (5xx) are the exception: they are transient and
+        # indicate the endpoint is temporarily broken regardless of whether
+        # it was explicitly chosen.  Falling back is always better than
+        # surfacing a cryptic 503 to the user.  (#25822)
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        is_server_err = _is_server_error(first_err)
+        if should_fallback and (is_auto or is_server_err):
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -4397,6 +4452,8 @@ def call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif is_server_err:
+                reason = "server error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -4591,6 +4648,7 @@ async def async_call_llm(
                     _is_payment_error(retry_err)
                     or _is_connection_error(retry_err)
                     or _is_auth_error(retry_err)
+                    or _is_server_error(retry_err)
                     or "max_tokens" in retry_err_str
                     or "unsupported_parameter" in retry_err_str
                 ):
@@ -4622,7 +4680,7 @@ async def async_call_llm(
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
-                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
+                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err) or _is_server_error(retry_err)):
                     raise
                 first_err = retry_err
 
@@ -4683,7 +4741,7 @@ async def async_call_llm(
                     return _validate_llm_response(
                         await client.chat.completions.create(**kwargs), task)
                 except Exception as retry_err:
-                    if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
+                    if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err) or _is_server_error(retry_err)):
                         raise
                     recovery_err = retry_err
             if _recover_provider_pool(pool_provider, recovery_err):
@@ -4707,14 +4765,16 @@ async def async_call_llm(
                     effective_extra_body=effective_extra_body,
                 )
 
-        # ── Payment / connection / rate-limit fallback (mirrors sync call_llm) ──
+        # ── Payment / connection / rate-limit / server-error fallback (mirrors sync call_llm) ──
         should_fallback = (
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_error(first_err)
         )
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        is_server_err = _is_server_error(first_err)
+        if should_fallback and (is_auto or is_server_err):
             if _is_payment_error(first_err):
                 reason = "payment error"
                 _mark_provider_unhealthy(
@@ -4722,6 +4782,8 @@ async def async_call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif is_server_err:
+                reason = "server error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -23,6 +23,7 @@ from agent.auxiliary_client import (
     _get_provider_chain,
     _is_payment_error,
     _is_rate_limit_error,
+    _is_server_error,
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
@@ -994,20 +995,20 @@ class TestCallLlmPaymentFallback:
         exc.status_code = 429
         return exc
 
-    def test_non_payment_error_not_caught(self, monkeypatch):
-        """Non-payment/non-connection errors (500) should NOT trigger fallback."""
+    def test_non_server_error_not_caught(self, monkeypatch):
+        """Non-payment/non-connection/non-server errors (400) should NOT trigger fallback."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
 
         primary_client = MagicMock()
-        server_err = Exception("Internal Server Error")
-        server_err.status_code = 500
-        primary_client.chat.completions.create.side_effect = server_err
+        bad_req_err = Exception("Bad Request: invalid model")
+        bad_req_err.status_code = 400
+        primary_client.chat.completions.create.side_effect = bad_req_err
 
         with patch("agent.auxiliary_client._get_cached_client",
                     return_value=(primary_client, "google/gemini-3-flash-preview")), \
              patch("agent.auxiliary_client._resolve_task_provider_model",
                     return_value=("auto", "google/gemini-3-flash-preview", None, None, None)):
-            with pytest.raises(Exception, match="Internal Server Error"):
+            with pytest.raises(Exception, match="Bad Request"):
                 call_llm(
                     task="compression",
                     messages=[{"role": "user", "content": "hello"}],
@@ -1037,6 +1038,65 @@ class TestCallLlmPaymentFallback:
                 messages=[{"role": "user", "content": "hello"}],
             )
         # Fallback client should have been used
+        assert fallback_client.chat.completions.create.called
+
+    def test_503_server_error_triggers_fallback(self, monkeypatch):
+        """503 server errors should trigger fallback to next provider (#25822)."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        server_err = Exception("Gemini HTTP 503 (UNAVAILABLE): This model is currently experiencing high demand.")
+        server_err.status_code = 503
+        primary_client.chat.completions.create.side_effect = server_err
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", "google/gemini-3-flash-preview", None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")):
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+        # Fallback client should have been used
+        assert fallback_client.chat.completions.create.called
+
+    def test_503_fallback_even_with_explicit_provider(self, monkeypatch):
+        """503 server errors should trigger fallback even for explicit providers (#25822).
+
+        Unlike payment/rate-limit errors, server errors are transient and
+        indicate the endpoint is temporarily broken regardless of whether it
+        was explicitly chosen by the user.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        server_err = Exception("Service Unavailable: 503")
+        server_err.status_code = 503
+        primary_client.chat.completions.create.side_effect = server_err
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gemini")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("gemini", "gemini-3-flash", None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")):
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+        # Fallback client should have been used even though provider was explicit
         assert fallback_client.chat.completions.create.called
 
 # ---------------------------------------------------------------------------
@@ -1125,6 +1185,99 @@ class TestIsConnectionError:
         err = Exception("Internal Server Error")
         err.status_code = 500
         assert _is_connection_error(err) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_server_error coverage (#25822)
+# ---------------------------------------------------------------------------
+
+
+class TestIsServerError:
+    """Tests for _is_server_error detection of transient 5xx errors."""
+
+    def test_500_status_code(self):
+        err = Exception("Internal Server Error")
+        err.status_code = 500
+        assert _is_server_error(err) is True
+
+    def test_502_status_code(self):
+        err = Exception("Bad Gateway")
+        err.status_code = 502
+        assert _is_server_error(err) is True
+
+    def test_503_status_code(self):
+        """Gemini UNAVAILABLE returns HTTP 503."""
+        err = Exception("Gemini HTTP 503 (UNAVAILABLE): This model is currently experiencing high demand.")
+        err.status_code = 503
+        assert _is_server_error(err) is True
+
+    def test_504_status_code(self):
+        err = Exception("Gateway Timeout")
+        err.status_code = 504
+        assert _is_server_error(err) is True
+
+    def test_599_status_code(self):
+        """Any 5xx should match."""
+        err = Exception("Network Connect Timeout Error")
+        err.status_code = 599
+        assert _is_server_error(err) is True
+
+    def test_400_is_not_server_error(self):
+        err = Exception("Bad Request: invalid model")
+        err.status_code = 400
+        assert _is_server_error(err) is False
+
+    def test_429_is_not_server_error(self):
+        """Rate limits are handled by _is_rate_limit_error, not _is_server_error."""
+        err = Exception("Rate limit exceeded")
+        err.status_code = 429
+        assert _is_server_error(err) is False
+
+    def test_402_is_not_server_error(self):
+        err = Exception("Payment Required")
+        err.status_code = 402
+        assert _is_server_error(err) is False
+
+    def test_no_status_code_with_503_text(self):
+        """Some providers embed 503 in error message without setting .status_code."""
+        err = Exception("Gemini HTTP 503 (UNAVAILABLE): high demand")
+        assert _is_server_error(err) is True
+
+    def test_no_status_code_with_service_unavailable_text(self):
+        err = Exception("503 service unavailable - please try again later")
+        assert _is_server_error(err) is True
+
+    def test_no_status_code_with_bad_gateway_text(self):
+        err = Exception("502 Bad Gateway")
+        assert _is_server_error(err) is True
+
+    def test_no_status_code_with_unavailable_keyword(self):
+        """Gemini-specific text pattern."""
+        err = Exception("The model is currently unavailable due to high demand")
+        assert _is_server_error(err) is True
+
+    def test_no_status_code_no_5xx_keywords(self):
+        err = Exception("connection reset")
+        assert _is_server_error(err) is False
+
+    def test_400_text_not_server_error(self):
+        err = Exception("Bad Request: 400 error")
+        err.status_code = 400
+        assert _is_server_error(err) is False
+
+    def test_internal_server_error_classname(self):
+        """OpenAI SDK InternalServerError detection by class name."""
+        class InternalServerError(Exception):
+            pass
+        err = InternalServerError("something went wrong")
+        assert _is_server_error(err) is True
+
+    def test_service_unavailable_classname(self):
+        """Detection by class name for providers that use ServiceUnavailable."""
+        class ServiceUnavailable(Exception):
+            pass
+        err = ServiceUnavailable("service temporarily unavailable")
+        assert _is_server_error(err) is True
 
 
 class TestKimiTemperatureOmitted:


### PR DESCRIPTION
## What

Add 5xx server error detection to the auxiliary client provider fallback chain. When a provider returns HTTP 500/502/503/504 or similar transient server errors, `call_llm()` and `async_call_llm()` now automatically retry with the next available provider instead of surfacing a cryptic error to the user.

## Why

Issue #25822: When `auxiliary.vision.provider` is set to `google` (Gemini), Gemini returns HTTP 503 (UNAVAILABLE) during high-demand periods. The error propagates directly to the caller because:

1. No `_is_server_error()` detector existed — 5xx errors match none of the existing checks (`_is_payment_error`, `_is_connection_error`, `_is_rate_limit_error`).
2. The `is_auto` gate (`if should_fallback and is_auto:`) blocks fallback for explicitly configured providers.

## How

### Changes to `agent/auxiliary_client.py`:

1. **New `_is_server_error()` function** — detects 5xx errors via `.status_code` attribute (500–599), text patterns in error messages (`"503 service unavailable"`, `"unavailable"`, `"high demand"`, etc.), and OpenAI SDK class names (`InternalServerError`, `ServiceUnavailable`).

2. **Updated `should_fallback`** — includes `_is_server_error` alongside payment/connection/rate-limit checks.

3. **Server errors bypass `is_auto` gate** — `if should_fallback and (is_auto or is_server_err):`. Unlike billing or rate-limit errors where explicit provider = hard constraint, server errors are transient and indicate the endpoint is temporarily broken regardless of provider choice.

4. **Updated retry guards** — `_is_server_error` added to the temperature retry, max_tokens retry, and credential pool retry guards.

5. **Applied to both sync and async paths** — `call_llm()` and `async_call_llm()`.

### Changes to `tests/agent/test_auxiliary_client.py`:

- **18 unit tests** for `_is_server_error` detection (5xx status codes, text patterns, class names, negative cases)
- **2 integration tests** for 503 fallback via `call_llm()` (auto provider and explicit provider)
- **Updated existing test** — `test_non_payment_error_not_caught` now uses 400 (not 500) since 500 now correctly triggers fallback

## Before vs After

**Before:**
```
User sends image -> vision provider is Gemini -> Gemini returns 503 UNAVAILABLE
-> Error propagates to user: "Gemini HTTP 503 (UNAVAILABLE): high demand"
-> No fallback attempted, task fails
```

**After:**
```
User sends image -> vision provider is Gemini -> Gemini returns 503 UNAVAILABLE
-> _is_server_error() detects 503 -> fallback to next provider (e.g. OpenRouter)
-> Vision task completes successfully with fallback provider
```

## Test results

```
172 passed in 6.42s (tests/agent/test_auxiliary_client.py)
```

Fixes #25822