### PR TITLE
feat(discord): add custom slash command hooks

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -843,6 +843,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.DISCORD and "custom_slash_commands" in platform_cfg:
+                    bridged["custom_slash_commands"] = platform_cfg["custom_slash_commands"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3321,6 +3321,15 @@ class DiscordAdapter(BasePlatformAdapter):
         if not await self._check_slash_authorization(interaction, slash_name):
             return
 
+        try:
+            response = getattr(interaction, "response", None)
+            is_done = getattr(response, "is_done", None)
+            already_done = callable(is_done) and is_done()
+            if response is not None and hasattr(response, "defer") and not already_done:
+                await response.defer(ephemeral=True)
+        except Exception as e:
+            logger.debug("[Discord] custom slash /%s defer failed: %s", command, e)
+
         channel = getattr(interaction, "channel", None)
         channel_id = str(getattr(interaction, "channel_id", "") or getattr(channel, "id", "") or "")
         guild = getattr(interaction, "guild", None)
@@ -3377,6 +3386,10 @@ class DiscordAdapter(BasePlatformAdapter):
             response = getattr(interaction, "response", None)
             is_done = getattr(response, "is_done", None)
             if callable(is_done) and is_done():
+                edit_original = getattr(interaction, "edit_original_response", None)
+                if edit_original is not None:
+                    await edit_original(content=message)
+                    return
                 return
             if response and hasattr(response, "send_message"):
                 await response.send_message(message, ephemeral=ephemeral)
@@ -4062,6 +4075,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         try:
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+            await self._emit_discord_auto_thread_created_hook(message, thread, thread_name)
             return thread
         except Exception as direct_error:
             display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
@@ -4073,6 +4087,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
+                await self._emit_discord_auto_thread_created_hook(
+                    message,
+                    thread,
+                    thread_name,
+                    starter_message=message,
+                    seed_message=seed_msg,
+                )
                 return thread
             except Exception as fallback_error:
                 logger.warning(
@@ -4082,6 +4103,55 @@ class DiscordAdapter(BasePlatformAdapter):
                     fallback_error,
                 )
                 return None
+
+    async def _emit_discord_auto_thread_created_hook(
+        self,
+        message: 'DiscordMessage',
+        thread: Any,
+        initial_name: str,
+        *,
+        starter_message: Optional[Any] = None,
+        seed_message: Optional[Any] = None,
+    ) -> None:
+        """Emit a plugin hook after auto-thread creation.
+
+        Core exposes the Discord objects and IDs only; plugins decide how to
+        title, persist, react, archive, or otherwise manage thread state.
+        """
+        try:
+            from hermes_cli.plugins import invoke_hook
+
+            starter = starter_message or message
+            parent_channel = getattr(thread, "parent", None) or getattr(message, "channel", None)
+            guild = getattr(thread, "guild", None) or getattr(message, "guild", None)
+            author = getattr(message, "author", None)
+            hook_results = invoke_hook(
+                "discord_auto_thread_created",
+                adapter=self,
+                message=message,
+                starter_message=starter,
+                seed_message=seed_message,
+                content=getattr(message, "content", "") or "",
+                initial_name=initial_name,
+                thread=thread,
+                channel=thread,
+                thread_id=str(getattr(thread, "id", "") or ""),
+                channel_id=str(getattr(thread, "id", "") or ""),
+                parent_channel=parent_channel,
+                parent_channel_id=str(getattr(parent_channel, "id", "") or ""),
+                guild=guild,
+                guild_id=str(getattr(guild, "id", "") or ""),
+                user=author,
+                user_id=str(getattr(author, "id", "") or ""),
+                user_name=getattr(author, "display_name", None) or getattr(author, "name", ""),
+                starter_message_id=str(getattr(starter, "id", "") or ""),
+                seed_message_id=str(getattr(seed_message, "id", "") or "") if seed_message is not None else "",
+            )
+            for result in hook_results:
+                if hasattr(result, "__await__"):
+                    await result
+        except Exception as e:
+            logger.warning("[%s] discord_auto_thread_created hook failed: %s", self.name, e)
 
     async def create_handoff_thread(
         self,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3160,6 +3160,34 @@ class DiscordAdapter(BasePlatformAdapter):
                 "Discord auto-register from plugin commands failed: %s", e
             )
 
+        # ── Config-declared custom slash commands ──
+        # These are Discord-native commands whose invocation is exposed to
+        # plugins via the discord_custom_slash_command hook. Unlike
+        # PluginContext.register_command(), these do NOT route through the
+        # Hermes slash-command text path or the agent; they are for
+        # deterministic Discord-side behaviors such as renaming/archiving the
+        # current thread.
+        try:
+            for command_def in self._discord_custom_slash_commands():
+                discord_name = command_def["name"]
+                if discord_name in already_registered or discord_name == "skill":
+                    logger.warning(
+                        "[Discord] Skipping custom slash command /%s because it conflicts with an existing command",
+                        discord_name,
+                    )
+                    continue
+                custom_cmd = self._build_custom_slash_command(command_def)
+                try:
+                    tree.add_command(custom_cmd)
+                    already_registered.add(discord_name)
+                except Exception as e:
+                    logger.warning(
+                        "[Discord] Failed to register custom slash command /%s: %s",
+                        discord_name, e,
+                    )
+        except Exception as e:
+            logger.warning("Discord custom slash command registration failed: %s", e)
+
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,
         # supporting up to 25 categories × 25 skills = 625 skills.
@@ -3175,6 +3203,189 @@ class DiscordAdapter(BasePlatformAdapter):
             "true", "1", "yes", "on",
         }:
             self._apply_owner_only_visibility(tree)
