### PR TITLE
fix(tools): wrap browser provider network calls with error handling

### DIFF
--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -137,12 +137,22 @@ class BrowserUseProvider(CloudBrowserProvider):
             else {}
         )
 
-        response = requests.post(
-            f"{config['base_url']}/browsers",
-            headers=headers,
-            json=payload,
-            timeout=30,
-        )
+        try:
+            response = requests.post(
+                f"{config['base_url']}/browsers",
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            # Managed mode: propagate raw so callers can retry with the
+            # preserved idempotency key. Direct mode: wrap network failures
+            # into a clean RuntimeError for end users.
+            if managed_mode:
+                raise
+            raise RuntimeError(
+                f"Browser Use API connection failed: {exc}"
+            ) from exc
 
         if not response.ok:
             if managed_mode and not _should_preserve_pending_create_key(response):

--- a/tools/browser_providers/browserbase.py
+++ b/tools/browser_providers/browserbase.py
@@ -92,45 +92,50 @@ class BrowserbaseProvider(CloudBrowserProvider):
             "X-BB-API-Key": config["api_key"],
         }
 
-        response = requests.post(
-            f"{config['base_url']}/v1/sessions",
-            headers=headers,
-            json=session_config,
-            timeout=30,
-        )
+        try:
+            response = requests.post(
+                f"{config['base_url']}/v1/sessions",
+                headers=headers,
+                json=session_config,
+                timeout=30,
+            )
 
-        proxies_fallback = False
-        keepalive_fallback = False
+            proxies_fallback = False
+            keepalive_fallback = False
 
-        # Handle 402 — paid features unavailable
-        if response.status_code == 402:
-            if enable_keep_alive:
-                keepalive_fallback = True
-                logger.warning(
-                    "keepAlive may require paid plan (402), retrying without it. "
-                    "Sessions may timeout during long operations."
-                )
-                session_config.pop("keepAlive", None)
-                response = requests.post(
-                    f"{config['base_url']}/v1/sessions",
-                    headers=headers,
-                    json=session_config,
-                    timeout=30,
-                )
+            # Handle 402 — paid features unavailable
+            if response.status_code == 402:
+                if enable_keep_alive:
+                    keepalive_fallback = True
+                    logger.warning(
+                        "keepAlive may require paid plan (402), retrying without it. "
+                        "Sessions may timeout during long operations."
+                    )
+                    session_config.pop("keepAlive", None)
+                    response = requests.post(
+                        f"{config['base_url']}/v1/sessions",
+                        headers=headers,
+                        json=session_config,
+                        timeout=30,
+                    )
 
-            if response.status_code == 402 and enable_proxies:
-                proxies_fallback = True
-                logger.warning(
-                    "Proxies unavailable (402), retrying without proxies. "
-                    "Bot detection may be less effective."
-                )
-                session_config.pop("proxies", None)
-                response = requests.post(
-                    f"{config['base_url']}/v1/sessions",
-                    headers=headers,
-                    json=session_config,
-                    timeout=30,
-                )
+                if response.status_code == 402 and enable_proxies:
+                    proxies_fallback = True
+                    logger.warning(
+                        "Proxies unavailable (402), retrying without proxies. "
+                        "Bot detection may be less effective."
+                    )
+                    session_config.pop("proxies", None)
+                    response = requests.post(
+                        f"{config['base_url']}/v1/sessions",
+                        headers=headers,
+                        json=session_config,
+                        timeout=30,
+                    )
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Browserbase API connection failed: {exc}"
+            ) from exc
 
         if not response.ok:
             raise RuntimeError(

--- a/tools/browser_providers/firecrawl.py
+++ b/tools/browser_providers/firecrawl.py
@@ -47,12 +47,17 @@ class FirecrawlProvider(CloudBrowserProvider):
 
         body: Dict[str, object] = {"ttl": ttl}
 
-        response = requests.post(
-            f"{self._api_url()}/v2/browser",
-            headers=self._headers(),
-            json=body,
-            timeout=30,
-        )
+        try:
+            response = requests.post(
+                f"{self._api_url()}/v2/browser",
+                headers=self._headers(),
+                json=body,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Firecrawl API connection failed: {exc}"
+            ) from exc
 
         if not response.ok:
             raise RuntimeError(


### PR DESCRIPTION
Network failures in cloud browser provider `create_session()` calls now surface as clean `RuntimeError` messages instead of raw `requests` exception tracebacks.

Salvage of #2753 (@nidhi-singh02) onto current main + widened to cover `firecrawl.py` which has the same bug class.

## Changes
- `tools/browser_providers/browser_use.py` — wrap `requests.post()` in `create_session()`; managed-gateway mode preserves raw exception propagation so the existing idempotency-key retry semantics keep working
- `tools/browser_providers/browserbase.py` — wrap all three `requests.post()` calls (initial + two 402 retry sites) in one try block
- `tools/browser_providers/firecrawl.py` — sibling fix, same bug class (out of original PR scope)
- `scripts/release.py` — AUTHOR_MAP entry for nidhi-singh02

## Validation
- Existing browser-provider tests: `tests/tools/test_managed_browserbase_and_modal.py`, `test_browser_cloud_provider_cache.py`, `test_browser_cloud_fallback.py` — 23/23 pass
- E2E with simulated `requests.ConnectionError`: all three providers' `create_session()` raise `RuntimeError: <Provider> API connection failed: ...`
- E2E parity check: managed-mode timeout test (`test_browser_use_managed_gateway_reuses_pending_idempotency_key_after_timeout`) still passes — `Timeout` propagates raw in managed mode

Closes #2746