### PR TITLE
fix(gateway): default streaming transport to edit to avoid Telegram DM flicker

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -352,12 +352,17 @@ class StreamingConfig:
     # Transport selection:
     #   "auto"  — prefer native streaming-draft updates when the platform
     #             supports them (Telegram sendMessageDraft, Bot API 9.5+);
-    #             fall back to edit-based when not.  Recommended.
+    #             fall back to edit-based when not.
     #   "draft" — explicitly request native drafts; falls back to edit when
     #             the platform/chat doesn't support them.
     #   "edit"  — progressive editMessageText only (legacy behaviour).
     #   "off"   — disable streaming entirely.
-    transport: str = "auto"
+    #
+    # Default is "edit" because native draft streaming (e.g. Telegram's
+    # sendMessageDraft) causes visible content flicker/rollback in DM
+    # responses.  Users who want draft streaming can opt in via
+    # ``streaming.transport: auto`` (or ``draft``).  See #26157.
+    transport: str = "edit"
     edit_interval: float = DEFAULT_STREAMING_EDIT_INTERVAL
     buffer_threshold: int = DEFAULT_STREAMING_BUFFER_THRESHOLD
     cursor: str = DEFAULT_STREAMING_CURSOR
@@ -386,7 +391,7 @@ class StreamingConfig:
             return cls()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "auto"),
+            transport=data.get("transport", "edit"),
             edit_interval=_coerce_float(
                 data.get("edit_interval"), DEFAULT_STREAMING_EDIT_INTERVAL,
             ),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14167,7 +14167,7 @@ class GatewayRunner:
                         cursor=_effective_cursor,
                         buffer_only=_buffer_only,
                         fresh_final_after_seconds=_fresh_final_secs,
-                        transport=_scfg.transport or "auto",
+                        transport=_scfg.transport or "edit",
                         chat_type=getattr(source, "chat_type", "") or "",
                     )
                     _stream_consumer = GatewayStreamConsumer(
@@ -14990,7 +14990,7 @@ class GatewayRunner:
                             cursor=_effective_cursor,
                             buffer_only=_buffer_only,
                             fresh_final_after_seconds=_fresh_final_secs,
-                            transport=_scfg.transport or "auto",
+                            transport=_scfg.transport or "edit",
                             chat_type=getattr(source, "chat_type", "") or "",
                         )
                         _stream_consumer = GatewayStreamConsumer(

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -67,7 +67,13 @@ class StreamConsumerConfig:
     #             edit when unsupported.
     #   "edit"  — progressive editMessageText (legacy behavior).
     #   "off"   — handled by the gateway before the consumer is even built.
-    transport: str = "auto"
+    #
+    # Default is "edit" because native draft streaming (e.g. Telegram's
+    # sendMessageDraft) causes visible content flicker/rollback in DM
+    # responses — each draft frame triggers a full re-render in the
+    # Telegram client.  Users who want draft streaming can opt in via
+    # config: ``streaming.transport: auto`` (or ``draft``).  See #26157.
+    transport: str = "edit"
     # Hint for the consumer about the originating chat type (e.g. "dm",
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
@@ -846,7 +852,7 @@ class GatewayStreamConsumer:
         the chat type (e.g. Telegram drafts are DM-only) and platform-version
         gates (e.g. python-telegram-bot 22.6+).
         """
-        transport = (self.cfg.transport or "auto").lower()
+        transport = (self.cfg.transport or "edit").lower()
         if transport == "edit":
             return False
         # "off" is filtered upstream by the gateway; treat as edit defensively.


### PR DESCRIPTION
## Summary

Change the default streaming transport from `"auto"` to `"edit"` to avoid visible content flicker/rollback in Telegram DM responses.

## Root Cause

Commit `4ed293b38` introduced native draft streaming via `sendMessageDraft` (Telegram Bot API 9.5+) and set the default transport to `"auto"`.  On DMs with python-telegram-bot ≥ 22.6, `supports_draft_streaming` returns `True`, routing mid-stream frames through `sendMessageDraft` instead of progressive `editMessageText`.

The problem: `sendMessageDraft` frames are "typing preview" animations in the Telegram client — not real messages.  Each time a new draft frame is sent with the same `draft_id` but more accumulated text, the Telegram client **re-renders the preview from scratch**: existing content briefly collapses or disappears before the updated text renders.  This is Telegram client behavior, not a Hermes bug per se, but the UX result is worse than the legacy edit-based path for most users.

## Fix

Change the default transport from `"auto"` to `"edit"` in three locations:
- `gateway/config.py` — `StreamingConfig.transport` default and `from_dict()` fallback
- `gateway/stream_consumer.py` — `StreamConsumerConfig.transport` default and `_resolve_draft_streaming()` fallback
- `gateway/run.py` — both `StreamConsumerConfig` construction sites

Users who want draft streaming can opt in via `streaming.transport: auto` (or `draft`) in config.yaml.

## Code Intelligence

- Analyzed: `_resolve_draft_streaming` (callers: 1, callees: 0, flows: 1)
- Blast radius: LOW — only `GatewayStreamConsumer.run()` calls this method
- Related patterns: PR #25907 adds empty placeholder drafts for topic mode (orthogonal change)

## Regression Coverage

- `tests/gateway/test_stream_consumer_draft.py` — 11 tests pass (all explicitly set `transport="auto"` for draft tests)
- `tests/gateway/test_stream_consumer.py` — 138 tests pass (existing edit-based tests unaffected)
- `tests/gateway/test_stream_consumer_fresh_final.py` — 15 tests pass
- `tests/test_gateway_streaming_nested_config.py` — passes
- `tests/gateway/test_config.py` — passes

## Testing

```bash
scripts/run_tests.sh tests/gateway/test_stream_consumer_draft.py tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/test_gateway_streaming_nested_config.py tests/gateway/test_config.py -x -q
# 164 passed
```

Fixes ux(telegram): sendMessageDraft (native draft streaming) causes visible content flicker/rollback in DM responses #26157
