### PR TITLE
test(windows): close SessionDB fixtures before TemporaryDirectory cleanup

### DIFF
--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -17,6 +17,25 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _close_test_session_db(db, agent=None):
+    """Close test-owned SessionDB handles before TemporaryDirectory cleanup."""
+    candidates = []
+    if agent is not None:
+        candidates.append(getattr(agent, "_session_db", None))
+    candidates.append(db)
+    seen = set()
+    for candidate in candidates:
+        if candidate is None or id(candidate) in seen:
+            continue
+        seen.add(id(candidate))
+        close = getattr(candidate, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Test: _flush_messages_to_session_db only writes new messages
 # ---------------------------------------------------------------------------
@@ -49,28 +68,31 @@ class TestFlushDeduplication:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            agent = self._make_agent(db)
+                conversation_history = [
+                    {"role": "user", "content": "old message"},
+                ]
+                messages = list(conversation_history) + [
+                    {"role": "user", "content": "new question"},
+                    {"role": "assistant", "content": "new answer"},
+                ]
 
-            conversation_history = [
-                {"role": "user", "content": "old message"},
-            ]
-            messages = list(conversation_history) + [
-                {"role": "user", "content": "new question"},
-                {"role": "assistant", "content": "new answer"},
-            ]
+                # First flush — should write 2 new messages
+                agent._flush_messages_to_session_db(messages, conversation_history)
 
-            # First flush — should write 2 new messages
-            agent._flush_messages_to_session_db(messages, conversation_history)
+                rows = db.get_messages(agent.session_id)
+                assert len(rows) == 2, f"Expected 2 messages, got {len(rows)}"
 
-            rows = db.get_messages(agent.session_id)
-            assert len(rows) == 2, f"Expected 2 messages, got {len(rows)}"
+                # Second flush with SAME messages — should write 0 new messages
+                agent._flush_messages_to_session_db(messages, conversation_history)
 
-            # Second flush with SAME messages — should write 0 new messages
-            agent._flush_messages_to_session_db(messages, conversation_history)
-
-            rows = db.get_messages(agent.session_id)
-            assert len(rows) == 2, f"Expected still 2 messages after second flush, got {len(rows)}"
+                rows = db.get_messages(agent.session_id)
+                assert len(rows) == 2, f"Expected still 2 messages after second flush, got {len(rows)}"
+            finally:
+                _close_test_session_db(db, agent)
 
     def test_flush_writes_incrementally(self):
         """Messages added between flushes are written exactly once."""
@@ -79,27 +101,30 @@ class TestFlushDeduplication:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            agent = self._make_agent(db)
+                conversation_history = []
+                messages = [
+                    {"role": "user", "content": "hello"},
+                ]
 
-            conversation_history = []
-            messages = [
-                {"role": "user", "content": "hello"},
-            ]
+                # First flush — 1 message
+                agent._flush_messages_to_session_db(messages, conversation_history)
+                rows = db.get_messages(agent.session_id)
+                assert len(rows) == 1
 
-            # First flush — 1 message
-            agent._flush_messages_to_session_db(messages, conversation_history)
-            rows = db.get_messages(agent.session_id)
-            assert len(rows) == 1
+                # Add more messages
+                messages.append({"role": "assistant", "content": "hi there"})
+                messages.append({"role": "user", "content": "follow up"})
 
-            # Add more messages
-            messages.append({"role": "assistant", "content": "hi there"})
-            messages.append({"role": "user", "content": "follow up"})
-
-            # Second flush — should write only 2 new messages
-            agent._flush_messages_to_session_db(messages, conversation_history)
-            rows = db.get_messages(agent.session_id)
-            assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
+                # Second flush — should write only 2 new messages
+                agent._flush_messages_to_session_db(messages, conversation_history)
+                rows = db.get_messages(agent.session_id)
+                assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
+            finally:
+                _close_test_session_db(db, agent)
 
     def test_persist_session_multiple_calls_no_duplication(self):
         """Multiple _persist_session calls don't duplicate DB entries."""
@@ -108,23 +133,28 @@ class TestFlushDeduplication:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
+                # Stub out _save_session_log to avoid file I/O
+                agent._save_session_log = MagicMock()
 
-            agent = self._make_agent(db)
+                conversation_history = [{"role": "user", "content": "old"}]
+                messages = list(conversation_history) + [
+                    {"role": "user", "content": "q1"},
+                    {"role": "assistant", "content": "a1"},
+                    {"role": "user", "content": "q2"},
+                    {"role": "assistant", "content": "a2"},
+                ]
 
-            conversation_history = [{"role": "user", "content": "old"}]
-            messages = list(conversation_history) + [
-                {"role": "user", "content": "q1"},
-                {"role": "assistant", "content": "a1"},
-                {"role": "user", "content": "q2"},
-                {"role": "assistant", "content": "a2"},
-            ]
+                # Simulate multiple persist calls (like the agent's many exit paths)
+                for _ in range(5):
+                    agent._persist_session(messages, conversation_history)
 
-            # Simulate multiple persist calls (like the agent's many exit paths)
-            for _ in range(5):
-                agent._persist_session(messages, conversation_history)
-
-            rows = db.get_messages(agent.session_id)
-            assert len(rows) == 4, f"Expected 4 messages, got {len(rows)} (duplication bug!)"
+                rows = db.get_messages(agent.session_id)
+                assert len(rows) == 4, f"Expected 4 messages, got {len(rows)} (duplication bug!)"
+            finally:
+                _close_test_session_db(db, agent)
 
     def test_flush_reset_after_compression(self):
         """After compression creates a new session, flush index resets."""
@@ -133,36 +163,39 @@ class TestFlushDeduplication:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            agent = self._make_agent(db)
+                # Write some messages
+                messages = [
+                    {"role": "user", "content": "msg1"},
+                    {"role": "assistant", "content": "reply1"},
+                ]
+                agent._flush_messages_to_session_db(messages, [])
 
-            # Write some messages
-            messages = [
-                {"role": "user", "content": "msg1"},
-                {"role": "assistant", "content": "reply1"},
-            ]
-            agent._flush_messages_to_session_db(messages, [])
+                old_session = agent.session_id
+                assert agent._last_flushed_db_idx == 2
 
-            old_session = agent.session_id
-            assert agent._last_flushed_db_idx == 2
+                # Simulate what _compress_context does: new session, reset idx
+                agent.session_id = "compressed-session-new"
+                db.create_session(session_id=agent.session_id, source="test")
+                agent._last_flushed_db_idx = 0
 
-            # Simulate what _compress_context does: new session, reset idx
-            agent.session_id = "compressed-session-new"
-            db.create_session(session_id=agent.session_id, source="test")
-            agent._last_flushed_db_idx = 0
+                # Now flush compressed messages to new session
+                compressed_messages = [
+                    {"role": "user", "content": "summary of conversation"},
+                ]
+                agent._flush_messages_to_session_db(compressed_messages, [])
 
-            # Now flush compressed messages to new session
-            compressed_messages = [
-                {"role": "user", "content": "summary of conversation"},
-            ]
-            agent._flush_messages_to_session_db(compressed_messages, [])
+                new_rows = db.get_messages(agent.session_id)
+                assert len(new_rows) == 1
 
-            new_rows = db.get_messages(agent.session_id)
-            assert len(new_rows) == 1
-
-            # Old session should still have its 2 messages
-            old_rows = db.get_messages(old_session)
-            assert len(old_rows) == 2
+                # Old session should still have its 2 messages
+                old_rows = db.get_messages(old_session)
+                assert len(old_rows) == 2
+            finally:
+                _close_test_session_db(db, agent)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -19,6 +19,25 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _close_test_session_db(db, agent=None):
+    """Close test-owned SessionDB handles before TemporaryDirectory cleanup."""
+    candidates = []
+    if agent is not None:
+        candidates.append(getattr(agent, "_session_db", None))
+    candidates.append(db)
+    seen = set()
+    for candidate in candidates:
+        if candidate is None or id(candidate) in seen:
+            continue
+        seen.add(id(candidate))
+        close = getattr(candidate, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+
 class TestCompressionBoundaryHook:
     def _make_agent(self, session_db):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
@@ -39,57 +58,61 @@ class TestCompressionBoundaryHook:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            # Stub the context compressor: we only need to observe the hook.
-            compressor = MagicMock()
-            compressor.compress.return_value = [
-                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
-                {"role": "user", "content": "tail question"},
-            ]
-            compressor.compression_count = 1
-            compressor.last_prompt_tokens = 0
-            compressor.last_completion_tokens = 0
-            # Avoid the summary-error warning path
-            compressor._last_summary_error = None
-            # MagicMock auto-creates truthy attrs; explicitly clear the abort
-            # flag so the post-compress abort branch in
-            # conversation_compression.py does not short-circuit before the
-            # session-id rotation we are asserting on.
-            compressor._last_compress_aborted = False
-            agent.context_compressor = compressor
+                # Stub the context compressor: we only need to observe the hook.
+                compressor = MagicMock()
+                compressor.compress.return_value = [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": "tail question"},
+                ]
+                compressor.compression_count = 1
+                compressor.last_prompt_tokens = 0
+                compressor.last_completion_tokens = 0
+                # Avoid the summary-error warning path
+                compressor._last_summary_error = None
+                # MagicMock auto-creates truthy attrs; explicitly clear the abort
+                # flag so the post-compress abort branch in
+                # conversation_compression.py does not short-circuit before the
+                # session-id rotation we are asserting on.
+                compressor._last_compress_aborted = False
+                agent.context_compressor = compressor
 
-            original_sid = agent.session_id
-            messages = [
-                {"role": "user", "content": f"m{i}"} for i in range(10)
-            ]
+                original_sid = agent.session_id
+                messages = [
+                    {"role": "user", "content": f"m{i}"} for i in range(10)
+                ]
 
-            agent._compress_context(messages, "sys", approx_tokens=10_000)
+                agent._compress_context(messages, "sys", approx_tokens=10_000)
 
-            # Session_id rotated
-            assert agent.session_id != original_sid, \
-                "compression should rotate session_id when session_db is set"
+                # Session_id rotated
+                assert agent.session_id != original_sid, \
+                    "compression should rotate session_id when session_db is set"
 
-            # Hook fired with boundary_reason="compression" and old_session_id
-            calls = [
-                c for c in compressor.on_session_start.call_args_list
-            ]
-            assert calls, "on_session_start was never called on the context engine"
-            # Find the compression boundary call (there may be others from init)
-            comp_calls = [
-                c for c in calls
-                if c.kwargs.get("boundary_reason") == "compression"
-            ]
-            assert comp_calls, (
-                f"Expected an on_session_start call with "
-                f"boundary_reason='compression', got {calls!r}"
-            )
-            call = comp_calls[-1]
-            # Positional new session_id
-            assert call.args and call.args[0] == agent.session_id, \
-                f"Expected new session_id as first positional arg, got {call!r}"
-            assert call.kwargs.get("old_session_id") == original_sid, \
-                f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+                # Hook fired with boundary_reason="compression" and old_session_id
+                calls = [
+                    c for c in compressor.on_session_start.call_args_list
+                ]
+                assert calls, "on_session_start was never called on the context engine"
+                # Find the compression boundary call (there may be others from init)
+                comp_calls = [
+                    c for c in calls
+                    if c.kwargs.get("boundary_reason") == "compression"
+                ]
+                assert comp_calls, (
+                    f"Expected an on_session_start call with "
+                    f"boundary_reason='compression', got {calls!r}"
+                )
+                call = comp_calls[-1]
+                # Positional new session_id
+                assert call.args and call.args[0] == agent.session_id, \
+                    f"Expected new session_id as first positional arg, got {call!r}"
+                assert call.kwargs.get("old_session_id") == original_sid, \
+                    f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+            finally:
+                _close_test_session_db(db, agent)
 
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""
@@ -134,29 +157,33 @@ class TestCompressionBoundaryHook:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SessionDB(db_path=Path(tmpdir) / "test.db")
-            agent = self._make_agent(db)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            compressor = MagicMock()
-            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
-            compressor.compression_count = 1
-            compressor.last_prompt_tokens = 0
-            compressor.last_completion_tokens = 0
-            compressor._last_summary_error = None
-            compressor._last_compress_aborted = False
+                compressor = MagicMock()
+                compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+                compressor.compression_count = 1
+                compressor.last_prompt_tokens = 0
+                compressor.last_completion_tokens = 0
+                compressor._last_summary_error = None
+                compressor._last_compress_aborted = False
 
-            # Raise only on the compression-boundary call, not on earlier calls.
-            def _raise_on_compression(*args, **kwargs):
-                if kwargs.get("boundary_reason") == "compression":
-                    raise RuntimeError("plugin exploded")
-                return None
-            compressor.on_session_start.side_effect = _raise_on_compression
-            agent.context_compressor = compressor
+                # Raise only on the compression-boundary call, not on earlier calls.
+                def _raise_on_compression(*args, **kwargs):
+                    if kwargs.get("boundary_reason") == "compression":
+                        raise RuntimeError("plugin exploded")
+                    return None
+                compressor.on_session_start.side_effect = _raise_on_compression
+                agent.context_compressor = compressor
 
-            original_sid = agent.session_id
+                original_sid = agent.session_id
 
-            # Must not raise
-            compressed, _prompt = agent._compress_context(
-                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
-            )
-            assert compressed
-            assert agent.session_id != original_sid
+                # Must not raise
+                compressed, _prompt = agent._compress_context(
+                    [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+                )
+                assert compressed
+                assert agent.session_id != original_sid
+            finally:
+                _close_test_session_db(db, agent)

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -24,6 +24,25 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _close_test_session_db(db, agent=None):
+    """Close test-owned SessionDB handles before TemporaryDirectory cleanup."""
+    candidates = []
+    if agent is not None:
+        candidates.append(getattr(agent, "_session_db", None))
+    candidates.append(db)
+    seen = set()
+    for candidate in candidates:
+        if candidate is None or id(candidate) in seen:
+            continue
+        seen.add(id(candidate))
+        close = getattr(candidate, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+
 # ---------------------------------------------------------------------------
 # Part 1: Agent-side — _flush_messages_to_session_db after compression
 # ---------------------------------------------------------------------------
@@ -61,45 +80,48 @@ class TestFlushAfterCompression:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            agent = self._make_agent(db)
+                # Simulate the original long history (200 messages)
+                original_history = [
+                    {"role": "user" if i % 2 == 0 else "assistant",
+                     "content": f"message {i}"}
+                    for i in range(200)
+                ]
 
-            # Simulate the original long history (200 messages)
-            original_history = [
-                {"role": "user" if i % 2 == 0 else "assistant",
-                 "content": f"message {i}"}
-                for i in range(200)
-            ]
+                # First, flush original messages to the original session
+                agent._flush_messages_to_session_db(original_history, [])
+                original_rows = db.get_messages("original-session")
+                assert len(original_rows) == 200
 
-            # First, flush original messages to the original session
-            agent._flush_messages_to_session_db(original_history, [])
-            original_rows = db.get_messages("original-session")
-            assert len(original_rows) == 200
+                # Now simulate compression: new session, reset idx, shorter messages
+                agent.session_id = "compressed-session"
+                db.create_session(session_id="compressed-session", source="test")
+                agent._last_flushed_db_idx = 0
 
-            # Now simulate compression: new session, reset idx, shorter messages
-            agent.session_id = "compressed-session"
-            db.create_session(session_id="compressed-session", source="test")
-            agent._last_flushed_db_idx = 0
+                # The compressed messages (summary + tail + new turn)
+                compressed_messages = [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] Summary of work..."},
+                    {"role": "user", "content": "What should we do next?"},
+                    {"role": "assistant", "content": "Let me check..."},
+                    {"role": "user", "content": "new question"},
+                    {"role": "assistant", "content": "new answer"},
+                ]
 
-            # The compressed messages (summary + tail + new turn)
-            compressed_messages = [
-                {"role": "user", "content": "[CONTEXT COMPACTION] Summary of work..."},
-                {"role": "user", "content": "What should we do next?"},
-                {"role": "assistant", "content": "Let me check..."},
-                {"role": "user", "content": "new question"},
-                {"role": "assistant", "content": "new answer"},
-            ]
+                # THE BUG: passing the original history as conversation_history
+                # causes flush_from = max(200, 0) = 200, skipping everything.
+                # After the fix, conversation_history should be None.
+                agent._flush_messages_to_session_db(compressed_messages, None)
 
-            # THE BUG: passing the original history as conversation_history
-            # causes flush_from = max(200, 0) = 200, skipping everything.
-            # After the fix, conversation_history should be None.
-            agent._flush_messages_to_session_db(compressed_messages, None)
-
-            new_rows = db.get_messages("compressed-session")
-            assert len(new_rows) == 5, (
-                f"Expected 5 compressed messages in new session, got {len(new_rows)}. "
-                f"Compression persistence bug: messages not written to SQLite."
-            )
+                new_rows = db.get_messages("compressed-session")
+                assert len(new_rows) == 5, (
+                    f"Expected 5 compressed messages in new session, got {len(new_rows)}. "
+                    f"Compression persistence bug: messages not written to SQLite."
+                )
+            finally:
+                _close_test_session_db(db, agent)
 
     def test_flush_with_stale_history_loses_messages(self):
         """Demonstrates the bug condition: stale conversation_history causes data loss."""
@@ -108,30 +130,33 @@ class TestFlushAfterCompression:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             db = SessionDB(db_path=db_path)
+            agent = None
+            try:
+                agent = self._make_agent(db)
 
-            agent = self._make_agent(db)
+                # Simulate compression reset
+                agent.session_id = "new-session"
+                db.create_session(session_id="new-session", source="test")
+                agent._last_flushed_db_idx = 0
 
-            # Simulate compression reset
-            agent.session_id = "new-session"
-            db.create_session(session_id="new-session", source="test")
-            agent._last_flushed_db_idx = 0
+                compressed = [
+                    {"role": "user", "content": "summary"},
+                    {"role": "assistant", "content": "continuing..."},
+                ]
 
-            compressed = [
-                {"role": "user", "content": "summary"},
-                {"role": "assistant", "content": "continuing..."},
-            ]
+                # Bug: passing a conversation_history longer than compressed messages
+                stale_history = [{"role": "user", "content": f"msg{i}"} for i in range(100)]
+                agent._flush_messages_to_session_db(compressed, stale_history)
 
-            # Bug: passing a conversation_history longer than compressed messages
-            stale_history = [{"role": "user", "content": f"msg{i}"} for i in range(100)]
-            agent._flush_messages_to_session_db(compressed, stale_history)
-
-            rows = db.get_messages("new-session")
-            # With the stale history, flush_from = max(100, 0) = 100
-            # But compressed only has 2 entries → messages[100:] = empty
-            assert len(rows) == 0, (
-                "Expected 0 messages with stale conversation_history "
-                "(this test verifies the bug condition exists)"
-            )
+                rows = db.get_messages("new-session")
+                # With the stale history, flush_from = max(100, 0) = 100
+                # But compressed only has 2 entries → messages[100:] = empty
+                assert len(rows) == 0, (
+                    "Expected 0 messages with stale conversation_history "
+                    "(this test verifies the bug condition exists)"
+                )
+            finally:
+                _close_test_session_db(db, agent)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

I reproduced the failure on clean upstream/main with:

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

On Windows, these tests keep state.db open until the surrounding TemporaryDirectory exits. That makes cleanup fail with PermissionError: [WinError 32] even on upstream/main.

I reproduced the failure on clean upstream/main with:

`powershell
python -m pytest tests/run_agent/test_860_dedup.py::TestFlushDeduplication::test_flush_writes_only_new_messages -q -o addopts= -p no:xdist
`

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

I reproduced the failure on clean upstream/main with:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
- close test-owned SessionDB handles before TemporaryDirectory teardown
- keep the fix scoped to Windows teardown behavior in persistence/compression tests
- avoid mixing this with the runtime performance branch work

## Why
On Windows, these tests keep state.db open until the surrounding TemporaryDirectory exits. That makes cleanup fail with PermissionError: [WinError 32] even on upstream/main.

I reproduced the failure on clean upstream/main with:

`powershell
python -m pytest tests/run_agent/test_860_dedup.py::TestFlushDeduplication::test_flush_writes_only_new_messages -q -o addopts= -p no:xdist
`

## Validation
`powershell
python -m pytest tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_boundary_hook.py -q -o addopts= -p no:xdist
`

Result: 18 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Run `python -m pytest tests/run_agent/test_860_dedup.py::TestFlushDeduplication::test_flush_writes_only_new_messages -q -o addopts= -p no:xdist`.
2. Run `python -m pytest tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_boundary_hook.py -q -o addopts= -p no:xdist`.
3. Confirm the scoped behavior described above still holds after the focused checks.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_