### PR TITLE
feat: add per-job cron reasoning effort

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -479,6 +479,30 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _normalize_reasoning_effort(reasoning_effort: Optional[str]) -> Optional[str]:
+    """Normalize and validate a per-job reasoning effort override.
+
+    Empty / None clears the job-level override, causing the scheduler to fall
+    back to the global ``agent.reasoning_effort`` config.  Accepted values
+    mirror ``hermes_constants.parse_reasoning_effort``: none, minimal, low,
+    medium, high, xhigh.
+    """
+    if reasoning_effort is None:
+        return None
+    effort = str(reasoning_effort).strip().lower()
+    if not effort:
+        return None
+    from hermes_constants import VALID_REASONING_EFFORTS
+
+    valid = {"none", *VALID_REASONING_EFFORTS}
+    if effort not in valid:
+        allowed = ", ".join(["none", *VALID_REASONING_EFFORTS])
+        raise ValueError(
+            f"Invalid reasoning_effort {reasoning_effort!r}. Expected one of: {allowed}."
+        )
+    return effort
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -495,6 +519,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     no_agent: bool = False,
 ) -> Dict[str, Any]:
     """
@@ -536,6 +561,9 @@ def create_job(
                 With ``no_agent=True``, ``workdir`` is still applied as the
                 script's cwd so relative paths inside the script behave
                 predictably.
+        reasoning_effort: Optional per-job reasoning override. One of
+                none|minimal|low|medium|high|xhigh. When unset, cron falls
+                back to the global agent.reasoning_effort config.
         no_agent: When True, skip the agent entirely — run ``script`` on schedule
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
@@ -573,6 +601,7 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
+    normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
     normalized_no_agent = bool(no_agent)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
@@ -627,6 +656,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "reasoning_effort": normalized_reasoning_effort,
     }
 
     jobs = load_jobs()
@@ -668,6 +698,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["workdir"] = None
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
+
+        if "reasoning_effort" in updates:
+            updates["reasoning_effort"] = _normalize_reasoning_effort(
+                updates["reasoning_effort"]
+            )
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1294,6 +1294,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             if os.path.exists(_cfg_path):
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
+                if not isinstance(_cfg, dict):
+                    _cfg = {}
                 _cfg = _expand_env_vars(_cfg)
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
@@ -1313,9 +1315,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception:
             pass
 
-        # Reasoning config from config.yaml
+        # Reasoning config: per-job override wins, then global config.yaml.
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        cfg_agent_value = _cfg.get("agent") if isinstance(_cfg, dict) else {}
+        agent_cfg = cfg_agent_value if isinstance(cfg_agent_value, dict) else {}
+        effort = str(
+            job.get("reasoning_effort")
+            or agent_cfg.get("reasoning_effort", "")
+        ).strip()
         reasoning_config = parse_reasoning_effort(effort)
 
         # Prefill messages from env or config.yaml

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2356,7 +2356,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name",
+        "schedule",
+        "prompt",
+        "deliver",
+        "skills",
+        "skill",
+        "repeat",
+        "enabled",
+        "reasoning_effort",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -2409,6 +2419,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            reasoning_effort = body.get("reasoning_effort")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -2435,6 +2446,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if reasoning_effort is not None:
+                kwargs["reasoning_effort"] = reasoning_effort
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2524,6 +2524,7 @@ class CronJobCreate(BaseModel):
     schedule: str
     name: str = ""
     deliver: str = "local"
+    reasoning_effort: str | None = None
 
 
 class CronJobUpdate(BaseModel):
@@ -2549,8 +2550,13 @@ async def get_cron_job(job_id: str):
 async def create_cron_job(body: CronJobCreate):
     from cron.jobs import create_job
     try:
-        job = create_job(prompt=body.prompt, schedule=body.schedule,
-                         name=body.name, deliver=body.deliver)
+        job = create_job(
+            prompt=body.prompt,
+            schedule=body.schedule,
+            name=body.name,
+            deliver=body.deliver,
+            reasoning_effort=body.reasoning_effort,
+        )
         return job
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -959,6 +959,49 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_prefers_job_reasoning_effort_over_global_config(self, tmp_path):
+        job = {
+            "id": "reasoning-job",
+            "name": "test",
+            "prompt": "hello",
+            "reasoning_effort": "xhigh",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: low\n",
+            encoding="utf-8",
+        )
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+    def test_run_job_uses_global_reasoning_effort_when_job_unset(self, tmp_path):
+        job = {
+            "id": "reasoning-global-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: high\n",
+            encoding="utf-8",
+        )
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
         resolves them from ``hermes tools`` platform config for ``cron``

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -151,6 +151,7 @@ class TestCreateJob:
                     "name": "test-job",
                     "schedule": "*/5 * * * *",
                     "prompt": "do something",
+                    "reasoning_effort": "xhigh",
                 })
                 assert resp.status == 200
                 data = await resp.json()
@@ -160,6 +161,7 @@ class TestCreateJob:
                 assert call_kwargs["name"] == "test-job"
                 assert call_kwargs["schedule"] == "*/5 * * * *"
                 assert call_kwargs["prompt"] == "do something"
+                assert call_kwargs["reasoning_effort"] == "xhigh"
 
     @pytest.mark.asyncio
     async def test_create_job_missing_name(self, adapter):
@@ -300,7 +302,11 @@ class TestUpdateJob:
             ):
                 resp = await cli.patch(
                     f"/api/jobs/{VALID_JOB_ID}",
-                    json={"name": "updated-name", "schedule": "0 * * * *"},
+                    json={
+                        "name": "updated-name",
+                        "schedule": "0 * * * *",
+                        "reasoning_effort": "high",
+                    },
                 )
                 assert resp.status == 200
                 data = await resp.json()
@@ -311,6 +317,7 @@ class TestUpdateJob:
                 sanitized = call_args[0][1]
                 assert "name" in sanitized
                 assert "schedule" in sanitized
+                assert sanitized["reasoning_effort"] == "high"
 
     @pytest.mark.asyncio
     async def test_update_job_rejects_unknown_fields(self, adapter):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -219,6 +219,53 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["provider"] == "openrouter"
         assert updated["job"]["base_url"] is None
 
+    def test_create_and_update_reasoning_effort(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Think carefully about the day ahead",
+                schedule="every 1h",
+                reasoning_effort="xhigh",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["reasoning_effort"] == "xhigh"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["reasoning_effort"] == "xhigh"
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                reasoning_effort="high",
+            )
+        )
+        assert updated["success"] is True
+        assert updated["job"]["reasoning_effort"] == "high"
+
+        cleared = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                reasoning_effort="",
+            )
+        )
+        assert cleared["success"] is True
+        assert cleared["job"].get("reasoning_effort") is None
+
+    def test_invalid_reasoning_effort_rejected(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Think with maximum galaxy brain",
+                schedule="every 1h",
+                reasoning_effort="galaxy",
+            )
+        )
+        assert created["success"] is False
+        assert "reasoning_effort" in created["error"]
+
     def test_create_skill_backed_job(self):
         result = json.loads(
             cronjob(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -33,6 +33,13 @@ from cron.jobs import (
 )
 
 
+def _normalize_reasoning_effort_param(value: Optional[Any]) -> Optional[str]:
+    """Normalize and validate the cron tool's reasoning_effort parameter."""
+    from cron.jobs import _normalize_reasoning_effort
+
+    return _normalize_reasoning_effort(value)
+
+
 # ---------------------------------------------------------------------------
 # Cron prompt scanning — critical-severity patterns only, since cron prompts
 # run in fresh sessions with full tool access.
