### PR TITLE
fix(goals): raise judge max_tokens 200 → 4096, make configurable

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -45,6 +45,16 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_TURNS = 20
 DEFAULT_JUDGE_TIMEOUT = 30.0
+# Judge output budget. The freeform judge returns a one-line JSON verdict, but
+# reasoning models (deepseek-v4, qwq, etc.) burn tokens on hidden reasoning
+# before emitting the visible JSON — and the first /goal turn's prompt is
+# larger than later turns, which pushes total reply length past tight caps.
+# 200 tokens (the original default) reliably truncated the JSON on reasoning
+# models, leaving '{"done": true, "reason": "The agent successfully' and
+# triggering the auto-pause. 4096 covers reasoning + verdict on every model
+# we've live-tested; override via auxiliary.goal_judge.max_tokens for
+# specifically constrained setups.
+DEFAULT_JUDGE_MAX_TOKENS = 4096
 # Cap how much of the last response + recent messages we send to the judge.
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # After this many consecutive judge *parse* failures (empty output / non-JSON),
@@ -282,6 +292,30 @@ def _truncate(text: str, limit: int) -> str:
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
+def _goal_judge_max_tokens() -> int:
+    """Resolve auxiliary.goal_judge.max_tokens, falling back to the default.
+
+    ``load_config()`` is cached on the config file's (mtime, size), so calling
+    this once per judge turn is cheap. A non-positive or non-int value falls
+    back to the default rather than crashing the goal loop.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        value = (
+            (cfg.get("auxiliary") or {})
+            .get("goal_judge", {})
+            .get("max_tokens", DEFAULT_JUDGE_MAX_TOKENS)
+        )
+        value = int(value)
+        if value > 0:
+            return value
+    except Exception:
+        pass
+    return DEFAULT_JUDGE_MAX_TOKENS
+
+
 def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
     """Parse the judge's reply. Fail-open to ``(False, "<reason>", parse_failed)``.
 
@@ -404,7 +438,7 @@ def judge_goal(
                 {"role": "user", "content": prompt},
             ],
             temperature=0,
-            max_tokens=200,
+            max_tokens=_goal_judge_max_tokens(),
             timeout=timeout,
             extra_body=get_auxiliary_extra_body() or None,
         )


### PR DESCRIPTION
## Summary

The /goal judge no longer pauses on reasoning-heavy aux models due to a truncated JSON verdict.

Root cause (diagnosed live by @helix4u): `max_tokens=200` was hardcoded for the freeform judge call. Reasoning models burn that budget on hidden reasoning before emitting the visible JSON, and the first /goal turn's prompt is larger than later turns, so the verdict gets cut mid-string (`'{"done": true, "reason": "The agent successfully'`). 5 consecutive parse failures → goal auto-pauses with a misleading 'judge model isn't returning the required JSON verdict' message. Affects users on Nous Plus with deepseek-v4-pro / qwq-style judges.

## Changes

- `hermes_cli/goals.py`
  - `DEFAULT_JUDGE_MAX_TOKENS = 4096` (up from 200)
  - New `auxiliary.goal_judge.max_tokens` config knob for further tuning
  - `_goal_judge_max_tokens()` resolves the value with fail-open semantics (non-int / non-positive / load failure → default). `load_config()` is mtime-cached so per-turn lookup is cheap.

Scoped narrowly to the verified root cause. Does **not** introduce the `submit_verdict` tool-call schema explored in #26162 / #23671 — that direction can land separately if we decide we want it.

## Validation

| | Before | After |
|---|---|---|
| Reasoning model judge on first /goal turn | Truncated JSON → parse fail → /goal pauses | Verdict fits in budget → continues normally |
| Targeted tests (goals + cli_goal_interrupt + goal_verdict_send) | 62/62 passing | 62/62 passing (no regressions, no new tests — existing coverage doesn't assert max_tokens value) |
| Config override (`max_tokens: 8192`) | n/a | Honored |
| Garbage / zero / missing override | n/a | Falls back to 4096 |
| No auxiliary section at all | n/a | Falls back to 4096 |

E2E run with isolated `HERMES_HOME` against the worktree confirmed all five branches.

## Credits

- @helix4u (Gille) — diagnosed the truncation via live testing on an unmodified worktree, drafted the original fix shape in #26162
- @AhmetArif0 — flagged the freeform judge fragility in #23671 from the tool-call angle
- @0xharryriddle (HarryRiddle.eth) — reported the failure from a Nous Plus subscription setup in #23876 with full debug reports

Closes #23876
Supersedes #26162, #23671, #23881