### PR TITLE
fix(feishu): prefer open_id over user_id in _resolve_sender_profile

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3762,8 +3762,8 @@ class FeishuAdapter(BasePlatformAdapter):
         """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
 
         Preference order for the primary ``user_id`` field:
-          1. user_id  (tenant-scoped, most stable — requires permission scope)
-          2. open_id  (app-scoped, always available — different per bot app)
+          1. open_id  (app-scoped, always available — matches FEISHU_ALLOWED_USERS)
+          2. user_id  (tenant-scoped, only available with permission scope)
 
         ``user_id_alt`` carries the union_id (developer-scoped, stable across
         all apps by the same developer).  Session-key generation prefers
@@ -3773,8 +3773,8 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
-        # Prefer tenant-scoped user_id; fall back to app-scoped open_id.
-        primary_id = user_id or open_id
+        # Prefer app-scoped open_id (matches FEISHU_ALLOWED_USERS); fall back to user_id.
+        primary_id = open_id or user_id
         # bot/v3/bots/basic_batch only accepts open_id.
         name_lookup_id = open_id if is_bot else (primary_id or union_id)
         display_name = await self._resolve_sender_name_from_api(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1579,7 +1579,7 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._dispatch_inbound_event.assert_awaited_once()
         event = adapter._dispatch_inbound_event.await_args.args[0]
         self.assertEqual(event.message_type, MessageType.TEXT)
-        self.assertEqual(event.source.user_id, "u_user")  # tenant-scoped user_id preferred over app-scoped open_id
+        self.assertEqual(event.source.user_id, "ou_user")  # app-scoped open_id preferred over tenant-scoped user_id
         self.assertEqual(event.source.user_name, "张三")
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")


### PR DESCRIPTION
## Summary

Closes #26183

When a Feishu app has contact permission scope, the event payload includes both a tenant-scoped `user_id` (e.g. `92dccg4d`) and an app-scoped `open_id` (e.g. `ou_5e9eefd6...`). `_resolve_sender_profile()` previously preferred `user_id`, but `FEISHU_ALLOWED_USERS` stores `open_id` (set via `hermes gateway setup`). The auth check compared `user_id` against a list of `open_id` values → mismatch → user rejected as unauthorized.

## Changes

`gateway/platforms/feishu.py` — one line plus docstring:
```python
# Before:
primary_id = user_id or open_id

# After:
primary_id = open_id or user_id
```

Session isolation is unaffected — `user_id_alt` (union_id) is already the stable cross-app identifier used by `gateway/session.py` for session key generation.

## Testing

`tests/gateway/test_feishu.py` — 1 assertion updated to match new preference order.
All 229 feishu tests pass.