### PR TITLE
fix(slack): guard split()[0] against whitespace-only command text

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2785,7 +2785,10 @@ class SlackAdapter(BasePlatformAdapter):
             from hermes_cli.commands import slack_subcommand_map
             subcommand_map = slack_subcommand_map()
             subcommand_map["compact"] = "/compress"
-            first_word = text.split()[0] if text else ""
+            # Guard against whitespace-only text where ``text`` is truthy but
+            # ``text.split()`` returns ``[]`` (e.g. user sends ``/hermes   ``).
+            parts = text.split() if text else []
+            first_word = parts[0] if parts else ""
             if first_word in subcommand_map:
                 rest = text[len(first_word):].strip()
                 text = f"{subcommand_map[first_word]} {rest}".strip() if rest else subcommand_map[first_word]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1069,6 +1069,8 @@ AUTHOR_MAP = {
     "37467487+yifengingit@users.noreply.github.com": "yifengingit",  # PR #25589 salvage (AUTOINCREMENT id ordering)
     "89525629+vanthinh6886@users.noreply.github.com": "vanthinh6886",  # PR #25562 salvage (.env 0600 perms)
     "16034932+Arkmusn@users.noreply.github.com": "Arkmusn",  # PR #25559 salvage (approvals.timeout from config)
+    "nidhi2894@gmail.com": "nidhi-singh02",  # PR #2752 salvage (slack whitespace-only IndexError guard)
+    "38173192+nidhi-singh02@users.noreply.github.com": "nidhi-singh02",
 }
 
 


### PR DESCRIPTION
Salvage of #2752 by @nidhi-singh02 — slack hunk only.

## Summary
A Slack user sending `/hermes   ` (trailing whitespace) crashes the slash router on `text.split()[0]` because `'   '.split() == []`. The guard `if text else ""` doesn't catch whitespace-only `text` (still truthy). Switched to a parts-list intermediate so we only index when non-empty.

## Why only the slack hunk
The PR also touched `tools/file_operations.py` and `agent/anthropic_adapter.py`. Both are unreachable in current code:
- `tools/file_operations.py` — `LINTERS` is a hardcoded constant dict (`py_compile`, `node --check`, …); no empty values, no user input path. `split()[0]` cannot raise IndexError.
- `agent/anthropic_adapter.py` — already guarded one line up: `if result.returncode == 0 and result.stdout.strip():`. A non-empty stripped string always splits to ≥1 token.

Defensive guards there would be harmless but noise. Dropped them; kept the real fix.

## Validation
`scripts/run_tests.sh tests/gateway/test_slack.py` → 186/186 passing.

Empirically:
| input | before | after |
|---|---|---|
| `""` | `""` | `""` |
| `"   "` | **IndexError** | `""` |
| `"\\t  \\n"` | **IndexError** | `""` |
| `"compress now"` | `"compress"` | `"compress"` |

Closes #2745.