### PR TITLE
fix(tts): honor config-only OpenAI audio endpoints

### DIFF
--- a/tests/tools/test_tts_openai_config.py
+++ b/tests/tools/test_tts_openai_config.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools import tts_tool
+
+
+class TestResolveOpenaiAudioClientConfig:
+    def test_prefers_tts_config_credentials_and_base_url(self):
+        config = {
+            "provider": "openai",
+            "openai": {
+                "api_key": "cfg-key",
+                "base_url": "http://localhost:4003/v1",
+            },
+        }
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "cfg-key",
+                "http://localhost:4003/v1",
+            )
+
+    def test_config_without_base_url_falls_back_to_default_openai_base(self):
+        config = {"openai": {"api_key": "cfg-key"}}
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "cfg-key",
+                tts_tool.DEFAULT_OPENAI_BASE_URL,
+            )
+
+    def test_use_gateway_overrides_config_credentials(self):
+        config = {"openai": {"api_key": "cfg-key", "base_url": "http://localhost:4003/v1"}}
+        managed = SimpleNamespace(
+            nous_user_token="managed-token",
+            gateway_origin="https://openai-audio-gateway.nousresearch.com",
+        )
+
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=True), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=managed):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "managed-token",
+                "https://openai-audio-gateway.nousresearch.com/v1",
+            )
+
+    def test_missing_config_and_env_raises_updated_error(self):
+        with patch.object(tts_tool, "_load_tts_config", return_value={}), \
+             patch.object(tts_tool, "prefers_gateway", return_value=False), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=""), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None), \
+             patch.object(tts_tool, "managed_nous_tools_enabled", return_value=False):
+            with pytest.raises(ValueError) as exc:
+                tts_tool._resolve_openai_audio_client_config()
+
+        assert (
+            str(exc.value)
+            == "Neither tts.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
+        )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1942,13 +1942,23 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
     When ``tts.use_gateway`` is set in config, the Tool Gateway is preferred
     even if direct OpenAI credentials are present.
     """
+    tts_config = _load_tts_config()
+    openai_cfg = tts_config.get("openai", {})
+    cfg_api_key = openai_cfg.get("api_key", "")
+    cfg_base_url = openai_cfg.get("base_url", "")
+    if cfg_api_key and not prefers_gateway("tts"):
+        return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL)
+
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key and not prefers_gateway("tts"):
         return direct_api_key, DEFAULT_OPENAI_BASE_URL
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
-        message = "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set"
+        message = (
+            "Neither tts.openai.api_key in config nor "
+            "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
+        )
         if managed_nous_tools_enabled():
             message += ", and the managed OpenAI audio gateway is unavailable"
         raise ValueError(message)


### PR DESCRIPTION
## What does this PR do?

Fixes OpenAI TTS config-only setups by making the TTS resolver honor
`tts.openai.api_key` and `tts.openai.base_url` from `config.yaml` before
falling back to environment variables or the managed gateway. This mirrors the
existing STT resolution order, so self-hosted OpenAI-compatible TTS endpoints
work without requiring placeholder env vars.

## Related Issue

Fixes #26175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`tools/tts_tool.py`](tools/tts_tool.py) so `_resolve_openai_audio_client_config()`
  now resolves TTS credentials in `config -> env -> managed gateway` order.
- Preserved the `tts.use_gateway` preference so managed routing still overrides
  direct config or env credentials when explicitly enabled.
- Added resolver regression coverage in
  [`tests/tools/test_tts_openai_config.py`](tests/tools/test_tts_openai_config.py).

## How to Test

1. Run:
   `python3 -m pytest -o addopts='' tests/tools/test_tts_openai_config.py tests/tools/test_managed_media_gateways.py`
2. Confirm the suite passes, including the config-only TTS resolver tests.
3. Optionally reproduce manually with only this config:
   `tts.openai.api_key` + `tts.openai.base_url`, no `VOICE_TOOLS_OPENAI_KEY` /
   `OPENAI_API_KEY`, then trigger TTS and verify Hermes uses the configured
   endpoint instead of raising a missing-key error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m pytest -o addopts='' tests/tools/test_tts_openai_config.py tests/tools/test_managed_media_gateways.py
9 passed in 2.22s
```
