### PR TITLE
fix(kanban): align worker terminal timeout with task runtime

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3931,6 +3931,18 @@ def _default_spawn(
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
 
+    def _lift_terminal_timeout(name: str, minimum_timeout: int) -> None:
+        raw = str(env.get(name, "") or "").strip()
+        if raw:
+            try:
+                existing = int(raw)
+            except ValueError:
+                existing = None
+            else:
+                if existing >= minimum_timeout:
+                    return
+        env[name] = str(minimum_timeout)
+
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
     # config.  Without this, `env = dict(os.environ)` copies only the parent's
@@ -3970,6 +3982,10 @@ def _default_spawn(
     # board slug still forces it to the right directory.
     resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
+    if task.max_runtime_seconds:
+        terminal_budget = max(1, int(task.max_runtime_seconds) - 30)
+        _lift_terminal_timeout("TERMINAL_TIMEOUT", terminal_budget)
+        _lift_terminal_timeout("TERMINAL_MAX_FOREGROUND_TIMEOUT", terminal_budget)
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2679,6 +2679,74 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     assert env.get("HERMES_PROFILE") == "some-profile"
 
 
+def test_default_spawn_raises_terminal_timeouts_to_task_budget(kanban_home, monkeypatch):
+    """Kanban max_runtime_seconds should lift worker terminal defaults."""
+    captured = {}
+
+    class FakeProc:
+        pid = 12345
+
+    def fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "180")
+    monkeypatch.setenv("TERMINAL_MAX_FOREGROUND_TIMEOUT", "240")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="long worker",
+            assignee="backend-worker",
+            max_runtime_seconds=3600,
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    env = captured["env"]
+    assert env["TERMINAL_TIMEOUT"] == "3570"
+    assert env["TERMINAL_MAX_FOREGROUND_TIMEOUT"] == "3570"
+
+
+def test_default_spawn_preserves_higher_terminal_timeouts(kanban_home, monkeypatch):
+    """Explicitly higher terminal env values should not be lowered."""
+    captured = {}
+
+    class FakeProc:
+        pid = 12346
+
+    def fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "5000")
+    monkeypatch.setenv("TERMINAL_MAX_FOREGROUND_TIMEOUT", "5000")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="very long worker",
+            assignee="backend-worker",
+            max_runtime_seconds=3600,
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    env = captured["env"]
+    assert env["TERMINAL_TIMEOUT"] == "5000"
+    assert env["TERMINAL_MAX_FOREGROUND_TIMEOUT"] == "5000"
+
+
 
 # ---------------------------------------------------------------------------
 # Per-task force-loaded skills


### PR DESCRIPTION
## What does this PR do?

Aligns Kanban worker terminal defaults with each task's `max_runtime_seconds` budget. When the dispatcher spawns a worker for a capped task, it now raises the child process's `TERMINAL_TIMEOUT` and `TERMINAL_MAX_FOREGROUND_TIMEOUT` to `max_runtime_seconds - 30s` when the inherited values are lower or invalid, while preserving any explicitly higher user-configured values.

## Related Issue

Fixes #26173

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/kanban_db.py` so `_default_spawn()` lifts worker terminal timeout env vars to the task runtime budget minus a 30-second grace window.
- Kept the change one-way only: inherited values above that floor are left untouched.
- Added regression tests in `tests/hermes_cli/test_kanban_core_functionality.py` covering both timeout lifting and higher-value preservation.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -k 'default_spawn and terminal_timeouts'`.
2. Confirm both new spawn-env regression tests pass.
3. Create a Kanban task with a long `max_runtime_seconds` and verify the spawned worker receives `TERMINAL_TIMEOUT` / `TERMINAL_MAX_FOREGROUND_TIMEOUT` near that task budget instead of the global default.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -k 'default_spawn and terminal_timeouts'` → `2 passed, 154 deselected in 0.76s`
