### PR TITLE
docs(slack): document SLACK_ALLOW_BOTS / allow_bots for bot-to-bot messaging

### DIFF
--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -430,6 +430,10 @@ SLACK_ALLOW_BOTS=mentions   # default: none
 | `mentions` | Accept only when the peer bot @mentions Hermes. |
 | `all` | Accept every peer bot message. |
 
+:::warning
+Prefer `mentions` in shared or busy channels. `all` accepts every peer bot message and can sharply increase inbound traffic — including feedback loops with automations that react to Hermes' own replies (Hermes drops self-originated traffic, but other bots may not). Reserve `all` for tightly controlled environments where the set of peer bots is known and trusted.
+:::
+
 Also configurable as `platforms.slack.extra.allow_bots` in `config.yaml`:
 
 ```yaml

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -416,6 +416,33 @@ Behavior:
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
 
+### Bot-to-Bot Messaging
+
+By default Hermes ignores messages sent by other bots. Enable bot-to-bot messaging when you want Hermes to participate in A2A orchestration or receive notifications from other bots in the same channel or thread.
+
+```bash
+SLACK_ALLOW_BOTS=mentions   # default: none
+```
+
+| Value | Behavior |
+|-------|----------|
+| `none` | Ignore all messages from other bots (default). |
+| `mentions` | Accept only when the peer bot @mentions Hermes. |
+| `all` | Accept every peer bot message. |
+
+Also configurable as `platforms.slack.extra.allow_bots` in `config.yaml`:
+
+```yaml
+platforms:
+  slack:
+    extra:
+      allow_bots: "mentions"
+```
+
+When both are set, `config.yaml` takes precedence over the environment variable (the env var is only consulted if `allow_bots` is missing or empty in config).
+
+Hermes never replies to its own messages regardless of this setting — the adapter compares the message sender against the bot's resolved user ID and drops self-originated traffic before further processing. Peer bots do not need to be added to `SLACK_ALLOWED_USERS`; that allowlist applies to human senders only.
+
 ### Unauthorized User Handling
 
 ```yaml
@@ -463,6 +490,7 @@ platforms:
     extra:
       reply_in_thread: true
       reply_broadcast: false
+      allow_bots: "none"        # "none" | "mentions" | "all"
 ```
 
 ---


### PR DESCRIPTION
## What does this PR do?

Adds a **Bot-to-Bot Messaging** subsection to the Slack user guide documenting the existing `platforms.slack.extra.allow_bots` config key and `SLACK_ALLOW_BOTS` env var. Threads `allow_bots: "none"` into the **Full Example** YAML so the canonical reference now covers it. Docs-only — no behavior change.

The Slack adapter has supported peer-bot messaging since the `allow_bots` knob was added at `gateway/platforms/slack.py:1774-1793`, but the feature is invisible to users — `allow_bots` and `SLACK_ALLOW_BOTS` don't appear anywhere in `website/docs/user-guide/messaging/slack.md`. The only way to discover it today is to grep the gateway source. Feishu already documents the same knob at `website/docs/user-guide/messaging/feishu.md:224-242`; this PR mirrors that documentation style for Slack so multi-agent Slack threads (A2A orchestration, peer bot notifications) become a config flip instead of a code-archaeology exercise.

## Related Issue

Fixes #26184

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/slack.md` — add `### Bot-to-Bot Messaging` subsection under `## Configuration Options`, document `SLACK_ALLOW_BOTS` env var with `none`/`mentions`/`all` behavior table, equivalent `platforms.slack.extra.allow_bots` YAML key, precedence (config > env), self-echo behavior, and relationship to `SLACK_ALLOWED_USERS`. Thread `allow_bots: "none"` into the Full Example YAML.

## How to Test

1. Build the docs site or preview the markdown locally.
2. Confirm the new `### Bot-to-Bot Messaging` heading sits inside `## Configuration Options` between `### Mention & Trigger Behavior` and `### Unauthorized User Handling`.
3. Cross-check every claim against `gateway/platforms/slack.py:1774-1793` — env var name, default, three accepted values, config key, precedence order, and self-echo behavior all match the code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass — N/A, docs-only
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, docs-only
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this IS the docs update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, docs-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #26184. Intentionally scoped to the docs piece only — the setup-wizard prompt and self-echo-guard hoist mentioned in that issue are deliberately out of scope here, since the reporter explicitly flagged the docs gap as the no-core-code-change ask.
- Mirrors the existing Feishu `## Bot-to-Bot Messaging` section at `website/docs/user-guide/messaging/feishu.md:224-242` for cross-platform doc parity.

> Audited siblings: every claim is cross-checked against `gateway/platforms/slack.py:1774-1793`. No code-side widening needed — the runtime already implements the documented behavior; this PR only closes the docs gap.
