### PR TITLE
fix(tts): read tts.openai.api_key/base_url from config.yaml before env vars

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1939,16 +1939,31 @@ def check_tts_requirements() -> bool:
 def _resolve_openai_audio_client_config() -> tuple[str, str]:
     """Return direct OpenAI audio config or a managed gateway fallback.
 
+    Resolution order:
+    1. ``tts.openai.api_key`` / ``tts.openai.base_url`` from ``config.yaml``
+    2. ``VOICE_TOOLS_OPENAI_KEY`` / ``OPENAI_API_KEY`` environment variables
+    3. Managed OpenAI audio tool gateway
+
     When ``tts.use_gateway`` is set in config, the Tool Gateway is preferred
-    even if direct OpenAI credentials are present.
+    even if direct credentials (config or env) are present.
     """
+    # 1. Config (tts.openai.*) — mirror STT resolution order
+    tts_config = _load_tts_config()
+    openai_cfg = tts_config.get("openai", {})
+    cfg_api_key = openai_cfg.get("api_key", "") or ""
+    cfg_base_url = openai_cfg.get("base_url", "") or ""
+    if cfg_api_key and not prefers_gateway("tts"):
+        return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL)
+
+    # 2. Environment variables
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key and not prefers_gateway("tts"):
-        return direct_api_key, DEFAULT_OPENAI_BASE_URL
+        return direct_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL)
 
+    # 3. Managed gateway
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
-        message = "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set"
+        message = "Neither tts.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         if managed_nous_tools_enabled():
             message += ", and the managed OpenAI audio gateway is unavailable"
         raise ValueError(message)


### PR DESCRIPTION
## Summary

`_resolve_openai_audio_client_config()` was env-only — it read `VOICE_TOOLS_OPENAI_KEY` / `OPENAI_API_KEY` and always returned `DEFAULT_OPENAI_BASE_URL`, ignoring `tts.openai.api_key` and `tts.openai.base_url` from `config.yaml`.

Closes #26175

## Problem

Users pointing TTS at a self-hosted or local OpenAI-compatible endpoint (llama.cpp, qwen3-tts, Ollama, etc.) either need a placeholder env var (and still cannot redirect the host) or get no audio at all.

## Solution

Mirror the STT resolver order used in `transcription_tools.py::_resolve_openai_audio_client_config`:

1. **Config** — read `tts.openai.api_key` + `tts.openai.base_url` from config via `_load_tts_config()`
2. **Env var** — existing `resolve_openai_audio_api_key()` fallback (now respects cfg_base_url)
3. **Managed gateway** — existing fallback with `prefers_gateway("tts")` check

## Files Changed

| File | Change |
|------|--------|
| tools/tts_tool.py | Add config-first resolution to `_resolve_openai_audio_client_config()` |

## Test Results

```
tests/tools/test_tts_speed.py .................. 19 passed
tests/tools/test_transcription_tools.py ....... 95 passed
tests/tools -k "tts" .......................... 182 passed
```