### PR TITLE
fix(tui): memo StatusRule + stabilize props to prevent duplicate layers on scroll

### DIFF
--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,6 +1,6 @@
 import { Box, type ScrollBoxHandle, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
@@ -270,7 +270,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   return <Text color={color}>♥</Text>
 }
 
-export function StatusRule({
+export const StatusRule = memo(function StatusRule({
   cwdLabel,
   cols,
   busy,
@@ -353,7 +353,7 @@ export function StatusRule({
       <Text color={t.color.label}>{cwdLabel}</Text>
     </Box>
   )
-}
+})
 
 export function FloatBox({ children, color }: { children: ReactNode; color: string }) {
   return (

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -348,25 +348,53 @@ const StatusRulePane = memo(function StatusRulePane({
     return null
   }
 
+  // Memoize primitive props so StatusRule (memo'd) doesn't re-render
+  // on every scroll event that produces a new status object reference.
+  const ruleProps = useMemo(
+    () => ({
+      bgCount: ui.bgTasks.size,
+      busy: ui.busy,
+      cols: composer.cols,
+      cwdLabel: status.cwdLabel,
+      model: ui.info?.model ?? '',
+      modelFast: ui.info?.fast || ui.info?.service_tier === 'priority',
+      modelReasoningEffort: ui.info?.reasoning_effort,
+      sessionStartedAt: status.sessionStartedAt,
+      showCost: ui.showCost,
+      status: ui.status,
+      statusColor: status.statusColor,
+      turnStartedAt: status.turnStartedAt,
+      usage: ui.usage,
+      voiceLabel: status.voiceLabel,
+    }),
+    [
+      ui.bgTasks.size,
+      ui.busy,
+      composer.cols,
+      status.cwdLabel,
+      ui.info?.model,
+      ui.info?.fast,
+      ui.info?.service_tier,
+      ui.info?.reasoning_effort,
+      status.sessionStartedAt,
+      ui.showCost,
+      ui.status,
+      status.statusColor,
+      status.turnStartedAt,
+      status.voiceLabel,
+      // usage changes on every token event — always re-compute
+      ui.usage?.context_percent,
+      ui.usage?.context_used,
+      ui.usage?.context_max,
+      ui.usage?.total,
+      ui.usage?.compressions,
+      ui.usage?.cost_usd,
+    ]
+  )
+
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
-      <StatusRule
-        bgCount={ui.bgTasks.size}
-        busy={ui.busy}
-        cols={composer.cols}
-        cwdLabel={status.cwdLabel}
-        model={ui.info?.model ?? ''}
-        modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
-        modelReasoningEffort={ui.info?.reasoning_effort}
-        sessionStartedAt={status.sessionStartedAt}
-        showCost={ui.showCost}
-        status={ui.status}
-        statusColor={status.statusColor}
-        t={ui.theme}
-        turnStartedAt={status.turnStartedAt}
-        usage={ui.usage}
-        voiceLabel={status.voiceLabel}
-      />
+      <StatusRule t={ui.theme} {...ruleProps} />
     </Box>
   )
 })


### PR DESCRIPTION
## Summary

Fix #25768 — TUI status bar renders duplicate layers after scrolling the transcript.

Root cause: `StatusRule` was unmemoized, causing a re-render on every scroll event that triggered a status store update. `StatusRulePane` passed object props (status, ui.usage) by reference — new object references every tick caused unnecessary reconcile cycles that eventually produced duplicate StatusRule layers.

## Fix

1. `StatusRule` wrapped in `memo()` — only re-renders when primitive props actually change
2. `StatusRulePane` uses `useMemo` to extract and stable-ize all primitive props before passing to `StatusRule` — scroll events that don't change status values no longer trigger StatusRule re-renders

## Testing

- Existing `test_cli_status_bar.py` tests pass
- Manual: scroll transcript up/down repeatedly — no duplicate status bar layers

Fixes #25768