### PR TITLE
feat(teams): port #13767 Teams adapter w/ file support to the plugin system

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -803,6 +803,64 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     return str(filepath)
 
 
+async def cache_video_from_url(url: str, ext: str = ".mp4", retries: int = 2) -> str:
+    """
+    Download a video file from a URL and save it to the local cache.
+
+    Same pattern as cache_audio_from_url — retries on transient failures.
+
+    Args:
+        url: The HTTP/HTTPS URL to download from.
+        ext: File extension including the dot (e.g. ".mp4", ".mov").
+        retries: Number of retry attempts on transient failures.
+
+    Returns:
+        Absolute path to the cached video file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal network (SSRF protection).
+    """
+    from tools.url_safety import is_safe_url
+    if not is_safe_url(url):
+        raise ValueError(f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}")
+
+    import httpx
+    _log = logging.getLogger(__name__)
+
+    async with httpx.AsyncClient(
+        timeout=60.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
+        for attempt in range(retries + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                        "Accept": "video/*,*/*;q=0.8",
+                    },
+                )
+                response.raise_for_status()
+                return cache_video_from_bytes(response.content, ext)
+            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                    raise
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "Video cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+
+
 # ---------------------------------------------------------------------------
 # Document cache utilities
 #
@@ -1952,6 +2010,14 @@ class BasePlatformAdapter(ABC):
         - <img src="https://example.com/image.png">
         - <img src="https://example.com/image.png"></img>
         
+        Both the markdown and HTML branches require the URL to either end in a
+        known image extension (.png/.jpg/.jpeg/.gif/.webp) or contain a known
+        image-CDN host fragment. Without that guard, the bot can boomerang any
+        ``<img>`` tag it merely *quotes* in prose (e.g. an inbound Teams AMS
+        URL or a teaching-example placeholder like ``<img src="https://...">``)
+        as a real outbound attachment, which the destination platform can't
+        authenticate and renders as a broken-image icon.
+        
         Args:
             content: The response text to scan.
         
@@ -1961,21 +2027,38 @@ class BasePlatformAdapter(ABC):
         images = []
         cleaned = content
         
+        def _looks_like_image_url(url: str) -> bool:
+            """Allowlist check shared by markdown and HTML branches.
+
+            A URL is treated as an image only if it has a recognized image
+            extension in its path (matched before any query string) or its
+            host/path contains a known image-CDN fragment.
+            """
+            lower = url.lower().split("?", 1)[0].split("#", 1)[0]
+            image_exts = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+            if lower.endswith(image_exts):
+                return True
+            cdn_fragments = ("fal.media", "fal-cdn", "replicate.delivery")
+            url_lower = url.lower()
+            return any(fragment in url_lower for fragment in cdn_fragments)
+        
         # Match markdown images: ![alt](url)
         md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
         for match in re.finditer(md_pattern, content):
             alt_text = match.group(1)
             url = match.group(2)
             # Only extract URLs that look like actual images
-            if any(url.lower().endswith(ext) or ext in url.lower() for ext in
-                   ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
+            if _looks_like_image_url(url):
                 images.append((url, alt_text))
         
         # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
         html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
         for match in re.finditer(html_pattern, content):
             url = match.group(1)
-            images.append((url, ""))
+            # Apply the same allowlist as the markdown branch so we don't peel
+            # quoted/example <img> tags and ship them as broken attachments.
+            if _looks_like_image_url(url):
+                images.append((url, ""))
         
         # Remove only the matched image tags from content (not all markdown images)
         if images:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1963,6 +1963,14 @@ class GatewayRunner:
                 await adapter.disconnect()
             finally:
                 self.adapters.pop(adapter.platform, None)
+                # Drop from the running-adapter registry too so a stale
+                # closed instance isn't left pointing at a dead
+                # connection. See tools/_running_adapters.py.
+                try:
+                    from tools._running_adapters import clear_running_adapter
+                    clear_running_adapter(adapter.platform.value)
+                except Exception:  # pragma: no cover
+                    logger.exception("Failed to clear %s from running-adapter registry", adapter.platform.value)
                 self.delivery_router.adapters = self.adapters
 
         # Queue retryable failures for background reconnection
@@ -3521,6 +3529,20 @@ class GatewayRunner:
                 success = await self._connect_adapter_with_timeout(adapter, platform)
                 if success:
                     self.adapters[platform] = adapter
+                    # Publish to the module-level running-adapter registry
+                    # so outbound code paths in webhook-receive platforms
+                    # (Teams Bot Framework, future Webex/Zoom/Google Chat)
+                    # can reach the *live* instance — not a fresh one.
+                    # Stateless REST adapters don't strictly need this but
+                    # registering them anyway keeps the API uniform and
+                    # opens the door to "send via running adapter" patterns
+                    # for any future use case. See
+                    # tools/_running_adapters.py for the rationale.
+                    try:
+                        from tools._running_adapters import set_running_adapter
+                        set_running_adapter(platform.value, adapter)
+                    except Exception:  # pragma: no cover — registry must never block connect
+                        logger.exception("Failed to publish %s to running-adapter registry", platform.value)
                     self._sync_voice_mode_state_to_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
@@ -4793,6 +4815,14 @@ class GatewayRunner:
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
                         self.adapters[platform] = adapter
+                        # Mirror the connect-time registry publish so the
+                        # reconnect path keeps the running-adapter registry
+                        # in sync. See tools/_running_adapters.py.
+                        try:
+                            from tools._running_adapters import set_running_adapter
+                            set_running_adapter(platform.value, adapter)
+                        except Exception:  # pragma: no cover
+                            logger.exception("Failed to publish %s to running-adapter registry", platform.value)
                         self._sync_voice_mode_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,6 +27,9 @@ import html
 import json
 import logging
 import os
+import re
+import time
+from collections import OrderedDict
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
@@ -53,6 +56,8 @@ try:
     from microsoft_teams.api import MessageActivity, ConversationReference
     from microsoft_teams.api.activities.typing import TypingActivityInput
     from microsoft_teams.api.activities.invoke.adaptive_card import AdaptiveCardInvokeActivity
+    from microsoft_teams.api.activities.invoke.file_consent import FileConsentInvokeActivity
+    from microsoft_teams.api.models import FileUploadInfo
     from microsoft_teams.api.models.adaptive_card import (
         AdaptiveCardActionCardResponse,
         AdaptiveCardActionMessageResponse,
@@ -76,6 +81,8 @@ except ImportError:
     ConversationReference = None  # type: ignore[assignment,misc]
     TypingActivityInput = None  # type: ignore[assignment,misc]
     AdaptiveCardInvokeActivity = None  # type: ignore[assignment,misc]
+    FileConsentInvokeActivity = None  # type: ignore[assignment,misc]
+    FileUploadInfo = None  # type: ignore[assignment,misc]
     AdaptiveCardActionCardResponse = None  # type: ignore[assignment,misc]
     AdaptiveCardActionMessageResponse = None  # type: ignore[assignment,misc]
     AdaptiveCardInvokeResponse = None  # type: ignore[assignment,misc,union-attr]
@@ -95,7 +102,11 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    SUPPORTED_DOCUMENT_TYPES,
+    cache_audio_from_url,
+    cache_document_from_bytes,
     cache_image_from_url,
+    cache_video_from_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -384,8 +395,66 @@ class _AiohttpBridgeAdapter:
 
 
 def check_requirements() -> bool:
-    """Return True when all Teams dependencies and credentials are present."""
-    return TEAMS_SDK_AVAILABLE and AIOHTTP_AVAILABLE
+    """Return True when all Teams dependencies and credentials are present.
+
+    Lazy-installs microsoft-teams-apps via ``tools.lazy_deps.ensure("platform.teams")``
+    on first call if not present, following the same pattern as check_slack_requirements().
+    """
+    global TEAMS_SDK_AVAILABLE, AIOHTTP_AVAILABLE, web
+    global App, ActivityContext, ClientOptions, MessageActivity, ConversationReference
+    global TypingActivityInput, AdaptiveCardInvokeActivity
+    global FileConsentInvokeActivity, FileUploadInfo
+    global AdaptiveCardActionCardResponse, AdaptiveCardActionMessageResponse
+    global InvokeResponse, AdaptiveCardInvokeResponse
+    global HttpMethod, HttpRequest, HttpResponse, HttpRouteHandler
+    global AdaptiveCard, ExecuteAction, TextBlock
+
+    if TEAMS_SDK_AVAILABLE and AIOHTTP_AVAILABLE:
+        return True
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("platform.teams", prompt=False)
+    except Exception:
+        return False
+    try:
+        from aiohttp import web as _web
+        from microsoft_teams.apps import App as _App, ActivityContext as _ActivityContext
+        from microsoft_teams.common.http.client import ClientOptions as _ClientOptions
+        from microsoft_teams.api import MessageActivity as _MessageActivity, ConversationReference as _ConversationReference
+        from microsoft_teams.api.activities.typing import TypingActivityInput as _TypingActivityInput
+        from microsoft_teams.api.activities.invoke.adaptive_card import AdaptiveCardInvokeActivity as _AdaptiveCardInvokeActivity
+        from microsoft_teams.api.activities.invoke.file_consent import FileConsentInvokeActivity as _FileConsentInvokeActivity
+        from microsoft_teams.api.models import FileUploadInfo as _FileUploadInfo
+        from microsoft_teams.api.models.adaptive_card import (
+            AdaptiveCardActionCardResponse as _AdaptiveCardActionCardResponse,
+            AdaptiveCardActionMessageResponse as _AdaptiveCardActionMessageResponse,
+        )
+        from microsoft_teams.api.models.invoke_response import InvokeResponse as _InvokeResponse, AdaptiveCardInvokeResponse as _AdaptiveCardInvokeResponse
+        from microsoft_teams.apps.http.adapter import (
+            HttpMethod as _HttpMethod,
+            HttpRequest as _HttpRequest,
+            HttpResponse as _HttpResponse,
+            HttpRouteHandler as _HttpRouteHandler,
+        )
+        from microsoft_teams.cards import AdaptiveCard as _AdaptiveCard, ExecuteAction as _ExecuteAction, TextBlock as _TextBlock
+    except ImportError:
+        return False
+    web = _web
+    App, ActivityContext, ClientOptions = _App, _ActivityContext, _ClientOptions
+    MessageActivity, ConversationReference = _MessageActivity, _ConversationReference
+    TypingActivityInput = _TypingActivityInput
+    AdaptiveCardInvokeActivity = _AdaptiveCardInvokeActivity
+    FileConsentInvokeActivity = _FileConsentInvokeActivity
+    FileUploadInfo = _FileUploadInfo
+    AdaptiveCardActionCardResponse = _AdaptiveCardActionCardResponse
+    AdaptiveCardActionMessageResponse = _AdaptiveCardActionMessageResponse
+    InvokeResponse, AdaptiveCardInvokeResponse = _InvokeResponse, _AdaptiveCardInvokeResponse
+    HttpMethod, HttpRequest = _HttpMethod, _HttpRequest
+    HttpResponse, HttpRouteHandler = _HttpResponse, _HttpRouteHandler
+    AdaptiveCard, ExecuteAction, TextBlock = _AdaptiveCard, _ExecuteAction, _TextBlock
+    AIOHTTP_AVAILABLE = True
+    TEAMS_SDK_AVAILABLE = True
+    return True
 
 
 def validate_config(config) -> bool:
@@ -612,10 +681,173 @@ async def _standalone_send(
 check_teams_requirements = check_requirements
 
 
+_HOSTED_CONTENT_RE = re.compile(
+    r"/hostedContents/([^/?#]+)(?:/\$value)?(?:[?#]|$)",
+    re.IGNORECASE,
+)
+
+
+# Bot Framework hosts that require an Authorization: Bearer header on GETs.
+# When an inbound activity references a content_url under one of these hosts
+# (typical shape: https://smba.trafficmanager.net/<region>/<tenant>/v3/
+# attachments/<id>/views/original) the shared cache_*_from_url helpers will
+# 401 because they don't carry per-platform auth. We fetch the bytes here
+# instead, using the SDK-managed bot token, then route to cache_*_from_bytes.
+_BF_ATTACHMENT_HOSTS = {"smba.trafficmanager.net"}
+
+
+def _is_bf_attachment_url(url: Optional[str]) -> bool:
+    """True if ``url`` points at a Bot Framework attachment endpoint that
+    needs a Bearer token."""
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        from urllib.parse import urlparse
+
+        host = (urlparse(url).hostname or "").lower()
+    except Exception:
+        return False
+    return host in _BF_ATTACHMENT_HOSTS
+
+
+# Magic-byte prefixes used when a Teams attachment arrives with a wildcard
+# or missing MIME subtype (e.g. ``image/*`` from inline-pasted images). The
+# subtype must never be passed straight through into a cache filename or it
+# leaks as a literal ``.*`` extension and breaks downstream tooling that
+# resolves files by extension.
+_IMAGE_DEFAULT_EXT = ".jpg"
+_AUDIO_DEFAULT_EXT = ".ogg"
+_VIDEO_DEFAULT_EXT = ".mp4"
+
+
+def _sniff_image_ext(data: bytes) -> Optional[str]:
+    if not data:
+        return None
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return ".png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return ".jpg"
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return ".gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    if data.startswith(b"BM"):
+        return ".bmp"
+    return None
+
+
+def _sniff_audio_ext(data: bytes) -> Optional[str]:
+    if not data:
+        return None
+    if data.startswith(b"OggS"):
+        return ".ogg"
+    if data.startswith(b"ID3") or data.startswith(b"\xff\xfb") or data.startswith(b"\xff\xf3") or data.startswith(b"\xff\xf2"):
+        return ".mp3"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return ".wav"
+    if data.startswith(b"fLaC"):
+        return ".flac"
+    # ISO BMFF (m4a/aac in mp4 container) — ftyp box at offset 4
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in (b"M4A ", b"M4B ", b"mp42", b"isom"):
+            return ".m4a"
+    return None
+
+
+def _sniff_video_ext(data: bytes) -> Optional[str]:
+    if not data:
+        return None
+    # ISO BMFF — common brands for mp4/mov
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand.startswith(b"qt"):
+            return ".mov"
+        # isom / mp42 / iso2 / dash / etc. all map to .mp4 for our purposes
+        return ".mp4"
+    # WebM / Matroska EBML header
+    if data.startswith(b"\x1aE\xdf\xa3"):
+        return ".webm"
+    # AVI
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"AVI ":
+        return ".avi"
+    return None
+
+
+def _resolve_media_ext(subtype: str, data: bytes, kind: str) -> str:
+    """Resolve a safe file extension for a Teams media attachment.
+
+    Teams sometimes posts attachments with ``content_type="image/*"`` (literal
+    asterisk wildcard) — particularly inline-pasted images. Splitting that on
+    ``"/"`` would yield ``"*"`` and produce a cache filename with a literal
+    ``.*`` extension, breaking every downstream consumer that opens files by
+    extension. Instead, when the subtype is missing, ``"*"``, or otherwise
+    meaningless, sniff the bytes via magic numbers and fall back to a sane
+    per-kind default.
+
+    Args:
+        subtype: The MIME subtype (already lowercased; e.g. ``"png"``,
+            ``"jpeg"``, ``"*"``, or ``""``).
+        data: The fetched bytes (may be empty if the fetch failed).
+        kind: ``"image"``, ``"audio"``, or ``"video"``.
+
+    Returns:
+        Extension including the leading dot, e.g. ``".png"``. Never returns
+        ``".*"`` or an empty string.
+    """
+    sub = (subtype or "").strip().lower()
+    # Strip any codec params left in the subtype (defence against caller bugs)
+    sub = sub.split(";", 1)[0].strip()
+
+    # jpeg → jpg normalisation, regardless of source
+    if sub == "jpeg":
+        return ".jpg"
+
+    # Explicit, non-wildcard subtype: trust it. Codec/container variants are
+    # too broad to whitelist and the caller already validated the kind via
+    # the ``image/`` / ``audio/`` / ``video/`` prefix.
+    if sub and sub != "*":
+        return "." + sub
+
+    # Wildcard or empty — sniff bytes.
+    if kind == "image":
+        sniffed = _sniff_image_ext(data)
+        return sniffed or _IMAGE_DEFAULT_EXT
+    if kind == "audio":
+        sniffed = _sniff_audio_ext(data)
+        return sniffed or _AUDIO_DEFAULT_EXT
+    if kind == "video":
+        sniffed = _sniff_video_ext(data)
+        return sniffed or _VIDEO_DEFAULT_EXT
+    return _IMAGE_DEFAULT_EXT
+
+
+def _parse_hosted_content_id(url: str) -> Optional[str]:
+    """Extract the hostedContents/{id} fragment from a Teams URL.
+
+    Returns the opaque id that Graph's
+    /teams/{team}/channels/{channel}/messages/{msg}/hostedContents/{id}
+    endpoint expects, or None when the URL isn't shaped that way
+    (e.g. a SharePoint file-upload URL — those have no Graph fallback).
+    """
+    if not url:
+        return None
+    match = _HOSTED_CONTENT_RE.search(url)
+    return match.group(1) if match else None
+
+
 class TeamsAdapter(BasePlatformAdapter):
     """Microsoft Teams adapter using the microsoft-teams-apps SDK."""
 
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
+
+    # Bound _pending_uploads memory: drop oldest beyond this many entries
+    # and sweep entries older than the TTL on every DM send. Without
+    # this, a long-running gateway holding many users' un-consented DM
+    # file sends grows unboundedly in RAM (especially when users send
+    # videos but never click Allow / Decline).
+    _PENDING_UPLOAD_MAX = 64
+    _PENDING_UPLOAD_TTL_SECONDS = 3600  # 1 hour
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("teams"))
@@ -626,10 +858,39 @@ class TeamsAdapter(BasePlatformAdapter):
         self._port = int(extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT)))
         self._app: Optional["App"] = None
         self._runner: Optional["web.AppRunner"] = None
+        # Captured in connect() so tools/send_message_tool._send_teams can
+        # bridge cross-loop calls back to the gateway loop the SDK App was
+        # built on. Stays None until connect() succeeds; cleared on
+        # disconnect(). See _send_teams' "Cross-loop bridge" docstring.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._dedup = MessageDeduplicator(max_size=1000)
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+
+        # SharePoint target for outbound channel/group file uploads.
+        # Defaults: site_id="" disables channel uploads; folder defaults to
+        # "hermes" so DM-only deployments without SharePoint config still
+        # construct cleanly (channel sends will return a clean error).
+        self._sharepoint_site_id: str = (
+            extra.get("sharepoint_site_id")
+            or os.getenv("TEAMS_SHAREPOINT_SITE_ID", "")
+        )
+        self._sharepoint_folder: str = (
+            extra.get("sharepoint_folder")
+            or os.getenv("TEAMS_SHAREPOINT_FOLDER", "hermes")
+        )
+        # Files awaiting FileConsent acceptance from a DM user — the
+        # fileConsent/invoke handler drains this dict; the DM send path
+        # primes it. Keyed by the upload_id seeded into the FileConsent
+        # acceptContext.
+        # OrderedDict + size cap + TTL bound memory; see
+        # _register_pending_upload / _evict_stale_pending_uploads.
+        self._pending_uploads: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        # Lazy Graph client + token provider; built on first channel send
+        # so DM-only deployments don't pay the msgraph-sdk import cost.
+        self._graph: Any = None
+        self._token_provider: Any = None
 
     async def connect(self) -> bool:
         if not TEAMS_SDK_AVAILABLE:
@@ -680,6 +941,12 @@ class TeamsAdapter(BasePlatformAdapter):
             ) -> InvokeResponse[AdaptiveCardActionMessageResponse]:
                 return await self._on_card_action(ctx)
 
+            @self._app.on_file_consent
+            async def _handle_file_consent(
+                ctx: ActivityContext[FileConsentInvokeActivity],
+            ) -> Optional[InvokeResponse[None]]:
+                return await self._handle_file_consent_invoke(ctx)
+
             # initialize() calls register_route() on the bridge, which adds
             # POST /api/messages to aiohttp_app automatically
             await self._app.initialize()
@@ -690,6 +957,12 @@ class TeamsAdapter(BasePlatformAdapter):
             await site.start()
 
             self._running = True
+            # Capture the gateway loop so cross-loop callers (e.g.
+            # tools/send_message_tool._send_teams invoked from the agent's
+            # worker loop) can hop here via run_coroutine_threadsafe. Done
+            # last — only after _app + aiohttp are fully wired so a partial
+            # init never publishes a half-baked loop.
+            self._loop = asyncio.get_running_loop()
             self._mark_connected()
             logger.info(
                 "[teams] Webhook server listening on 0.0.0.0:%d%s",
@@ -713,8 +986,58 @@ class TeamsAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        # Clear the captured loop reference so a stale send_message tool
+        # call doesn't try to hop to a loop that's about to close.
+        self._loop = None
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
+
+    async def _fetch_bf_attachment_bytes(self, url: str) -> Optional[bytes]:
+        """GET a Bot Framework attachment URL with an SDK-minted bearer token.
+
+        BF attachment endpoints (``smba.trafficmanager.net/.../v3/attachments/
+        .../views/original``) reject anonymous GETs with 401. The SDK already
+        manages an MSAL-cached bot token via ``self._app._get_bot_token``;
+        we stringify that token (``JsonWebToken.__str__`` returns the raw JWT)
+        and attach it as ``Authorization: Bearer <jwt>``.
+
+        Returns the response body on 2xx, or ``None`` on any failure (no
+        token, non-200, network error). Logs at WARNING for diagnosable
+        failures so the same ``[teams][attach]`` log breadcrumbs the rest
+        of the attachment loop emits remain greppable.
+        """
+        if not url:
+            return None
+        if self._app is None:
+            logger.warning("[teams][attach] BF fetch skipped — no SDK app available")
+            return None
+        try:
+            token = await self._app._get_bot_token()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[teams][attach] BF token fetch failed: %s", exc)
+            return None
+        if token is None:
+            logger.warning("[teams][attach] BF token fetch returned None")
+            return None
+        bearer = str(token)
+        headers = {"Authorization": f"Bearer {bearer}"}
+
+        try:
+            import aiohttp as _aiohttp
+
+            timeout = _aiohttp.ClientTimeout(total=60)
+            async with _aiohttp.ClientSession(timeout=timeout) as sess:
+                async with sess.get(url, headers=headers) as resp:
+                    if resp.status != 200:
+                        logger.warning(
+                            "[teams][attach] BF GET %s -> status=%s",
+                            url, resp.status,
+                        )
+                        return None
+                    return await resp.read()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[teams][attach] BF GET %s raised: %s", url, exc)
+            return None
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""
@@ -770,22 +1093,325 @@ class TeamsAdapter(BasePlatformAdapter):
             guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
         )
 
-        # Handle image attachments
+        # Handle inbound attachments — images, audio, video, and documents.
+        #
+        # Teams delivers attachments in two shapes:
+        #   1. ``content_type: "image/<sub>"`` (or "audio/...", "video/...") with
+        #      a Bot Framework URL in ``content_url``. These can be cached
+        #      directly from the URL.
+        #   2. ``content_type: "application/vnd.microsoft.teams.file.download.info"``
+        #      — file uploads from the Teams web/desktop client. The real
+        #      filename and download URL live in ``content`` (a SharePoint
+        #      tempauth URL — Authorization header MUST be omitted on the GET
+        #      or it returns 401). We fetch the bytes ourselves and route to
+        #      the appropriate cache_* helper based on file extension.
         media_urls = []
         media_types = []
-        for att in getattr(activity, "attachments", None) or []:
-            content_url = getattr(att, "content_url", None)
-            content_type = getattr(att, "content_type", None) or ""
-            if content_url and content_type.startswith("image/"):
-                try:
+        msg_type_override: Optional[MessageType] = None  # set by first non-image/non-text attachment
+        _IMAGE_EXTS = {"png", "jpg", "jpeg", "gif", "webp"}
+        _AUDIO_EXTS = {"mp3", "ogg", "wav", "m4a", "aac", "flac"}
+        _VIDEO_EXTS = {"mp4", "mov", "webm", "mkv", "avi"}
+        _DOC_EXT_TO_MIME = {
+            ext.lstrip("."): mime for ext, mime in SUPPORTED_DOCUMENT_TYPES.items()
+        }
+
+        attachments = getattr(activity, "attachments", None) or []
+        logger.info("[teams][attach] received %d attachment(s)", len(attachments))
+
+        # Context for Graph hostedContents fallback. Channel attachments
+        # (not DM uploads) carry team_id + channel_id under channel_data;
+        # without all three of (team, channel, activity_id) the fallback
+        # cannot address the blob and we just take the direct-failure path.
+        channel_data = getattr(activity, "channel_data", None) or {}
+        graph_team_id: Optional[str] = None
+        graph_channel_id: Optional[str] = None
+        graph_activity_id: str = str(getattr(activity, "id", "") or "")
+        if isinstance(channel_data, dict):
+            team_block = channel_data.get("team") or {}
+            channel_block = channel_data.get("channel") or {}
+            graph_team_id = team_block.get("id")
+            graph_channel_id = channel_block.get("id")
+
+        for idx, att in enumerate(attachments):
+            content_url = getattr(att, "content_url", None) or getattr(att, "contentUrl", None)
+            content_type = (getattr(att, "content_type", None) or getattr(att, "contentType", None) or "").lower()
+            att_name = getattr(att, "name", None)
+            logger.info(
+                "[teams][attach][%d] content_type=%r name=%r content_url=%r has_content=%s",
+                idx, content_type, att_name, content_url, getattr(att, "content", None) is not None,
+            )
+
+            try:
+                # ── Shape 1: classic content_url with image/audio/video MIME ─
+                if content_url and content_type.startswith("image/"):
+                    if _is_bf_attachment_url(content_url):
+                        logger.info("[teams][attach][%d] dispatch=image_bf_url", idx)
+                        data = await self._fetch_bf_attachment_bytes(content_url)
+                        cached = None
+                        if data is not None:
+                            from gateway.platforms.base import cache_image_from_bytes
+                            sub = content_type.split("/", 1)[1].split(";")[0].strip()
+                            ext = _resolve_media_ext(sub, data, "image")
+                            try:
+                                cached = cache_image_from_bytes(data, ext=ext)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.exception(
+                                    "[teams][attach][%d] cache_image_from_bytes failed: %s",
+                                    idx, exc,
+                                )
+                                cached = None
+                            logger.info("[teams][attach][%d] cache_image_from_bytes -> %r", idx, cached)
+                        if cached is None:
+                            cached = await self._try_graph_hosted_fallback(
+                                idx=idx,
+                                url=content_url,
+                                team_id=graph_team_id,
+                                channel_id=graph_channel_id,
+                                activity_id=graph_activity_id,
+                                kind="image",
+                                ext=".jpg",
+                                filename=att_name,
+                            )
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                        continue
+                    logger.info("[teams][attach][%d] dispatch=image_url", idx)
                     cached = await cache_image_from_url(content_url)