@@ -279,6 +286,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("reasoning_effort"):
+        result["reasoning_effort"] = job["reasoning_effort"]
     return result
 
 
@@ -301,6 +310,7 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     no_agent: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
@@ -367,6 +377,7 @@ def cronjob(
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
+                reasoning_effort=_normalize_reasoning_effort_param(reasoning_effort),
                 no_agent=_no_agent,
             )
             return json.dumps(
@@ -481,6 +492,8 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if reasoning_effort is not None:
+                updates["reasoning_effort"] = _normalize_reasoning_effort_param(reasoning_effort)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -634,6 +647,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["", "none", "minimal", "low", "medium", "high", "xhigh"],
+                "description": "Optional per-job reasoning effort override. Values: none, minimal, low, medium, high, xhigh. When unset, the job uses global agent.reasoning_effort. On update, pass empty string to clear."
+            },
         },
         "required": ["action"]
     }
@@ -681,6 +699,7 @@ registry.register(
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        reasoning_effort=args.get("reasoning_effort"),
         no_agent=args.get("no_agent"),
         task_id=kw.get("task_id"),
     ))(),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -15,6 +15,7 @@ Cron jobs can:
 - schedule one-shot or recurring tasks
 - pause, resume, edit, trigger, and remove jobs
 - attach zero, one, or multiple skills to a job
