### PR TITLE
fix(openrouter): show all tool-capable models from live API in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1160,7 +1160,19 @@ def list_authenticated_providers(
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
-    curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
+    # OpenRouter uses the live catalog via fetch_openrouter_models() — the
+    # curated list below is only a fallback; the model picker path
+    # (_model_flow_openrouter) always calls model_ids() which fetches live.
+    # Keep the curated snapshot here for the provider-list model count.
+    from hermes_cli.models import fetch_openrouter_models as _fetch_or_models
+    try:
+        _or_live = [mid for mid, _ in _fetch_or_models()]
+        if _or_live:
+            curated["openrouter"] = _or_live
+        else:
+            curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
+    except Exception:
+        curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
     # "nous" pulls from the remote model-catalog manifest published at
     # https://hermes-agent.nousresearch.com/docs/api/model-catalog.json so
     # newly added Portal models surface in the /model picker without

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1099,28 +1099,43 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return "tools" in params
 
 
+def _openrouter_model_sort_key(item: tuple[str, str]) -> tuple[str, str]:
+    """Sort key for OpenRouter models: (vendor_lower, model_id_lower)."""
+    mid, _ = item
+    if "/" in mid:
+        vendor, model = mid.split("/", 1)
+    else:
+        vendor, model = "", mid
+    return (vendor.lower(), model.lower())
+
+
 def fetch_openrouter_models(
     timeout: float = 8.0,
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
+    """Return ALL tool-capable OpenRouter models from the live API.
+
+    Fetches the full OpenRouter catalog (400+ models) from the live
+    ``/v1/models`` endpoint and filters out models that don't advertise
+    tool-calling support via ``supported_parameters``.  Models with zero
+    prompt+completion pricing are tagged as ``free``.
+
+    Falls back to the curated list (remote catalog manifest or in-repo
+    ``OPENROUTER_MODELS`` snapshot) when the live API is unreachable.
+    """
     global _openrouter_catalog_cache
 
     if _openrouter_catalog_cache is not None and not force_refresh:
         return list(_openrouter_catalog_cache)
 
-    # Prefer the remotely-hosted catalog manifest; fall back to the in-repo
-    # snapshot when the manifest is unreachable. Both are curated lists that
-    # drive the picker; the OpenRouter live /v1/models filter (tool support,
-    # free pricing) is applied on top either way.
+    # Build fallback from curated model lists (used when live API fails).
     try:
         from hermes_cli.model_catalog import get_curated_openrouter_models
         remote = get_curated_openrouter_models()
     except Exception:
         remote = None
     fallback = list(remote) if remote else list(OPENROUTER_MODELS)
-    preferred_ids = [mid for mid, _ in fallback]
 
     try:
         req = urllib.request.Request(
@@ -1136,35 +1151,32 @@ def fetch_openrouter_models(
     if not isinstance(live_items, list):
         return list(_openrouter_catalog_cache or fallback)
 
-    live_by_id: dict[str, dict[str, Any]] = {}
+    # Process ALL live models, filtering out non-tool-capable ones.
+    result: list[tuple[str, str]] = []
     for item in live_items:
         if not isinstance(item, dict):
             continue
         mid = str(item.get("id") or "").strip()
         if not mid:
             continue
-        live_by_id[mid] = item
-
-    curated: list[tuple[str, str]] = []
-    for preferred_id in preferred_ids:
-        live_item = live_by_id.get(preferred_id)
-        if live_item is None:
+        if not _openrouter_model_supports_tools(item):
             continue
-        # Hide models that don't advertise tool-calling support — hermes-agent
-        # requires it and surfacing them leads to immediate runtime failures
-        # when the user selects them. Ported from Kilo-Org/kilocode#9068.
-        if not _openrouter_model_supports_tools(live_item):
-            continue
-        desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
-        curated.append((preferred_id, desc))
+        desc = "free" if _openrouter_model_is_free(item.get("pricing")) else ""
+        result.append((mid, desc))
 
-    if not curated:
+    if not result:
         return list(_openrouter_catalog_cache or fallback)
 
-    first_id, _ = curated[0]
-    curated[0] = (first_id, "recommended")
-    _openrouter_catalog_cache = curated
-    return list(curated)
+    # Sort alphabetically by (vendor, model) so related models group together.
+    result.sort(key=_openrouter_model_sort_key)
+
+    # Mark the first entry as "recommended" (unless it's a free model).
+    first_id, first_desc = result[0]
+    if first_desc == "":
+        result[0] = (first_id, "recommended")
+
+    _openrouter_catalog_cache = list(result)
+    return result
 
 
 def model_ids(*, force_refresh: bool = False) -> list[str]:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -76,10 +76,14 @@ class TestFetchOpenRouterModels:
         with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
             models = fetch_openrouter_models(force_refresh=True)
 
+        # Models are sorted alphabetically by (vendor, model).
+        # anthropic/... is first (non-free) → "recommended".
+        # nvidia/... is free → "free".
+        # qwen/... has no special tag → "".
         assert models == [
             ("anthropic/claude-opus-4.6", "recommended"),
-            ("qwen/qwen3.6-plus", ""),
             ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
+            ("qwen/qwen3.6-plus", ""),
         ]
 
     def test_falls_back_to_static_snapshot_on_fetch_failure(self, monkeypatch):


### PR DESCRIPTION
## Summary
The OpenRouter model picker was previously limited to a curated subset of ~31 models from a hardcoded `OPENROUTER_MODELS` list. However, the live OpenRouter API returns over 400 models, all of which are accessible if the user manually types the model name. This update ensures the picker dynamically reflects the full range of models available via the API, rather than relying on a static, maintainer-selected list.

## Root Cause
The `fetch_openrouter_models()` function was fetching the live catalog but only using it to validate the curated list. It iterated specifically over `preferred_ids` (from the hardcoded list) and looked for matches in the live data. As a result, any model not explicitly included in the curated list was silently discarded.

## Changes

### `hermes_cli/models.py` — `fetch_openrouter_models()`
- **Before:** Built `preferred_ids` from a curated list/manifest and only returned models found in both the list and the API.
- **After:** Now iterates over all entries in the live API's data array.
- **Filtering & Sorting:** Continues to filter out models that don't support tool-calling via `supported_parameters`. Introduced a `_openrouter_model_sort_key()` helper to provide a stable, alphabetical sort order by vendor and model name.
- **Fallback:** Preserved the hardcoded list as a fallback mechanism if the live API is unreachable.

### `hermes_cli/model_switch.py` — `list_authenticated_providers()`
- Updated the provider picker to use the count from `fetch_openrouter_models()` instead of the hardcoded list, ensuring the UI displays an accurate count of available models for OpenRouter.

### `tests/hermes_cli/test_models.py`
- Updated `test_live_fetch_recomputes_free_tags` to align with the new alphabetical sorting logic.

## Testing
Successfully verified with the following test suites:
- `tests/hermes_cli/test_models.py` — 73 passed
- `tests/hermes_cli/test_list_picker_providers.py` — 15 passed
- `tests/hermes_cli/test_model_validation.py` — 81 passed
- `tests/test_tui_gateway_server.py` — 265 passed
