### PR TITLE
fix(gateway): isinstance-guard string-form 429 error body

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7991,6 +7991,8 @@ class GatewayRunner:
                 try:
                     if _err_body is not None:
                         _err_json = _err_body.json().get("error", {})
+                        if not isinstance(_err_json, dict):
+                            _err_json = {}
                 except Exception:
                     pass
                 if _err_json.get("type") == "usage_limit_reached":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -637,6 +637,7 @@ AUTHOR_MAP = {
     "skmishra1991@gmail.com": "bugkill3r",
     "karamusti912@gmail.com": "MustafaKara7",
     "kira@ariaki.me": "kira-ariaki",
+    "kira.ops@proton.me": "KiraKatana",
     "knopki@duck.com": "knopki",
     "limars874@gmail.com": "limars874",
     "lisicheng168@gmail.com": "lesterli",


### PR DESCRIPTION
## Summary
Gateway 429 handler no longer crashes when a provider returns the error body as a string instead of a dict.

When a non-Anthropic provider (e.g. Morpheus proxy) returns `{"error": "Too Many Requests"}` instead of the expected `{"error": {"type": ...}}` dict, `_err_body.json().get("error", {})` returns the raw string and the next `.get("type")` line crashes with AttributeError, taking down the message handler. Now guarded with `isinstance(_err_json, dict)`.

## Changes
- `gateway/run.py`: isinstance-check parsed error body before treating it as a dict.
- `scripts/release.py`: add AUTHOR_MAP entry for @KiraKatana.

## Credit
Salvaged from #2587 by @KiraKatana. The PR's other change (fallback-config `base_url`/`api_key_env` plumbing in `_try_activate_fallback`) was already implemented independently on main at `run_agent.py:8759-8780` with additional aliases (`key_env`/`api_key_env`) and Ollama Cloud host-match handling, so only the gateway guard is cherry-picked here.