+- pin per-job model/provider settings and reasoning effort for higher-quality scheduled runs
 - deliver results back to the origin chat, local files, or configured platform targets
 - run in fresh agent sessions with the normal static tool list
 - run in **no-agent mode** — a script on a schedule, its stdout delivered verbatim, zero LLM involvement (see the [no-agent mode](#no-agent-mode-script-only-jobs) section below)
@@ -88,6 +89,23 @@ cronjob(
 ```
 
 This is useful when you want a scheduled agent to inherit reusable workflows without stuffing the full skill text into the cron prompt itself.
+
+## Per-job reasoning effort
+
+By default, scheduled jobs inherit the global `agent.reasoning_effort` setting from `config.yaml`. For important scheduled work, you can override that per job so deeper background analysis does not have to share the same latency/quality tradeoff as interactive chat.
+
+Supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+
+```python
+cronjob(
+    action="create",
+    schedule="0 9 * * *",
+    prompt="Research the market and send a concise morning strategy brief.",
+    reasoning_effort="xhigh",
+)
+```
+
+Set `reasoning_effort` on an existing job with `action="update"`; pass an empty string to clear the job-level override and return to the global config default.
 
 ## Running a job inside a project directory
 


### PR DESCRIPTION
## Summary

Adds a per-job `reasoning_effort` override for cron jobs, so scheduled tasks can opt into deeper or lighter model reasoning independently from the global interactive-agent setting.

Cron jobs already support per-job model/provider/base URL overrides. This change completes that pattern for reasoning: important scheduled analysis can run with higher effort, while interactive chat can keep a different latency/quality tradeoff.

## What changed

- Adds `reasoning_effort` to cron job creation/update storage.
- Validates accepted values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
- Treats empty/omitted values as “no job-level override,” preserving fallback to global `agent.reasoning_effort`.
- Updates the scheduler to prefer `job["reasoning_effort"]` over global config before constructing `AIAgent`.
- Exposes the option through:
  - the unified `cronjob` tool schema and handler
  - API server job create/update paths
  - web server cron job create path
- Documents the feature in the cron user guide.
- Adds regression coverage for creation, update, validation, list formatting, scheduler precedence, and API forwarding.

## Behavior

Precedence is now:

1. Per-job `reasoning_effort`, if set
2. Global `config.yaml` → `agent.reasoning_effort`
3. Default/no reasoning config if neither is set

`reasoning_effort=""` clears the job-level override. `reasoning_effort="none"` remains a valid explicit value and maps through existing `parse_reasoning_effort()` behavior to disable reasoning.

## Why

Scheduled tasks often benefit from deeper reasoning than interactive chat. Examples: daily research briefs, long-running monitoring summaries, content planning, maintenance recommendations, and other background jobs where quality matters more than immediate latency.

Without a per-job override, users must either raise global reasoning for everything or accept lower-quality scheduled work. This lets users tune cron jobs independently and keeps existing defaults backward-compatible.

## Test plan

- `python -m pytest tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py tests/gateway/test_api_server_jobs.py -q -o 'addopts='`
  - `261 passed, 35 warnings`
- `ruff check cron/jobs.py cron/scheduler.py tools/cronjob_tools.py gateway/platforms/api_server.py hermes_cli/web_server.py tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py tests/gateway/test_api_server_jobs.py`
  - `All checks passed!`

Also ran an independent pre-commit review pass over the diff; the only issue found was the tool schema documenting empty-string clearing while the enum initially omitted `""`. That is fixed in this PR.
