### PR TITLE
fix(cli): log swallowed exception in runtime model auto-detection

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -102,8 +102,10 @@ def _auto_detect_local_model(base_url: str) -> str:
                 model_id = models[0].get("id", "")
                 if model_id:
                     return model_id
-    except Exception:
-        pass
+    except Exception as exc:
+        # Log instead of silently swallowing — aids debugging when
+        # local model auto-detection fails unexpectedly.
+        logger.debug("Auto-detect model from %s failed: %s", base_url, exc)
     return ""
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
+    "nidhi2894@gmail.com": "nidhi-singh02",
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",
     "oleksii.lisikh@gmail.com": "olisikh",
     "jeremy@geocaching.com": "outdoorsea",


### PR DESCRIPTION
Salvages #2754 onto current main with authorship preserved.

## Summary
Replaces `except Exception: pass` in `_auto_detect_local_model()` with a debug-level log so local-endpoint auto-detect failures are diagnosable instead of silently hidden.

## Changes
- `hermes_cli/runtime_provider.py`: bare except → `logger.debug("Auto-detect model from %s failed: %s", ...)` using the existing module-level `logger` (contributor's version re-imported `logging` inside the except; folded into the same commit with authorship preserved).
- `scripts/release.py`: AUTHOR_MAP entry for nidhi-singh02.

## Validation
- 131/131 `tests/hermes_cli/` runtime_provider/auto_detect tests pass.
- E2E: pointed `_auto_detect_local_model('http://127.0.0.1:1/')` at an unreachable port — function returns `''` (unchanged) and the debug log line fires.

Closes #2754. Closes #2747.