### PR TITLE
fix: cap long telegram turns and harden slash-confirm fallback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2787,7 +2787,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                     {"thread_id": str(thread_id)},
                                 )
                             )
-                        await self._send_message_with_thread_fallback(**send_kwargs)
+                        try:
+                            await self._send_message_with_thread_fallback(**send_kwargs)
+                        except Exception as md_error:
+                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
+                                plain_kwargs = dict(send_kwargs)
+                                plain_kwargs["text"] = _strip_mdv2(result_text)
+                                plain_kwargs["parse_mode"] = None
+                                await self._send_message_with_thread_fallback(**plain_kwargs)
+                            else:
+                                raise
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -3454,6 +3454,52 @@ class AIAgent:
 
         return 300.0, True
 
+    def _resolved_turn_wall_clock_max(self) -> float:
+        """Resolve the outer turn-loop wall-clock limit in seconds.
+
+        ``HERMES_TURN_WALL_CLOCK_MAX`` caps the total wall-clock time a single
+        ``run_conversation()`` turn may spend inside the outer tool / retry loop.
+        This is a last-resort guard above the per-request stale detectors.
+
+        Invalid or non-positive values fall back to the safe default of 600s.
+        """
+        raw = os.getenv("HERMES_TURN_WALL_CLOCK_MAX")
+        if raw is None:
+            return 600.0
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return 600.0
+        return value if value > 0 else 600.0
+
+    def _compute_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
+        """Compute the effective streaming stale timeout for this request.
+
+        ``HERMES_STREAM_STALE_TIMEOUT`` remains the explicit override. When it is
+        unset, Telegram turns use a shorter implicit baseline to reduce long
+        silent stalls on chat platforms, while local endpoints still disable the
+        detector entirely unless the user opted in.
+        """
+        raw = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+        implicit_default = raw is None
+        if raw is None:
+            platform_name = str(getattr(self, "platform", "") or "").lower()
+            stale_base = 120.0 if platform_name == "telegram" else 180.0
+        else:
+            stale_base = float(raw)
+
+        base_url = getattr(self, "_base_url", None) or self.base_url or ""
+        if implicit_default and base_url and is_local_endpoint(base_url):
+            logger.debug("Local provider detected (%s) — stale stream timeout disabled", base_url)
+            return float("inf")
+
+        est_tokens = sum(len(str(v)) for v in messages) // 4
+        if est_tokens > 100_000:
+            return max(stale_base, 300.0)
+        if est_tokens > 50_000:
+            return max(stale_base, 240.0)
+        return stale_base
+
     def _compute_non_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
         """Compute the effective non-stream stale timeout for this request."""
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
@@ -8534,26 +8580,9 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
-        # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-        # for prefill on large contexts.  Disable the stale detector unless
-        # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-        if _stream_stale_timeout_base == 180.0 and self.base_url and is_local_endpoint(self.base_url):
-            _stream_stale_timeout = float("inf")
-            logger.debug("Local provider detected (%s) — stale stream timeout disabled", self.base_url)
-        else:
-            # Scale the stale timeout for large contexts: slow models (like Opus)
-            # can legitimately think for minutes before producing the first token
-            # when the context is large.  Without this, the stale detector kills
-            # healthy connections during the model's thinking phase, producing
-            # spurious RemoteProtocolError ("peer closed connection").
-            _est_tokens = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
-            if _est_tokens > 100_000:
-                _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-            elif _est_tokens > 50_000:
-                _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-            else:
-                _stream_stale_timeout = _stream_stale_timeout_base
+        _stream_stale_timeout = self._compute_stream_stale_timeout(
+            api_kwargs.get("messages", [])
+        )
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()
@@ -12218,7 +12247,9 @@ class AIAgent:
         # present are surfaced in an advisory footer so the model cannot
         # over-claim success while the file is actually unchanged on disk.
         self._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
-        
+        _turn_wall_clock_max = self._resolved_turn_wall_clock_max()
+        _turn_started_at = time.time()
+
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
         # Must be set before any thread-scoped interrupt syncing.
@@ -12273,6 +12304,29 @@ class AIAgent:
             )
 
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
+            _turn_elapsed = time.time() - _turn_started_at
+            if _turn_elapsed > _turn_wall_clock_max:
+                _turn_exit_reason = "turn_wall_clock_exhausted"
+                timeout_msg = (
+                    f"Turn wall-clock limit exceeded after {int(_turn_elapsed)}s "
+                    f"(max {int(_turn_wall_clock_max)}s)."
+                )
+                logger.warning(
+                    "%s %s",
+                    self._client_log_context(),
+                    timeout_msg,
+                )
+                self._emit_status(f"⚠️ {timeout_msg}")
+                self._persist_session(messages, conversation_history)
+                return {
+                    "final_response": timeout_msg,
+                    "messages": messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "failed": True,
+                    "error": timeout_msg,
+                }
+
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -883,6 +883,55 @@ async def test_slash_confirm_forum_callback_followup_keeps_existing_thread_behav
 
 
 @pytest.mark.asyncio
