### PR TITLE
feat(plugins): add Cognee as an external memory plugin

### DIFF
--- a/external_plugins/memory/cognee/README.md
+++ b/external_plugins/memory/cognee/README.md
@@ -1,0 +1,54 @@
+# Cognee memory plugin
+
+This directory is a standalone Hermes memory plugin. It is no longer meant to
+live under the bundled `plugins/memory/` tree.
+
+Install it by copying this folder to your Hermes home:
+
+```bash
+mkdir -p ~/.hermes/plugins
+cp -R external_plugins/memory/cognee ~/.hermes/plugins/cognee
+hermes config set memory.provider cognee
+```
+
+Then add the required environment variables to the active profile `.env` file.
+The easiest path is:
+
+```bash
+hermes memory setup
+```
+
+You can also set the values manually:
+
+```bash
+echo "LLM_API_KEY=sk-..." >> ~/.hermes/.env
+echo "LLM_PROVIDER=deepseek" >> ~/.hermes/.env
+echo "LLM_BASE_URL=https://api.deepseek.com/v1" >> ~/.hermes/.env
+echo "GEMINI_API_KEY=..." >> ~/.hermes/.env
+echo "COGNEE_SKIP_CONNECTION_TEST=true" >> ~/.hermes/.env
+```
+
+What you need installed:
+
+- `pip install cognee>=1.0.9`
+- an OpenAI-compatible chat model backend for `LLM_API_KEY`
+- a Gemini embedding key, or equivalent embedding setup supported by Cognee
+- when using `gemini/gemini-embedding-001`, Hermes sets `EMBEDDING_DIMENSIONS=3072`
+
+What the plugin exposes:
+
+- `cognee_remember` to store durable facts
+- `cognee_recall` to retrieve semantic and graph-linked memories
+- `cognee_forget` to delete stored memories, guarded by `confirm=true`
+
+Cognee also runs background flows:
+
+- `queue_prefetch` before turns to fetch likely-relevant memories
+- `sync_turn` after responses to persist useful conversation state
+- `on_session_end` to flush the last part of the conversation
+
+Notes:
+
+- The default dataset name is `hermes_memory`.
+- For faster tests, set `COGNEE_SKIP_CONNECTION_TEST=true`.
+- For persistent graph storage beyond in-memory NetworkX, configure Cognee to use a durable graph backend such as Neo4j.

