### PR TITLE
fix(mcp): pre-compile env-var regex and unify interpolation

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -25,6 +25,7 @@ from hermes_cli.config import (
 )
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
+from tools.mcp_tool import _ENV_VAR_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -551,7 +552,7 @@ def cmd_mcp_test(args):
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
                 # Mask the value
-                resolved = _interpolate_value(v)
+                resolved = _ENV_VAR_PATTERN.sub(lambda m: os.getenv(m.group(1), ""), v)
                 if len(resolved) > 8:
                     masked = resolved[:4] + "***" + resolved[-4:]
                 else:
@@ -579,13 +580,6 @@ def cmd_mcp_test(args):
             short = desc[:55] + "..." if len(desc) > 55 else desc
             print(f"    {color(tool_name, Colors.GREEN):36s} {short}")
     print()
-
-
-def _interpolate_value(value: str) -> str:
-    """Resolve ``${ENV_VAR}`` references in a string."""
-    def _replace(m):
-        return os.getenv(m.group(1), "")
-    return re.sub(r"\$\{(\w+)\}", _replace, value)
 
 
 # ─── hermes mcp login ────────────────────────────────────────────────────────

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -111,6 +111,7 @@ AUTHOR_MAP = {
     "oswaldb22@users.noreply.github.com": "oswaldb22",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
+    "108541149+amethystani@users.noreply.github.com": "amethystani",
     "ytchen0719@gmail.com": "liquidchen",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "mike@grossmann.at": "ReqX",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -279,6 +279,11 @@ _CREDENTIAL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Pre-compiled pattern for ${VAR_NAME} style env-var interpolation.
+# Supports any non-} characters in the variable name (hyphens, dots, etc.)
+# so providers like MY-VAR or my.var work correctly.
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
 
 # ---------------------------------------------------------------------------
 # Security helpers
@@ -2104,7 +2109,7 @@ def _interpolate_env_vars(value):
     if isinstance(value, str):
         def _replace(m):
             return os.environ.get(m.group(1), m.group(0))
-        return re.sub(r"\$\{([^}]+)\}", _replace, value)
+        return _ENV_VAR_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
         return {k: _interpolate_env_vars(v) for k, v in value.items()}
     if isinstance(value, list):


### PR DESCRIPTION
Salvage of #2719 by @amethystani onto current main.

## Summary
Pre-compiles the `${VAR}` regex once at module level in `tools/mcp_tool.py` and replaces the diverged `\w+` copy in `hermes_cli/mcp_config.py` with the shared pattern. Fixes #2711 and #2712.

## Changes
- `tools/mcp_tool.py`: add `_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")` near `_CREDENTIAL_PATTERN`; `_interpolate_env_vars` uses it.
- `hermes_cli/mcp_config.py`: delete `_interpolate_value()` (its `\w+` pattern silently dropped env vars with `-` or `.`), reuse `_ENV_VAR_PATTERN` at the single call site in `cmd_mcp_test`. Kept `import re` (still used by `_ENV_VAR_NAME_RE` on current main).
- Moved the `from tools.mcp_tool import ...` to the first-party import group (PEP 8 grouping).

## Validation
- Targeted mcp tests: 259/259 passing.
- E2E: both runtime and CLI display paths share the same compiled pattern; `${MY-VAR}` / `${my.var}` now resolve correctly in the CLI test masking path (previously dropped silently).

Original PR: https://github.com/NousResearch/hermes-agent/pull/2719
Closes #2711
Closes #2712

Co-authored-by: amethystani <108541149+amethystani@users.noreply.github.com>