### PR TITLE
fix(dashboard): detect gateway running as PID 1 in Docker/Kubernetes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -534,6 +534,75 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+def _read_proc_cmdline_tokens(pid: int) -> Optional[List[str]]:
+    """Read ``/proc/<pid>/cmdline`` and return the NUL-split argv tokens.
+
+    Returns ``None`` when the file is unreadable (process gone, permission
+    denied, non-Linux host).  Split into a helper so the validation step in
+    :func:`_scan_gateway_pid_in_container` is easy to mock in tests.
+    """
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as f:
+            return [a.decode("utf-8", "replace") for a in f.read().split(b"\x00") if a]
+    except OSError:
+        return None
+
+
+def _scan_gateway_pid_in_container() -> Optional[int]:
+    """Find a live ``hermes gateway run`` PID — container deployment fallback.
+
+    In Docker/Kubernetes deployments where the gateway runs as the container
+    entrypoint, ``gateway.pid`` / ``gateway.lock`` files are never reliably
+    written, so :func:`get_running_pid` returns ``None`` even when the
+    gateway is alive.  This mirrors the ``pgrep`` fallback already adopted
+    upstream for the ``hermes status`` CLI (issue #4776 — refactored into
+    :func:`hermes_cli.gateway.get_gateway_runtime_snapshot`); the dashboard's
+    ``/api/status`` handler took a different code path and was missed by
+    that refactor.
+
+    Only runs when :func:`is_container` reports True, so non-container hosts
+    (where ``pgrep`` may be unavailable on Windows) are unaffected.
+
+    Uses ``pgrep`` for a fast candidate list, then re-validates each PID by
+    checking ``gateway`` and ``run`` appear as independent argv tokens in
+    ``/proc/<pid>/cmdline`` — guards against ``pgrep -f``'s substring match
+    accidentally hitting a cmdline that *contains* the literal string
+    ``"hermes gateway run"`` (e.g. a debug ``python -c`` invocation).
+    """
+    try:
+        from hermes_constants import is_container
+    except Exception:
+        return None
+    if not is_container():
+        return None
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["pgrep", "-f", "hermes gateway run"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    self_pid = os.getpid()
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.isdigit():
+            continue
+        pid = int(line)
+        if pid == self_pid:
+            continue
+        argv = _read_proc_cmdline_tokens(pid)
+        if argv is None:
+            continue
+        if "gateway" in argv and "run" in argv:
+            return pid
+    return None
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()
@@ -543,6 +612,11 @@ async def get_status():
     # GATEWAY_HEALTH_URL is configured, probe the gateway over HTTP so the
     # dashboard works when the gateway runs in a separate container.
     gateway_pid = get_running_pid()
+    if gateway_pid is None:
+        # Docker/Kubernetes fallback: get_running_pid() depends on pid/lock
+        # files that aren't written in the PID-1 entrypoint pattern.  See
+        # _scan_gateway_pid_in_container() for the full rationale.
+        gateway_pid = _scan_gateway_pid_in_container()
     gateway_running = gateway_pid is not None
     remote_health_body: dict | None = None
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -534,40 +534,20 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
-def _read_proc_cmdline_tokens(pid: int) -> Optional[List[str]]:
-    """Read ``/proc/<pid>/cmdline`` and return the NUL-split argv tokens.
-
-    Returns ``None`` when the file is unreadable (process gone, permission
-    denied, non-Linux host).  Split into a helper so the validation step in
-    :func:`_scan_gateway_pid_in_container` is easy to mock in tests.
-    """
-    try:
-        with open(f"/proc/{pid}/cmdline", "rb") as f:
-            return [a.decode("utf-8", "replace") for a in f.read().split(b"\x00") if a]
-    except OSError:
-        return None
-
-
 def _scan_gateway_pid_in_container() -> Optional[int]:
-    """Find a live ``hermes gateway run`` PID — container deployment fallback.
+    """Find a live gateway PID — container deployment fallback.
 
     In Docker/Kubernetes deployments where the gateway runs as the container
     entrypoint, ``gateway.pid`` / ``gateway.lock`` files are never reliably
     written, so :func:`get_running_pid` returns ``None`` even when the
-    gateway is alive.  This mirrors the ``pgrep`` fallback already adopted
-    upstream for the ``hermes status`` CLI (issue #4776 — refactored into
-    :func:`hermes_cli.gateway.get_gateway_runtime_snapshot`); the dashboard's
-    ``/api/status`` handler took a different code path and was missed by
-    that refactor.
+    gateway is alive.  Reuse the canonical gateway process scanner instead of
+    duplicating a narrower ``pgrep`` pattern here; the shared scanner already
+    covers supported entrypoints such as ``hermes gateway run``,
+    ``python -m hermes_cli.main gateway run``, and
+    ``python /path/hermes_cli/main.py gateway run``.
 
     Only runs when :func:`is_container` reports True, so non-container hosts
-    (where ``pgrep`` may be unavailable on Windows) are unaffected.
-
-    Uses ``pgrep`` for a fast candidate list, then re-validates each PID by
-    checking ``gateway`` and ``run`` appear as independent argv tokens in
-    ``/proc/<pid>/cmdline`` — guards against ``pgrep -f``'s substring match
-    accidentally hitting a cmdline that *contains* the literal string
-    ``"hermes gateway run"`` (e.g. a debug ``python -c`` invocation).
+    are unaffected.
     """
     try:
         from hermes_constants import is_container
@@ -576,29 +556,17 @@ def _scan_gateway_pid_in_container() -> Optional[int]:
     if not is_container():
         return None
     try:
-        import subprocess
-        result = subprocess.run(
-            ["pgrep", "-f", "hermes gateway run"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+        from hermes_cli.gateway import find_gateway_pids
+
+        pids = find_gateway_pids()
     except Exception:
         return None
-    if result.returncode != 0:
-        return None
+
     self_pid = os.getpid()
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line.isdigit():
-            continue
-        pid = int(line)
+    for pid in pids:
         if pid == self_pid:
             continue
-        argv = _read_proc_cmdline_tokens(pid)
-        if argv is None:
-            continue
-        if "gateway" in argv and "run" in argv:
+        if isinstance(pid, int) and pid > 0:
             return pid
     return None
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1440,6 +1440,7 @@ class TestStatusRemoteGateway:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", lambda: None)
         monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
         monkeypatch.setattr(ws, "_probe_gateway_health", lambda: (True, {
@@ -1485,6 +1486,7 @@ class TestStatusRemoteGateway:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", lambda: None)
         monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
 
@@ -1499,6 +1501,7 @@ class TestStatusRemoteGateway:
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", lambda: None)
         monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
         monkeypatch.setattr(ws, "_probe_gateway_health", lambda: (True, {
@@ -1511,6 +1514,191 @@ class TestStatusRemoteGateway:
         assert data["gateway_running"] is True
         assert data["gateway_pid"] is None
         assert data["gateway_state"] == "running"
+
+
+class TestStatusContainerFallback:
+    """Tests for /api/status pgrep fallback when the gateway runs as PID 1.
+
+    Complements the upstream fix for issue #4776 (CLI status path) — the
+    dashboard's /api/status handler took a different code path and was
+    missed by that refactor.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_container_fallback_supplies_pid_when_local_returns_none(self, monkeypatch):
+        """get_running_pid None + container scan finds PID → gateway shows running."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", lambda: 7)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is True
+        assert data["gateway_pid"] == 7
+
+    def test_container_fallback_both_none_keeps_stopped(self, monkeypatch):
+        """get_running_pid None + container scan also None → gateway stays stopped."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", lambda: None)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is False
+        assert data["gateway_pid"] is None
+
+    def test_container_fallback_not_invoked_when_local_pid_found(self, monkeypatch):
+        """When get_running_pid returns a PID, container scan must not run."""
+        import hermes_cli.web_server as ws
+
+        scan_called = [False]
+
+        def _track_scan():
+            scan_called[0] = True
+            return 99
+
+        monkeypatch.setattr(ws, "get_running_pid", lambda: 1234)
+        monkeypatch.setattr(ws, "_scan_gateway_pid_in_container", _track_scan)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        assert resp.json()["gateway_pid"] == 1234
+        assert scan_called[0] is False
+
+
+class TestScanGatewayPidInContainer:
+    """Unit tests for the _scan_gateway_pid_in_container() helper itself."""
+
+    def test_returns_none_outside_container(self, monkeypatch):
+        """Helper short-circuits to None when is_container() is False."""
+        import hermes_constants as hc
+        monkeypatch.setattr(hc, "is_container", lambda: False)
+
+        from hermes_cli.web_server import _scan_gateway_pid_in_container
+        assert _scan_gateway_pid_in_container() is None
+
+    def test_returns_pid_from_pgrep_inside_container(self, monkeypatch):
+        """Helper parses pgrep stdout and returns the PID once cmdline validates."""
+        import hermes_constants as hc
+        import subprocess
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(hc, "is_container", lambda: True)
+
+        class _FakeProc:
+            returncode = 0
+            stdout = "42\n"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
+        monkeypatch.setattr(
+            ws,
+            "_read_proc_cmdline_tokens",
+            lambda pid: ["python3", "/opt/hermes/.venv/bin/hermes", "gateway", "run"]
+            if pid == 42
+            else None,
+        )
+
+        assert ws._scan_gateway_pid_in_container() == 42
+
+    def test_returns_none_when_cmdline_lacks_gateway_tokens(self, monkeypatch):
+        """pgrep substring-matched a bogus cmdline → cmdline validation rejects it."""
+        import hermes_constants as hc
+        import subprocess
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(hc, "is_container", lambda: True)
+
+        class _FakeProc:
+            returncode = 0
+            stdout = "13\n"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
+        # PID 13 is a `python -c '...hermes gateway run...'` debug invocation —
+        # pgrep -f substring-matched it, but argv has no 'gateway'/'run' token.
+        monkeypatch.setattr(
+            ws,
+            "_read_proc_cmdline_tokens",
+            lambda pid: ["python", "-c", 'print("hermes gateway run debug")'],
+        )
+
+        assert ws._scan_gateway_pid_in_container() is None
+
+    def test_skips_self_pid_in_pgrep_results(self, monkeypatch):
+        """If pgrep returns self PID first, helper skips and continues scanning."""
+        import os
+        import hermes_constants as hc
+        import subprocess
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(hc, "is_container", lambda: True)
+
+        self_pid = os.getpid()
+
+        class _FakeProc:
+            returncode = 0
+            stdout = f"{self_pid}\n55\n"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
+        monkeypatch.setattr(
+            ws,
+            "_read_proc_cmdline_tokens",
+            lambda pid: ["python3", "/path/hermes", "gateway", "run"]
+            if pid == 55
+            else None,
+        )
+
+        assert ws._scan_gateway_pid_in_container() == 55
+
+    def test_returns_none_when_pgrep_finds_nothing(self, monkeypatch):
+        """pgrep exit code != 0 → no match → helper returns None."""
+        import hermes_constants as hc
+        import subprocess
+
+        monkeypatch.setattr(hc, "is_container", lambda: True)
+
+        class _FakeProc:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
+
+        from hermes_cli.web_server import _scan_gateway_pid_in_container
+        assert _scan_gateway_pid_in_container() is None
+
+    def test_returns_none_when_pgrep_raises(self, monkeypatch):
+        """subprocess.run failure (e.g. pgrep missing) → helper swallows + returns None."""
+        import hermes_constants as hc
+        import subprocess
+
+        monkeypatch.setattr(hc, "is_container", lambda: True)
+
+        def _boom(*a, **kw):
+            raise FileNotFoundError("pgrep not installed")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        from hermes_cli.web_server import _scan_gateway_pid_in_container
+        assert _scan_gateway_pid_in_container() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1517,7 +1517,7 @@ class TestStatusRemoteGateway:
 
 
 class TestStatusContainerFallback:
