### PR TITLE
fix(agent): keep max-iteration warnings out of quiet stdout

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1937,7 +1937,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
-    print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
+    warning = f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
+    if agent.quiet_mode:
+        # Quiet mode is used by automation wrappers as a machine-readable stdout
+        # channel. Keep diagnostics out of stdout so wrappers receive only the
+        # final assistant content.
+        logger.warning(warning)
+    else:
+        agent._safe_print(warning)
 
     summary_request = (
         "You've reached the maximum number of tool-calling iterations allowed. "

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3871,6 +3871,21 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
+    def test_quiet_mode_does_not_print_iteration_warning_to_stdout(self, agent, capsys):
+        """Machine-readable quiet mode must not contaminate stdout with diagnostics."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            1,
+        )
+
+        captured = capsys.readouterr()
+        assert result == "Summary"
+        assert "Reached maximum iterations" not in captured.out
+
     def test_api_failure_returns_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."


### PR DESCRIPTION
## Summary
- keep the max-iterations diagnostic out of stdout when `quiet_mode` is active
- route that diagnostic through the logger instead, while preserving the existing visible warning for interactive runs
- add a regression test for quiet max-iteration summary handling
- rebase onto the current `main` refactor by applying the fix in `agent/chat_completion_helpers.py`

## Why
Automation wrappers use quiet-mode stdout as a machine-readable channel. A max-iteration warning printed directly to stdout can contaminate the wrapper output even when the final assistant summary is otherwise valid.

## Test Plan
- RED: `python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_quiet_mode_does_not_print_iteration_warning_to_stdout -q -o 'addopts='` failed with the old implementation because stdout contained `Reached maximum iterations`.
- GREEN: `python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_quiet_mode_does_not_print_iteration_warning_to_stdout -q -o 'addopts='` → `1 passed, 1 warning`
- GREEN: `python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations -q -o 'addopts='` → `10 passed, 1 warning in 13.38s`
- GREEN: local Hermes runtime smoke using `AIAgent(quiet_mode=True)` and the real `_handle_max_iterations` path → returned the summary and captured `stdout_len=0`, `stdout_contains_warning=False`
- GREEN: `python -m ruff check agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py` → `All checks passed!`
- GREEN: `git diff --check`
