### PR TITLE
fix(cli): strip OSC-8 links from chat banner redraw

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -98,6 +98,7 @@ from agent.markdown_tables import (
 from hermes_cli.banner import _format_context_length, format_banner_version_label
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+_OSC8_SEQUENCE_RE = re.compile(r"\x1b]8;[^\x07\x1b]*(?:\x07|\x1b\\)")
 
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
@@ -2332,7 +2333,7 @@ class ChatConsole:
         # Read terminal width at render time so panels adapt to current size
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
-        output = self._buffer.getvalue()
+        output = _OSC8_SEQUENCE_RE.sub("", self._buffer.getvalue())
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -12,6 +12,7 @@ These tests verify the routing logic without spinning up a real PT app.
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -262,6 +263,24 @@ def test_replay_output_history_rerenders_callable_entries(monkeypatch):
     assert widths_seen == ["called"]
     assert printed == ["top border\nbody"]
     assert list(cli._OUTPUT_HISTORY) == [_render_current_width]
+
+
+def test_chat_console_strips_osc8_sequences_but_keeps_link_text(monkeypatch):
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", lambda text: printed.append(text))
+    monkeypatch.setattr(cli.shutil, "get_terminal_size", lambda fallback=(80, 24): os.terminal_size((160, 24)))
+
+    console = cli.ChatConsole()
+    console.print(
+        "\x1b]8;;https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.7\x1b\\"
+        "Hermes Agent v0.13.0 (2026.5.7)"
+        "\x1b]8;;\x1b\\"
+    )
+
+    joined = " ".join(part.strip() for part in printed if part.strip())
+    assert joined == "Hermes Agent v0.13.0 (2026.5.7)"
+    assert "\x1b]8;" not in joined
+    assert "releases/tag/" not in joined
 
 
 def test_replay_output_history_batches_rendered_lines_into_one_print(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the interactive CLI banner redraw path used by `/clear`, `/reset`, and `/new`. Those slash commands route Rich output through `ChatConsole.print()`, which was forwarding OSC-8 hyperlink control sequences to prompt_toolkit. prompt_toolkit does not understand OSC-8, so the release URL metadata leaked into the banner title as visible garbage. This change strips only the OSC-8 control sequences before `_cprint`, preserving the visible title text and existing ANSI color styling.

## Related Issue

Fixes #25939

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an OSC-8 control-sequence regex in `cli.py`
- Sanitized `ChatConsole.print()` output before splitting lines for `_cprint`
- Added a regression test in `tests/cli/test_cprint_bg_thread.py` to assert the hyperlink metadata is removed while the version text remains
- Kept `tests/hermes_cli/test_banner.py` green to verify the startup Rich path still emits OSC-8 hyperlinks normally

## How to Test

1. Start Hermes CLI and confirm the initial startup banner still shows the normal hyperlinked release title
2. Run `/clear`, `/reset`, or `/new` and confirm the redrawn banner title no longer shows raw OSC-8 hyperlink garbage
3. Run `python3 -m pytest -o addopts='' tests/cli/test_cprint_bg_thread.py tests/hermes_cli/test_banner.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python3 -m pytest -o addopts='' tests/cli/test_cprint_bg_thread.py tests/hermes_cli/test_banner.py
============================== 20 passed in 1.76s ==============================
```
