### PR TITLE
fix(codex-runtime): prevent HERMES_HOME tempdir leakage into config.toml (Bug #26250-C)

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 
@@ -445,9 +447,16 @@ def _build_hermes_tools_mcp_entry() -> dict:
     env: dict[str, str] = {}
     # HERMES_HOME passes through if set so the MCP subprocess sees the
     # same config / auth / sessions DB as the parent CLI.
-    hermes_home = os.environ.get("HERMES_HOME")
+    # Derive HERMES_HOME canonically from get_hermes_home() rather than
+    # reading os.environ at migrate-time. This prevents pytest tempdir
+    # leakage into user's real ~/.codex/config.toml (Bug #26250-C).
+    # Sanity check: the path must exist and not be a pytest tempdir.
+    hermes_home = str(get_hermes_home())
     if hermes_home:
-        env["HERMES_HOME"] = hermes_home
+        # Sanity checks: path must exist and not be a pytest tempdir
+        hermes_path = Path(hermes_home)
+        if hermes_path.exists() and "pytest-of-" not in hermes_home:
+            env["HERMES_HOME"] = hermes_home
     # PYTHONPATH passes through so a worktree-launched hermes finds the
     # branch's modules instead of the installed package.
     pythonpath = os.environ.get("PYTHONPATH")

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -635,3 +635,78 @@ class TestMigrate:
         assert "Migrated 2 MCP server(s)" in summary
         assert "- a" in summary
         assert "- b" in summary
+
+class TestHERMESHomeSanity:
+    """Bug #26250-C: HERMES_HOME should not leak pytest tempdir into config.toml."""
+
+    def test_pytest_tempdir_blocked(self, tmp_path, monkeypatch):
+        """When HERMES_HOME points at a pytest tempdir, it should NOT be written."""
+        import os
+
+        # Simulate pytest monkeypatch setting HERMES_HOME to a tempdir
+        fake_tempdir = tmp_path / "pytest-of-test123"
+        fake_tempdir.mkdir(exist_ok=True)
+
+        # Save original HERMES_HOME
+        original_hermes_home = os.environ.get("HERMES_HOME")
+        output_content = None
+        try:
+            monkeypatch.setenv("HERMES_HOME", str(fake_tempdir))
+            report = migrate(
+                {"mcp_servers": {"test-server": {"command": "echo"}}},
+                codex_home=tmp_path,
+                expose_hermes_tools=False,
+            )
+            # Cache output before pytest cleans up tmp_path
+            output_content = (tmp_path / "config.toml").read_text()
+        finally:
+            # Restore original HERMES_HOME
+            if original_hermes_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = original_hermes_home
+
+        # Verify migration succeeded
+        assert report.written
+        # BUT HERMES_HOME from tempdir should NOT be in the output
+        assert output_content is not None
+        assert "HERMES_HOME" not in output_content, (
+            "HERMES_HOME from pytest tempdir leaked into config.toml"
+        )
+        # The test-server entry should still be there
+        assert "[mcp_servers.test-server]" in output_content
+
+    def test_nonexistent_hermes_home_blocked(self, tmp_path, monkeypatch):
+        """When HERMES_HOME points at a nonexistent path, it should NOT be written."""
+        import os
+
+        fake_path = tmp_path / "does-not-exist" / ".hermes"
+
+        # Save original HERMES_HOME
+        original_hermes_home = os.environ.get("HERMES_HOME")
+        output_content = None
+        try:
+            monkeypatch.setenv("HERMES_HOME", str(fake_path))
+            report = migrate(
+                {"mcp_servers": {"test-server": {"command": "echo"}}},
+                codex_home=tmp_path,
+                expose_hermes_tools=False,
+            )
+            # Cache output before pytest cleans up tmp_path
+            output_content = (tmp_path / "config.toml").read_text()
+        finally:
+            # Restore original HERMES_HOME
+            if original_hermes_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = original_hermes_home
+
+        # Verify migration succeeded
+        assert report.written
+        # BUT HERMES_HOME for a nonexistent path should NOT be in the output
+        assert output_content is not None
+        assert "HERMES_HOME" not in output_content, (
+            "HERMES_HOME for nonexistent path leaked into config.toml"
+        )
+        # The test-server entry should still be there
+        assert "[mcp_servers.test-server]" in output_content


### PR DESCRIPTION
Fixes hermes codex-runtime migrate produces invalid ~/.codex/config.toml (HERMES_HOME tempdir leakage) #26250-C

## Summary

Prevent `HERMES_HOME` from `os.environ` leaking into user's real `~/.codex/config.toml` when `hermes codex-runtime migrate` runs in a pytest environment. Pytest tempdirs (e.g., `pytest-of-*`) should NOT be written to the generated config file.

## Root Cause

`_build_hermes_tools_mcp_entry()` read `HERMES_HOME` directly from `os.environ.get("HERMES_HOME")` without any sanity checks. When pytest monkeypatch sets `HERMES_HOME` to a tempdir, that path gets burned into the user's real config file, causing codex MCP subprocess to fail silently.

## Fix

- Derive `HERMES_HOME` canonically from `get_hermes_home()` instead of reading `os.environ` at migrate-time
- Add sanity checks before writing to config:
  - Path must exist (`hermes_path.exists()`)
  - Path must NOT be a pytest tempdir (`"pytest-of-" not in hermes_home`)

If both checks fail, omit `HERMES_HOME` from the generated config entirely. Codex's spawned subprocess will resolve its own `HERMES_HOME` on startup, so passthrough is optional.

## Regression Coverage

Added `TestHERMESHomeSanity` class with two tests:
- `test_pytest_tempdir_blocked`: Verifies that `HERMES_HOME` pointing at a pytest tempdir is NOT written to config.toml
- `test_nonexistent_hermes_home_blocked`: Verifies that `HERMES_HOME` pointing at a nonexistent path is NOT written to config.toml

Both tests verify migration succeeds but the invalid HERMES_HOME value is not present in the output.

## Test Plan

- `python -m pytest tests/hermes_cli/test_codex_runtime_plugin_migration.py::TestHERMESHomeSanity -v`
- `python -m pytest tests/hermes_cli/test_codex_runtime_plugin_migration.py -x` (full test file)
- All 58 existing tests pass

## Risk Assessment

Low — change is scoped to `hermes_tools_mcp_entry()` env passthrough logic. MCP server migration and permissions rendering use the same paths as before. Migration behavior only changes when HERMES_HOME would have been written; codex subprocesses resolve their own HERMES_HOME anyway.