-    """Tests for /api/status pgrep fallback when the gateway runs as PID 1.
+    """Tests for /api/status container fallback when the gateway runs as PID 1.
 
     Complements the upstream fix for issue #4776 (CLI status path) — the
     dashboard's /api/status handler took a different code path and was
@@ -1592,110 +1592,76 @@ class TestScanGatewayPidInContainer:
     def test_returns_none_outside_container(self, monkeypatch):
         """Helper short-circuits to None when is_container() is False."""
         import hermes_constants as hc
+        import hermes_cli.gateway as gw
+
         monkeypatch.setattr(hc, "is_container", lambda: False)
+        monkeypatch.setattr(gw, "find_gateway_pids", lambda: [42])
 
         from hermes_cli.web_server import _scan_gateway_pid_in_container
         assert _scan_gateway_pid_in_container() is None
 
-    def test_returns_pid_from_pgrep_inside_container(self, monkeypatch):
-        """Helper parses pgrep stdout and returns the PID once cmdline validates."""
+    def test_returns_first_pid_from_canonical_scanner_inside_container(self, monkeypatch):
+        """Helper delegates to the shared gateway process scanner in containers."""
         import hermes_constants as hc
-        import subprocess
+        import hermes_cli.gateway as gw
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(hc, "is_container", lambda: True)
-
-        class _FakeProc:
-            returncode = 0
-            stdout = "42\n"
-
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
-        monkeypatch.setattr(
-            ws,
-            "_read_proc_cmdline_tokens",
-            lambda pid: ["python3", "/opt/hermes/.venv/bin/hermes", "gateway", "run"]
-            if pid == 42
-            else None,
-        )
+        monkeypatch.setattr(gw, "find_gateway_pids", lambda: [42, 55])
 
         assert ws._scan_gateway_pid_in_container() == 42
 
