### PR TITLE
fix(whatsapp): fail fast when Baileys sendMessage hangs

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -57,9 +57,26 @@ const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
 const MAX_MESSAGE_LENGTH = parseInt(process.env.WHATSAPP_MAX_MESSAGE_LENGTH || '4096', 10);
 const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10);
+// Per-call timeout for sock.sendMessage(). Baileys occasionally hangs forever
+// when uploading media to WhatsApp servers (and, less often, on text sends),
+// which pins the bridge's HTTP handler until the upstream aiohttp timeout
+// fires. Fail fast instead so the gateway can surface a real error and retry.
+const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function sendWithTimeout(chatId, payload, timeoutMs = SEND_TIMEOUT_MS) {
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`sendMessage timed out after ${timeoutMs / 1000}s`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([sock.sendMessage(chatId, payload), timeoutPromise])
+    .finally(() => clearTimeout(timer));
 }
 
 function formatOutgoingMessage(message) {
@@ -487,7 +504,7 @@ app.post('/send', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
-      const sent = await sock.sendMessage(chatId, { text: chunks[i] });
+      const sent = await sendWithTimeout(chatId, { text: chunks[i] });
       trackSentMessageId(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {
@@ -521,10 +538,10 @@ app.post('/edit', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
 
-    await sock.sendMessage(chatId, { text: chunks[0], edit: key });
+    await sendWithTimeout(chatId, { text: chunks[0], edit: key });
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
-        const sent = await sock.sendMessage(chatId, { text: chunks[i] });
+        const sent = await sendWithTimeout(chatId, { text: chunks[i] });
         trackSentMessageId(sent);
         if (sent?.key?.id) messageIds.push(sent.key.id);
         if (i < chunks.length - 1) {
@@ -625,7 +642,7 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sock.sendMessage(chatId, msgPayload);
+    const sent = await sendWithTimeout(chatId, msgPayload);
 
     trackSentMessageId(sent);
 


### PR DESCRIPTION
## Summary
Bridge no longer hangs the gateway when Baileys' sock.sendMessage stalls.

## Root cause
sock.sendMessage() in the WhatsApp bridge can hang forever on media upload (and sometimes on text). The Express handler awaits it with no timeout, so the only thing that ever resolves the call is the gateway's 120s aiohttp ClientTimeout — surfacing to the user as the TTS/voice path silently dying after two minutes.

## Changes
- scripts/whatsapp-bridge/bridge.js: new sendWithTimeout(chatId, payload, ms?) helper wraps sock.sendMessage in Promise.race with WHATSAPP_SEND_TIMEOUT_MS (default 60s). All four sock.sendMessage call sites use it: /send (text chunks), /edit (text + continuation chunks), /send-media (the primary upload). Express handlers already have a try/catch around these calls, so a timeout reject becomes a real HTTP 500 with a clear message string the gateway can log and retry on.

## Validation
| | Before | After |
|---|---|---|
| Fast send | resolves immediately | resolves immediately |
| Hanging send | pins handler indefinitely (until upstream 120s timeout) | rejects after 60s with `sendMessage timed out after 60s` |
| Timer leak on fast resolve | n/a (no timer) | cleared via `.finally(clearTimeout)` — verified no event-loop leak |

E2E test: stub sock.sendMessage with (a) immediate resolve, (b) never-resolving Promise + 300ms override, (c) explicit per-call 200ms override. All three cases pass; process exits cleanly (no leaked timers).

## Attribution
Salvaged from #2608 by @wysie. Their diagnosis identified the hang and the Promise.race pattern is theirs. The other two parts of that PR — gateway HTTP session pooling and base.py metadata kwarg removal — already landed on main via separate routes (#18451 for the session work, the `**kwargs` signature change for the metadata path), so only the bridge fix was carried over. Closes #2608.