### PR TITLE
feat(cli): show YOLO mode warning in banner and status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3370,8 +3370,11 @@ class HermesCLI:
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
 
+            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                if yolo_active:
+                    text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
@@ -3379,6 +3382,8 @@ class HermesCLI:
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
                 parts.append(duration_label)
+                if yolo_active:
+                    parts.append("⚠ YOLO")
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
             if snapshot["context_length"]:
@@ -3396,6 +3401,8 @@ class HermesCLI:
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)
+            if yolo_active:
+                parts.append("⚠ YOLO")
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -3412,6 +3419,7 @@ class HermesCLI:
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
 
             if width < 52:
                 frags = [
@@ -3419,8 +3427,11 @@ class HermesCLI:
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                    ("class:status-bar", " "),
                 ]
+                if yolo_active:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                frags.append(("class:status-bar", " "))
             else:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
@@ -3438,8 +3449,11 @@ class HermesCLI:
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ])
+                    if yolo_active:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                    frags.append(("class:status-bar", " "))
                 else:
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
@@ -3472,6 +3486,9 @@ class HermesCLI:
                     if prompt_elapsed:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-dim", prompt_elapsed))
+                    if yolo_active:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-yolo", "⚠ YOLO"))
                     frags.append(("class:status-bar", " "))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
@@ -13344,6 +13361,7 @@ class HermesCLI:
             'status-bar-warn': 'bg:#1a1a2e #FFD700 bold',
             'status-bar-bad': 'bg:#1a1a2e #FF8C00 bold',
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
+            'status-bar-yolo': 'bg:#1a1a2e #FF4444 bold',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -470,6 +470,9 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         model_short = model_short[:25] + "..."
     ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
     left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+
+    if os.getenv("HERMES_YOLO_MODE"):
+        left_lines.append(f"[bold red]⚠ YOLO mode[/] [dim {dim}]— all approval prompts bypassed[/]")
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
         left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")


### PR DESCRIPTION
Salvages #2665 (@Mibayy) onto current main with text refinements and broader status-bar coverage.

## Summary
Shows a permissions warning when `--yolo` is active so users can't forget all approval prompts are bypassed. Default case stays silent — no always-on 'restricted' label cluttering the banner.

## Changes
- `hermes_cli/banner.py` — `⚠ YOLO mode — all approval prompts bypassed` line in red, only when YOLO is active
- `cli.py` — `⚠ YOLO` fragment in all three status-bar width tiers (<52, <76, ≥76), in both `_get_status_bar_fragments` and the `_build_status_bar_text` plain-text fallback; `status-bar-yolo` style (`bg:#1a1a2e #FF4444 bold`)

## Notes
Differences from #2665:
- Text `⚠ FULL ACCESS` → `⚠ YOLO` (matches the flag name; fits narrow bars)
- Dropped the always-on `✓ RESTRICTED ACCESS` banner line — silent default is cleaner
- Added coverage to the two narrow width tiers the original missed

## Validation
| Width | YOLO off | YOLO on |
|---|---|---|
| 40 | `⚕ claude-sonnet-4 · 1m 23s` | `⚕ claude-sonnet-4 · 1m 23s · ⚠ YOLO` |
| 60 | `⚕ claude-sonnet-4 · 12% · 1m 23s` | `⚕ claude-sonnet-4 · 12% · 1m 23s · ⚠ YOLO` |
| 120 | `⚕ claude-sonnet-4 │ 24K/200K │ ▰▱▱▱▱ 12% │ 1m 23s` | `…│ 1m 23s │ ⚠ YOLO` |

Banner E2E confirmed: YOLO off → no permissions line; YOLO on → red warning line.

Closes #2663
Closes #2665

Co-authored-by: Mibayy <Mibayy@users.noreply.github.com>