-    def test_returns_none_when_cmdline_lacks_gateway_tokens(self, monkeypatch):
-        """pgrep substring-matched a bogus cmdline → cmdline validation rejects it."""
+    def test_uses_canonical_scanner_not_pgrep_substring_matching(self, monkeypatch):
+        """Module-style gateway invocations are covered by the shared scanner."""
         import hermes_constants as hc
         import subprocess
+        import hermes_cli.gateway as gw
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(hc, "is_container", lambda: True)
+        monkeypatch.setattr(gw, "find_gateway_pids", lambda: [77])
 
-        class _FakeProc:
-            returncode = 0
-            stdout = "13\n"
+        def _pgrep_should_not_run(*args, **kwargs):
+            raise AssertionError("dashboard fallback should not call pgrep directly")
 
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
-        # PID 13 is a `python -c '...hermes gateway run...'` debug invocation —
-        # pgrep -f substring-matched it, but argv has no 'gateway'/'run' token.
-        monkeypatch.setattr(
-            ws,
-            "_read_proc_cmdline_tokens",
-            lambda pid: ["python", "-c", 'print("hermes gateway run debug")'],
-        )
+        monkeypatch.setattr(subprocess, "run", _pgrep_should_not_run)
+        assert ws._scan_gateway_pid_in_container() == 77
 