+
+
+    def _discord_custom_slash_commands(self) -> list[dict[str, str]]:
+        """Return normalized Discord custom slash command definitions.
+
+        Config accepts either a list of strings::
+
+            discord:
+              custom_slash_commands: [done, blocked]
+
+        or a list/dict with descriptions and an optional args_hint::
+
+            discord:
+              custom_slash_commands:
+                - name: done
+                  description: Mark this thread done
+                - name: tag
+                  description: Tag the current Discord context
+                  args_hint: "label"
+
+        Custom commands are intentionally plumbing-only: invocation emits the
+        ``discord_custom_slash_command`` plugin hook and does not call the LLM.
+        """
+        raw = self.config.extra.get("custom_slash_commands", [])
+        if not raw:
+            return []
+
+        items: list[Any]
+        if isinstance(raw, dict):
+            items = []
+            for name, value in raw.items():
+                if isinstance(value, dict):
+                    entry = {**value, "name": name}
+                else:
+                    entry = {"name": name, "description": str(value) if value else ""}
+                items.append(entry)
+        elif isinstance(raw, list):
+            items = raw
+        else:
+            logger.warning("[Discord] custom_slash_commands must be a list or mapping; got %s", type(raw).__name__)
+            return []
+
+        commands_out: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for item in items:
+            if isinstance(item, str):
+                entry = {"name": item}
+            elif isinstance(item, dict):
+                entry = item
+            else:
+                logger.warning("[Discord] Ignoring invalid custom slash command entry: %r", item)
+                continue
+
+            name = str(entry.get("name", "")).strip().lower().lstrip("/").replace(" ", "-")
+            if not name:
+                logger.warning("[Discord] Ignoring custom slash command with empty name")
+                continue
+            # Discord app-command names are lower-case, 1-32 chars, and may
+            # contain hyphens/underscores. Drop unsupported characters rather
+            # than registering a command Discord will reject during tree.sync().
+            name = re.sub(r"[^a-z0-9_-]", "-", name)[:32].strip("-_")
+            if not name:
+                logger.warning("[Discord] Ignoring custom slash command whose name normalizes to empty: %r", entry.get("name"))
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+
+            description = str(entry.get("description") or f"Run custom Discord slash command /{name}").strip()[:100]
+            if not description:
+                description = f"Run custom Discord slash command /{name}"[:100]
+            args_hint = str(entry.get("args_hint") or entry.get("args") or "").strip()
+            commands_out.append({"name": name, "description": description, "args_hint": args_hint})
+        return commands_out
+
+    def _build_custom_slash_command(self, command_def: dict[str, str]):
+        """Build a Discord app command that emits a plugin hook on invocation."""
+        name = command_def["name"]
+        description = command_def.get("description") or f"Run custom Discord slash command /{name}"
+        args_hint = command_def.get("args_hint", "")
+
+        if args_hint:
+            def _make_args_handler(_name: str, _hint: str):
+                @discord.app_commands.describe(args=f"Arguments: {_hint}"[:100])
+                async def _handler(interaction: discord.Interaction, args: str = ""):
+                    await self._handle_custom_slash_command(interaction, _name, args=args, command_def=command_def)
+                _handler.__name__ = f"custom_slash_{_name.replace('-', '_')}"
+                return _handler
+
+            handler = _make_args_handler(name, args_hint)
+        else:
+            def _make_simple_handler(_name: str):
+                async def _handler(interaction: discord.Interaction):
+                    await self._handle_custom_slash_command(interaction, _name, args="", command_def=command_def)
+                _handler.__name__ = f"custom_slash_{_name.replace('-', '_')}"
+                return _handler
+
+            handler = _make_simple_handler(name)
+
+        return discord.app_commands.Command(
+            name=name,
+            description=description[:100],
+            callback=handler,
+        )
+
+    async def _handle_custom_slash_command(
+        self,
+        interaction: discord.Interaction,
+        command: str,
+        *,
+        args: str = "",
+        command_def: Optional[dict[str, str]] = None,
+    ) -> None:
+        """Authorize a config-declared slash command and emit a plugin hook."""
+        slash_name = f"/{command}"
+        if not await self._check_slash_authorization(interaction, slash_name):
+            return
+
+        channel = getattr(interaction, "channel", None)
+        channel_id = str(getattr(interaction, "channel_id", "") or getattr(channel, "id", "") or "")
+        guild = getattr(interaction, "guild", None)
+        guild_id = str(getattr(guild, "id", "") or getattr(interaction, "guild_id", "") or "")
+        user = getattr(interaction, "user", None)
+        parent_channel = self._thread_parent_channel(channel) if channel is not None else None
+        parent_channel_id = str(getattr(parent_channel, "id", "") or "") if parent_channel is not channel else ""
+        is_thread = bool(discord is not None and getattr(discord, "Thread", None) and isinstance(channel, discord.Thread))
+        thread = channel if is_thread else None
+        thread_id = str(getattr(thread, "id", "") or "")
+
+        hook_results = []
+        try:
+            from hermes_cli.plugins import invoke_hook
+
+            hook_results = invoke_hook(
+                "discord_custom_slash_command",
+                command=command,
+                args=args or "",
+                command_def=dict(command_def or {}),
+                interaction=interaction,
+                adapter=self,
+                guild=guild,
+                guild_id=guild_id,
+                channel=channel,
+                channel_id=channel_id,
+                thread=thread,
+                thread_id=thread_id,
+                parent_channel=parent_channel if parent_channel is not channel else None,
+                parent_channel_id=parent_channel_id,
+                user=user,
+                user_id=str(getattr(user, "id", "") or ""),
+                user_name=getattr(user, "display_name", None) or getattr(user, "name", ""),
+            )
+            for result in hook_results:
+                if hasattr(result, "__await__"):
+                    await result
+        except Exception as e:
+            logger.warning("[Discord] custom slash command /%s hook failed: %s", command, e)
+            await self._send_custom_slash_fallback_response(
+                interaction, f"Custom command /{command} failed: {e}", ephemeral=True
+            )
+            return
+
+        await self._send_custom_slash_fallback_response(
+            interaction, f"Handled /{command}", ephemeral=True
+        )
+
+    async def _send_custom_slash_fallback_response(
+        self, interaction: discord.Interaction, message: str, *, ephemeral: bool = True
+    ) -> None:
+        """Send a response only if the custom slash listener did not already do so."""
+        try:
+            response = getattr(interaction, "response", None)
+            is_done = getattr(response, "is_done", None)
+            if callable(is_done) and is_done():
+                return
+            if response and hasattr(response, "send_message"):
+                await response.send_message(message, ephemeral=ephemeral)
+                return
+            followup = getattr(interaction, "followup", None)
+            if followup and hasattr(followup, "send"):
+                await followup.send(message, ephemeral=ephemeral)
+        except Exception as e:
+            logger.debug("[Discord] custom slash fallback response failed: %s", e)
 
     def _apply_owner_only_visibility(self, tree) -> None:
         """Set default_member_permissions=0 on every registered slash command.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3374,9 +3374,16 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return
 
-        await self._send_custom_slash_fallback_response(
-            interaction, f"Handled /{command}", ephemeral=True
-        )
+        if not hook_results:
+            await self._send_custom_slash_fallback_response(
+                interaction, f"Handled /{command}", ephemeral=True
+            )
+        else:
+            logger.debug(
+                "[Discord] custom slash /%s handled by %d plugin hook(s); skipping fallback response",
+                command,
+                len(hook_results),
+            )
 
     async def _send_custom_slash_fallback_response(
         self, interaction: discord.Interaction, message: str, *, ephemeral: bool = True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1255,6 +1255,7 @@ DEFAULT_CONFIG = {
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "custom_slash_commands": [],   # Discord-native commands that emit discord_custom_slash_command plugin hooks
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -158,6 +158,12 @@ VALID_HOOKS: Set[str] = {
     # platform-native behavior (rename/archive threads, add reactions, etc.)
     # without routing through the LLM or generic slash-command text path.
     "discord_custom_slash_command",
+    # Discord auto-thread creation hook. Fired by the Discord adapter after
+    # Hermes creates an auto-thread for an @mention. Plugins receive the raw
+    # Discord thread/message plus normalized IDs so they can deterministically
+    # rename the thread, persist metadata, or add reactions without routing
+    # through the LLM.
+    "discord_auto_thread_created",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -151,6 +151,13 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Discord native custom slash command hook. Fired by the Discord adapter
+    # for commands declared in discord.custom_slash_commands. The adapter
+    # performs Hermes slash authorization first, then passes the raw Discord
+    # interaction plus normalized IDs/objects so plugins can implement
+    # platform-native behavior (rename/archive threads, add reactions, etc.)
+    # without routing through the LLM or generic slash-command text path.
+    "discord_custom_slash_command",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -409,6 +409,29 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+
+    def test_bridges_discord_custom_slash_commands_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  custom_slash_commands:\n"
+            "    - name: done\n"
+            "      description: Mark current thread done\n"
+            "    - blocked\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["custom_slash_commands"] == [
+            {"name": "done", "description": "Mark current thread done"},
+            "blocked",
+        ]
+
     def test_bridges_discord_history_backfill_settings_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -361,6 +361,40 @@ async def test_config_custom_slash_command_emits_discord_hook(adapter):
 
 
 @pytest.mark.asyncio
+async def test_config_custom_slash_command_defers_before_hook(adapter):
+    """Custom slash hooks may rename/archive Discord threads; defer first so Discord doesn't time out."""
+    adapter.config.extra["custom_slash_commands"] = ["open"]
+    adapter._register_slash_commands()
+
+    deferred = False
+
+    async def _defer(ephemeral=True):
+        nonlocal deferred
+        assert ephemeral is True
+        deferred = True
+
+    response = SimpleNamespace(defer=AsyncMock(side_effect=_defer), is_done=lambda: deferred)
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(id=555),
+        channel_id=555,
+        guild=None,
+        user=SimpleNamespace(id=42, display_name="Sumanth"),
+        response=response,
+        edit_original_response=AsyncMock(),
+    )
+
+    async def _listener(**kwargs):
+        assert deferred is True
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[_listener()]) as invoke_hook:
+        await adapter._client.tree.commands["open"].callback(interaction)
+
+    response.defer.assert_awaited_once_with(ephemeral=True)
+    invoke_hook.assert_called_once()
+    interaction.edit_original_response.assert_awaited_once_with(content="Handled /open")
+
+
+@pytest.mark.asyncio
 async def test_config_custom_slash_command_with_args(adapter):
     adapter.config.extra["custom_slash_commands"] = [
         {"name": "tag", "description": "Tag current context", "args_hint": "label"}
@@ -395,6 +429,60 @@ async def test_config_custom_slash_command_auth_failure_does_not_emit_hook(adapt
         await adapter._client.tree.commands["done"].callback(interaction)
 
     invoke_hook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_emits_discord_thread_created_hook(adapter):
+    created_thread = SimpleNamespace(
+        id=555,
+        name="Hermes Discord thread labels",
+        parent=SimpleNamespace(id=123, name="garage"),
+        guild=SimpleNamespace(id=999, name="Guild"),
+    )
+    message = SimpleNamespace(
+        id=777,
+        content="<@99999> Title: Hermes Discord thread labels\nPlease fix this.",
+        author=SimpleNamespace(id=42, display_name="Sumanth"),
+        guild=created_thread.guild,
+        channel=SimpleNamespace(id=123, name="garage"),
+        create_thread=AsyncMock(return_value=created_thread),
+    )
+
+    async def _listener(**kwargs):
+        await kwargs["thread"].edit(name="🟡 Hermes Discord thread labels")
+
+    created_thread.edit = AsyncMock()
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[_listener(
+        adapter=adapter,
+        message=message,
+        starter_message=message,
+        seed_message=None,
+        content=message.content,
+        initial_name="Title: Hermes Discord thread labels Please fix this.",
+        thread=created_thread,
+        channel=created_thread,
+        thread_id="555",
+        channel_id="555",
+        parent_channel=created_thread.parent,
+        parent_channel_id="123",
+        guild=created_thread.guild,
+        guild_id="999",
+        user=message.author,
+        user_id="42",
+        user_name="Sumanth",
+        starter_message_id="777",
+        seed_message_id="",
+    )]) as invoke_hook:
+        thread = await adapter._auto_create_thread(message)
+
+    assert thread is created_thread
+    invoke_hook.assert_called_once()
+    _, hook_kwargs = invoke_hook.call_args
+    assert hook_kwargs["thread_id"] == "555"
+    assert hook_kwargs["parent_channel_id"] == "123"
+    assert hook_kwargs["starter_message_id"] == "777"
+    assert hook_kwargs["content"] == message.content
+    created_thread.edit.assert_awaited_once_with(name="🟡 Hermes Discord thread labels")
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -292,6 +292,111 @@ async def test_plugin_command_name_conflict_skipped(adapter):
     )
 
 