+async def test_slash_confirm_callback_markdown_fallback_preserves_dm_topic_thread_kwargs(monkeypatch):
+    adapter = _make_adapter()
+    adapter._slash_confirm_state = {"confirm-1": "session-1"}
+    adapter._is_callback_user_authorized = lambda *args, **kwargs: True
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Markdown parse error")
+        return SimpleNamespace(message_id=9002)
+
+    async def resolve(_session_key, _confirm_id, _choice):
+        return "*done* _now_"
+
+    from tools import slash_confirm
+
+    monkeypatch.setattr(slash_confirm, "resolve", resolve)
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    class Query:
+        data = "sc:once:confirm-1"
+        from_user = SimpleNamespace(id=42, first_name="Alice")
+        message = SimpleNamespace(
+            chat_id=12345,
+            chat=SimpleNamespace(type=_fake_telegram_constants.ChatType.PRIVATE),
+            message_thread_id=20197,
+            message_id=462,
+        )
+
+        async def answer(self, **kwargs):
+            return None
+
+        async def edit_message_text(self, **kwargs):
+            return None
+
+    await adapter._handle_callback_query(SimpleNamespace(callback_query=Query()), SimpleNamespace())
+
+    assert len(call_log) == 2
+    assert call_log[0]["parse_mode"] == _fake_telegram_constants.ParseMode.MARKDOWN_V2
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[1]["parse_mode"] is None
+    assert call_log[1]["text"] == "done now"
+    assert call_log[1]["message_thread_id"] == 20197
+    assert call_log[1]["reply_to_message_id"] == 462
+
+
+@pytest.mark.asyncio
 async def test_base_send_image_fallback_preserves_metadata():
     """Base image fallback should pass metadata through instead of referencing kwargs."""
     from gateway.platforms.base import BasePlatformAdapter

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib
 import textwrap
+
+import pytest
 
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
@@ -306,3 +309,158 @@ def test_explicit_non_stream_stale_timeout_is_honored_for_local_endpoints(monkey
     )
 
     assert agent._compute_non_stream_stale_timeout([]) == 300.0
+
+
+def test_default_stream_stale_timeout_is_shorter_for_telegram(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+    from run_agent import AIAgent
+    agent = AIAgent(
+        model="gpt-5.4",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="telegram",
+    )
+
+    assert agent._compute_stream_stale_timeout([]) == 120.0
+
+
+def test_explicit_stream_stale_timeout_override_beats_telegram_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "210")
+
+    from run_agent import AIAgent
+    agent = AIAgent(
+        model="gpt-5.4",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="telegram",
+    )
+
+    assert agent._compute_stream_stale_timeout([]) == 210.0
+
+
+def test_default_stream_stale_timeout_auto_disables_for_local_endpoints(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+    from run_agent import AIAgent
+    agent = AIAgent(
+        model="qwen3:32b",
+        provider="ollama-local",
+        api_key="sk-dummy",
+        base_url="http://127.0.0.1:11434/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="telegram",
+    )
+
+    assert agent._compute_stream_stale_timeout([]) == float("inf")
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (None, 600.0),
+        ("900", 900.0),
+        ("0", 600.0),
+        ("-5", 600.0),
+        ("nope", 600.0),
+    ],
+)
+def test_resolved_turn_wall_clock_max(monkeypatch, tmp_path, raw_value, expected):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    if raw_value is None:
+        monkeypatch.delenv("HERMES_TURN_WALL_CLOCK_MAX", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_TURN_WALL_CLOCK_MAX", raw_value)
+
+    import run_agent as ra_mod
+
+    importlib.reload(ra_mod)
+
+    agent = ra_mod.AIAgent(
+        model="gpt-5.4",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+    assert agent._resolved_turn_wall_clock_max() == expected
+
+
+def test_turn_wall_clock_timeout_short_circuits_outer_loop(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_TURN_WALL_CLOCK_MAX", "600")
+
+    import run_agent as ra_mod
+
+    importlib.reload(ra_mod)
+
+    agent = ra_mod.AIAgent(
+        model="gpt-5.4",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+        max_iterations=3,
+    )
+
+    agent._persist_session = lambda *args, **kwargs: None
+    agent._emit_status = lambda *args, **kwargs: None
+    agent._client_log_context = lambda: "ctx"
+    agent._execution_thread_id = None
+    agent._checkpoint_mgr.new_turn = lambda: None
+    agent._interrupt_requested = False
+    agent._budget_grace_call = False
+    agent._touch_activity = lambda *_args, **_kwargs: None
+
+    class _Budget:
+        remaining = 3
+        used = 0
+        max_total = 3
+
+        def consume(self):
+            self.used += 1
+            self.remaining = max(0, self.remaining - 1)
+            return True
+
+    agent.iteration_budget = _Budget()
+
+    tick = {"value": 0.0}
+
+    def _fake_time():
+        tick["value"] += 700.0
+        return tick["value"]
+
+    monkeypatch.setattr(ra_mod.time, "time", _fake_time)
+
+    result = agent.run_conversation("hello")
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["api_calls"] == 0
+    assert result["error"] == "Turn wall-clock limit exceeded after 700s (max 600s)."
+    assert result["final_response"] == result["error"]


### PR DESCRIPTION
## Summary
- add a hard outer turn wall-clock cap via `HERMES_TURN_WALL_CLOCK_MAX` (default 600s)
- shorten the implicit streaming stale timeout for Telegram turns while preserving explicit overrides and local-endpoint exemption
- retry slash-confirm callback followups as plain text when Telegram rejects markdown/entity formatting, preserving thread/reply routing
- add focused regression coverage for timeout resolution and Telegram callback fallback behavior

## Test Plan
- [x] `pytest tests/hermes_cli/test_timeouts.py tests/gateway/test_telegram_thread_fallback.py -q -o 'addopts='`

## Notes
- branch was rebased by stashing the local patch, fast-forwarding `main`, then reapplying and resolving conflicts on this feature branch
- local `main` is now clean and up to date so the safe updater LaunchAgent can keep working
