### PR TITLE
fix(url-safety): restrict is_safe_url() to http/https schemes

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -22,6 +22,14 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("https://example.com/image.png") is True
 
+    def test_ftp_scheme_blocked(self):
+        """Only http/https should be allowed for fetch tools."""
+        assert is_safe_url("ftp://example.com/file.txt") is False
+
+    def test_missing_scheme_blocked(self):
+        """Bare host/path should be rejected to avoid ambiguous handling."""
+        assert is_safe_url("example.com/path") is False
+
     def test_localhost_blocked(self):
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("127.0.0.1", 0)),

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -263,6 +263,9 @@ def is_safe_url(url: str) -> bool:
         parsed = urlparse(url)
         hostname = (parsed.hostname or "").strip().lower().rstrip(".")
         scheme = (parsed.scheme or "").strip().lower()
+        if scheme not in {"http", "https"}:
+            logger.warning("Blocked request — unsupported URL scheme: %s", scheme or "<empty>")
+            return False
         if not hostname:
             return False
 


### PR DESCRIPTION
## Summary
SSRF preflight now rejects URLs whose scheme isn't `http` or `https` — `ftp://`, `file://`, `gopher://`, scheme-less hosts, etc. all fail closed at the gate instead of leaking past to hostname/DNS checks.

Salvages #2760 by @aydnOktay onto current main. Original commit cherry-picked with authorship preserved; conflict was a trivial overlap with the trailing-dot hostname fix that landed on main after the PR was opened.

## Changes
- `tools/url_safety.py`: scheme allowlist check at the top of `is_safe_url()` (4 LOC)
- `tests/tools/test_url_safety.py`: regression tests for `ftp://` and scheme-less inputs

## Safety audit
Every caller (`vision_tools`, `browser_tool`, `web_tools`, every gateway platform adapter) already feeds only http/https URLs into `is_safe_url`. `vision_tools._is_valid_image_url` already filters schemes upstream. This just makes `is_safe_url` honest about what it accepts.

## Validation
- `tests/tools/test_url_safety.py`: 99/99 passing (includes 2 new regression tests)
- `tests/tools/test_browser_ssrf_local.py`, `test_website_policy.py`, `test_web_tools_tavily.py`: 57/57 passing

Closes #2760.