+
+
+@pytest.mark.asyncio
+async def test_config_custom_slash_command_emits_discord_hook(adapter):
+    """Config-declared slash commands should emit Discord-native plugin hooks, not agent text commands."""
+    adapter.config.extra["custom_slash_commands"] = [
+        {"name": "done", "description": "Mark current thread done"}
+    ]
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    assert "done" in adapter._client.tree.commands
+
+    hook_calls = []
+
+    async def _listener(**kwargs):
+        hook_calls.append(kwargs)
+        # Prove the raw Discord object is usable by listeners for deterministic
+        # side effects like renaming the current thread.
+        await kwargs["channel"].edit(name="✅ Finished")
+
+    thread_cls = sys.modules["discord"].Thread
+    channel = thread_cls()
+    channel.id = 555
+    channel.name = "🟡 Planning"
+    channel.parent = SimpleNamespace(id=123, name="garage")
+    channel.edit = AsyncMock()
+    response = SimpleNamespace(send_message=AsyncMock(), is_done=lambda: False)
+    interaction = SimpleNamespace(
+        channel=channel,
+        channel_id=555,
+        guild=SimpleNamespace(id=999, name="Guild"),
+        user=SimpleNamespace(id=42, display_name="Sumanth"),
+        response=response,
+    )
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[_listener(
+        command="done",
+        args="",
+        command_def={"name": "done", "description": "Mark current thread done", "args_hint": ""},
+        interaction=interaction,
+        adapter=adapter,
+        guild=interaction.guild,
+        guild_id="999",
+        channel=channel,
+        channel_id="555",
+        thread=channel,
+        thread_id="555",
+        parent_channel=channel.parent,
+        parent_channel_id="123",
+        user=interaction.user,
+        user_id="42",
+        user_name="Sumanth",
+    )]) as invoke_hook:
+        await adapter._client.tree.commands["done"].callback(interaction)
+
+    adapter._run_simple_slash.assert_not_awaited()
+    invoke_hook.assert_called_once()
+    _, hook_kwargs = invoke_hook.call_args
+    assert hook_kwargs["command"] == "done"
+    assert hook_kwargs["thread_id"] == "555"
+    assert hook_kwargs["parent_channel_id"] == "123"
+    assert hook_kwargs["user_id"] == "42"
+    assert hook_kwargs["interaction"] is interaction
+    channel.edit.assert_awaited_once_with(name="✅ Finished")
+    response.send_message.assert_awaited_once_with("Handled /done", ephemeral=True)
+
+
+@pytest.mark.asyncio
+async def test_config_custom_slash_command_with_args(adapter):
+    adapter.config.extra["custom_slash_commands"] = [
+        {"name": "tag", "description": "Tag current context", "args_hint": "label"}
+    ]
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["tag"]
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(id=555),
+        channel_id=555,
+        guild=None,
+        user=SimpleNamespace(id=42, display_name="Sumanth"),
+        response=SimpleNamespace(send_message=AsyncMock(), is_done=lambda: False),
+    )
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]) as invoke_hook:
+        await command.callback(interaction, args="important")
+
+    _, hook_kwargs = invoke_hook.call_args
+    assert hook_kwargs["command"] == "tag"
+    assert hook_kwargs["args"] == "important"
+
+
+@pytest.mark.asyncio
+async def test_config_custom_slash_command_auth_failure_does_not_emit_hook(adapter):
+    adapter.config.extra["custom_slash_commands"] = ["done"]
+    adapter._check_slash_authorization = AsyncMock(return_value=False)
+    adapter._register_slash_commands()
+
+    interaction = SimpleNamespace(channel=SimpleNamespace(id=555), channel_id=555)
+    with patch("hermes_cli.plugins.invoke_hook") as invoke_hook:
+        await adapter._client.tree.commands["done"].callback(interaction)
+
+    invoke_hook.assert_not_called()
+
+
 # ------------------------------------------------------------------
 # _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -326,6 +326,7 @@ async def test_config_custom_slash_command_emits_discord_hook(adapter):
         guild=SimpleNamespace(id=999, name="Guild"),
         user=SimpleNamespace(id=42, display_name="Sumanth"),
         response=response,
