### PR TITLE
fix(hermes_cli): add minimax-cn to _MODELS_DEV_PREFERRED

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2098,6 +2098,7 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "zai",
     "gemini",
     "google",
+    "minimax-cn",
 })
 
 

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -99,6 +99,36 @@ class TestProviderModelIdsPreferred:
         assert "kimi-k2.6" in out
 
 
+class TestMinimaxCnPreferred:
+    """minimax-cn was added to _MODELS_DEV_PREFERRED so that /model picker
+    shows the same models as `hermes setup model` (which always calls the
+    live models.dev API). Without this, MiniMax-M2.7-highspeed and other
+    variant models only appeared in the setup wizard but not in /model."""
+
+    def test_minimax_cn_is_in_preferred_set(self):
+        assert "minimax-cn" in _MODELS_DEV_PREFERRED
+
+    def test_minimax_cn_includes_highspeed_from_models_dev(self):
+        """The primary bug: MiniMax-M2.7-highspeed must appear in the
+        /model picker once minimax-cn is preferred."""
+        mdev = ["MiniMax-M2.7-highspeed", "MiniMax-M2.7", "MiniMax-M2.5"]
+        with patch("agent.models_dev.list_agentic_models", return_value=mdev):
+            out = provider_model_ids("minimax-cn")
+        assert "MiniMax-M2.7-highspeed" in out
+        assert "MiniMax-M2.7" in out
+        assert "MiniMax-M2.5" in out
+
+    def test_minimax_cn_offline_falls_back_to_curated(self):
+        """Offline models.dev → curated-only list, no crash."""
+        with patch("agent.models_dev.list_agentic_models", return_value=[]):
+            out = provider_model_ids("minimax-cn")
+        # Curated floor (see _PROVIDER_MODELS["minimax-cn"])
+        assert "MiniMax-M2.7" in out
+        assert "MiniMax-M2.5" in out
+        assert "MiniMax-M2.1" in out
+        assert "MiniMax-M2" in out
+
+
 class TestOpenRouterAndNousUnchanged:
     """Per Teknium: openrouter and nous are NEVER merged with models.dev."""
 


### PR DESCRIPTION
## Summary

Fixes the /model slash command picker missing MiniMax-M2.7-highspeed (and other variant models) that are visible in `hermes setup model`.

## Root Cause

- `hermes setup model` calls `fetch_models_dev()` (live REST API)
- `/model` picker calls `provider_model_ids()` which uses the static `_PROVIDER_MODELS` dict for providers **not** in `_MODELS_DEV_PREFERRED`
- `minimax-cn` was absent from `_MODELS_DEV_PREFERRED`, so it never merged live models.dev entries in the /model picker path
- Result: MiniMax-M2.7-highspeed (a models.dev-only variant) appeared in setup wizard but not in /model

## Fix

Add `"minimax-cn"` to `_MODELS_DEV_PREFERRED` (line ~2100 of `hermes_cli/models.py`), which triggers the existing merge logic that:
1. Fetches the live models.dev catalog for minimax-cn
2. Prepends those live entries to the curated static list
3. Falls back to the curated list on network failure (no crash)

## Changes

- `hermes_cli/models.py`: +1 line - add `"minimax-cn"` to `_MODELS_DEV_PREFERRED`
- `tests/hermes_cli/test_models_dev_preferred_merge.py`: +3 test cases covering:
  - `minimax-cn` is in the preferred set
  - `MiniMax-M2.7-highspeed` appears in picker when minimax-cn is preferred
  - Offline fallback to curated list (no crash)

## Testing

- `tests/hermes_cli/test_models_dev_preferred_merge.py`: **14 passed** (11 pre-existing + 3 new)
- Full hermes_cli suite: **4409 passed, 7 skipped, 2 warnings** (134s)
- No regressions

## Related Issues

Closes #26146
Refs: #23359 (tracking issue for provider/model inventory discrepancy), #25542, #26016, #26130
