### PR TITLE
fix: use git diff --cached for staged context refs

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -218,7 +218,7 @@ async def _expand_reference(
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
-            return _expand_git_reference(ref, cwd, ["diff", "--staged"], "git diff --staged")
+            return _expand_git_reference(ref, cwd, ["diff", "--cached"], "git diff --cached")
         if ref.kind == "git":
             count = max(1, min(int(ref.target or "1"), 10))
             return _expand_git_reference(ref, cwd, ["log", f"-{count}", "-p"], f"git log -{count} -p")

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -185,11 +185,35 @@ def test_expand_git_diff_staged_and_log(sample_repo: Path):
 
     assert result.expanded
     assert "git diff" in result.message
-    assert "git diff --staged" in result.message
+    assert "git diff --cached" in result.message
     assert "git log -1 -p" in result.message
     assert "initial" in result.message
     assert "return 'changed'" in result.message
     assert "VALUE = 2" in result.message
+
+
+def test_expand_staged_uses_git_diff_cached(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    real_run = subprocess.run
+    seen_git_commands: list[list[str]] = []
+
+    def track_git_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if isinstance(cmd, list) and cmd and cmd[0] == "git":
+            seen_git_commands.append(cmd)
+        return real_run(*args, **kwargs)
+
+    with patch("agent.context_references.subprocess.run", side_effect=track_git_run):
+        result = preprocess_context_references(
+            "Inspect @staged",
+            cwd=sample_repo,
+            context_length=100_000,
+        )
+
+    assert result.expanded
+    assert ["git", "diff", "--cached"] in seen_git_commands
+    assert ["git", "diff", "--staged"] not in seen_git_commands
 
 
 def test_binary_and_missing_files_become_warnings(sample_repo: Path):


### PR DESCRIPTION
## What does this PR do?

Fixes `@staged` context expansion on MSYS/git-bash by switching the underlying command from `git diff --staged` to `git diff --cached`, which is the portable spelling supported there. The change also adds a regression test that asserts Hermes now invokes the cached form for staged diffs.

## Related Issue

Fixes #26143

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/context_references.py` so `@staged` expands via `git diff --cached` instead of `git diff --staged`
- Updated `tests/agent/test_context_references.py` to reflect the new label in attached context output
- Added a regression test that records subprocess git invocations and asserts Hermes uses `git diff --cached` for staged references

## How to Test

1. Create a repo with staged changes and run Hermes context preprocessing with `@staged`
2. Confirm the attached context block now labels the command as `git diff --cached`
3. Run `python3 -m pytest -o addopts='' tests/agent/test_context_references.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m pytest -o addopts='' tests/agent/test_context_references.py
============================== 15 passed in 1.38s ==============================
```