--- a/external_plugins/memory/cognee/__init__.py
+++ b/external_plugins/memory/cognee/__init__.py
@@ -1,0 +1,420 @@
+"""Cognee memory provider for Hermes Agent."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from hermes_cli.config import save_env_value
+from tools.registry import tool_error
+
+from .client import (
+    CogneeClientConfig,
+    cognee_forget,
+    cognee_recall,
+    cognee_remember,
+    ensure_wal_mode,
+    run_async,
+    serialize_result,
+    stop_event_loop,
+)
+
+logger = logging.getLogger(__name__)
+
+_PREFETCH_TIMEOUT = 8.0
+_SYNC_TIMEOUT = 20.0
+_TOOL_TIMEOUT = 60.0
+_SESSION_END_TIMEOUT = 90.0
+_MIN_TURN_LENGTH = 16
+
+REMEMBER_SCHEMA = {
+    "name": "cognee_remember",
+    "description": (
+        "Store durable memory in Cognee. Use for explicit user preferences, stable facts, "
+        "project context, documents, or URLs that should become searchable later."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Text, path, or URL to store."},
+            "dataset_name": {"type": "string", "description": "Optional Cognee dataset name. Defaults to Hermes dataset."},
+            "session_scoped": {"type": "boolean", "description": "Store as fast session memory first (default false)."},
+            "self_improvement": {"type": "boolean", "description": "Let Cognee bridge/enrich memory automatically (default true)."},
+        },
+        "required": ["content"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "cognee_recall",
+    "description": (
+        "Recall relevant context from Cognee memory using semantic/graph/session retrieval. "
+        "Use when past facts or project context may help answer the user."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language memory query."},
+            "dataset_name": {"type": "string", "description": "Optional Cognee dataset to search."},
+            "top_k": {"type": "integer", "description": "Maximum results. Defaults to 10."},
+            "only_context": {"type": "boolean", "description": "Return retrieved context without final Cognee answer."},
+            "session_scoped": {"type": "boolean", "description": "Include current session cache in recall (default true)."},
+        },
+        "required": ["query"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "cognee_forget",
+    "description": (
+        "Delete or reset Cognee memory. Use only when the user explicitly asks to forget/delete data."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dataset_name": {"type": "string", "description": "Dataset to forget/reset."},
+            "data_id": {"type": "string", "description": "Optional specific data/item id to forget if supported by Cognee."},
+            "confirm": {"type": "boolean", "description": "Must be true to execute deletion."},
+        },
+        "required": ["confirm"],
+    },
+}
+
+
+def _json_result(**payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _clean_turn_text(text: str) -> str:
+    return (text or "").strip()
+
+
+async def _init_cognee_loop() -> None:
+    """Warm up cognee on the background event loop so that asyncio locks
+    (used by LadybugDB and cognee's pipeline runner) are created on the
+    same loop where ``_handle_remember`` / ``_handle_recall`` will run.
+    """
+    import cognee.infrastructure.llm.config as _lc
+    _lc.get_llm_config()
+    import cognee.infrastructure.databases.vector.embeddings.config as _ec
+    _ec.get_embedding_config()
+
+
+class CogneeMemoryProvider(MemoryProvider):
+    """Cognee v1 memory provider with automatic recall and turn capture."""
+
+    def __init__(self) -> None:
+        self._config = CogneeClientConfig.from_global_config()
+        self._session_id = ""
+        self._hermes_home = ""
+        self._agent_context = "primary"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+        self._initialized = False
+
+    @property
+    def name(self) -> str:
+        return "cognee"
+
+    def is_available(self) -> bool:
+        cfg = CogneeClientConfig.from_global_config()
+        return bool(cfg.enabled and cfg.api_key and importlib.util.find_spec("cognee"))
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "api_key",
+                "description": "LLM API key used by Cognee for graph extraction and recall",
+                "secret": True,
+                "required": True,
+                "env_var": "LLM_API_KEY",
+                "url": "https://docs.cognee.ai/setup-configuration/llm-configuration",
+            },
+            {
+                "key": "provider",
+                "description": "Cognee LLM provider",
+                "default": "openai",
+                "env_var": "LLM_PROVIDER",
+            },
+            {
+                "key": "base_url",
+                "description": "Optional OpenAI-compatible base URL for the Cognee LLM provider",
+                "required": False,
+                "env_var": "LLM_BASE_URL",
+            },
+            {
+                "key": "dataset_name",
+                "description": "Default Cognee dataset for Hermes durable memory",
+                "default": "hermes_memory",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Persist Cognee setup values.
+
+        The generic memory setup flow writes secret env vars itself. This method
+        also supports direct calls and writes all provided env-var fields to
+        ``$HERMES_HOME/.env`` through Hermes' config helper.
+        """
+
+        env_keys = {
+            "api_key": "LLM_API_KEY",
+            "provider": "LLM_PROVIDER",
+            "base_url": "LLM_BASE_URL",
+        }
+        for key, env_var in env_keys.items():
+            value = values.get(key)
+            if value:
+                save_env_value(env_var, str(value))
+
+        non_secret = {k: v for k, v in values.items() if k not in env_keys and v not in (None, "")}
+        if non_secret:
+            cfg_path = Path(hermes_home) / "cognee.json"
+            existing: Dict[str, Any] = {}
+            if cfg_path.exists():
+                try:
+                    raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+                    if isinstance(raw, dict):
+                        existing = raw
+                except Exception:
+                    existing = {}
+            existing.update(non_secret)
+            cfg_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._config = CogneeClientConfig.from_global_config()
+        self._config.apply_to_environment()
+        self._session_id = session_id or ""
+        self._hermes_home = str(kwargs.get("hermes_home") or "")
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        self._initialized = True
+        # Warm up cognee on the background loop so asyncio locks
+        # are created on the right event loop, not the agent's main loop.
+        try:
+            run_async(_init_cognee_loop(), timeout=5.0)
+        except Exception:
+            logger.debug("Cognee background init (non-fatal)", exc_info=True)
+
+    def system_prompt_block(self) -> str:
+        dataset = self._config.dataset_name
+        return (
+            "# Cognee Memory (Primary Provider)\n"
+            f"Cognee is the ONLY active memory provider. Default dataset: {dataset}.\n"
+            "Cognee provides vector + knowledge-graph recall with semantic search.\n"
+            "The built-in `memory` tool is DISABLED — do NOT use it.\n"
+            "Use `cognee_remember` to save durable facts, `cognee_recall` for explicit searches, "
+            "and `cognee_forget` only after an explicit deletion request."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=0.25)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"<cognee-memory>\n{result}\n</cognee-memory>"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        query = (query or "").strip()
+        if not query or not self._initialized:
+            return
+
+        effective_session = session_id or self._session_id
+
+        def _run() -> None:
+            try:
+                result = run_async(
+                    cognee_recall(
+                        query,
+                        session_id=effective_session or None,
+                        datasets=[self._config.dataset_name],
+                        top_k=5,
+                        only_context=True,
+                    ),
+                    timeout=_PREFETCH_TIMEOUT,
+                )
+                serialized = serialize_result(result)
+                if serialized:
+                    with self._prefetch_lock:
+                        self._prefetch_result = self._format_recall(serialized)
+            except Exception as exc:
+                logger.debug("Cognee prefetch failed: %s", exc)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="cognee-prefetch")
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._agent_context != "primary":
+            return
+        user_content = _clean_turn_text(user_content)
+        assistant_content = _clean_turn_text(assistant_content)
+        if len(user_content) + len(assistant_content) < _MIN_TURN_LENGTH:
+            return
+
+        effective_session = session_id or self._session_id
+        turn_text = f"[user]\n{user_content}\n\n[assistant]\n{assistant_content}"
+
+        def _sync() -> None:
+            try:
+                run_async(
+                    cognee_remember(
+                        turn_text,
+                        session_id=effective_session or None,
+                        dataset_name=self._config.dataset_name,
+                        self_improvement=True,
+                    ),
+                    timeout=_SYNC_TIMEOUT,
+                )
+            except Exception as exc:
+                logger.warning("Cognee turn sync failed: %s", exc)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=1.0)
+        self._sync_thread = threading.Thread(target=_sync, daemon=True, name="cognee-sync")
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [REMEMBER_SCHEMA, RECALL_SCHEMA, FORGET_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        try:
+            if tool_name == "cognee_remember":
+                return self._handle_remember(args)
+            if tool_name == "cognee_recall":
+                return self._handle_recall(args)
+            if tool_name == "cognee_forget":
+                return self._handle_forget(args)
+            return tool_error(f"Unknown Cognee tool: {tool_name}")
+        except Exception as exc:
+            logger.warning("Cognee tool %s failed: %s", tool_name, exc)
+            return tool_error(str(exc))
+
+    def _handle_remember(self, args: Dict[str, Any]) -> str:
+        content = str(args.get("content") or "").strip()
+        if not content:
+            return tool_error("content is required")
+        self._config = CogneeClientConfig.from_global_config()
+        self._config.apply_to_environment()
+        # Clear cognee's cached config so it picks up fresh env vars
+        import cognee.infrastructure.llm.config as _lc
+        _lc.get_llm_config.cache_clear()
+        import cognee.infrastructure.databases.vector.embeddings.config as _ec
+        _ec.get_embedding_config.cache_clear()
+        session_scoped = bool(args.get("session_scoped", False))
+        dataset_name = str(args.get("dataset_name") or self._config.dataset_name)
+        result = run_async(
+            cognee_remember(
+                content,
+                dataset_name=dataset_name,
+                session_id=self._session_id if session_scoped else None,
+                self_improvement=args.get("self_improvement", True),
+            ),
+            timeout=_TOOL_TIMEOUT,
+        )
+        return _json_result(ok=True, result=serialize_result(result))
+
+    def _handle_recall(self, args: Dict[str, Any]) -> str:
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return tool_error("query is required")
+        self._config = CogneeClientConfig.from_global_config()
+        self._config.apply_to_environment()
+        # Clear cognee's cached config so it picks up fresh env vars
+        import cognee.infrastructure.llm.config as _lc
+        _lc.get_llm_config.cache_clear()
+        import cognee.infrastructure.databases.vector.embeddings.config as _ec
+        _ec.get_embedding_config.cache_clear()
+        dataset_name = str(args.get("dataset_name") or self._config.dataset_name)
+        session_scoped = args.get("session_scoped", True)
+        kwargs: Dict[str, Any] = {
+            "datasets": [dataset_name] if dataset_name else None,
+            "session_id": self._session_id if session_scoped else None,
+            "top_k": int(args.get("top_k") or 10),
+            "only_context": bool(args.get("only_context", False)),
+        }
+        result = run_async(cognee_recall(query, **kwargs), timeout=_TOOL_TIMEOUT)
+        return _json_result(ok=True, result=serialize_result(result))
+
+    def _handle_forget(self, args: Dict[str, Any]) -> str:
+        if args.get("confirm") is not True:
+            return tool_error("cognee_forget requires confirm=true after an explicit user deletion request")
+        dataset_name = str(args.get("dataset_name") or self._config.dataset_name)
+        data_id = str(args.get("data_id") or "").strip()
+        kwargs: Dict[str, Any] = {"dataset": dataset_name}
+        if data_id:
+            kwargs["data_id"] = data_id
+        result = run_async(cognee_forget(**kwargs), timeout=_TOOL_TIMEOUT)
+        return _json_result(ok=True, result=serialize_result(result))
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if self._agent_context != "primary" or not messages:
+            return
+        chunks: List[str] = []
+        for msg in messages[-40:]:
+            role = msg.get("role")
+            content = msg.get("content")
+            if role not in {"user", "assistant"} or not isinstance(content, str) or not content.strip():
+                continue
+            chunks.append(f"[{role}] {content.strip()}")
+        if not chunks:
+            return
+        payload = "Session transcript excerpt for durable memory extraction:\n\n" + "\n\n".join(chunks)
+        try:
+            run_async(
+                cognee_remember(
+                    payload,
+                    dataset_name=self._config.dataset_name,
+                    session_ids=[self._session_id] if self._session_id else None,
+                    self_improvement=True,
+                    run_in_background=True,
+                ),
+                timeout=_SESSION_END_TIMEOUT,
+            )
+        except Exception as exc:
+            logger.warning("Cognee session-end save failed: %s", exc)
+
+    def on_session_switch(self, new_session_id: str, *, reset: bool = False, **kwargs: Any) -> None:
+        self._session_id = new_session_id or ""
+        if reset:
+            with self._prefetch_lock:
+                self._prefetch_result = ""
+
+    def shutdown(self) -> None:
+        for thread in (self._prefetch_thread, self._sync_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=2.0)
+        stop_event_loop()
+
+    @staticmethod
+    def _format_recall(result: Any) -> str:
+        if isinstance(result, str):
+            return result
+        if isinstance(result, list):
+            lines = []
+            for item in result[:10]:
+                if isinstance(item, dict):
+                    text = item.get("text") or item.get("content") or item.get("memory") or item.get("answer") or json.dumps(item, ensure_ascii=False)
+                else:
+                    text = str(item)
+                if text:
+                    lines.append(f"- {text}")
+            return "\n".join(lines)
+        if isinstance(result, dict):
+            for key in ("answer", "result", "context", "content", "text"):
+                if result.get(key):
+                    value = result[key]
+                    return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+            return json.dumps(result, ensure_ascii=False)
+        return str(result)
+
+
+__all__ = ["CogneeMemoryProvider"]

--- a/external_plugins/memory/cognee/cli.py
+++ b/external_plugins/memory/cognee/cli.py
@@ -1,0 +1,42 @@
+"""CLI helpers for the Cognee memory provider."""
+
+from __future__ import annotations
+
+from getpass import getpass
+from typing import Any
+
+from hermes_cli.config import get_env_path, save_env_value
+
+
+def _prompt(default: str = "", *, label: str) -> str:
+    suffix = f" [{default}]" if default else ""
+    value = input(f"{label}{suffix}: ").strip()
+    return value or default
+
+
+def cmd_setup(args: Any = None) -> None:
+    """Interactive Cognee setup.
+
+    Stores secrets in Hermes' profile-scoped .env file. The generic
+    ``hermes memory setup`` path can use CogneeMemoryProvider.get_config_schema();
+    this helper exists for plugin-specific routing if needed later.
+    """
+
+    print("\nCognee memory setup\n")
+    api_key = getpass("LLM API key for Cognee (LLM_API_KEY): ").strip()
+    provider = _prompt("openai", label="LLM provider (LLM_PROVIDER)")
+    base_url = _prompt("", label="Optional LLM base URL (LLM_BASE_URL)")
+    dataset_name = _prompt("hermes_memory", label="Default Cognee dataset (COGNEE_DATASET_NAME)")
+
+    if api_key:
+        save_env_value("LLM_API_KEY", api_key)
+    if provider:
+        save_env_value("LLM_PROVIDER", provider)
+    if base_url:
+        save_env_value("LLM_BASE_URL", base_url)
+    if dataset_name:
+        save_env_value("COGNEE_DATASET_NAME", dataset_name)
+
+    print(f"\nSaved Cognee environment config to {get_env_path()}")
+    print("Enable it with: hermes config set memory.provider cognee")
+    print("Restart Hermes after enabling the provider.\n")

--- a/external_plugins/memory/cognee/client.py
+++ b/external_plugins/memory/cognee/client.py
@@ -1,0 +1,360 @@
+"""Cognee client configuration and sync bridge.
+
+Cognee exposes async ``remember`` / ``recall`` APIs. Hermes memory providers are
+synchronous, so this module owns one background asyncio loop and exposes a small
+``run_async`` helper for safe sync calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict
+
+from hermes_cli.config import cfg_get, load_config
+from hermes_constants import get_hermes_home
+
+# ---- Stale instructor cache scrub at module load time ----
+# instructor 1.15.x caches import chains for optional backends (mistralai,
+# google, etc.) at its first import.  If a backend was installed when
+# instructor was first loaded and later removed, the stale chain survives
+# in sys.modules and causes ImportError on any import cognee.
+# We must scrub before importing anything that triggers instructor.
+import sys as _sys
+for _k in list(_sys.modules):
+    if _k.startswith("instructor.") or _k == "instructor" or _k == "mistralai":
+        del _sys.modules[_k]
+del _k, _sys
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PROVIDER = "openai"
+_DEFAULT_DATASET = "hermes_memory"
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_loop_lock = threading.Lock()
+
+
+@dataclass
+class CogneeClientConfig:
+    """Runtime config for the Cognee SDK."""
+
+    api_key: str = ""
+    provider: str = _DEFAULT_PROVIDER
+    base_url: str = ""
+    dataset_name: str = _DEFAULT_DATASET
+    enabled: bool = True
+
+    @classmethod
+    def from_global_config(cls) -> "CogneeClientConfig":
+        """Read Cognee config from Hermes config.yaml and environment.
+
+        Resolution order is: environment variables override config.yaml, and
+        config.yaml overrides safe defaults. Secrets live in ``.env`` via the
+        env vars below; non-secrets may be stored under ``memory.cognee``.
+        """
+
+        try:
+            cfg = load_config()
+        except Exception:
+            logger.debug("Failed to load Hermes config for Cognee", exc_info=True)
+            cfg = {}
+
+        mem_cfg = cfg_get(cfg, "memory", "cognee", default={}) or {}
+        model_cfg = cfg_get(cfg, "model", default={}) or {}
+        try:
+            file_cfg_path = get_hermes_home() / "cognee.json"
+            if file_cfg_path.exists():
+                import json
+                file_cfg = json.loads(file_cfg_path.read_text(encoding="utf-8"))
+                if isinstance(file_cfg, dict):
+                    mem_cfg = {**mem_cfg, **{k: v for k, v in file_cfg.items() if v not in (None, "")}}
+        except Exception:
+            logger.debug("Failed to load Cognee provider config file", exc_info=True)
+
+        provider = (
+            os.environ.get("LLM_PROVIDER")
+            or os.environ.get("COGNEE_LLM_PROVIDER")
+            or str(mem_cfg.get("provider") or mem_cfg.get("llm_provider") or "").strip()
+            or str(model_cfg.get("provider") or "").strip()
+            or _DEFAULT_PROVIDER
+        )
+        api_key = (
+            os.environ.get("LLM_API_KEY")
+            or os.environ.get("COGNEE_LLM_API_KEY")
+            or str(mem_cfg.get("api_key") or "").strip()
+            or str(model_cfg.get("api_key") or "").strip()
+        )
+        base_url = (
+            os.environ.get("LLM_BASE_URL")
+            or os.environ.get("COGNEE_LLM_BASE_URL")
+            or str(mem_cfg.get("base_url") or "").strip()
+            or str(model_cfg.get("base_url") or "").strip()
+        )
+        dataset_name = (
+            os.environ.get("COGNEE_DATASET_NAME")
+            or str(mem_cfg.get("dataset_name") or "").strip()
+            or _DEFAULT_DATASET
+        )
+        enabled = mem_cfg.get("enabled", True)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() not in {"0", "false", "no", "off"}
+
+        return cls(
+            api_key=api_key,
+            provider=provider,
+            base_url=base_url,
+            dataset_name=dataset_name,
+            enabled=bool(enabled),
+        )
+
+    def apply_to_environment(self) -> None:
+        """Expose config in the env names Cognee v1.0 understands.
+
+        Uses direct assignment (not ``setdefault``) for the provider's own
+        env vars so that values stay correct even when another component
+        (e.g. an inference provider) has already set the same var before
+        the memory provider was initialised.
+        """
+
+        if self.api_key:
+            os.environ["LLM_API_KEY"] = self.api_key
+        if self.provider:
+            os.environ["LLM_PROVIDER"] = self.provider
+        if self.base_url:
+            os.environ["LLM_BASE_URL"] = self.base_url
+            os.environ["LLM_ENDPOINT"] = self.base_url
+        if self.provider == "deepseek":
+            os.environ["LLM_MODEL"] = "deepseek/deepseek-chat"
+            gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY") or ""
+            if gemini_key:
+                os.environ["EMBEDDING_PROVIDER"] = "gemini"
+                os.environ["EMBEDDING_MODEL"] = "gemini/gemini-embedding-001"
+                os.environ["EMBEDDING_DIMENSIONS"] = "3072"
+                os.environ["EMBEDDING_API_KEY"] = gemini_key
+
+        # SQLite multi-process safety — force WAL mode + non-zero busy timeout
+        # so the gateway and agent can both write to Cognee's databases.
+        os.environ.setdefault("DATABASE_CONNECT_ARGS", json.dumps({"timeout": 60}))
+        ensure_wal_mode(timeout_ms=5000)
+
+
+def _loop_worker(loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide background event loop for Cognee calls."""
+
+    global _loop, _loop_thread
+    with _loop_lock:
+        if _loop and _loop.is_running():
+            return _loop
+        _loop = asyncio.new_event_loop()
+        _loop_thread = threading.Thread(target=_loop_worker, args=(_loop,), daemon=True, name="cognee-loop")
+        _loop_thread.start()
+        return _loop
+
+
+def run_async(awaitable: Awaitable[Any], timeout: float | None = None) -> Any:
+    """Run an awaitable on the Cognee loop and block for the result."""
+
+    future = asyncio.run_coroutine_threadsafe(awaitable, get_event_loop())
+    return future.result(timeout=timeout)
+
+
+def stop_event_loop(timeout: float = 2.0) -> None:
+    """Stop the global Cognee loop if it is running."""
+
+    global _loop, _loop_thread
+    with _loop_lock:
+        loop = _loop
+        thread = _loop_thread
+        _loop = None
+        _loop_thread = None
+    if loop and loop.is_running():
+        loop.call_soon_threadsafe(loop.stop)
+    if thread and thread.is_alive():
+        thread.join(timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# WAL mode enforcement for multi-process SQLite safety
+# ---------------------------------------------------------------------------
+
+_COGNEE_DB_GLOBS = (
+    ".cognee_system/databases/**/*.lance.db",
+    ".data_storage/**/cache.db",
+    ".cognee_system/**/*.sqlite",
+)
+
+
+def _find_cognee_databases() -> list[str]:
+    """Yield paths to known Cognee SQLite databases on disk."""
+    import cognee
+
+    if hasattr(cognee, "__file__") and cognee.__file__:
+        root = Path(cognee.__file__).resolve().parent
+        found: list[str] = []
+        for pattern in _COGNEE_DB_GLOBS:
+            found.extend(str(p) for p in root.glob(pattern))
+        return found
+    return []
+
+
+def ensure_wal_mode(timeout_ms: int = 5000) -> None:
+    """Set WAL journal mode + busy timeout on all Cognee SQLite databases.
+
+    SQLite's default ``delete`` journal mode serialises all writers, causing
+    ``database is locked`` when two processes (e.g. gateway + agent) access
+    Cognee concurrently.  WAL mode allows one writer + multiple readers,
+    and a non-zero busy timeout makes writers retry instead of failing fast.
+
+    This is idempotent — WAL mode is stored in the database file header and
+    persists across restarts.  Safe to call on every ``initialize()``.
+    """
+    try:
+        import cognee
+    except Exception:
+        logger.debug("Cognee not importable — skipping WAL setup")
+        return
+
+    dbs = _find_cognee_databases()
+    if not dbs:
+        logger.debug("No Cognee SQLite databases found for WAL setup")
+        return
+
+    for path in dbs:
+        try:
+            conn = sqlite3.connect(str(path), timeout=timeout_ms / 1000)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(f"PRAGMA busy_timeout={timeout_ms}")
+            conn.close()
+            logger.debug("WAL mode set on %s", path)
+        except Exception as exc:
+            logger.warning("Could not set WAL on %s: %s", path, exc)
+
+
+# ---------------------------------------------------------------------------
+# Instructor import compatibility shim
+# ---------------------------------------------------------------------------
+
+_INSTRUCTOR_PROVIDERS_INIT = "instructor.providers"
+
+
+def _scrub_stale_instructor_cache() -> None:
+    """Drop cached instructor modules from ``sys.modules``.
+
+    ``instructor`` 1.15.x probes for optional backends (mistralai, google,
+    etc.) via ``importlib.util.find_spec`` at import time.  If a backend was
+    installed when instructor was first loaded and later uninstalled, the
+    stale import chain remains cached and causes ``ImportError`` on
+    subsequent ``import cognee`` in the same process.
+
+    By evicting all instructor modules before we import cognee, we force a
+    fresh re-evaluation of backend availability.
+    """
+    import sys
+
+    keys = [k for k in sys.modules if k.startswith("instructor.") or k == "instructor"]
+    for k in keys:
+        del sys.modules[k]
+
+    # Also purge any empty namespace packages that instructor probes eagerly.
+    # These can linger as namespace packages even after the backend is removed.
+    _stale_namespaces = ("mistralai",)
+    for ns in _stale_namespaces:
+        if ns in sys.modules:
+            del sys.modules[ns]
+
+    # Also flush cached provider init modules since they cached the old
+    # find_spec result at first import time.
+    for k in list(sys.modules):
+        if k.startswith("instructor.providers."):
+            del sys.modules[k]
+
+
+def _call_accepting_kwargs(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Call SDK functions while tolerating minor Cognee signature drift."""
+
+    try:
+        sig = inspect.signature(func)
+        accepts_var_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+        if not accepts_var_kwargs:
+            kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters}
+    except (TypeError, ValueError):
+        pass
+    return func(*args, **kwargs)
+
+
+async def cognee_remember(data: Any, **kwargs: Any) -> Any:
+    _scrub_stale_instructor_cache()
+    import cognee
+
+    result = _call_accepting_kwargs(cognee.remember, data, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def cognee_recall(query_text: str, **kwargs: Any) -> Any:
+    _scrub_stale_instructor_cache()
+    import cognee
+
+    result = _call_accepting_kwargs(cognee.recall, query_text, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def cognee_forget(**kwargs: Any) -> Any:
+    _scrub_stale_instructor_cache()
+    import cognee
+
+    forget = getattr(cognee, "forget", None)
+    if forget is None:
+        prune = getattr(cognee, "prune", None)
+        if prune is None:
+            raise RuntimeError("Installed cognee package has no forget() or prune() API")
+        result = _call_accepting_kwargs(prune, **kwargs)
+    else:
+        result = _call_accepting_kwargs(forget, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+def serialize_result(value: Any) -> Any:
+    """Best-effort JSON-safe serialization for Cognee SDK result objects."""
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): serialize_result(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [serialize_result(v) for v in value]
+    if hasattr(value, "model_dump"):
+        try:
+            return serialize_result(value.model_dump())
+        except Exception:
+            pass
+    if hasattr(value, "dict"):
+        try:
+            return serialize_result(value.dict())
+        except Exception:
+            pass
+    if hasattr(value, "__dict__"):
+        data: Dict[str, Any] = {
+            k: v for k, v in vars(value).items() if not k.startswith("_")
+        }
+        if data:
+            return serialize_result(data)
+    return str(value)

--- a/external_plugins/memory/cognee/plugin.yaml
+++ b/external_plugins/memory/cognee/plugin.yaml
@@ -1,0 +1,7 @@
+name: cognee
+version: 1.0.0
+description: "Cognee memory provider with vector + knowledge-graph recall for Hermes"
+pip_dependencies:
+  - cognee>=1.0.9
+hooks:
+  - on_session_end

--- a/tests/plugins/memory/test_cognee_provider.py
+++ b/tests/plugins/memory/test_cognee_provider.py
@@ -1,0 +1,428 @@
+"""Tests for the standalone Cognee memory plugin loaded from $HERMES_HOME/plugins.
+
+These tests intentionally exercise the user-plugin discovery path instead of
+importing a bundled provider directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+PLUGIN_SOURCE_DIR = (
+    Path(__file__).resolve().parents[3] / "external_plugins" / "memory" / "cognee"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unload_staged_cognee_modules() -> None:
+    for name in list(sys.modules):
+        if name == "_hermes_user_memory.cognee" or name.startswith(
+            "_hermes_user_memory.cognee."
+        ):
+            sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def staged_cognee(tmp_path, monkeypatch):
+    from plugins.memory import load_memory_provider
+
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "cognee"
+    plugins_root.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(PLUGIN_SOURCE_DIR, plugin_dir)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("plugins.memory._get_user_plugins_dir", lambda: plugins_root)
+
+    _unload_staged_cognee_modules()
+    provider = load_memory_provider("cognee")
+    assert provider is not None
+
+    provider_module = importlib.import_module(provider.__class__.__module__)
+    client_module = importlib.import_module(f"{provider.__class__.__module__}.client")
+
+    yield SimpleNamespace(
+        plugin_dir=plugin_dir,
+        provider=provider,
+        provider_cls=provider.__class__,
+        provider_module=provider_module,
+        client_module=client_module,
+        config_cls=client_module.CogneeClientConfig,
+    )
+
+    _unload_staged_cognee_modules()
+
+
+class FakeCogneeAPI:
+    """Stand-in for the async cognee SDK functions."""
+
+    def __init__(self) -> None:
+        self.remembered: list[str] = []
+        self.recalled: list[str] = []
+        self.forgotten: list[dict] = []
+        self.captured_remember: dict = {}
+        self.captured_recall: dict = {}
+
+    async def remember(self, content: str, **kwargs: object) -> dict:
+        self.remembered.append(content)
+        self.captured_remember = {"content": content, **kwargs}
+        return {
+            "status": "completed",
+            "dataset_name": kwargs.get("dataset_name", "hermes_memory"),
+        }
+
+    async def recall(self, query: str, **kwargs: object) -> list[dict]:
+        self.recalled.append(query)
+        self.captured_recall = {"query": query, **kwargs}
+        return [{"kind": "graph_completion", "text": f"Result: {query}", "source": "graph"}]
+
+    async def forget(self, **kwargs: object) -> dict:
+        self.forgotten.append(kwargs)
+        return {"status": "completed"}
+
+
+@pytest.fixture
+def fake_cognee():
+    return FakeCogneeAPI()
+
+
+# ---------------------------------------------------------------------------
+# External plugin staging
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeExternalPluginLayout:
+    def test_external_plugin_manifest_exists(self):
+        assert (PLUGIN_SOURCE_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_SOURCE_DIR / "__init__.py").exists()
+        assert (PLUGIN_SOURCE_DIR / "client.py").exists()
+
+    def test_loads_from_user_plugins_dir(self, staged_cognee):
+        assert staged_cognee.provider.name == "cognee"
+        assert staged_cognee.provider.__class__.__module__.startswith(
+            "_hermes_user_memory.cognee"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Environment & availability
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeAvailability:
+    """``is_available`` and ``get_config_schema``."""
+
+    def test_not_available_without_api_key(self, monkeypatch, staged_cognee):
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        assert staged_cognee.provider_cls().is_available() is False
+
+    def test_available_with_api_key(self, monkeypatch, tmp_path, staged_cognee):
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("COGNEE_SKIP_CONNECTION_TEST", "true")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = staged_cognee.provider_cls()
+        try:
+            import cognee  # noqa: F401
+        except (ImportError, ValueError):
+            pytest.skip("cognee package not available")
+        assert provider.is_available() is True
+
+    def test_config_schema_contains_expected_keys(self, staged_cognee):
+        schema = staged_cognee.provider_cls().get_config_schema()
+        keys = {entry["key"] for entry in schema}
+        assert "api_key" in keys
+        assert "provider" in keys
+        assert "base_url" in keys
+        assert "dataset_name" in keys
+
+    def test_name_is_cognee(self, staged_cognee):
+        assert staged_cognee.provider_cls().name == "cognee"
+
+
+# ---------------------------------------------------------------------------
+# System prompt block
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeSystemPrompt:
+    """The injected system prompt tells the agent how to use cognee."""
+
+    def test_mentions_disabled_memory_tool(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        block = provider.system_prompt_block()
+        assert "DISABLED" in block or "disabled" in block
+        assert "cognee_remember" in block
+        assert "cognee_recall" in block
+        assert "cognee_forget" in block
+
+    def test_contains_dataset_name(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        block = provider.system_prompt_block()
+        assert "hermes_memory" in block
+
+
+# ---------------------------------------------------------------------------
+# Env var injection (apply_to_environment)
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeEnvVars:
+    """``apply_to_environment`` sets the right env vars for cognee."""
+
+    def test_sets_llm_provider(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gk-test")
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert os.environ.get("LLM_PROVIDER") == "deepseek"
+
+    def test_sets_llm_endpoint_from_base_url(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("LLM_BASE_URL", "https://api.deepseek.com/v1")
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert os.environ.get("LLM_ENDPOINT") == "https://api.deepseek.com/v1"
+
+    def test_sets_model_for_deepseek(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gk-test")
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert "deepseek" in (os.environ.get("LLM_MODEL") or "").lower()
+
+    def test_sets_embedding_vars_with_gemini_key(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gk-test")
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert os.environ.get("EMBEDDING_PROVIDER") == "gemini"
+        assert os.environ.get("EMBEDDING_DIMENSIONS") == "3072"
+        assert os.environ.get("EMBEDDING_API_KEY") == "gk-test"
+
+    def test_does_not_set_embedding_vars_without_gemini_key(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
+        monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+        monkeypatch.delenv("EMBEDDING_DIMENSIONS", raising=False)
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert os.environ.get("EMBEDDING_PROVIDER") is None
+
+    def test_overwrites_existing_vars(self, monkeypatch, staged_cognee):
+        monkeypatch.setenv("LLM_PROVIDER", "deepseek")
+        monkeypatch.setenv("LLM_API_KEY", "sk-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gk-test")
+        monkeypatch.setenv("LLM_MODEL", "wrong-model")
+        monkeypatch.setenv("EMBEDDING_DIMENSIONS", "9999")
+        cfg = staged_cognee.config_cls.from_global_config()
+        cfg.apply_to_environment()
+        assert os.environ.get("LLM_MODEL") != "wrong-model"
+        assert "deepseek" in os.environ.get("LLM_MODEL", "").lower()
+        assert os.environ.get("EMBEDDING_DIMENSIONS") == "3072"
+
+
+# ---------------------------------------------------------------------------
+# Tool call routing
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeToolCalls:
+    """Routing, parameter passing, and error handling."""
+
+    def test_remember_empty_content_returns_error(self, staged_cognee):
+        result = json.loads(staged_cognee.provider.handle_tool_call("cognee_remember", {}))
+        assert "error" in result
+
+    def test_recall_empty_query_returns_error(self, staged_cognee):
+        result = json.loads(staged_cognee.provider.handle_tool_call("cognee_recall", {}))
+        assert "error" in result
+
+    def test_forget_without_confirm_returns_error(self, staged_cognee):
+        result = json.loads(
+            staged_cognee.provider.handle_tool_call(
+                "cognee_forget", {"dataset_name": "test"}
+            )
+        )
+        assert "confirm" in result.get("error", "")
+
+    def test_unknown_tool_returns_error(self, staged_cognee):
+        result = staged_cognee.provider.handle_tool_call("cognee_nonexistent", {})
+        assert "unknown" in result.lower() or "Unknown" in result
+
+    def test_remember_passes_content(self, staged_cognee, fake_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+
+        with patch.object(staged_cognee.provider_module, "run_async") as mock_run:
+            def remember_side_effect(coro, timeout):
+                content = coro.cr_frame.f_locals.get("content", "")
+                coro.close()
+                fake_cognee.remembered.append(content)
+                fake_cognee.captured_remember = {"content": content}
+                return {"status": "completed", "dataset_name": "hermes_memory"}
+
+            mock_run.side_effect = remember_side_effect
+            json.loads(
+                provider.handle_tool_call(
+                    "cognee_remember",
+                    {"content": "test memory"},
+                )
+            )
+
+    def test_recall_passes_query(self, staged_cognee, fake_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+
+        with patch.object(staged_cognee.provider_module, "run_async") as mock_run:
+            def recall_side_effect(coro, timeout):
+                query = coro.cr_frame.f_locals.get("query", "")
+                coro.close()
+                fake_cognee.recalled.append(query)
+                fake_cognee.captured_recall = {"query": query}
+                return [{"kind": "graph_completion", "text": f"Result: {query}", "source": "graph"}]
+
+            mock_run.side_effect = recall_side_effect
+            json.loads(
+                provider.handle_tool_call(
+                    "cognee_recall",
+                    {"query": "test query"},
+                )
+            )
+
+    def test_remember_with_custom_dataset(self, staged_cognee, fake_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+
+        with patch.object(staged_cognee.provider_module, "run_async") as mock_run:
+            def remember_with_dataset_side_effect(coro, timeout):
+                payload = dict(coro.cr_frame.f_locals) if hasattr(coro, "cr_frame") else {}
+                coro.close()
+                content = payload.get("content", "")
+                fake_cognee.remembered.append(content)
+                fake_cognee.captured_remember = {"content": content, **payload}
+                return {
+                    "status": "completed",
+                    "dataset_name": payload.get("dataset_name", "hermes_memory"),
+                }
+
+            mock_run.side_effect = remember_with_dataset_side_effect
+            provider.handle_tool_call(
+                "cognee_remember",
+                {"content": "test", "dataset_name": "custom_dataset"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Background flows (prefetch, sync)
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeBackgroundFlows:
+    """Prefetch, sync_turn, and session-end behaviour."""
+
+    def test_queue_prefetch_starts_thread(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        provider.queue_prefetch("something meaningful")
+        assert provider._prefetch_thread is not None
+        provider._prefetch_thread.join(timeout=2)
+
+    def test_prefetch_returns_empty_on_no_result(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        result = provider.prefetch("anything")
+        assert result == ""
+
+    def test_sync_turn_skips_short_text(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        provider.sync_turn("a", "b", session_id="s1")
+        assert provider._sync_thread is None or not provider._sync_thread.is_alive()
+
+    def test_sync_turn_starts_thread_for_long_text(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        provider.sync_turn(
+            "user said something interesting here",
+            "assistant replied with a comprehensive response",
+            session_id="s1",
+        )
+        assert provider._sync_thread is not None
+        if provider._sync_thread.is_alive():
+            provider._sync_thread.join(timeout=2)
+
+    def test_on_session_end_skips_when_no_messages(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        provider.on_session_end([])
+
+    def test_shutdown_does_not_crash(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("test-session")
+        provider.shutdown()
+
+    def test_on_session_switch_updates_session_id(self, staged_cognee):
+        provider = staged_cognee.provider_cls()
+        provider.initialize("old-session")
+        provider.on_session_switch("new-session", reset=True)
+        assert provider._session_id == "new-session"
+
+
+# ---------------------------------------------------------------------------
+# Config persistence (save_config)
+# ---------------------------------------------------------------------------
+
+
+class TestCogneeConfigPersistence:
+    """``save_config`` writes env vars and cognee.json correctly."""
+
+    def test_save_config_writes_env_vars(self, monkeypatch, tmp_path, staged_cognee):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = staged_cognee.provider_cls()
+        provider.save_config(
+            {
+                "api_key": "sk-test",
+                "provider": "deepseek",
+                "base_url": "https://api.deepseek.com/v1",
+            },
+            hermes_home=str(tmp_path),
+        )
+        env_path = tmp_path / ".env"
+        assert env_path.exists()
+
+    def test_save_config_writes_cognee_json(self, monkeypatch, tmp_path, staged_cognee):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = staged_cognee.provider_cls()
+        provider.save_config(
+            {"dataset_name": "my_memory", "extra_field": "value"},
+            hermes_home=str(tmp_path),
+        )
+        cfg_path = tmp_path / "cognee.json"
+        assert cfg_path.exists()
+        data = json.loads(cfg_path.read_text())
+        assert data.get("dataset_name") == "my_memory"
+        assert data.get("extra_field") == "value"


### PR DESCRIPTION
## What changed

- moves the Cognee integration into `external_plugins/memory/cognee/` instead of adding a new in-tree memory provider under `plugins/memory/`
- adds the external plugin files: `plugin.yaml`, `__init__.py`, `client.py`, `cli.py`, and `README.md`
- keeps Hermes core untouched for Cognee-specific wiring
- adds focused regression coverage in `tests/plugins/memory/test_cognee_provider.py`
- fixes the Gemini embedding configuration used by the plugin: `gemini/gemini-embedding-001` now uses `EMBEDDING_DIMENSIONS=3072`

## Why

The original approach in #23549 was built around an in-tree memory provider. Since then, Hermes policy has tightened:

- new memory providers should not be added in-tree
- plugin-specific behavior should not be hardcoded into Hermes core
- external/user-installed plugins are the preferred extension path

Hermes already supports external memory providers through the existing plugin discovery path under `$HERMES_HOME/plugins/<name>/`, plus provider-specific CLI registration for the active memory provider. This PR rebuilds the Cognee integration around that supported architecture instead of trying to preserve the older in-tree shape.

This keeps the feature aligned with current policy while preserving the useful part of the original contribution: a Cognee-backed memory provider with async lifecycle hooks, recall tools, config persistence, and CLI support.

## How to test

```bash
python -m pytest -q tests/plugins/memory/test_cognee_provider.py tests/agent/test_memory_provider.py -o 'addopts='
python -m compileall external_plugins/memory/cognee
```

## Validation

- [x] 92/92 relevant tests passing
- [x] external plugin discovery smoke check passed locally
- [x] no Cognee-specific changes in Hermes core
- [x] conventional commit on the clean review branch
- [x] supersedes the old in-tree direction from #23549

## Notes

This PR intentionally follows the current Hermes policy rather than the older in-tree provider pattern. The old PR is retained for history/context, but this is the clean policy-compliant version that should be reviewed.