### PR TITLE
fix(gateway): publish compression route advances

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1812,6 +1812,81 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _compression_tip_for_session(self, session_id: str) -> str:
+        """Return the compression continuation tip for a session id."""
+        if not session_id:
+            return session_id
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return session_id
+        try:
+            tip = session_db.get_compression_tip(session_id)
+        except Exception:
+            logger.debug("Failed to resolve compression tip", exc_info=True)
+            return session_id
+        return str(tip or session_id)
+
+    def _rebind_telegram_topic_binding_to_session(
+        self,
+        source: SessionSource,
+        binding: Dict[str, Any],
+        *,
+        session_key: str,
+        session_id: str,
+    ) -> bool:
+        """Rewrite one Telegram topic binding to a new session id."""
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or not binding or not session_id:
+            return False
+        chat_id = str(binding.get("chat_id") or source.chat_id or "")
+        thread_id = str(binding.get("thread_id") or source.thread_id or "")
+        if not chat_id or not thread_id:
+            return False
+        try:
+            session_db.bind_telegram_topic(
+                chat_id=chat_id,
+                thread_id=thread_id,
+                user_id=str(binding.get("user_id") or source.user_id or ""),
+                session_key=str(binding.get("session_key") or session_key or ""),
+                session_id=str(session_id),
+                managed_mode=str(binding.get("managed_mode") or "auto"),
+            )
+            return True
+        except Exception:
+            logger.debug("Failed to rewrite Telegram topic binding", exc_info=True)
+            return False
+
+    def _evict_cached_agent_on_session_mismatch(
+        self,
+        session_key: str,
+        canonical_session_id: str,
+    ) -> None:
+        """Evict cached agents that disagree with the canonical route session."""
+        if not session_key or not canonical_session_id:
+            return
+        _cache = getattr(self, "_agent_cache", None)
+        _lock = getattr(self, "_agent_cache_lock", None)
+        if _cache is None or _lock is None:
+            return
+        with _lock:
+            cached = _cache.get(session_key)
+            agent = cached[0] if isinstance(cached, tuple) and cached else cached
+            cached_session_id = (
+                getattr(agent, "session_id", None) if agent is not None else None
+            )
+            if (
+                isinstance(cached_session_id, str)
+                and cached_session_id
+                and cached_session_id != canonical_session_id
+            ):
+                logger.warning(
+                    "Evicting cached agent for %s after session mismatch: agent=%s canonical=%s",
+                    session_key,
+                    cached_session_id,
+                    canonical_session_id,
+                )
+                _cache.pop(session_key, None)
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -7047,7 +7122,49 @@ class GatewayRunner:
                 binding = None
             if binding:
                 bound_session_id = str(binding.get("session_id") or "")
-                if bound_session_id and bound_session_id != session_entry.session_id:
+                compression_tip = self._compression_tip_for_session(bound_session_id)
+                followed_compression_tip = False
+                if compression_tip and compression_tip != bound_session_id:
+                    followed_compression_tip = True
+                    if self._rebind_telegram_topic_binding_to_session(
+                        source,
+                        binding,
+                        session_key=session_key,
+                        session_id=compression_tip,
+                    ):
+                        logger.info(
+                            "Telegram topic binding followed compression: %s → %s",
+                            bound_session_id,
+                            compression_tip,
+                        )
+                    route_session_id = session_entry.session_id
+                    if compression_tip != route_session_id:
+                        try:
+                            advanced_entry = self.session_store.advance_session_after_compression(
+                                session_key,
+                                route_session_id,
+                                compression_tip,
+                            )
+                            if advanced_entry is not None:
+                                session_entry = advanced_entry
+                        except Exception:
+                            logger.debug(
+                                "Failed to advance Telegram topic route after compression",
+                                exc_info=True,
+                            )
+                            session_entry.session_id = compression_tip
+                        if getattr(session_entry, "session_id", None) != compression_tip:
+                            session_entry.session_id = compression_tip
+                    bound_session_id = compression_tip
+                    self._evict_cached_agent_on_session_mismatch(
+                        session_key,
+                        session_entry.session_id,
+                    )
+                if (
+                    bound_session_id
+                    and bound_session_id != session_entry.session_id
+                    and not followed_compression_tip
+                ):
                     # Route the override through SessionStore so the session_key
                     # → session_id mapping is persisted to disk and the previous
                     # lane session is ended cleanly. Mutating session_entry in