+                    logger.info("[teams][attach][%d] cache_image_from_url -> %r", idx, cached)
+                    if cached is None:
+                        cached = await self._try_graph_hosted_fallback(
+                            idx=idx,
+                            url=content_url,
+                            team_id=graph_team_id,
+                            channel_id=graph_channel_id,
+                            activity_id=graph_activity_id,
+                            kind="image",
+                            ext=".jpg",  # default — most hosted contents are jpegs
+                            filename=att_name,
+                        )
                     if cached:
                         media_urls.append(cached)
                         media_types.append(content_type)
-                except Exception as e:
-                    logger.warning("[teams] Failed to cache image attachment: %s", e)
+                    continue
+                if content_url and content_type.startswith("audio/"):
+                    sub = content_type.split("/", 1)[1].split(";")[0].strip()
+                    if _is_bf_attachment_url(content_url):
+                        logger.info("[teams][attach][%d] dispatch=audio_bf_url subtype=%s", idx, sub or "*")
+                        data = await self._fetch_bf_attachment_bytes(content_url)
+                        cached = None
+                        if data is not None:
+                            from gateway.platforms.base import cache_audio_from_bytes
+                            ext = _resolve_media_ext(sub, data, "audio")
+                            try:
+                                cached = cache_audio_from_bytes(data, ext=ext)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.exception(
+                                    "[teams][attach][%d] cache_audio_from_bytes failed: %s",
+                                    idx, exc,
+                                )
+                                cached = None
+                            logger.info("[teams][attach][%d] cache_audio_from_bytes -> %r (ext=%s)", idx, cached, ext)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            msg_type_override = msg_type_override or MessageType.VOICE
+                        continue
+                    ext = _resolve_media_ext(sub, b"", "audio")
+                    logger.info("[teams][attach][%d] dispatch=audio_url ext=%s", idx, ext)
+                    cached = await cache_audio_from_url(content_url, ext=ext)
+                    logger.info("[teams][attach][%d] cache_audio_from_url -> %r", idx, cached)
+                    if cached:
+                        media_urls.append(cached)
+                        media_types.append(content_type)
+                        msg_type_override = msg_type_override or MessageType.VOICE
+                    continue
+                if content_url and content_type.startswith("video/"):
+                    sub = content_type.split("/", 1)[1].split(";")[0].strip()
+                    if _is_bf_attachment_url(content_url):
+                        logger.info("[teams][attach][%d] dispatch=video_bf_url subtype=%s", idx, sub or "*")
+                        data = await self._fetch_bf_attachment_bytes(content_url)
+                        cached = None
+                        if data is not None:
+                            from gateway.platforms.base import cache_video_from_bytes
+                            ext = _resolve_media_ext(sub, data, "video")
+                            try:
+                                cached = cache_video_from_bytes(data, ext=ext)
+                            except Exception as exc:  # noqa: BLE001
+                                logger.exception(
+                                    "[teams][attach][%d] cache_video_from_bytes failed: %s",
+                                    idx, exc,
+                                )
+                                cached = None
+                            logger.info("[teams][attach][%d] cache_video_from_bytes -> %r (ext=%s)", idx, cached, ext)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            msg_type_override = msg_type_override or MessageType.VIDEO
+                        continue
+                    ext = _resolve_media_ext(sub, b"", "video")
+                    logger.info("[teams][attach][%d] dispatch=video_url ext=%s", idx, ext)
+                    cached = await cache_video_from_url(content_url, ext=ext)
+                    logger.info("[teams][attach][%d] cache_video_from_url -> %r", idx, cached)
+                    if cached:
+                        media_urls.append(cached)
+                        media_types.append(content_type)
+                        msg_type_override = msg_type_override or MessageType.VIDEO
+                    continue
 
-        msg_type = MessageType.PHOTO if media_urls else MessageType.TEXT
+                # ── Shape 2: file.download.info ─────────────────────────────
+                if content_type == "application/vnd.microsoft.teams.file.download.info":
+                    logger.info("[teams][attach][%d] dispatch=file.download.info", idx)
+                    content_block = getattr(att, "content", None) or {}
+                    # Bot Framework SDK delivers `content` as either a dict or
+                    # a typed object — handle both.
+                    def _field(obj, *names):
+                        for n in names:
+                            if isinstance(obj, dict):
+                                v = obj.get(n)
+                            else:
+                                v = getattr(obj, n, None)
+                            if v is not None:
+                                return v
+                        return None
+
+                    file_type = str(_field(content_block, "file_type", "fileType") or "").lower().lstrip(".")
+                    download_url = str(_field(content_block, "download_url", "downloadUrl") or "")
+                    filename = str(getattr(att, "name", None) or "").strip() or f"attachment.{file_type or 'bin'}"
+                    logger.info(
+                        "[teams][attach][%d] file.download.info parsed: filename=%r file_type=%r download_url=%r",
+                        idx, filename, file_type, download_url,
+                    )
+
+                    if not download_url or not file_type:
+                        logger.info(
+                            "[teams][attach][%d] DROP missing fields (name=%r, file_type=%r, has_url=%s)",
+                            idx, filename, file_type, bool(download_url),
+                        )
+                        continue
+
+                    # SharePoint tempauth URLs reject the Authorization header — fetch raw.
+                    import aiohttp as _aiohttp
+                    timeout = _aiohttp.ClientTimeout(total=60)
+                    async with _aiohttp.ClientSession(timeout=timeout) as sess:
+                        async with sess.get(download_url) as resp:
+                            logger.info(
+                                "[teams][attach][%d] tempauth GET %s -> status=%s",
+                                idx, filename, resp.status,
+                            )
+                            if resp.status != 200:
+                                logger.warning(
+                                    "[teams][attach][%d] tempauth GET %s returned %s — trying Graph fallback",
+                                    idx, filename, resp.status,
+                                )
+                                data = await self._try_graph_hosted_bytes(
+                                    url=download_url,
+                                    team_id=graph_team_id,
+                                    channel_id=graph_channel_id,
+                                    activity_id=graph_activity_id,
+                                )
+                                if data is None:
+                                    logger.warning(
+                                        "[teams][attach][%d] Graph fallback also failed for %s",
+                                        idx, filename,
+                                    )
+                                    continue
+                            else:
+                                data = await resp.read()
+                    logger.info("[teams][attach][%d] tempauth body len=%d bytes", idx, len(data))
+
+                    if file_type in _IMAGE_EXTS:
+                        logger.info("[teams][attach][%d] dispatch=image_bytes ext=%s", idx, file_type)
+                        # Treat as image — no _from_url helper needed since we have bytes.
+                        from gateway.platforms.base import cache_image_from_bytes
+                        cached = cache_image_from_bytes(data, ext="." + file_type)
+                        logger.info("[teams][attach][%d] cache_image_from_bytes -> %r", idx, cached)
+                        media_urls.append(cached)
+                        media_types.append(f"image/{file_type if file_type != 'jpg' else 'jpeg'}")
+                    elif file_type in _AUDIO_EXTS:
+                        logger.info("[teams][attach][%d] dispatch=audio_bytes ext=%s", idx, file_type)
+                        from gateway.platforms.base import cache_audio_from_bytes
+                        cached = cache_audio_from_bytes(data, ext="." + file_type)
+                        logger.info("[teams][attach][%d] cache_audio_from_bytes -> %r", idx, cached)
+                        media_urls.append(cached)
+                        media_types.append(f"audio/{file_type}")
+                        msg_type_override = msg_type_override or MessageType.VOICE
+                    elif file_type in _VIDEO_EXTS:
+                        logger.info("[teams][attach][%d] dispatch=video_bytes ext=%s", idx, file_type)
+                        from gateway.platforms.base import cache_video_from_bytes
+                        cached = cache_video_from_bytes(data, ext="." + file_type)
+                        logger.info("[teams][attach][%d] cache_video_from_bytes -> %r", idx, cached)
+                        media_urls.append(cached)
+                        media_types.append(f"video/{file_type}")
+                        msg_type_override = msg_type_override or MessageType.VIDEO
+                    elif file_type in _DOC_EXT_TO_MIME:
+                        logger.info("[teams][attach][%d] dispatch=document_bytes ext=%s mime=%s", idx, file_type, _DOC_EXT_TO_MIME[file_type])
+                        cached = cache_document_from_bytes(data, filename)
+                        logger.info("[teams][attach][%d] cache_document_from_bytes -> %r", idx, cached)
+                        media_urls.append(cached)
+                        media_types.append(_DOC_EXT_TO_MIME[file_type])
+                        msg_type_override = msg_type_override or MessageType.DOCUMENT
+                    else:
+                        logger.info(
+                            "[teams][attach][%d] DROP unsupported file_type (file_type=%r, name=%r)",
+                            idx, file_type, filename,
+                        )
+                    continue
+
+                # ── Fell through every branch ────────────────────────────────
+                # FORENSICS: dump the full content payload for text/html and
+                # other dropped attachments so we can see whether Teams is
+                # shipping inline <img src=".../hostedContents/.../$value">
+                # references in there. DEBUG-level so it's off in production
+                # but available when troubleshooting the channel-message inline
+                # image flow (PR #2's Graph hostedContents fallback path).
+                # Truncate to 8KB to keep logs sane.
+                if content_type == "text/html":
+                    raw_content = getattr(att, "content", None)
+                    if isinstance(raw_content, str):
+                        html_text = raw_content
+                    elif isinstance(raw_content, dict):
+                        html_text = raw_content.get("text") or raw_content.get("html") or repr(raw_content)
+                    else:
+                        html_text = repr(raw_content)
+                    snippet = html_text[:8192]
+                    truncated = "...[truncated]" if len(html_text) > 8192 else ""
+                    # Pull out any hostedContents URLs explicitly so they're greppable
+                    import re as _re
+                    hc_urls = _re.findall(
+                        r"https?://[^\"'\s>]*?hostedContents/[^\"'\s>]+",
+                        html_text,
+                    )
+                    logger.debug(
+                        "[teams][attach][%d] dropped html payload (%d chars, %d hostedContents refs): %s%s",
+                        idx, len(html_text), len(hc_urls), snippet, truncated,
+                    )
+                    for hc_idx, hc_url in enumerate(hc_urls):
+                        logger.debug(
+                            "[teams][attach][%d] dropped hostedContents[%d]: %s",
+                            idx, hc_idx, hc_url,
+                        )
+                logger.info(
+                    "[teams][attach][%d] DROP unhandled (content_type=%r, has_url=%s)",
+                    idx, content_type, bool(content_url),
+                )
+            except Exception as e:
+                logger.warning("[teams][attach][%d] EXCEPTION (content_type=%s): %s", idx, content_type, e)
+
+        logger.info(
+            "[teams][attach] done: %d cached, types=%r, msg_override=%r",
+            len(media_urls), media_types, msg_type_override,
+        )
+
+        # Image always wins over other media for downstream classification —
+        # the vision pipeline is the most useful interpretation when the user
+        # sent both an image and (e.g.) a document in the same message.
+        if any(t.startswith("image/") for t in media_types):
+            msg_type = MessageType.PHOTO
+        elif msg_type_override is not None:
+            msg_type = msg_type_override
+        else:
+            msg_type = MessageType.TEXT
 
         event = MessageEvent(
             text=text,
@@ -1066,6 +1692,606 @@ class TeamsAdapter(BasePlatformAdapter):
             caption=caption,
             reply_to=reply_to,
         )
