### PR TITLE
fix(terminal): expand ~ and env vars in workdir for background processes

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -51,6 +51,20 @@ class TestResolveSafeCwd:
         monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
         assert _resolve_safe_cwd("/no/such/deep/dir") == sep
 
+    def test_expands_tilde_to_home(self, monkeypatch, tmp_path):
+        """Paths with ~ must be expanded before checking existence."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        nested = tmp_path / "Projects" / "DaemonCraft"
+        nested.mkdir(parents=True)
+        assert _resolve_safe_cwd("~/Projects/DaemonCraft") == str(nested)
+
+    def test_expands_environment_variables(self, monkeypatch, tmp_path):
+        """Paths with $VAR must be expanded before checking existence."""
+        monkeypatch.setenv("DAEMONCRAFT_ROOT", str(tmp_path))
+        nested = tmp_path / "agents" / "bot"
+        nested.mkdir(parents=True)
+        assert _resolve_safe_cwd("$DAEMONCRAFT_ROOT/agents/bot") == str(nested)
+
 
 def _fake_interrupt():
     return threading.Event()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -30,6 +30,10 @@ def _resolve_safe_cwd(cwd: str) -> str:
     raises ``FileNotFoundError`` before bash starts, wedging every subsequent
     terminal call until the gateway restarts.
     """
+    # Expand ~ and environment variables so callers can pass paths like
+    # ~/Projects/DaemonCraft/agents/bot without falling through to /tmp.
+    if cwd:
+        cwd = os.path.expandvars(os.path.expanduser(cwd))
     if cwd and os.path.isdir(cwd):
         return cwd
     parent = os.path.dirname(cwd) if cwd else ""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1901,6 +1901,8 @@ def terminal_tool(
 
             session_key = get_current_session_key(default="")
             effective_cwd = workdir or cwd
+            if effective_cwd:
+                effective_cwd = os.path.expandvars(os.path.expanduser(effective_cwd))
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `terminal(background=true, workdir="~/Projects/...")` silently starts the process in `/tmp` instead of the intended directory, because `~` and environment variables are not expanded before the existence check in `_resolve_safe_cwd()`.

## Root Cause

`_resolve_safe_cwd()` in `tools/environments/local.py` does:

```python
if cwd and os.path.isdir(cwd):
    return cwd
```

When `cwd="~/Projects/myapp"`, `os.path.isdir()` returns `False` (there is no literal directory named `~`), so the function falls back to `tempfile.gettempdir()` → `/tmp`. The background process then fails with `MODULE_NOT_FOUND` or other cwd-dependent errors.

## Changes

1. **`tools/environments/local.py`** — expand `~` and `$VAR` in `_resolve_safe_cwd()` before the `isdir` check.
2. **`tools/terminal_tool.py`** — also expand before passing `effective_cwd` to the process registry (belt-and-braces).
3. **`tests/tools/test_local_env_cwd_recovery.py`** — add regression tests for tilde and env-var expansion.

## Related Issue

Fixes #26151

## Related PRs / Issues (no conflict)

- #17558 — `_resolve_safe_cwd()` was introduced here; this is an expansion edge case.
- #23866 — MSYS path normalization in the same function (orthogonal; both can coexist).

## Testing

```bash
scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py -v
```

Expected: all tests pass, including the two new ones:
- `test_expands_tilde_to_home`
- `test_expands_environment_variables`
