### PR TITLE
fix(tirith): skip auto-install on Termux native (Bionic libc)

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1152,6 +1152,77 @@ class TestDiskFailureMarker:
 
 
 # ---------------------------------------------------------------------------
+# Termux native (Bionic libc) skip
+# ---------------------------------------------------------------------------
+
+class TestTermuxNativeSkip:
+    """Issue #26275: tirith binary spawned on Termux native (no proot) fails
+    with `[Errno 2] No such file or directory` because the unknown-linux-gnu
+    binary embeds /lib/ld-linux-aarch64.so.1 as its dynamic interpreter,
+    which doesn't exist on Termux's Bionic-libc filesystem. The auto-installer
+    must skip this environment so we don't write a binary that can't run."""
+
+    def test_is_termux_native_true_when_prefix_set(self):
+        from tools.tirith_security import _is_termux_native
+        with patch.dict(os.environ, {"PREFIX": "/data/data/com.termux/files/usr"}):
+            assert _is_termux_native() is True
+
+    def test_is_termux_native_false_when_prefix_unset(self):
+        from tools.tirith_security import _is_termux_native
+        env = {k: v for k, v in os.environ.items() if k != "PREFIX"}
+        with patch.dict(os.environ, env, clear=True):
+            assert _is_termux_native() is False
+
+    def test_is_termux_native_false_for_unrelated_prefix(self):
+        """A non-Termux PREFIX (e.g. Conda's $PREFIX) must NOT match."""
+        from tools.tirith_security import _is_termux_native
+        with patch.dict(os.environ, {"PREFIX": "/opt/conda/envs/dev"}):
+            assert _is_termux_native() is False
+
+    def test_detect_target_returns_none_on_termux_native(self):
+        """Even on Linux/aarch64 (which would otherwise resolve to
+        aarch64-unknown-linux-gnu), Termux native must short-circuit to None
+        so the unsupported_platform path is taken in _install_tirith."""
+        from tools.tirith_security import _detect_target
+        with patch.dict(os.environ, {"PREFIX": "/data/data/com.termux/files/usr"}), \
+             patch("tools.tirith_security.platform.system", return_value="Linux"), \
+             patch("tools.tirith_security.platform.machine", return_value="aarch64"):
+            assert _detect_target() is None
+
+    def test_detect_target_returns_none_when_termux_reports_android(self):
+        """Some Python builds on Termux report platform.system() == 'Android'
+        instead of 'Linux'. The Termux PREFIX check must catch both."""
+        from tools.tirith_security import _detect_target
+        with patch.dict(os.environ, {"PREFIX": "/data/data/com.termux/files/usr"}), \
+             patch("tools.tirith_security.platform.system", return_value="Android"), \
+             patch("tools.tirith_security.platform.machine", return_value="aarch64"):
+            assert _detect_target() is None
+
+    def test_detect_target_proot_ubuntu_inside_termux_still_works(self):
+        """Inside a proot Ubuntu on Termux, PREFIX is rewritten away from
+        /data/data/com.termux/files/, so a real glibc is available and the
+        Linux-gnu binaries work normally. Must NOT return None."""
+        from tools.tirith_security import _detect_target
+        with patch.dict(os.environ, {"PREFIX": "/usr"}), \
+             patch("tools.tirith_security.platform.system", return_value="Linux"), \
+             patch("tools.tirith_security.platform.machine", return_value="aarch64"):
+            assert _detect_target() == "aarch64-unknown-linux-gnu"
+
+    def test_install_returns_termux_native_unsupported_reason(self):
+        """The install entrypoint must return a distinct failure reason on
+        Termux so the disk marker / log message can be specific. A generic
+        unsupported_platform tag would also be retried whenever a binary
+        appears, but Termux native NEVER works — keep the marker sticky."""
+        from tools.tirith_security import _install_tirith
+        with patch.dict(os.environ, {"PREFIX": "/data/data/com.termux/files/usr"}), \
+             patch("tools.tirith_security.platform.system", return_value="Linux"), \
+             patch("tools.tirith_security.platform.machine", return_value="aarch64"):
+            path, reason = _install_tirith()
+        assert path is None
+        assert reason == "termux_native_unsupported"
+
+
+# ---------------------------------------------------------------------------
 # HERMES_HOME isolation
 # ---------------------------------------------------------------------------
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -213,6 +213,19 @@ def _hermes_bin_dir() -> str:
     return d
 
 
