### PR TITLE
fix(cron): retry failed delivery sends

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -43,6 +43,8 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
+PENDING_DELIVERIES_FILE = CRON_DIR / "pending_deliveries.json"
+_pending_deliveries_file_lock = threading.Lock()
 ONESHOT_GRACE_SECONDS = 120
 
 
@@ -444,6 +446,133 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         except OSError:
             pass
         raise
+
+
+# =============================================================================
+# Pending delivery retry queue
+# =============================================================================
+
+def _delivery_job_snapshot(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the small routing-only job shape needed to retry delivery.
+
+    Pending delivery records must survive the source job being completed or
+    removed, but they should not persist prompts, scripts, skills, model
+    configuration, or other execution fields. Delivery only needs the job id,
+    display name, deliver setting, and origin routing metadata.
+    """
+    snapshot: Dict[str, Any] = {
+        "id": str(job.get("id", "")),
+        "name": job.get("name"),
+        "deliver": job.get("deliver", "local"),
+        "origin": copy.deepcopy(job.get("origin")),
+    }
+    # Keep the JSON compact for jobs without a name/origin while preserving the
+    # expected default delivery behavior.
+    return {k: v for k, v in snapshot.items() if v is not None and v != ""}
+
+
+def _load_pending_deliveries_unlocked() -> List[Dict[str, Any]]:
+    ensure_dirs()
+    if not PENDING_DELIVERIES_FILE.exists():
+        return []
+
+    try:
+        with open(PENDING_DELIVERIES_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        try:
+            with open(PENDING_DELIVERIES_FILE, 'r', encoding='utf-8') as f:
+                data = json.loads(f.read(), strict=False)
+            deliveries = data.get("pending_deliveries", []) if isinstance(data, dict) else []
+            if deliveries:
+                _save_pending_deliveries_unlocked(deliveries)
+                logger.warning("Auto-repaired pending_deliveries.json (had invalid control characters)")
+            return [d for d in deliveries if isinstance(d, dict)]
+        except Exception as e:
+            logger.error("Failed to auto-repair pending_deliveries.json: %s", e)
+            raise RuntimeError(f"Cron pending-delivery database corrupted and unrepairable: {e}") from e
+    except IOError as e:
+        logger.error("IOError reading pending_deliveries.json: %s", e)
+        raise RuntimeError(f"Failed to read cron pending-delivery database: {e}") from e
+
+    deliveries = data.get("pending_deliveries", []) if isinstance(data, dict) else []
+    return [d for d in deliveries if isinstance(d, dict)]
+
+
+def _save_pending_deliveries_unlocked(deliveries: List[Dict[str, Any]]):
+    ensure_dirs()
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(PENDING_DELIVERIES_FILE.parent), suffix='.tmp', prefix='.pending_deliveries_'
+    )
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(
+                {"pending_deliveries": deliveries, "updated_at": _hermes_now().isoformat()},
+                f,
+                indent=2,
+            )
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, PENDING_DELIVERIES_FILE)
+        _secure_file(PENDING_DELIVERIES_FILE)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_pending_deliveries() -> List[Dict[str, Any]]:
+    """Load durable cron delivery retry records."""
+    with _pending_deliveries_file_lock:
+        return copy.deepcopy(_load_pending_deliveries_unlocked())
+
+
+def enqueue_pending_delivery(job: Dict[str, Any], content: str, error: Optional[str] = None) -> Dict[str, Any]:
+    """Persist a failed cron delivery so future ticks retry until success."""
+    now = _hermes_now().isoformat()
+    record = {
+        "id": uuid.uuid4().hex,
+        "job_id": str(job.get("id", "")),
+        "job_name": job.get("name") or job.get("id") or "cron job",
+        "job": _delivery_job_snapshot(job),
+        "content": str(content or ""),
+        "attempts": 1,
+        "created_at": now,
+        "last_attempt_at": now,
+        "last_error": error,
+    }
+    with _pending_deliveries_file_lock:
+        deliveries = _load_pending_deliveries_unlocked()
+        deliveries.append(record)
+        _save_pending_deliveries_unlocked(deliveries)
+    return copy.deepcopy(record)
+
+
+def record_pending_delivery_attempt(delivery_id: str, error: Optional[str]) -> bool:
+    """Record another failed attempt for a queued cron delivery."""
+    with _pending_deliveries_file_lock:
+        deliveries = _load_pending_deliveries_unlocked()
+        for delivery in deliveries:
+            if delivery.get("id") == delivery_id:
+                delivery["attempts"] = int(delivery.get("attempts") or 0) + 1
+                delivery["last_attempt_at"] = _hermes_now().isoformat()
+                delivery["last_error"] = error
+                _save_pending_deliveries_unlocked(deliveries)
+                return True
+    return False
+
+
+def remove_pending_delivery(delivery_id: str) -> bool:
+    """Remove a queued cron delivery after it sends successfully."""
+    with _pending_deliveries_file_lock:
+        deliveries = _load_pending_deliveries_unlocked()
+        kept = [d for d in deliveries if d.get("id") != delivery_id]
+        if len(kept) == len(deliveries):
+            return False
+        _save_pending_deliveries_unlocked(kept)
+        return True
 
 
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -122,7 +122,16 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    get_due_jobs,
+    mark_job_run,
+    save_job_output,
+    advance_next_run,
+    enqueue_pending_delivery,
+    load_pending_deliveries,
+    record_pending_delivery_attempt,
+    remove_pending_delivery,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -654,6 +663,54 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if delivery_errors:
         return "; ".join(delivery_errors)
     return None
+
+
+def _retry_pending_deliveries(adapters=None, loop=None) -> int:
+    """Retry durable cron delivery failures once per scheduler tick.
+
+    Failed sends are not allowed to vanish: each queued record is retried on
+    every tick until _deliver_result reports success, then it is removed. A
+    failed retry only updates attempts/last_error and remains queued.
+    """
+    try:
+        pending = load_pending_deliveries()
+    except Exception as exc:
+        logger.error("Failed to load pending cron deliveries: %s", exc)
+        return 0
+
+    attempted = 0
+    for delivery in pending:
+        delivery_id = delivery.get("id")
+        job = delivery.get("job")
+        content = delivery.get("content", "")
+        if not delivery_id or not isinstance(job, dict) or not content:
+            logger.warning("Skipping malformed pending cron delivery record: %s", delivery)
+            continue
+
+        attempted += 1
+        try:
+            delivery_error = _deliver_result(job, str(content), adapters=adapters, loop=loop)
+        except Exception as exc:
+            delivery_error = str(exc)
+            logger.error("Pending delivery %s failed: %s", delivery_id, exc)
+
+        if delivery_error:
+            record_pending_delivery_attempt(str(delivery_id), delivery_error)
+            logger.warning(
+                "Pending delivery %s for job %s still failing: %s",
+                delivery_id,
+                delivery.get("job_id") or job.get("id", "?"),
+                delivery_error,
+            )
+        else:
+            remove_pending_delivery(str(delivery_id))
+            logger.info(
+                "Pending delivery %s for job %s delivered successfully",
+                delivery_id,
+                delivery.get("job_id") or job.get("id", "?"),
+            )
+
+    return attempted
 
 
 _DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
@@ -1688,10 +1745,18 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         return 0
 
     try:
+        pending_retries = _retry_pending_deliveries(adapters=adapters, loop=loop)
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            if pending_retries:
+                logger.info(
+                    "%s - No jobs due; retried %d pending delivery(s)",
+                    _hermes_now().strftime('%H:%M:%S'),
+                    pending_retries,
+                )
+            else:
+                logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
             return 0
 
         if verbose:
@@ -1754,6 +1819,21 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     except Exception as de:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+                    if delivery_error:
+                        try:
+                            enqueue_pending_delivery(job, deliver_content, delivery_error)
+                            logger.warning(
+                                "Job '%s': delivery failed; queued for retry until success: %s",
+                                job["id"],
+                                delivery_error,
+                            )
+                        except Exception as qe:
+                            logger.error(
+                                "Job '%s': failed to queue delivery retry after send failure: %s",
+                                job["id"],
+                                qe,
+                            )
 
                 # Treat empty final_response as a soft failure so last_status
                 # is not "ok" — the agent ran but produced nothing useful.

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,6 +24,10 @@ from cron.jobs import (
     advance_next_run,
     get_due_jobs,
     save_job_output,
+    enqueue_pending_delivery,
+    load_pending_deliveries,
+    record_pending_delivery_attempt,
+    remove_pending_delivery,
 )
 
 
@@ -186,6 +190,7 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr("cron.jobs.PENDING_DELIVERIES_FILE", tmp_path / "cron" / "pending_deliveries.json")
     return tmp_path
 
 
@@ -558,6 +563,44 @@ class TestMarkJobRun:
         assert updated["next_run_at"] is None
         assert updated["enabled"] is False
         assert updated["state"] == "completed"
+
+
+class TestPendingDeliveries:
+    """Durable retry queue for cron outputs whose platform delivery failed."""
+
+    def test_enqueue_retry_and_remove_pending_delivery(self, tmp_cron_dir):
+        job = {
+            "id": "job-1",
+            "name": "daily report",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "chan-1", "thread_id": "thread-9"},
+            # Non-routing execution fields should not be copied into retry records.
+            "prompt": "expensive agent prompt",
+        }
+
+        pending = enqueue_pending_delivery(job, "report body", "HTTP 503")
+
+        queued = load_pending_deliveries()
+        assert len(queued) == 1
+        assert queued[0]["id"] == pending["id"]
+        assert queued[0]["content"] == "report body"
+        assert queued[0]["attempts"] == 1
+        assert queued[0]["last_error"] == "HTTP 503"
+        assert queued[0]["job"] == {
+            "id": "job-1",
+            "name": "daily report",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "chan-1", "thread_id": "thread-9"},
+        }
+
+        record_pending_delivery_attempt(pending["id"], "still down")
+        queued = load_pending_deliveries()
+        assert queued[0]["attempts"] == 2
+        assert queued[0]["last_error"] == "still down"
+        assert queued[0]["last_attempt_at"] is not None
+
+        assert remove_pending_delivery(pending["id"]) is True
+        assert load_pending_deliveries() == []
 
 
 class TestAdvanceNextRun:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -429,8 +429,14 @@ class TestRoutingIntents:
 
     def test_all_token_case_insensitive(self, monkeypatch):
         """'ALL' / 'All' / 'all' are all recognized."""
-        from cron.scheduler import _resolve_delivery_targets
+        from cron.scheduler import (
+            _HOME_TARGET_ENV_VARS,
+            _LEGACY_HOME_TARGET_ENV_VARS,
+            _resolve_delivery_targets,
+        )
 
+        for env_var in set(_HOME_TARGET_ENV_VARS.values()) | set(_LEGACY_HOME_TARGET_ENV_VARS.values()):
+            monkeypatch.delenv(env_var, raising=False)
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
 
@@ -803,6 +809,86 @@ class TestDeliverResultErrorReturns:
         result = _deliver_result(job, "Output.")
         assert result is not None
         assert "no delivery target" in result
+
+
+class TestPendingDeliveryRetries:
+    """tick() retries durable failed-delivery records until they send successfully."""
+
+    def _isolate_pending_store(self, tmp_path, monkeypatch):
+        import cron.jobs as jobs
+
+        cron_dir = tmp_path / "cron"
+        monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+        monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", cron_dir / "output")
+        monkeypatch.setattr(jobs, "PENDING_DELIVERIES_FILE", cron_dir / "pending_deliveries.json")
+        return jobs
+
+    def test_tick_retries_existing_pending_delivery_until_success(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+
+        jobs = self._isolate_pending_store(tmp_path, monkeypatch)
+        pending_job = {
+            "id": "job-1",
+            "name": "daily",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "chan"},
+        }
+        jobs.enqueue_pending_delivery(pending_job, "body", "initial outage")
+
+        attempts = []
+        outcomes = iter(["still down", None])
+
+        def fake_deliver(job, content, adapters=None, loop=None):
+            attempts.append((job, content))
+            return next(outcomes)
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [])
+        monkeypatch.setattr(sched, "_deliver_result", fake_deliver)
+
+        assert sched.tick(verbose=False) == 0
+        queued = jobs.load_pending_deliveries()
+        assert len(queued) == 1
+        assert queued[0]["attempts"] == 2
+        assert queued[0]["last_error"] == "still down"
+        assert attempts == [(pending_job, "body")]
+
+        assert sched.tick(verbose=False) == 0
+        assert jobs.load_pending_deliveries() == []
+        assert attempts == [(pending_job, "body"), (pending_job, "body")]
+
+    def test_tick_enqueues_new_delivery_failure_for_later_retry(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+
+        jobs = self._isolate_pending_store(tmp_path, monkeypatch)
+        due_job = {
+            "id": "due-1",
+            "name": "due report",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "chan", "thread_id": "thread"},
+        }
+        marks = []
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [due_job])
+        monkeypatch.setattr(sched, "advance_next_run", lambda _job_id: False)
+        monkeypatch.setattr(sched, "run_job", lambda _job: (True, "full doc", "final body", None))
+        monkeypatch.setattr(sched, "save_job_output", lambda _job_id, _output: tmp_path / "out.md")
+        monkeypatch.setattr(sched, "_deliver_result", lambda *_args, **_kwargs: "network down")
+        monkeypatch.setattr(sched, "mark_job_run", lambda *args, **kwargs: marks.append((args, kwargs)))
+
+        assert sched.tick(verbose=False) == 1
+
+        queued = jobs.load_pending_deliveries()
+        assert len(queued) == 1
+        assert queued[0]["content"] == "final body"
+        assert queued[0]["last_error"] == "network down"
+        assert queued[0]["job"] == {
+            "id": "due-1",
+            "name": "due report",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "chan", "thread_id": "thread"},
+        }
+        assert marks[0][1]["delivery_error"] == "network down"
 
 
 class TestRunJobSessionPersistence:


### PR DESCRIPTION
## Summary
- Persist failed cron delivery outputs to a pending-delivery retry queue
- Retry queued deliveries on each scheduler tick until sending succeeds
- Add tests for queue persistence, retry success/removal, and failed-send enqueueing

## Test plan
- pytest tests/cron -q
- git diff --check
- python -m py_compile cron/jobs.py cron/scheduler.py tests/cron/test_jobs.py tests/cron/test_scheduler.py

Note: attempted full pytest tests -q locally; it timed out at 600s after reaching 68% with unrelated failures outside the cron suite.