### PR TITLE
chore: harden dependency and runtime validation

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -11,6 +11,8 @@ on:
       - '**/sitecustomize.py'
       - '**/usercustomize.py'
       - '**/__init__.pth'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 permissions:
   pull-requests: write
@@ -49,6 +51,48 @@ jobs:
           DIFF=$(git diff "$BASE".."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
 
           FINDINGS=""
+
+          # --- Known-bad exact upstream releases ---
+          MISTRALAI_246_HITS=$(python - "$BASE" "$HEAD" <<'PY'
+          import subprocess
+          import sys
+
+          base, head = sys.argv[1:3]
+          diff = subprocess.check_output(
+              ["git", "diff", f"{base}..{head}", "--", "pyproject.toml", "uv.lock"],
+              text=True,
+          )
+          lines = diff.splitlines()
+          hits = []
+          for index, line in enumerate(lines, start=1):
+              if not line.startswith("+") or line.startswith("+++"):
+                  continue
+              added = line[1:]
+              normalized = added.lower()
+              if "mistralai" in normalized and "2.4.6" in normalized:
+                  hits.append(f"{index}:{added}")
+                  continue
+              if normalized.strip() == 'version = "2.4.6"':
+                  context = "\n".join(
+                      item[1:] if item[:1] in "+- " else item
+                      for item in lines[max(0, index - 5):index]
+                  ).lower()
+                  if 'name = "mistralai"' in context:
+                      hits.append(f"{index}:{added}")
+          print("\n".join(hits[:10]))
+          PY
+          )
+          if [ -n "$MISTRALAI_246_HITS" ]; then
+            FINDINGS="${FINDINGS}
+          ### 🚨 CRITICAL: known-bad mistralai release referenced
+          \`mistralai==2.4.6\` (including lockfile filenames like \`mistralai-2.4.6\`) was reported as a compromised upstream release. Do not allow project metadata, lockfiles, or CI installs to reference it.
+
+          **Matches:**
+          \`\`\`
+          ${MISTRALAI_246_HITS}
+          \`\`\`
+          "
+          fi
 
           # --- .pth files (auto-execute on Python startup) ---
           # The exact mechanism used in the litellm supply chain attack:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv .venv --python 3.11
-          source .venv/bin/activate
-          uv pip install -e ".[all,dev]"
+          uv sync --frozen --python 3.11 --extra all
 
       - name: Run tests
         run: |
@@ -71,9 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv .venv --python 3.11
-          source .venv/bin/activate
-          uv pip install -e ".[all,dev]"
+          uv sync --frozen --python 3.11 --extra all
 
       - name: Run e2e tests
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,23 @@
 #     this on an internet-facing host.
 #
 services:
+  # Safe one-shot validation path:
+  #   HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose --profile smoke run --rm smoke
+  #
+  # This intentionally avoids ~/.hermes, host networking, restart loops, and
+  # gateway startup. It is for first-pass image/runtime validation only.
+  smoke:
+    profiles: ["smoke"]
+    build: .
+    image: hermes-agent
+    restart: "no"
+    volumes:
+      - ./runtime/docker-smoke:/opt/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    command: ["doctor"]
+
   gateway:
     build: .
     image: hermes-agent

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -1,0 +1,84 @@
+"""Regression tests for dependency-level supply-chain guardrails.
+
+These tests intentionally inspect project metadata instead of importing Hermes.
+They protect optional extras from resolving a known-bad upstream package version
+and keep the lockfile from reintroducing the same exact release later.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+KNOWN_BAD_MISTRALAI = Version("2.4.6")
+
+
+def _mistralai_specs(dependencies: list[str]) -> list[str]:
+    """Return Mistral SDK requirements using Python's case-insensitive names."""
+
+    return [
+        dep
+        for dep in dependencies
+        if canonicalize_name(Requirement(dep).name) == "mistralai"
+    ]
+
+
+def test_mistralai_dependency_detection_is_case_insensitive() -> None:
+    """Package names are case-insensitive, so mixed-case restores must be caught."""
+
+    assert _mistralai_specs(["MistralAI==2.4.6"]) == ["MistralAI==2.4.6"]
+
+
+def test_mistral_extra_absent_or_excludes_known_bad_mistralai_version() -> None:
+    """The Mistral extra may stay quarantined, but must not allow 2.4.6."""
+
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    optional_deps = pyproject["project"]["optional-dependencies"]
+    mistral_deps = optional_deps.get("mistral", [])
+
+    # Upstream may remove the extra entirely while the SDK is quarantined.
+    # If it is restored later, this regression test forces the restored
+    # specifier to keep excluding the compromised exact release.
+    mistralai_specs = _mistralai_specs(mistral_deps)
+    if not mistralai_specs:
+        assert "mistral: extra REMOVED" in (PROJECT_ROOT / "pyproject.toml").read_text()
+        return
+
+    assert len(mistralai_specs) == 1
+    spec = Requirement(mistralai_specs[0]).specifier
+    assert isinstance(spec, SpecifierSet)
+    assert KNOWN_BAD_MISTRALAI not in spec
+
+
+def test_uv_lock_does_not_pin_known_bad_mistralai_version() -> None:
+    """The committed lockfile must not contain the known-bad exact release."""
+
+    lock_text = (PROJECT_ROOT / "uv.lock").read_text()
+
+    assert not re.search(
+        r'(?m)^name = "mistralai"\nversion = "2\.4\.6"$',
+        lock_text,
+    )
+    assert "mistralai-2.4.6" not in lock_text
+
+
+def test_supply_chain_audit_blocks_known_bad_mistralai_version() -> None:
+    """CI should fail fast if a future PR reintroduces the bad Mistral SDK."""
+
+    workflow = (PROJECT_ROOT / ".github/workflows/supply-chain-audit.yml").read_text()
+
+    assert "pyproject.toml" in workflow
+    assert "uv.lock" in workflow
+    assert "mistralai" in workflow
+    assert "2.4.6" in workflow
+    assert ".lower()" in workflow
+    assert 'name = "mistralai"' in workflow
+    assert 'version = "2.4.6"' in workflow

--- a/tests/tools/test_docker_compose_smoke_profile.py
+++ b/tests/tools/test_docker_compose_smoke_profile.py
@@ -1,0 +1,56 @@
+"""Contract tests for the safe Docker Compose smoke profile.
+
+These tests protect the beginner-friendly Docker trial path: users should be
+able to build/run a one-shot container without mounting their live ~/.hermes
+profile, starting a gateway, exposing host networking, or creating a persistent
+restart loop.  The smoke profile is intentionally boring and reversible.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+
+def _compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text())
+
+
+def test_compose_has_isolated_smoke_profile() -> None:
+    services = _compose()["services"]
+
+    assert "smoke" in services, (
+        "docker-compose.yml should include a one-shot `smoke` service so users "
+        "can validate the image without touching the live gateway profile."
+    )
+
+    smoke = services["smoke"]
+    assert "smoke" in smoke.get("profiles", [])
+    assert smoke.get("command") == ["doctor"]
+    assert smoke.get("restart", "no") == "no"
+    assert smoke.get("network_mode") != "host"
+
+
+def test_smoke_profile_mounts_only_local_throwaway_data() -> None:
+    smoke = _compose()["services"]["smoke"]
+    volumes = smoke.get("volumes", [])
+    joined = "\n".join(volumes)
+
+    assert "~/.hermes" not in joined, (
+        "the smoke profile must not mount the operator's live ~/.hermes data"
+    )
+    assert "./runtime/docker-smoke:/opt/data" in joined, (
+        "the smoke profile should use a repo-local throwaway data directory"
+    )
+
+
+def test_smoke_profile_does_not_start_live_gateway() -> None:
+    smoke = _compose()["services"]["smoke"]
+    command = " ".join(smoke.get("command", []))
+
+    assert "gateway run" not in command
+    assert not any("API_SERVER_KEY" in item for item in smoke.get("environment", []))

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,5 +1,6 @@
 import logging
 from io import StringIO
+import os
 import subprocess
 import sys
 import types
@@ -208,9 +209,33 @@ def test_non_persistent_cleanup_removes_container(monkeypatch):
     calls = _mock_subprocess_run(monkeypatch)
 
     popen_cmds = []
+    class _CleanupPopen:
+        """Tiny Popen double with a real fileno-backed stdout.
+
+        DockerEnvironment initialization runs a shell bootstrap path that drains
+        proc.stdout via fileno()/select().  A plain iterator makes that helper
+        throw in a background thread, so this fake uses /dev/null like an empty
+        subprocess pipe.
+        """
+
+        def __init__(self, cmd, **kwargs):
+            self.cmd = cmd
+            self.kwargs = kwargs
+            self.stdout = open(os.devnull, "rb")
+            self.stdin = None
+            self.returncode = 0
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, **kwargs):
+            self.stdout.close()
+            return self.returncode
+
     monkeypatch.setattr(
-        docker_env.subprocess, "Popen",
-        lambda cmd, **kw: (popen_cmds.append(cmd), type("P", (), {"poll": lambda s: 0, "wait": lambda s, **k: None, "returncode": 0, "stdout": iter([]), "stdin": None})())[1],
+        docker_env.subprocess,
+        "Popen",
+        lambda cmd, **kw: (popen_cmds.append(cmd), _CleanupPopen(cmd, **kw))[1],
     )
 
     env = _make_dummy_env(persistent_filesystem=False, task_id="ephemeral-task")

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -200,6 +200,29 @@ class TestSyncSkills:
         stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
         return stack
 
+    def test_no_bundled_skills_marker_skips_global_sync(self, tmp_path):
+        """Profiles created with --no-skills must stay empty on normal CLI startup.
+
+        The CLI calls sync_skills() directly on launch, not only the profile
+        helper.  This marker check keeps opted-out role profiles from being
+        re-seeded the first time they run `hermes --profile <name> chat ...`.
+        """
+        bundled = self._setup_bundled(tmp_path)
+        profile_home = tmp_path / "profile_home"
+        skills_dir = profile_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        profile_home.mkdir()
+        (profile_home / ".no-bundled-skills").write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert result["skipped_opt_out"] is True
+        assert result["copied"] == []
+        assert not manifest_file.exists()
+        assert not (skills_dir / "category" / "new-skill").exists()
+        assert not (skills_dir / "old-skill").exists()
+
     def test_fresh_install_copies_all(self, tmp_path):
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+NO_BUNDLED_SKILLS_MARKER = ".no-bundled-skills"
 
 
 def _get_bundled_dir() -> Path:
@@ -182,6 +183,22 @@ def sync_skills(quiet: bool = False) -> dict:
         dict with keys: copied (list), updated (list), skipped (int),
                         user_modified (list), cleaned (list), total_bundled (int)
     """
+    # `hermes profile create --no-skills` writes this marker to the profile
+    # home, not to skills/.  The CLI launch path calls sync_skills() directly,
+    # so the guard must live here as well as in profile creation helpers.
+    # Without this check, an opted-out role profile gets silently re-seeded on
+    # its first normal command (`hermes --profile <name> chat ...`).
+    if (SKILLS_DIR.parent / NO_BUNDLED_SKILLS_MARKER).exists():
+        return {
+            "copied": [],
+            "updated": [],
+            "skipped": 0,
+            "user_modified": [],
+            "cleaned": [],
+            "total_bundled": 0,
+            "skipped_opt_out": True,
+        }
+
     bundled_dir = _get_bundled_dir()
     if not bundled_dir.exists():
         return {


### PR DESCRIPTION
## Summary

- Add a high-signal supply-chain check for known-bad `mistralai` 2.4.6 references in dependency metadata/lockfile changes.
- Switch CI dependency setup to frozen `uv sync --python 3.11 --extra all`.
- Add a safe one-shot Docker Compose `smoke` profile that avoids live `~/.hermes`, gateway startup, host networking, and restart loops.
- Preserve `--no-skills` profile opt-out when `sync_skills()` is called directly during normal CLI startup.

## Test Plan

- [x] YAML parse for changed workflows
- [x] `git diff --check`
- [x] `python -m pytest tests/test_dependency_policy.py -q --tb=short`
- [x] `python -m pytest tests/tools/test_skills_sync.py -q --tb=short`
- [x] `python -m pytest tests/tools/test_docker_compose_smoke_profile.py tests/tools/test_docker_environment.py -q --tb=short`
- [x] `uv lock --check`
- [x] `docker compose --profile smoke config`
- [x] `gitleaks protect --staged --redact --no-banner --exit-code 1`
- [x] `gitleaks git --redact --no-banner --exit-code 1 --log-opts="origin/main..HEAD"`

## Review Notes

Independent review initially flagged two blocking issues in the new Mistral guardrail:

1. A regex-only scanner could miss PEP 440 forms like `mistralai>=2.4.6,<3`.
2. Case-sensitive package matching could miss valid case variants like `MistralAI==2.4.6`.

Both were fixed before this PR:

- The workflow now uses a small Python diff scanner.
- Regression tests use `packaging.Requirement` and `canonicalize_name()`.

Final independent review found no blocking security concerns or logic errors.
