### PR TITLE
feat(skills-hub): add huggingface/skills as trusted default tap (closes #2549)

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -36,7 +36,7 @@ from typing import List, Tuple
 # Hardcoded trust configuration
 # ---------------------------------------------------------------------------
 
-TRUSTED_REPOS = {"openai/skills", "anthropics/skills"}
+TRUSTED_REPOS = {"openai/skills", "anthropics/skills", "huggingface/skills"}
 
 INSTALL_POLICY = {
     #                  safe      caution    dangerous

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -329,6 +329,7 @@ class GitHubSource(SkillSource):
     DEFAULT_TAPS = [
         {"repo": "openai/skills", "path": "skills/"},
         {"repo": "anthropics/skills", "path": "skills/"},
+        {"repo": "huggingface/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
         {"repo": "MiniMax-AI/cli", "path": "skill/"},

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -360,7 +360,7 @@ All hub-installed skills go through a security scanner that checks for:
 Trust levels:
 - `builtin` — ships with Hermes (always trusted)
 - `official` — from `optional-skills/` in the repo (builtin trust, no third-party warning)
-- `trusted` — from openai/skills, anthropics/skills
+- `trusted` — from openai/skills, anthropics/skills, huggingface/skills
 - `community` — non-dangerous findings can be overridden with `--force`; `dangerous` verdicts remain blocked
 
 Hermes can now consume third-party skills from multiple external discovery models:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -351,6 +351,7 @@ Hermes can install directly from GitHub repositories and GitHub-based taps. This
 Default taps (browsable without any setup):
 - [openai/skills](https://github.com/openai/skills)
 - [anthropics/skills](https://github.com/anthropics/skills)
+- [huggingface/skills](https://github.com/huggingface/skills)
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 - [garrytan/gstack](https://github.com/garrytan/gstack)
 
@@ -445,7 +446,7 @@ Important behavior:
 |-------|--------|--------|
 | `builtin` | Ships with Hermes | Always trusted |
 | `official` | `optional-skills/` in the repo | Builtin trust, no third-party warning |
-| `trusted` | Trusted registries/repos such as `openai/skills`, `anthropics/skills` | More permissive policy than community sources |
+| `trusted` | Trusted registries/repos such as `openai/skills`, `anthropics/skills`, `huggingface/skills` | More permissive policy than community sources |
 | `community` | Everything else (`skills.sh`, well-known endpoints, custom GitHub repos, most marketplaces) | Non-dangerous findings can be overridden with `--force`; `dangerous` verdicts stay blocked |
 
 ### Update lifecycle


### PR DESCRIPTION
Closes #2549. Salvaged from @kshitijk4poor's issue request.

## Summary
Hugging Face's official skill catalog (https://github.com/huggingface/skills — 10.5k★, Apache-2.0, 14 skills) is now a default tap and a trusted source, on par with \`openai/skills\` and \`anthropics/skills\`.

## Changes
- \`tools/skills_guard.py\`: add \`huggingface/skills\` to \`TRUSTED_REPOS\`
- \`tools/skills_hub.py\`: add \`{"repo": "huggingface/skills", "path": "skills/"}\` to \`GitHubSource.DEFAULT_TAPS\`
- \`website/docs/user-guide/features/skills.md\`: list it under default taps and in the trusted-source row
- \`website/docs/developer-guide/creating-skills.md\`: add it to the trusted-source bullet

## Validation
\`scripts/run_tests.sh tests/tools/test_skills_hub.py tests/tools/test_skills_guard.py tests/hermes_cli/test_skills_hub.py\` → 186/186 pass.

The repo follows the same \`skills/<name>/SKILL.md\` layout as the existing trusted taps, so the existing \`GitHubSource\` fetch/inspect/install paths work without further code changes.