### PR TITLE
fix(terminal): expand background workdir home paths

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -27,6 +27,15 @@ class TestResolveSafeCwd:
         path = str(tmp_path)
         assert _resolve_safe_cwd(path) == path
 
+    def test_expands_user_and_env_vars_before_isdir_check(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_TEST_CWD", str(project))
+
+        assert _resolve_safe_cwd("~/project") == str(project)
+        assert _resolve_safe_cwd("$HERMES_TEST_CWD") == str(project)
+
     def test_walks_up_to_first_existing_ancestor(self, tmp_path):
         nested = tmp_path / "child" / "grandchild"
         nested.mkdir(parents=True)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -320,6 +320,32 @@ class TestStdinHelpers:
         finally:
             registry.kill_process(session.id)
 
+    def test_spawn_local_expands_user_workdir(self, registry, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        session = registry.spawn_local(
+            'python3 -c "import os; print(os.getcwd())"',
+            cwd="~/project",
+            use_pty=False,
+        )
+
+        try:
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                poll = registry.poll(session.id)
+                if poll["status"] == "exited":
+                    assert poll["exit_code"] == 0
+                    assert str(project) in poll["output_preview"]
+                    assert session.cwd == str(project)
+                    return
+                time.sleep(0.2)
+
+            pytest.fail("process did not exit after expanded-home cwd spawn")
+        finally:
+            registry.kill_process(session.id)
+
 
 # =========================================================================
 # List sessions

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -30,9 +30,10 @@ def _resolve_safe_cwd(cwd: str) -> str:
     raises ``FileNotFoundError`` before bash starts, wedging every subsequent
     terminal call until the gateway restarts.
     """
-    if cwd and os.path.isdir(cwd):
-        return cwd
-    parent = os.path.dirname(cwd) if cwd else ""
+    expanded = os.path.expandvars(os.path.expanduser(cwd)) if cwd else ""
+    if expanded and os.path.isdir(expanded):
+        return expanded
+    parent = os.path.dirname(expanded) if expanded else ""
     while parent:
         if os.path.isdir(parent):
             return parent


### PR DESCRIPTION
## What does this PR do?

Fixes background `terminal()` workdir handling when callers pass `~` or environment variables.

`process_registry.spawn_local()` routes the requested cwd through
`tools.environments.local._resolve_safe_cwd()`. That helper previously checked
`os.path.isdir()` on the raw string, so `~/project` and `$PROJECT_DIR` failed
the directory check and background local processes fell back to `/tmp`.

This patch expands user and env references before validating the directory or
walking ancestors, which keeps background spawns in the intended project cwd
without changing the existing deleted-cwd recovery behavior.

## Related Issue

Fixes #26151

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Expand `~` and environment variables inside `tools/environments/local.py:_resolve_safe_cwd()` before the existence check and ancestor walk.
- Add helper coverage in `tests/tools/test_local_env_cwd_recovery.py` for both `~/...` and `$VAR` cwd inputs.
- Add a background-process regression in `tests/tools/test_process_registry.py` proving `spawn_local(..., cwd="~/project")` runs in the expanded project directory.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/tools/test_local_env_cwd_recovery.py tests/tools/test_process_registry.py`
2. Confirm the new `test_spawn_local_expands_user_workdir` passes and prints no cwd fallback failures.
3. Optionally reproduce the original issue with `terminal(background=true, workdir="~/project", ...)` and verify the process now starts in the expanded home-relative directory instead of `/tmp`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/tools/test_local_env_cwd_recovery.py tests/tools/test_process_registry.py` → `61 passed in 2.85s`
- `git diff --check` → clean
- `python3 -m py_compile tools/environments/local.py tests/tools/test_local_env_cwd_recovery.py tests/tools/test_process_registry.py` → clean