@@ -15055,16 +15172,31 @@ class GatewayRunner:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
-                        agent = cached[0]
-                        # Refresh LRU order so the cap enforcement evicts
-                        # truly-oldest entries, not the one we just used.
-                        if hasattr(_cache, "move_to_end"):
-                            try:
-                                _cache.move_to_end(session_key)
-                            except KeyError:
-                                pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+                        cached_agent = cached[0]
+                        cached_session_id = getattr(cached_agent, "session_id", None)
+                        if (
+                            isinstance(cached_session_id, str)
+                            and cached_session_id
+                            and cached_session_id != session_id
+                        ):
+                            logger.warning(
+                                "Evicting cached agent for %s before turn: agent=%s canonical=%s",
+                                session_key,
+                                cached_session_id,
+                                session_id,
+                            )
+                            _cache.pop(session_key, None)
+                        else:
+                            agent = cached_agent
+                            # Refresh LRU order so the cap enforcement evicts
+                            # truly-oldest entries, not the one we just used.
+                            if hasattr(_cache, "move_to_end"):
+                                try:
+                                    _cache.move_to_end(session_key)
+                                except KeyError:
+                                    pass
+                            self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                            logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
                 # Config changed or first message — create fresh agent
@@ -15610,10 +15742,43 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                try:
+                    self.session_store.advance_session_after_compression(
+                        session_key,
+                        session_id,
+                        agent.session_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to advance session route after compression",
+                        exc_info=True,
+                    )
+                    entry = self.session_store._entries.get(session_key)
+                    if entry:
+                        entry.session_id = agent.session_id
+                        self.session_store._save()
+                if self._is_telegram_topic_lane(source):
+                    try:
+                        binding = (
+                            self._session_db.get_telegram_topic_binding(
+                                chat_id=str(source.chat_id),
+                                thread_id=str(source.thread_id),
+                            )
+                            if self._session_db
+                            else None
+                        )
+                        if binding and str(binding.get("session_id") or "") == session_id:
+                            self._rebind_telegram_topic_binding_to_session(
+                                source,
+                                binding,
+                                session_key=session_key,
+                                session_id=agent.session_id,
+                            )
+                    except Exception:
+                        logger.debug(
+                            "Failed to advance Telegram topic binding after compression",
+                            exc_info=True,
+                        )
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -964,6 +964,48 @@ class SessionStore:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
 
