### PR TITLE
fix(cli): invalidate update-check cache on HEAD changes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -151,6 +151,22 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _git_rev(repo_dir: Path, rev: str) -> Optional[str]:
+    """Return the full git SHA for ``rev`` in ``repo_dir``."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", rev],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     try:
@@ -189,23 +205,10 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
+    local_head: Optional[str] = None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text())
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
-    if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
-    else:
+    if not embedded_rev:
         # Prefer the running code's location over the profile-scoped path.
         # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
         # Path(__file__) always resolves to the actual installed checkout.
@@ -214,10 +217,38 @@ def check_for_updates() -> Optional[int]:
             repo_dir = hermes_home / "hermes-agent"
         if not (repo_dir / ".git").exists():
             return None
+        assert repo_dir is not None
+        local_head = _git_rev(repo_dir, "HEAD")
+
+    # Read cache — invalidate if the embedded rev or local git HEAD has
+    # changed since last check. Without the HEAD key, rebasing/switching a
+    # git install can leave a stale "N commits behind" banner for six hours.
+    now = time.time()
+    try:
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text())
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == embedded_rev
+                and cached.get("head") == local_head
+            ):
+                return cached.get("behind")
+    except Exception:
+        pass
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+    else:
+        assert repo_dir is not None
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(json.dumps({
+            "ts": now,
+            "behind": behind,
+            "rev": embedded_rev,
+            "head": local_head,
+        }))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,23 +17,73 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    """When cache is fresh for the current HEAD, reuse it without fetch/count."""
+    import hermes_cli.banner as banner
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "rev": None,
+        "head": "abc123",
+    }))
 
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    rev_parse_result = MagicMock(returncode=0, stdout="abc123\n")
+    with patch("hermes_cli.banner.subprocess.run", return_value=rev_parse_result) as mock_run:
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.args[0][:2] == ["git", "rev-parse"]
+
+
+def test_check_for_updates_invalidates_cache_when_head_changes(tmp_path, monkeypatch):
+    """A rebase/branch switch must not leave a stale behind-count cached."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 71,
+        "rev": None,
+        "head": "old-head",
+    }))
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    rev_parse_result = MagicMock(returncode=0, stdout="new-head\n")
+    fetch_result = MagicMock(returncode=0, stdout="")
+    rev_list_result = MagicMock(returncode=0, stdout="0\n")
+
+    with patch(
+        "hermes_cli.banner.subprocess.run",
+        side_effect=[rev_parse_result, fetch_result, rev_list_result],
+    ) as mock_run:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 3
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["head"] == "new-head"
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
@@ -55,7 +105,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git rev-parse HEAD + fetch + rev-list
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Key the CLI update-check cache by the current git `HEAD` for source installs
- Recompute the behind count after branch switches/rebases instead of reusing stale cache entries for up to six hours
- Add regression coverage for cache reuse and HEAD-change invalidation

## Test plan
- `bash scripts/run_tests.sh tests/hermes_cli/test_update_check.py -q`
- `python -m py_compile hermes_cli/banner.py`

## Notes
Observed locally after rebasing a runtime branch: the banner kept reporting `71 commits behind` even though `git rev-list --left-right --count origin/main...HEAD` was `0 N`. The stale value came from `~/.hermes/.update_check`, which previously did not include the git `HEAD` in its cache key.
