### PR TITLE
fix(acp): avoid json shadowing in tool start fallback

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -1123,7 +1123,6 @@ def build_tool_start(
         )
 
     # Generic fallback
-    import json
     try:
         args_text = json.dumps(arguments, indent=2, default=str)
     except (TypeError, ValueError):

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -257,6 +257,13 @@ class TestBuildToolStart:
         assert result.content[0].new_text == "new advice"
         assert result.raw_input is None
 
+    def test_build_tool_start_polished_fallback_uses_module_json(self):
+        """Polished fallback tools should not trip local import shadowing."""
+        result = build_tool_start("tc-browser-back", "browser_back", {})
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "execute"
+        assert result.raw_input is None
+
     def test_build_tool_start_generic_fallback(self):
         """Unknown tools should get a generic text representation."""
         args = {"foo": "bar", "baz": 42}


### PR DESCRIPTION
## Summary
- remove the local `import json` inside `acp_adapter.tools.build_tool_start()` so the function uses the module-level import consistently
- add a regression test for polished fallback tool rendering, which previously failed before the generic fallback's local import executed

## Test Plan
- `/home/valentin/.hermes/hermes-agent/venv/bin/python -m pytest tests/acp/test_tools.py -q -o 'addopts='`
- `git diff --check`

## Context
A replayed ACP session can call `build_tool_start()` for a polished tool that falls through to the polished fallback branch. Because the function also had an inner `import json` later in the generic fallback, Python treated `json` as a local variable throughout the function, causing `UnboundLocalError` before the local import was reached.