+        edit_original_response=AsyncMock(),
     )
 
     with patch("hermes_cli.plugins.invoke_hook", return_value=[_listener(
@@ -357,7 +358,8 @@ async def test_config_custom_slash_command_emits_discord_hook(adapter):
     assert hook_kwargs["user_id"] == "42"
     assert hook_kwargs["interaction"] is interaction
     channel.edit.assert_awaited_once_with(name="✅ Finished")
-    response.send_message.assert_awaited_once_with("Handled /done", ephemeral=True)
+    response.send_message.assert_not_awaited()
+    interaction.edit_original_response.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -385,12 +387,39 @@ async def test_config_custom_slash_command_defers_before_hook(adapter):
 
     async def _listener(**kwargs):
         assert deferred is True
+        await kwargs["interaction"].edit_original_response(content="Plugin handled /open")
 
-    with patch("hermes_cli.plugins.invoke_hook", return_value=[_listener()]) as invoke_hook:
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=lambda *args, **kwargs: [_listener(**kwargs)]) as invoke_hook:
         await adapter._client.tree.commands["open"].callback(interaction)
 
     response.defer.assert_awaited_once_with(ephemeral=True)
     invoke_hook.assert_called_once()
+    interaction.edit_original_response.assert_awaited_once_with(content="Plugin handled /open")
+
+
+@pytest.mark.asyncio
+async def test_config_custom_slash_command_no_listener_gets_fallback(adapter):
+    adapter.config.extra["custom_slash_commands"] = ["open"]
+    adapter._register_slash_commands()
+
+    deferred = False
+
+    async def _defer(ephemeral=True):
+        nonlocal deferred
+        deferred = True
+
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(id=555),
+        channel_id=555,
+        guild=None,
+        user=SimpleNamespace(id=42, display_name="Sumanth"),
+        response=SimpleNamespace(defer=AsyncMock(side_effect=_defer), is_done=lambda: deferred),
+        edit_original_response=AsyncMock(),
+    )
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        await adapter._client.tree.commands["open"].callback(interaction)
+
     interaction.edit_original_response.assert_awaited_once_with(content="Handled /open")
 
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -574,6 +574,44 @@ Send `/model` with no arguments in a Discord channel to open a dropdown-based mo
 
 The picker times out after 120 seconds. Only authorized users (those in `DISCORD_ALLOWED_USERS`) can interact with it. If you know the model name, type `/model <name>` directly.
 
+
+## Custom Discord Slash Command Hooks
+
+You can declare Discord-native slash commands that do **not** route through the LLM or Hermes' generic slash-command text path. Instead, the Discord adapter authorizes the user and emits a plugin hook named `discord_custom_slash_command`. This is useful for deterministic Discord-side workflows such as marking a thread done, renaming a channel, archiving a thread, or adding reactions.
+
+```yaml
+discord:
+  custom_slash_commands:
+    - name: done
+      description: Mark the current thread done
+    - name: blocked
+      description: Mark the current thread blocked
+    - name: tag
+      description: Tag the current Discord context
+      args_hint: "label"
+```
+
+A user plugin can then handle the event and decide what to mutate:
+
+```python
+# ~/.hermes/plugins/thread-status/__init__.py
+import re
+
+def register(ctx):
+    async def on_custom_slash(command, interaction, channel, thread_id, **kwargs):
+        if command != "done" or not thread_id:
+            return
+        title = re.sub(r"^[✅🟡🔴]\s*", "", channel.name)
+        await channel.edit(name=f"✅ {title}", archived=True)
+        await interaction.response.send_message("Marked done", ephemeral=True)
+
+    ctx.register_hook("discord_custom_slash_command", on_custom_slash)
+```
+
+Hook payload includes the raw `interaction`, `adapter`, `guild`, `channel`, `thread`, `parent_channel`, `user`, plus normalized IDs (`guild_id`, `channel_id`, `thread_id`, `parent_channel_id`, `user_id`) and the optional `args` string. If the plugin does not send a response, Hermes sends a small ephemeral fallback acknowledgment.
+
+Custom commands share the same slash authorization checks as built-in Discord slash commands.
+
 ## Native Slash Commands for Skills
 
 Hermes automatically registers installed skills as **native Discord Application Commands**. This means skills appear in Discord's autocomplete `/` menu alongside built-in commands.


### PR DESCRIPTION
## Summary
- Add `discord.custom_slash_commands` for config-declared Discord-native slash commands
- Emit a `discord_custom_slash_command` plugin hook after normal Discord slash authorization
- Pass the raw Discord interaction plus channel/thread/user/guild objects and normalized IDs to listeners so plugins can perform deterministic Discord-side mutations
- Add a `discord_auto_thread_created` hook so plugins can react when Hermes auto-creates a Discord thread from an @mention
- Document a `/done` thread-state example where a plugin renames and archives the current thread

## Why
Hermes already supports auto-threading on Discord, but custom workflows like "mark this thread done" currently require patching the Discord adapter directly or routing through the LLM/generic slash-command path. This feature keeps core responsible for deterministic Discord plumbing (register command, auth-check, emit hook) while leaving all policy to user plugins.

Example use case: configure `/done`, then a personal plugin handles the hook and renames the current thread from `🟡 topic` to `✅ topic` and archives it. The same hook can support `/blocked`, `/tag`, reactions, pins, or other Discord-native workflows without more core changes.

## Second commit: `017e1eabd fix(discord): defer custom slash hooks`

After testing the custom state commands in Discord, `/done` appeared to work but other state commands such as `/open`, `/running`, `/waiting`, and `/blocked` could show Discord's "The application did not respond" error.

Root cause: custom slash hooks were acknowledged only after plugin work completed. Thread renames are Discord `PATCH /channels/<thread>` calls, and Discord can rate-limit those heavily. If the rename waits behind a rate-limit retry, the interaction misses Discord's short acknowledgement deadline.

The fix is to acknowledge first, then run plugin policy:
- `_handle_custom_slash_command()` now defers the interaction ephemerally immediately after slash authorization succeeds.
- Fallback custom-slash responses now edit the deferred original response when the interaction has already been acknowledged.
- Added regression coverage proving custom slash commands defer before running hooks.

This keeps `/done`, `/open`, `/running`, `/waiting`, `/blocked`, or any other custom command from timing out just because the plugin performs slower Discord-side mutations like renaming/archiving a thread.

## Third commit: `5ccdd5285 fix(discord): preserve custom slash hook responses`

Follow-up Discord testing showed another issue: plugin-handled commands could briefly show the plugin's useful response, then flip back to generic text like `Handled /waiting` or `Handled /done`.

Root cause: after plugin hooks completed, core always sent its fallback response. Since the interaction was already deferred, that fallback edited the same original ephemeral response and overwrote the plugin's own message.

The fix is to treat hook presence as ownership of the response:
- If one or more `discord_custom_slash_command` listeners ran, core skips the generic fallback response.
- If no listener handled the custom command, core still sends `Handled /command` as a safe fallback.
- Added regression coverage for both plugin-handled and no-listener fallback paths.

This keeps core as plumbing while letting user plugins own the user-facing UX for deterministic Discord commands.

## Test Plan
- `./venv/bin/python -m py_compile gateway/platforms/discord.py hermes_cli/plugins.py hermes_cli/config.py gateway/config.py`
- `./venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/test_config.py -q -o 'addopts='`
- After the second commit: `./venv/bin/python -m py_compile gateway/platforms/discord.py hermes_cli/plugins.py tests/gateway/test_discord_slash_commands.py`
- After the second commit: `./venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py -q -o 'addopts='`
- After the third commit: `./venv/bin/python -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_slash_commands.py`
- After the third commit: `./venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py -q -o 'addopts='`