### PR TITLE
fix: align Feishu DM allowlist auth with setup open_id

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3762,8 +3762,8 @@ class FeishuAdapter(BasePlatformAdapter):
         """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
 
         Preference order for the primary ``user_id`` field:
-          1. user_id  (tenant-scoped, most stable — requires permission scope)
-          2. open_id  (app-scoped, always available — different per bot app)
+          1. open_id  (app-scoped, always available and written by setup)
+          2. user_id  (tenant-scoped, available with extra contact scopes)
 
         ``user_id_alt`` carries the union_id (developer-scoped, stable across
         all apps by the same developer).  Session-key generation prefers
@@ -3773,8 +3773,9 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
-        # Prefer tenant-scoped user_id; fall back to app-scoped open_id.
-        primary_id = user_id or open_id
+        # Prefer app-scoped open_id so runtime authorization matches the
+        # allowlist values written by `hermes gateway setup`.
+        primary_id = open_id or user_id
         # bot/v3/bots/basic_batch only accepts open_id.
         name_lookup_id = open_id if is_bot else (primary_id or union_id)
         display_name = await self._resolve_sender_name_from_api(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1579,7 +1579,7 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._dispatch_inbound_event.assert_awaited_once()
         event = adapter._dispatch_inbound_event.await_args.args[0]
         self.assertEqual(event.message_type, MessageType.TEXT)
-        self.assertEqual(event.source.user_id, "u_user")  # tenant-scoped user_id preferred over app-scoped open_id
+        self.assertEqual(event.source.user_id, "ou_user")  # setup writes open_id into FEISHU_ALLOWED_USERS
         self.assertEqual(event.source.user_name, "张三")
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -537,8 +537,28 @@ def test_resolve_sender_profile_uses_open_id_for_bot_name_lookup():
     )
 
     assert seen_ids == ["ou_peer"]
-    assert profile["user_id"] == "u_peer"
+    assert profile["user_id"] == "ou_peer"
     assert profile["user_name"] == "Peer Bot"
+
+
+def test_resolve_sender_profile_prefers_open_id_for_human_allowlist_match():
+    import asyncio
+
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+    adapter._client = None
+    adapter._sender_name_cache = {}
+
+    profile = asyncio.run(
+        adapter._resolve_sender_profile(
+            SimpleNamespace(open_id="ou_human", user_id="u_human", union_id="on_human"),
+            is_bot=False,
+        )
+    )
+
+    assert profile["user_id"] == "ou_human"
+    assert profile["user_id_alt"] == "on_human"
 
 
 # --- _allow_group_message matrix -------------------------------------------

--- a/tests/gateway/test_feishu_bot_auth_bypass.py
+++ b/tests/gateway/test_feishu_bot_auth_bypass.py
@@ -98,6 +98,23 @@ def test_feishu_human_still_checked_against_allowlist_when_bot_policy_set(monkey
     assert runner._is_user_authorized(_make_feishu_human_source("ou_human")) is True
 
 
+def test_feishu_human_allowlist_matches_open_id_even_when_contact_scope_adds_user_id(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_human")
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_dm",
+        chat_type="dm",
+        user_id="ou_human",
+        user_id_alt="on_human",
+        user_name="Human",
+        is_bot=False,
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
 def test_feishu_bot_bypass_does_not_leak_to_other_platforms(monkeypatch):
     """FEISHU_ALLOW_BOTS=all must not authorize Telegram/Discord bot sources."""
     runner = _make_bare_runner()


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu DM authorization when `hermes gateway setup` writes an `open_id`
to `FEISHU_ALLOWED_USERS` but inbound events arrive with both `open_id` and
contact-scoped `user_id`. The adapter now prefers `open_id` as the canonical
sender `user_id` so runtime allowlist checks match setup output, while keeping
`union_id` as the stable alternate identity for session tracking.

## Related Issue

Fixes #26183

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`gateway/platforms/feishu.py`](gateway/platforms/feishu.py) to prefer
  `open_id` over contact-scoped `user_id` when building the primary sender ID.
- Updated Feishu DM parsing expectations in
  [`tests/gateway/test_feishu.py`](tests/gateway/test_feishu.py).
- Extended Feishu sender-profile coverage in
  [`tests/gateway/test_feishu_bot_admission.py`](tests/gateway/test_feishu_bot_admission.py)
  to verify human allowlist behavior.
- Added an authorization regression test in
  [`tests/gateway/test_feishu_bot_auth_bypass.py`](tests/gateway/test_feishu_bot_auth_bypass.py)
  covering a DM source with both `open_id` and `union_id`.

## How to Test

1. Run:
   `python3 -m pytest -o addopts='' tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu_bot_auth_bypass.py`
2. Confirm the suite passes, including the new open-id authorization regression.
3. Optionally reproduce the issue by configuring `FEISHU_ALLOWED_USERS` with the
   `open_id` emitted by `hermes gateway setup`, then verify the same DM user is
   accepted at runtime instead of rejected with the contact-scoped `user_id`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m pytest -o addopts='' tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu_bot_auth_bypass.py
223 passed, 43 skipped in 5.08s
```
