### PR TITLE
fix(providers): set User-Agent on ProviderProfile.fetch_models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3702,13 +3702,12 @@ def validate_requested_model(
 
     # Static-catalog fallback: when the /models probe was unreachable,
     # validate against the curated list from provider_model_ids() — same
-    # pattern as the openai-codex and minimax branches above.  This fixes
-    # /model switches in the gateway for providers like opencode-go and
-    # opencode-zen whose /models endpoint returns 404 against the HTML
-    # marketing site.  Without this block, validate_requested_model would
-    # reject every model on such providers, switch_model() would return
-    # success=False, and the gateway would never write to
-    # _session_model_overrides.
+    # pattern as the openai-codex and minimax branches above.  This keeps
+    # /model switches working in the gateway for providers whose /models
+    # endpoint is temporarily unreachable or returns a non-JSON payload.
+    # Without this block, validate_requested_model would reject every model
+    # on such providers, switch_model() would return success=False, and
+    # the gateway would never write to _session_model_overrides.
     provider_label = _PROVIDER_LABELS.get(normalized, normalized)
     try:
         catalog_models = provider_model_ids(normalized)

--- a/providers/base.py
+++ b/providers/base.py
@@ -21,6 +21,20 @@ logger = logging.getLogger(__name__)
 OMIT_TEMPERATURE = object()
 
 
+def _profile_user_agent() -> str:
+    """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
+
+    Used by ``ProviderProfile.fetch_models`` so the catalog probe is not
+    served the default ``Python-urllib/<ver>`` UA — some providers
+    (OpenCode Zen, etc.) sit behind a WAF that returns 403 for that.
+    """
+    try:
+        from hermes_cli import __version__ as _ver  # lazy: avoid layer cycle at import time
+        return f"hermes-cli/{_ver}"
+    except Exception:
+        return "hermes-cli"
+
+
 @dataclass
 class ProviderProfile:
     """Base provider profile — subclass or instantiate with overrides."""
@@ -153,6 +167,10 @@ class ProviderProfile:
         if api_key:
             req.add_header("Authorization", f"Bearer {api_key}")
         req.add_header("Accept", "application/json")
+        # Some providers (e.g. OpenCode Zen) sit behind a WAF that blocks
+        # the default ``Python-urllib/<ver>`` User-Agent.  Set a generic
+        # hermes-cli UA so the catalog endpoint is reachable.
+        req.add_header("User-Agent", _profile_user_agent())
         for k, v in self.default_headers.items():
             req.add_header(k, v)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,8 @@ AUTHOR_MAP = {
     "altriatree@gmail.com": "TruaShamu",
     "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
+    "mr.aashiz@gmail.com": "aashizpoudel",
+    "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",
     "oleksii.lisikh@gmail.com": "olisikh",
     "jeremy@geocaching.com": "outdoorsea",
     "leone.parise@gmail.com": "leoneparise",


### PR DESCRIPTION
## Summary
Provider catalog live-fetch now works for endpoints behind a WAF that 403s the default `Python-urllib/<ver>` User-Agent. Surfaced by #2651 — fixed at the right layer so every api_key provider profile gets live catalogs through the generic dispatch.

## Root cause
`ProviderProfile.fetch_models()` in `providers/base.py` builds the catalog probe with no `User-Agent` header. urllib defaults to `Python-urllib/3.11`, which Cloudflare/WAF in front of `opencode.ai` rejects with 403. The generic profile-based live-fetch in `provider_model_ids()` was silently swallowing the 403 and falling back to the static catalog plus the models.dev merge.

## Changes
- `providers/base.py`: add `_profile_user_agent()` helper and send `User-Agent: hermes-cli/<version>` on every catalog probe. Lazy version import keeps the layering clean.
- `hermes_cli/models.py`: strip the now-stale comment in `validate_requested_model()` claiming opencode-zen's `/models` returns 404 against the HTML marketing site — verified false (returns 200 JSON at `/zen/v1/models`).
- `scripts/release.py`: AUTHOR_MAP entries for the co-author.

## Validation
E2E with isolated `HERMES_HOME` and a real (non-placeholder) key:

| | Before | After |
|---|---|---|
| `profile.fetch_models(api_key='...')` direct | urllib HTTPError 403 → returns None | 42 models |
| `provider_model_ids('opencode-zen')` with key | 60 (static + models.dev merge — no live fetch) | 42 (live API only) |
| `provider_model_ids('opencode-zen')` no key | 60 (static + models.dev merge) | 60 (unchanged) |
| Live-only models present (`gpt-5.5`, `gpt-5.5-pro`, `kimi-k2.6`, `glm-5.1`, `*-free` variants) | partially via models.dev | yes via live |

Also: `scripts/run_tests.sh tests/providers/` → 92/92 passing.

Co-authored-by: Aashish Poudel <mr.aashiz@gmail.com>

Closes #2651