+
+    # ------------------------------------------------------------------
+    # Outbound files — documents, video, voice
+    #
+    # Teams' wire protocol for file delivery is split:
+    #   • DMs: the bot sends a FileConsentCard, the user clicks accept,
+    #     Teams fires a fileConsent/invoke with a OneDrive upload URL,
+    #     the bot PUTs the bytes there. The DM send path primes
+    #     _pending_uploads; the fileConsent/invoke handler drains it.
+    #   • Channels / group chats: the bot uploads to a SharePoint
+    #     document library via Microsoft Graph, then sends a
+    #     file.download.info attachment pointing at the resulting
+    #     drive item's webUrl.
+    # ------------------------------------------------------------------
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        # ``file_name`` and ``metadata`` are accepted for parity with the base
+        # class signature; Teams cards always render the on-disk basename and
+        # Teams has no per-message metadata channel like Telegram's.
+        del file_name, metadata
+        return await self._send_local_file(chat_id, file_path, caption, reply_to)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        del metadata
+        return await self._send_local_file(chat_id, video_path, caption, reply_to)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        del metadata
+        return await self._send_local_file(chat_id, audio_path, caption, reply_to)
+
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        path: str,
+        caption: Optional[str],
+        reply_to: Optional[str],
+    ) -> SendResult:
+        """Read *path* from disk and dispatch via the right Teams flow."""
+        if not os.path.isfile(path):
+            return SendResult(
+                success=False,
+                error=f"file not found: {path}",
+                retryable=False,
+            )
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+        except OSError as e:
+            return SendResult(
+                success=False,
+                error=f"could not read file {path}: {e}",
+                retryable=False,
+            )
+        filename = os.path.basename(path)
+        if self._is_channel_chat(chat_id):
+            return await self._send_channel_file(
+                chat_id, filename, data, caption, reply_to
+            )
+        return await self._send_dm_file_consent(
+            chat_id, filename, data, caption, reply_to
+        )
+
+    def _is_channel_chat(self, chat_id: str) -> bool:
+        """Return True if *chat_id* refers to a Teams channel conversation.
+
+        Channel ids are shaped ``19:<groupId>@thread.tacv2`` whereas DMs
+        use ``a:...`` or ``19:<userId>@unq.gbl.spaces``. The id-shape
+        heuristic is necessary for cold-path sends (no inbound activity
+        seen yet) but a stored conversation reference is authoritative
+        when present — Teams tells us the conversation type explicitly.
+        """
+        ref = self._conv_refs.get(chat_id)
+        if ref is not None:
+            convo = getattr(ref, "conversation", None)
+            convo_type = getattr(convo, "conversation_type", None)
+            if convo_type:
+                return convo_type == "channel"
+        return chat_id.startswith("19:") and "@thread." in chat_id
+
+    async def _handle_file_consent_invoke(
+        self,
+        ctx: "ActivityContext[FileConsentInvokeActivity]",
+    ) -> "Optional[InvokeResponse[None]]":
+        """Resolve a fileConsent/invoke (Allow/Decline) activity.
+
+        Looks up the pending upload by ``context.upload_id``, declines
+        silently or PUTs the bytes to OneDrive on accept, then posts a
+        FileInfoCard so the attachment renders natively in the DM. The
+        pending entry is popped under every exit path so a Teams retry
+        cannot double-handle the upload.
+
+        Always returns None (the SDK auto-acks 200) — fileConsent retries
+        are noisy, and we'd rather log + drop a flaky upload than
+        retry-loop on it.
+        """
+        # Sweep stale pending entries before lookup (mirrors send-side eviction).
+        self._evict_stale_pending_uploads()
+
+        value = ctx.activity.value
+        if value is None:
+            logger.warning("[teams] fileConsent/invoke without value")
+            return None
+
+        # Defensive: context may arrive as a dict, an arbitrary pydantic-
+        # serialised object, or a plain string. Only the dict shape carries
+        # the upload_id we seeded in build_file_consent_card.
+        context = value.context or {}
+        if isinstance(context, dict):
+            upload_id = str(context.get("upload_id") or "")
+        else:
+            upload_id = ""
+
+        pending = self._pending_uploads.pop(upload_id, None) if upload_id else None
+        if pending is None:
+            logger.info(
+                "[teams] fileConsent invoke for unknown upload_id=%r "
+                "(stale card from a previous gateway run, restart between "
+                "send and click, or eviction)",
+                upload_id,
+            )
+            return None
+
+        action = str(getattr(value, "action", "") or "").lower()
+        # Action enum stringifies as "Action.ACCEPT" — fall back to .value.
+        if action.startswith("action."):
+            action = action.split(".", 1)[1]
+        if action != "accept":
+            logger.info(
+                "[teams] fileConsent declined for %s", pending["filename"]
+            )
+            await self._delete_consent_card(ctx, pending)
+            return None
+
+        upload_info = value.upload_info
+        if upload_info is None or not upload_info.upload_url:
+            logger.warning(
+                "[teams] fileConsent/invoke missing upload_info.upload_url for %s",
+                pending["filename"],
+            )
+            return None
+
+        # PUT the bytes to the OneDrive upload session.
+        success = await self._put_consent_bytes(
+            upload_info.upload_url, pending["bytes"]
+        )
+        if not success:
+            return None
+
+        # Delete the consent card so the buttons don't sit grey-then-re-enabled.
+        # Done before the FileInfoCard so the user sees the card disappear
+        # then the file appear, rather than two cards stacked briefly.
+        await self._delete_consent_card(ctx, pending)
+
+        # Post the FileInfoCard so the file renders as a native attachment.
+        await self._post_file_info_card(
+            chat_id=pending["chat_id"],
+            filename=pending["filename"],
+            upload_info=upload_info,
+            caption=pending.get("caption"),
+            reply_to=pending.get("reply_to"),
+        )
+        return None
+
+    async def _delete_consent_card(
+        self,
+        ctx: "ActivityContext[FileConsentInvokeActivity]",
+        pending: Dict[str, Any],
+    ) -> None:
+        """Delete the FileConsentCard activity that triggered this invoke.
+
+        Without this, Teams shows the card buttons greying out for a moment
+        then re-enabling — the card never reaches a resolved state in the
+        UI. Failures are swallowed and logged; consent-card cleanup must
+        never break the invoke handler (the upload itself already succeeded
+        / was declined).
+        """
+        activity_id = pending.get("activity_id")
+        if not activity_id:
+            # Older entries (or send_failed paths) won't have one.
+            return
+        try:
+            conversation_id = ctx.activity.conversation.id
+        except AttributeError:
+            logger.warning(
+                "[teams] consent-card delete skipped — no conversation.id on ctx"
+            )
+            return
+        try:
+            await ctx.api.conversations.activities(conversation_id).delete(
+                activity_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[teams] consent-card delete failed for activity_id=%s: %s",
+                activity_id,
+                e,
+            )
+
+    async def _put_consent_bytes(self, upload_url: str, data: bytes) -> bool:
+        """PUT *data* to a OneDrive upload-session URL using the
+        single-shot content-range protocol. Returns ``True`` on a 2xx
+        response.
+
+        A fresh ``aiohttp.ClientSession`` is created per call. File
+        uploads are rare and transient so the per-call cost is fine; if
+        throughput becomes a concern we can plumb a shared session
+        through the adapter (upstream caches one on a ``_get_http_session``
+        helper).
+        """
+        try:
+            import aiohttp
+        except ImportError:
+            logger.error("[teams] aiohttp missing; cannot PUT FileConsent bytes")
+            return False
+
+        size = len(data)
+        headers = {
+            "Content-Type": "application/octet-stream",
+            "Content-Length": str(size),
+            "Content-Range": f"bytes 0-{max(size - 1, 0)}/{size}",
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.put(upload_url, data=data, headers=headers) as resp:
+                    if resp.status not in (200, 201):
+                        body = await resp.text()
+                        logger.warning(
+                            "[teams] FileConsent PUT failed status=%d body=%s",
+                            resp.status,
+                            body[:200],
+                        )
+                        return False
+        except aiohttp.ClientError as exc:
+            logger.warning("[teams] FileConsent PUT transport error: %s", exc)
+            return False
+        except Exception:
+            logger.exception("[teams] FileConsent PUT raised")
+            return False
+        return True
+
+    async def _post_file_info_card(
+        self,
+        *,
+        chat_id: str,
+        filename: str,
+        upload_info: "FileUploadInfo",
+        caption: Optional[str],
+        reply_to: Optional[str],
+    ) -> None:
+        """Send the FileInfoCard follow-up after a successful PUT."""
+        from plugins.platforms.teams.cards import build_file_info_card
+
+        card = build_file_info_card(
+            filename=filename,
+            content_url=upload_info.content_url or "",
+            unique_id=upload_info.unique_id,
+            file_type=upload_info.file_type,
+        )
+        result = await self._send_attachment(
+            chat_id, card, caption=caption, reply_to=reply_to
+        )
+        if not result.success:
+            logger.warning(
+                "[teams] FileInfoCard follow-up failed for %s: %s",
+                filename,
+                result.error,
+            )
+
+    async def _send_dm_file_consent(
+        self,
+        chat_id: str,
+        filename: str,
+        data: bytes,
+        caption: Optional[str],
+        reply_to: Optional[str],
+    ) -> SendResult:
+        """Send a FileConsentCard and remember the bytes for the invoke handler."""
+        from plugins.platforms.teams.cards import build_file_consent_card
+
+        # Sweep TTL-expired entries on every DM send so a long-running
+        # gateway with users who never click Allow / Decline doesn't grow
+        # unboundedly.
+        self._evict_stale_pending_uploads()
+
+        size = len(data)
+        accept_ctx = {"filename": filename, "service_url_chat_id": chat_id}
+        card = build_file_consent_card(
+            filename=filename,
+            size_bytes=size,
+            description=caption or f"Hermes wants to send you {filename}",
+            accept_context=accept_ctx,
+        )
+        upload_id = card["content"]["acceptContext"]["upload_id"]
+        # Stash the bytes + routing info; the fileConsent/invoke handler
+        # reads this back when the user clicks Accept.
+        self._register_pending_upload(
+            upload_id,
+            {
+                "filename": filename,
+                "bytes": data,
+                "chat_id": chat_id,
+                "caption": caption,
+                "reply_to": reply_to,
+            },
+        )
+        result = await self._send_attachment(
+            chat_id, card, caption=caption, reply_to=reply_to
+        )
+        if not result.success:
+            # Send failed — drop the stashed bytes so we don't leak
+            # ~one-file-of-RAM per failed FileConsent send. The user
+            # never got a card to click, so the entry is dead weight.
+            self._pending_uploads.pop(upload_id, None)
+            logger.warning(
+                "[teams] FileConsent send failed for upload_id=%s — "
+                "bytes dropped, user got no card",
+                upload_id,
+            )
+        else:
+            # Stash the consent card's activity_id so the invoke handler
+            # can delete the card on Accept/Decline. Without this, Teams
+            # leaves the card buttons grey-then-re-enabled (no resolution
+            # state) — the user reports the card "doesn't go away".
+            entry = self._pending_uploads.get(upload_id)
+            if entry is not None:
+                entry["activity_id"] = result.message_id
+        return result
+
+    def _register_pending_upload(
+        self, upload_id: str, entry: Dict[str, Any]
+    ) -> None:
+        """Insert a pending-upload entry, stamping it and enforcing the size cap.
+
+        Entries are stored with a monotonic timestamp so
+        ``_evict_stale_pending_uploads`` can sweep stale ones. When the cap
+        is reached we drop the oldest (FIFO via OrderedDict insertion order)
+        and emit a warning so saturation is visible in logs.
+        """
+        self._evict_stale_pending_uploads()
+        entry["ts"] = time.monotonic()
+        self._pending_uploads[upload_id] = entry
+        while len(self._pending_uploads) > self._PENDING_UPLOAD_MAX:
+            evicted_id, _evicted = self._pending_uploads.popitem(last=False)
+            logger.warning(
+                "[teams] _pending_uploads at cap (%d) — evicted oldest upload_id=%s",
+                self._PENDING_UPLOAD_MAX,
+                evicted_id,
+            )
+
+    def _evict_stale_pending_uploads(self) -> None:
+        """Drop pending-upload entries older than the TTL."""
+        now = time.monotonic()
+        ttl = self._PENDING_UPLOAD_TTL_SECONDS
+        stale = [
+            uid
+            for uid, entry in self._pending_uploads.items()
+            if now - entry.get("ts", now) > ttl
+        ]
+        for uid in stale:
+            self._pending_uploads.pop(uid, None)
+            logger.info(
+                "[teams] _pending_uploads evicted stale entry upload_id=%s (TTL %ds)",
+                uid,
+                ttl,
+            )
+
+    async def _send_channel_file(
+        self,
+        chat_id: str,
+        filename: str,
+        data: bytes,
+        caption: Optional[str],
+        reply_to: Optional[str],
+    ) -> SendResult:
+        """Upload to SharePoint via Graph and post a FileDownload card."""
+        if not self._sharepoint_site_id:
+            return SendResult(
+                success=False,
+                error=(
+                    "TEAMS_SHAREPOINT_SITE_ID not configured — "
+                    "channel uploads disabled"
+                ),
+                retryable=False,
+            )
+        graph = await self._ensure_graph()
+        # Sanitize the chat_id for use as a folder name. Teams ids contain
+        # ':' and '@' which work in URLs but make for ugly SharePoint
+        # paths. The mapping is one-way; we never reverse-engineer the
+        # chat_id from the folder.
+        safe_chat_id = chat_id.replace(":", "_").replace("@", "_at_")
+        folder = f"{self._sharepoint_folder}/{safe_chat_id}"
+        url = await graph.upload_to_sharepoint(
+            site_id=self._sharepoint_site_id,
+            folder_path=folder,
+            filename=filename,
+            content=data,
+        )
+        if not url:
+            # Graph errors are logged inside the client; surface a
+            # retryable failure so the gateway can re-queue.
+            return SendResult(
+                success=False,
+                error="SharePoint upload failed",
+                retryable=True,
+            )
+        from plugins.platforms.teams.cards import build_file_download_card
+
+        # Channel uploads don't have a Graph drive-item id readily on hand
+        # here (upload_to_sharepoint returns the webUrl, not the item id).
+        # Pass the filename + URL; cards.py infers fileType from the
+        # extension. unique_id is omitted — the card still renders.
+        card = build_file_download_card(
+            filename=filename,
+            content_url=url,
+        )
+        return await self._send_attachment(
+            chat_id, card, caption=caption, reply_to=reply_to
+        )
+
+    async def _ensure_graph(self):
+        """Lazily build the GraphClient + GraphTokenProvider."""
+        # Lazy single-init: there's no await between the check and the
+        # assignments, so asyncio's cooperative scheduler guarantees this
+        # block is atomic. Even on the (impossible) double-init path,
+        # GraphTokenProvider's per-scope locks make duplicate construction
+        # harmless.
+        if self._graph is None:
+            from plugins.platforms.teams.auth_graph import GraphTokenProvider
+            from plugins.platforms.teams.graph import GraphClient
+
+            self._token_provider = GraphTokenProvider(
+                client_id=self._client_id,
+                tenant_id=self._tenant_id,
+                client_secret=self._client_secret,
+            )
+            self._graph = GraphClient(self._token_provider)
+        return self._graph
+
+    async def _try_graph_hosted_bytes(
+        self,
+        *,
+        url: str,
+        team_id: Optional[str],
+        channel_id: Optional[str],
+        activity_id: str,
+    ) -> Optional[bytes]:
+        """Best-effort Graph hostedContents retrieval.
+
+        Returns the bytes on success, None on every failure path
+        (missing context, no hostedContents id in the URL, Graph
+        SDK not installed, Graph call raised, or Graph returned no
+        data). Callers fall through to whatever the direct path
+        produced (which may also be None — that's fine, the
+        attachment is just dropped at the higher level).
+        """
+        hosted_id = _parse_hosted_content_id(url)
+        if not (hosted_id and team_id and channel_id and activity_id):
+            return None
+        try:
+            graph = await self._ensure_graph()
+        except Exception as exc:
+            logger.warning(
+                "[teams][graph-fallback] Graph not available: %s", exc,
+            )
+            return None
+        if graph is None:
+            return None
+        try:
+            data = await graph.download_hosted_content(
+                team_id=team_id,
+                channel_id=channel_id,
+                message_id=activity_id,
+                hosted_content_id=hosted_id,
+            )
+        except Exception:
+            logger.exception(
+                "[teams][graph-fallback] download_hosted_content raised "
+                "for msg=%s hc=%s", activity_id, hosted_id,
+            )
+            return None
+        if data is not None:
+            logger.info(
+                "[teams][graph-fallback] recovered %d bytes via Graph "
+                "hostedContents (msg=%s, hc=%s)",
+                len(data), activity_id, hosted_id,
+            )
+        return data
+
+    async def _try_graph_hosted_fallback(
+        self,
+        *,
+        idx: int,
+        url: str,
+        team_id: Optional[str],
+        channel_id: Optional[str],
+        activity_id: str,
+        kind: str,                 # "image" — only image path uses this v1
+        ext: str,
+        filename: Optional[str] = None,
+    ) -> Optional[str]:
+        """Attempt Graph hostedContents fallback then cache the bytes.
+
+        Image-path entry point. Returns a cached file path on
+        success, None on failure. Documents from the file.download.info
+        branch use _try_graph_hosted_bytes directly (they need to
+        fan out to image / audio / video / doc caches based on
+        file_type, which the caller already has).
+        """
+        data = await self._try_graph_hosted_bytes(
+            url=url,
+            team_id=team_id,
+            channel_id=channel_id,
+            activity_id=activity_id,
+        )
+        if data is None:
+            return None
+        try:
+            from gateway.platforms.base import cache_image_from_bytes
+            return cache_image_from_bytes(data, ext=ext)
+        except Exception:
+            logger.exception(
+                "[teams][graph-fallback][%d] cache failed for %r",
+                idx, filename,
+            )
+            return None
+
+    async def _send_attachment(
+        self,
+        chat_id: str,
+        attachment_dict: Dict[str, Any],
+        *,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a Bot Framework Attachment dict via the Teams SDK.
+
+        The card builders in :mod:`plugins.platforms.teams.cards` produce
+        dicts in Bot Framework wire shape. ``microsoft_teams.api.Attachment``
+        is a pydantic model whose ``content_type`` / ``content`` / ``name``
+        fields map cleanly. We wrap the dict, attach it to a fresh
+        ``MessageActivityInput``, and send via the same conv_ref / direct
+        path the existing ``send_image`` uses.
+
+        ``reply_to`` is currently ignored — matching ``send_image``'s
+        behaviour. Threading file deliveries to a parent message can be
+        added later without changing the public surface.
+        """
+        # reply_to is a parity arg for the public send_* methods; threading
+        # behaviour is a future improvement.
+        del reply_to
+
+        if not self._app:
+            return SendResult(success=False, error="Teams app not initialized")
+        try:
+            from microsoft_teams.api import Attachment, MessageActivityInput
+
+            att = Attachment(
+                content_type=attachment_dict["contentType"],
+                content_url=attachment_dict.get("contentUrl"),
+                content=attachment_dict.get("content"),
+                name=attachment_dict.get("name"),
+            )
+            activity = MessageActivityInput().add_attachments(att)
+            if caption:
+                activity = activity.add_text(caption)
+
+            conv_ref = self._conv_refs.get(chat_id)
+            if conv_ref:
+                result = await self._app.activity_sender.send(activity, conv_ref)
+            else:
+                result = await self._app.send(chat_id, activity)
+            return SendResult(success=True, message_id=getattr(result, "id", None))
+        except Exception as e:
+            logger.error("[teams] _send_attachment failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e), retryable=True)
 
     async def get_chat_info(self, chat_id: str) -> dict:
         return {"name": chat_id, "type": "unknown", "chat_id": chat_id}

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -23,6 +23,7 @@ Configuration in config.yaml:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import html
 import json
 import logging
@@ -687,13 +688,49 @@ _HOSTED_CONTENT_RE = re.compile(
 )
 
 
-# Bot Framework hosts that require an Authorization: Bearer header on GETs.
+# Bot Framework hosts that require an Authorization: Bearer *** on GETs.
 # When an inbound activity references a content_url under one of these hosts
 # (typical shape: https://smba.trafficmanager.net/<region>/<tenant>/v3/
 # attachments/<id>/views/original) the shared cache_*_from_url helpers will
 # 401 because they don't carry per-platform auth. We fetch the bytes here
 # instead, using the SDK-managed bot token, then route to cache_*_from_bytes.
 _BF_ATTACHMENT_HOSTS = {"smba.trafficmanager.net"}
+
+
+def _url_fingerprint(url: Optional[str], *, path_chars: int = 24) -> str:
+    """Return a log-safe fingerprint of ``url`` — host + truncated path + sha8.
+
+    Teams/SharePoint download URLs frequently embed bearer or ``tempauth``
+    material in the query string or path (and sometimes deeper-path tokens
+    like ``/_api/v2.0/drives/<id>/items/<id>/content?tempauth=...``). Logging
+    the raw URL leaks file-access credentials into gateway logs, where a
+    log-aggregator subscriber or anyone reading ``gateway.log`` can replay
+    them until they expire (minutes-to-hours window).
+
+    The fingerprint preserves enough signal to debug routing/dispatch
+    (which host, roughly which path) while stripping query strings, fragments,
+    userinfo, and most of the path. The trailing ``#<sha8>`` lets two log
+    lines referencing the *same* URL be correlated without exposing the URL
+    itself. Output for a malformed/empty URL is the literal ``"<no-url>"``
+    rather than ``None`` so format-string callers can use ``%s`` safely.
+    """
+    if not url or not isinstance(url, str):
+        return "<no-url>"
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        host = (parsed.hostname or "?").lower()
+        path = parsed.path or ""
+        if len(path) > path_chars:
+            path = path[:path_chars] + "..."
+        # SHA-256 over the *full* original URL so the same URL always
+        # produces the same 8-char tag — useful for grepping log
+        # correlations without exposing token material.
+        digest = hashlib.sha256(url.encode("utf-8", errors="replace")).hexdigest()[:8]
+        return f"{host}{path}#{digest}"
+    except Exception:  # noqa: BLE001 — never raise from a logging helper
+        return "<unparseable-url>"
 
 
 def _is_bf_attachment_url(url: Optional[str]) -> bool:
@@ -1031,12 +1068,12 @@ class TeamsAdapter(BasePlatformAdapter):
                     if resp.status != 200:
                         logger.warning(
                             "[teams][attach] BF GET %s -> status=%s",
-                            url, resp.status,
+                            _url_fingerprint(url), resp.status,
                         )
                         return None
                     return await resp.read()
         except Exception as exc:  # noqa: BLE001
-            logger.warning("[teams][attach] BF GET %s raised: %s", url, exc)
+            logger.warning("[teams][attach] BF GET %s raised: %s", _url_fingerprint(url), exc)
             return None
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
@@ -1137,8 +1174,8 @@ class TeamsAdapter(BasePlatformAdapter):
             content_type = (getattr(att, "content_type", None) or getattr(att, "contentType", None) or "").lower()
             att_name = getattr(att, "name", None)
             logger.info(
-                "[teams][attach][%d] content_type=%r name=%r content_url=%r has_content=%s",
-                idx, content_type, att_name, content_url, getattr(att, "content", None) is not None,
+                "[teams][attach][%d] content_type=%r name=%r content_url=%s has_content=%s",
+                idx, content_type, att_name, _url_fingerprint(content_url), getattr(att, "content", None) is not None,
             )
 
             try:
@@ -1279,8 +1316,8 @@ class TeamsAdapter(BasePlatformAdapter):
                     download_url = str(_field(content_block, "download_url", "downloadUrl") or "")
                     filename = str(getattr(att, "name", None) or "").strip() or f"attachment.{file_type or 'bin'}"
                     logger.info(
-                        "[teams][attach][%d] file.download.info parsed: filename=%r file_type=%r download_url=%r",
-                        idx, filename, file_type, download_url,
+                        "[teams][attach][%d] file.download.info parsed: filename=%r file_type=%r download_url=%s",
+                        idx, filename, file_type, _url_fingerprint(download_url),
                     )
 
                     if not download_url or not file_type:
@@ -1374,22 +1411,25 @@ class TeamsAdapter(BasePlatformAdapter):
                         html_text = raw_content.get("text") or raw_content.get("html") or repr(raw_content)
                     else:
                         html_text = repr(raw_content)
-                    snippet = html_text[:8192]
-                    truncated = "...[truncated]" if len(html_text) > 8192 else ""
                     # Pull out any hostedContents URLs explicitly so they're greppable
                     import re as _re
                     hc_urls = _re.findall(
                         r"https?://[^\"'\s>]*?hostedContents/[^\"'\s>]+",
                         html_text,
                     )
+                    # The HTML body itself can carry token-bearing URLs (Teams
+                    # often inlines hostedContents/SharePoint refs as <img src>
+                    # or <a href>), so we deliberately don't log a raw snippet.
+                    # Length + URL count is enough to debug routing; individual
+                    # URL fingerprints are emitted in the loop below.
                     logger.debug(
-                        "[teams][attach][%d] dropped html payload (%d chars, %d hostedContents refs): %s%s",
-                        idx, len(html_text), len(hc_urls), snippet, truncated,
+                        "[teams][attach][%d] dropped html payload (%d chars, %d hostedContents refs)",
+                        idx, len(html_text), len(hc_urls),
                     )
                     for hc_idx, hc_url in enumerate(hc_urls):
                         logger.debug(
                             "[teams][attach][%d] dropped hostedContents[%d]: %s",
-                            idx, hc_idx, hc_url,
+                            idx, hc_idx, _url_fingerprint(hc_url),
                         )
                 logger.info(
                     "[teams][attach][%d] DROP unhandled (content_type=%r, has_url=%s)",

--- a/plugins/platforms/teams/auth_graph.py
+++ b/plugins/platforms/teams/auth_graph.py
@@ -1,0 +1,167 @@
+"""MSAL-backed Microsoft Graph token provider.
+
+Provides :class:`GraphTokenProvider`, a thin async-friendly wrapper around
+``msal.ConfidentialClientApplication`` that:
+
+* Caches access tokens **per scope** (keyed on the scope string), so the
+  same provider can mint tokens for both Bot Framework (``...default``)
+  and Graph (``https://graph.microsoft.com/.default``) without stomping on
+  itself.
+* Uses a **per-scope** ``asyncio.Lock`` so concurrent ``get_token`` callers
+  collapse onto a single MSAL round-trip rather than racing.
+* Refreshes proactively when the cached token is within
+  ``refresh_if_within_seconds`` of expiry (default 60s).
+* Defers the ``import msal`` until ``_build_msal_app()`` actually runs so
+  the module is cheap to import even when msal isn't installed (the
+  plugin's lazy-deps mechanism will install it on first use).
+
+MSAL itself is synchronous; calls are dispatched to the default executor
+via ``loop.run_in_executor``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import msal  # noqa: F401
+
+
+__all__ = ["AuthError", "GraphTokenProvider"]
+
+log = logging.getLogger(__name__)
+
+
+class AuthError(Exception):
+    """Raised when MSAL returns an error response for token acquisition."""
+
+
+class GraphTokenProvider:
+    """Async-safe MSAL client-credential token provider with per-scope cache.
+
+    Parameters
+    ----------
+    client_id:
+        Azure AD application (client) ID.
+    tenant_id:
+        Azure AD tenant ID. Used to build the authority URL
+        ``https://login.microsoftonline.com/{tenant_id}``.
+    client_secret:
+        Application client secret (the "Value" from the Azure portal's
+        Certificates & secrets blade — *not* the secret ID).
+    """
+
+    def __init__(self, client_id: str, tenant_id: str, client_secret: str) -> None:
+        self.client_id = client_id
+        self.tenant_id = tenant_id
+        self.client_secret = client_secret
+        # Lazily built — see _get_app(). Tests monkeypatch _build_msal_app.
+        self._msal_app: object | None = None
+        # scope -> (access_token, expires_at_epoch_seconds)
+        self._cache: dict[str, tuple[str, float]] = {}
+        # scope -> asyncio.Lock guarding refresh of that scope's entry.
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    # MSAL plumbing
+    # ------------------------------------------------------------------
+
+    def _build_msal_app(self):  # type: ignore[no-untyped-def]
+        """Construct the underlying ``ConfidentialClientApplication``.
+
+        ``msal`` is imported here (not at module top) so that the plugin
+        can be loaded even when msal is not yet installed — the lazy-deps
+        loader will install it before this method is invoked.
+        """
+        import msal  # local import: keeps module import cheap & lazy
+
+        authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+        return msal.ConfidentialClientApplication(
+            self.client_id,
+            authority=authority,
+            client_credential=self.client_secret,
+        )
+
+    def _get_app(self):  # type: ignore[no-untyped-def]
+        if self._msal_app is None:
+            self._msal_app = self._build_msal_app()
+        return self._msal_app
+
+    def _get_lock(self, scope: str) -> asyncio.Lock:
+        # setdefault is the conventional safe pattern: it atomically returns
+        # the existing lock or installs a new one. asyncio is single-threaded
+        # so a get-then-set sequence is safe-by-accident today, but using
+        # setdefault makes the per-scope-lock invariant robust to future
+        # refactors that might introduce an await between check and set.
+        return self._locks.setdefault(scope, asyncio.Lock())
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_token(
+        self,
+        scope: str,
+        *,
+        refresh_if_within_seconds: int = 60,
+    ) -> str:
+        """Return a valid access token for ``scope``, refreshing if needed.
+
+        Parameters
+        ----------
+        scope:
+            OAuth2 scope to request (e.g. ``"https://graph.microsoft.com/.default"``).
+        refresh_if_within_seconds:
+            Refresh proactively if the cached token expires within this many
+            seconds (default 60). Bumping this value above the token's
+            remaining lifetime forces a refresh on the next call.
+
+        Raises
+        ------
+        AuthError
+            If MSAL returns an ``error`` field instead of an ``access_token``.
+        """
+        # Fast path: cached and not near expiry → no lock needed.
+        cached = self._cache.get(scope)
+        if cached is not None:
+            token, expires_at = cached
+            if expires_at - time.time() > refresh_if_within_seconds:
+                return token
+
+        # Slow path: take the per-scope lock, double-check, then refresh.
+        lock = self._get_lock(scope)
+        async with lock:
+            cached = self._cache.get(scope)
+            if cached is not None:
+                token, expires_at = cached
+                if expires_at - time.time() > refresh_if_within_seconds:
+                    return token
+
+            app = self._get_app()
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: app.acquire_token_for_client([scope]),
+            )
+
+            if "error" in result:
+                err = result["error"]
+                desc = result.get("error_description", "")
+                log.warning("graph token error scope=%s err=%s", scope, err)
+                raise AuthError(f"{err}: {desc}")
+
+            token = result["access_token"]
+            # Floor expires_in at 60s so a malformed/zero/negative value from
+            # the IdP can't poison the fast path or trigger a refresh thrash.
+            expires_in = max(int(result.get("expires_in", 3600)), 60)
+            # Wall-clock time matches MSAL's expires_in semantics. A backwards
+            # system-clock jump could over-extend cache freshness; 401 retries
+            # elsewhere handle that, and Azure rotates infrequently enough
+            # that switching to time.monotonic() isn't worth the complexity.
+            self._cache[scope] = (token, time.time() + expires_in)
+            log.debug(
+                "graph token refresh scope=%s expires_in=%ss", scope, expires_in
+            )
+            return token

--- a/plugins/platforms/teams/cards.py
+++ b/plugins/platforms/teams/cards.py
@@ -1,0 +1,141 @@
+"""Teams card builders for file delivery flows.
+
+These are pure dict factories. They emit the JSON shapes the Teams Bot
+Framework recognizes; no SDK objects are involved so they work with any
+Teams transport layer.
+
+References:
+- FileConsentCard: https://learn.microsoft.com/microsoftteams/platform/bots/how-to/bots-files
+- FileInfoCard:    same doc, "Notify the user about the uploaded file"
+- file.download.info attachment: channel / group upload references
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+FILE_CONSENT_CONTENT_TYPE = "application/vnd.microsoft.teams.card.file.consent"
+FILE_INFO_CONTENT_TYPE = "application/vnd.microsoft.teams.card.file.info"
+FILE_DOWNLOAD_INFO_CONTENT_TYPE = "application/vnd.microsoft.teams.file.download.info"
+
+
+def build_file_consent_card(
+    filename: str,
+    size_bytes: int,
+    accept_context: Optional[Dict[str, Any]] = None,
+    description: str = "",
+) -> Dict[str, Any]:
+    """Build the FileConsentCard attachment that kicks off an outbound DM upload.
+
+    The user's accept/decline triggers a ``fileConsent/invoke`` activity;
+    on accept the payload includes ``uploadInfo`` with a OneDrive URL the
+    bot PUTs the bytes to. ``acceptContext`` is echoed back unchanged so
+    the bot can correlate the invoke with the original upload request.
+
+    A fresh ``upload_id`` is seeded into the context if the caller did not
+    supply one — that's the natural correlation id for the upload.
+    ``declineContext`` is a value-equal *copy* of ``acceptContext`` (not the
+    same object): downstream handlers (e.g. the fileConsent/invoke handler)
+    routinely mutate one branch's context to record status, and aliasing
+    would silently leak those writes into the other branch.
+    """
+    ctx: Dict[str, Any] = dict(accept_context or {})
+    ctx.setdefault("upload_id", str(uuid.uuid4()))
+    return {
+        "contentType": FILE_CONSENT_CONTENT_TYPE,
+        "name": filename,
+        "content": {
+            "description": description,
+            "sizeInBytes": int(size_bytes),
+            "acceptContext": ctx,
+            "declineContext": dict(ctx),
+        },
+    }
+
+
+def build_file_info_card(
+    filename: str,
+    content_url: str,
+    *,
+    unique_id: Optional[str] = None,
+    file_type: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the FileInfoCard the bot sends *after* a successful FileConsent upload.
+
+    Without this, the file does not render as a native attachment in the
+    DM — the user just sees the consent card flip to 'uploaded'.
+
+    ``content_url`` is the OneDrive ``contentUrl`` echoed back in the
+    ``fileConsent/invoke`` ``upload_info``. ``unique_id`` is the OneDrive
+    drive-item id from ``upload_info.unique_id`` — required by Teams
+    clients to render the file as a native preview-able attachment;
+    when omitted, a fresh uuid is generated as a fallback (the file
+    still renders but the link may not resolve to a previewable item).
+    ``file_type`` is auto-inferred from the filename extension when
+    omitted (e.g. ``foo.pdf`` → ``"pdf"``).
+    """
+    return {
+        "contentType": FILE_INFO_CONTENT_TYPE,
+        "contentUrl": content_url,
+        "name": filename,
+        "content": {
+            "uniqueId": unique_id or str(uuid.uuid4()),
+            "fileType": file_type or _infer_file_type(filename),
+        },
+    }
+
+
+def build_file_download_card(
+    filename: str,
+    content_url: str,
+    *,
+    unique_id: Optional[str] = None,
+    file_type: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a ``file.download.info`` attachment for channel / group uploads.
+
+    Used after the bot has uploaded to SharePoint via Graph and has the
+    drive item's webUrl. Teams clients render this as a downloadable
+    attachment in channel posts.
+
+    ``content_url`` is the SharePoint webUrl returned by
+    :meth:`GraphClient.upload_to_sharepoint`. ``unique_id`` should be the
+    Graph drive-item id when known (so subsequent interactions can resolve
+    back to the file); when omitted, the card still renders but the bot
+    cannot use it to look the file up later. ``file_type`` is auto-inferred
+    from the filename extension when omitted (e.g. ``foo.pdf`` → ``"pdf"``).
+    """
+    content: Dict[str, Any] = {"downloadUrl": content_url}
+    if unique_id:
+        content["uniqueId"] = unique_id
+    content["fileType"] = file_type or _infer_file_type(filename)
+    return {
+        "contentType": FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        "contentUrl": content_url,
+        "content": content,
+        "name": filename,
+    }
+
+
+def _infer_file_type(filename: str) -> str:
+    """Return the Teams-style file type token for *filename*.
+
+    Teams accepts ``"png"`` / ``"jpg"`` / ``"pdf"`` / ... strings; the mapping
+    lines up with common extension suffixes. Files without a dotted
+    extension (``LICENSE``, ``Makefile``) fall back to ``"file"`` so Teams
+    renders a generic document icon.
+    """
+    _head, sep, ext = filename.rpartition(".")
+    if not sep:
+        return "file"
+    return ext.lower() or "file"
+
+
+__all__ = [
+    "FILE_CONSENT_CONTENT_TYPE",
+    "FILE_INFO_CONTENT_TYPE",
+    "FILE_DOWNLOAD_INFO_CONTENT_TYPE",
+    "build_file_consent_card",
+    "build_file_info_card",
+    "build_file_download_card",
+]

--- a/plugins/platforms/teams/graph.py
+++ b/plugins/platforms/teams/graph.py
@@ -1,0 +1,202 @@
+"""Microsoft Graph client wrapper for Teams file upload/download.
+
+A narrow façade over :class:`msgraph.GraphServiceClient` that exposes only
+the operations the Teams plugin actually needs:
+
+* :meth:`GraphClient.download_hosted_content` — fallback retrieval of inline
+  hosted attachments on channel messages, when the Bot Framework activity
+  does not include the bytes itself.
+* :meth:`GraphClient.upload_to_sharepoint` — outbound channel/group file
+  shares: PUT bytes to a SharePoint document library and return the
+  ``webUrl`` for inclusion in a FileInfo card.
+
+The Microsoft Graph SDK (``msgraph-sdk``) and Azure SDK (``azure-identity``,
+``azure-core``) are **lazy-imported** inside method bodies so this module is
+cheap to import even when those packages are not yet installed — the
+plugin's lazy-deps mechanism installs them on first use.
+
+:class:`_HermesTokenCredential` adapts our synchronous-ish
+:class:`~plugins.platforms.teams.auth_graph.GraphTokenProvider` to the
+``AsyncTokenCredential`` contract the Graph SDK expects.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Optional
+
+from plugins.platforms.teams.auth_graph import AuthError, GraphTokenProvider
+
+__all__ = ["GraphClient", "GRAPH_SCOPE", "_HermesTokenCredential"]
+
+log = logging.getLogger(__name__)
+
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+
+
+# ---------------------------------------------------------------------------
+# Credential adapter — bridges our async provider to azure.core.credentials
+# ---------------------------------------------------------------------------
+
+class _HermesTokenCredential:
+    """Adapt :class:`GraphTokenProvider` to ``AsyncTokenCredential``.
+
+    The Graph SDK calls ``await cred.get_token(*scopes, **kwargs)`` and
+    expects a named tuple ``AccessToken(token, expires_on)``. We delegate
+    to the underlying provider and report an approximate ``expires_on``
+    — our provider already manages real expiry/refresh internally, and
+    the Graph SDK only uses ``expires_on`` as a best-effort refresh hint
+    because it always re-requests on a 401.
+    """
+
+    def __init__(self, provider: GraphTokenProvider) -> None:
+        self._provider = provider
+
+    async def get_token(self, *scopes: str, **kwargs: Any):
+        # Local import keeps this module importable when azure-identity /
+        # azure-core haven't been installed yet (lazy-deps fetches them on
+        # first plugin use).
+        from azure.core.credentials import AccessToken
+
+        if not scopes:
+            raise AuthError(
+                "AsyncTokenCredential.get_token requires at least one scope"
+            )
+        token = await self._provider.get_token(scopes[0])
+        return AccessToken(token, int(time.time()) + 3000)
+
+    async def close(self) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Error-tolerant helpers
+# ---------------------------------------------------------------------------
+
+async def _safe(call, *, action: str, default: Any) -> Any:
+    """Run *call()* and return ``default`` on Graph errors after logging.
+
+    Centralises error handling so every public method on
+    :class:`GraphClient` stays short. ``action`` is a free-form label
+    that appears in log lines and makes Graph failures identifiable.
+    """
+    try:
+        return await call()
+    except Exception as exc:  # noqa: BLE001 — broad on purpose
+        log.warning("teams.graph error action=%s err=%s", action, exc)
+        return default
+
+
+def _attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Attribute access that also tolerates dicts and ``None``."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+# ---------------------------------------------------------------------------
+# GraphClient
+# ---------------------------------------------------------------------------
+
+class GraphClient:
+    """Narrow façade over :class:`msgraph.GraphServiceClient`.
+
+    The Teams adapter constructs one instance per connect() cycle and
+    shares it across inbound handlers and outbound senders. The Graph
+    SDK builds its HTTPS session lazily on the first call so a
+    GraphClient with no in-flight calls has no real network footprint.
+    """
+
+    def __init__(self, provider: GraphTokenProvider) -> None:
+        self._provider = provider
+        # Built lazily on first .client access — msgraph-sdk pulls a lot
+        # of generated kiota modules and is expensive to import.
+        self._client: Any = None
+
+    def _build_client(self) -> Any:
+        # Local import: only pay the cost when somebody actually makes a
+        # Graph call. Tests monkeypatch this method to inject a fake.
+        from msgraph import GraphServiceClient
+
+        credential = _HermesTokenCredential(self._provider)
+        return GraphServiceClient(
+            credentials=credential,
+            scopes=[GRAPH_SCOPE],
+        )
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            self._client = self._build_client()
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Hosted content (inline attachments inside channel messages)
+    # ------------------------------------------------------------------
+
+    async def download_hosted_content(
+        self,
+        team_id: str,
+        channel_id: str,
+        message_id: str,
+        hosted_content_id: str,
+    ) -> Optional[bytes]:
+        """Fetch the raw bytes of an inline image / attachment.
+
+        Returns ``None`` if the call fails — the adapter logs the miss
+        and passes only the URL reference through to the agent.
+        """
+
+        async def _call() -> Optional[bytes]:
+            return await (
+                self.client.teams.by_team_id(team_id)
+                .channels.by_channel_id(channel_id)
+                .messages.by_chat_message_id(message_id)
+                .hosted_contents.by_chat_message_hosted_content_id(hosted_content_id)
+                .content.get()
+            )
+
+        return await _safe(
+            _call,
+            action=f"download_hosted_content({message_id}/{hosted_content_id})",
+            default=None,
+        )
+
+    # ------------------------------------------------------------------
+    # SharePoint upload (channel / group file attachments)
+    # ------------------------------------------------------------------
+
+    async def upload_to_sharepoint(
+        self,
+        site_id: str,
+        folder_path: str,
+        filename: str,
+        content: bytes,
+    ) -> Optional[str]:
+        """Upload *content* to a SharePoint document library folder.
+
+        Returns the ``webUrl`` the adapter can attach to a Teams message
+        so recipients see a proper file card. Graph's simple-upload
+        endpoint (PUT /content) caps at 4 MB per request — callers with
+        larger payloads should chunk via createUploadSession, which is
+        out of scope for the MVP.
+        """
+        clean_folder = folder_path.strip("/")
+        path_prefix = f"/{clean_folder}/" if clean_folder else "/"
+        # Graph drive item paths use colon-delimited "path" syntax:
+        # /sites/{site}/drive/root:/folder/file.png:/content
+        encoded_path = f"{path_prefix}{filename}"
+
+        async def _call() -> Optional[str]:
+            drive = self.client.sites.by_site_id(site_id).drive
+            item = drive.items.by_drive_item_id(f"root:{encoded_path}:")
+            result = await item.content.put(content)
+            return _attr(result, "web_url") or _attr(result, "_raw_url")
+
+        return await _safe(
+            _call,
+            action=f"upload_to_sharepoint({site_id}/{filename})",
+            default=None,
+        )

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -46,3 +46,19 @@ optional_env:
     description: "Display name for the Teams home channel"
     prompt: "Home channel display name"
     password: false
+  - name: TEAMS_SHAREPOINT_SITE_ID
+    description: >
+      SharePoint site ID where the bot uploads files when sending to a
+      channel or group chat (e.g. tenant.sharepoint.com,GUID,GUID).
+      Required only for outbound channel/group file sends — DM file
+      sends use the FileConsent flow and skip SharePoint entirely.
+      Find via Graph: GET /sites/{hostname}:/{server-relative-path}.
+    prompt: "SharePoint site ID (or empty for DM-only file sends)"
+    password: false
+  - name: TEAMS_SHAREPOINT_FOLDER
+    description: >
+      Folder path under the SharePoint site's default drive where bot
+      uploads land (default: hermes). Created on first upload if it
+      doesn't exist. Only used when TEAMS_SHAREPOINT_SITE_ID is set.
+    prompt: "SharePoint folder (default: hermes)"
+    password: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,22 @@ termux-all = [
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
 feishu = ["lark-oapi==1.5.3", "qrcode==7.4.2"]
+# Microsoft Graph SDK — used by the Teams platform plugin's outbound file
+# upload path (cards/graph/auth_graph). Kept separate from any base `teams`
+# extra so Graph stays opt-in; lazy-installs on first use via
+# `platform.teams.graph` in tools/lazy_deps.py.
+# Pinned exactly per the policy block at the top of this file
+# (post-Mini-Shai-Hulud, 2026-05-12). These are auth/identity packages —
+# the policy applies even more strongly. msal is kept as an explicit pin
+# (in addition to azure-identity, which depends on it transitively) because
+# the Graph token-acquisition path uses msal.ConfidentialClientApplication
+# directly for client-credentials flow.
+teams-files = [
+  "msgraph-sdk==1.57.0",
+  "msgraph-core==1.3.8",
+  "azure-identity==1.25.3",
+  "msal==1.36.0",
+]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so packagers (Nix, Homebrew) ship them with

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -251,6 +251,86 @@ class TestExtractImages:
         # The PDF link must survive in cleaned content
         assert "![report](https://example.com/report.pdf)" in cleaned
 
+    # ----- HTML <img> allowlist (slash-bug regression) ------------------------
+    # The HTML <img src=...> branch must apply the same allowlist (image
+    # extension or known CDN host) as the markdown branch. Otherwise, when the
+    # bot quotes an <img> tag in prose — even inside a backticked code span —
+    # the regex peels the URL out and ships it as a native attachment, which
+    # the platform can't authenticate/fetch and renders as a broken-image
+    # placeholder. Reproduced repeatedly on Teams DM today.
+
+    def test_html_img_placeholder_url_not_extracted(self):
+        """Pure prose teaching-example like `<img src="https://...">` must
+        not become a real attachment. This is the literal trigger that
+        produced a slash icon in Teams DM today."""
+        content = '`<img src="https://...">`'
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert images == []
+
+    def test_html_img_no_extension_not_extracted(self):
+        """An <img> tag whose URL has no image extension and is not on an
+        allowlisted CDN must not be extracted — even if otherwise well-formed."""
+        content = 'See `<img src="https://example.com/some/path">` for the shape.'
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert images == []
+
+    def test_html_img_ams_skype_url_not_extracted(self):
+        """AMSImage URL from Skype/Teams object store has no extension and is
+        not on the allowlist. The bot only sees these because Teams sent them
+        inbound; quoting them in prose must not boomerang them as outbound
+        attachments."""
+        content = (
+            'Inbound HTML payload contained '
+            '`<img src="https://us-api.asm.skype.com/v1/objects/0-eus-d16-abc/views/imgo">` '
+            'which is the AMS object-store URL.'
+        )
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert images == []
+
+    def test_html_img_graph_hostedcontents_url_not_extracted(self):
+        """Microsoft Graph hostedContents URL (`/$value`) has no extension and
+        requires Graph auth; must not be extracted as a public image URL."""
+        content = (
+            'Channel inline path uses '
+            '`<img src="https://graph.microsoft.com/v1.0/chats/x/messages/y/'
+            'hostedContents/z/$value">` references.'
+        )
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert images == []
+
+    def test_html_img_with_image_extension_still_extracted(self):
+        """Regression: real <img> tags with image extensions must keep working."""
+        content = '<img src="https://example.com/cat.png">'
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert len(images) == 1
+        assert images[0][0] == "https://example.com/cat.png"
+
+    def test_html_img_with_query_string_and_image_extension(self):
+        """Image URL with a query string (e.g. CDN cache-busting) should still
+        match the allowlist via the extension-in-path check."""
+        content = '<img src="https://example.com/cat.png?w=400&h=300">'
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert len(images) == 1
+        assert images[0][0] == "https://example.com/cat.png?w=400&h=300"
+
+    def test_html_img_with_allowlisted_cdn_still_extracted(self):
+        """Regression: <img> with a known image-CDN host (e.g. fal.media) must
+        still be extracted even without a recognized extension."""
+        content = '<img src="https://fal.media/files/abc/output">'
+        images, _ = BasePlatformAdapter.extract_images(content)
+        assert len(images) == 1
+        assert images[0][0] == "https://fal.media/files/abc/output"
+
+    def test_html_img_non_image_url_preserved_in_cleaned_text(self):
+        """When an <img> tag is rejected by the allowlist, the original tag
+        must survive in the cleaned content — we don't extract it AND we
+        don't silently strip it."""
+        original = '`<img src="https://example.com/some/path">`'
+        content = f"Discussion: {original} as an example."
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+        assert images == []
+        assert original in cleaned
+
 
 # ---------------------------------------------------------------------------
 # extract_media

--- a/tests/plugins/platforms/teams/test_adapter_graph_fallback.py
+++ b/tests/plugins/platforms/teams/test_adapter_graph_fallback.py
@@ -1,0 +1,265 @@
+"""Tests for inbound Graph hostedContents fallback (Task 8).
+
+When a user shares an inline image (or document) in a Teams channel, the
+direct download URL embedded in the activity is short-lived. By the time
+the gateway issues a GET, the tempauth/bearer can already be rejected
+(403 / 410 / 401) — even though the underlying ``hostedContents`` blob is
+still addressable through Microsoft Graph.
+
+These tests cover:
+
+* :func:`_parse_hosted_content_id` — pure URL parser.
+* :meth:`TeamsAdapter._try_graph_hosted_bytes` — Graph fallback that
+  returns raw bytes (used by the file.download.info path).
+* :meth:`TeamsAdapter._try_graph_hosted_fallback` — image-path entry
+  point that runs the bytes fallback then caches the result.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.teams.adapter import (
+    TeamsAdapter,
+    _parse_hosted_content_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — _parse_hosted_content_id
+# ---------------------------------------------------------------------------
+
+
+def test_parse_hosted_content_id_extracts_id():
+    url = (
+        "https://graph.microsoft.com/v1.0/teams/T/channels/C/messages/"
+        "123/hostedContents/abc-xyz/$value?token=foo"
+    )
+    assert _parse_hosted_content_id(url) == "abc-xyz"
+
+
+def test_parse_hosted_content_id_returns_none_for_sharepoint_url():
+    url = "https://contoso.sharepoint.com/sites/X/Documents/file.pdf?tempauth=Y..."
+    assert _parse_hosted_content_id(url) is None
+
+
+def test_parse_hosted_content_id_handles_empty_or_none():
+    assert _parse_hosted_content_id("") is None
+    assert _parse_hosted_content_id(None) is None  # type: ignore[arg-type]
+
+
+def test_parse_hosted_content_id_with_terminating_slash_then_value():
+    base = "https://graph.microsoft.com/v1.0/teams/T/channels/C/messages/M/hostedContents"
+    assert _parse_hosted_content_id(f"{base}/abc/$value") == "abc"
+    assert _parse_hosted_content_id(f"{base}/abc/$value?x=y") == "abc"
+    assert _parse_hosted_content_id(f"{base}/abc?x=y") == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Adapter fixture — minimal, no connect()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter(monkeypatch) -> TeamsAdapter:
+    for var in (
+        "TEAMS_CLIENT_ID",
+        "TEAMS_CLIENT_SECRET",
+        "TEAMS_TENANT_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "fake-client",
+            "client_secret": "fake-secret",
+            "tenant_id": "fake-tenant",
+        },
+    )
+    return TeamsAdapter(cfg)
+
+
+_HC_URL = (
+    "https://graph.microsoft.com/v1.0/teams/T/channels/C/messages/M/"
+    "hostedContents/abc-xyz/$value"
+)
+
+
+# ---------------------------------------------------------------------------
+# _try_graph_hosted_bytes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_missing_context_returns_none(adapter):
+    # _ensure_graph would raise if it were called (no real creds wired)
+    ensure_graph = AsyncMock(side_effect=AssertionError("should not be called"))
+    adapter._ensure_graph = ensure_graph  # type: ignore[method-assign]
+
+    out = await adapter._try_graph_hosted_bytes(
+        url=_HC_URL,
+        team_id=None,
+        channel_id="C",
+        activity_id="A1",
+    )
+    assert out is None
+    ensure_graph.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_no_hosted_id_in_url_returns_none(adapter):
+    ensure_graph = AsyncMock(side_effect=AssertionError("should not be called"))
+    adapter._ensure_graph = ensure_graph  # type: ignore[method-assign]
+
+    out = await adapter._try_graph_hosted_bytes(
+        url="https://contoso.sharepoint.com/sites/X/Documents/file.pdf?tempauth=Y",
+        team_id="T",
+        channel_id="C",
+        activity_id="A1",
+    )
+    assert out is None
+    ensure_graph.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_graph_unavailable_returns_none(adapter, caplog):
+    adapter._ensure_graph = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ImportError("msgraph")
+    )
+    with caplog.at_level(logging.WARNING):
+        out = await adapter._try_graph_hosted_bytes(
+            url=_HC_URL,
+            team_id="T",
+            channel_id="C",
+            activity_id="A1",
+        )
+    assert out is None
+    assert "Graph not available" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_graph_returns_none_returns_none(adapter, caplog):
+    fake_graph = MagicMock()
+    fake_graph.download_hosted_content = AsyncMock(return_value=None)
+    adapter._ensure_graph = AsyncMock(return_value=fake_graph)  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.INFO):
+        out = await adapter._try_graph_hosted_bytes(
+            url=_HC_URL,
+            team_id="T",
+            channel_id="C",
+            activity_id="A1",
+        )
+    assert out is None
+    assert "recovered" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_graph_raises_returns_none_logs_exception(
+    adapter, caplog
+):
+    fake_graph = MagicMock()
+    fake_graph.download_hosted_content = AsyncMock(side_effect=ValueError("boom"))
+    adapter._ensure_graph = AsyncMock(return_value=fake_graph)  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR):
+        out = await adapter._try_graph_hosted_bytes(
+            url=_HC_URL,
+            team_id="T",
+            channel_id="C",
+            activity_id="A1",
+        )
+    assert out is None
+    assert "download_hosted_content raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_bytes_happy_path(adapter, caplog):
+    fake_graph = MagicMock()
+    fake_graph.download_hosted_content = AsyncMock(return_value=b"abc123")
+    adapter._ensure_graph = AsyncMock(return_value=fake_graph)  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.INFO):
+        out = await adapter._try_graph_hosted_bytes(
+            url=_HC_URL,
+            team_id="T",
+            channel_id="C",
+            activity_id="A1",
+        )
+    assert out == b"abc123"
+    fake_graph.download_hosted_content.assert_awaited_once_with(
+        team_id="T",
+        channel_id="C",
+        message_id="A1",
+        hosted_content_id="abc-xyz",
+    )
+    assert "recovered 6 bytes" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _try_graph_hosted_fallback (image path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_fallback_image_caches_and_returns_path(
+    adapter, monkeypatch
+):
+    fake_graph = MagicMock()
+    fake_graph.download_hosted_content = AsyncMock(return_value=b"PNGDATA")
+    adapter._ensure_graph = AsyncMock(return_value=fake_graph)  # type: ignore[method-assign]
+
+    captured: dict = {}
+
+    def fake_cache(data: bytes, ext: str) -> str:
+        captured["data"] = data
+        captured["ext"] = ext
+        return "/cache/abc.jpg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", fake_cache)
+
+    out = await adapter._try_graph_hosted_fallback(
+        idx=0,
+        url=_HC_URL,
+        team_id="T",
+        channel_id="C",
+        activity_id="A1",
+        kind="image",
+        ext=".jpg",
+        filename="image.jpg",
+    )
+    assert out == "/cache/abc.jpg"
+    assert captured == {"data": b"PNGDATA", "ext": ".jpg"}
+
+
+@pytest.mark.asyncio
+async def test_try_graph_hosted_fallback_image_cache_failure_returns_none(
+    adapter, monkeypatch, caplog
+):
+    fake_graph = MagicMock()
+    fake_graph.download_hosted_content = AsyncMock(return_value=b"PNGDATA")
+    adapter._ensure_graph = AsyncMock(return_value=fake_graph)  # type: ignore[method-assign]
+
+    def boom(data: bytes, ext: str) -> str:
+        raise ValueError("cache pop")
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", boom)
+
+    with caplog.at_level(logging.ERROR):
+        out = await adapter._try_graph_hosted_fallback(
+            idx=3,
+            url=_HC_URL,
+            team_id="T",
+            channel_id="C",
+            activity_id="A1",
+            kind="image",
+            ext=".jpg",
+            filename="bad.jpg",
+        )
+    assert out is None
+    assert "cache failed" in caplog.text

--- a/tests/plugins/platforms/teams/test_adapter_inbound_bf_auth.py
+++ b/tests/plugins/platforms/teams/test_adapter_inbound_bf_auth.py
@@ -1,0 +1,342 @@
+"""Tests for Bot Framework attachment auth (Bearer token) on inbound media.
+
+Bot Framework attachment URLs (``https://smba.trafficmanager.net/.../v3/
+attachments/.../views/original``) require an ``Authorization: Bearer ...``
+header — without one the service returns 401 Unauthorized. The shared
+``cache_image_from_url`` / ``cache_audio_from_url`` / ``cache_video_from_url``
+helpers do not (and should not) carry per-platform auth.
+
+The adapter therefore detects BF-hosted URLs by host, fetches the bytes
+ourselves with the SDK-managed bearer token (``self._app._get_bot_token``)
+and routes raw bytes into the ``cache_*_from_bytes`` helpers. Only the
+Teams adapter knows how to mint that token, so the fix lives here, not in
+``gateway/platforms/base.py``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.teams.adapter import (
+    TeamsAdapter,
+    _is_bf_attachment_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — _is_bf_attachment_url
+# ---------------------------------------------------------------------------
+
+
+def test_is_bf_attachment_url_recognises_smba_trafficmanager():
+    url = (
+        "https://smba.trafficmanager.net/amer/def57894-de93-412b-8ce2-87faabe44453/"
+        "v3/attachments/0-eus-d6-0d3d6109e0e45c3a5a11f8cd7c3731bf/views/original"
+    )
+    assert _is_bf_attachment_url(url) is True
+
+
+def test_is_bf_attachment_url_rejects_graph_url():
+    url = (
+        "https://graph.microsoft.com/v1.0/teams/T/channels/C/messages/M/"
+        "hostedContents/abc/$value"
+    )
+    assert _is_bf_attachment_url(url) is False
+
+
+def test_is_bf_attachment_url_rejects_sharepoint_url():
+    url = "https://contoso.sharepoint.com/sites/X/Documents/file.pdf?tempauth=Y"
+    assert _is_bf_attachment_url(url) is False
+
+
+def test_is_bf_attachment_url_handles_empty_or_none():
+    assert _is_bf_attachment_url("") is False
+    assert _is_bf_attachment_url(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Adapter fixture — minimal, no connect()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter(monkeypatch) -> TeamsAdapter:
+    for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "fake-client",
+            "client_secret": "fake-secret",
+            "tenant_id": "fake-tenant",
+        },
+    )
+    a = TeamsAdapter(cfg)
+    # Stand in for the SDK-built App with its token machinery.
+    fake_app = MagicMock()
+    fake_token = MagicMock()
+    fake_token.__str__ = lambda self: "FAKE.JWT.TOKEN"  # type: ignore[assignment]
+    fake_app._get_bot_token = AsyncMock(return_value=fake_token)
+    a._app = fake_app
+    return a
+
+
+_BF_URL = (
+    "https://smba.trafficmanager.net/amer/def57894-de93-412b-8ce2-87faabe44453/"
+    "v3/attachments/0-eus-d6-0d3d6109e0e45c3a5a11f8cd7c3731bf/views/original"
+)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_bf_attachment_bytes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: bytes = b""):
+        self.status = status
+        self._body = body
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            from aiohttp import ClientResponseError
+            from aiohttp.client_reqrep import RequestInfo
+            from yarl import URL
+
+            raise ClientResponseError(
+                request_info=RequestInfo(URL(_BF_URL), "GET", {}, URL(_BF_URL)),
+                history=(),
+                status=self.status,
+                message="err",
+            )
+
+
+class _FakeSession:
+    """aiohttp.ClientSession stand-in capturing the headers used on get()."""
+
+    def __init__(self, response: _FakeResp):
+        self._response = response
+        self.captured_headers: dict | None = None
+        self.captured_url: str | None = None
+
+    def get(self, url, headers=None):
+        self.captured_url = url
+        self.captured_headers = headers or {}
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_fetch_bf_attachment_bytes_attaches_bearer_header(adapter, monkeypatch):
+    fake_resp = _FakeResp(200, body=b"PNGDATA")
+    fake_session = _FakeSession(fake_resp)
+
+    import aiohttp
+
+    monkeypatch.setattr(
+        aiohttp, "ClientSession", lambda *a, **kw: fake_session
+    )
+
+    data = await adapter._fetch_bf_attachment_bytes(_BF_URL)
+    assert data == b"PNGDATA"
+    assert fake_session.captured_url == _BF_URL
+    assert fake_session.captured_headers is not None
+    assert fake_session.captured_headers.get("Authorization") == "Bearer FAKE.JWT.TOKEN"
+    adapter._app._get_bot_token.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_bf_attachment_bytes_returns_none_on_401(adapter, monkeypatch):
+    fake_resp = _FakeResp(401)
+    fake_session = _FakeSession(fake_resp)
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **kw: fake_session)
+
+    data = await adapter._fetch_bf_attachment_bytes(_BF_URL)
+    assert data is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_bf_attachment_bytes_returns_none_when_no_app(monkeypatch):
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "fake-client",
+            "client_secret": "fake-secret",
+            "tenant_id": "fake-tenant",
+        },
+    )
+    a = TeamsAdapter(cfg)
+    # _app is None here — nothing to mint a token from.
+    assert a._app is None
+    out = await a._fetch_bf_attachment_bytes(_BF_URL)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests — image / audio / video paths in _on_message attachment loop
+# ---------------------------------------------------------------------------
+
+
+def _make_activity(attachments):
+    """Build a minimal MessageActivity-shaped object for _on_message."""
+    activity = MagicMock()
+    activity.text = ""
+    activity.attachments = attachments
+    activity.id = "ACT-1"
+    activity.channel_data = None
+    conv = MagicMock()
+    conv.id = "chat-id"
+    conv.name = ""
+    conv.conversation_type = "personal"
+    conv.tenant_id = "tenant-1"
+    activity.conversation = conv
+    from_acct = MagicMock()
+    from_acct.aad_object_id = "user-1"
+    from_acct.id = "user-1"
+    from_acct.name = "Test User"
+    activity.from_ = from_acct
+    return activity
+
+
+def _make_attachment(content_type, content_url, name=None):
+    a = MagicMock()
+    a.content_type = content_type
+    a.contentType = content_type
+    a.content_url = content_url
+    a.contentUrl = content_url
+    a.name = name
+    a.content = None
+    return a
+
+
+@pytest.mark.asyncio
+async def test_image_branch_uses_bf_fetch_when_url_is_bf(adapter, monkeypatch):
+    """BF image URL should go through _fetch_bf_attachment_bytes + cache_image_from_bytes."""
+    fetch_spy = AsyncMock(return_value=b"PNGBYTES")
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["data"] = data
+        captured["ext"] = ext
+        return "/cache/img.jpg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", fake_cache_bytes)
+
+    # cache_image_from_url MUST NOT be called for BF URLs.
+    bad_url_helper = AsyncMock(side_effect=AssertionError("should not call cache_image_from_url for BF urls"))
+    import plugins.platforms.teams.adapter as adapter_mod
+    monkeypatch.setattr(adapter_mod, "cache_image_from_url", bad_url_helper)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("image/png", _BF_URL, name="paste.png")])
+
+    # Stub send() so on_message's downstream path doesn't blow up
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    fetch_spy.assert_awaited_once_with(_BF_URL)
+    assert captured["data"] == b"PNGBYTES"
+
+
+@pytest.mark.asyncio
+async def test_image_branch_uses_url_helper_when_url_is_not_bf(adapter, monkeypatch):
+    """Non-BF image URL should keep using cache_image_from_url unchanged."""
+    fetch_spy = AsyncMock(side_effect=AssertionError("should not BF-fetch for non-BF urls"))
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    url_helper = AsyncMock(return_value="/cache/img.jpg")
+    import plugins.platforms.teams.adapter as adapter_mod
+    monkeypatch.setattr(adapter_mod, "cache_image_from_url", url_helper)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([
+        _make_attachment("image/png", "https://example.com/foo.png", name="foo.png")
+    ])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    url_helper.assert_awaited_once_with("https://example.com/foo.png")
+    fetch_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_audio_branch_uses_bf_fetch_when_url_is_bf(adapter, monkeypatch):
+    fetch_spy = AsyncMock(return_value=b"OGGDATA")
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["data"] = data
+        captured["ext"] = ext
+        return "/cache/voice.ogg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_audio_from_bytes", fake_cache_bytes)
+
+    import plugins.platforms.teams.adapter as adapter_mod
+    bad_url_helper = AsyncMock(side_effect=AssertionError("should not call cache_audio_from_url for BF urls"))
+    monkeypatch.setattr(adapter_mod, "cache_audio_from_url", bad_url_helper)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("audio/ogg", _BF_URL, name="voice.ogg")])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    fetch_spy.assert_awaited_once_with(_BF_URL)
+    assert captured["data"] == b"OGGDATA"
+    assert captured["ext"] == ".ogg"
+
+
+@pytest.mark.asyncio
+async def test_video_branch_uses_bf_fetch_when_url_is_bf(adapter, monkeypatch):
+    fetch_spy = AsyncMock(return_value=b"MP4DATA")
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["data"] = data
+        captured["ext"] = ext
+        return "/cache/clip.mp4"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_video_from_bytes", fake_cache_bytes)
+
+    import plugins.platforms.teams.adapter as adapter_mod
+    bad_url_helper = AsyncMock(side_effect=AssertionError("should not call cache_video_from_url for BF urls"))
+    monkeypatch.setattr(adapter_mod, "cache_video_from_url", bad_url_helper)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("video/mp4", _BF_URL, name="clip.mp4")])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    fetch_spy.assert_awaited_once_with(_BF_URL)
+    assert captured["data"] == b"MP4DATA"
+    assert captured["ext"] == ".mp4"

