### PR TITLE
fix(terminal): expand ~ and $VAR in workdir before directory check (#26151)

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -51,6 +51,35 @@ class TestResolveSafeCwd:
         monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
         assert _resolve_safe_cwd("/no/such/deep/dir") == sep
 
+    def test_expands_tilde_to_home_directory(self):
+        """``~`` must be expanded before the ``os.path.isdir`` check so that
+        ``terminal(background=True, workdir="~/Projects/...")`` does not fall
+        back to ``tempfile.gettempdir()``.
+
+        Regression coverage for
+        https://github.com/NousResearch/hermes-agent/issues/26151
+        """
+        home = os.path.expanduser("~")
+        result = _resolve_safe_cwd("~")
+        assert result == home, (
+            f"Expected tilde to expand to {home!r}, got {result!r}"
+        )
+
+    def test_expands_tilde_subdirectory(self, tmp_path, monkeypatch):
+        """A ``~/subdir`` path that exists after expansion must be returned
+        as-is (expanded) rather than triggering the ``/tmp`` fallback."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        subdir = tmp_path / "myproject"
+        subdir.mkdir()
+        result = _resolve_safe_cwd("~/myproject")
+        assert result == str(subdir)
+
+    def test_expands_env_vars_in_workdir(self, tmp_path, monkeypatch):
+        """``$HOME`` and other env-var references must also be expanded."""
+        monkeypatch.setenv("MY_PROJECT", str(tmp_path))
+        result = _resolve_safe_cwd("$MY_PROJECT")
+        assert result == str(tmp_path)
+
 
 def _fake_interrupt():
     return threading.Event()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -29,7 +29,14 @@ def _resolve_safe_cwd(cwd: str) -> str:
     (issue #17558).  Without this guard, ``subprocess.Popen(..., cwd=...)``
     raises ``FileNotFoundError`` before bash starts, wedging every subsequent
     terminal call until the gateway restarts.
+
+    ``~`` and ``$HOME``-style references are expanded before the directory
+    check so that paths like ``~/Projects/myapp`` are resolved correctly
+    instead of silently falling back to ``tempfile.gettempdir()``.
+    See https://github.com/NousResearch/hermes-agent/issues/26151
     """
+    if cwd:
+        cwd = os.path.expandvars(os.path.expanduser(cwd))
     if cwd and os.path.isdir(cwd):
         return cwd
     parent = os.path.dirname(cwd) if cwd else ""


### PR DESCRIPTION
## Problem

`terminal(background=True, workdir="~/Projects/myapp")` silently starts in `/tmp` instead of the intended directory.

### Root Cause

`_resolve_safe_cwd()` in `tools/environments/local.py` calls `os.path.isdir(cwd)` on the **raw** workdir string before expanding `~`. Since `~/Projects/myapp` is not a real directory name, `isdir` always returns `False` and the function falls back to `tempfile.gettempdir()` — usually `/tmp`.

```python
# Before fix — broken
def _resolve_safe_cwd(cwd: str) -> str:
    if cwd and os.path.isdir(cwd):   # "~/Projects" always False
        return cwd
    ...
    return tempfile.gettempdir()     # silently falls back to /tmp
```

This causes downstream failures like `MODULE_NOT_FOUND` (Node.js can't find `node_modules`), missing config files, or any other cwd-relative dependency.

## Fix

Expand `~` and environment variables at the top of `_resolve_safe_cwd()` before any `isdir()` check:

```python
if cwd:
    cwd = os.path.expandvars(os.path.expanduser(cwd))
if cwd and os.path.isdir(cwd):
    return cwd
```

The expansion also applies to the ancestor walk, so `~/nonexistent` falls back to the home directory (the nearest existing ancestor) rather than `/tmp`.

Note that `terminal_tool.py` and `process_registry.spawn_local()` both funnel through `_resolve_safe_cwd()`, so this single-point fix covers all code paths.

## Tests Added

Three new cases in `tests/tools/test_local_env_cwd_recovery.py`:

| Test | What it verifies |
|------|-----------------|
| `test_expands_tilde_to_home_directory` | `~` expands to `os.path.expanduser('~')` |
| `test_expands_tilde_subdirectory` | `~/myproject` (exists after expansion) is returned as-is |
| `test_expands_env_vars_in_workdir` | `$MY_PROJECT` env-var reference is expanded |

Fixes #26151