### PR TITLE
fix(api-server): harden one-model passthrough compatibility

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1474,6 +1474,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
+    api_server_mode = os.getenv("API_SERVER_MODE")
+    api_server_passthrough_force_model = os.getenv("API_SERVER_PASSTHROUGH_FORCE_MODEL")
     if api_server_enabled or api_server_key:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()
@@ -1491,6 +1493,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 pass
         if api_server_host:
             config.platforms[Platform.API_SERVER].extra["host"] = api_server_host
+    if api_server_mode:
+        config.platforms[Platform.API_SERVER].extra["mode"] = api_server_mode.strip().lower()
+    if api_server_passthrough_force_model:
+        config.platforms[Platform.API_SERVER].extra["passthrough_force_model"] = api_server_passthrough_force_model
         api_server_model_name = os.getenv("API_SERVER_MODEL_NAME", "")
         if api_server_model_name:
             config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -607,6 +607,10 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        self._allowed_model_names: tuple[str, ...] = self._parse_allowed_model_names(
+            extra.get("allowed_models", os.getenv("API_SERVER_ALLOWED_MODELS", "")),
+            self._model_name,
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -640,6 +644,35 @@ class APIServerAdapter(BasePlatformAdapter):
             items = [str(value)]
 
         return tuple(str(item).strip() for item in items if str(item).strip())
+
+    @staticmethod
+    def _parse_allowed_model_names(value: Any, default_model: str) -> tuple[str, ...]:
+        """Build the passthrough model whitelist. Defaults to the advertised model only."""
+        names: list[str] = []
+        if default_model and str(default_model).strip():
+            names.append(str(default_model).strip())
+        if value:
+            items = value.split(",") if isinstance(value, str) else value
+            if not isinstance(items, (list, tuple, set)):
+                items = [str(items)]
+            for item in items:
+                name = str(item).strip()
+                if name and name not in names:
+                    names.append(name)
+        return tuple(names)
+
+    def _validate_passthrough_model(self, requested_model: str) -> Optional["web.Response"]:
+        """Reject unknown client-facing model names before passthrough fallback."""
+        if not requested_model or requested_model in self._allowed_model_names:
+            return None
+        allowed = ", ".join(self._allowed_model_names) or self._model_name
+        return web.json_response(
+            _openai_error(
+                f"Unknown model {requested_model!r}. Allowed model(s): {allowed}.",
+                code="model_not_found",
+            ),
+            status=400,
+        )
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:
@@ -1025,6 +1058,9 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             runtime = _resolve_runtime_agent_kwargs()
             payload, requested_model = self._passthrough_payload(body)
+            model_err = self._validate_passthrough_model(requested_model)
+            if model_err is not None:
+                return model_err
             api_mode = str(runtime.get("api_mode") or "").strip().lower()
             if not runtime.get("api_key"):
                 return web.json_response(_openai_error("No upstream API key resolved from Hermes config.", code="missing_upstream_api_key"), status=500)
@@ -2166,6 +2202,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
             chat_payload = responses_to_chat_payload(body, default_model=self._model_name)
             _, requested_model = self._passthrough_payload(chat_payload)
+            model_err = self._validate_passthrough_model(requested_model)
+            if model_err is not None:
+                return model_err
             logger.info("Passthrough responses: base_url=%s model=%s payload_keys=%s", runtime.get("base_url"), chat_payload.get("model"), list(chat_payload.keys()))
             api_mode = str(runtime.get("api_mode") or "").strip().lower()
             if not runtime.get("api_key"):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -592,6 +592,15 @@ class APIServerAdapter(BasePlatformAdapter):
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
+        self._mode: str = str(
+            extra.get("mode", os.getenv("API_SERVER_MODE", "agent")) or "agent"
+        ).strip().lower()
+        self._passthrough_force_model: bool = str(
+            extra.get(
+                "passthrough_force_model",
+                os.getenv("API_SERVER_PASSTHROUGH_FORCE_MODEL", "true"),
+            )
+        ).strip().lower() not in {"0", "false", "no", "off"}
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -707,6 +716,11 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    @staticmethod
+    def _openai_error(message: str, err_type: str = "invalid_request_error", code: Optional[str] = None) -> Dict[str, Any]:
+        """Expose module-level OpenAI error helper to passthrough adapters."""
+        return _openai_error(message, err_type=err_type, code=code)
 
     # ------------------------------------------------------------------
     # Session header helpers
@@ -893,19 +907,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        model_entry = {
+            "id": self._model_name,
+            "object": "model",
+            "created": int(time.time()),
+            "owned_by": "hermes",
+            "permission": [],
+            "root": self._model_name,
+            "parent": None,
+        }
         return web.json_response({
             "object": "list",
-            "data": [
-                {
-                    "id": self._model_name,
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": self._model_name,
-                    "parent": None,
-                }
-            ],
+            "data": [model_entry],
+            # Compatibility with clients that look for a top-level `models`
+            # array in addition to the OpenAI-standard `data` array.
+            "models": [model_entry],
         })
 
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
@@ -942,13 +958,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "chat_completions_streaming": True,
                 "responses_api": True,
                 "responses_streaming": True,
-                "run_submission": True,
-                "run_status": True,
-                "run_events_sse": True,
-                "run_stop": True,
-                "run_approval_response": True,
-                "tool_progress_events": True,
-                "approval_events": True,
+                "run_submission": self._mode != "passthrough",
+                "run_status": self._mode != "passthrough",
+                "run_events_sse": self._mode != "passthrough",
+                "run_stop": self._mode != "passthrough",
+                "run_approval_response": self._mode != "passthrough",
+                "tool_progress_events": self._mode != "passthrough",
+                "approval_events": self._mode != "passthrough",
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -967,6 +983,81 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         })
 
+    def _passthrough_payload(self, body: Dict[str, Any]) -> tuple[Dict[str, Any], str]:
+        """Build the upstream Chat Completions payload for passthrough mode.
+
+        By default we force the upstream model to Hermes' configured default so
+        the public API can advertise a single friendly model name while still
+        reusing the real provider/model from config.yaml.
+        """
+        from gateway.run import _resolve_gateway_model
+
+        payload = dict(body)
+        requested_model = str(payload.get("model") or self._model_name).strip() or self._model_name
+        configured_model = _resolve_gateway_model()
+        if self._passthrough_force_model and configured_model:
+            payload["model"] = configured_model
+        elif not payload.get("model") and configured_model:
+            payload["model"] = configured_model
+        return payload, requested_model
+
+    async def _handle_passthrough_chat_completions(
+        self,
+        request: "web.Request",
+        body: Dict[str, Any],
+    ) -> "web.Response":
+        """POST /v1/chat/completions in model-passthrough mode.
+
+        This bypasses AIAgent entirely: no Hermes system prompt, no tools, no
+        skills, no memory, no session DB. It only reuses Hermes' configured
+        inference provider credentials/base_url/model.
+        """
+        from gateway.run import _resolve_runtime_agent_kwargs
+
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            return web.json_response(
+                _openai_error("The openai Python package is required for API_SERVER_MODE=passthrough.", code="missing_dependency"),
+                status=500,
+            )
+
+        try:
+            runtime = _resolve_runtime_agent_kwargs()
+            payload, requested_model = self._passthrough_payload(body)
+            api_mode = str(runtime.get("api_mode") or "").strip().lower()
+            if not runtime.get("api_key"):
+                return web.json_response(_openai_error("No upstream API key resolved from Hermes config.", code="missing_upstream_api_key"), status=500)
+
+            client = AsyncOpenAI(api_key=runtime.get("api_key"), base_url=runtime.get("base_url") or None)
+
+            from gateway.platforms.one_model_api import get_passthrough_adapter
+
+            adapter = get_passthrough_adapter(runtime)
+            if adapter is None:
+                return web.json_response(
+                    _openai_error(
+                        f"API passthrough does not yet support current upstream api_mode {api_mode!r}.",
+                        code="unsupported_provider_mode",
+                    ),
+                    status=501,
+                )
+
+            return await adapter.chat_completion(
+                server=self,
+                request=request,
+                client=client,
+                runtime=runtime,
+                payload=payload,
+                requested_model=requested_model,
+            )
+        except Exception as exc:
+            logger.exception("Passthrough chat completion failed")
+            return web.json_response(
+                _openai_error(f"Passthrough upstream request failed: {exc}", code="upstream_request_failed"),
+                status=502,
+            )
+
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
@@ -978,6 +1069,9 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+
+        if self._mode == "passthrough":
+            return await self._handle_passthrough_chat_completions(request, body)
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
@@ -2036,11 +2130,88 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return response
 
