### PR TITLE
fix(gateway): remove --replace flag from systemd/launchd/windows service definitions

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -563,7 +563,7 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     args = [get_python_path(), "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
-    args.extend(["gateway", "run", "--replace"])
+    args.extend(["gateway", "run"])
     return args
 
 
@@ -2155,7 +2155,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2193,7 +2193,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -2781,7 +2781,7 @@ def generate_launchd_plist() -> str:
     prog_args.extend([
         "<string>gateway</string>",
         "<string>run</string>",
-        "<string>--replace</string>",
+        ,
     ])
     prog_args_xml = "\n        ".join(prog_args)
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -13,7 +13,7 @@ Design notes
   ``schtasks /Run`` immediately after install so the gateway starts right
   away without waiting for the next logon.
 * We write two files: a shared ``gateway.cmd`` wrapper script (cwd + env + the
-  actual ``python -m hermes_cli.main gateway run --replace`` invocation) and
+  actual ``python -m hermes_cli.main gateway run`` invocation) and
   EITHER a schtasks entry pointing at it OR a Startup-folder ``.cmd`` that
   spawns it detached.
 * Status = merge of "is the schtasks entry registered?" + "is the startup
@@ -206,7 +206,7 @@ def _build_gateway_cmd_script(
     The script:
       - cd's into the project directory
       - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
-      - invokes ``python -m hermes_cli.main [--profile X] gateway run --replace``
+      - invokes ``python -m hermes_cli.main [--profile X] gateway run``
 
     We intentionally do NOT inline PATH overrides here — cmd.exe inherits
     the per-user PATH the Scheduled Task was created with, and forcibly
@@ -225,7 +225,7 @@ def _build_gateway_cmd_script(
     prog_args = [python_path, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())
-    prog_args.extend(["gateway", "run", "--replace"])
+    prog_args.extend(["gateway", "run"])
     lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
     return "\r\n".join(lines) + "\r\n"
 
@@ -367,7 +367,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     argv = [python_exe, "-m", "hermes_cli.main"]
     if profile_arg:
         argv.extend(profile_arg.split())
-    argv.extend(["gateway", "run", "--replace"])
+    argv.extend(["gateway", "run"])
 
     env_overlay = {
         "HERMES_HOME": hermes_home,
@@ -381,7 +381,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
 def _spawn_detached(script_path: Path | None = None) -> int:
     """Launch the gateway as a fully detached background process.
 
-    We spawn ``pythonw.exe -m hermes_cli.main gateway run --replace``
+    We spawn ``pythonw.exe -m hermes_cli.main gateway run``
     directly — NOT through a cmd.exe shim — because on Windows a cmd.exe
     child inherits the parent session's console handle and tends to get
     reaped when the spawning shell exits. pythonw.exe has no console, and


### PR DESCRIPTION
Re-creates #23330 on a fresh branch from current `origin/main`.

#23330 had fallen 386 commits behind `origin/main` and showed `mergeStateStatus: UNKNOWN` — likely too stale to rebase cleanly.

## What changed
- Removes `--replace` flag from all gateway service-installation paths
  - `hermes_cli/gateway.py`: `_gateway_run_args_for_profile()`, `generate_systemd_unit()` (system + user), `generate_launchd_plist()`
  - `hermes_cli/gateway_windows.py`: `_build_gateway_cmd_script()`, `_build_gateway_argv()`, docstrings
- Fixes #23272