-        assert ws._scan_gateway_pid_in_container() is None
-
-    def test_skips_self_pid_in_pgrep_results(self, monkeypatch):
-        """If pgrep returns self PID first, helper skips and continues scanning."""
+    def test_skips_self_pid_in_scanner_results(self, monkeypatch):
+        """If the shared scanner ever returns self PID, helper skips it."""
         import os
         import hermes_constants as hc
-        import subprocess
+        import hermes_cli.gateway as gw
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(hc, "is_container", lambda: True)
-
         self_pid = os.getpid()
-
-        class _FakeProc:
-            returncode = 0
-            stdout = f"{self_pid}\n55\n"
-
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
-        monkeypatch.setattr(
-            ws,
-            "_read_proc_cmdline_tokens",
-            lambda pid: ["python3", "/path/hermes", "gateway", "run"]
-            if pid == 55
-            else None,
-        )
+        monkeypatch.setattr(gw, "find_gateway_pids", lambda: [self_pid, 55])
 
         assert ws._scan_gateway_pid_in_container() == 55
 
-    def test_returns_none_when_pgrep_finds_nothing(self, monkeypatch):
-        """pgrep exit code != 0 → no match → helper returns None."""
+    def test_returns_none_when_canonical_scanner_finds_nothing(self, monkeypatch):
+        """No scanner matches → helper returns None."""
         import hermes_constants as hc