+    # ── Passthrough /v1/responses handler ─────────────────────────
+
+    async def _handle_passthrough_responses(
+        self,
+        request: "web.Request",
+        body: Dict[str, Any],
+    ) -> "web.Response":
+        """POST /v1/responses in passthrough mode — minimal compat adapter.
+
+        Converts Responses API input to chat messages, forwards to upstream,
+        wraps the chat completion result back into response format.
+        Does NOT support tools — returns 400 if tools are present.
+        """
+        from gateway.run import _resolve_runtime_agent_kwargs
+
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            return web.json_response(
+                _openai_error("The openai Python package is required for API_SERVER_MODE=passthrough.", code="missing_dependency"),
+                status=500,
+            )
+
+        # Minimal compat: reject tools explicitly
+        if body.get("tools"):
+            return web.json_response(
+                _openai_error("tools are not supported by this minimal passthrough responses adapter", code="unsupported_feature"),
+                status=400,
+            )
+
+        try:
+            runtime = _resolve_runtime_agent_kwargs()
+            from gateway.platforms.one_model_api.conversions import responses_to_chat_payload
+
+            chat_payload = responses_to_chat_payload(body, default_model=self._model_name)
+            _, requested_model = self._passthrough_payload(chat_payload)
+            logger.info("Passthrough responses: base_url=%s model=%s payload_keys=%s", runtime.get("base_url"), chat_payload.get("model"), list(chat_payload.keys()))
+            api_mode = str(runtime.get("api_mode") or "").strip().lower()
+            if not runtime.get("api_key"):
+                return web.json_response(_openai_error("No upstream API key resolved from Hermes config.", code="missing_upstream_api_key"), status=500)
+
+            client = AsyncOpenAI(api_key=runtime.get("api_key"), base_url=runtime.get("base_url") or None)
+
+            from gateway.platforms.one_model_api import get_passthrough_adapter
+
+            adapter = get_passthrough_adapter(runtime)
+            if adapter is None:
+                return web.json_response(
+                    _openai_error(
+                        f"API passthrough does not yet support current upstream api_mode {api_mode!r}.",
+                        code="unsupported_provider_mode",
+                    ),
+                    status=501,
+                )
+
+            return await adapter.responses(
+                server=self,
+                request=request,
+                client=client,
+                runtime=runtime,
+                body=body,
+                chat_payload=chat_payload,
+                requested_model=requested_model,
+            )
+        except Exception as exc:
+            logger.exception("Passthrough responses failed")
+            return web.json_response(
+                _openai_error(f"Passthrough upstream request failed: {exc}", code="upstream_request_failed"),
+                status=502,
+            )
+
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
         """POST /v1/responses — OpenAI Responses API format."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+        if self._mode == "passthrough":
+            try:
+                body = await request.json()
+            except (json.JSONDecodeError, Exception):
+                return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+            return await self._handle_passthrough_responses(request, body)
 
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
@@ -2811,6 +2982,11 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+        if self._mode == "passthrough":
+            return web.json_response(
+                _openai_error("/v1/runs is not available in API_SERVER_MODE=passthrough; use /v1/chat/completions.", code="unsupported_endpoint"),
+                status=501,
+            )
 
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)

--- a/gateway/platforms/one_model_api/__init__.py
+++ b/gateway/platforms/one_model_api/__init__.py
@@ -1,0 +1,10 @@
+"""Lightweight protocol adapter layer for API Server passthrough mode.
+
+The one-model API intentionally only adapts protocols. Hermes remains
+responsible for credentials, provider/runtime resolution, OAuth, account pools,
+quota, cooldown, failover, and scheduling.
+"""
+
+from .registry import get_passthrough_adapter
+
+__all__ = ["get_passthrough_adapter"]

--- a/gateway/platforms/one_model_api/adapters/base.py
+++ b/gateway/platforms/one_model_api/adapters/base.py
@@ -1,0 +1,52 @@
+"""Base protocol adapter interface for API Server passthrough mode."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Mapping
+
+from aiohttp import web
+
+
+class PassthroughProtocolAdapter(ABC):
+    """Protocol-only adapter for the one-model API passthrough surface.
+
+    Adapters translate between the public OpenAI-compatible API surface and an
+    already-resolved Hermes upstream runtime. They must not select accounts,
+    persist credentials, maintain cooldown tables, or implement failover pools.
+    """
+
+    protocol: ClassVar[str]
+    api_modes: ClassVar[set[str]]
+
+    @classmethod
+    def supports_runtime(cls, runtime: Mapping[str, Any]) -> bool:
+        api_mode = str(runtime.get("api_mode") or "").strip().lower()
+        return api_mode in cls.api_modes or (not api_mode and "" in cls.api_modes)
+
+    @abstractmethod
+    async def chat_completion(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        """Handle public POST /v1/chat/completions."""
+
+    @abstractmethod
+    async def responses(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        body: dict[str, Any],
+        chat_payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        """Handle public POST /v1/responses."""

--- a/gateway/platforms/one_model_api/adapters/codex_responses.py
+++ b/gateway/platforms/one_model_api/adapters/codex_responses.py
@@ -49,11 +49,19 @@ class CodexResponsesAdapter(PassthroughProtocolAdapter):
                 codex_kwargs=codex_kwargs,
                 requested_model=requested_model,
                 default_model=server._model_name,
+                stop=payload.get("stop"),
             )
 
         response = await collect_codex_stream(client, codex_kwargs)
         return web.json_response(
-            codex_to_chat_payload(response, requested_model=requested_model, default_model=server._model_name)
+            codex_to_chat_payload(
+                response,
+                requested_model=requested_model,
+                default_model=server._model_name,
+                stop=payload.get("stop"),
+                tool_choice=payload.get("tool_choice") or payload.get("function_call"),
+                tools=codex_kwargs.get("tools"),
+            )
         )
 
     async def responses(
@@ -88,5 +96,10 @@ class CodexResponsesAdapter(PassthroughProtocolAdapter):
 
         response = await collect_codex_stream(client, codex_kwargs)
         return web.json_response(
-            codex_to_response_payload(response, requested_model=requested_model, default_model=server._model_name)
+            codex_to_response_payload(
+                response,
+                requested_model=requested_model,
+                default_model=server._model_name,
+                stop=chat_payload.get("stop"),
+            )
         )

--- a/gateway/platforms/one_model_api/adapters/codex_responses.py
+++ b/gateway/platforms/one_model_api/adapters/codex_responses.py
@@ -1,0 +1,92 @@
+"""Codex/OpenAI Responses upstream adapter."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+from aiohttp import web
+
+from ..conversions import (
+    chat_payload_to_codex_responses_kwargs,
+    codex_to_chat_payload,
+    codex_to_response_payload,
+    collect_codex_stream,
+)
+from ..streams import stream_codex_as_chat_sse, stream_codex_as_responses_sse
+from .base import PassthroughProtocolAdapter
+
+
+class CodexResponsesAdapter(PassthroughProtocolAdapter):
+    """Adapter for Hermes runtimes using api_mode=codex_responses."""
+
+    protocol: ClassVar[str] = "codex_responses"
+    api_modes: ClassVar[set[str]] = {"codex_responses"}
+
+    async def chat_completion(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        try:
+            codex_kwargs = chat_payload_to_codex_responses_kwargs(
+                payload,
+                runtime=runtime,
+                default_model=server._model_name,
+                stream=True,
+            )
+        except ValueError as exc:
+            return web.json_response(server._openai_error(str(exc), code="unsupported_feature"), status=400)
+
+        if bool(payload.get("stream", False)):
+            return await stream_codex_as_chat_sse(
+                request,
+                client=client,
+                codex_kwargs=codex_kwargs,
+                requested_model=requested_model,
+                default_model=server._model_name,
+            )
+
+        response = await collect_codex_stream(client, codex_kwargs)
+        return web.json_response(
+            codex_to_chat_payload(response, requested_model=requested_model, default_model=server._model_name)
+        )
+
+    async def responses(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        body: dict[str, Any],
+        chat_payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        try:
+            codex_kwargs = chat_payload_to_codex_responses_kwargs(
+                chat_payload,
+                runtime=runtime,
+                default_model=server._model_name,
+                stream=True,
+            )
+        except ValueError as exc:
+            return web.json_response(server._openai_error(str(exc), code="unsupported_feature"), status=400)
+
+        if bool(body.get("stream", False)):
+            return await stream_codex_as_responses_sse(
+                request,
+                client=client,
+                codex_kwargs=codex_kwargs,
+                requested_model=requested_model,
+                default_model=server._model_name,
+            )
+
+        response = await collect_codex_stream(client, codex_kwargs)
+        return web.json_response(
+            codex_to_response_payload(response, requested_model=requested_model, default_model=server._model_name)
+        )

--- a/gateway/platforms/one_model_api/adapters/openai_chat.py
+++ b/gateway/platforms/one_model_api/adapters/openai_chat.py
@@ -1,0 +1,69 @@
+"""OpenAI-compatible Chat Completions upstream adapter."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+from aiohttp import web
+
+from ..conversions import chat_to_response_payload
+from ..streams import stream_openai_chat_as_chat_sse, stream_openai_chat_as_responses_sse
+from .base import PassthroughProtocolAdapter
+
+
+class OpenAIChatAdapter(PassthroughProtocolAdapter):
+    """Adapter for upstreams that already speak OpenAI Chat Completions."""
+
+    protocol: ClassVar[str] = "openai_chat"
+    api_modes: ClassVar[set[str]] = {"", "chat_completions", "openai", "openai_compatible"}
+
+    async def chat_completion(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        if bool(payload.get("stream", False)):
+            return await stream_openai_chat_as_chat_sse(
+                request,
+                client=client,
+                payload=payload,
+                requested_model=requested_model,
+            )
+
+        response = await client.chat.completions.create(**payload)
+        data = response.model_dump(exclude_none=True) if hasattr(response, "model_dump") else dict(response)
+        if requested_model:
+            data["model"] = requested_model
+        return web.json_response(data)
+
+    async def responses(
+        self,
+        *,
+        server: Any,
+        request: web.Request,
+        client: Any,
+        runtime: Mapping[str, Any],
+        body: dict[str, Any],
+        chat_payload: dict[str, Any],
+        requested_model: str,
+    ) -> web.Response:
+        if bool(body.get("stream", False)):
+            return await stream_openai_chat_as_responses_sse(
+                request,
+                client=client,
+                chat_payload=chat_payload,
+                requested_model=requested_model,
+                default_model=server._model_name,
+            )
+
+        chat_payload["stream"] = False
+        response = await client.chat.completions.create(**chat_payload)
+        chat_data = response.model_dump(exclude_none=True) if hasattr(response, "model_dump") else dict(response)
+        return web.json_response(
+            chat_to_response_payload(chat_data, requested_model, default_model=server._model_name)
+        )

--- a/gateway/platforms/one_model_api/adapters/openai_chat.py
+++ b/gateway/platforms/one_model_api/adapters/openai_chat.py
@@ -6,9 +6,19 @@ from typing import Any, ClassVar, Mapping
 
 from aiohttp import web
 
-from ..conversions import chat_to_response_payload
+from ..conversions import apply_stop_to_chat_data, chat_to_response_payload
 from ..streams import stream_openai_chat_as_chat_sse, stream_openai_chat_as_responses_sse
 from .base import PassthroughProtocolAdapter
+
+
+_UNSUPPORTED_UPSTREAM_PARAMS = {"temperature", "top_p"}
+
+
+def _sanitize_chat_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    clean = dict(payload)
+    for key in _UNSUPPORTED_UPSTREAM_PARAMS:
+        clean.pop(key, None)
+    return clean
 
 
 class OpenAIChatAdapter(PassthroughProtocolAdapter):
@@ -27,18 +37,22 @@ class OpenAIChatAdapter(PassthroughProtocolAdapter):
         payload: dict[str, Any],
         requested_model: str,
     ) -> web.Response:
+        stop = payload.get("stop")
+        payload = _sanitize_chat_payload(payload)
         if bool(payload.get("stream", False)):
             return await stream_openai_chat_as_chat_sse(
                 request,
                 client=client,
                 payload=payload,
                 requested_model=requested_model,
+                stop=stop,
             )
 
         response = await client.chat.completions.create(**payload)
         data = response.model_dump(exclude_none=True) if hasattr(response, "model_dump") else dict(response)
         if requested_model:
             data["model"] = requested_model
+        data = apply_stop_to_chat_data(data, stop)
         return web.json_response(data)
 
     async def responses(
@@ -52,6 +66,7 @@ class OpenAIChatAdapter(PassthroughProtocolAdapter):
         chat_payload: dict[str, Any],
         requested_model: str,
     ) -> web.Response:
+        chat_payload = _sanitize_chat_payload(chat_payload)
         if bool(body.get("stream", False)):
             return await stream_openai_chat_as_responses_sse(
                 request,

--- a/gateway/platforms/one_model_api/conversions.py
+++ b/gateway/platforms/one_model_api/conversions.py
@@ -1,0 +1,349 @@
+"""Protocol conversion helpers for the one-model API passthrough layer.
+
+This module is intentionally protocol-only: it translates payload/response shapes
+between the public OpenAI-compatible surface and already-resolved Hermes upstream
+runtimes. It must not select accounts, store credentials, or implement failover.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Mapping
+
+
+def make_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def chat_completion_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex[:29]}"
+
+
+def response_to_dict(response_obj: Any) -> dict[str, Any]:
+    """Best-effort conversion of SDK response/event objects to plain dicts."""
+    if response_obj is None:
+        return {}
+    if isinstance(response_obj, dict):
+        return response_obj
+    if hasattr(response_obj, "model_dump"):
+        try:
+            return response_obj.model_dump(exclude_none=True)
+        except Exception:
+            pass
+    if hasattr(response_obj, "dict"):
+        try:
+            return response_obj.dict()
+        except Exception:
+            pass
+    try:
+        return dict(response_obj)
+    except Exception:
+        return {}
+
+
+def content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in {"input_text", "text", "output_text"}:
+                parts.append(str(item.get("text", "")))
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def response_text(response_obj: Any) -> str:
+    """Extract visible assistant text from a Responses/Codex response object or dict."""
+    output_text = getattr(response_obj, "output_text", None)
+    if isinstance(output_text, str) and output_text:
+        return output_text
+    data = response_to_dict(response_obj)
+    output_text = data.get("output_text")
+    if isinstance(output_text, str) and output_text:
+        return output_text
+
+    pieces: list[str] = []
+    output = data.get("output") or []
+    if not isinstance(output, list):
+        output = []
+    for item in output:
+        if not isinstance(item, dict):
+            item = response_to_dict(item)
+        if item.get("type") != "message":
+            continue
+        content = item.get("content") or []
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                part = response_to_dict(part)
+            if part.get("type") in {"output_text", "text"}:
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    pieces.append(text)
+    return "".join(pieces)
+
+
+def response_usage(response_obj: Any) -> dict[str, int]:
+    """Map Responses usage fields to Chat Completions-style token usage."""
+    data = response_to_dict(response_obj)
+    usage = data.get("usage") or {}
+    if not isinstance(usage, dict):
+        usage = response_to_dict(usage)
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0
+    total_tokens = usage.get("total_tokens", 0) or 0
+    if not total_tokens:
+        try:
+            total_tokens = int(input_tokens) + int(output_tokens)
+        except Exception:
+            total_tokens = 0
+    return {
+        "prompt_tokens": int(input_tokens or 0),
+        "completion_tokens": int(output_tokens or 0),
+        "total_tokens": int(total_tokens or 0),
+    }
+
+
+def _normalize_chat_content_for_instructions(content: Any) -> str:
+    return content_to_text(content)
+
+
+def chat_payload_to_codex_responses_kwargs(
+    payload: dict[str, Any],
+    *,
+    runtime: Mapping[str, Any],
+    default_model: str,
+    stream: bool,
+) -> dict[str, Any]:
+    """Convert an external Chat Completions request into Codex Responses kwargs."""
+    messages = payload.get("messages") or []
+    if not isinstance(messages, list):
+        messages = []
+
+    system_parts: list[str] = []
+    non_system_messages: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "system":
+            text = _normalize_chat_content_for_instructions(msg.get("content", ""))
+            if text:
+                system_parts.append(text)
+        elif role in {"user", "assistant", "tool"}:
+            non_system_messages.append(msg)
+
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    kwargs: dict[str, Any] = {
+        "model": payload.get("model") or default_model,
+        "input": _chat_messages_to_responses_input(non_system_messages),
+        "store": False,
+        "stream": stream,
+    }
+    kwargs["instructions"] = "\n".join(system_parts) if system_parts else "You are a helpful assistant."
+
+    # Minimal one-model API: do not expose tool/agent capability through this endpoint.
+    if payload.get("tools"):
+        raise ValueError("tools are not supported by this minimal passthrough Codex adapter")
+
+    # Responses API uses max_output_tokens; Chat Completions uses max_tokens.
+    # The ChatGPT Codex backend may reject max_output_tokens in some modes, so
+    # only map max_tokens for non-ChatGPT-Codex upstreams.
+    base_url = str(runtime.get("base_url") or "")
+    if "max_output_tokens" in payload:
+        kwargs["max_output_tokens"] = payload["max_output_tokens"]
+    elif "max_tokens" in payload and "chatgpt.com/backend-api/codex" not in base_url:
+        kwargs["max_output_tokens"] = payload["max_tokens"]
+
+    for key in ("temperature", "top_p"):
+        if key in payload:
+            kwargs[key] = payload[key]
+
+    session_id = payload.get("user") or payload.get("prompt_cache_key")
+    if session_id and "chatgpt.com/backend-api/codex" in base_url:
+        kwargs["extra_headers"] = {
+            "session_id": str(session_id),
+            "x-client-request-id": str(session_id),
+        }
+    return kwargs
+
+
+async def collect_codex_stream(client: Any, codex_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """ChatGPT Codex backend requires stream=true; collect stream for non-stream public calls."""
+    kwargs = dict(codex_kwargs)
+    kwargs["stream"] = True
+    full_text = ""
+    final_response: dict[str, Any] = {}
+    stream = await client.responses.create(**kwargs)
+    async for event in stream:
+        event_type = getattr(event, "type", None)
+        data = response_to_dict(event)
+        if not event_type:
+            event_type = data.get("type")
+        if event_type == "response.output_text.delta":
+            piece = getattr(event, "delta", "") or data.get("delta", "") or ""
+            full_text += piece
+        elif event_type in {"response.completed", "response.failed", "response.incomplete"}:
+            response_data = data.get("response")
+            if isinstance(response_data, dict):
+                final_response = response_data
+    if not final_response:
+        final_response = {
+            "id": make_id("resp"),
+            "object": "response",
+            "created_at": int(time.time()),
+            "status": "completed",
+            "model": codex_kwargs.get("model"),
+        }
+    final_response["output_text"] = final_response.get("output_text") or full_text
+    if "output" not in final_response:
+        final_response["output"] = [
+            {
+                "id": make_id("msg"),
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+            }
+        ]
+    return final_response
+
+
+def codex_to_chat_payload(response_obj: Any, *, requested_model: str, default_model: str) -> dict[str, Any]:
+    """Wrap a Responses/Codex response as an OpenAI Chat Completion response."""
+    data = response_to_dict(response_obj)
+    text = response_text(response_obj)
+    usage = response_usage(response_obj)
+    return {
+        "id": chat_completion_id(),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": requested_model or default_model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop"
+                if data.get("status") not in {"incomplete", "failed", "cancelled"}
+                else data.get("status"),
+            }
+        ],
+        "usage": usage,
+    }
+
+
+def codex_to_response_payload(response_obj: Any, *, requested_model: str, default_model: str) -> dict[str, Any]:
+    """Normalize a Responses/Codex response and keep the public model name."""
+    data = response_to_dict(response_obj)
+    text = response_text(response_obj)
+    usage = response_usage(response_obj)
+    return {
+        "id": data.get("id") or make_id("resp"),
+        "object": "response",
+        "created_at": data.get("created_at") or int(time.time()),
+        "status": data.get("status") or "completed",
+        "error": data.get("error"),
+        "incomplete_details": data.get("incomplete_details"),
+        "model": requested_model or default_model,
+        "output": [
+            {
+                "id": make_id("msg"),
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+        "output_text": text,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        },
+    }
+
+
+def responses_input_to_messages(body: Mapping[str, Any]) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    instructions = body.get("instructions")
+    if instructions:
+        messages.append({"role": "system", "content": str(instructions)})
+    input_value = body.get("input")
+    if isinstance(input_value, str):
+        messages.append({"role": "user", "content": input_value})
+        return messages
+    if isinstance(input_value, list):
+        for item in input_value:
+            if isinstance(item, str):
+                messages.append({"role": "user", "content": item})
+                continue
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type in {None, "message"} or "role" in item:
+                role = item.get("role", "user")
+                content = content_to_text(item.get("content", ""))
+                if content:
+                    messages.append({"role": role, "content": content})
+        return messages
+    return messages
+
+
+def responses_to_chat_payload(body: Mapping[str, Any], *, default_model: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": default_model,
+        "messages": responses_input_to_messages(body),
+        "stream": bool(body.get("stream", False)),
+    }
+    if "temperature" in body:
+        payload["temperature"] = body["temperature"]
+    if "top_p" in body:
+        payload["top_p"] = body["top_p"]
+    if "max_output_tokens" in body:
+        payload["max_tokens"] = body["max_output_tokens"]
+    return payload
+
+
+def chat_to_response_payload(chat_data: Mapping[str, Any], requested_model: str, *, default_model: str) -> dict[str, Any]:
+    text = ""
+    choices = chat_data.get("choices") or []
+    if choices:
+        message = choices[0].get("message") or {}
+        text = content_to_text(message.get("content"))
+    usage = chat_data.get("usage") or {}
+    return {
+        "id": make_id("resp"),
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "error": None,
+        "incomplete_details": None,
+        "model": requested_model or default_model,
+        "output": [
+            {
+                "id": make_id("msg"),
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+        "output_text": text,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        },
+    }

--- a/gateway/platforms/one_model_api/conversions.py
+++ b/gateway/platforms/one_model_api/conversions.py
@@ -7,6 +7,7 @@ runtimes. It must not select accounts, store credentials, or implement failover.
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 from typing import Any, Mapping
@@ -94,6 +95,80 @@ def response_text(response_obj: Any) -> str:
     return "".join(pieces)
 
 
+def truncate_at_stop_sequence(text: str, stop: Any) -> str:
+    """Apply OpenAI-style local stop truncation to text.
+
+    Some upstreams ignore or reject `stop`; the passthrough layer accepts it on
+    the public API and enforces truncation locally on converted text.
+    """
+    if not text or not stop:
+        return text
+    sequences = [stop] if isinstance(stop, str) else stop
+    if not isinstance(sequences, list):
+        return text
+    positions = [text.find(seq) for seq in sequences if isinstance(seq, str) and seq]
+    positions = [pos for pos in positions if pos >= 0]
+    if not positions:
+        return text
+    return text[: min(positions)]
+
+
+def apply_stop_to_chat_data(chat_data: dict[str, Any], stop: Any) -> dict[str, Any]:
+    """Apply local stop truncation to Chat Completions response data."""
+    if not stop:
+        return chat_data
+    data = dict(chat_data)
+    choices = data.get("choices")
+    if not isinstance(choices, list):
+        return data
+    truncated_choices: list[Any] = []
+    for choice in choices:
+        if not isinstance(choice, dict):
+            truncated_choices.append(choice)
+            continue
+        new_choice = dict(choice)
+        message = new_choice.get("message")
+        if isinstance(message, dict):
+            new_message = dict(message)
+            content = new_message.get("content")
+            if isinstance(content, str):
+                new_message["content"] = truncate_at_stop_sequence(content, stop)
+            new_choice["message"] = new_message
+        truncated_choices.append(new_choice)
+    data["choices"] = truncated_choices
+    return data
+
+
+def extract_chat_tool_calls_from_response(response_obj: Any) -> list[dict[str, Any]]:
+    """Extract OpenAI Chat-style tool_calls from Responses function_call output."""
+    data = response_to_dict(response_obj)
+    output = data.get("output") or []
+    if not isinstance(output, list):
+        return []
+    tool_calls: list[dict[str, Any]] = []
+    for index, item in enumerate(output):
+        if not isinstance(item, dict):
+            item = response_to_dict(item)
+        item_type = item.get("type")
+        if item_type not in {"function_call", "custom_tool_call"}:
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        arguments = item.get("input", "{}") if item_type == "custom_tool_call" else item.get("arguments", "{}")
+        if isinstance(arguments, dict):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        elif not isinstance(arguments, str):
+            arguments = str(arguments)
+        call_id = item.get("call_id") or item.get("id") or f"call_{index}"
+        tool_calls.append({
+            "id": str(call_id),
+            "type": "function",
+            "function": {"name": name.strip(), "arguments": arguments or "{}"},
+        })
+    return tool_calls
+
+
 def response_usage(response_obj: Any) -> dict[str, int]:
     """Map Responses usage fields to Chat Completions-style token usage."""
     data = response_to_dict(response_obj)
@@ -117,6 +192,77 @@ def response_usage(response_obj: Any) -> dict[str, int]:
 
 def _normalize_chat_content_for_instructions(content: Any) -> str:
     return content_to_text(content)
+
+
+def _responses_tool_choice(tool_choice: Any) -> Any:
+    """Convert Chat Completions/Anthropic-style tool_choice to Responses shape."""
+    if tool_choice is None:
+        return None
+    if isinstance(tool_choice, str):
+        if tool_choice == "any":
+            return "required"
+        return tool_choice
+    if not isinstance(tool_choice, dict):
+        return tool_choice
+
+    choice_type = tool_choice.get("type")
+    if choice_type == "any":
+        return "required"
+    if choice_type == "tool" and isinstance(tool_choice.get("name"), str):
+        return {"type": "function", "name": tool_choice["name"]}
+    if choice_type == "function":
+        fn = tool_choice.get("function")
+        if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+            return {"type": "function", "name": fn["name"]}
+        if isinstance(tool_choice.get("name"), str):
+            return {"type": "function", "name": tool_choice["name"]}
+    return tool_choice
+
+
+def _forced_tool_choice_name(tool_choice: Any, tools: Any = None) -> str | None:
+    """Return a concrete function name when the client explicitly requires one."""
+    normalized = _responses_tool_choice(tool_choice)
+    if isinstance(normalized, dict) and normalized.get("type") == "function":
+        name = normalized.get("name")
+        return name if isinstance(name, str) and name else None
+    if normalized == "required" and isinstance(tools, list):
+        for tool in tools:
+            if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("name"), str):
+                return tool["name"]
+    return None
+
+
+def _fallback_arguments_from_text(text: str) -> str:
+    stripped = (text or "").strip()
+    if stripped:
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, dict):
+                return json.dumps(parsed, ensure_ascii=False)
+        except Exception:
+            pass
+    return "{}"
+
+
+def forced_tool_call_fallback(tool_choice: Any, tools: Any = None, *, text: str = "") -> list[dict[str, Any]]:
+    name = _forced_tool_choice_name(tool_choice, tools)
+    if not name:
+        return []
+    return [{
+        "id": make_id("call"),
+        "type": "function",
+        "function": {"name": name, "arguments": _fallback_arguments_from_text(text)},
+    }]
+
+
+def _legacy_function_call_to_tool_choice(function_call: Any) -> Any:
+    if function_call is None:
+        return None
+    if isinstance(function_call, str):
+        return function_call
+    if isinstance(function_call, dict) and isinstance(function_call.get("name"), str):
+        return {"type": "function", "name": function_call["name"]}
+    return function_call
 
 
 def chat_payload_to_codex_responses_kwargs(
@@ -144,7 +290,7 @@ def chat_payload_to_codex_responses_kwargs(
         elif role in {"user", "assistant", "tool"}:
             non_system_messages.append(msg)
 
-    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input, _responses_tools
 
     kwargs: dict[str, Any] = {
         "model": payload.get("model") or default_model,
@@ -154,9 +300,15 @@ def chat_payload_to_codex_responses_kwargs(
     }
     kwargs["instructions"] = "\n".join(system_parts) if system_parts else "You are a helpful assistant."
 
-    # Minimal one-model API: do not expose tool/agent capability through this endpoint.
-    if payload.get("tools"):
-        raise ValueError("tools are not supported by this minimal passthrough Codex adapter")
+    tools = _responses_tools(payload.get("tools"))
+    if tools:
+        kwargs["tools"] = tools
+    if payload.get("tool_choice") is not None:
+        kwargs["tool_choice"] = _responses_tool_choice(payload.get("tool_choice"))
+    elif payload.get("function_call") is not None:
+        kwargs["tool_choice"] = _legacy_function_call_to_tool_choice(payload.get("function_call"))
+    if payload.get("parallel_tool_calls") is not None:
+        kwargs["parallel_tool_calls"] = payload.get("parallel_tool_calls")
 
     # Responses API uses max_output_tokens; Chat Completions uses max_tokens.
     # The ChatGPT Codex backend may reject max_output_tokens in some modes, so
@@ -167,9 +319,10 @@ def chat_payload_to_codex_responses_kwargs(
     elif "max_tokens" in payload and "chatgpt.com/backend-api/codex" not in base_url:
         kwargs["max_output_tokens"] = payload["max_tokens"]
 
-    for key in ("temperature", "top_p"):
-        if key in payload:
-            kwargs[key] = payload[key]
+    # Some Codex/Responses-style upstreams reject OpenAI Chat sampling controls
+    # outright (for example: "Unsupported parameter: temperature/top_p").
+    # one-model-api intentionally exposes one compatible public surface, so these
+    # optional controls are accepted from clients but not forwarded upstream.
 
     session_id = payload.get("user") or payload.get("prompt_cache_key")
     if session_id and "chatgpt.com/backend-api/codex" in base_url:
@@ -181,24 +334,66 @@ def chat_payload_to_codex_responses_kwargs(
 
 
 async def collect_codex_stream(client: Any, codex_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """ChatGPT Codex backend requires stream=true; collect stream for non-stream public calls."""
+    """Collect a streamed Codex/Responses response, including function calls."""
     kwargs = dict(codex_kwargs)
     kwargs["stream"] = True
     full_text = ""
     final_response: dict[str, Any] = {}
+    function_calls: list[dict[str, Any]] = []
+    output_index_to_call_index: dict[int, int] = {}
+
     stream = await client.responses.create(**kwargs)
     async for event in stream:
         event_type = getattr(event, "type", None)
         data = response_to_dict(event)
         if not event_type:
             event_type = data.get("type")
+
         if event_type == "response.output_text.delta":
             piece = getattr(event, "delta", "") or data.get("delta", "") or ""
             full_text += piece
-        elif event_type in {"response.completed", "response.failed", "response.incomplete"}:
+            continue
+
+        if event_type == "response.output_item.added":
+            item = data.get("item") or response_to_dict(getattr(event, "item", None))
+            if isinstance(item, dict) and item.get("type") in {"function_call", "custom_tool_call"}:
+                output_index = data.get("output_index", getattr(event, "output_index", len(function_calls)))
+                call_id = item.get("call_id") or item.get("id") or make_id("call")
+                function_calls.append({
+                    "type": "function_call",
+                    "call_id": str(call_id),
+                    "name": item.get("name") or "",
+                    "arguments": item.get("arguments") or item.get("input") or "",
+                })
+                try:
+                    output_index_to_call_index[int(output_index)] = len(function_calls) - 1
+                except Exception:
+                    pass
+            continue
+
+        if event_type in {"response.function_call_arguments.delta", "response.function_call_arguments.done"}:
+            output_index = data.get("output_index", getattr(event, "output_index", None))
+            idx = None
+            try:
+                idx = output_index_to_call_index.get(int(output_index))
+            except Exception:
+                idx = None
+            if idx is None:
+                continue
+            if event_type.endswith(".delta"):
+                delta = getattr(event, "delta", "") or data.get("delta", "") or ""
+                function_calls[idx]["arguments"] = str(function_calls[idx].get("arguments") or "") + str(delta)
+            else:
+                arguments = data.get("arguments") or getattr(event, "arguments", None)
+                if arguments is not None:
+                    function_calls[idx]["arguments"] = arguments
+            continue
+
+        if event_type in {"response.completed", "response.failed", "response.incomplete", "response.done"}:
             response_data = data.get("response")
             if isinstance(response_data, dict):
                 final_response = response_data
+
     if not final_response:
         final_response = {
             "id": make_id("resp"),
@@ -208,24 +403,58 @@ async def collect_codex_stream(client: Any, codex_kwargs: dict[str, Any]) -> dic
             "model": codex_kwargs.get("model"),
         }
     final_response["output_text"] = final_response.get("output_text") or full_text
-    if "output" not in final_response:
-        final_response["output"] = [
-            {
+    if not final_response.get("output"):
+        output: list[dict[str, Any]] = []
+        if full_text:
+            output.append({
                 "id": make_id("msg"),
                 "type": "message",
                 "status": "completed",
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": full_text, "annotations": []}],
-            }
-        ]
+            })
+        for call in function_calls:
+            args = call.get("arguments", "{}")
+            if isinstance(args, dict):
+                args = json.dumps(args, ensure_ascii=False)
+            elif not isinstance(args, str):
+                args = str(args)
+            output.append({
+                "type": "function_call",
+                "call_id": call.get("call_id") or make_id("call"),
+                "name": call.get("name") or "",
+                "arguments": args or "{}",
+            })
+        if not output:
+            output.append({
+                "id": make_id("msg"),
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+            })
+        final_response["output"] = output
     return final_response
 
-
-def codex_to_chat_payload(response_obj: Any, *, requested_model: str, default_model: str) -> dict[str, Any]:
+def codex_to_chat_payload(
+    response_obj: Any,
+    *,
+    requested_model: str,
+    default_model: str,
+    stop: Any = None,
+    tool_choice: Any = None,
+    tools: Any = None,
+) -> dict[str, Any]:
     """Wrap a Responses/Codex response as an OpenAI Chat Completion response."""
     data = response_to_dict(response_obj)
-    text = response_text(response_obj)
+    text = truncate_at_stop_sequence(response_text(response_obj), stop)
     usage = response_usage(response_obj)
+    tool_calls = extract_chat_tool_calls_from_response(response_obj)
+    if not tool_calls:
+        tool_calls = forced_tool_call_fallback(tool_choice, tools, text=text)
+    message: dict[str, Any] = {"role": "assistant", "content": None if tool_calls else text}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
     return {
         "id": chat_completion_id(),
         "object": "chat.completion",
@@ -234,21 +463,36 @@ def codex_to_chat_payload(response_obj: Any, *, requested_model: str, default_mo
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": text},
-                "finish_reason": "stop"
-                if data.get("status") not in {"incomplete", "failed", "cancelled"}
-                else data.get("status"),
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else (
+                    "stop"
+                    if data.get("status") not in {"incomplete", "failed", "cancelled"}
+                    else data.get("status")
+                ),
             }
         ],
         "usage": usage,
     }
 
 
-def codex_to_response_payload(response_obj: Any, *, requested_model: str, default_model: str) -> dict[str, Any]:
-    """Normalize a Responses/Codex response and keep the public model name."""
+def codex_to_response_payload(response_obj: Any, *, requested_model: str, default_model: str, stop: Any = None) -> dict[str, Any]:
+    """Normalize a Responses/Codex response and keep function_call output items."""
     data = response_to_dict(response_obj)
-    text = response_text(response_obj)
+    text = truncate_at_stop_sequence(response_text(response_obj), stop)
     usage = response_usage(response_obj)
+    output = data.get("output")
+    if isinstance(output, list) and output:
+        normalized_output = output
+    else:
+        normalized_output = [
+            {
+                "id": make_id("msg"),
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ]
     return {
         "id": data.get("id") or make_id("resp"),
         "object": "response",
@@ -257,15 +501,7 @@ def codex_to_response_payload(response_obj: Any, *, requested_model: str, defaul
         "error": data.get("error"),
         "incomplete_details": data.get("incomplete_details"),
         "model": requested_model or default_model,
-        "output": [
-            {
-                "id": make_id("msg"),
-                "type": "message",
-                "status": "completed",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": text, "annotations": []}],
-            }
-        ],
+        "output": normalized_output,
         "output_text": text,
         "usage": {
             "input_tokens": usage.get("prompt_tokens", 0),
@@ -303,14 +539,14 @@ def responses_input_to_messages(body: Mapping[str, Any]) -> list[dict[str, Any]]
 
 def responses_to_chat_payload(body: Mapping[str, Any], *, default_model: str) -> dict[str, Any]:
     payload: dict[str, Any] = {
-        "model": default_model,
+        # Preserve the client-facing Responses model so passthrough model
+        # whitelist validation can reject typos before the upstream model is
+        # forced. The upstream payload is still rewritten later by
+        # APIServerAdapter._passthrough_payload when force_model is enabled.
+        "model": body.get("model") or default_model,
         "messages": responses_input_to_messages(body),
         "stream": bool(body.get("stream", False)),
     }
-    if "temperature" in body:
-        payload["temperature"] = body["temperature"]
-    if "top_p" in body:
-        payload["top_p"] = body["top_p"]
     if "max_output_tokens" in body:
         payload["max_tokens"] = body["max_output_tokens"]
     return payload

--- a/gateway/platforms/one_model_api/registry.py
+++ b/gateway/platforms/one_model_api/registry.py
@@ -1,0 +1,34 @@
+"""Adapter registry for one-model API passthrough protocols."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .adapters.base import PassthroughProtocolAdapter
+from .adapters.codex_responses import CodexResponsesAdapter
+from .adapters.openai_chat import OpenAIChatAdapter
+
+_ADAPTERS: tuple[type[PassthroughProtocolAdapter], ...] = (
+    CodexResponsesAdapter,
+    OpenAIChatAdapter,
+)
+
+
+def get_passthrough_adapter(runtime: Mapping[str, Any]) -> PassthroughProtocolAdapter | None:
+    """Return the protocol adapter for a Hermes-resolved runtime.
+
+    The registry key is protocol/api_mode only. It intentionally does not look
+    at account metadata or credentials; those belong to Hermes' runtime layer.
+    """
+
+    for adapter_cls in _ADAPTERS:
+        if adapter_cls.supports_runtime(runtime):
+            return adapter_cls()
+    return None
+
+
+def supported_api_modes() -> set[str]:
+    modes: set[str] = set()
+    for adapter_cls in _ADAPTERS:
+        modes.update(adapter_cls.api_modes)
+    return modes

--- a/gateway/platforms/one_model_api/streams.py
+++ b/gateway/platforms/one_model_api/streams.py
@@ -1,0 +1,338 @@
+"""SSE stream translators for the one-model API passthrough layer."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from aiohttp import web
+
+from .conversions import chat_completion_id, make_id, response_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+def sse_event(event: str, data: dict[str, Any]) -> bytes:
+    payload = json.dumps(data, ensure_ascii=False)
+    return f"event: {event}\ndata: {payload}\n\n".encode("utf-8")
+
+
+def openai_error(message: str, type_: str = "invalid_request_error", code: str | None = None) -> dict[str, Any]:
+    error: dict[str, Any] = {"message": message, "type": type_}
+    if code:
+        error["code"] = code
+    return {"error": error}
+
+
+def _sse_headers() -> dict[str, str]:
+    return {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
+    }
+
+
+async def stream_openai_chat_as_chat_sse(
+    request: web.Request,
+    *,
+    client: Any,
+    payload: dict[str, Any],
+    requested_model: str,
+) -> web.StreamResponse:
+    """Stream upstream OpenAI-compatible chunks as Chat Completions SSE."""
+    response = web.StreamResponse(status=200, headers=_sse_headers())
+    await response.prepare(request)
+    try:
+        stream = await client.chat.completions.create(**payload)
+        async for chunk in stream:
+            data = chunk.model_dump(exclude_none=True) if hasattr(chunk, "model_dump") else dict(chunk)
+            if requested_model:
+                data["model"] = requested_model
+            await response.write(f"data: {json.dumps(data, ensure_ascii=False)}\n\n".encode("utf-8"))
+        await response.write(b"data: [DONE]\n\n")
+    except Exception as exc:
+        logger.exception("Passthrough streaming chat completion failed")
+        err = openai_error(f"Passthrough upstream stream failed: {exc}", code="upstream_stream_failed")
+        await response.write(f"data: {json.dumps(err, ensure_ascii=False)}\n\n".encode("utf-8"))
+        await response.write(b"data: [DONE]\n\n")
+    finally:
+        try:
+            await response.write_eof()
+        except Exception:
+            pass
+    return response
+
+
+async def stream_codex_as_chat_sse(
+    request: web.Request,
+    *,
+    client: Any,
+    codex_kwargs: dict[str, Any],
+    requested_model: str,
+    default_model: str,
+) -> web.StreamResponse:
+    """Stream a Codex Responses upstream as OpenAI Chat Completions SSE."""
+    response = web.StreamResponse(status=200, headers=_sse_headers())
+    await response.prepare(request)
+    completion_id = chat_completion_id()
+    created = int(time.time())
+    try:
+        stream = await client.responses.create(**codex_kwargs)
+        async for event in stream:
+            event_type = getattr(event, "type", None)
+            if not event_type and isinstance(event, dict):
+                event_type = event.get("type")
+            piece = ""
+            if event_type == "response.output_text.delta":
+                piece = getattr(event, "delta", "")
+                if not piece and isinstance(event, dict):
+                    piece = event.get("delta", "") or ""
+            elif event_type == "response.failed":
+                data = response_to_dict(event)
+                await response.write(
+                    f"data: {json.dumps(openai_error(str(data), code='upstream_response_failed'), ensure_ascii=False)}\n\n".encode("utf-8")
+                )
+                break
+            if not piece:
+                continue
+            chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": requested_model or default_model,
+                "choices": [{"index": 0, "delta": {"content": piece}, "finish_reason": None}],
+            }
+            await response.write(f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+
+        done_chunk = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": requested_model or default_model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }
+        await response.write(f"data: {json.dumps(done_chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+        await response.write(b"data: [DONE]\n\n")
+    except Exception as exc:
+        logger.exception("Passthrough Codex streaming chat completion failed")
+        err = openai_error(f"Passthrough Codex upstream stream failed: {exc}", code="upstream_stream_failed")
+        await response.write(f"data: {json.dumps(err, ensure_ascii=False)}\n\n".encode("utf-8"))
+        await response.write(b"data: [DONE]\n\n")
+    finally:
+        try:
+            await response.write_eof()
+        except Exception:
+            pass
+    return response
+
+
+async def stream_codex_as_responses_sse(
+    request: web.Request,
+    *,
+    client: Any,
+    codex_kwargs: dict[str, Any],
+    requested_model: str,
+    default_model: str,
+) -> web.StreamResponse:
+    """Stream a Codex Responses upstream as minimal OpenAI Responses SSE."""
+    response_id = make_id("resp")
+    message_id = make_id("msg")
+    created_at = int(time.time())
+    sse_resp = web.StreamResponse(status=200, headers=_sse_headers())
+    await sse_resp.prepare(request)
+    full_text = ""
+    try:
+        await sse_resp.write(sse_event("response.created", {
+            "type": "response.created",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": created_at,
+                "status": "in_progress",
+                "model": requested_model or default_model,
+                "output": [],
+            },
+        }))
+        await sse_resp.write(sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "response_id": response_id,
+            "output_index": 0,
+            "item": {"id": message_id, "type": "message", "status": "in_progress", "role": "assistant", "content": []},
+        }))
+
+        stream = await client.responses.create(**codex_kwargs)
+        async for event in stream:
+            event_type = getattr(event, "type", None)
+            if not event_type and isinstance(event, dict):
+                event_type = event.get("type")
+            if event_type == "response.output_text.delta":
+                piece = getattr(event, "delta", "")
+                if not piece and isinstance(event, dict):
+                    piece = event.get("delta", "") or ""
+                if not piece:
+                    continue
+                full_text += piece
+                await sse_resp.write(sse_event("response.output_text.delta", {
+                    "type": "response.output_text.delta",
+                    "response_id": response_id,
+                    "item_id": message_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": piece,
+                }))
+            elif event_type == "response.failed":
+                data = response_to_dict(event)
+                await sse_resp.write(sse_event("response.failed", {
+                    "type": "response.failed",
+                    "response": {
+                        "id": response_id,
+                        "object": "response",
+                        "created_at": created_at,
+                        "status": "failed",
+                        "model": requested_model or default_model,
+                        "error": {"message": json.dumps(data, ensure_ascii=False), "type": "upstream_error"},
+                    },
+                }))
+                return sse_resp
+
+        await sse_resp.write(sse_event("response.output_text.done", {
+            "type": "response.output_text.done",
+            "response_id": response_id,
+            "item_id": message_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": full_text,
+        }))
+        await sse_resp.write(sse_event("response.completed", {
+            "type": "response.completed",
+            "response": _completed_response(response_id, message_id, created_at, requested_model or default_model, full_text),
+        }))
+    except Exception as exc:
+        logger.exception("Passthrough Codex streaming responses failed")
+        await sse_resp.write(sse_event("response.failed", {
+            "type": "response.failed",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": created_at,
+                "status": "failed",
+                "model": requested_model or default_model,
+                "error": {"message": str(exc), "type": "upstream_stream_failed"},
+            },
+        }))
+    finally:
+        try:
+            await sse_resp.write_eof()
+        except Exception:
+            pass
+    return sse_resp
+
+
+async def stream_openai_chat_as_responses_sse(
+    request: web.Request,
+    *,
+    client: Any,
+    chat_payload: dict[str, Any],
+    requested_model: str,
+    default_model: str,
+) -> web.StreamResponse:
+    """Stream OpenAI chat chunks as minimal OpenAI Responses SSE."""
+    response_id = make_id("resp")
+    message_id = make_id("msg")
+    created_at = int(time.time())
+    sse_resp = web.StreamResponse(status=200, headers=_sse_headers())
+    await sse_resp.prepare(request)
+    try:
+        await sse_resp.write(sse_event("response.created", {
+            "type": "response.created",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": created_at,
+                "status": "in_progress",
+                "model": requested_model or default_model,
+                "output": [],
+            },
+        }))
+        await sse_resp.write(sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "response_id": response_id,
+            "output_index": 0,
+            "item": {"id": message_id, "type": "message", "status": "in_progress", "role": "assistant", "content": []},
+        }))
+
+        full_text = ""
+        stream = await client.chat.completions.create(**chat_payload)
+        async for chunk in stream:
+            chunk_data = chunk.model_dump(exclude_none=True) if hasattr(chunk, "model_dump") else dict(chunk)
+            choices = chunk_data.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            piece = delta.get("content")
+            if not piece:
+                continue
+            full_text += piece
+            await sse_resp.write(sse_event("response.output_text.delta", {
+                "type": "response.output_text.delta",
+                "response_id": response_id,
+                "item_id": message_id,
+                "output_index": 0,
+                "content_index": 0,
+                "delta": piece,
+            }))
+
+        await sse_resp.write(sse_event("response.output_text.done", {
+            "type": "response.output_text.done",
+            "response_id": response_id,
+            "item_id": message_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": full_text,
+        }))
+        await sse_resp.write(sse_event("response.completed", {
+            "type": "response.completed",
+            "response": _completed_response(response_id, message_id, created_at, requested_model or default_model, full_text),
+        }))
+    except Exception as exc:
+        logger.exception("Passthrough streaming responses failed")
+        await sse_resp.write(sse_event("response.failed", {
+            "type": "response.failed",
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "created_at": created_at,
+                "status": "failed",
+                "model": requested_model or default_model,
+                "error": {"message": str(exc), "type": "upstream_error"},
+            },
+        }))
+    finally:
+        try:
+            await sse_resp.write_eof()
+        except Exception:
+            pass
+    return sse_resp
+
+
+def _completed_response(response_id: str, message_id: str, created_at: int, model: str, text: str) -> dict[str, Any]:
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": "completed",
+        "model": model,
+        "output": [
+            {
+                "id": message_id,
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+        "output_text": text,
+    }

--- a/gateway/platforms/one_model_api/streams.py
+++ b/gateway/platforms/one_model_api/streams.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from aiohttp import web
 
-from .conversions import chat_completion_id, make_id, response_to_dict
+from .conversions import chat_completion_id, forced_tool_call_fallback, make_id, response_to_dict, truncate_at_stop_sequence
 
 logger = logging.getLogger(__name__)
 
@@ -35,23 +35,127 @@ def _sse_headers() -> dict[str, str]:
     }
 
 
+def _stop_sequences(stop: Any) -> list[str]:
+    if isinstance(stop, str):
+        return [stop] if stop else []
+    if isinstance(stop, list):
+        return [seq for seq in stop if isinstance(seq, str) and seq]
+    return []
+
+
+def _stream_stop_filter_piece(piece: str, state: dict[str, Any], stop: Any) -> str:
+    """Return safe text to emit while holding a tail for split stop sequences."""
+    if not piece or state.get("stop_seen"):
+        return ""
+    sequences = _stop_sequences(stop)
+    if not sequences:
+        return piece
+
+    pending = str(state.get("stop_pending", "")) + piece
+    earliest = -1
+    for seq in sequences:
+        pos = pending.find(seq)
+        if pos >= 0 and (earliest < 0 or pos < earliest):
+            earliest = pos
+    if earliest >= 0:
+        state["stop_seen"] = True
+        state["stop_pending"] = ""
+        return pending[:earliest]
+
+    hold = max(len(seq) for seq in sequences) - 1
+    if hold <= 0:
+        state["stop_pending"] = ""
+        return pending
+    if len(pending) <= hold:
+        state["stop_pending"] = pending
+        return ""
+    state["stop_pending"] = pending[-hold:]
+    return pending[:-hold]
+
+
+def _stream_stop_flush(state: dict[str, Any], stop: Any) -> str:
+    if state.get("stop_seen") or not _stop_sequences(stop):
+        state["stop_pending"] = ""
+        return ""
+    pending = str(state.get("stop_pending", ""))
+    state["stop_pending"] = ""
+    return truncate_at_stop_sequence(pending, stop)
+
+
 async def stream_openai_chat_as_chat_sse(
     request: web.Request,
     *,
     client: Any,
     payload: dict[str, Any],
     requested_model: str,
+    stop: Any = None,
 ) -> web.StreamResponse:
     """Stream upstream OpenAI-compatible chunks as Chat Completions SSE."""
-    response = web.StreamResponse(status=200, headers=_sse_headers())
-    await response.prepare(request)
     try:
         stream = await client.chat.completions.create(**payload)
-        async for chunk in stream:
-            data = chunk.model_dump(exclude_none=True) if hasattr(chunk, "model_dump") else dict(chunk)
-            if requested_model:
-                data["model"] = requested_model
+    except Exception as exc:
+        logger.exception("Passthrough streaming chat completion failed before SSE started")
+        err = openai_error(f"Passthrough upstream stream failed: {exc}", code="upstream_stream_failed")
+        return web.json_response(err, status=502)
+
+    iterator = stream.__aiter__()
+    try:
+        first_chunk = await iterator.__anext__()
+    except StopAsyncIteration:
+        first_chunk = None
+    except Exception as exc:
+        logger.exception("Passthrough streaming chat completion failed before SSE started")
+        err = openai_error(f"Passthrough upstream stream failed: {exc}", code="upstream_stream_failed")
+        return web.json_response(err, status=502)
+
+    response = web.StreamResponse(status=200, headers=_sse_headers())
+    await response.prepare(request)
+    stop_state: dict[str, Any] = {}
+
+    async def write_filtered_chunk(chunk_obj: Any) -> None:
+        data = chunk_obj.model_dump(exclude_none=True) if hasattr(chunk_obj, "model_dump") else dict(chunk_obj)
+        if requested_model:
+            data["model"] = requested_model
+        choices = data.get("choices")
+        if isinstance(choices, list):
+            new_choices = []
+            for choice in choices:
+                if not isinstance(choice, dict):
+                    new_choices.append(choice)
+                    continue
+                new_choice = dict(choice)
+                delta = new_choice.get("delta")
+                if isinstance(delta, dict) and isinstance(delta.get("content"), str):
+                    filtered = _stream_stop_filter_piece(delta.get("content") or "", stop_state, stop)
+                    if filtered:
+                        new_delta = dict(delta)
+                        new_delta["content"] = filtered
+                        new_choice["delta"] = new_delta
+                        new_choices.append(new_choice)
+                    continue
+                new_choices.append(new_choice)
+            data["choices"] = new_choices
+        if data.get("choices"):
             await response.write(f"data: {json.dumps(data, ensure_ascii=False)}\n\n".encode("utf-8"))
+
+    try:
+        if first_chunk is not None:
+            await write_filtered_chunk(first_chunk)
+        if not stop_state.get("stop_seen"):
+            async for chunk in iterator:
+                await write_filtered_chunk(chunk)
+                if stop_state.get("stop_seen"):
+                    break
+        tail = _stream_stop_flush(stop_state, stop)
+        done_model = requested_model or payload.get("model", "")
+        completion_id = chat_completion_id()
+        created = int(time.time())
+        if tail:
+            tail_chunk = _chat_sse_chunk(completion_id, created, done_model, {"content": tail})
+            await response.write(f"data: {json.dumps(tail_chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+        if stop_state.get("stop_seen"):
+            done_chunk = _chat_sse_chunk(completion_id, created, done_model, {}, "stop")
+            await response.write(f"data: {json.dumps(done_chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
         await response.write(b"data: [DONE]\n\n")
     except Exception as exc:
         logger.exception("Passthrough streaming chat completion failed")
@@ -66,6 +170,98 @@ async def stream_openai_chat_as_chat_sse(
     return response
 
 
+def _chat_sse_chunk(completion_id: str, created: int, model: str, delta: dict[str, Any], finish_reason: str | None = None) -> dict[str, Any]:
+    return {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    }
+
+
+def codex_event_to_chat_chunks(
+    event: Any,
+    *,
+    completion_id: str,
+    created: int,
+    model: str,
+    state: dict[str, Any],
+    stop: Any = None,
+) -> list[dict[str, Any]]:
+    """Convert one Responses/Codex stream event into Chat Completions chunks."""
+    event_type = getattr(event, "type", None)
+    data = response_to_dict(event)
+    if not event_type:
+        event_type = data.get("type")
+    chunks: list[dict[str, Any]] = []
+
+    if event_type == "response.output_text.delta":
+        piece = getattr(event, "delta", "") or data.get("delta", "") or ""
+        if piece:
+            filtered = _stream_stop_filter_piece(piece, state, stop)
+            if filtered:
+                state["saw_text"] = True
+                state["text"] = state.get("text", "") + filtered
+                chunks.append(_chat_sse_chunk(completion_id, created, model, {"content": filtered}))
+        return chunks
+
+    if event_type == "response.output_item.added":
+        item = data.get("item") or response_to_dict(getattr(event, "item", None))
+        if isinstance(item, dict) and item.get("type") in {"function_call", "custom_tool_call"}:
+            idx = int(state.get("next_tool_index", 0))
+            state["next_tool_index"] = idx + 1
+            output_index = data.get("output_index", getattr(event, "output_index", idx))
+            try:
+                state.setdefault("output_index_to_tool_index", {})[int(output_index)] = idx
+            except Exception:
+                pass
+            state["saw_tool_call"] = True
+            call_id = item.get("call_id") or item.get("id") or make_id("call")
+            name = item.get("name") or ""
+            chunks.append(_chat_sse_chunk(completion_id, created, model, {
+                "tool_calls": [{
+                    "index": idx,
+                    "id": str(call_id),
+                    "type": "function",
+                    "function": {"name": name},
+                }]
+            }))
+        return chunks
+
+    if event_type in {"response.function_call_arguments.delta", "response.function_call_arguments.done"}:
+        output_index = data.get("output_index", getattr(event, "output_index", None))
+        idx = None
+        try:
+            idx = state.setdefault("output_index_to_tool_index", {}).get(int(output_index))
+        except Exception:
+            idx = None
+        if idx is None:
+            return chunks
+        # Chat Completions streaming expects argument *deltas*. Responses .done
+        # may carry the full argument string; re-emitting it after deltas would
+        # duplicate arguments on OpenAI SDK clients. Use .done only as a marker.
+        if not event_type.endswith(".delta"):
+            return chunks
+        args = getattr(event, "delta", "") or data.get("delta", "") or ""
+        if args:
+            chunks.append(_chat_sse_chunk(completion_id, created, model, {
+                "tool_calls": [{"index": idx, "function": {"arguments": args}}]
+            }))
+        return chunks
+
+    if event_type in {"response.completed", "response.done", "response.incomplete"}:
+        state["completed"] = True
+        return chunks
+
+    if event_type == "response.failed":
+        state["failed"] = True
+        chunks.append(openai_error(json.dumps(data, ensure_ascii=False), code="upstream_response_failed"))
+        return chunks
+
+    return chunks
+
+
 async def stream_codex_as_chat_sse(
     request: web.Request,
     *,
@@ -73,48 +269,71 @@ async def stream_codex_as_chat_sse(
     codex_kwargs: dict[str, Any],
     requested_model: str,
     default_model: str,
+    stop: Any = None,
 ) -> web.StreamResponse:
     """Stream a Codex Responses upstream as OpenAI Chat Completions SSE."""
+    try:
+        stream = await client.responses.create(**codex_kwargs)
+    except Exception as exc:
+        logger.exception("Passthrough Codex streaming chat completion failed before SSE started")
+        err = openai_error(f"Passthrough Codex upstream stream failed: {exc}", code="upstream_stream_failed")
+        return web.json_response(err, status=502)
+
+    iterator = stream.__aiter__()
+    try:
+        first_event = await iterator.__anext__()
+    except StopAsyncIteration:
+        first_event = None
+    except Exception as exc:
+        logger.exception("Passthrough Codex streaming chat completion failed before SSE started")
+        err = openai_error(f"Passthrough Codex upstream stream failed: {exc}", code="upstream_stream_failed")
+        return web.json_response(err, status=502)
+
     response = web.StreamResponse(status=200, headers=_sse_headers())
     await response.prepare(request)
     completion_id = chat_completion_id()
     created = int(time.time())
-    try:
-        stream = await client.responses.create(**codex_kwargs)
-        async for event in stream:
-            event_type = getattr(event, "type", None)
-            if not event_type and isinstance(event, dict):
-                event_type = event.get("type")
-            piece = ""
-            if event_type == "response.output_text.delta":
-                piece = getattr(event, "delta", "")
-                if not piece and isinstance(event, dict):
-                    piece = event.get("delta", "") or ""
-            elif event_type == "response.failed":
-                data = response_to_dict(event)
-                await response.write(
-                    f"data: {json.dumps(openai_error(str(data), code='upstream_response_failed'), ensure_ascii=False)}\n\n".encode("utf-8")
-                )
-                break
-            if not piece:
-                continue
-            chunk = {
-                "id": completion_id,
-                "object": "chat.completion.chunk",
-                "created": created,
-                "model": requested_model or default_model,
-                "choices": [{"index": 0, "delta": {"content": piece}, "finish_reason": None}],
-            }
-            await response.write(f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+    model = requested_model or default_model
+    state: dict[str, Any] = {"output_index_to_tool_index": {}, "next_tool_index": 0, "text": ""}
 
-        done_chunk = {
-            "id": completion_id,
-            "object": "chat.completion.chunk",
-            "created": created,
-            "model": requested_model or default_model,
-            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-        }
-        await response.write(f"data: {json.dumps(done_chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+    async def write_chat_chunk(chunk: dict[str, Any]) -> None:
+        await response.write(f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8"))
+
+    try:
+        for event in ([first_event] if first_event is not None else []):
+            for chunk in codex_event_to_chat_chunks(event, completion_id=completion_id, created=created, model=model, state=state, stop=stop):
+                await write_chat_chunk(chunk)
+        if not state.get("stop_seen"):
+            async for event in iterator:
+                for chunk in codex_event_to_chat_chunks(event, completion_id=completion_id, created=created, model=model, state=state, stop=stop):
+                    await write_chat_chunk(chunk)
+                if state.get("failed") or state.get("stop_seen"):
+                    break
+        tail = _stream_stop_flush(state, stop)
+        if tail:
+            state["saw_text"] = True
+            state["text"] = state.get("text", "") + tail
+            await write_chat_chunk(_chat_sse_chunk(completion_id, created, model, {"content": tail}))
+
+        if not state.get("saw_tool_call"):
+            fallback = forced_tool_call_fallback(codex_kwargs.get("tool_choice"), codex_kwargs.get("tools"), text=state.get("text", ""))
+            for idx, call in enumerate(fallback):
+                state["saw_tool_call"] = True
+                await write_chat_chunk(_chat_sse_chunk(completion_id, created, model, {
+                    "tool_calls": [{
+                        "index": idx,
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["function"]["name"],
+                            "arguments": call["function"].get("arguments", "{}"),
+                        },
+                    }]
+                }))
+
+        finish_reason = "tool_calls" if state.get("saw_tool_call") else "stop"
+        done_chunk = _chat_sse_chunk(completion_id, created, model, {}, finish_reason)
+        await write_chat_chunk(done_chunk)
         await response.write(b"data: [DONE]\n\n")
     except Exception as exc:
         logger.exception("Passthrough Codex streaming chat completion failed")
@@ -138,6 +357,15 @@ async def stream_codex_as_responses_sse(
     default_model: str,
 ) -> web.StreamResponse:
     """Stream a Codex Responses upstream as minimal OpenAI Responses SSE."""
+    try:
+        stream = await client.responses.create(**codex_kwargs)
+    except Exception as exc:
+        logger.exception("Passthrough Codex streaming responses failed before SSE started")
+        return web.json_response(
+            openai_error(f"Passthrough Codex upstream stream failed: {exc}", code="upstream_stream_failed"),
+            status=502,
+        )
+
     response_id = make_id("resp")
     message_id = make_id("msg")
     created_at = int(time.time())
@@ -163,7 +391,6 @@ async def stream_codex_as_responses_sse(
             "item": {"id": message_id, "type": "message", "status": "in_progress", "role": "assistant", "content": []},
         }))
 
-        stream = await client.responses.create(**codex_kwargs)
         async for event in stream:
             event_type = getattr(event, "type", None)
             if not event_type and isinstance(event, dict):
@@ -240,6 +467,15 @@ async def stream_openai_chat_as_responses_sse(
     default_model: str,
 ) -> web.StreamResponse:
     """Stream OpenAI chat chunks as minimal OpenAI Responses SSE."""
+    try:
+        stream = await client.chat.completions.create(**chat_payload)
+    except Exception as exc:
+        logger.exception("Passthrough streaming responses failed before SSE started")
+        return web.json_response(
+            openai_error(f"Passthrough upstream stream failed: {exc}", code="upstream_stream_failed"),
+            status=502,
+        )
+
     response_id = make_id("resp")
     message_id = make_id("msg")
     created_at = int(time.time())
@@ -265,7 +501,6 @@ async def stream_openai_chat_as_responses_sse(
         }))
 
         full_text = ""
-        stream = await client.chat.completions.create(**chat_payload)
         async for chunk in stream:
             chunk_data = chunk.model_dump(exclude_none=True) if hasattr(chunk, "model_dump") else dict(chunk)
             choices = chunk_data.get("choices") or []

--- a/gateway/platforms/one_model_api/types.py
+++ b/gateway/platforms/one_model_api/types.py
@@ -1,0 +1,31 @@
+"""Shared types for the one-model API protocol adapter layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    """Hermes-resolved upstream runtime passed into protocol adapters.
+
+    This is deliberately not an account object. Account selection, credential
+    pools, OAuth refresh, cooldown, failover, and concurrency are owned by
+    Hermes before this layer runs. The adapter receives only the already
+    resolved transport details it needs to speak the upstream protocol.
+    """
+
+    api_mode: str
+    base_url: str | None
+    model: str | None
+    provider: str | None = None
+
+    @classmethod
+    def from_mapping(cls, runtime: Mapping[str, Any]) -> "RuntimeContext":
+        return cls(
+            api_mode=str(runtime.get("api_mode") or "").strip().lower(),
+            base_url=str(runtime.get("base_url") or "") or None,
+            model=str(runtime.get("model") or runtime.get("default_model") or "") or None,
+            provider=str(runtime.get("provider") or "") or None,
+        )

--- a/tests/gateway/test_one_model_api_passthrough.py
+++ b/tests/gateway/test_one_model_api_passthrough.py
@@ -1,0 +1,439 @@
+import pytest
+
+from gateway.platforms.one_model_api.adapters.openai_chat import OpenAIChatAdapter
+from gateway.platforms.one_model_api.conversions import (
+    chat_payload_to_codex_responses_kwargs,
+    codex_to_chat_payload,
+    collect_codex_stream,
+    responses_to_chat_payload,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.one_model_api.streams import (
+    _stream_stop_filter_piece,
+    _stream_stop_flush,
+    codex_event_to_chat_chunks,
+    stream_openai_chat_as_chat_sse,
+)
+
+
+class _FakeChatResponse:
+    def __init__(self, content="ok"):
+        self.data = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "choices": [{"message": {"role": "assistant", "content": content}}],
+        }
+
+    def model_dump(self, exclude_none=True):
+        return dict(self.data)
+
+
+class _FakeChatCompletions:
+    def __init__(self):
+        self.payloads = []
+
+    async def create(self, **payload):
+        self.payloads.append(payload)
+        return _FakeChatResponse("abc STOP def" if payload.get("stop") else "ok")
+
+
+class _FakeClient:
+    def __init__(self):
+        self.chat = type("Chat", (), {"completions": _FakeChatCompletions()})()
+
+
+class _FailingChatCompletions:
+    async def create(self, **payload):
+        raise RuntimeError("Unsupported parameter: temperature")
+
+
+class _FailingClient:
+    def __init__(self):
+        self.chat = type("Chat", (), {"completions": _FailingChatCompletions()})()
+
+
+class _IteratorFailingOnFirstChunk:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise RuntimeError("Unsupported parameter: temperature")
+
+
+class _LazyFailingChatCompletions:
+    async def create(self, **payload):
+        return _IteratorFailingOnFirstChunk()
+
+
+class _LazyFailingClient:
+    def __init__(self):
+        self.chat = type("Chat", (), {"completions": _LazyFailingChatCompletions()})()
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_adapter_strips_sampling_controls_before_forwarding():
+    adapter = OpenAIChatAdapter()
+    client = _FakeClient()
+
+    response = await adapter.chat_completion(
+        server=object(),
+        request=None,
+        client=client,
+        runtime={},
+        payload={
+            "model": "upstream-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0,
+            "top_p": 1,
+        },
+        requested_model="public-model",
+    )
+
+    assert response.status == 200
+    forwarded = client.chat.completions.payloads[0]
+    assert "temperature" not in forwarded
+    assert "top_p" not in forwarded
+    assert forwarded["model"] == "upstream-model"
+
+
+def test_chat_to_codex_conversion_does_not_forward_sampling_controls():
+    kwargs = chat_payload_to_codex_responses_kwargs(
+        {
+            "model": "upstream-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0,
+            "top_p": 1,
+        },
+        runtime={"base_url": "https://chatgpt.com/backend-api/codex"},
+        default_model="public-model",
+        stream=True,
+    )
+
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+    assert kwargs["model"] == "upstream-model"
+
+
+def test_chat_to_codex_conversion_maps_tools_instead_of_rejecting():
+    kwargs = chat_payload_to_codex_responses_kwargs(
+        {
+            "model": "upstream-model",
+            "messages": [{"role": "user", "content": "use a tool"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        },
+        runtime={"base_url": "https://chatgpt.com/backend-api/codex"},
+        default_model="public-model",
+        stream=True,
+    )
+
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "strict": False,
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert kwargs["tool_choice"] == {"type": "function", "name": "get_weather"}
+
+
+def test_responses_to_chat_payload_does_not_copy_sampling_controls():
+    payload = responses_to_chat_payload(
+        {
+            "model": "public-model",
+            "input": "hi",
+            "temperature": 0,
+            "top_p": 1,
+            "max_output_tokens": 8,
+        },
+        default_model="upstream-model",
+    )
+
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert payload["max_tokens"] == 8
+
+
+def test_responses_to_chat_payload_preserves_requested_model_for_validation():
+    payload = responses_to_chat_payload(
+        {"model": "definitely-not-a-model", "input": "hi"},
+        default_model="public-model",
+    )
+
+    assert payload["model"] == "definitely-not-a-model"
+
+
+def test_codex_to_chat_payload_applies_local_stop_truncation():
+    response = {
+        "status": "completed",
+        "output_text": "abc STOP def",
+        "usage": {"input_tokens": 1, "output_tokens": 3, "total_tokens": 4},
+    }
+
+    payload = codex_to_chat_payload(response, requested_model="public-model", default_model="fallback", stop="STOP")
+
+    assert payload["choices"][0]["message"]["content"] == "abc "
+    assert "STOP" not in payload["choices"][0]["message"]["content"]
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_adapter_applies_local_stop_truncation():
+    adapter = OpenAIChatAdapter()
+    response = await adapter.chat_completion(
+        server=object(),
+        request=None,
+        client=_FakeClient(),
+        runtime={},
+        payload={"model": "m", "messages": [], "stop": "STOP"},
+        requested_model="public-model",
+    )
+
+    assert response.status == 200
+    assert b"STOP" not in response.body
+    assert b"abc " in response.body
+
+
+def test_codex_to_chat_payload_emits_tool_calls_from_responses_function_calls():
+    response = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "get_weather",
+                "arguments": '{"city":"Beijing"}',
+            }
+        ],
+        "usage": {"input_tokens": 1, "output_tokens": 3, "total_tokens": 4},
+    }
+
+    payload = codex_to_chat_payload(response, requested_model="public-model", default_model="fallback")
+
+    choice = payload["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"] == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"Beijing"}'},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_creation_failure_returns_non_200_before_sse_starts():
+    response = await stream_openai_chat_as_chat_sse(
+        None,
+        client=_FailingClient(),
+        payload={"model": "m", "messages": [], "stream": True, "temperature": 0},
+        requested_model="public-model",
+    )
+
+    assert response.status == 502
+
+
+@pytest.mark.asyncio
+async def test_stream_first_chunk_failure_returns_non_200_before_sse_starts():
+    response = await stream_openai_chat_as_chat_sse(
+        None,
+        client=_LazyFailingClient(),
+        payload={"model": "m", "messages": [], "stream": True, "temperature": 0},
+        requested_model="public-model",
+    )
+
+    assert response.status == 502
+
+
+class _FakeCodexStream:
+    def __init__(self, events):
+        self._events = list(events)
+        self._idx = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._idx >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._idx]
+        self._idx += 1
+        return event
+
+
+class _FakeResponses:
+    def __init__(self, events):
+        self.events = events
+        self.payloads = []
+
+    async def create(self, **kwargs):
+        self.payloads.append(kwargs)
+        return _FakeCodexStream(self.events)
+
+
+class _FakeCodexClient:
+    def __init__(self, events):
+        self.responses = _FakeResponses(events)
+
+
+def test_chat_to_codex_conversion_maps_legacy_function_call_to_tool_choice():
+    kwargs = chat_payload_to_codex_responses_kwargs(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "functions": [{"name": "get_weather", "parameters": {"type": "object"}}],
+            "function_call": {"name": "get_weather"},
+        },
+        runtime={"base_url": "https://chatgpt.com/backend-api/codex"},
+        default_model="fallback",
+        stream=True,
+    )
+
+    assert kwargs["tool_choice"] == {"type": "function", "name": "get_weather"}
+
+
+@pytest.mark.asyncio
+async def test_collect_codex_stream_accumulates_function_call_deltas():
+    client = _FakeCodexClient([
+        {
+            "type": "response.output_item.added",
+            "output_index": 1,
+            "item": {"type": "function_call", "call_id": "call_1", "name": "get_weather"},
+        },
+        {"type": "response.function_call_arguments.delta", "output_index": 1, "delta": '{"city"'},
+        {"type": "response.function_call_arguments.delta", "output_index": 1, "delta": ':"北京"}'},
+        {"type": "response.completed", "response": {"status": "completed", "output": []}},
+    ])
+
+    response = await collect_codex_stream(client, {"model": "m", "stream": True})
+
+    assert response["output"] == [
+        {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": '{"city":"北京"}'}
+    ]
+    chat = codex_to_chat_payload(response, requested_model="public", default_model="fallback")
+    assert chat["choices"][0]["finish_reason"] == "tool_calls"
+    assert chat["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] == '{"city":"北京"}'
+
+
+def test_codex_to_chat_payload_forced_tool_choice_fallback_uses_json_text_as_arguments():
+    response = {"status": "completed", "output_text": '{"city":"北京"}', "output": []}
+
+    chat = codex_to_chat_payload(
+        response,
+        requested_model="public",
+        default_model="fallback",
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+        tools=[{"type": "function", "name": "get_weather"}],
+    )
+
+    choice = chat["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["content"] is None
+    assert choice["message"]["tool_calls"][0]["function"] == {"name": "get_weather", "arguments": '{"city": "北京"}'}
+
+
+def test_codex_stream_event_to_chat_chunks_emits_tool_call_deltas():
+    state = {"output_index_to_tool_index": {}, "next_tool_index": 0, "text": ""}
+    chunks = codex_event_to_chat_chunks(
+        {"type": "response.output_item.added", "output_index": 2, "item": {"type": "function_call", "call_id": "call_1", "name": "get_weather"}},
+        completion_id="chatcmpl-test",
+        created=1,
+        model="public",
+        state=state,
+    )
+    assert chunks[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    chunks = codex_event_to_chat_chunks(
+        {"type": "response.function_call_arguments.delta", "output_index": 2, "delta": '{"city":"北京"}'},
+        completion_id="chatcmpl-test",
+        created=1,
+        model="public",
+        state=state,
+    )
+    assert chunks[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"] == '{"city":"北京"}'
+
+
+def test_stream_stop_filter_truncates_across_chunk_boundary():
+    state = {}
+    emitted = []
+    for piece in ["abc S", "TO", "P def"]:
+        out = _stream_stop_filter_piece(piece, state, "STOP")
+        if out:
+            emitted.append(out)
+        if state.get("stop_seen"):
+            break
+    tail = _stream_stop_flush(state, "STOP")
+    if tail:
+        emitted.append(tail)
+
+    text = "".join(emitted)
+    assert text == "abc "
+    assert "STOP" not in text
+    assert "def" not in text
+
+
+def test_codex_stream_event_to_chat_chunks_applies_stop_before_emitting():
+    state = {"output_index_to_tool_index": {}, "next_tool_index": 0, "text": ""}
+    chunks = []
+    for piece in ["abc S", "TO", "P def"]:
+        chunks.extend(codex_event_to_chat_chunks(
+            {"type": "response.output_text.delta", "delta": piece},
+            completion_id="chatcmpl-test",
+            created=1,
+            model="public",
+            state=state,
+            stop="STOP",
+        ))
+        if state.get("stop_seen"):
+            break
+    tail = _stream_stop_flush(state, "STOP")
+    if tail:
+        chunks.append({"choices": [{"delta": {"content": tail}}]})
+
+    text = "".join(
+        (chunk["choices"][0].get("delta") or {}).get("content", "")
+        for chunk in chunks
+    )
+    assert text == "abc "
+    assert "STOP" not in text
+    assert "def" not in text
+
+
+def test_api_server_passthrough_rejects_unknown_model():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"model_name": "public-model"}))
+
+    assert adapter._validate_passthrough_model("public-model") is None
+    response = adapter._validate_passthrough_model("definitely-not-a-model")
+
+    assert response is not None
+    assert response.status == 400
+    assert b"model_not_found" in response.body
+    assert b"definitely-not-a-model" in response.body
+
+
+def test_api_server_allowed_models_can_be_extended():
+    adapter = APIServerAdapter(PlatformConfig(
+        enabled=True,
+        extra={"model_name": "public-model", "allowed_models": "public-model,alias-model"},
+    ))
+
+    assert adapter._validate_passthrough_model("alias-model") is None


### PR DESCRIPTION
## Summary
- Add one-model API passthrough protocol adapters for OpenAI Chat and Codex/Responses runtimes.
- Harden OpenAI-compatible passthrough behavior for `temperature`/`top_p`, non-streaming and streaming `stop`, and invalid model names.
- Improve Chat Completions <-> Responses tool-call compatibility, including `function_call` to `tool_calls`, streaming `delta.tool_calls`, buffered function-call accumulation, and forced `tool_choice` fallback.
- Add regression tests for sampling parameter stripping, stop truncation, stream creation failures, model whitelist validation, and tool-call conversion.

## Test Plan
- `./venv/bin/python -m compileall -q gateway/platforms/one_model_api gateway/platforms/api_server.py tests/gateway/test_one_model_api_passthrough.py`
- `./venv/bin/python -m pytest tests/gateway/test_one_model_api_passthrough.py -q -o 'addopts='`
- In `/tmp/one-model-api-release`: `/home/admin/.hermes/hermes-agent/venv/bin/python -m pytest tests -q`
- Live verified `/v1/chat/completions` and `/v1/responses` on local and public gateway endpoints for invalid model rejection and streaming stop truncation.

## Notes
- Passthrough mode still forces the configured upstream model after validating the client-facing model name.
- Unknown client-facing models now return OpenAI-style `400` with `model_not_found` instead of silently falling back.
