### PR TITLE
revert(cli): drop scrollback box width clamp, restore full-width borders

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3235,25 +3235,27 @@ class HermesCLI:
 
     @staticmethod
     def _scrollback_box_width(width: Optional[int] = None) -> int:
-        """Return a resize-safe width for printed scrollback box rules.
+        """Return the full viewport width for printed scrollback box rules.
 
-        Lines already printed to terminal scrollback are reflowed by the
-        terminal emulator when the column count shrinks. A full-width response
-        border drawn at, say, 200 columns will wrap into two or three rows of
-        dashes after the user resizes to 80 columns, looking like duplicated
-        separator lines (the family of bugs tracked by #18449, #19280, #22976).
+        Previously this clamped to ``max(32, min(width, 56))`` as a defense
+        against terminal-emulator reflow on column-shrink (#25975, salvaging
+        #24403).  That clamp made response/reasoning borders look stubby on
+        any modern wide terminal.  We now trust the prompt_toolkit
+        ``_output_screen_diff`` monkey-patch landed in #26137 (salvaging
+        #25981) to keep chrome out of scrollback in the first place, and
+        accept that an aggressive column-shrink may visually reflow already
+        printed Panel borders — that's a cosmetic artifact of stamped
+        scrollback history, not a live-render bug.
 
-        Keep decorative scrollback boxes intentionally narrower than the
-        viewport so a moderate resize never triggers reflow. The live TUI
-        footer (status bar, input rule) still uses the full width — only
-        content that is *stamped into scrollback* needs this clamp.
+        A small floor (32 cols) is kept so the box still renders on tiny
+        terminals without negative ``'─' * (w - 2)`` math.
         """
         if width is None:
             try:
                 width = shutil.get_terminal_size((80, 24)).columns
             except Exception:
                 width = 80
-        return max(32, min(int(width or 80), 56))
+        return max(32, int(width or 80))
 
     def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
         """Return the visible height for the top/bottom input separator rules."""

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -349,20 +349,27 @@ class TestCLIStatusBar:
         assert cli_obj._tui_input_rule_height("top", width=90) == 1
         assert cli_obj._tui_input_rule_height("bottom", width=90) == 1
 
-    def test_scrollback_box_width_caps_to_resize_safe_value(self):
-        """Decorative scrollback boxes clamp to a width small enough that
-        moderate terminal shrinks don't cause reflow into scrollback."""
+    def test_scrollback_box_width_returns_viewport_width(self):
+        """Decorative scrollback boxes use the full viewport width.
+
+        The previous clamp (max 56 cols) was reverted in favour of the
+        prompt_toolkit ``_output_screen_diff`` monkey-patch landed in
+        #26137, which keeps chrome out of scrollback at the source.
+        We accept that an aggressive column-shrink may visually reflow
+        already printed Panel borders — that's a cosmetic artifact of
+        stamped scrollback history, not a live-render bug.
+        """
         from cli import HermesCLI
 
-        # Floor at 32 — narrow terminals still get something usable.
+        # Floor at 32 — narrow terminals still get something usable
+        # (avoids negative ``'─' * (w - 2)`` math).
         assert HermesCLI._scrollback_box_width(20) == 32
         assert HermesCLI._scrollback_box_width(32) == 32
-        # Cap at 56 — wide terminals don't get full-width boxes.
-        assert HermesCLI._scrollback_box_width(80) == 56
-        assert HermesCLI._scrollback_box_width(120) == 56
-        assert HermesCLI._scrollback_box_width(200) == 56
-        # Mid-range passes through up to the cap.
+        # Above the floor, return the actual viewport width — no cap.
         assert HermesCLI._scrollback_box_width(48) == 48
+        assert HermesCLI._scrollback_box_width(80) == 80
+        assert HermesCLI._scrollback_box_width(120) == 120
+        assert HermesCLI._scrollback_box_width(200) == 200
 
     def test_agent_spacer_reclaimed_on_narrow_terminals(self):
         cli_obj = _make_cli()


### PR DESCRIPTION
## Summary
Removes the 56-col cap on decorative scrollback Panel/box widths so response & reasoning borders extend across the full terminal viewport again.

#25975 (salvaging #24403) clamped `_scrollback_box_width()` to `max(32, min(width, 56))` as defense against terminal-emulator reflow on column shrink. On any wide terminal this made the response/reasoning borders look stubby — visibly broken at 200 cols.

#26137 (salvaging #25981, by @OutThisLife — just merged) landed a more fundamental fix: prompt_toolkit's `_output_screen_diff` is monkey-patched so its reserve-vertical-space cursor move no longer pushes chrome into scrollback at all. With that in place, the clamp's chrome-into-scrollback class of bugs is solved at the source.

The remaining risk is purely cosmetic: *already-stamped* Panel borders in scrollback history can still be reflowed by the terminal on aggressive column shrinks. We accept that tradeoff for restoring full-width borders.

## Changes
- `cli.py` — `_scrollback_box_width()` returns `max(32, width)` (floor only, no cap). All 10 call sites stay valid.
- `tests/cli/test_cli_status_bar.py` — `test_scrollback_box_width_caps_to_resize_safe_value` renamed to `test_scrollback_box_width_returns_viewport_width`, asserts full-width passthrough above the 32-col floor.

Floor of 32 is kept so `'─' * (w - 2)` math stays positive on tiny terminals.

## Validation

| input | Before | After |
|---|---|---|
| `_scrollback_box_width(200)` | 56 | 200 |
| `_scrollback_box_width(80)`  | 56 | 80  |
| `_scrollback_box_width(20)`  | 32 (floor) | 32 (floor) |

tests/cli/test_cli_status_bar.py + test_cli_force_redraw.py + test_cli_light_mode.py → 61/61 pass in 2.0s.

Refs #18449 #19280 #22976 (the original reflow class) and #25975 (the clamp this reverts).
