### PR TITLE
fix(update): consult upstream before early return

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7705,6 +7705,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         commit_count = int(result.stdout.strip())
 
         if commit_count == 0:
+            if is_fork and branch == "main":
+                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
             _invalidate_update_cache()
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -106,6 +106,26 @@ class TestCmdUpdateBranchFallback:
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_on_fork_checks_upstream_before_up_to_date_early_return(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm, "_get_origin_url", return_value="https://github.com/example/hermes-agent.git"
+        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+            cmd_update(mock_args)
+
+        sync_mock.assert_called_once_with(["git"], PROJECT_ROOT)
+        captured = capsys.readouterr()
+        assert "Already up to date!" in captured.out
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes update` fork no-op path when local `HEAD` already matches `origin/main` but `upstream/main` is ahead. The early-return branch in `_cmd_update_impl()` now checks upstream sync before printing `Already up to date!`, so fork users on `main` still pull official upstream changes instead of bailing out early.

## Related Issue

Fixes #26172

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/main.py` so the `commit_count == 0` early-return path calls `_sync_with_upstream_if_needed()` for forked `main` checkouts before reporting `Already up to date!`.
- Added a regression test in `tests/hermes_cli/test_cmd_update.py` covering the fork early-return path and asserting upstream sync is consulted.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py -k 'up_to_date or upstream_before_up_to_date_early_return or falls_back_to_main_when_branch_not_on_remote or uses_current_branch_when_on_remote'`.
2. Confirm the new fork regression passes and the existing update branch-selection tests still pass.
3. Optionally reproduce on a fork where `HEAD == origin/main` and `upstream/main` is ahead, then run `hermes update` and verify Hermes fetches upstream instead of exiting immediately.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py -k 'up_to_date or upstream_before_up_to_date_early_return or falls_back_to_main_when_branch_not_on_remote or uses_current_branch_when_on_remote'` → `4 passed, 7 deselected in 6.62s`
- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
- `git diff --check`