-        import subprocess
+        import hermes_cli.gateway as gw
 
         monkeypatch.setattr(hc, "is_container", lambda: True)
-
-        class _FakeProc:
-            returncode = 1
-            stdout = ""
-
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeProc())
+        monkeypatch.setattr(gw, "find_gateway_pids", lambda: [])
 
         from hermes_cli.web_server import _scan_gateway_pid_in_container
         assert _scan_gateway_pid_in_container() is None
 
-    def test_returns_none_when_pgrep_raises(self, monkeypatch):
-        """subprocess.run failure (e.g. pgrep missing) → helper swallows + returns None."""
+    def test_returns_none_when_canonical_scanner_raises(self, monkeypatch):
+        """Scanner failure → helper swallows + returns None."""
         import hermes_constants as hc
-        import subprocess
+        import hermes_cli.gateway as gw
 
         monkeypatch.setattr(hc, "is_container", lambda: True)
 
         def _boom(*a, **kw):
-            raise FileNotFoundError("pgrep not installed")
+            raise RuntimeError("process scan failed")
 
-        monkeypatch.setattr(subprocess, "run", _boom)
+        monkeypatch.setattr(gw, "find_gateway_pids", _boom)
 
         from hermes_cli.web_server import _scan_gateway_pid_in_container
         assert _scan_gateway_pid_in_container() is None


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard `/api/status` gateway liveness detection for Docker/Kubernetes PID-1 deployments.

When the gateway runs as the container entrypoint, the dashboard can report `gateway_running: false` / `gateway_state: "stopped"` even though the gateway is alive and `hermes status` reports it as running. The dashboard still used `gateway.status.get_running_pid()`, which depends on pid/lock files that are not reliable in this container pattern.

This PR adds a container-only fallback for the dashboard status handler. When the pid/lock check returns `None`, `/api/status` now reuses the canonical `hermes_cli.gateway.find_gateway_pids()` scanner instead of duplicating a narrow `pgrep` substring search. This keeps dashboard status detection aligned with the CLI path and covers supported invocations such as:

- `hermes gateway run`
- `python -m hermes_cli.main gateway run`
- `python /path/hermes_cli/main.py gateway run`

## Related Issue

Fixes #26181

Companion to #4776 / the CLI status-path container fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Adds a container-only fallback in `/api/status` when `get_running_pid()` returns `None`.
  - Reuses `hermes_cli.gateway.find_gateway_pids()` for gateway process detection instead of a direct `pgrep -f "hermes gateway run"` search.
  - Keeps non-container hosts, existing pid/lock success path, and remote `GATEWAY_HEALTH_URL` probe behavior unchanged.

- `tests/hermes_cli/test_web_server.py`
  - Adds handler-level coverage for the dashboard container fallback.
  - Adds helper coverage for outside-container short-circuit, canonical scanner delegation, self-PID skipping, empty scanner results, and scanner exceptions.
  - Preserves the existing remote gateway health-probe tests by explicitly disabling the new container fallback in those tests.

## How to Test

1. Run the focused status tests:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'status or ScanGateway'
   ```
2. Run the full web server test file:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_web_server.py
   ```
3. In a Docker/Kubernetes PID-1 gateway deployment, compare dashboard status before and after the change:
   ```bash
   curl http://127.0.0.1:9119/api/status
   ```
   Expected after this change: `gateway_running: true`, a non-null `gateway_pid`, and `gateway_state: "running"` when the gateway process is alive.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Targeted verification completed instead:
    - `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'status or ScanGateway'` → 16 passed
    - `scripts/run_tests.sh tests/hermes_cli/test_web_server.py` → 153 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Python 3.13.11; Docker PID-1 behavior verified in the issue reproduction environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — container-only fallback is gated on `is_container()`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused tests:

```text
scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'status or ScanGateway'
16 passed
```

Full web server test file:

```text
scripts/run_tests.sh tests/hermes_cli/test_web_server.py
153 passed, 5 warnings
```

Container end-to-end verification from the original reproduction:

```text
Before: /api/status => gateway_running=false, gateway_pid=null, gateway_state=stopped
After:  /api/status => gateway_running=true, gateway_pid=7, gateway_state=running
```
