### PR TITLE
fix(web): include cache token buckets in analytics

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13614,10 +13614,15 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
         cutoff = time.time() - (days * 86400)
         cur = db._conn.execute("""
             SELECT date(started_at, 'unixepoch') as day,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(output_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)
+                     + COALESCE(SUM(cache_write_tokens), 0) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
@@ -13629,21 +13634,33 @@ async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
 
         cur2 = db._conn.execute("""
             SELECT model,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(output_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)
+                     + COALESCE(SUM(cache_write_tokens), 0) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            GROUP BY model ORDER BY total_tokens DESC
         """, (cutoff,))
         by_model = [dict(r) for r in cur2.fetchall()]
 
         cur3 = db._conn.execute("""
-            SELECT SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
+            SELECT COALESCE(SUM(input_tokens), 0) as total_input,
+                   COALESCE(SUM(output_tokens), 0) as total_output,
+                   COALESCE(SUM(cache_read_tokens), 0) as total_cache_read,
+                   COALESCE(SUM(cache_write_tokens), 0) as total_cache_write,
+                   COALESCE(SUM(reasoning_tokens), 0) as total_reasoning,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(output_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)
+                     + COALESCE(SUM(cache_write_tokens), 0) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,
@@ -13690,20 +13707,30 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
         cur = db._conn.execute("""
             SELECT model,
                    billing_provider,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0) as input_tokens,
+                   COALESCE(SUM(output_tokens), 0) as output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) as cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+                   COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(output_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)
+                     + COALESCE(SUM(cache_write_tokens), 0) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls,
                    SUM(tool_call_count) as tool_calls,
                    MAX(started_at) as last_used_at,
-                   AVG(input_tokens + output_tokens) as avg_tokens_per_session
+                   AVG(
+                       COALESCE(input_tokens, 0)
+                       + COALESCE(output_tokens, 0)
+                       + COALESCE(cache_read_tokens, 0)
+                       + COALESCE(cache_write_tokens, 0)
+                   ) as avg_tokens_per_session
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
             GROUP BY model, billing_provider
-            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            ORDER BY total_tokens DESC
         """, (cutoff,))
         raw_rows = [dict(r) for r in cur.fetchall()]
 
@@ -13717,6 +13744,30 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
         for row in raw_rows:
             rows_by_model.setdefault(row.get("model") or "", []).append(row)
 
+        accounted_usage_keys = (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "total_tokens",
+            "reasoning_tokens",
+            "estimated_cost",
+            "actual_cost",
+            "api_calls",
+            "tool_calls",
+        )
+
+        def has_accounted_usage(row: Dict[str, Any]) -> bool:
+            return any((row.get(key) or 0) != 0 for key in accounted_usage_keys)
+
+        def tracked_token_total(row: Dict[str, Any]) -> float:
+            return row.get("total_tokens") or (
+                (row.get("input_tokens") or 0)
+                + (row.get("output_tokens") or 0)
+                + (row.get("cache_read_tokens") or 0)
+                + (row.get("cache_write_tokens") or 0)
+            )
+
         rows: List[Dict[str, Any]] = []
         for model_rows in rows_by_model.values():
             provider_rows = [r for r in model_rows if r.get("billing_provider")]
@@ -13725,51 +13776,23 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 for row in model_rows:
                     if row is target or row.get("billing_provider"):
                         continue
-                    has_usage = any(
-                        (row.get(key) or 0) != 0
-                        for key in (
-                            "input_tokens",
-                            "output_tokens",
-                            "cache_read_tokens",
-                            "reasoning_tokens",
-                            "estimated_cost",
-                            "actual_cost",
-                            "api_calls",
-                            "tool_calls",
-                        )
-                    )
-                    if has_usage:
+                    if has_accounted_usage(row):
                         continue
                     target["sessions"] = (target.get("sessions") or 0) + (row.get("sessions") or 0)
                     target["last_used_at"] = max(target.get("last_used_at") or 0, row.get("last_used_at") or 0)
-                    total_tokens = (target.get("input_tokens") or 0) + (target.get("output_tokens") or 0)
+                    total_tokens = tracked_token_total(target)
                     sessions = target.get("sessions") or 0
                     target["avg_tokens_per_session"] = total_tokens / sessions if sessions else 0
                 rows.append(target)
                 rows.extend(
                     r for r in model_rows
                     if r is not target
-                    and (r.get("billing_provider") or any(
-                        (r.get(key) or 0) != 0
-                        for key in (
-                            "input_tokens",
-                            "output_tokens",
-                            "cache_read_tokens",
-                            "reasoning_tokens",
-                            "estimated_cost",
-                            "actual_cost",
-                            "api_calls",
-                            "tool_calls",
-                        )
-                    ))
+                    and (r.get("billing_provider") or has_accounted_usage(r))
                 )
             else:
                 rows.extend(model_rows)
 
-        rows.sort(
-            key=lambda r: (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0),
-            reverse=True,
-        )
+        rows.sort(key=tracked_token_total, reverse=True)
 
         models = []
         for row in rows:
@@ -13797,7 +13820,9 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 "input_tokens": row["input_tokens"],
                 "output_tokens": row["output_tokens"],
                 "cache_read_tokens": row["cache_read_tokens"],
+                "cache_write_tokens": row["cache_write_tokens"],
                 "reasoning_tokens": row["reasoning_tokens"],
+                "total_tokens": row["total_tokens"],
                 "estimated_cost": row["estimated_cost"],
                 "actual_cost": row["actual_cost"],
                 "sessions": row["sessions"],
@@ -13810,10 +13835,15 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
 
         totals_cur = db._conn.execute("""
             SELECT COUNT(DISTINCT model) as distinct_models,
-                   SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
+                   COALESCE(SUM(input_tokens), 0) as total_input,
+                   COALESCE(SUM(output_tokens), 0) as total_output,
+                   COALESCE(SUM(cache_read_tokens), 0) as total_cache_read,
+                   COALESCE(SUM(cache_write_tokens), 0) as total_cache_write,
+                   COALESCE(SUM(reasoning_tokens), 0) as total_reasoning,
+                   COALESCE(SUM(input_tokens), 0)
+                     + COALESCE(SUM(output_tokens), 0)
+                     + COALESCE(SUM(cache_read_tokens), 0)
+                     + COALESCE(SUM(cache_write_tokens), 0) as total_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4432,8 +4432,29 @@ class TestNewEndpoints:
                 "deepseek-accounted",
                 input_tokens=20_000,
                 output_tokens=7_100,
+                cache_read_tokens=800,
+                cache_write_tokens=100,
                 billing_provider="openrouter",
                 api_call_count=9,
+            )
+            db.create_session(
+                session_id="cache-write-provider",
+                source="cli",
+                model="cache-write-model",
+            )
+            db.update_token_counts(
+                "cache-write-provider",
+                input_tokens=10,
+                billing_provider="openrouter",
+            )
+            db.create_session(
+                session_id="cache-write-only",
+                source="cli",
+                model="cache-write-model",
+            )
+            db.update_token_counts(
+                "cache-write-only",
+                cache_write_tokens=300,
             )
         finally:
             db.close()
@@ -4447,14 +4468,134 @@ class TestNewEndpoints:
             if row["model"] == "deepseek/deepseek-v4-flash"
         ]
 
+        # The zero-token session-only row folds into the provider row.
         assert len(deepseek_rows) == 1
-        row = deepseek_rows[0]
-        assert row["provider"] == "openrouter"
-        assert row["sessions"] == 2
-        assert row["input_tokens"] == 20_000
-        assert row["output_tokens"] == 7_100
-        assert row["api_calls"] == 9
-        assert row["avg_tokens_per_session"] == 13_550
+        provider_row = deepseek_rows[0]
+        assert provider_row["provider"] == "openrouter"
+        assert provider_row["sessions"] == 2
+        assert provider_row["input_tokens"] == 20_000
+        assert provider_row["output_tokens"] == 7_100
+        assert provider_row["cache_read_tokens"] == 800
+        assert provider_row["cache_write_tokens"] == 100
+        assert provider_row["total_tokens"] == 28_000
+        assert provider_row["api_calls"] == 9
+        assert provider_row["avg_tokens_per_session"] == 14_000
+
+        # A cache-write-only row with no provider is real accounting. It must
+        # remain visible instead of being treated as a disposable zero row.
+        cache_write_rows = [
+            row for row in models
+            if row["model"] == "cache-write-model"
+        ]
+        assert len(cache_write_rows) == 2
+        cache_write_row = next(row for row in cache_write_rows if row["provider"] == "")
+        assert cache_write_row["cache_write_tokens"] == 300
+        assert cache_write_row["total_tokens"] == 300
+
+    def test_analytics_usage_accounts_for_cache_token_buckets(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="cache-analytics-test",
+                source="cli",
+                model="gpt-cache-test",
+            )
+            db.update_token_counts(
+                "cache-analytics-test",
+                input_tokens=100,
+                output_tokens=25,
+                cache_read_tokens=40,
+                cache_write_tokens=5,
+                reasoning_tokens=7,
+                api_call_count=2,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/usage?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["totals"]["total_input"] == 100
+        assert data["totals"]["total_output"] == 25
+        assert data["totals"]["total_cache_read"] == 40
+        assert data["totals"]["total_cache_write"] == 5
+        assert data["totals"]["total_reasoning"] == 7
+        assert data["totals"]["total_tokens"] == 170
+
+        assert len(data["daily"]) == 1
+        day = data["daily"][0]
+        assert day["input_tokens"] == 100
+        assert day["output_tokens"] == 25
+        assert day["cache_read_tokens"] == 40
+        assert day["cache_write_tokens"] == 5
+        assert day["reasoning_tokens"] == 7
+        assert day["total_tokens"] == 170
+
+        model = next(row for row in data["by_model"] if row["model"] == "gpt-cache-test")
+        assert model["input_tokens"] == 100
+        assert model["output_tokens"] == 25
+        assert model["cache_read_tokens"] == 40
+        assert model["cache_write_tokens"] == 5
+        assert model["reasoning_tokens"] == 7
+        assert model["total_tokens"] == 170
+
+    def test_analytics_models_accounts_for_cache_token_buckets(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="cache-models-analytics-test",
+                source="cli",
+                model="gpt-cache-test",
+            )
+            db.update_token_counts(
+                "cache-models-analytics-test",
+                input_tokens=100,
+                output_tokens=25,
+                cache_read_tokens=40,
+                cache_write_tokens=5,
+                reasoning_tokens=7,
+                api_call_count=2,
+            )
+            db.create_session(
+                session_id="plain-models-analytics-test",
+                source="cli",
+                model="gpt-plain-test",
+            )
+            db.update_token_counts(
+                "plain-models-analytics-test",
+                input_tokens=160,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/models?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["totals"]["total_input"] == 260
+        assert data["totals"]["total_output"] == 25
+        assert data["totals"]["total_cache_read"] == 40
+        assert data["totals"]["total_cache_write"] == 5
+        assert data["totals"]["total_reasoning"] == 7
+        assert data["totals"]["total_tokens"] == 330
+
+        assert [row["model"] for row in data["models"][:2]] == [
+            "gpt-cache-test",
+            "gpt-plain-test",
+        ]
+        model = next(row for row in data["models"] if row["model"] == "gpt-cache-test")
+        assert model["input_tokens"] == 100
+        assert model["output_tokens"] == 25
+        assert model["cache_read_tokens"] == 40
+        assert model["cache_write_tokens"] == 5
+        assert model["reasoning_tokens"] == 7
+        assert model["total_tokens"] == 170
+        assert model["avg_tokens_per_session"] == 170
 
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1985,7 +1985,9 @@ export interface AnalyticsDailyEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   actual_cost: number;
   sessions: number;
@@ -1996,6 +1998,10 @@ export interface AnalyticsModelEntry {
   model: string;
   input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   sessions: number;
   api_calls: number;
@@ -2024,7 +2030,9 @@ export interface AnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
     total_reasoning: number;
+    total_tokens: number;
     total_estimated_cost: number;
     total_actual_cost: number;
     total_sessions: number;
@@ -2071,7 +2079,9 @@ export interface ModelsAnalyticsModelEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
   reasoning_tokens: number;
+  total_tokens: number;
   estimated_cost: number;
   actual_cost: number;
   sessions: number;
@@ -2096,7 +2106,9 @@ export interface ModelsAnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
     total_reasoning: number;
+    total_tokens: number;
     total_estimated_cost: number;
     total_actual_cost: number;
     total_sessions: number;

--- a/web/src/lib/token-breakdown.test.ts
+++ b/web/src/lib/token-breakdown.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { tokenBarBreakdown } from "./token-breakdown";
+
+describe("tokenBarBreakdown", () => {
+  it("uses the canonical total for bar proportions and reports reasoning separately", () => {
+    const breakdown = tokenBarBreakdown({
+      input: 100,
+      output: 50,
+      cacheRead: 25,
+      cacheWrite: 25,
+      reasoning: 40,
+    });
+
+    expect(breakdown.total).toBe(200);
+    expect(breakdown.segments.map((segment) => segment.key)).toEqual([
+      "cacheRead",
+      "cacheWrite",
+      "input",
+      "output",
+    ]);
+    expect(
+      breakdown.segments.reduce((sum, segment) => sum + segment.value, 0),
+    ).toBe(breakdown.total);
+    expect(
+      breakdown.segments.reduce(
+        (sum, segment) => sum + (segment.value / breakdown.total) * 100,
+        0,
+      ),
+    ).toBe(100);
+    expect(breakdown.metadata).toEqual([
+      { key: "reasoning", label: "Reasoning", value: 40 },
+    ]);
+  });
+});

--- a/web/src/lib/token-breakdown.ts
+++ b/web/src/lib/token-breakdown.ts
@@ -1,0 +1,42 @@
+export interface TokenBreakdown {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  reasoning: number;
+}
+
+export interface TokenSegment {
+  key: "cacheRead" | "cacheWrite" | "reasoning" | "input" | "output";
+  label: string;
+  value: number;
+}
+
+export interface TokenBarBreakdown {
+  total: number;
+  segments: TokenSegment[];
+  metadata: TokenSegment[];
+}
+
+export function tokenBarBreakdown({
+  input,
+  output,
+  cacheRead,
+  cacheWrite,
+  reasoning,
+}: TokenBreakdown): TokenBarBreakdown {
+  // CanonicalUsage.total_tokens is prompt + output. Reasoning tokens are
+  // separately reported metadata and may already be represented in output.
+  const total = input + output + cacheRead + cacheWrite;
+  const segments = [
+    { key: "cacheRead", label: "Cache Read", value: cacheRead },
+    { key: "cacheWrite", label: "Cache Write", value: cacheWrite },
+    { key: "input", label: "Input", value: input },
+    { key: "output", label: "Output", value: output },
+  ].filter((segment) => segment.value > 0) as TokenSegment[];
+  const metadata = [
+    { key: "reasoning", label: "Reasoning", value: reasoning },
+  ].filter((segment) => segment.value > 0) as TokenSegment[];
+
+  return { total, segments, metadata };
+}

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -33,6 +33,22 @@ const PERIODS = [
 
 const CHART_HEIGHT_PX = 160;
 
+type TokenBuckets = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  total_tokens?: number;
+};
+
+function cacheTokens(d: TokenBuckets): number {
+  return (d.cache_read_tokens ?? 0) + (d.cache_write_tokens ?? 0);
+}
+
+function totalTrackedTokens(d: TokenBuckets): number {
+  return d.total_tokens ?? d.input_tokens + d.output_tokens + cacheTokens(d);
+}
+
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -132,7 +148,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
   if (daily.length === 0) return null;
 
   const maxTokens = Math.max(
-    ...daily.map((d) => d.input_tokens + d.output_tokens),
+    ...daily.map((d) => totalTrackedTokens(d)),
     1,
   );
 
@@ -156,6 +172,13 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
           <div className="flex items-center gap-1.5">
             <div
               className="h-2.5 w-2.5"
+              style={{ backgroundColor: "#60a5fa" }}
+            />
+            Cache
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div
+              className="h-2.5 w-2.5"
               style={{ backgroundColor: "var(--series-output-token)" }}
             />
             {t.analytics.output}
@@ -168,9 +191,13 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
           style={{ height: CHART_HEIGHT_PX }}
         >
           {daily.map((d) => {
-            const total = d.input_tokens + d.output_tokens;
+            const cache = cacheTokens(d);
+            const total = totalTrackedTokens(d);
             const inputH = Math.round(
               (d.input_tokens / maxTokens) * CHART_HEIGHT_PX,
+            );
+            const cacheH = Math.round(
+              (cache / maxTokens) * CHART_HEIGHT_PX,
             );
             const outputH = Math.round(
               (d.output_tokens / maxTokens) * CHART_HEIGHT_PX,
@@ -188,6 +215,9 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                       {t.analytics.input}: {formatTokens(d.input_tokens)}
                     </div>
                     <div>
+                      Cache: {formatTokens(cache)}
+                    </div>
+                    <div>
                       {t.analytics.output}: {formatTokens(d.output_tokens)}
                     </div>
                     <div>
@@ -202,6 +232,14 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                     backgroundColor:
                       "color-mix(in srgb, var(--series-input-token) 70%, transparent)",
                     height: Math.max(inputH, total > 0 ? 1 : 0),
+                  }}
+                />
+
+                <div
+                  className="w-full"
+                  style={{
+                    backgroundColor: "color-mix(in srgb, #60a5fa 70%, transparent)",
+                    height: Math.max(cacheH, cache > 0 ? 1 : 0),
                   }}
                 />
 
@@ -234,7 +272,16 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
 
 function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
   const { t } = useI18n();
-  const { sorted, sortKey, sortDir, toggle } = useTableSort(daily, "day", "desc");
+  const sortableDaily = useMemo(
+    () =>
+      daily.map((entry) => ({
+        ...entry,
+        cache_tokens: cacheTokens(entry),
+        total_tokens: totalTrackedTokens(entry),
+      })),
+    [daily],
+  );
+  const { sorted, sortKey, sortDir, toggle } = useTableSort(sortableDaily, "day", "desc");
 
   if (daily.length === 0) return null;
 
@@ -256,7 +303,9 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                 <SortHeader label={t.analytics.date} col="day" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
                 <SortHeader label={t.analytics.input} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label="Cache" col="cache_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.analytics.total} col="total_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -276,10 +325,18 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                         {formatTokens(d.input_tokens)}
                       </span>
                   </td>
-                  <td className="text-right py-2 pl-4">
+                  <td className="text-right py-2 px-4">
+                    <span style={{ color: "#60a5fa" }}>
+                        {formatTokens(cacheTokens(d))}
+                      </span>
+                  </td>
+                  <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-output-token)" }}>
                         {formatTokens(d.output_tokens)}
                       </span>
+                  </td>
+                  <td className="text-right py-2 pl-4 font-medium">
+                    {formatTokens(totalTrackedTokens(d))}
                   </td>
                 </tr>
               ))}
@@ -293,7 +350,7 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
 
 function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
   const { t } = useI18n();
-  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "input_tokens", "desc");
+  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "total_tokens", "desc");
 
   if (models.length === 0) return null;
 
@@ -314,7 +371,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.model} col="model" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.tokens} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label={t.analytics.tokens} col="total_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -330,13 +387,22 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
                     {m.sessions}
                   </td>
                   <td className="text-right py-2 pl-4">
-                    <span style={{ color: "var(--series-input-token)" }}>
-                      {formatTokens(m.input_tokens)}
+                    <span className="font-medium">
+                      {formatTokens(totalTrackedTokens(m))}
                     </span>
-                    {" / "}
-                    <span style={{ color: "var(--series-output-token)" }}>
-                      {formatTokens(m.output_tokens)}
-                    </span>
+                    <div className="text-[10px] text-muted-foreground">
+                      <span style={{ color: "var(--series-input-token)" }}>
+                        {formatTokens(m.input_tokens)}
+                      </span>
+                      {" / "}
+                      <span style={{ color: "#60a5fa" }}>
+                        {formatTokens(cacheTokens(m))}
+                      </span>
+                      {" / "}
+                      <span style={{ color: "var(--series-output-token)" }}>
+                        {formatTokens(m.output_tokens)}
+                      </span>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -498,9 +564,8 @@ export default function AnalyticsPage() {
                 responses with a usable <span className="font-mono">usage</span>{" "}
                 block, and silently exclude auxiliary calls (context
                 compression, title generation, vision, session search, web
-                extract, smart approvals, MCP routing, plugin LLM access)
-                plus provider-side retries and fallback attempts. Cache
-                writes are missing entirely.
+                extract, smart approvals, MCP routing, plugin LLM access),
+                plus provider-side retries and fallback attempts.
               </p>
               <p>
                 On models with heavy auxiliary traffic (Kimi K2.6, MiniMax
@@ -546,12 +611,23 @@ export default function AnalyticsPage() {
                     {
                       label: t.analytics.totalTokens,
                       value: formatTokens(
-                        data.totals.total_input + data.totals.total_output,
+                        data.totals.total_tokens ??
+                          data.totals.total_input +
+                            data.totals.total_output +
+                            data.totals.total_cache_read +
+                            (data.totals.total_cache_write ?? 0),
                       ),
                     },
                     {
                       label: t.analytics.input,
                       value: formatTokens(data.totals.total_input),
+                    },
+                    {
+                      label: "Cache",
+                      value: formatTokens(
+                        data.totals.total_cache_read +
+                          (data.totals.total_cache_write ?? 0),
+                      ),
                     },
                     {
                       label: t.analytics.output,

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -88,14 +88,16 @@ function TokenBar({
   input,
   output,
   cacheRead,
+  cacheWrite,
   reasoning,
 }: {
   input: number;
   output: number;
   cacheRead: number;
+  cacheWrite: number;
   reasoning: number;
 }) {
-  const total = input + output + cacheRead + reasoning;
+  const total = input + output + cacheRead + cacheWrite + reasoning;
   if (total === 0) return null;
 
   // Segments carry a CSS color value (hex or `var(--token)`) rather than
@@ -106,6 +108,7 @@ function TokenBar({
   // separate hex literals.
   const segments: Array<{ color: string; label: string; value: number }> = [
     { value: cacheRead, color: "#60a5fa", label: "Cache Read" }, // tailwind blue-400
+    { value: cacheWrite, color: "#22d3ee", label: "Cache Write" }, // tailwind cyan-400
     { value: reasoning, color: "#c084fc", label: "Reasoning" }, // tailwind purple-400
     { value: input, color: "var(--series-input-token)", label: "Input" },
     { value: output, color: "var(--series-output-token)", label: "Output" },
@@ -376,7 +379,7 @@ function ModelCard({
 }) {
   const { t } = useI18n();
   const provider = entry.provider || modelVendor(entry.model);
-  const totalTokens = entry.input_tokens + entry.output_tokens;
+  const totalTokens = entry.total_tokens ?? entry.input_tokens + entry.output_tokens + entry.cache_read_tokens + entry.cache_write_tokens;
   const caps = entry.capabilities;
 
   const isMain =
@@ -472,6 +475,7 @@ function ModelCard({
               input={entry.input_tokens}
               output={entry.output_tokens}
               cacheRead={entry.cache_read_tokens}
+              cacheWrite={entry.cache_write_tokens}
               reasoning={entry.reasoning_tokens}
             />
 
@@ -1205,7 +1209,11 @@ export default function ModelsPage() {
                         {
                           label: t.analytics.totalTokens,
                           value: formatTokens(
-                            data.totals.total_input + data.totals.total_output,
+                            data.totals.total_tokens ??
+                              data.totals.total_input +
+                                data.totals.total_output +
+                                data.totals.total_cache_read +
+                                (data.totals.total_cache_write ?? 0),
                           ),
                         },
                         {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -23,6 +23,10 @@ import type {
 } from "@/lib/api";
 import { timeAgo, cn, themedBody } from "@/lib/utils";
 import { formatTokenCount } from "@/lib/format";
+import {
+  tokenBarBreakdown,
+  type TokenSegment,
+} from "@/lib/token-breakdown";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Stats } from "@nous-research/ui/ui/components/stats";
@@ -84,6 +88,14 @@ function modelVendor(model: string, fallback?: string): string {
   return fallback || "";
 }
 
+const TOKEN_SEGMENT_COLORS: Record<TokenSegment["key"], string> = {
+  cacheRead: "#60a5fa", // tailwind blue-400
+  cacheWrite: "#22d3ee", // tailwind cyan-400
+  reasoning: "#c084fc", // tailwind purple-400
+  input: "var(--series-input-token)",
+  output: "var(--series-output-token)",
+};
+
 function TokenBar({
   input,
   output,
@@ -97,8 +109,14 @@ function TokenBar({
   cacheWrite: number;
   reasoning: number;
 }) {
-  const total = input + output + cacheRead + cacheWrite + reasoning;
-  if (total === 0) return null;
+  const { total, segments, metadata } = tokenBarBreakdown({
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    reasoning,
+  });
+  if (total === 0 && metadata.length === 0) return null;
 
   // Segments carry a CSS color value (hex or `var(--token)`) rather than
   // a Tailwind class so the input/output series can pick up the active
@@ -106,48 +124,51 @@ function TokenBar({
   // `ThemeSeriesColors`. The /60–/70 fade on the bar is applied via
   // color-mix on the same value so themes don't need to ship two
   // separate hex literals.
-  const segments: Array<{ color: string; label: string; value: number }> = [
-    { value: cacheRead, color: "#60a5fa", label: "Cache Read" }, // tailwind blue-400
-    { value: cacheWrite, color: "#22d3ee", label: "Cache Write" }, // tailwind cyan-400
-    { value: reasoning, color: "#c084fc", label: "Reasoning" }, // tailwind purple-400
-    { value: input, color: "var(--series-input-token)", label: "Input" },
-    { value: output, color: "var(--series-output-token)", label: "Output" },
-  ].filter((s) => s.value > 0);
-
   return (
     <div className="space-y-1.5">
-      {/* Stacked bar — segments fill proportionally to their share of total */}
-      <div className="relative flex min-h-[1.5rem] w-full items-stretch overflow-hidden">
-        {segments.map((s, i) => (
-          <div
-            key={i}
-            className="relative flex items-center transition-all duration-300"
-            style={{
-              backgroundColor: `color-mix(in srgb, ${s.color} 70%, transparent)`,
-              width: `${(s.value / total) * 100}%`,
-            }}
-          >
-            {/* Stepped fill pattern overlay */}
+      {/* Only canonical additive buckets participate in the stacked bar. */}
+      {total > 0 && (
+        <div className="relative flex min-h-[1.5rem] w-full items-stretch overflow-hidden">
+          {segments.map((s) => (
             <div
-              className="absolute inset-0 opacity-30"
+              key={s.key}
+              className="relative flex items-center transition-all duration-300"
               style={{
-                backgroundImage:
-                  "repeating-linear-gradient(to right, transparent 0 0.4rem, currentColor 0.4rem calc(0.4rem + 1px))",
+                backgroundColor: `color-mix(in srgb, ${TOKEN_SEGMENT_COLORS[s.key]} 70%, transparent)`,
+                width: `${(s.value / total) * 100}%`,
               }}
-            />
-          </div>
-        ))}
-      </div>
+            >
+              {/* Stepped fill pattern overlay */}
+              <div
+                className="absolute inset-0 opacity-30"
+                style={{
+                  backgroundImage:
+                    "repeating-linear-gradient(to right, transparent 0 0.4rem, currentColor 0.4rem calc(0.4rem + 1px))",
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Legend */}
       <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
-        {segments.map((s, i) => (
-          <span key={i} className="flex items-center gap-1">
+        {segments.map((s) => (
+          <span key={s.key} className="flex items-center gap-1">
             <span
               className="inline-block h-1.5 w-1.5 rounded-full"
-              style={{ backgroundColor: s.color }}
+              style={{ backgroundColor: TOKEN_SEGMENT_COLORS[s.key] }}
             />
             {s.label} {formatTokens(s.value)}
+          </span>
+        ))}
+        {metadata.map((s) => (
+          <span key={s.key} className="flex items-center gap-1">
+            <span
+              className="inline-block h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: TOKEN_SEGMENT_COLORS[s.key] }}
+            />
+            {s.label} {formatTokens(s.value)} (reported separately)
           </span>
         ))}
       </div>


### PR DESCRIPTION
## Summary

Fix dashboard analytics token accounting so the Token Usage views include all persisted token buckets, not just input/output.

This updates `/api/analytics/usage` and `/api/analytics/models` to aggregate and return:

- `cache_read_tokens`
- `cache_write_tokens`
- `reasoning_tokens`
- `total_tokens` = input + output + cache read + cache write

The Analytics and Models pages now display/sort using the corrected totals, including cache tokens. Reasoning tokens remain exposed separately and are not double-counted into `total_tokens`.

Related context: #23270 and #25400 cover adjacent token visibility gaps, but this PR is specifically about persisted dashboard analytics undercounting cache buckets.

## Changes

- Add cache write and total token fields to usage/model analytics API responses.
- Sort model analytics by `total_tokens`, not only input/output.
- Include cache read/write in model average token calculations.
- Show cache token usage in Analytics daily chart/table/model table.
- Show cache write in Models token bars.
- Keep separately reported reasoning metadata outside the proportional Models token bar so its four additive segments use the same canonical denominator as the displayed card total.
- Update TypeScript API interfaces for the new fields.
- Add API regressions plus an adversarial UI-contract regression with every token bucket nonzero.

## Semantic contract

`CanonicalUsage.total_tokens` is authoritative: input + cache read + cache write + output. The API totals, sorting key, card total/fallback, and proportional token-bar denominator route through that same four-bucket contract. `reasoning_tokens` is separately reported metadata and does not consume stacked-bar width.

## Verification

Current reviewed head: `a71bd8bf79384b46aeb1d1737a52c1b66d1aef41`

- RED reproduced on the reviewed implementation: adversarial fixture produced bar total `240` instead of canonical `200` when reasoning was nonzero.
- `npm --workspace web test` — 34 passed.
- `npm --workspace web run typecheck` — passed.
- `npm --workspace web run build` — passed.
- `python -m pytest -q tests/hermes_cli/test_web_server.py -k 'analytics_usage_accounts_for_cache_token_buckets or analytics_models_accounts_for_cache_token_buckets or models_analytics'` — 3 passed, 356 deselected.
- `git diff --cached --check` and added-line secret/danger scan — clean.
- Independent embedded-diff re-review — PASS; no security concerns or logic errors.
- Repository-wide ESLint remains at the exact current-head baseline of 28 errors and 3 warnings; the only touched-file finding is the pre-existing `ModelsPage` effect at line 1185. No new lint finding was introduced.
- A repository-wide Python run was attempted but not claimed as a passing gate: the old branch's broad suite entered live network paths and exhausted file descriptors before completion. The affected Python and complete web gates above passed.

No public API or schema compatibility change is introduced by the review remediation; it only corrects the Models proportional visual and labels reasoning as separately reported.
