### PR TITLE
fix(codex-runtime): reject ephemeral HERMES_HOME before embedding in codex config

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -431,6 +431,32 @@ def _query_codex_plugins(
     return out, None
 
 
+def _is_safe_hermes_home(value: str) -> bool:
+    """Reject HERMES_HOME values that would corrupt the user's persistent
+    ~/.codex/config.toml if embedded.
+
+    The migrate() output is written to the user's real codex config and
+    survives across runs. If a test or stray invocation has set
+    HERMES_HOME to an ephemeral path (a pytest tempdir, a deleted dir),
+    embedding that string verbatim points codex's later MCP subprocess
+    spawn at a directory that no longer exists, silently breaking every
+    codex-routed hermes tool call. See #26250.
+    """
+    if not value:
+        return False
+    p = Path(value)
+    if not p.is_dir():
+        return False
+    # Reject pytest tempdir ancestors. pytest-of-<user>/pytest-<N>/popen-gw*
+    # is the canonical leaked path; the prefix `pytest-` covers both pytest
+    # and pytest-xdist worker dirs on macOS (/private/var/folders/...) and
+    # Linux (/tmp/...).
+    for part in p.resolve().parts:
+        if part.startswith("pytest-of-") or part.startswith("pytest-"):
+            return False
+    return True
+
+
 def _build_hermes_tools_mcp_entry() -> dict:
     """Build the codex stdio-transport entry that launches Hermes' own
     tool surface as an MCP server. Codex's subprocess will call back into
@@ -444,10 +470,20 @@ def _build_hermes_tools_mcp_entry() -> dict:
 
     env: dict[str, str] = {}
     # HERMES_HOME passes through if set so the MCP subprocess sees the
-    # same config / auth / sessions DB as the parent CLI.
+    # same config / auth / sessions DB as the parent CLI. Validated first
+    # because the value lands in the user's persistent ~/.codex/config.toml
+    # — a leaked pytest tempdir there would silently brick codex-routed
+    # hermes tool calls until the user hand-fixes the file (#26250).
     hermes_home = os.environ.get("HERMES_HOME")
-    if hermes_home:
+    if hermes_home and _is_safe_hermes_home(hermes_home):
         env["HERMES_HOME"] = hermes_home
+    elif hermes_home:
+        logger.warning(
+            "Not embedding HERMES_HOME=%r in ~/.codex/config.toml: path "
+            "is missing or looks ephemeral. The codex MCP subprocess will "
+            "resolve its own HERMES_HOME on startup.",
+            hermes_home,
+        )
     # PYTHONPATH passes through so a worktree-launched hermes finds the
     # branch's modules instead of the installed package.
     pythonpath = os.environ.get("PYTHONPATH")

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -635,3 +635,99 @@ class TestMigrate:
         assert "Migrated 2 MCP server(s)" in summary
         assert "- a" in summary
         assert "- b" in summary
+
+
+# ---- HERMES_HOME passthrough validation (#26250 Bug C) ----
+
+class TestHermesHomePassthrough:
+    """Validate that _build_hermes_tools_mcp_entry refuses to embed an
+    ephemeral HERMES_HOME into the user's persistent ~/.codex/config.toml.
+
+    The migrate() output survives across runs. A stray pytest tempdir or
+    deleted directory leaked from os.environ would point codex's later
+    MCP subprocess spawn at a path that no longer exists, silently breaking
+    every codex-routed hermes tool call. See #26250.
+    """
+
+    def test_safe_helper_accepts_real_directory(self):
+        from hermes_cli.codex_runtime_plugin_migration import _is_safe_hermes_home
+        # Use this test file's repo root — reliably a real directory and
+        # never under a pytest-of-* hierarchy.
+        repo_root = Path(__file__).resolve().parents[2]
+        assert repo_root.is_dir()
+        assert _is_safe_hermes_home(str(repo_root)) is True
+
+    def test_safe_helper_rejects_empty(self):
+        from hermes_cli.codex_runtime_plugin_migration import _is_safe_hermes_home
+        assert _is_safe_hermes_home("") is False
+
+    def test_safe_helper_rejects_missing_path(self, tmp_path):
+        from hermes_cli.codex_runtime_plugin_migration import _is_safe_hermes_home
+        missing = tmp_path / "does-not-exist"
+        assert _is_safe_hermes_home(str(missing)) is False
+
+    def test_safe_helper_rejects_pytest_tempdir(self, tmp_path):
+        """tmp_path itself lives under pytest-of-<user>/pytest-<N>/ —
+        if the helper accepts it, real pytest tempdirs leak through."""
+        from hermes_cli.codex_runtime_plugin_migration import _is_safe_hermes_home
+        assert _is_safe_hermes_home(str(tmp_path)) is False
+
+    def test_build_entry_skips_pytest_tempdir(self, tmp_path, monkeypatch):
+        from hermes_cli.codex_runtime_plugin_migration import (
+            _build_hermes_tools_mcp_entry,
+        )
+        # Simulate a real test-run leak: HERMES_HOME points at a pytest tempdir.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        entry = _build_hermes_tools_mcp_entry()
+        env = entry.get("env", {})
+        assert "HERMES_HOME" not in env, (
+            "pytest tempdir HERMES_HOME must not be embedded in codex config"
+        )
+
+    def test_build_entry_skips_missing_path(self, tmp_path, monkeypatch):
+        from hermes_cli.codex_runtime_plugin_migration import (
+            _build_hermes_tools_mcp_entry,
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+        entry = _build_hermes_tools_mcp_entry()
+        env = entry.get("env", {})
+        assert "HERMES_HOME" not in env
+
+    def test_build_entry_skips_unset(self, monkeypatch):
+        from hermes_cli.codex_runtime_plugin_migration import (
+            _build_hermes_tools_mcp_entry,
+        )
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        entry = _build_hermes_tools_mcp_entry()
+        env = entry.get("env", {})
+        assert "HERMES_HOME" not in env
+
+    def test_migrate_does_not_leak_pytest_tempdir_into_config(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: a pytest-tempdir HERMES_HOME in the calling process's
+        environment must NOT appear in the rendered ~/.codex/config.toml.
+
+        Regression guard for the #26250 repro: another test set
+        monkeypatch.setenv("HERMES_HOME", "<pytest tempdir>") on its own
+        worker, then crs.apply() called migrate() against the real
+        Path.home()/".codex" — leaking the tempdir into the user's
+        persistent codex config.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "leaked"))
+        (tmp_path / "leaked").mkdir()  # exists but under pytest-of-*
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+        report = migrate(
+            {}, codex_home=codex_home,
+            discover_plugins=False,
+            default_permission_profile=None,
+            expose_hermes_tools=True,
+        )
+        assert report.written
+        text = (codex_home / "config.toml").read_text()
+        assert "[mcp_servers.hermes-tools]" in text
+        assert "leaked" not in text, (
+            f"HERMES_HOME pytest tempdir leaked into config.toml:\n{text}"
+        )
+        assert "HERMES_HOME" not in text


### PR DESCRIPTION
## Summary

- Refuse to embed an ephemeral `HERMES_HOME` (pytest tempdir, missing path) into the user's persistent `~/.codex/config.toml`.
- Add a focused regression guard plus 7 unit tests covering the validator and the end-to-end migrate() leak path.
- Bug C from #26250. Sibling bugs left to follow-up — see *Related* below.

## The bug

`hermes codex-runtime migrate` writes `[mcp_servers.hermes-tools]` with an `env` table:

```python
hermes_home = os.environ.get("HERMES_HOME")
if hermes_home:
    env["HERMES_HOME"] = hermes_home
```

Whatever value `os.environ` has at migrate-time gets burned verbatim into the user's real `~/.codex/config.toml`, which survives across runs. The canonical leak from #26250:

```toml
[mcp_servers.hermes-tools]
env = { HERMES_HOME = "/private/var/folders/.../pytest-of-<user>/pytest-137/popen-gw2/test_enable_succeeds_when_code0/hermes_test" }
```

A sibling test (`test_enable_succeeds_when_codex_present` in `tests/hermes_cli/test_codex_runtime_switch.py`) called `crs.apply()` against the real `Path.home() / ".codex"` while `monkeypatch.setenv("HERMES_HOME", str(tmp_path))` was active on its xdist worker. Codex then spawned `hermes_tools_mcp_server` against the long-deleted pytest tempdir, so every codex-routed Hermes tool call failed silently until the user hand-fixed the file.

## The fix

A new `_is_safe_hermes_home(value)` helper validates the env value before passthrough:

- Empty or non-`Path.is_dir()` → reject.
- Any ancestor part starting with `pytest-of-` or `pytest-` → reject (covers pytest + pytest-xdist worker dirs on macOS `/private/var/folders/...` and Linux `/tmp/...`).

`_build_hermes_tools_mcp_entry` calls the helper before adding `HERMES_HOME` to the rendered env. If the value is set but rejected, a one-shot `logger.warning` records the rejected path so users still get diagnostic signal — the codex MCP subprocess resolves its own `HERMES_HOME` via `hermes_constants.get_hermes_home()` on startup, so a rejected passthrough is a safe default.

## Test plan

- [x] Focused regression test: `TestHermesHomePassthrough::test_migrate_does_not_leak_pytest_tempdir_into_config` — end-to-end, sets `HERMES_HOME` to a pytest-tempdir path, runs `migrate()`, asserts the leaked string never appears in the rendered `config.toml`.
- [x] Pure-helper coverage: 4 tests for `_is_safe_hermes_home` (empty / missing path / pytest tempdir / real directory).
- [x] Build-entry coverage: 3 tests for `_build_hermes_tools_mcp_entry` (pytest tempdir / missing path / unset env).
- [x] Adjacent suite: `tests/hermes_cli/test_codex_runtime_plugin_migration.py` — 64/64 pass (was 56/56 before, +8 new).
- [x] Cluster scan: `tests/hermes_cli/ -k codex_runtime` — 97 passed / 2 skipped on this branch. Unrelated `test_web_oauth_dispatch.py` fastapi `ModuleNotFoundError` is a local-install artifact (CI's `pip install -e .[all,dev]` pulls fastapi in).
- [x] Regression guard: with the validator removed, `test_migrate_does_not_leak_pytest_tempdir_into_config` fails on the `"leaked" not in text` assertion; with the validator restored it passes.

## Related

- Fixes part of #26250 (Bug C — `HERMES_HOME` from `os.environ` leaks into the user's persistent codex config).
- Bug B (duplicate `[plugins.*]` tables outside the managed block) is being addressed separately in #26090 (y0shua1ee). No code overlap — that PR restructures `migrate()` itself; this PR only touches `_build_hermes_tools_mcp_entry`.
- Bug A (`default_permissions` lands scoped inside a preceding user table) needs a structural change to where the key is written in the file. Intentionally left out to keep this diff narrow and to avoid conflicting with #26090's restructuring of the migrate() write path.

> Sibling code paths that may need the same fix: `_build_hermes_tools_mcp_entry`'s `PYTHONPATH` passthrough is structurally identical and could leak a pytest-injected `PYTHONPATH` the same way. Less common in the wild (no observed user report) but mechanically the same shape — happy to widen the validator to cover it if preferred.