--- a/tests/plugins/platforms/teams/test_adapter_log_redaction.py
+++ b/tests/plugins/platforms/teams/test_adapter_log_redaction.py
@@ -1,0 +1,154 @@
+"""Tests for log redaction of token-bearing URLs in the Teams adapter.
+
+Teams Bot Framework and SharePoint download URLs frequently carry bearer
+or ``tempauth`` material in the query string (``?tempauth=...``,
+``?upload_session_token=...``) or path. Logging raw URLs to ``gateway.log``
+leaks file-access credentials to log aggregators and anyone with read access
+to the gateway logs — a replayable token until expiry (typically minutes to
+hours).
+
+These tests verify:
+
+* ``_url_fingerprint`` strips query strings, fragments, and userinfo;
+* the deterministic sha8 tag remains stable for the same URL (so two log
+  lines referencing the same URL can be correlated);
+* the attachment-dispatch log sites in the inbound flow no longer use
+  format strings that interpolate raw URL strings.
+
+This is the regression suite for the security review on PR #26289.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from plugins.platforms.teams.adapter import _url_fingerprint
+
+
+# ---------------------------------------------------------------------------
+# _url_fingerprint — pure unit tests
+# ---------------------------------------------------------------------------
+
+# Real-world-shaped tokens that MUST NOT appear in fingerprint output.
+# Synthesised here, not real secrets — but the strings exercise the same
+# parser paths a live token would.
+_BEARER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsInkid2lWRGoyN3UifQ.PAYLOAD.SIG"
+_TEMPAUTH = "0e6f1a01-tempauth-90ab-cdef-1234567890ab&access_token=opaque-tok"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Bot Framework attachment URL (path token style).
+        f"https://smba.trafficmanager.net/amer/v3/attachments/{_BEARER}/views/original",
+        # SharePoint tempauth download URL (query-string token).
+        f"https://contoso.sharepoint.com/sites/x/_api/v2.0/drives/abc/items/def/content?tempauth={_TEMPAUTH}",
+        # OneDrive upload session URL (token in query).
+        f"https://api.onedrive.com/upload/sessions/abc?upload_session_token={_BEARER}",
+        # Fragment-encoded token.
+        f"https://example.com/path#access_token={_BEARER}",
+        # userinfo-encoded credentials.
+        f"https://user:{_BEARER}@example.com/path",
+        # Hosted contents Graph URL (id is sensitive — opaque bearer-ish blob).
+        f"https://graph.microsoft.com/v1.0/teams/X/channels/Y/messages/Z/hostedContents/{_BEARER}/$value",
+    ],
+)
+def test_fingerprint_never_leaks_token_material(url: str) -> None:
+    """No fingerprint should contain any of the bearer/tempauth substrings."""
+    fp = _url_fingerprint(url)
+    assert _BEARER not in fp, f"bearer leaked into fingerprint: {fp!r}"
+    assert _TEMPAUTH not in fp, f"tempauth leaked into fingerprint: {fp!r}"
+    assert "?" not in fp, f"query string leaked: {fp!r}"
+    assert "#access_token" not in fp, f"fragment leaked: {fp!r}"
+    # userinfo (user:pass@) must not survive.
+    assert "@" not in fp, f"userinfo leaked: {fp!r}"
+
+
+def test_fingerprint_preserves_host_and_path_prefix() -> None:
+    fp = _url_fingerprint(
+        f"https://contoso.sharepoint.com/sites/x/_api/v2.0/drives/abc/items/def/content?tempauth={_TEMPAUTH}"
+    )
+    assert fp.startswith("contoso.sharepoint.com/sites/x/_api/v2.0/")
+    # 8-char sha tag at the end after `#`.
+    host_path, _, tag = fp.partition("#")
+    assert len(tag) == 8 and all(c in "0123456789abcdef" for c in tag)
+
+
+def test_fingerprint_is_deterministic_for_correlation() -> None:
+    """Two log lines for the same URL must produce the same fingerprint
+    so operators can grep correlations across multi-line attachment flows.
+    """
+    url = f"https://smba.trafficmanager.net/amer/v3/attachments/{_BEARER}/views/original"
+    assert _url_fingerprint(url) == _url_fingerprint(url)
+
+
+def test_fingerprint_differs_for_different_urls() -> None:
+    a = _url_fingerprint("https://smba.trafficmanager.net/amer/v3/attachments/A/views/original")
+    b = _url_fingerprint("https://smba.trafficmanager.net/amer/v3/attachments/B/views/original")
+    # Same host+path prefix but different sha tag.
+    assert a != b
+
+
+@pytest.mark.parametrize("bad", [None, "", 0, 12345, b"https://x", object()])
+def test_fingerprint_safe_for_non_string_inputs(bad) -> None:
+    """The helper is called from logging hot paths — it must never raise."""
+    out = _url_fingerprint(bad)  # type: ignore[arg-type]
+    assert isinstance(out, str)
+    assert out  # non-empty sentinel
+    assert "no-url" in out or "unparseable" in out
+
+
+def test_fingerprint_truncates_long_paths() -> None:
+    long_path = "/a" * 500
+    fp = _url_fingerprint(f"https://x.example.com{long_path}?tempauth=secret")
+    assert "tempauth" not in fp
+    assert "..." in fp  # truncation marker
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard — ensure log sites never re-introduce raw URL formatting
+# ---------------------------------------------------------------------------
+
+# Format-string fragments that historically leaked Teams/SharePoint URLs.
+# If somebody adds a new ``content_url=%r`` or ``download_url=%r`` log
+# without going through ``_url_fingerprint`` first, this test fails.
+_FORBIDDEN_LOG_PATTERNS = [
+    "content_url=%r",
+    "download_url=%r",
+    "upload_url=%r",
+]
+
+
+def test_no_raw_url_format_strings_in_adapter() -> None:
+    src = (
+        Path(__file__).resolve().parents[4]
+        / "plugins" / "platforms" / "teams" / "adapter.py"
+    ).read_text(encoding="utf-8")
+    for pat in _FORBIDDEN_LOG_PATTERNS:
+        assert pat not in src, (
+            f"adapter.py contains forbidden log format {pat!r} — "
+            f"raw URLs must be wrapped in _url_fingerprint() before logging"
+        )
+
+
+def test_bf_get_log_uses_fingerprint() -> None:
+    """The two BF GET log lines flagged in the security review must wrap
+    their URL through ``_url_fingerprint``."""
+    src = (
+        Path(__file__).resolve().parents[4]
+        / "plugins" / "platforms" / "teams" / "adapter.py"
+    ).read_text(encoding="utf-8")
+    # Both occurrences of ``BF GET %s`` should now feed through fingerprint.
+    bf_get_lines = re.findall(r'.*"\[teams\]\[attach\] BF GET %s.*', src)
+    assert bf_get_lines, "expected BF GET log lines to exist"
+    for line in bf_get_lines:
+        # Either the format string contains both the call (next line)
+        # or the format and call are on the same line. Find the matching
+        # ``logger.warning(...)`` call by widening to a small window.
+        idx = src.index(line)
+        window = src[idx : idx + 400]
+        assert "_url_fingerprint(" in window, (
+            f"BF GET log line does not wrap URL through _url_fingerprint:\n{window}"
+        )

--- a/tests/plugins/platforms/teams/test_adapter_outbound.py
+++ b/tests/plugins/platforms/teams/test_adapter_outbound.py
@@ -1,0 +1,1080 @@
+"""Tests for outbound file methods on TeamsAdapter (Task 6).
+
+Covers:
+
+* Public ``send_document`` / ``send_video`` / ``send_voice``.
+* DM dispatch via FileConsent card + ``_pending_uploads`` bookkeeping.
+* Channel dispatch via Graph SharePoint upload + FileDownload card.
+* ``_is_channel_chat`` heuristic — conv_ref override beats id-shape.
+* ``_send_attachment`` activity_sender vs send selection on conv_ref presence.
+
+The fixture builds a ``TeamsAdapter`` *without* calling ``connect()`` so we
+do not need the real SDK app, aiohttp listener, or MSAL credentials. The
+``self._app`` slot is filled with an ``AsyncMock`` whose ``send`` and
+``activity_sender.send`` methods record their arguments.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.teams.adapter import TeamsAdapter
+from plugins.platforms.teams.cards import (
+    FILE_CONSENT_CONTENT_TYPE,
+    FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter(monkeypatch) -> TeamsAdapter:
+    """Build a TeamsAdapter with mocked SDK app, no live network."""
+    # Make sure stale env vars don't seep into _sharepoint_site_id / etc.
+    for var in (
+        "TEAMS_CLIENT_ID",
+        "TEAMS_CLIENT_SECRET",
+        "TEAMS_TENANT_ID",
+        "TEAMS_SHAREPOINT_SITE_ID",
+        "TEAMS_SHAREPOINT_FOLDER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "fake-client",
+            "client_secret": "fake-secret",
+            "tenant_id": "fake-tenant",
+        },
+    )
+    a = TeamsAdapter(cfg)
+
+    # Replace the SDK App with a Mock that has the two send entry points
+    # the adapter dispatches through.
+    fake_app = MagicMock()
+    fake_app.send = AsyncMock(return_value=Mock(id="sent-msg-id"))
+    fake_app.activity_sender = MagicMock()
+    fake_app.activity_sender.send = AsyncMock(return_value=Mock(id="conv-msg-id"))
+    a._app = fake_app
+    return a
+
+
+@pytest.fixture
+def doc_file(tmp_path: Path) -> Path:
+    p = tmp_path / "doc.pdf"
+    p.write_bytes(b"X" * 100)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Public send_* surface — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_document_missing_file_returns_failure(adapter):
+    result = await adapter.send_document("19:foo@unq.gbl.spaces", "/nonexistent/file.txt")
+    assert result.success is False
+    assert result.retryable is False
+    assert "not found" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_send_document_unreadable_file_returns_failure(adapter, tmp_path):
+    # Pass a directory path — open() on it raises IsADirectoryError.
+    bad = tmp_path / "as_dir"
+    bad.mkdir()
+    result = await adapter.send_document("19:foo@unq.gbl.spaces", str(bad))
+    assert result.success is False
+    # "not found" path treats directories as non-files; either way it's a hard fail.
+    assert result.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# DM (FileConsent) dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_document_to_dm_uses_file_consent_card(adapter, doc_file):
+    chat_id = "a:dm-thread-id"  # DM-shaped — no @thread.
+    result = await adapter.send_document(chat_id, str(doc_file))
+
+    assert result.success is True
+    # The send happened via _app.send (no conv_ref stored).
+    assert adapter._app.send.await_count == 1
+    activity = adapter._app.send.await_args.args[1]
+    # The Attachment carries the FileConsentCard contentType.
+    atts = activity.attachments
+    assert len(atts) == 1
+    assert atts[0].content_type == FILE_CONSENT_CONTENT_TYPE
+    # Pending uploads bookkeeping populated.
+    assert len(adapter._pending_uploads) == 1
+    upload_id, payload = next(iter(adapter._pending_uploads.items()))
+    assert payload["filename"] == "doc.pdf"
+    assert payload["bytes"] == b"X" * 100
+    assert payload["chat_id"] == chat_id
+
+
+@pytest.mark.asyncio
+async def test_pending_upload_recorded_with_correct_payload(adapter, doc_file):
+    chat_id = "a:dm-thread-id"
+    await adapter.send_document(
+        chat_id, str(doc_file), caption="hello there", reply_to="parent-msg-1"
+    )
+
+    assert len(adapter._pending_uploads) == 1
+    payload = next(iter(adapter._pending_uploads.values()))
+    assert set(payload.keys()) >= {"filename", "bytes", "chat_id", "caption", "reply_to"}
+    assert payload["filename"] == "doc.pdf"
+    assert payload["bytes"] == b"X" * 100
+    assert payload["chat_id"] == chat_id
+    assert payload["caption"] == "hello there"
+    assert payload["reply_to"] == "parent-msg-1"
+
+
+@pytest.mark.asyncio
+async def test_send_local_file_uses_basename_not_full_path(adapter, tmp_path):
+    nested = tmp_path / "deep" / "deeper"
+    nested.mkdir(parents=True)
+    file = nested / "report.pdf"
+    file.write_bytes(b"PDFDATA")
+    chat_id = "a:dm"
+    await adapter.send_document(chat_id, str(file))
+
+    payload = next(iter(adapter._pending_uploads.values()))
+    assert payload["filename"] == "report.pdf"
+    # The card's content also carries the bare basename.
+    activity = adapter._app.send.await_args.args[1]
+    att = activity.attachments[0]
+    assert att.name == "report.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Channel (Graph SharePoint) dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_document_to_channel_uploads_via_graph(adapter, doc_file):
+    chat_id = "19:abc@thread.tacv2"
+    adapter._sharepoint_site_id = "site1"
+
+    # Stub the lazy-built GraphClient so no MSAL / Graph SDK is touched.
+    fake_graph = MagicMock()
+    fake_graph.upload_to_sharepoint = AsyncMock(
+        return_value="https://sp.example.com/x.pdf"
+    )
+
+    async def _ensure():
+        adapter._graph = fake_graph
+        return fake_graph
+
+    adapter._ensure_graph = _ensure  # type: ignore[assignment]
+
+    result = await adapter.send_document(chat_id, str(doc_file))
+
+    assert result.success is True
+    fake_graph.upload_to_sharepoint.assert_awaited_once()
+    kwargs = fake_graph.upload_to_sharepoint.await_args.kwargs
+    assert kwargs["site_id"] == "site1"
+    assert kwargs["filename"] == "doc.pdf"
+    assert kwargs["content"] == b"X" * 100
+    # Folder is "<base>/<sanitized chat id>".
+    assert kwargs["folder_path"] == "hermes/19_abc_at_thread.tacv2"
+    # _app.send received an activity carrying a FileDownload attachment.
+    adapter._app.send.assert_awaited_once()
+    activity = adapter._app.send.await_args.args[1]
+    assert activity.attachments[0].content_type == FILE_DOWNLOAD_INFO_CONTENT_TYPE
+
+
+@pytest.mark.asyncio
+async def test_send_document_to_channel_without_sharepoint_config_fails(
+    adapter, doc_file
+):
+    adapter._sharepoint_site_id = ""
+    result = await adapter.send_document("19:abc@thread.tacv2", str(doc_file))
+    assert result.success is False
+    assert result.retryable is False
+    assert "SHAREPOINT" in (result.error or "").upper()
+
+
+@pytest.mark.asyncio
+async def test_send_document_to_channel_when_upload_fails(adapter, doc_file):
+    adapter._sharepoint_site_id = "site1"
+    fake_graph = MagicMock()
+    fake_graph.upload_to_sharepoint = AsyncMock(return_value=None)
+
+    async def _ensure():
+        return fake_graph
+
+    adapter._ensure_graph = _ensure  # type: ignore[assignment]
+    result = await adapter.send_document("19:abc@thread.tacv2", str(doc_file))
+    assert result.success is False
+    assert result.retryable is True
+    assert "upload failed" in (result.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Public send_video / send_voice — they just delegate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_video_dispatches_through_send_local_file(adapter, doc_file):
+    sentinel = SendResult(success=True, message_id="ok-video")
+    adapter._send_local_file = AsyncMock(return_value=sentinel)  # type: ignore[assignment]
+    result = await adapter.send_video("a:dm", str(doc_file), caption="demo")
+    assert result is sentinel
+    adapter._send_local_file.assert_awaited_once()
+    args = adapter._send_local_file.await_args.args
+    # (chat_id, path, caption, reply_to)
+    assert args[0] == "a:dm"
+    assert args[1] == str(doc_file)
+    assert args[2] == "demo"
+
+
+@pytest.mark.asyncio
+async def test_send_voice_dispatches_through_send_local_file(adapter, doc_file):
+    sentinel = SendResult(success=True, message_id="ok-voice")
+    adapter._send_local_file = AsyncMock(return_value=sentinel)  # type: ignore[assignment]
+    result = await adapter.send_voice("a:dm", str(doc_file))
+    assert result is sentinel
+    adapter._send_local_file.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _is_channel_chat heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_is_channel_chat_conv_ref_says_channel(adapter):
+    chat_id = "any-id-shape"
+    ref = Mock()
+    ref.conversation = Mock(conversation_type="channel")
+    adapter._conv_refs[chat_id] = ref
+    assert adapter._is_channel_chat(chat_id) is True
+
+
+def test_is_channel_chat_conv_ref_says_personal_overrides_id_shape(adapter):
+    # ID looks like a channel (19:...@thread.) but conv_ref says personal.
+    chat_id = "19:foo@thread.bar"
+    ref = Mock()
+    ref.conversation = Mock(conversation_type="personal")
+    adapter._conv_refs[chat_id] = ref
+    assert adapter._is_channel_chat(chat_id) is False
+
+
+def test_is_channel_chat_no_conv_ref_thread_substring_treated_as_channel(adapter):
+    assert adapter._is_channel_chat("19:abc@thread.tacv2") is True
+
+
+def test_is_channel_chat_no_conv_ref_dm_shape_returns_false(adapter):
+    assert adapter._is_channel_chat("a:dm-thread-id") is False
+    assert adapter._is_channel_chat("19:user@unq.gbl.spaces") is False
+
+
+# ---------------------------------------------------------------------------
+# _send_attachment dispatch — uses activity_sender when conv_ref present.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_attachment_uses_conv_ref_when_available(adapter, doc_file):
+    chat_id = "a:dm-with-ref"
+    ref = Mock()
+    ref.conversation = Mock(conversation_type="personal")
+    adapter._conv_refs[chat_id] = ref
+    result = await adapter.send_document(chat_id, str(doc_file))
+    assert result.success is True
+    adapter._app.activity_sender.send.assert_awaited_once()
+    adapter._app.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_attachment_forwards_content_url_to_sdk_attachment(adapter):
+    """``_send_attachment`` must forward ``contentUrl`` to the SDK Attachment.
+
+    FileInfoCard / FileDownloadInfoCard responses to a FileConsent invoke have
+    ``contentUrl`` at the *top level* of the Bot Framework attachment dict. The
+    SDK ``Attachment`` model exposes ``content_url`` as a real field — dropping
+    it makes Bot Framework reject the activity with HTTP 400 and the consent
+    card buttons unfreeze with no visible result. Pin the four-field wrap.
+    """
+    chat_id = "a:dm-content-url"
+    attachment_dict = {
+        "contentType": "application/vnd.microsoft.teams.file.download.info",
+        "contentUrl": "https://example.sharepoint.com/sites/x/file.pdf",
+        "name": "Canvas Clinical Call.pdf",
+        "content": {"uniqueId": "abc-123", "fileType": "pdf"},
+    }
+
+    captured: dict = {}
+
+    async def fake_send(_chat_id, activity):
+        # MessageActivityInput.add_attachments stashes the SDK Attachment on
+        # the activity — grab the first one so the assertion can inspect it.
+        captured["attachment"] = activity.attachments[0]
+        return Mock(id="mid-1")
+
+    adapter._app.send = AsyncMock(side_effect=fake_send)
+
+    result = await adapter._send_attachment(chat_id, attachment_dict)
+
+    assert result.success is True
+    att = captured["attachment"]
+    assert att.content_type == attachment_dict["contentType"]
+    assert att.content_url == attachment_dict["contentUrl"], (
+        "Attachment.content_url must be forwarded from attachment_dict['contentUrl']; "
+        "Bot Framework returns 400 for FileInfoCard responses without it."
+    )
+    assert att.name == attachment_dict["name"]
+    assert att.content == attachment_dict["content"]
+
+
+# ---------------------------------------------------------------------------
+# Constructor — extra config & env plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_picks_up_sharepoint_config_from_extra(monkeypatch):
+    for var in ("TEAMS_SHAREPOINT_SITE_ID", "TEAMS_SHAREPOINT_FOLDER"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "x",
+            "client_secret": "y",
+            "tenant_id": "z",
+            "sharepoint_site_id": "site-from-config",
+            "sharepoint_folder": "shared/hermes",
+        },
+    )
+    a = TeamsAdapter(cfg)
+    assert a._sharepoint_site_id == "site-from-config"
+    assert a._sharepoint_folder == "shared/hermes"
+    assert a._pending_uploads == {}
+    assert a._graph is None
+    assert a._token_provider is None
+
+
+def test_constructor_falls_back_to_env_vars(monkeypatch):
+    monkeypatch.setenv("TEAMS_SHAREPOINT_SITE_ID", "site-from-env")
+    monkeypatch.setenv("TEAMS_SHAREPOINT_FOLDER", "env/folder")
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"},
+    )
+    a = TeamsAdapter(cfg)
+    assert a._sharepoint_site_id == "site-from-env"
+    assert a._sharepoint_folder == "env/folder"
+
+
+def test_constructor_default_folder_is_hermes(monkeypatch):
+    for var in ("TEAMS_SHAREPOINT_SITE_ID", "TEAMS_SHAREPOINT_FOLDER"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"},
+    )
+    a = TeamsAdapter(cfg)
+    assert a._sharepoint_site_id == ""
+    assert a._sharepoint_folder == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# _pending_uploads memory bounds + send-failure cleanup (quality fixes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_upload_dropped_when_send_fails(
+    adapter, doc_file, monkeypatch, caplog
+):
+    """If FileConsent send fails, the stashed bytes must be popped."""
+    monkeypatch.setattr(
+        adapter,
+        "_send_attachment",
+        AsyncMock(
+            return_value=SendResult(success=False, error="boom", retryable=True)
+        ),
+    )
+    chat_id = "a:dm-thread-id"
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter.send_document(chat_id, str(doc_file))
+
+    assert result.success is False
+    # Crucially: no leak of bytes when the user never got a card.
+    assert len(adapter._pending_uploads) == 0
+    assert any(
+        "FileConsent send failed" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_uploads_bounded_at_max(
+    adapter, doc_file, monkeypatch, caplog
+):
+    """Beyond the cap, oldest entries are evicted FIFO with a warning."""
+    monkeypatch.setattr(adapter, "_PENDING_UPLOAD_MAX", 3)
+
+    captured_ids: list[str] = []
+
+    # Send 4 documents, capturing the upload_id registered for each.
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        for i in range(4):
+            before = set(adapter._pending_uploads.keys())
+            await adapter.send_document(f"a:dm-{i}", str(doc_file))
+            after = set(adapter._pending_uploads.keys())
+            new_ids = after - before
+            # The send may both add and (on the 4th) evict; what we want
+            # is the id that *got registered* this round.
+            if new_ids:
+                captured_ids.append(next(iter(new_ids)))
+            else:
+                # Registration + immediate eviction in same call shouldn't
+                # happen at MAX=3 with one new send (cap holds 3, we add
+                # the 4th, the oldest goes), so this branch is unexpected.
+                captured_ids.append("<missing>")
+
+    # Cap holds exactly MAX entries.
+    assert len(adapter._pending_uploads) == 3
+    # The first registered upload_id is gone.
+    assert captured_ids[0] not in adapter._pending_uploads
+    # The last 3 are present.
+    for uid in captured_ids[1:]:
+        assert uid in adapter._pending_uploads
+    # The eviction emitted a warning.
+    assert any(
+        "evicted oldest" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_uploads_evict_stale_by_ttl(adapter, doc_file):
+    """Entries older than TTL are swept on the next DM send."""
+    # First send: register a normal entry.
+    await adapter.send_document("a:dm-old", str(doc_file))
+    assert len(adapter._pending_uploads) == 1
+    old_id = next(iter(adapter._pending_uploads))
+
+    # Manually backdate the entry's timestamp past the TTL (2h ago).
+    adapter._pending_uploads[old_id]["ts"] = time.monotonic() - 7200
+
+    # Second send triggers _evict_stale_pending_uploads at the top of
+    # _send_dm_file_consent, sweeping the stale entry before registering
+    # the new one.
+    await adapter.send_document("a:dm-new", str(doc_file))
+
+    assert old_id not in adapter._pending_uploads
+    # Only the fresh entry remains.
+    assert len(adapter._pending_uploads) == 1
+
+
+def test_register_pending_upload_sets_timestamp(adapter):
+    """_register_pending_upload stamps a monotonic ts on the entry."""
+    before = time.monotonic()
+    adapter._register_pending_upload(
+        "upload-xyz",
+        {
+            "filename": "f.pdf",
+            "bytes": b"x",
+            "chat_id": "a:dm",
+            "caption": None,
+            "reply_to": None,
+        },
+    )
+    after = time.monotonic()
+
+    entry = adapter._pending_uploads["upload-xyz"]
+    assert "ts" in entry
+    assert isinstance(entry["ts"], float)
+    assert before <= entry["ts"] <= after
+
+
+# ---------------------------------------------------------------------------
+# fileConsent/invoke handler — Allow / Decline lifecycle (Task 7)
+# ---------------------------------------------------------------------------
+
+
+def _make_consent_activity(
+    *,
+    action: str = "accept",
+    context: object = None,
+    upload_info=None,
+):
+    """Build a minimal FileConsentInvokeActivity for handler tests.
+
+    Uses ``model_construct`` to skip pydantic validation — the activity
+    in production carries a full Bot Framework envelope (from_, conversation,
+    id, recipient) that's irrelevant to the handler logic we're exercising.
+    """
+    from microsoft_teams.api.activities.invoke.file_consent import (
+        FileConsentInvokeActivity,
+    )
+    from microsoft_teams.api.models import FileConsentCardResponse
+
+    response = FileConsentCardResponse.model_construct(
+        action=action,
+        context=context,
+        upload_info=upload_info,
+    )
+    return FileConsentInvokeActivity.model_construct(value=response)
+
+
+def _make_ctx(activity, *, conversation_id: str = "dm:user1"):
+    """Wrap an activity in the minimal ``ctx`` shape the handler reads.
+
+    Also attaches a ``conversation`` with ``id`` to the activity (so the
+    handler can read ``ctx.activity.conversation.id`` for consent-card
+    cleanup) and an ``api.conversations.activities(conv_id).delete(...)``
+    chain whose ``delete`` is an ``AsyncMock`` tests can inspect.
+    """
+    ctx = MagicMock()
+    ctx.activity = activity
+    # Attach conversation.id without blocking pydantic model_construct shape.
+    if not hasattr(activity, "conversation") or activity.conversation is None:
+        try:
+            activity.conversation = MagicMock(id=conversation_id)
+        except (AttributeError, TypeError):
+            # Pydantic model with frozen fields — skip; tests targeting
+            # delete will use _make_ctx_with_api below instead.
+            pass
+    # api.conversations.activities(conv_id) returns an object with async delete.
+    delete_mock = AsyncMock()
+    activity_ops = MagicMock()
+    activity_ops.delete = delete_mock
+    ctx.api = MagicMock()
+    ctx.api.conversations.activities = MagicMock(return_value=activity_ops)
+    # Stash the delete mock on ctx for direct test inspection.
+    ctx._delete_mock = delete_mock
+    return ctx
+
+
+@pytest.fixture
+def mock_aiohttp_put(monkeypatch):
+    """Patch aiohttp.ClientSession to capture PUT calls and return a
+    configurable status. Returns a recorder dict that tests can mutate
+    (status, body) and inspect (calls).
+    """
+    recorder: dict = {"status": 200, "body": "", "calls": [], "raise_on_put": None}
+
+    class _MockResp:
+        def __init__(self, status, body):
+            self.status, self._body = status, body
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+        async def text(self):
+            return self._body
+
+    class _MockSession:
+        def __init__(self):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+        def put(self, url, data=None, headers=None):
+            recorder["calls"].append(
+                {"url": url, "data": data, "headers": headers}
+            )
+            if recorder["raise_on_put"] is not None:
+                raise recorder["raise_on_put"]
+            return _MockResp(recorder["status"], recorder["body"])
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _MockSession)
+    return recorder
+
+
+def _register(adapter, upload_id: str, *, filename="r.pdf", data=b"PDFCONTENT", chat_id="dm:user1", activity_id="consent-msg-id"):
+    adapter._register_pending_upload(
+        upload_id,
+        {
+            "filename": filename,
+            "bytes": data,
+            "chat_id": chat_id,
+            "caption": None,
+            "reply_to": None,
+            "activity_id": activity_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_decline_pops_entry_no_put(
+    adapter, mock_aiohttp_put, caplog
+):
+    _register(adapter, "u1")
+    activity = _make_consent_activity(
+        action="decline", context={"upload_id": "u1"}
+    )
+
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert adapter._pending_uploads == {}
+    assert mock_aiohttp_put["calls"] == []
+    assert any(
+        "declined" in rec.getMessage().lower() for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_unknown_upload_id_logs_and_returns(
+    adapter, mock_aiohttp_put, caplog
+):
+    activity = _make_consent_activity(
+        action="accept", context={"upload_id": "missing"}
+    )
+
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert mock_aiohttp_put["calls"] == []
+    assert any("unknown upload_id" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_missing_value_returns_none(
+    adapter, mock_aiohttp_put, caplog
+):
+    from microsoft_teams.api.activities.invoke.file_consent import (
+        FileConsentInvokeActivity,
+    )
+
+    activity = FileConsentInvokeActivity.model_construct(value=None)
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert mock_aiohttp_put["calls"] == []
+    assert any("without value" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_accept_no_upload_url_warns(
+    adapter, mock_aiohttp_put, caplog
+):
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u-no-url")
+    upload_info = FileUploadInfo.model_construct(
+        upload_url=None, content_url="https://x/y", unique_id="id1", file_type="pdf"
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-no-url"},
+        upload_info=upload_info,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    # Entry was popped (consumed) even though we couldn't PUT.
+    assert adapter._pending_uploads == {}
+    assert mock_aiohttp_put["calls"] == []
+    assert any(
+        "missing upload_info.upload_url" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_accept_happy_path(
+    adapter, mock_aiohttp_put, monkeypatch
+):
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(
+        adapter,
+        "u-happy",
+        filename="r.pdf",
+        data=b"PDFCONTENT",
+        chat_id="dm:user1",
+    )
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/upload-session/123",
+        content_url="https://onedrive.example/files/r.pdf",
+        unique_id="graph-drive-item-abc",
+        file_type="pdf",
+        name="r.pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-happy"},
+        upload_info=upload_info,
+    )
+
+    # Capture the FileInfoCard payload sent via _send_attachment.
+    send_attachment_mock = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+    monkeypatch.setattr(adapter, "_send_attachment", send_attachment_mock)
+
+    result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert adapter._pending_uploads == {}
+
+    # Exactly one PUT, with the expected single-shot OneDrive headers.
+    assert len(mock_aiohttp_put["calls"]) == 1
+    call = mock_aiohttp_put["calls"][0]
+    assert call["url"] == "https://onedrive.example/upload-session/123"
+    assert call["data"] == b"PDFCONTENT"
+    headers = call["headers"]
+    assert headers["Content-Type"] == "application/octet-stream"
+    assert headers["Content-Length"] == "10"
+    assert headers["Content-Range"] == "bytes 0-9/10"
+
+    # FileInfoCard follow-up sent to the same chat_id.
+    send_attachment_mock.assert_awaited_once()
+    args, kwargs = send_attachment_mock.await_args
+    assert args[0] == "dm:user1"
+    card = args[1]
+    assert card["contentType"] == "application/vnd.microsoft.teams.card.file.info"
+    # The Graph drive-item id is echoed through, not a fresh uuid.
+    assert card["content"]["uniqueId"] == "graph-drive-item-abc"
+    assert card["content"]["fileType"] == "pdf"
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_accept_put_500_no_followup(
+    adapter, mock_aiohttp_put, monkeypatch, caplog
+):
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u-500")
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/u",
+        content_url="https://x/y",
+        unique_id="id",
+        file_type="pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-500"},
+        upload_info=upload_info,
+    )
+    mock_aiohttp_put["status"] = 500
+    mock_aiohttp_put["body"] = "internal error"
+
+    send_attachment_mock = AsyncMock(return_value=SendResult(success=True))
+    monkeypatch.setattr(adapter, "_send_attachment", send_attachment_mock)
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert len(mock_aiohttp_put["calls"]) == 1
+    send_attachment_mock.assert_not_awaited()
+    assert any(
+        "PUT failed status=500" in rec.getMessage() for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_accept_put_transport_error_no_followup(
+    adapter, mock_aiohttp_put, monkeypatch, caplog
+):
+    import aiohttp
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u-boom")
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/u",
+        content_url="https://x/y",
+        unique_id="id",
+        file_type="pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-boom"},
+        upload_info=upload_info,
+    )
+    mock_aiohttp_put["raise_on_put"] = aiohttp.ClientError("boom")
+
+    send_attachment_mock = AsyncMock(return_value=SendResult(success=True))
+    monkeypatch.setattr(adapter, "_send_attachment", send_attachment_mock)
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    send_attachment_mock.assert_not_awaited()
+    assert any(
+        "transport error" in rec.getMessage() for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_accept_followup_failure_logs(
+    adapter, mock_aiohttp_put, monkeypatch, caplog
+):
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u-followup")
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/u",
+        content_url="https://x/y",
+        unique_id="id",
+        file_type="pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-followup"},
+        upload_info=upload_info,
+    )
+    # PUT succeeds, but the FileInfoCard send fails.
+    send_attachment_mock = AsyncMock(
+        return_value=SendResult(success=False, error="x", retryable=True)
+    )
+    monkeypatch.setattr(adapter, "_send_attachment", send_attachment_mock)
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    send_attachment_mock.assert_awaited_once()
+    assert any(
+        "FileInfoCard follow-up failed" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_evicts_stale_before_lookup(
+    adapter, mock_aiohttp_put
+):
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u-stale")
+    # Backdate so the entry is stale by the time the invoke arrives.
+    adapter._pending_uploads["u-stale"]["ts"] = time.monotonic() - 7200
+
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/u",
+        content_url="https://x/y",
+        unique_id="id",
+        file_type="pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u-stale"},
+        upload_info=upload_info,
+    )
+    result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    # Eviction happened before lookup → unknown-id path → no PUT.
+    assert mock_aiohttp_put["calls"] == []
+    assert "u-stale" not in adapter._pending_uploads
+
+
+@pytest.mark.asyncio
+async def test_file_consent_invoke_context_not_dict_returns_unknown(
+    adapter, mock_aiohttp_put, caplog
+):
+    activity = _make_consent_activity(
+        action="accept", context="stale-context-from-old-card"
+    )
+
+    with caplog.at_level(logging.INFO, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(_make_ctx(activity))
+
+    assert result is None
+    assert mock_aiohttp_put["calls"] == []
+    assert any("unknown upload_id" in rec.getMessage() for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Cross-loop bridge: gateway-loop capture
+#
+# The Microsoft Teams SDK's ``App`` caches asyncio primitives bound to the
+# loop that constructed it. Tools dispatched via model_tools._run_async
+# run on a *worker* loop in a sidecar thread — awaiting App methods from
+# there raises::
+#
+#     RuntimeError: <Event ... [unset]> is bound to a different event loop
+#
+# tools/send_message_tool._send_teams bridges over this by hopping to
+# ``adapter._loop`` via ``asyncio.run_coroutine_threadsafe``. That bridge
+# only works if connect() actually captures the loop. These tests pin the
+# capture/clear contract.
+# ---------------------------------------------------------------------------
+
+
+def test_loop_attribute_is_none_pre_connect(adapter):
+    """Fresh adapter: ``_loop`` is the documented sentinel (None)."""
+    assert adapter._loop is None
+
+
+@pytest.mark.asyncio
+async def test_connect_captures_running_loop(monkeypatch, adapter):
+    """Stub the heavy bits of connect() (App init, aiohttp listener) and
+    confirm the running gateway loop lands in ``self._loop``."""
+    import asyncio as _asyncio
+
+    # Stub out the SDK App + its initialize() coro. The fixture already
+    # filled ``adapter._app`` with a mock; we replace the App() *class*
+    # used inside connect() so the new instance also matches.
+    fake_app = MagicMock()
+    fake_app.initialize = AsyncMock()
+    fake_app.on_message = lambda fn: fn
+    fake_app.on_card_action = lambda fn: fn
+    fake_app.on_file_consent = lambda fn: fn
+
+    monkeypatch.setattr(
+        "plugins.platforms.teams.adapter.App", lambda **kw: fake_app
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.teams.adapter.TEAMS_SDK_AVAILABLE", True
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.teams.adapter.AIOHTTP_AVAILABLE", True
+    )
+
+    # Stub out the aiohttp listener so we don't bind a port.
+    fake_runner = MagicMock()
+    fake_runner.setup = AsyncMock()
+    fake_runner.cleanup = AsyncMock()
+    monkeypatch.setattr(
+        "plugins.platforms.teams.adapter.web.AppRunner", lambda app: fake_runner
+    )
+
+    fake_site = MagicMock()
+    fake_site.start = AsyncMock()
+    monkeypatch.setattr(
+        "plugins.platforms.teams.adapter.web.TCPSite",
+        lambda runner, host, port: fake_site,
+    )
+
+    ok = await adapter.connect()
+    try:
+        assert ok is True
+        assert adapter._loop is _asyncio.get_running_loop(), (
+            "connect() must capture the running event loop so cross-loop "
+            "tool calls can bridge back via run_coroutine_threadsafe"
+        )
+    finally:
+        await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_loop(adapter):
+    """``disconnect()`` clears ``_loop`` so a stale tool call doesn't try
+    to schedule on a torn-down loop."""
+    import asyncio as _asyncio
+
+    # Pretend connect() ran: stamp the loop manually rather than going
+    # through the full stub path.
+    adapter._loop = _asyncio.get_running_loop()
+    adapter._runner = None  # the fixture leaves this unset; disconnect tolerates it
+
+    await adapter.disconnect()
+    assert adapter._loop is None
+
+
+# ---------------------------------------------------------------------------
+# Consent card cleanup — both Accept and Decline must delete the card so
+# Teams' UI doesn't leave the buttons re-enabling indefinitely.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_file_consent_decline_deletes_consent_card(
+    adapter, mock_aiohttp_put
+):
+    """Decline path must delete the original FileConsentCard activity."""
+    _register(adapter, "u1", chat_id="dm:user1", activity_id="consent-act-1")
+    activity = _make_consent_activity(
+        action="decline", context={"upload_id": "u1"}
+    )
+    ctx = _make_ctx(activity, conversation_id="dm:user1")
+
+    await adapter._handle_file_consent_invoke(ctx)
+
+    # The handler should have called ctx.api.conversations.activities("dm:user1").delete("consent-act-1")
+    ctx.api.conversations.activities.assert_called_once_with("dm:user1")
+    ctx._delete_mock.assert_awaited_once_with("consent-act-1")
+
+
+@pytest.mark.asyncio
+async def test_file_consent_accept_deletes_consent_card(
+    adapter, mock_aiohttp_put
+):
+    """Accept path must also delete the original card after PUT succeeds."""
+    from microsoft_teams.api.models import FileUploadInfo
+
+    _register(adapter, "u1", chat_id="dm:user1", activity_id="consent-act-2")
+    upload_info = FileUploadInfo.model_construct(
+        upload_url="https://onedrive.example/upload",
+        content_url="https://example/content",
+        unique_id="uid",
+        file_type="pdf",
+        name="r.pdf",
+    )
+    activity = _make_consent_activity(
+        action="accept",
+        context={"upload_id": "u1"},
+        upload_info=upload_info,
+    )
+    ctx = _make_ctx(activity, conversation_id="dm:user1")
+    mock_aiohttp_put["status"] = 201
+
+    # Stub _post_file_info_card so we don't go down the FileInfo path.
+    adapter._post_file_info_card = AsyncMock(return_value=None)
+
+    await adapter._handle_file_consent_invoke(ctx)
+
+    ctx.api.conversations.activities.assert_called_once_with("dm:user1")
+    ctx._delete_mock.assert_awaited_once_with("consent-act-2")
+
+
+@pytest.mark.asyncio
+async def test_file_consent_delete_failure_swallowed(
+    adapter, mock_aiohttp_put, caplog
+):
+    """A failed delete must not propagate or break the invoke handler."""
+    _register(adapter, "u1", chat_id="dm:user1", activity_id="consent-act-3")
+    activity = _make_consent_activity(
+        action="decline", context={"upload_id": "u1"}
+    )
+    ctx = _make_ctx(activity, conversation_id="dm:user1")
+    ctx._delete_mock.side_effect = RuntimeError("graph 404")
+
+    # Should not raise.
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.teams.adapter"):
+        result = await adapter._handle_file_consent_invoke(ctx)
+
+    assert result is None
+    # Warning logged.
+    assert any(
+        "consent" in rec.getMessage().lower() and "delete" in rec.getMessage().lower()
+        for rec in caplog.records
+    )

--- a/tests/plugins/platforms/teams/test_adapter_wildcard_mime.py
+++ b/tests/plugins/platforms/teams/test_adapter_wildcard_mime.py
@@ -1,0 +1,285 @@
+"""Tests for wildcard / missing MIME subtypes on inbound BF attachments.
+
+Teams sometimes posts attachments with ``content_type="image/*"`` (literal
+asterisk) — particularly when a user pastes an image inline rather than
+attaching a typed file. Naively splitting that on ``"/"`` produced an extension
+of ``".*"`` which then leaked into the cache filename
+(``img_xxx.*``) and broke downstream tooling that opens files by extension.
+
+Fix: when the subtype is empty, ``"*"``, or otherwise unrecognised, sniff the
+fetched bytes via magic numbers and pick a sensible extension. Fall back to
+the kind's default (``.jpg`` / ``.ogg`` / ``.mp4``) only as a last resort.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.teams.adapter import (
+    TeamsAdapter,
+    _resolve_media_ext,
+)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_media_ext — magic-byte sniffer
+# ---------------------------------------------------------------------------
+
+# Magic-byte fixtures. Only the prefix needs to match the sniffer — payload
+# beyond the header is irrelevant for these unit tests.
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+_JPG = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+_GIF87 = b"GIF87a" + b"\x00" * 32
+_GIF89 = b"GIF89a" + b"\x00" * 32
+_WEBP = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 32
+_OGG = b"OggS" + b"\x00" * 32
+_MP3_ID3 = b"ID3" + b"\x00" * 32
+_MP3_FRAME = b"\xff\xfb" + b"\x00" * 32
+_WAV = b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"\x00" * 32
+_FLAC = b"fLaC" + b"\x00" * 32
+_MP4 = b"\x00\x00\x00\x20ftypisom" + b"\x00" * 32
+_MOV = b"\x00\x00\x00\x14ftypqt  " + b"\x00" * 32
+_WEBM = b"\x1aE\xdf\xa3" + b"\x00" * 32
+
+
+@pytest.mark.parametrize(
+    "subtype,data,kind,expected",
+    [
+        # explicit, well-known subtypes pass straight through
+        ("png", b"", "image", ".png"),
+        ("jpeg", b"", "image", ".jpg"),  # jpeg → jpg normalisation
+        ("gif", b"", "image", ".gif"),
+        ("webp", b"", "image", ".webp"),
+        ("ogg", b"", "audio", ".ogg"),
+        ("mp3", b"", "audio", ".mp3"),
+        ("mp4", b"", "video", ".mp4"),
+
+        # wildcard / empty subtype → sniff bytes
+        ("*", _PNG, "image", ".png"),
+        ("*", _JPG, "image", ".jpg"),
+        ("*", _GIF87, "image", ".gif"),
+        ("*", _GIF89, "image", ".gif"),
+        ("*", _WEBP, "image", ".webp"),
+        ("", _PNG, "image", ".png"),
+        ("*", _OGG, "audio", ".ogg"),
+        ("*", _MP3_ID3, "audio", ".mp3"),
+        ("*", _MP3_FRAME, "audio", ".mp3"),
+        ("*", _WAV, "audio", ".wav"),
+        ("*", _FLAC, "audio", ".flac"),
+        ("*", _MP4, "video", ".mp4"),
+        ("*", _MOV, "video", ".mov"),
+        ("*", _WEBM, "video", ".webm"),
+
+        # last-resort defaults when sniff also fails
+        ("*", b"\x00\x00\x00\x00\x00", "image", ".jpg"),
+        ("*", b"\x00\x00\x00\x00\x00", "audio", ".ogg"),
+        ("*", b"\x00\x00\x00\x00\x00", "video", ".mp4"),
+        ("*", b"", "image", ".jpg"),
+    ],
+)
+def test_resolve_media_ext(subtype, data, kind, expected):
+    assert _resolve_media_ext(subtype, data, kind) == expected
+
+
+def test_resolve_media_ext_strips_codec_params():
+    # MIME params like ``image/jpeg; codecs=...`` would arrive after the caller
+    # already split on ``";"``; we still defend against accidental leakage.
+    assert _resolve_media_ext("jpeg ", b"", "image") == ".jpg"
+
+
+def test_resolve_media_ext_unknown_subtype_falls_through_to_default():
+    # Unknown but non-wildcard subtype: trust it for image/audio (codecs vary
+    # too widely to whitelist) — caller validated category via prefix.
+    assert _resolve_media_ext("heic", b"", "image") == ".heic"
+
+
+# ---------------------------------------------------------------------------
+# Adapter fixture (mirrors test_adapter_inbound_bf_auth.py)
+# ---------------------------------------------------------------------------
+
+
+_BF_URL = (
+    "https://smba.trafficmanager.net/amer/def57894-de93-412b-8ce2-87faabe44453/"
+    "v3/attachments/0-eus-d6-0d3d6109e0e45c3a5a11f8cd7c3731bf/views/original"
+)
+
+
+@pytest.fixture
+def adapter(monkeypatch) -> TeamsAdapter:
+    for var in ("TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "client_id": "fake-client",
+            "client_secret": "fake-secret",
+            "tenant_id": "fake-tenant",
+        },
+    )
+    a = TeamsAdapter(cfg)
+    fake_app = MagicMock()
+    fake_token = MagicMock()
+    fake_token.__str__ = lambda self: "FAKE.JWT.TOKEN"  # type: ignore[assignment]
+    fake_app._get_bot_token = AsyncMock(return_value=fake_token)
+    a._app = fake_app
+    return a
+
+
+def _make_activity(attachments):
+    activity = MagicMock()
+    activity.text = ""
+    activity.attachments = attachments
+    activity.id = "ACT-1"
+    activity.channel_data = None
+    conv = MagicMock()
+    conv.id = "chat-id"
+    conv.name = ""
+    conv.conversation_type = "personal"
+    conv.tenant_id = "tenant-1"
+    activity.conversation = conv
+    from_acct = MagicMock()
+    from_acct.aad_object_id = "user-1"
+    from_acct.id = "user-1"
+    from_acct.name = "Test User"
+    activity.from_ = from_acct
+    return activity
+
+
+def _make_attachment(content_type, content_url, name=None):
+    a = MagicMock()
+    a.content_type = content_type
+    a.contentType = content_type
+    a.content_url = content_url
+    a.contentUrl = content_url
+    a.name = name
+    a.content = None
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests — _on_message must NOT cache files with literal '*' extension
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_image_wildcard_mime_with_png_bytes_sniffs_to_png(adapter, monkeypatch):
+    """Regression: content_type='image/*' + PNG bytes used to cache as 'img_xxx.*'."""
+    fetch_spy = AsyncMock(return_value=_PNG)
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["data"] = data
+        captured["ext"] = ext
+        return f"/cache/img.{ext.lstrip('.')}"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", fake_cache_bytes)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("image/*", _BF_URL)])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    assert captured["ext"] == ".png", f"expected .png, got {captured.get('ext')!r}"
+    assert "*" not in captured["ext"]
+
+
+@pytest.mark.asyncio
+async def test_image_wildcard_mime_with_jpeg_bytes_sniffs_to_jpg(adapter, monkeypatch):
+    fetch_spy = AsyncMock(return_value=_JPG)
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["ext"] = ext
+        return "/cache/img.jpg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", fake_cache_bytes)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("image/*", _BF_URL)])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    assert captured["ext"] == ".jpg"
+
+
+@pytest.mark.asyncio
+async def test_audio_wildcard_mime_with_ogg_bytes_sniffs_to_ogg(adapter, monkeypatch):
+    fetch_spy = AsyncMock(return_value=_OGG)
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["ext"] = ext
+        return "/cache/voice.ogg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_audio_from_bytes", fake_cache_bytes)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("audio/*", _BF_URL)])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    assert captured["ext"] == ".ogg"
+    assert "*" not in captured["ext"]
+
+
+@pytest.mark.asyncio
+async def test_video_wildcard_mime_with_mp4_bytes_sniffs_to_mp4(adapter, monkeypatch):
+    fetch_spy = AsyncMock(return_value=_MP4)
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["ext"] = ext
+        return "/cache/clip.mp4"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_video_from_bytes", fake_cache_bytes)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("video/*", _BF_URL)])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    assert captured["ext"] == ".mp4"
+    assert "*" not in captured["ext"]
+
+
+@pytest.mark.asyncio
+async def test_image_wildcard_mime_unsniffable_falls_back_to_jpg(adapter, monkeypatch):
+    """When sniffer can't ID the bytes, default to ``.jpg`` — never ``.*``."""
+    fetch_spy = AsyncMock(return_value=b"\x00\x00\x00\x00garbage")
+    adapter._fetch_bf_attachment_bytes = fetch_spy  # type: ignore[method-assign]
+
+    captured = {}
+
+    def fake_cache_bytes(data, ext):
+        captured["ext"] = ext
+        return "/cache/img.jpg"
+
+    import gateway.platforms.base as base
+    monkeypatch.setattr(base, "cache_image_from_bytes", fake_cache_bytes)
+
+    ctx = MagicMock()
+    ctx.activity = _make_activity([_make_attachment("image/*", _BF_URL)])
+    adapter.send = AsyncMock()  # type: ignore[method-assign]
+
+    await adapter._on_message(ctx)
+
+    assert captured["ext"] == ".jpg"
+    assert "*" not in captured["ext"]

--- a/tests/plugins/platforms/teams/test_auth_graph.py
+++ b/tests/plugins/platforms/teams/test_auth_graph.py
@@ -1,0 +1,338 @@
+"""Tests for the MSAL-backed Graph token provider."""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.platforms.teams.auth_graph import AuthError, GraphTokenProvider
+
+
+def _make_fake_msal_app(token: str = "tok", expires_in: int = 3600) -> MagicMock:
+    """Return a MagicMock standing in for msal.ConfidentialClientApplication."""
+    fake = MagicMock()
+    fake.acquire_token_for_client.return_value = {
+        "access_token": token,
+        "expires_in": expires_in,
+    }
+    return fake
+
+
+def _make_provider_with_fake(fake_app: MagicMock) -> GraphTokenProvider:
+    p = GraphTokenProvider(
+        client_id="client-id",
+        tenant_id="tenant-id",
+        client_secret="secret",
+    )
+    # Patch the lazy builder to return our fake — never touches MSAL or network.
+    p._build_msal_app = lambda: fake_app  # type: ignore[method-assign]
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_token_caches_per_scope():
+    fake = _make_fake_msal_app(token="tok", expires_in=3600)
+    p = _make_provider_with_fake(fake)
+
+    t1 = await p.get_token("https://graph.microsoft.com/.default")
+    t2 = await p.get_token("https://graph.microsoft.com/.default")
+
+    assert t1 == "tok"
+    assert t2 == "tok"
+    assert fake.acquire_token_for_client.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_token_separates_caches_per_scope():
+    fake = _make_fake_msal_app(token="tok", expires_in=3600)
+    p = _make_provider_with_fake(fake)
+
+    await p.get_token("scope-a")
+    await p.get_token("scope-b")
+
+    assert fake.acquire_token_for_client.call_count == 2
+    # Verify the actual scope arg was passed in each call.
+    call_scopes = [
+        call.args[0] if call.args else call.kwargs.get("scopes")
+        for call in fake.acquire_token_for_client.call_args_list
+    ]
+    assert call_scopes == [["scope-a"], ["scope-b"]]
+
+
+# ---------------------------------------------------------------------------
+# Refresh near expiry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_token_refreshes_when_near_expiry():
+    fake = _make_fake_msal_app(token="tok", expires_in=120)
+    p = _make_provider_with_fake(fake)
+
+    # First call caches with ~120s lifetime.
+    await p.get_token("scope-x")
+    assert fake.acquire_token_for_client.call_count == 1
+
+    # Second call with a refresh window LARGER than the remaining lifetime
+    # should treat the cached token as near-expiry and refresh.
+    await p.get_token("scope-x", refresh_if_within_seconds=200)
+    assert fake.acquire_token_for_client.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_token_refreshes_when_clock_advances(monkeypatch):
+    """If wall-clock advances past expires_at - leeway, refresh."""
+    fake = _make_fake_msal_app(token="tok", expires_in=120)
+    p = _make_provider_with_fake(fake)
+
+    real_time = time.time
+    fake_now = [real_time()]
+
+    def fake_time() -> float:
+        return fake_now[0]
+
+    # Patch the time function used inside auth_graph.
+    monkeypatch.setattr(
+        "plugins.platforms.teams.auth_graph.time.time",
+        fake_time,
+    )
+
+    await p.get_token("scope-x")
+    assert fake.acquire_token_for_client.call_count == 1
+
+    # Jump forward beyond the cached token's effective lifetime.
+    fake_now[0] += 200
+
+    await p.get_token("scope-x")
+    assert fake.acquire_token_for_client.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Error path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_token_raises_on_msal_error():
+    fake = MagicMock()
+    fake.acquire_token_for_client.return_value = {
+        "error": "invalid_client",
+        "error_description": "bad",
+    }
+    p = _make_provider_with_fake(fake)
+
+    with pytest.raises(AuthError) as exc_info:
+        await p.get_token("scope-x")
+
+    msg = str(exc_info.value)
+    assert "invalid_client" in msg
+    assert "bad" in msg
+
+
+@pytest.mark.asyncio
+async def test_get_token_raises_on_msal_error_without_description():
+    fake = MagicMock()
+    fake.acquire_token_for_client.return_value = {"error": "invalid_client"}
+    p = _make_provider_with_fake(fake)
+
+    with pytest.raises(AuthError) as exc_info:
+        await p.get_token("scope-x")
+
+    assert "invalid_client" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_token_concurrent_calls_only_acquire_once():
+    """Two concurrent get_token calls for the same scope must collapse into
+    a single MSAL acquisition thanks to the per-scope async lock."""
+    import threading
+
+    loop = asyncio.get_running_loop()
+    call_event = asyncio.Event()
+    release_event = threading.Event()  # cross-thread signal — safe from worker
+
+    call_count = 0
+
+    def _acquire(scopes):
+        nonlocal call_count
+        call_count += 1
+        # Signal (from worker thread) that we're inside MSAL.
+        loop.call_soon_threadsafe(call_event.set)
+        # Block until the test releases us, forcing the second coroutine
+        # to contend on the per-scope lock.
+        release_event.wait(timeout=5.0)
+        return {"access_token": "tok", "expires_in": 3600}
+
+    fake = MagicMock()
+    fake.acquire_token_for_client.side_effect = _acquire
+    p = _make_provider_with_fake(fake)
+
+    async def call() -> str:
+        return await p.get_token("scope-shared")
+
+    task1 = asyncio.create_task(call())
+    # Wait until task1 has reached the executor (and thus is holding the lock).
+    await call_event.wait()
+    task2 = asyncio.create_task(call())
+    # Give task2 a moment to reach the lock.
+    await asyncio.sleep(0.05)
+    # Now release the MSAL call so both tasks can complete.
+    release_event.set()
+
+    results = await asyncio.gather(task1, task2)
+
+    assert results == ["tok", "tok"]
+    assert call_count == 1
+    assert fake.acquire_token_for_client.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_token_concurrent_unseen_scope_locks_correctly():
+    """Two concurrent get_token() calls on a scope NEVER seen before must
+    still collapse onto a single MSAL acquisition.
+
+    This pins the lock-dict invariant: the lock for a fresh scope must be
+    created atomically (setdefault), not via a get-check-set sequence that
+    could race even if today's CPython asyncio scheduling masks it.
+    """
+    import threading
+
+    loop = asyncio.get_running_loop()
+    call_event = asyncio.Event()
+    release_event = threading.Event()
+
+    call_count = 0
+
+    def _acquire(scopes):
+        nonlocal call_count
+        call_count += 1
+        loop.call_soon_threadsafe(call_event.set)
+        release_event.wait(timeout=5.0)
+        return {"access_token": "tok", "expires_in": 3600}
+
+    fake = MagicMock()
+    fake.acquire_token_for_client.side_effect = _acquire
+    p = _make_provider_with_fake(fake)
+
+    # Sanity: scope has never been seen — no lock entry yet.
+    assert "fresh-scope" not in p._locks
+
+    async def call() -> str:
+        return await p.get_token("fresh-scope")
+
+    # Kick off two tasks before the lock dict has any entry for this scope.
+    task1 = asyncio.create_task(call())
+    task2 = asyncio.create_task(call())
+
+    # Wait until at least one task is inside MSAL.
+    await call_event.wait()
+    # Give the other task time to attempt the lock.
+    await asyncio.sleep(0.05)
+    release_event.set()
+
+    results = await asyncio.gather(task1, task2)
+
+    assert results == ["tok", "tok"]
+    assert call_count == 1
+    assert fake.acquire_token_for_client.call_count == 1
+    # Both coroutines must have ended up sharing the same Lock instance.
+    assert len(p._locks) == 1
+    assert "fresh-scope" in p._locks
+
+
+@pytest.mark.asyncio
+async def test_get_token_different_scopes_do_not_block():
+    """Per-scope locks must not serialize calls across different scopes.
+
+    With scope A's MSAL call blocked, a concurrent call for scope B must
+    complete promptly — proving locks are partitioned per scope, not global.
+    """
+    import threading
+
+    loop = asyncio.get_running_loop()
+    a_in_msal = asyncio.Event()
+    a_release = threading.Event()
+    b_done = asyncio.Event()
+
+    def _acquire(scopes):
+        scope = scopes[0]
+        if scope == "scope-A":
+            loop.call_soon_threadsafe(a_in_msal.set)
+            a_release.wait(timeout=5.0)
+            return {"access_token": "tok-a", "expires_in": 3600}
+        # scope-B: return immediately.
+        return {"access_token": "tok-b", "expires_in": 3600}
+
+    fake = MagicMock()
+    fake.acquire_token_for_client.side_effect = _acquire
+    p = _make_provider_with_fake(fake)
+
+    async def call_a() -> str:
+        return await p.get_token("scope-A")
+
+    async def call_b() -> str:
+        try:
+            return await p.get_token("scope-B")
+        finally:
+            b_done.set()
+
+    task_a = asyncio.create_task(call_a())
+    # Wait until A is inside MSAL and holding A's lock.
+    await a_in_msal.wait()
+    # Now start B — it must NOT be blocked by A.
+    task_b = asyncio.create_task(call_b())
+
+    # B must complete BEFORE we release A.
+    await asyncio.wait_for(b_done.wait(), timeout=2.0)
+    assert task_b.done(), "scope-B was blocked by scope-A's lock"
+    assert not task_a.done(), "scope-A should still be waiting on MSAL"
+
+    # Now let A finish.
+    a_release.set()
+
+    results = await asyncio.gather(task_a, task_b)
+    assert results == ["tok-a", "tok-b"]
+    assert fake.acquire_token_for_client.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Lazy import of msal
+# ---------------------------------------------------------------------------
+
+def test_msal_is_lazy_imported():
+    """Importing the auth_graph module must NOT pull in msal at import time.
+
+    msal is only needed when _build_msal_app() actually runs, so the
+    plugin can be loaded even if msal isn't installed (lazy_deps will
+    install it on demand).
+    """
+    # Drop msal & auth_graph from sys.modules so we can observe a fresh import.
+    sys.modules.pop("msal", None)
+    sys.modules.pop("plugins.platforms.teams.auth_graph", None)
+    # Importing should not pull msal in.
+    import importlib
+    importlib.import_module("plugins.platforms.teams.auth_graph")
+    assert "msal" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# expires_in default
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_token_handles_missing_expires_in():
+    fake = MagicMock()
+    fake.acquire_token_for_client.return_value = {"access_token": "tok"}
+    p = _make_provider_with_fake(fake)
+
+    token = await p.get_token("scope-x")
+    assert token == "tok"

--- a/tests/plugins/platforms/teams/test_cards.py
+++ b/tests/plugins/platforms/teams/test_cards.py
@@ -1,0 +1,178 @@
+"""Tests for Teams card builders (FileConsent / FileInfo / FileDownload)."""
+from __future__ import annotations
+
+from plugins.platforms.teams.cards import (
+    FILE_CONSENT_CONTENT_TYPE,
+    FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+    FILE_INFO_CONTENT_TYPE,
+    build_file_consent_card,
+    build_file_download_card,
+    build_file_info_card,
+)
+
+
+# ---------------------------------------------------------------------------
+# FileConsentCard
+# ---------------------------------------------------------------------------
+
+def test_file_consent_card_has_correct_content_type():
+    card = build_file_consent_card(
+        "foo.pdf",
+        size_bytes=1234,
+        accept_context={"upload_id": "u1"},
+        description="hello",
+    )
+    assert card["contentType"] == FILE_CONSENT_CONTENT_TYPE
+    assert card["contentType"] == "application/vnd.microsoft.teams.card.file.consent"
+    assert card["name"] == "foo.pdf"
+    assert card["content"]["sizeInBytes"] == 1234
+    assert card["content"]["description"] == "hello"
+    # acceptContext is echoed back so the bot can correlate the invoke
+    assert card["content"]["acceptContext"] == {"upload_id": "u1"}
+
+
+def test_file_consent_card_seeds_upload_id_when_missing():
+    card = build_file_consent_card("foo.pdf", size_bytes=1, accept_context={})
+    ctx = card["content"]["acceptContext"]
+    assert "upload_id" in ctx
+    assert isinstance(ctx["upload_id"], str)
+    assert ctx["upload_id"]  # non-empty
+
+
+def test_file_consent_card_seeds_upload_id_when_context_is_none():
+    card = build_file_consent_card("foo.pdf", size_bytes=1)
+    ctx = card["content"]["acceptContext"]
+    assert "upload_id" in ctx
+    assert ctx["upload_id"]
+
+
+def test_file_consent_card_preserves_caller_upload_id():
+    card = build_file_consent_card(
+        "foo.pdf", size_bytes=1, accept_context={"upload_id": "fixed-id"}
+    )
+    assert card["content"]["acceptContext"]["upload_id"] == "fixed-id"
+
+
+def test_file_consent_card_decline_context_matches_accept():
+    card = build_file_consent_card(
+        "foo.pdf", size_bytes=1, accept_context={"upload_id": "u1", "extra": 7}
+    )
+    # They should be value-equal so either user response correlates back identically...
+    assert card["content"]["acceptContext"] == card["content"]["declineContext"]
+    # ...but NOT the same object — mutation of one must not bleed into the other.
+    assert card["content"]["acceptContext"] is not card["content"]["declineContext"]
+    # Prove independence: mutating accept must leave decline untouched.
+    card["content"]["acceptContext"]["status"] = "x"
+    assert "status" not in card["content"]["declineContext"]
+
+
+def test_file_consent_card_does_not_mutate_caller_context():
+    caller = {}
+    build_file_consent_card("f.pdf", 1, accept_context=caller)
+    # upload_id was added to the COPY, not the caller's dict.
+    assert caller == {}
+
+
+def test_file_consent_card_size_is_coerced_to_int():
+    card = build_file_consent_card("foo.pdf", size_bytes="2048")
+    assert card["content"]["sizeInBytes"] == 2048
+    assert isinstance(card["content"]["sizeInBytes"], int)
+
+
+def test_file_consent_card_description_defaults_to_empty():
+    card = build_file_consent_card("foo.pdf", size_bytes=1)
+    assert card["content"]["description"] == ""
+
+
+# ---------------------------------------------------------------------------
+# FileInfoCard
+# ---------------------------------------------------------------------------
+
+def test_file_info_card_uses_correct_content_type():
+    card = build_file_info_card(
+        "foo.pdf",
+        content_url="https://example/foo.pdf",
+        unique_id="drive-item-123",
+        file_type="pdf",
+    )
+    assert card["contentType"] == FILE_INFO_CONTENT_TYPE
+    assert card["contentType"] == "application/vnd.microsoft.teams.card.file.info"
+    assert card["contentUrl"] == "https://example/foo.pdf"
+    assert card["name"] == "foo.pdf"
+    assert card["content"]["fileType"] == "pdf"
+    # When unique_id is supplied (the Graph drive-item id) it is echoed
+    # through unchanged so Teams clients can resolve the attachment.
+    assert card["content"]["uniqueId"] == "drive-item-123"
+
+
+def test_file_info_card_uniqueId_falls_back_to_uuid_when_unknown():
+    # Two cards built without unique_id should each get a fresh uuid
+    # (preserves the old behaviour for callers that don't yet have the
+    # Graph drive-item id).
+    a = build_file_info_card("a.pdf", content_url="https://x/a")
+    b = build_file_info_card("a.pdf", content_url="https://x/a")
+    assert a["content"]["uniqueId"] != b["content"]["uniqueId"]
+
+
+def test_file_info_card_passes_unique_id_through():
+    card = build_file_info_card(
+        "report.docx",
+        content_url="https://x/y",
+        unique_id="graph-item-xyz",
+    )
+    assert card["content"]["uniqueId"] == "graph-item-xyz"
+    assert card["name"] == "report.docx"
+
+
+def test_file_info_card_infers_file_type_from_filename():
+    card = build_file_info_card("diagram.PNG", content_url="https://x/y")
+    assert card["content"]["fileType"] == "png"
+    # No extension → "file" fallback.
+    card2 = build_file_info_card("LICENSE", content_url="https://x/y")
+    assert card2["content"]["fileType"] == "file"
+
+
+# ---------------------------------------------------------------------------
+# FileDownloadCard (file.download.info)
+# ---------------------------------------------------------------------------
+
+def test_file_download_card_uses_download_info_content_type():
+    card = build_file_download_card(
+        filename="foo.pdf",
+        content_url="https://contoso.sharepoint.com/sites/foo/Shared%20Documents/foo.pdf",
+        unique_id="aaaa-bbbb",
+    )
+    assert card["contentType"] == FILE_DOWNLOAD_INFO_CONTENT_TYPE
+    assert card["contentType"] == "application/vnd.microsoft.teams.file.download.info"
+    assert card["contentUrl"].startswith("https://contoso.sharepoint.com/")
+    assert card["content"]["uniqueId"] == "aaaa-bbbb"
+    assert card["content"]["fileType"] == "pdf"
+    assert card["name"] == "foo.pdf"
+
+
+def test_file_download_card_passes_unique_id_through():
+    card = build_file_download_card(
+        filename="report.docx",
+        content_url="https://x/y",
+        unique_id="xyz-123",
+    )
+    assert card["content"]["uniqueId"] == "xyz-123"
+    # The card's `name` is the filename (Teams uses this as the on-screen label).
+    assert card["name"] == "report.docx"
+
+
+def test_file_download_card_infers_file_type_from_filename():
+    card = build_file_download_card(filename="diagram.PNG", content_url="https://x/y")
+    assert card["content"]["fileType"] == "png"
+    # No extension → "file" fallback.
+    card2 = build_file_download_card(filename="LICENSE", content_url="https://x/y")
+    assert card2["content"]["fileType"] == "file"
+    # Empty after dot → also "file".
+    card3 = build_file_download_card(filename="weird.", content_url="https://x/y")
+    assert card3["content"]["fileType"] == "file"
+
+
+def test_file_download_card_omits_unique_id_when_unknown():
+    card = build_file_download_card(filename="x.txt", content_url="https://x/y")
+    assert "uniqueId" not in card["content"]
+    assert card["content"]["downloadUrl"] == "https://x/y"

--- a/tests/plugins/platforms/teams/test_graph.py
+++ b/tests/plugins/platforms/teams/test_graph.py
@@ -1,0 +1,312 @@
+"""Tests for the narrow Microsoft Graph client wrapper."""
+from __future__ import annotations
+
+import sys
+import time
+import types
+from collections import namedtuple
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub azure.core.credentials.AccessToken before importing graph.py.
+#
+# The Graph client wrapper lazy-imports ``from azure.core.credentials import
+# AccessToken`` inside ``_HermesTokenCredential.get_token``. The azure-core
+# package is in the optional ``teams-files`` extra and is not installed in
+# the default dev venv, so we provide a minimal stand-in. This keeps the
+# tests honest about the boundary (``AccessToken`` is just a named tuple of
+# ``(token, expires_on)``) without forcing every developer to install the
+# Azure SDK to run the unit suite.
+# ---------------------------------------------------------------------------
+if "azure.core.credentials" not in sys.modules:
+    _FakeAccessToken = namedtuple("AccessToken", ["token", "expires_on"])
+    azure_pkg = sys.modules.setdefault("azure", types.ModuleType("azure"))
+    azure_pkg.__path__ = []  # mark as package
+    azure_core_pkg = sys.modules.setdefault("azure.core", types.ModuleType("azure.core"))
+    azure_core_pkg.__path__ = []
+    azure_creds_mod = types.ModuleType("azure.core.credentials")
+    azure_creds_mod.AccessToken = _FakeAccessToken
+    sys.modules["azure.core.credentials"] = azure_creds_mod
+
+
+from plugins.platforms.teams.auth_graph import AuthError  # noqa: E402
+from plugins.platforms.teams.graph import (  # noqa: E402
+    GRAPH_SCOPE,
+    GraphClient,
+    _HermesTokenCredential,
+    _attr,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+def test_graph_scope_constant():
+    assert GRAPH_SCOPE == "https://graph.microsoft.com/.default"
+
+
+# ---------------------------------------------------------------------------
+# _HermesTokenCredential
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_hermes_token_credential_returns_access_token():
+    provider = Mock()
+    provider.get_token = AsyncMock(return_value="abc")
+
+    cred = _HermesTokenCredential(provider)
+    before = int(time.time())
+    tok = await cred.get_token("scope1")
+
+    assert tok.token == "abc"
+    # expires_on should be roughly +3000 seconds from now
+    assert tok.expires_on >= before + 2900
+    assert tok.expires_on <= before + 3100
+    provider.get_token.assert_awaited_once_with("scope1")
+
+
+@pytest.mark.asyncio
+async def test_hermes_token_credential_no_scopes_raises():
+    provider = Mock()
+    provider.get_token = AsyncMock(return_value="abc")
+
+    cred = _HermesTokenCredential(provider)
+
+    with pytest.raises(AuthError):
+        await cred.get_token()
+
+
+@pytest.mark.asyncio
+async def test_hermes_token_credential_close_is_noop():
+    cred = _HermesTokenCredential(Mock())
+    assert await cred.close() is None
+
+
+@pytest.mark.asyncio
+async def test_hermes_token_credential_uses_first_scope_only():
+    provider = Mock()
+    provider.get_token = AsyncMock(return_value="multi")
+
+    cred = _HermesTokenCredential(provider)
+    tok = await cred.get_token("first-scope", "second-scope")
+
+    assert tok.token == "multi"
+    provider.get_token.assert_awaited_once_with("first-scope")
+
+
+# ---------------------------------------------------------------------------
+# _attr helper
+# ---------------------------------------------------------------------------
+
+def test_attr_tolerates_dict_and_object_and_none():
+    # dict
+    assert _attr({"a": 1}, "a") == 1
+    assert _attr({"a": 1}, "missing", default="x") == "x"
+    # object
+    obj = Mock(spec=["foo"])
+    obj.foo = "bar"
+    assert _attr(obj, "foo") == "bar"
+    assert _attr(obj, "missing", default="dflt") == "dflt"
+    # None
+    assert _attr(None, "anything") is None
+    assert _attr(None, "anything", default="z") == "z"
+
+
+# ---------------------------------------------------------------------------
+# GraphClient — lazy SDK import
+# ---------------------------------------------------------------------------
+
+def test_graph_client_lazy_builds_msgraph():
+    # If msgraph was previously imported (by other tests), pop it so we can
+    # confirm GraphClient construction itself does not import it.
+    sys.modules.pop("msgraph", None)
+
+    g = GraphClient(provider=Mock())
+    assert g._client is None
+    # Constructing GraphClient must NOT have triggered the heavy import.
+    assert "msgraph" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# download_hosted_content
+# ---------------------------------------------------------------------------
+
+def _build_hosted_chain(return_value=b"PNG-bytes", side_effect=None):
+    """Build a fluent fake chain for download_hosted_content."""
+    fake_client = MagicMock()
+    get = AsyncMock(return_value=return_value)
+    if side_effect is not None:
+        get.side_effect = side_effect
+        get.return_value = None
+    (
+        fake_client.teams.by_team_id.return_value
+        .channels.by_channel_id.return_value
+        .messages.by_chat_message_id.return_value
+        .hosted_contents.by_chat_message_hosted_content_id.return_value
+        .content.get
+    ) = get
+    return fake_client, get
+
+
+@pytest.mark.asyncio
+async def test_download_hosted_content_returns_bytes():
+    fake_client, _get = _build_hosted_chain(return_value=b"PNG-bytes")
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    result = await g.download_hosted_content("t", "c", "m", "h")
+
+    assert result == b"PNG-bytes"
+    fake_client.teams.by_team_id.assert_called_once_with("t")
+    fake_client.teams.by_team_id.return_value.channels.by_channel_id.assert_called_once_with("c")
+    (
+        fake_client.teams.by_team_id.return_value
+        .channels.by_channel_id.return_value
+        .messages.by_chat_message_id.assert_called_once_with("m")
+    )
+    (
+        fake_client.teams.by_team_id.return_value
+        .channels.by_channel_id.return_value
+        .messages.by_chat_message_id.return_value
+        .hosted_contents.by_chat_message_hosted_content_id.assert_called_once_with("h")
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_hosted_content_returns_none_on_error(caplog):
+    fake_client, _get = _build_hosted_chain(side_effect=Exception("graph 404"))
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING"):
+        result = await g.download_hosted_content("t", "c", "m", "h")
+
+    assert result is None
+    assert any("download_hosted_content" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# upload_to_sharepoint
+# ---------------------------------------------------------------------------
+
+def _build_upload_chain(put_return=None, put_side_effect=None):
+    """Build a fluent fake chain for upload_to_sharepoint."""
+    fake_client = MagicMock()
+    put = AsyncMock(return_value=put_return)
+    if put_side_effect is not None:
+        put.side_effect = put_side_effect
+    (
+        fake_client.sites.by_site_id.return_value
+        .drive.items.by_drive_item_id.return_value
+        .content.put
+    ) = put
+    return fake_client, put
+
+
+@pytest.mark.asyncio
+async def test_upload_to_sharepoint_returns_web_url():
+    result_obj = Mock()
+    result_obj.web_url = "https://example.com/x.png"
+    result_obj._raw_url = None
+    fake_client, _put = _build_upload_chain(put_return=result_obj)
+
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    url = await g.upload_to_sharepoint("site", "folder", "x.png", b"data")
+
+    assert url == "https://example.com/x.png"
+    fake_client.sites.by_site_id.assert_called_once_with("site")
+    fake_client.sites.by_site_id.return_value.drive.items.by_drive_item_id.assert_called_once_with(
+        "root:/folder/x.png:"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_to_sharepoint_strips_leading_trailing_slashes_in_folder():
+    result_obj = Mock()
+    result_obj.web_url = "https://example.com/file.png"
+    result_obj._raw_url = None
+    fake_client, _put = _build_upload_chain(put_return=result_obj)
+
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    await g.upload_to_sharepoint("site", "/sub/dir/", "file.png", b"data")
+
+    fake_client.sites.by_site_id.return_value.drive.items.by_drive_item_id.assert_called_once_with(
+        "root:/sub/dir/file.png:"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_to_sharepoint_empty_folder_uses_root():
+    result_obj = Mock()
+    result_obj.web_url = "https://example.com/file.png"
+    result_obj._raw_url = None
+
+    for folder in ("", "/"):
+        fake_client, _put = _build_upload_chain(put_return=result_obj)
+        g = GraphClient(provider=Mock())
+        g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+        await g.upload_to_sharepoint("site", folder, "file.png", b"data")
+
+        fake_client.sites.by_site_id.return_value.drive.items.by_drive_item_id.assert_called_once_with(
+            "root:/file.png:"
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_to_sharepoint_falls_back_to_raw_url():
+    result_obj = Mock()
+    result_obj.web_url = None
+    result_obj._raw_url = "https://raw"
+    fake_client, _put = _build_upload_chain(put_return=result_obj)
+
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    url = await g.upload_to_sharepoint("site", "folder", "x.png", b"data")
+
+    assert url == "https://raw"
+
+
+@pytest.mark.asyncio
+async def test_upload_to_sharepoint_returns_none_on_error(caplog):
+    fake_client, _put = _build_upload_chain(put_side_effect=Exception("graph 500"))
+
+    g = GraphClient(provider=Mock())
+    g._build_client = lambda: fake_client  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING"):
+        url = await g.upload_to_sharepoint("site", "folder", "x.png", b"data")
+
+    assert url is None
+    assert any("upload_to_sharepoint" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Caching of built client
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_graph_client_caches_built_client():
+    fake_client, _get = _build_hosted_chain(return_value=b"x")
+    g = GraphClient(provider=Mock())
+    calls = {"n": 0}
+
+    def builder():
+        calls["n"] += 1
+        return fake_client
+
+    g._build_client = builder  # type: ignore[method-assign]
+
+    await g.download_hosted_content("t", "c", "m", "h")
+    await g.download_hosted_content("t", "c", "m", "h")
+
+    assert calls["n"] == 1

--- a/tests/tools/test_running_adapters.py
+++ b/tests/tools/test_running_adapters.py
@@ -1,0 +1,88 @@
+"""Tests for tools/_running_adapters.py — the running-adapter registry.
+
+The registry exists so that *outbound* code paths in webhook-receive
+platforms (Teams, and any future Bot-Framework-style adapter) can reach
+the live adapter instance held by the running gateway. Stateless REST
+adapters (Telegram, Discord, Feishu, ...) instantiate fresh per call;
+webhook-receive adapters cannot, because they hold per-process state
+(``_pending_uploads``, ``_conv_refs``) that is the rendezvous point
+between an outbound action and a later inbound webhook.
+
+See ``hermes-agent-pilot`` skill, reference
+``outbound-media-wiring-by-send-model.md`` for the full architecture
+discussion.
+"""
+
+import pytest
+
+
+def test_registry_returns_none_when_no_adapter_registered():
+    """An unset platform yields ``None`` rather than raising."""
+    from tools._running_adapters import get_running_adapter, clear_running_adapters
+
+    clear_running_adapters()
+    assert get_running_adapter("teams") is None
+
+
+def test_registry_round_trips_a_set_adapter():
+    """``set`` + ``get`` returns the same instance."""
+    from tools._running_adapters import (
+        clear_running_adapters,
+        get_running_adapter,
+        set_running_adapter,
+    )
+
+    clear_running_adapters()
+    sentinel = object()
+    set_running_adapter("teams", sentinel)
+    assert get_running_adapter("teams") is sentinel
+
+
+def test_registry_isolates_platforms():
+    """Setting one platform does not leak into another."""
+    from tools._running_adapters import (
+        clear_running_adapters,
+        get_running_adapter,
+        set_running_adapter,
+    )
+
+    clear_running_adapters()
+    teams = object()
+    set_running_adapter("teams", teams)
+    assert get_running_adapter("matrix") is None
+    assert get_running_adapter("teams") is teams
+
+
+def test_registry_overwrites_on_reconnect():
+    """If the gateway reconnects an adapter, the new instance replaces the old."""
+    from tools._running_adapters import (
+        clear_running_adapters,
+        get_running_adapter,
+        set_running_adapter,
+    )
+
+    clear_running_adapters()
+    first = object()
+    second = object()
+    set_running_adapter("teams", first)
+    set_running_adapter("teams", second)
+    assert get_running_adapter("teams") is second
+
+
+def test_registry_clear_removes_a_specific_platform():
+    """``clear_running_adapter(platform)`` drops only that entry."""
+    from tools._running_adapters import (
+        clear_running_adapter,
+        clear_running_adapters,
+        get_running_adapter,
+        set_running_adapter,
+    )
+
+    clear_running_adapters()
+    set_running_adapter("teams", object())
+    set_running_adapter("matrix", object())
+
+    clear_running_adapter("teams")
+
+    assert get_running_adapter("teams") is None
+    assert get_running_adapter("matrix") is not None

--- a/tests/tools/test_send_teams.py
+++ b/tests/tools/test_send_teams.py
@@ -1,0 +1,401 @@
+"""Tests for ``_send_teams`` — outbound media path through the running
+Teams adapter.
+
+Companion to ``tests/tools/test_running_adapters.py``. The registry is
+the plumbing; ``_send_teams`` is the actual outbound call site that
+``send_message_tool.py`` dispatches to when a caller sends to Teams
+with ``MEDIA:/path`` payloads.
+
+Why these tests use a mock adapter rather than a real ``TeamsAdapter``:
+the real adapter requires Microsoft Bot Framework auth, an Azure
+service URL, and an established ``ConversationReference`` — none of
+which fits a unit test. The tests verify ``_send_teams`` correctly
+*dispatches* to the registered adapter's ``send_*`` methods by file
+extension, which is the contract the helper owes its caller.
+"""
+
+import asyncio
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_send_result(success=True, message_id="msg-1", error=None):
+    """SendResult-shaped object — duck-typed so we don't import the
+    base class (which would drag the full plugin-registry loader)."""
+    return SimpleNamespace(
+        success=success,
+        message_id=message_id,
+        error=error,
+        retryable=False,
+    )
+
+
+def _register_mock_adapter():
+    """Register a fresh mock adapter for ``teams`` and return it."""
+    from tools._running_adapters import (
+        clear_running_adapters,
+        set_running_adapter,
+    )
+
+    clear_running_adapters()
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=_make_send_result(message_id="text-1"))
+    adapter.send_image_file = AsyncMock(return_value=_make_send_result(message_id="img-1"))
+    adapter.send_video = AsyncMock(return_value=_make_send_result(message_id="vid-1"))
+    adapter.send_voice = AsyncMock(return_value=_make_send_result(message_id="voice-1"))
+    adapter.send_document = AsyncMock(return_value=_make_send_result(message_id="doc-1"))
+    set_running_adapter("teams", adapter)
+    return adapter
+
+
+@pytest.fixture
+def tmp_pdf(tmp_path):
+    """A throwaway file with a non-image extension — exercises the
+    document branch."""
+    path = tmp_path / "report.pdf"
+    path.write_bytes(b"%PDF-1.4\n")
+    return str(path)
+
+
+@pytest.fixture
+def tmp_png(tmp_path):
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG\r\n")
+    return str(path)
+
+
+@pytest.fixture
+def tmp_mp4(tmp_path):
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(b"\x00\x00\x00\x18ftyp")
+    return str(path)
+
+
+@pytest.fixture
+def tmp_ogg(tmp_path):
+    path = tmp_path / "voice.ogg"
+    path.write_bytes(b"OggS")
+    return str(path)
+
+
+def test_send_teams_routes_pdf_to_send_document(tmp_pdf):
+    """A non-image, non-video, non-voice path lands on send_document."""
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="here is the report",
+            media_files=[(tmp_pdf, False)],
+        )
+    )
+
+    assert result.get("success") is True
+    assert result.get("platform") == "teams"
+    adapter.send.assert_awaited_once()
+    adapter.send_document.assert_awaited_once()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+
+
+def test_send_teams_routes_png_to_send_image_file(tmp_png):
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[(tmp_png, False)],
+        )
+    )
+
+    assert result.get("success") is True
+    adapter.send_image_file.assert_awaited_once()
+    adapter.send_document.assert_not_awaited()
+
+
+def test_send_teams_routes_mp4_to_send_video(tmp_mp4):
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[(tmp_mp4, False)],
+        )
+    )
+
+    assert result.get("success") is True
+    adapter.send_video.assert_awaited_once()
+
+
+def test_send_teams_routes_ogg_voice_to_send_voice(tmp_ogg):
+    """``is_voice=True`` for an ogg/opus file picks the voice path."""
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[(tmp_ogg, True)],
+        )
+    )
+
+    assert result.get("success") is True
+    adapter.send_voice.assert_awaited_once()
+
+
+def test_send_teams_returns_error_when_no_running_adapter(tmp_pdf):
+    """If the gateway hasn't connected the Teams adapter, the helper
+    returns a clear error rather than crashing or silently dropping."""
+    from tools._running_adapters import clear_running_adapters
+    from tools.send_message_tool import _send_teams
+
+    clear_running_adapters()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="hi",
+            media_files=[(tmp_pdf, False)],
+        )
+    )
+
+    assert "error" in result
+    assert "teams" in result["error"].lower()
+    assert "not connected" in result["error"].lower() or "running adapter" in result["error"].lower()
+
+
+def test_send_teams_returns_error_when_media_file_missing():
+    """Bad media path is reported, not silently swallowed."""
+    from tools.send_message_tool import _send_teams
+
+    _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[("/nonexistent/path.pdf", False)],
+        )
+    )
+
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+def test_send_teams_propagates_adapter_failure(tmp_pdf):
+    """If the live adapter returns ``success=False``, surface the error."""
+    from tools._running_adapters import (
+        clear_running_adapters,
+        set_running_adapter,
+    )
+    from tools.send_message_tool import _send_teams
+
+    clear_running_adapters()
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=_make_send_result(success=True))
+    adapter.send_document = AsyncMock(
+        return_value=_make_send_result(success=False, error="upload denied")
+    )
+    set_running_adapter("teams", adapter)
+
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[(tmp_pdf, False)],
+        )
+    )
+
+    assert "error" in result
+    assert "upload denied" in result["error"]
+
+
+def test_send_teams_text_only_does_not_touch_media_methods():
+    """A text-only call (no MEDIA tag) just hits ``send`` once."""
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="just text",
+            media_files=[],
+        )
+    )
+
+    assert result.get("success") is True
+    adapter.send.assert_awaited_once()
+    adapter.send_document.assert_not_awaited()
+    adapter.send_image_file.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+    adapter.send_voice.assert_not_awaited()
+
+
+# ── Cross-event-loop bridge ─────────────────────────────────────────────────
+#
+# In production the gateway runs the TeamsAdapter on its main event loop
+# (call it loop A). The agent's tool dispatch (``model_tools._run_async``)
+# detects an already-running outer loop and spins up a *separate worker
+# loop* in a sidecar thread (call it loop B) so ``asyncio.run_until_complete``
+# can drive the coroutine without nesting loops.
+#
+# The Microsoft Teams SDK's ``App`` object — built on loop A at gateway
+# startup — internally caches ``asyncio.Event``/``Lock`` primitives bound
+# to loop A. ``_send_teams`` invoked from loop B awaiting those primitives
+# raises ``RuntimeError: ... is bound to a different event loop``.
+#
+# The fix: ``TeamsAdapter.connect()`` records ``self._loop`` and
+# ``_send_teams`` bridges to that loop via
+# ``asyncio.run_coroutine_threadsafe`` when the call site loop differs.
+#
+# The two tests below pin both branches of that bridge:
+#   - same-loop: no bridging needed, the coroutine awaits inline
+#   - cross-loop: we must hop to the adapter's captured loop
+def test_send_teams_bridges_to_adapter_loop_when_called_from_different_loop(tmp_pdf):
+    """If the running adapter has captured its own event loop and the
+    caller is on a different loop, ``_send_teams`` must dispatch the
+    underlying ``adapter.send*`` coroutines onto the adapter's loop —
+    otherwise SDK-internal ``asyncio.Event`` instances bound to the
+    adapter's loop blow up.
+    """
+    from tools._running_adapters import (
+        clear_running_adapters,
+        set_running_adapter,
+    )
+    from tools.send_message_tool import _send_teams
+
+    # 1. Spin up a dedicated "gateway loop" in a sidecar thread.
+    import threading
+
+    adapter_loop = asyncio.new_event_loop()
+    loop_ready = threading.Event()
+
+    def _run_loop():
+        asyncio.set_event_loop(adapter_loop)
+        loop_ready.set()
+        adapter_loop.run_forever()
+
+    loop_thread = threading.Thread(target=_run_loop, daemon=True)
+    loop_thread.start()
+    loop_ready.wait(timeout=2.0)
+
+    try:
+        # 2. Build an adapter with send_* coroutines that *assert* they
+        #    are running on adapter_loop. If _send_teams forgets to bridge,
+        #    these assertions fire and the test fails.
+        clear_running_adapters()
+
+        async def _send_on_adapter_loop(*args, **kwargs):
+            assert asyncio.get_running_loop() is adapter_loop, (
+                "send must run on the adapter's loop, not the caller's"
+            )
+            return _make_send_result(message_id="text-x")
+
+        async def _send_doc_on_adapter_loop(*args, **kwargs):
+            assert asyncio.get_running_loop() is adapter_loop, (
+                "send_document must run on the adapter's loop"
+            )
+            return _make_send_result(message_id="doc-x")
+
+        adapter = MagicMock()
+        adapter._loop = adapter_loop  # the contract _send_teams must honor
+        adapter.send = AsyncMock(side_effect=_send_on_adapter_loop)
+        adapter.send_document = AsyncMock(side_effect=_send_doc_on_adapter_loop)
+        adapter.send_image_file = AsyncMock(return_value=_make_send_result())
+        adapter.send_video = AsyncMock(return_value=_make_send_result())
+        adapter.send_voice = AsyncMock(return_value=_make_send_result())
+        set_running_adapter("teams", adapter)
+
+        # 3. Drive _send_teams from a *different* loop (the test's
+        #    asyncio.run() loop) — mirrors how model_tools._run_async
+        #    dispatches tool calls from the gateway's worker loop.
+        result = _run(
+            _send_teams(
+                chat_id="a:abc",
+                message="here it is",
+                media_files=[(tmp_pdf, False)],
+            )
+        )
+
+        assert result.get("success") is True, f"got {result!r}"
+        assert result.get("platform") == "teams"
+        adapter.send.assert_awaited_once()
+        adapter.send_document.assert_awaited_once()
+    finally:
+        adapter_loop.call_soon_threadsafe(adapter_loop.stop)
+        loop_thread.join(timeout=2.0)
+        adapter_loop.close()
+
+
+def test_send_teams_uses_inline_await_when_adapter_loop_matches(tmp_pdf):
+    """If ``adapter._loop`` is the *same* loop the caller is already on,
+    bridging is unnecessary — _send_teams should await directly. This
+    pins the same-loop fast path so we don't accidentally introduce
+    a thread-hop on every call (which would be an order-of-magnitude
+    latency regression).
+    """
+    from tools._running_adapters import (
+        clear_running_adapters,
+        set_running_adapter,
+    )
+    from tools.send_message_tool import _send_teams
+
+    async def _drive():
+        clear_running_adapters()
+        adapter = MagicMock()
+        adapter._loop = asyncio.get_running_loop()
+        adapter.send = AsyncMock(return_value=_make_send_result(message_id="t"))
+        adapter.send_document = AsyncMock(return_value=_make_send_result(message_id="d"))
+        adapter.send_image_file = AsyncMock(return_value=_make_send_result())
+        adapter.send_video = AsyncMock(return_value=_make_send_result())
+        adapter.send_voice = AsyncMock(return_value=_make_send_result())
+        set_running_adapter("teams", adapter)
+
+        return await _send_teams(
+            chat_id="a:abc",
+            message="hi",
+            media_files=[(tmp_pdf, False)],
+        )
+
+    result = asyncio.run(_drive())
+    assert result.get("success") is True
+
+
+def test_send_teams_works_when_adapter_has_no_loop_attribute(tmp_pdf):
+    """Backward compat: an adapter that hasn't (or can't) capture
+    ``_loop`` must still work — _send_teams should fall back to inline
+    await rather than crash with AttributeError. This protects the
+    Yuanbao/Mattermost-style adapters that don't yet implement the
+    loop-capture protocol."""
+    from tools.send_message_tool import _send_teams
+
+    adapter = _register_mock_adapter()
+    # _register_mock_adapter() builds a bare MagicMock — accessing _loop on
+    # it returns a MagicMock, not a real loop. Force the attribute away so
+    # the helper sees the "no loop captured" shape.
+    if hasattr(adapter, "_loop"):
+        del adapter._loop
+
+    result = _run(
+        _send_teams(
+            chat_id="a:abc",
+            message="",
+            media_files=[(tmp_pdf, False)],
+        )
+    )
+
+    assert result.get("success") is True
+    adapter.send_document.assert_awaited_once()

