### PR TITLE
perf(run_agent): accumulate length-continuation prefix via list+join

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -12207,7 +12207,7 @@ class AIAgent:
         codex_ack_continuations = 0
         length_continue_retries = 0
         truncated_tool_call_retries = 0
-        truncated_response_prefix = ""
+        truncated_response_parts: List[str] = []
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
@@ -13100,7 +13100,7 @@ class AIAgent:
                                 interim_msg = self._build_assistant_message(assistant_message, finish_reason)
                                 messages.append(interim_msg)
                                 if assistant_message.content:
-                                    truncated_response_prefix += assistant_message.content
+                                    truncated_response_parts.append(assistant_message.content)
 
                                 if length_continue_retries < 3:
                                     self._vprint(
@@ -13121,7 +13121,7 @@ class AIAgent:
                                     restart_with_length_continuation = True
                                     break
 
-                                partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
+                                partial_response = self._strip_think_blocks("".join(truncated_response_parts)).strip()
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
@@ -15325,9 +15325,9 @@ class AIAgent:
 
                     codex_ack_continuations = 0
 
-                    if truncated_response_prefix:
-                        final_response = truncated_response_prefix + final_response
-                        truncated_response_prefix = ""
+                    if truncated_response_parts:
+                        final_response = "".join(truncated_response_parts) + final_response
+                        truncated_response_parts = []
                         length_continue_retries = 0
                     
                     final_response = self._strip_think_blocks(final_response).strip()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -89,6 +89,8 @@ AUTHOR_MAP = {
     "zhanganzhe@tenclass.com": "luoyuctl",
     "51604064+luoyuctl@users.noreply.github.com": "luoyuctl",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "tolle.lege+github@gmail.com": "InB4DevOps",
+    "73686890+InB4DevOps@users.noreply.github.com": "InB4DevOps",
     "147827411+EloquentBrush@users.noreply.github.com": "AhmetArif0",
     "97489706+purzbeats@users.noreply.github.com": "purzbeats",
     "hugosequier@gmail.com": "Hugo-SEQUIER",

--- a/tests/run_agent/test_anthropic_truncation_continuation.py
+++ b/tests/run_agent/test_anthropic_truncation_continuation.py
@@ -59,7 +59,7 @@ class TestTruncatedAnthropicResponseNormalization:
         nr = get_transport("anthropic_messages").normalize_response(response)
 
         # The continuation block checks these two attributes:
-        #   assistant_message.content  → appended to truncated_response_prefix
+        #   assistant_message.content  → appended to truncated_response_parts
         #   assistant_message.tool_calls → guards the text-retry branch
         assert nr.content is not None
         assert "partial response" in nr.content


### PR DESCRIPTION
Salvages the run_conversation portion of #2717 (@InB4DevOps).

## Summary
Replace `truncated_response_prefix += content` in the length-continuation retry path with list-append + `"".join()`. Functionally equivalent; matches the idiom used elsewhere in the codebase.

## Changes
- `run_agent.py` (3 sites in `run_conversation`): rename to `truncated_response_parts: List[str]`, switch accumulation/use to list + join.
- `tests/run_agent/test_anthropic_truncation_continuation.py`: update doc comment to match new variable name.
- `scripts/release.py`: AUTHOR_MAP entries for InB4DevOps.

## What was dropped from the original PR
The trajectory-builder refactor in `_convert_to_trajectory_format()` contained a silent regression — it replaced `tool_response += "\n</tool_response>"` with `tool_response_parts.append("\n</think>")`, which would have produced malformed trajectory XML on every save. Trajectory section dropped; only the `truncated_response_prefix` rename retained.

## Validation
- `scripts/run_tests.sh tests/run_agent/test_anthropic_truncation_continuation.py` → 7/7 pass (pre-existing tests, no regressions).
- `py_compile.compile("run_agent.py", doraise=True)` clean.
- `grep truncated_response_prefix run_agent.py` → 0 hits (all 6 references migrated).

Closes #2717.