### PR TITLE
fix(cli): preserve tab completion inside space-containing paths

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1178,18 +1178,21 @@ class SlashCommandCompleter(Completer):
         """
         if not text:
             return None
-        # Walk backwards to find the start of the current "word".
-        # Words are delimited by spaces, but paths can contain almost anything.
-        i = len(text) - 1
-        while i >= 0 and text[i] != " ":
-            i -= 1
-        word = text[i + 1:]
-        if not word:
+        parts = text.split(" ")
+        candidate = parts[-1]
+        if not candidate:
             return None
-        # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
-            return word
-        return None
+
+        def _is_path_like(word: str) -> bool:
+            return word.startswith(("./", "../", "~/", "/")) or "/" in word
+
+        if not _is_path_like(candidate):
+            return None
+
+        for idx in range(len(parts) - 2, -1, -1):
+            if _is_path_like(parts[idx]):
+                return " ".join(parts[idx:])
+        return candidate
 
     @staticmethod
     def _path_completions(word: str, limit: int = 30):

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -59,6 +59,14 @@ class TestExtractPathWord:
     def test_just_tilde_slash(self):
         assert SlashCommandCompleter._extract_path_word("~/") == "~/"
 
+    def test_path_with_spaces_after_completion(self):
+        text = "edit ./My Documents/"
+        assert SlashCommandCompleter._extract_path_word(text) == "./My Documents/"
+
+    def test_path_with_spaces_and_nested_prefix(self):
+        text = "edit ./My Documents/no"
+        assert SlashCommandCompleter._extract_path_word(text) == "./My Documents/no"
+
 
 class TestPathCompletions:
     def test_lists_current_directory(self, tmp_path):
@@ -162,6 +170,22 @@ class TestIntegration:
         names = _display_names(completions)
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
+
+    def test_completion_continues_inside_directory_with_spaces(self, completer, tmp_path):
+        spaced_dir = tmp_path / "My Documents"
+        spaced_dir.mkdir()
+        (spaced_dir / "notes.txt").touch()
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("edit ./My Documents/no", cursor_position=len("edit ./My Documents/no"))
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+            names = _display_names(completions)
+            assert "notes.txt" in names
+        finally:
+            os.chdir(old_cwd)
 
 
 class TestFileSizeLabel:


### PR DESCRIPTION
## What does this PR do?

Fixes CLI path completion after completing into a directory whose name contains
spaces. Hermes now keeps the full path token under the cursor instead of
dropping the earlier path segment, so repeated Tab presses can continue
completing inside directories like `./My Documents/`.

## Related Issue

Fixes #26223

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`hermes_cli/commands.py`](hermes_cli/commands.py) so
  `_extract_path_word()` returns the nearest path-like token chain ending at the
  cursor, including space-separated directory segments.
- Added regression coverage in
  [`tests/hermes_cli/test_path_completion.py`](tests/hermes_cli/test_path_completion.py)
  for `_extract_path_word()` and repeated Tab completion inside a directory with
  spaces.

## How to Test

1. Run:
   `python3 -m pytest -o addopts='' tests/hermes_cli/test_path_completion.py`
2. Confirm the suite passes, including the new `My Documents` regression tests.
3. Optionally reproduce manually in `hermes`:
   type `edit ./My`, press Tab to complete a directory like `./My Documents/`,
   then press Tab again and verify nested files are suggested.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m pytest -o addopts='' tests/hermes_cli/test_path_completion.py
29 passed in 0.71s
```
