### PR TITLE
fix(prompt): widen HERMES_AGENT_HELP_GUIDANCE for uncertainty triggers

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -144,7 +144,16 @@ DEFAULT_AGENT_IDENTITY = (
 HERMES_AGENT_HELP_GUIDANCE = (
     "If the user asks about configuring, setting up, or using Hermes Agent "
     "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "before answering. Docs: https://hermes-agent.nousresearch.com/docs"
+    "before answering. Also use this skill when you are uncertain about "
+    "your own capabilities — whether a feature exists, how something is configured, "
+    "or if your cached knowledge about a feature seems stale or incomplete. "
+    "Hermes is open-source; when docs are ambiguous, read the actual source code "
+    "at `~/.hermes/hermes-agent/` as ground truth, or check `hermes --help` and "
+    "`hermes <subcommand> --help` for CLI verification. "
+    "Docs: https://hermes-agent.nousresearch.com/docs. "
+    "See live-documentation-sources.md in the hermes-agent skill "
+    "for a structured lookup table mapping feature categories to docs, "
+    "source paths, and verification commands."
 )
 
 MEMORY_GUIDANCE = (

--- a/skills/autonomous-ai-agents/hermes-agent/references/live-documentation-sources.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/live-documentation-sources.md
@@ -1,0 +1,51 @@
+# Live Documentation Sources
+
+Structured lookup table for verifying Hermes Agent capabilities when uncertain.
+
+When you're unsure whether a feature exists, how it's configured, or how something works, use this table to find the canonical source of truth — from most authoritative (source code) to quickest (CLI --help).
+
+## Feature Category Reference
+
+| Category | Source Code (ground truth) | CLI Verification | Docs URL |
+|----------|---------------------------|------------------|----------|
+| **Core agent loop** | `run_agent.py` — `AIAgent.run_conversation()` | `hermes chat -q "test"` | https://hermes-agent.nousresearch.com/docs/guide/agent-loop |
+| **CLI commands** | `cli.py` — `HermesCLI.process_command()` + `hermes_cli/commands.py` — `COMMAND_REGISTRY` | `hermes --help` → `hermes <cmd> --help` | https://hermes-agent.nousresearch.com/docs/cli/commands |
+| **Tools** | `tools/registry.py` — tool auto-discovery; `tools/*.py` — individual tool impls | `hermes tools list` | https://hermes-agent.nousresearch.com/docs/guide/tools |
+| **MCP servers** | `mcp_serve.py` + `tools/mcp/` | `hermes mcp list` (or check `config.yaml` → `mcp_servers`) | https://hermes-agent.nousresearch.com/docs/guide/mcp |
+| **Cron/scheduling** | `cron/scheduler.py` — `run_job()`, `cron/jobs.py` | `cronjob list` | https://hermes-agent.nousresearch.com/docs/guide/cron |
+| **Gateway (platforms)** | `gateway/run.py` — `Gateway.run()`, `gateway/platforms/*.py` — per-platform adapters | `hermes gateway status` | https://hermes-agent.nousresearch.com/docs/gateway/intro |
+| **Memory** | `tools/memory_tool.py` — memory tool handler; `plugins/memory/` — memory backends | `hermes doctor` (checks memory subsystem) | https://hermes-agent.nousresearch.com/docs/guide/memory |
+| **Skills** | `hermes_cli/skills.py` — skill loader; `skills/*/SKILL.md` — bundled skills | `skills_list` | https://hermes-agent.nousresearch.com/docs/guide/skills |
+| **Config** | `hermes_constants.py` — `get_hermes_home()`, path resolution; config YAML at `~/.hermes/config.yaml` | `hermes config list` or cat `~/.hermes/config.yaml` | https://hermes-agent.nousresearch.com/docs/guide/configuration |
+| **Provider/Models** | `plugins/model-providers/` — provider adapters; `agent/model_metadata.py` — model metadata | `/model` (in-chat model picker), `hermes model` | https://hermes-agent.nousresearch.com/docs/guide/providers |
+| **Plugins** | `plugins/` — plugin index; each subdir has its own `README.md` or `plugin.py` | `hermes plugins list` | https://hermes-agent.nousresearch.com/docs/plugins/intro |
+| **Auth/Credentials** | `agent/credential_pool.py` — credential pool rotation; `agent/auth.py` — OAuth flows | Check `~/.hermes/auth.json` and `~/.hermes/.env` | https://hermes-agent.nousresearch.com/docs/guide/authentication |
+| **Profiles** | `hermes_constants.py` — profile-aware path resolution | `hermes -p <name> chat` | https://hermes-agent.nousresearch.com/docs/guide/profiles |
+| **Kanban boards** | `hermes_cli/kanban_db.py` — SQLite-backed board DB | `hermes kanban boards list` | https://hermes-agent.nousresearch.com/docs/guide/kanban |
+| **Agent/Subagent** | `run_agent.py` — main agent loop; `tools/delegate_task.py` — subagent spawning | `hermes chat` (main), `delegate_task` tool (subagent) | https://hermes-agent.nousresearch.com/docs/guide/subagents |
+| **Setup wizard** | `hermes_cli/setup_wizard.py` — interactive config wizard | `hermes setup` | https://hermes-agent.nousresearch.com/docs/guide/setup |
+| **Debug/Health** | `hermes_cli/doctor.py` — `hermes doctor` | `hermes doctor` | https://hermes-agent.nousresearch.com/docs/guide/troubleshooting |
+| **Plugins: image_gen** | `plugins/image_gen/` — image generation providers | `hermes plugins list` | (plugin-specific docs) |
+| **Plugins: observability** | `plugins/observability/` — metrics, traces, logging | `hermes plugins list` | (plugin-specific docs) |
+| **TUI** | `ui-tui/src/` (TypeScript/React) + `tui_gateway/` (Python backend) | `hermes --tui` | https://hermes-agent.nousresearch.com/docs/guide/tui |
+
+## Three-Tier Fallback
+
+When uncertain about a capability:
+
+1. **Docs first** — check the Docs URL column above. If the docs are clear, use that.
+2. **Source code as ground truth** — Hermes is open-source. Read the actual source at `~/.hermes/hermes-agent/<path>`. The source code never lies.
+3. **CLI verification** — run the CLI verification command to confirm behavior at runtime.
+
+## Quick Diagnostic Commands
+
+```bash
+hermes doctor          # Full health check
+hermes config list     # Show current config
+hermes tools list      # Show available tools
+hermes plugins list    # Show loaded plugins
+hermes --help          # CLI reference
+hermes <cmd> --help    # Per-command help
+cat ~/.hermes/config.yaml  # Raw config
+ls ~/.hermes/hermes-agent/ # Source tree
+```

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    HERMES_AGENT_HELP_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -48,6 +49,18 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_hermes_agent_help_guidance_covers_uncertainty_triggers(self):
+        # Still covers original trigger
+        assert "configuring, setting up, or using" in HERMES_AGENT_HELP_GUIDANCE
+        # New uncertainty triggers
+        assert "uncertain about" in HERMES_AGENT_HELP_GUIDANCE
+        assert "your own capabilities" in HERMES_AGENT_HELP_GUIDANCE
+        assert "cached knowledge" in HERMES_AGENT_HELP_GUIDANCE
+        # Source code as ground truth
+        assert "source code" in HERMES_AGENT_HELP_GUIDANCE
+        # Reference to the new lookup table
+        assert "live-documentation-sources.md" in HERMES_AGENT_HELP_GUIDANCE
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Closes #26167

When Hermes Agent is uncertain about its own capabilities — whether a feature exists, how something is configured, or if cached knowledge seems stale — it currently has no trigger to check documentation or source code. The only existing guidance (`HERMES_AGENT_HELP_GUIDANCE`) fires only on the narrow trigger: "if the user asks about configuring, setting up, or using Hermes Agent itself."

## Changes

### 1. `agent/prompt_builder.py` — widened `HERMES_AGENT_HELP_GUIDANCE`

Added uncertainty-aware triggers alongside the existing config/setup trigger:
- "if you are uncertain about your own capabilities"
- "if your cached knowledge about a feature seems stale or incomplete"

Also added a three-tier fallback instruction:
1. Docs first
2. Source code as ground truth (Hermes is open-source)
3. CLI --help verification

And a pointer to the new reference file in the hermes-agent skill.

### 2. `skills/autonomous-ai-agents/hermes-agent/references/live-documentation-sources.md` (NEW)

Structured lookup table mapping 20 Hermes feature categories to:
- Source code paths (ground truth)
- CLI verification commands
- Docs URLs

Includes a "Three-Tier Fallback" guide and quick diagnostic commands section.

### 3. `tests/agent/test_prompt_builder.py` — new test

`test_hermes_agent_help_guidance_covers_uncertainty_triggers` verifies:
- Original trigger still present
- New uncertainty triggers present
- Source code guidance present
- Reference to live-documentation-sources.md present

## Design Principles

- Zero token cost when not triggered (string constant, only injected when model's conversation warrants it)
- Hermes is open-source and locally installed — agent can read actual source code as ground truth
- Three-tier fallback (docs -> source -> CLI) leverages Hermes' openness uniquely among AI agents

## Testing

All 3 tests in `TestGuidanceConstants` pass:
- `test_memory_guidance_discourages_task_logs`
- `test_session_search_guidance_is_simple_cross_session_recall`
- `test_hermes_agent_help_guidance_covers_uncertainty_triggers` (NEW)