### PR TITLE
fix(tools): return_exceptions=True on web_tools asyncio.gather (salvage #2751)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -221,6 +221,7 @@ AUTHOR_MAP = {
     "74749461+yuga-hashimoto@users.noreply.github.com": "yuga-hashimoto",
     "xiangyong@zspace.cn": "CES4751",
     "harish.kukreja@gmail.com": "counterposition",
+    "nidhi2894@gmail.com": "nidhi-singh02",
     "35294173+Fearvox@users.noreply.github.com": "Fearvox",
     "hypnus.yuan@gmail.com": "Hypnus-Yuan",
     "15558128926@qq.com": "xsfX20",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -586,11 +586,20 @@ async def _process_large_content_chunked(
     
     # Run all chunk summarizations in parallel
     tasks = [summarize_chunk(i, chunk) for i, chunk in enumerate(chunks)]
-    results = await asyncio.gather(*tasks)
-    
-    # Collect successful summaries in order
+    # Use return_exceptions=True so a single task failure does not discard
+    # all other successfully summarized chunks.
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Filter out exceptions, then collect successful summaries in order
+    successful_results = []
+    for result_item in results:
+        if isinstance(result_item, BaseException):
+            logger.warning("Chunk summarization task failed: %s", result_item)
+            continue
+        successful_results.append(result_item)
+
     summaries = []
-    for chunk_idx, summary in sorted(results, key=lambda x: x[0]):
+    for chunk_idx, summary in sorted(successful_results, key=lambda x: x[0]):
         if summary:
             summaries.append(f"## Section {chunk_idx + 1}\n{summary}")
     
@@ -1038,10 +1047,16 @@ async def web_extract_tool(
             # Run all LLM processing in parallel
             results_list = response.get('results', [])
             tasks = [process_single_result(result) for result in results_list]
-            processed_results = await asyncio.gather(*tasks)
-            
+            # Use return_exceptions=True so a single task failure does not
+            # discard all other successfully processed results.
+            processed_results = await asyncio.gather(*tasks, return_exceptions=True)
+
             # Collect metrics and print results
-            for result, metrics, status in processed_results:
+            for result_item in processed_results:
+                if isinstance(result_item, BaseException):
+                    logger.warning("Web result processing task failed: %s", result_item)
+                    continue
+                result, metrics, status = result_item
                 url = result.get('url', 'Unknown URL')
                 if status == "processed":
                     debug_call_data["compression_metrics"].append(metrics)
@@ -1285,8 +1300,14 @@ async def web_crawl_tool(
                     return result, metrics, "too_short"
 
                 tasks = [_process_tavily_crawl(r) for r in response.get('results', [])]
-                processed_results = await asyncio.gather(*tasks)
-                for result, metrics, status in processed_results:
+                # Use return_exceptions=True so a single task failure does not
+                # discard all other successfully processed crawl results.
+                processed_results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result_item in processed_results:
+                    if isinstance(result_item, BaseException):
+                        logger.warning("Tavily crawl processing task failed: %s", result_item)
+                        continue
+                    result, metrics, status = result_item
                     if status == "processed":
                         debug_call_data["compression_metrics"].append(metrics)
                         debug_call_data["pages_processed_with_llm"] += 1


### PR DESCRIPTION
Salvage of #2751 by @nidhi-singh02 onto current main.

## Summary
A single failing task in any of the three `asyncio.gather()` calls in `tools/web_tools.py` previously raised out of gather() and discarded every other successfully fetched/summarized result. This PR passes `return_exceptions=True` at each call site and filters `BaseException` entries with a warning log before unpacking.

## Changes
- `tools/web_tools.py`: 3 gather call sites (chunk summarization, firecrawl per-result, tavily crawl per-result)
- `scripts/release.py`: AUTHOR_MAP entry for nidhi2894@gmail.com → nidhi-singh02

## Why salvaged
- Original PR conflicted with main: the 4th call site it touched was removed when firecrawl crawl moved to plugin (commit 21e3a863b).
- Cleaned up the chunk-summarize sort-key (previously a sentinel-tuple lambda) by filtering exceptions before sorting.

## Sibling audit
Checked the other ~10 production `asyncio.gather` sites repo-wide. All are either already `return_exceptions=True` (mcp_tool, matrix, dingtalk, telegram_network, feishu, qqbot) or wrap each task internally (mixture_of_agents `_run_reference_model_safe`, trajectory_compressor `process_single`). No widening needed.

## Validation
E2E: simulated a mix of raising / None / successful tasks through the same gather+filter pattern at each site — failures filtered, successes preserved, order maintained, legitimate empty summaries still skipped by the existing `if summary:` guard.

Closes #2744
Supersedes #2751