### PR TITLE
fix(cron): stop escaping non-ASCII characters in jobs.json and tool output (#26128)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -433,7 +433,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -385,12 +385,12 @@ def cronjob(
                     "job": _format_job(job),
                     "message": f"Cron job '{job['name']}' created.",
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
-            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2, ensure_ascii=False)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
@@ -412,12 +412,12 @@ def cronjob(
                         for m in exc.matches
                     ],
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
         if not job:
             return json.dumps(
                 {"success": False, "error": f"Job with ID or name '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
@@ -436,20 +436,20 @@ def cronjob(
                         "schedule": job.get("schedule_display"),
                     },
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
 
         if normalized == "pause":
             updated = pause_job(job_id, reason=reason)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized == "resume":
             updated = resume_job(job_id)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized in {"run", "run_now", "trigger"}:
             updated = trigger_job(job_id)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized == "update":
             updates: Dict[str, Any] = {}
@@ -533,7 +533,7 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 


### PR DESCRIPTION
## Summary

Stops escaping non-ASCII characters (CJK, emoji, etc.) in cron job JSON storage and tool output. Fixes `cronjob list`/`cronjob update` displaying Chinese text as `\uXXXX` escape sequences.

Closes #26128

## Problem

Python's `json.dump`/`json.dumps` default to `ensure_ascii=True`, which converts all non-ASCII characters to `\uXXXX` escape sequences. When a cron job has Chinese text in its `prompt` field, `cronjob list` returns:

```json
"prompt": "\u751f\u6210\u5e76\u53d1\u9001\u9732\u5a1c\u7684\u81ea\u62cd\u7167\u7247\u7ed9\u4e3b\u4eba\u3002"
```

Instead of:

```json
"prompt": "生成并发送露娜的自拍照片给主人。"
```

## Fix

Add `ensure_ascii=False` to all `json.dump`/`json.dumps` calls in:
- `cron/jobs.py` (1 call — writing `jobs.json`)
- `tools/cronjob_tools.py` (9 calls — all return paths for `cronjob` tool)

## Files Changed

| File | Change |
|------|--------|
| `cron/jobs.py` | +1, −1 — add `ensure_ascii=False` to `json.dump` |
| `tools/cronjob_tools.py` | +9, −9 — add `ensure_ascii=False` to all `json.dumps` |

## Test Results

```
tests/cron/ + tests/tools/test_cronjob_tools.py ... 174 passed (1 pre-existing MobaXterm failure)
```