+    def advance_session_after_compression(
+        self,
+        session_key: str,
+        old_session_id: str,
+        new_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """Advance a gateway route after context compression.
+
+        This is deliberately narrower than ``switch_session()``. Compression
+        already ended ``old_session_id`` with ``end_reason='compression'`` and
+        created ``new_session_id`` as the continuation; following that lineage
+        must not re-end the parent as ``session_switch`` or reopen the child.
+        """
+        if not session_key or not new_session_id:
+            return None
+
+        with self._lock:
+            self._ensure_loaded_locked()
+
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+
+            if entry.session_id == new_session_id:
+                return entry
+
+            if old_session_id and entry.session_id != old_session_id:
+                logger.warning(
+                    "Compression route advance skipped for %s: route points at %s, expected %s -> %s",
+                    session_key,
+                    entry.session_id,
+                    old_session_id,
+                    new_session_id,
+                )
+                return entry
+
+            entry.session_id = new_session_id
+            entry.updated_at = _now()
+            entry.last_prompt_tokens = 0
+            self._save()
+            return entry
+
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -399,6 +399,40 @@ class TestAgentCacheLifecycle:
             assert "session-A" not in runner._agent_cache
             assert "session-B" in runner._agent_cache
 
+    def test_evicts_cached_agent_on_session_mismatch(self):
+        """Cached agents must agree with the canonical route session."""
+        runner = _make_runner()
+        stale_agent = MagicMock()
+        stale_agent.session_id = "compressed-child"
+
+        with runner._agent_cache_lock:
+            runner._agent_cache["session-key"] = (stale_agent, "sig")
+
+        runner._evict_cached_agent_on_session_mismatch(
+            "session-key",
+            "route-parent",
+        )
+
+        with runner._agent_cache_lock:
+            assert "session-key" not in runner._agent_cache
+
+    def test_keeps_cached_agent_on_session_match(self):
+        """Matching cached agents remain reusable."""
+        runner = _make_runner()
+        cached_agent = MagicMock()
+        cached_agent.session_id = "route-session"
+
+        with runner._agent_cache_lock:
+            runner._agent_cache["session-key"] = (cached_agent, "sig")
+
+        runner._evict_cached_agent_on_session_mismatch(
+            "session-key",
+            "route-session",
+        )
+
+        with runner._agent_cache_lock:
+            assert runner._agent_cache["session-key"][0] is cached_agent
+
     def test_reasoning_config_updates_in_place(self):
         """Reasoning config can be set on a cached agent without eviction."""
         from run_agent import AIAgent
@@ -575,13 +609,13 @@ class TestAgentCacheBoundedGrowth:
         """_sweep_idle_cached_agents removes agents idle past the TTL."""
         from gateway import run as gw_run
 
-        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.05)
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 60.0)
         runner = self._bounded_runner()
         runner._cleanup_agent_resources = MagicMock()
 
         import time as _t
         fresh = self._fake_agent(last_activity=_t.time())
