### PR TITLE
fix(tests): mock keychain in TestReadClaudeCodeCredentials to prevent credential leakage

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -157,6 +157,13 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- `TestReadClaudeCodeCredentials` tests were written before `_read_claude_code_credentials_from_keychain` was added to `read_claude_code_credentials()`
- On macOS machines with real Claude Code credentials in the Keychain, the unmocked keychain call returns live credentials, causing test assertions to fail and leaking real tokens in test output
- Added an `autouse` fixture that stubs `_read_claude_code_credentials_from_keychain` to `None` so all tests in the class exclusively exercise the file-based credential path

## Test plan

- [ ] Run `python -m pytest tests/agent/test_anthropic_adapter.py::TestReadClaudeCodeCredentials -v` — all 5 tests pass
- [ ] Confirm tests also pass on machines without Claude Code credentials in the Keychain (no regression)

## Platforms tested
- macOS (Darwin) with real Claude Code credentials present in Keychain

🤖 Generated with [Claude Code](https://claude.com/claude-code)