+def _is_termux_native() -> bool:
+    """Detect a non-proot Termux environment on Android.
+
+    Termux sets PREFIX=/data/data/com.termux/files/usr and ships Bionic
+    libc with shared objects under that prefix — there is no glibc and
+    no /lib/ld-linux-*.so.* dynamic linker. Inside a proot Ubuntu (or
+    similar chroot) running on top of Termux, PREFIX is rewritten to
+    the chroot's /usr and a real glibc is available, so this check
+    returns False there.
+    """
+    return os.environ.get("PREFIX", "").startswith("/data/data/com.termux/files/")
+
+
 def _detect_target() -> str | None:
     """Return the Rust target triple for the current platform, or None.
 
@@ -223,7 +236,19 @@ def _detect_target() -> str | None:
     system = platform.system()
     machine = platform.machine().lower()
 
-    # Android (Termux) is ABI-compatible with Linux — reuse Linux binaries.
+    # Termux native (Bionic libc) is NOT ABI-compatible with the
+    # unknown-linux-gnu binaries — the prebuilt tirith ELF embeds
+    # /lib/ld-linux-aarch64.so.1 (or x86_64 equivalent) as its dynamic
+    # interpreter, which doesn't exist on Termux's filesystem. Spawning
+    # the binary then fails with ENOENT and a misleading message that
+    # points at the tirith path itself even though only the interpreter
+    # is missing. Skip auto-install and let the user run inside a proot
+    # Ubuntu chroot or set TIRITH_ENABLED=false.
+    if _is_termux_native():
+        return None
+
+    # Android Python outside Termux native (proot Ubuntu, Pydroid w/ glibc)
+    # is ABI-compatible with Linux — reuse Linux binaries.
     if system == "Darwin":
         plat = "apple-darwin"
     elif system in {"Linux", "Android"}:
@@ -364,6 +389,14 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
 
     target = _detect_target()
     if not target:
+        if _is_termux_native():
+            logger.info(
+                "tirith auto-install: Termux native (Bionic libc) is unsupported; "
+                "the linux-gnu binary's dynamic interpreter (/lib/ld-linux-*.so.*) "
+                "is not present on Termux. Run inside a proot Ubuntu chroot, "
+                "install tirith manually, or set TIRITH_ENABLED=false."
+            )
+            return None, "termux_native_unsupported"
         logger.info("tirith auto-install: unsupported platform %s/%s",
                      platform.system(), platform.machine())
         return None, "unsupported_platform"


### PR DESCRIPTION
## Summary
- Detect Termux native (`PREFIX=/data/data/com.termux/files/...`) in `_detect_target()` and short-circuit to `None` so the linux-gnu binaries — whose dynamic interpreter `/lib/ld-linux-*.so.*` doesn't exist on Termux's Bionic-libc filesystem — are never downloaded.
- Surface a distinct `termux_native_unsupported` reason from `_install_tirith()` plus an actionable INFO log pointing the user at proot Ubuntu or `TIRITH_ENABLED=false`.
- 7 focused regression tests covering true/false detection, the Termux/Android system-string variants, the proot-Ubuntu pass-through, and the install-side reason tag.

Fixes #26275.

## The bug
Issue #26275: hermes-agent on Termux for Android 26 (aarch64) emits

```
WARNING tools.tirith_security: tirith spawn failed: [Errno 2] No such file or directory: '/data/data/com.termux/files/home/.hermes/profiles/vira/bin/tirith'
```

— even though the binary file is present at the path. The reporter pinned this down via `file tirith`:

```
tirith: ELF 64-bit LSB pie executable, ARM aarch64, ... interpreter /lib/ld-linux-aarch64.so.1, ...
```

The kernel can't load `/lib/ld-linux-aarch64.so.1` (Termux has no `/lib` at all — its filesystem lives entirely under `/data/data/com.termux/files/usr/`), so it returns ENOENT for the interpreter, which Python surfaces as a `FileNotFoundError` whose path attribute is the *binary*'s path, not the *interpreter*'s. The error message is misleading; the binary is fine, the dynamic linker is missing.

The auto-installer downloaded that broken binary because commit [99af222ec](https://github.com/NousResearch/hermes-agent/commit/99af222ec) (`fix(tirith): detect Android/Termux as Linux ABI-compatible`) opted Android into the `unknown-linux-gnu` Rust target on the assumption that Bionic is ABI-compatible with glibc. It isn't, for any binary that's dynamically linked against glibc — the prebuilt tirith ELF embeds a glibc dynamic interpreter path that Termux can't satisfy.

## The fix
Narrow the `Linux`/`Android` branch in `_detect_target()` to skip Termux native, detected via `PREFIX=/data/data/com.termux/files/...` (Termux's canonical env var, set by every Termux session). Inside a proot Ubuntu chroot on top of Termux, `PREFIX` is rewritten to the chroot's `/usr` and a real glibc is available, so that path is unaffected — verified by `test_detect_target_proot_ubuntu_inside_termux_still_works`.

`_install_tirith()` returns a distinct `termux_native_unsupported` reason so the disk failure marker is specific (rather than the generic `unsupported_platform` tag), and emits an INFO log telling the user the actual cause and three workarounds:

```
tirith auto-install: Termux native (Bionic libc) is unsupported;
the linux-gnu binary's dynamic interpreter (/lib/ld-linux-*.so.*) is not
present on Termux. Run inside a proot Ubuntu chroot, install tirith
manually, or set TIRITH_ENABLED=false.
```

A `Conda`-style `PREFIX` (e.g. `/opt/conda/envs/dev`) would NOT match — the prefix-string check is anchored at `/data/data/com.termux/files/`, verified by `test_is_termux_native_false_for_unrelated_prefix`.

## Test plan
- [x] Focused regression tests: `tests/tools/test_tirith_security.py::TestTermuxNativeSkip` — 7/7 pass
- [x] Adjacent suite: `tests/tools/test_tirith_security.py` — 70/70 pass; `tests/tools/test_command_guards.py tests/tools/test_yolo_mode.py` — 38/38 pass
- [x] Regression guard: with `tools/tirith_security.py` reverted via `git stash`, `test_detect_target_returns_none_on_termux_native` fails with `AssertionError: assert 'aarch64-unknown-linux-gnu' is None`, demonstrating the exact bug path from the issue. Restored fix → passes.

## Related
- Fixes #26275
- Narrows commit [99af222ec](https://github.com/NousResearch/hermes-agent/commit/99af222ec) (`fix(tirith): detect Android/Termux as Linux ABI-compatible`) which incorrectly assumed Bionic + glibc are ABI-compatible for dynamically-linked binaries.