--- a/tools/_running_adapters.py
+++ b/tools/_running_adapters.py
@@ -1,0 +1,70 @@
+"""Module-level registry for *running* platform-adapter instances.
+
+Stateless adapters (Telegram, Discord, Feishu, ...) instantiate fresh
+per outbound call from ``send_message_tool.py``. That pattern silently
+breaks for **webhook-receive** platforms — Teams Bot Framework being
+the first instance, with Webex / Zoom Apps / Google Chat all following
+the same shape — because those adapters hold per-process state
+(``_pending_uploads``, ``_conv_refs``, message-id maps, ...) that is
+the rendezvous point between an *outbound* action and a later
+*inbound* webhook from the platform. A fresh instance has empty
+state, so the inbound webhook lands on the running instance whose
+state was never seeded — and the action silently fails.
+
+This registry lets the gateway publish the live adapter when it
+connects, and lets ``send_message_tool.py`` reach it from outbound
+code paths. Single Python process — gateway, ``run_agent.py``, and
+tool dispatch all share memory in the standard topology.
+
+If a future deployment splits the gateway and tool runners across a
+process boundary, this registry needs an RPC backing instead — but
+that is not the world we live in.
+
+Architecture context: see the ``hermes-agent-pilot`` skill, reference
+``outbound-media-wiring-by-send-model.md`` for why webhook-receive
+platforms cannot use the stateless / client-pull patterns.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Module-level state. Keyed by ``platform.value`` (the lowercase string
+# form, e.g. ``"teams"``) so callers don't need to import ``Platform``.
+_RUNNING_ADAPTERS: Dict[str, Any] = {}
+
+
+def set_running_adapter(platform: str, adapter: Any) -> None:
+    """Publish ``adapter`` as the live instance for ``platform``.
+
+    Called by the gateway after a successful ``connect()``. Idempotent:
+    re-registering replaces the previous entry, which is the right
+    behavior on adapter reconnect.
+    """
+    _RUNNING_ADAPTERS[platform] = adapter
+
+
+def get_running_adapter(platform: str) -> Optional[Any]:
+    """Return the running adapter for ``platform``, or ``None`` if none.
+
+    Returning ``None`` (rather than raising) lets the caller emit a
+    clear platform-level error message ("Teams not connected — cannot
+    send proactive media") instead of leaking a ``KeyError`` traceback
+    through the agent's tool result.
+    """
+    return _RUNNING_ADAPTERS.get(platform)
+
+
+def clear_running_adapter(platform: str) -> None:
+    """Drop the entry for ``platform``. No-op if not present.
+
+    Called when the gateway disconnects an adapter, so a stale instance
+    isn't left in the registry pointing at a closed connection.
+    """
+    _RUNNING_ADAPTERS.pop(platform, None)
+
+
+def clear_running_adapters() -> None:
+    """Drop every entry. Test fixture only — production should use the
+    per-platform ``clear_running_adapter``."""
+    _RUNNING_ADAPTERS.clear()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -127,6 +127,16 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "slack-sdk==3.40.1",
         "aiohttp==3.13.3",
     ),
+    "platform.teams": (
+        "microsoft-teams-apps==2.0.0",
+        "aiohttp==3.13.3",
+    ),
+    "platform.teams.graph": (
+        "msgraph-sdk==1.57.0",
+        "msgraph-core==1.3.8",
+        "azure-identity==1.25.3",
+        "msal==1.36.0",
+    ),
     "platform.matrix": (
         "mautrix[encryption]==0.21.0",
         "Markdown==3.10.2",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -685,11 +685,33 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Teams: outbound media via the *running* adapter (FileConsent +
+    # SharePoint/Graph fallback). Cannot use a fresh adapter — the live
+    # instance owns _pending_uploads / _conv_refs which back the
+    # outbound→inbound webhook rendezvous. See _send_teams docstring.
+    # Teams is a plugin adapter so it has no static Platform.TEAMS — use
+    # the value-based comparison (Platform._missing_ caches the pseudo-
+    # member, so identity is stable across calls). ---
+    if platform == Platform("teams") and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_teams(
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and teams; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -697,7 +719,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and teams"
         )
 
     last_result = None
@@ -1758,6 +1780,135 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         }
     except Exception as e:
         return _error(f"Feishu send failed: {e}")
+
+
+async def _send_teams(chat_id, message, media_files=None, thread_id=None):
+    """Send via the *running* Microsoft Teams adapter held by the gateway.
+
+    Unlike stateless REST adapters (Feishu, Telegram, Discord, ...) the
+    Teams adapter holds per-process state — most importantly
+    ``_pending_uploads``, the rendezvous between an outbound
+    ``FileConsentCard`` and the later inbound ``fileConsent/invoke``
+    webhook the user triggers by clicking *Accept*. Instantiating a
+    fresh ``TeamsAdapter`` here would seed *its own* dict, send the
+    card, and exit; the user's Accept click would then route to the
+    gateway's running adapter (whose state was never seeded) and the
+    upload would silently fail. Same trap will recur in any future
+    Bot-Framework-style adapter (Webex, Zoom Apps, Google Chat).
+
+    Cross-loop bridge
+    -----------------
+    The Microsoft Teams SDK ``App`` is constructed at gateway startup
+    on the gateway's main event loop. It caches ``asyncio.Event`` /
+    ``asyncio.Lock`` primitives that are forever bound to *that* loop.
+
+    Tool calls reach this helper via ``model_tools._run_async``, which
+    — when an outer loop is already running — spawns a fresh worker
+    loop in a sidecar thread and runs the coroutine there. Awaiting
+    ``adapter.send_*`` from that worker loop touches the SDK's
+    loop-bound primitives and raises::
+
+        RuntimeError: <Event ... [unset]> is bound to a different
+        event loop
+
+    Workaround: ``TeamsAdapter.connect()`` records ``self._loop`` (the
+    gateway's loop) and we hop to it via
+    ``asyncio.run_coroutine_threadsafe`` when the call site loop
+    differs.
+
+    Architecture writeup: ``hermes-agent-pilot`` skill, reference
+    ``outbound-media-wiring-by-send-model.md``.
+    """
+    from tools._running_adapters import get_running_adapter
+
+    adapter = get_running_adapter("teams")
+    if adapter is None:
+        return _error(
+            "Teams not connected — no running adapter registered. "
+            "Outbound Teams sends require the gateway's Teams adapter to "
+            "be active so per-process state (_pending_uploads, "
+            "_conv_refs) is available for the FileConsent rendezvous."
+        )
+
+    media_files = media_files or []
+    metadata = {"thread_id": thread_id} if thread_id else None
+
+    # Bridge factory: returns an awaitable that runs ``coro`` on the
+    # adapter's loop when one was captured and differs from ours;
+    # otherwise awaits inline. Wrapping every send in this keeps the
+    # cross-loop trap from re-emerging if a new send_* is added later.
+    async def _on_adapter_loop(coro_factory):
+        adapter_loop = getattr(adapter, "_loop", None)
+        # Treat anything that isn't a real running loop as "not captured"
+        # — protects against MagicMock auto-attributes and adapters that
+        # haven't opted in yet.
+        if not isinstance(adapter_loop, asyncio.AbstractEventLoop):
+            return await coro_factory()
+
+        try:
+            current = asyncio.get_running_loop()
+        except RuntimeError:
+            current = None
+
+        if current is adapter_loop or not adapter_loop.is_running():
+            # Same loop, or adapter loop isn't running (test/teardown) —
+            # inline await is correct and avoids a thread hop.
+            return await coro_factory()
+
+        # Cross-loop: schedule on the adapter's loop, await the result
+        # from ours via asyncio.wrap_future.
+        future = asyncio.run_coroutine_threadsafe(coro_factory(), adapter_loop)
+        return await asyncio.wrap_future(future)
+
+    try:
+        last_result = None
+        if message.strip():
+            last_result = await _on_adapter_loop(
+                lambda: adapter.send(chat_id, message, metadata=metadata)
+            )
+            if not last_result.success:
+                return _error(f"Teams send failed: {last_result.error}")
+
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                return _error(f"Media file not found: {media_path}")
+
+            ext = os.path.splitext(media_path)[1].lower()
+            if ext in _IMAGE_EXTS:
+                last_result = await _on_adapter_loop(
+                    lambda p=media_path: adapter.send_image_file(chat_id, p, metadata=metadata)
+                )
+            elif ext in _VIDEO_EXTS:
+                last_result = await _on_adapter_loop(
+                    lambda p=media_path: adapter.send_video(chat_id, p, metadata=metadata)
+                )
+            elif ext in _VOICE_EXTS and is_voice:
+                last_result = await _on_adapter_loop(
+                    lambda p=media_path: adapter.send_voice(chat_id, p, metadata=metadata)
+                )
+            elif ext in _AUDIO_EXTS:
+                last_result = await _on_adapter_loop(
+                    lambda p=media_path: adapter.send_voice(chat_id, p, metadata=metadata)
+                )
+            else:
+                last_result = await _on_adapter_loop(
+                    lambda p=media_path: adapter.send_document(chat_id, p, metadata=metadata)
+                )
+
+            if not last_result.success:
+                return _error(f"Teams media send failed: {last_result.error}")
+
+        if last_result is None:
+            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+        return {
+            "success": True,
+            "platform": "teams",
+            "chat_id": chat_id,
+            "message_id": last_result.message_id,
+        }
+    except Exception as e:
+        return _error(f"Teams send failed: {e}")
 
 
 def _check_send_message():

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -33,7 +33,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | BlueBubbles | — | ✅ | ✅ | — | ✅ | ✅ | — |
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | Yuanbao | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
-| Microsoft Teams | — | ✅ | — | ✅ | — | ✅ | — |
+| Microsoft Teams | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | LINE | — | ✅ | ✅ | — | — | ✅ | — |
 
 **Voice** = TTS audio replies and/or voice message transcription. **Images** = send/receive images. **Files** = send/receive file attachments. **Threads** = threaded conversations. **Reactions** = emoji reactions on messages. **Typing** = typing indicator while processing. **Streaming** = progressive message updates via editing.

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -135,6 +135,8 @@ Open the printed link in your browser — it opens directly in the Teams client.
 | `TEAMS_HOME_CHANNEL` | Conversation ID for cron/proactive message delivery |
 | `TEAMS_HOME_CHANNEL_NAME` | Display name for the home channel |
 | `TEAMS_PORT` | Webhook port (default: `3978`) |
+| `TEAMS_SHAREPOINT_SITE_ID` | SharePoint site ID for outbound channel/group file uploads (e.g. `tenant.sharepoint.com,GUID,GUID`). Optional — leave unset for DM-only file sends. |
+| `TEAMS_SHAREPOINT_FOLDER` | Folder path under the SharePoint site's default drive where uploads land. Default: `hermes`. Created on first upload. |
 
 ### config.yaml
 
@@ -165,6 +167,49 @@ When the agent needs to run a potentially dangerous command, it sends an Adaptiv
 - **Deny** — reject the command
 
 Clicking a button resolves the approval inline and replaces the card with the decision.
+
+### File Attachments
+
+The Teams adapter handles file attachments in both directions, so the agent can read what users send it and reply with images, audio, video, and documents.
+
+#### Inbound (user → Hermes)
+
+When you attach a file in a Teams chat, the adapter downloads the bytes and hands them to the agent as a regular file the model can see (images and PDFs go through vision; audio is transcribed; video and other documents arrive as cached files the agent can `read_file`).
+
+| Type | Supported |
+|------|-----------|
+| Images | PNG, JPEG, GIF, WebP (rendered via vision) |
+| Audio | MP3, WAV, M4A, OGG (transcribed) |
+| Video | MP4, MOV, WebM (cached as a file reference) |
+| Documents | PDF, DOCX, XLSX, TXT (cached as a file reference) |
+
+The adapter first tries the Bot Framework attachment URL, then falls back to **Microsoft Graph hosted-content download** if the Bot Framework returns 401/403. The Graph fallback uses the same Azure AD app credentials (`TEAMS_CLIENT_ID` / `TEAMS_CLIENT_SECRET` / `TEAMS_TENANT_ID`) — no extra setup is needed when the bot already has the standard Teams permissions, but tenants with stricter scopes may need to grant the bot additional Graph application permissions to download hosted content.
+
+#### Outbound (Hermes → user)
+
+When the agent sends a file (via `send_message` with a `MEDIA:<path>` body, or any tool that produces a file artifact), the path the adapter takes depends on the conversation type:
+
+| Conversation | Delivery mechanism |
+|--------------|--------------------|
+| **Personal chat (DM)** | **FileConsent card flow.** The bot posts a `FileConsentCard`, the user clicks **Accept**, and the adapter uploads bytes to the Teams-provided OneDrive upload URL. No SharePoint required. |
+| **Channel or group chat** | **SharePoint upload.** The adapter uploads the file to the configured SharePoint document library, then posts a `FileInfoCard` linking to it. Requires `TEAMS_SHAREPOINT_SITE_ID` to be set. |
+
+To enable channel/group file sends, set the SharePoint site and (optionally) folder:
+
+```bash
+TEAMS_SHAREPOINT_SITE_ID=tenant.sharepoint.com,<site-guid>,<web-guid>
+TEAMS_SHAREPOINT_FOLDER=hermes   # default; created on first upload
+```
+
+Find the site ID via Microsoft Graph:
+
+```
+GET https://graph.microsoft.com/v1.0/sites/{hostname}:/{server-relative-path}
+```
+
+The bot's Azure AD app needs `Files.ReadWrite.All` and `Sites.ReadWrite.All` application permissions for SharePoint uploads. DM file sends via FileConsent need no extra Graph permissions.
+
+If `TEAMS_SHAREPOINT_SITE_ID` is unset, the adapter still handles DM file sends; channel/group file sends will be skipped with a warning in the logs.
 
 ### Meeting Summary Delivery (Teams Meeting Pipeline)
 


### PR DESCRIPTION
## What does this PR do?

Refactor and re-submission of @AlexLuzik's Teams V2 adapter (#13767) onto the current platform-plugin architecture. Same feature surface, repackaged as `plugins/platforms/teams/` instead of `gateway/platforms/msteams/`.

Credit for the adapter design, Bot Framework / Graph integration, FileConsent + SharePoint upload flows, and the original test surface goes to #13767. This PR ports that work forward, fits it to the plugin contract, and adds the small bits of glue the plugin system needs.

## Related Issue

Refactor of #13767 (AlexLuzik's Teams V2). See also #10037 (earlier text-only attempt, no attachment support).

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Repackaging (port from `gateway/platforms/msteams/` → `plugins/platforms/teams/`):**
- `plugins/platforms/teams/plugin.yaml` — env-var manifest for the plugin loader
- `plugins/platforms/teams/adapter.py` — Bot Framework adapter (was `gateway/platforms/msteams/adapter.py`)
- `plugins/platforms/teams/auth_graph.py` — Graph auth helpers (split out of `auth.py`)
- `plugins/platforms/teams/graph.py`, `cards.py` — unchanged in spirit, now plugin-scoped
- Registry / wiring moved into the plugin's `register()` entry point (out of `hermes_cli/platforms.py` and `gateway/run.py`)
- `tools/lazy_deps.py` — registers `platform.teams` and `platform.teams.graph` extras for on-demand install (replaces a top-level `[msteams]` extra)

**Carried forward from #13767 (unchanged in spirit):**
- Bot Framework webhook + JWT validation, message / invoke / edit activities
- DM / channel / group dispatch with `dm_policy` / `allowlist` / `require_mention` / per-team + per-channel overrides
- Inbound `image/*`, `application/vnd.microsoft.teams.file.download.info`, and Graph `hostedContents` fallback
- Document handling (PDF / DOCX / XLSX / PPTX / ZIP / TXT / MD) → document cache with original filename
- DM FileConsentCard upload flow (invoke-activity handler)
- Channel / group SharePoint uploads via Graph `upload_to_sharepoint`
- Out-of-process `send_message` via MSAL + cached `serviceUrl` sidecar
- Markdown → Teams HTML, Adaptive cards, file_info / file_download_info cards

**New since #13767:**
- `gateway/platforms/base.py` — `cache_video_from_url` helper, symmetric with the existing image / audio cache helpers; used by inbound video attachments (MP4 / MOV / WebM)
- `tools/_running_adapters.py` — small helper used by `send_message`
- `tools/send_message_tool.py` — Teams target resolution + outbound file path
- `website/docs/user-guide/messaging/teams.md` — File Attachments section, SharePoint env vars, Graph site-ID lookup, required-permissions note
- `website/docs/user-guide/messaging/index.md` — Teams "Files" column flipped to ✅
- Tests: `tests/plugins/platforms/teams/`, `tests/tools/test_running_adapters.py`, `tests/tools/test_send_teams.py`, `tests/gateway/test_platform_base.py`

## How to Test

1. `pip install hermes-agent` then in `cli-config.yaml` enable the `teams` platform — `tools/lazy_deps.py` will install the Bot Framework / Graph dependencies on first use.
2. Walk through `website/docs/user-guide/messaging/teams.md` to register the Azure App, Bot Framework resource, and Teams app manifest.
3. Run `hermes setup` → Microsoft Teams → enter App ID / tenant / secret. Set `TEAMS_SHAREPOINT_SITE_ID` and `TEAMS_SHAREPOINT_FOLDER` if you want channel/group file uploads.
4. Send a DM with a PDF / image / video attachment — agent ingests and responds.
5. Ask the agent to send a file back in DM — FileConsent card → accept → file delivered.
6. In a channel or group chat, ask the agent to send a file — uploaded to SharePoint, posted as a `file_info` card.
``` (1/2)