-        stale = self._fake_agent(last_activity=_t.time() - 10.0)
+        stale = self._fake_agent(last_activity=_t.time() - 120.0)
         runner._agent_cache["fresh"] = (fresh, "s1")
         runner._agent_cache["stale"] = (stale, "s2")
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -4,9 +4,11 @@ Topic mode makes the root Telegram DM a system lobby while user-created
 Telegram topics act as independent Hermes session lanes.
 """
 
+from collections import OrderedDict
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+import threading
 
 import pytest
 
@@ -76,30 +78,48 @@ def _make_runner(session_db=None):
     )
 
     runner.session_store = MagicMock()
+    runner.session_store._entries = {}
     runner.session_store._generate_session_key.side_effect = lambda source: build_session_key(
         source,
         group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),
         thread_sessions_per_user=getattr(runner.config, "thread_sessions_per_user", False),
     )
-    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False: SessionEntry(
-        session_key=build_session_key(
+    def _get_or_create_session(source, force_new=False):
+        session_key = build_session_key(
             source,
             group_sessions_per_user=getattr(runner.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(runner.config, "thread_sessions_per_user", False),
-        ),
-        session_id="sess-topic" if source.thread_id else "sess-root",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
-        chat_type="dm",
-        origin=source,
-    )
+        )
+        entry = SessionEntry(
+            session_key=session_key,
+            session_id="sess-topic" if source.thread_id else "sess-root",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            origin=source,
+        )
+        runner.session_store._entries[session_key] = entry
+        return entry
+    runner.session_store.get_or_create_session.side_effect = _get_or_create_session
     runner.session_store.load_transcript.return_value = []
     runner.session_store.has_any_sessions.return_value = True
     runner.session_store.append_to_transcript = MagicMock()
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner.session_store.reset_session = MagicMock(return_value=None)
+
+    def _advance_after_compression(session_key, old_session_id, new_session_id):
+        entry = runner.session_store._entries.get(session_key)
+        if entry is None:
+            return None
+        if entry.session_id == old_session_id:
+            entry.session_id = new_session_id
+            entry.last_prompt_tokens = 0
+        return entry
+    runner.session_store.advance_session_after_compression = MagicMock(
+        side_effect=_advance_after_compression,
+    )
 
     # Default switch_session impl: returns a SessionEntry carrying the target
     # session_id. Mirrors SessionStore.switch_session semantics for tests that
@@ -124,6 +144,8 @@ def _make_runner(session_db=None):
     runner._session_model_overrides = {}
     runner._pending_model_notes = {}
     runner._session_db = session_db
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -264,6 +286,119 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
 
     assert result == "restored response"
     assert captured["session_id"] == "restored-session"
+
+
+@pytest.mark.asyncio
+async def test_topic_binding_follows_compression_tip_without_switch_session(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    chat_id = topic_source.chat_id
+    thread_id = topic_source.thread_id
+    user_id = topic_source.user_id
+    parent_session_id = "topic-parent-session"
+    compressed_session_id = "topic-compressed-session"
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id=chat_id, user_id=user_id)
+    session_db.create_session(
+        session_id=parent_session_id,
+        source="telegram",
+        user_id=user_id,
+    )
+    session_db.end_session(parent_session_id, "compression")
+    session_db.create_session(
+        session_id=compressed_session_id,
+        source="telegram",
+        user_id=user_id,
+        parent_session_id=parent_session_id,
+    )
+
+    session_db.bind_telegram_topic(
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        session_key=topic_key,
+        session_id=parent_session_id,
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    route_entry = SessionEntry(
+        session_key=topic_key,
+        session_id=parent_session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store._entries[topic_key] = route_entry
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, force_new=False: route_entry
+    )
+
+    captured = {}
+    parent_history = [
+        {"role": "user", "content": f"parent message {i}"}
+        for i in range(20)
+    ]
+    compressed_history = [{"role": "user", "content": "compressed summary"}]
+
+    def _load_transcript(session_id):
+        captured["loaded_session_id"] = session_id
+        return (
+            compressed_history
+            if session_id == compressed_session_id
+            else parent_history
+        )
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["run_session_id"] = kwargs.get("session_id")
+        captured["history"] = list(kwargs.get("history") or [])
+        history = list(kwargs.get("history") or [])
+        return {
+            "success": True,
+            "final_response": "compressed response",
+            "session_id": kwargs.get("session_id"),
+            "history_offset": len(history),
+            "messages": history
+            + [
+                {"role": "user", "content": "continue"},
+                {"role": "assistant", "content": "compressed response"},
+            ],
+        }
+
+    runner.session_store.load_transcript.side_effect = _load_transcript
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+    runner._agent_cache[topic_key] = (
+        SimpleNamespace(session_id=parent_session_id),
+        "signature",
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue", thread_id="17585"))
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id=chat_id,
+        thread_id=thread_id,
+    )
+    assert result == "compressed response"
+    assert binding is not None
+    assert binding["session_id"] == compressed_session_id
+    assert binding["managed_mode"] == "restored"
+    assert captured["loaded_session_id"] == compressed_session_id
+    assert captured["run_session_id"] == compressed_session_id
+    assert captured["history"] == compressed_history
+    assert topic_key not in runner._agent_cache
+    runner.session_store.switch_session.assert_not_called()
+    assert session_db.get_session(parent_session_id)["end_reason"] == "compression"
 
 
 @pytest.mark.asyncio
@@ -1048,7 +1183,3 @@ async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
         ).fetchall()
     }
     assert tables == set()
-
-
-
-


### PR DESCRIPTION
## Summary
- Publish compression-induced route advances through SessionStore without using explicit session-switch semantics.
- Follow Telegram topic bindings to compression tips before transcript load and rebind topic lanes after compression splits.
- Evict cached agents when their session id disagrees with the canonical route session.

## Tests
- /opt/hermes/src/venv/bin/python -m pytest -q tests/gateway/test_telegram_topic_mode.py tests/gateway/test_agent_cache.py tests/gateway/test_session_hygiene.py tests/gateway/test_compress_command.py

Closes #25921