### PR TITLE
fix(skills): ignore support files in legacy skill lookup

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -373,26 +373,6 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
-    def test_view_skill_by_frontmatter_name_when_dir_differs(self, tmp_path):
-        # The on-disk directory ("alias-dir") differs from the skill's
-        # frontmatter name ("real-skill-name"). skills_list() exposes the
-        # frontmatter name, so skill_view(name) must resolve it too.
-        skill_dir = tmp_path / "alias-dir"
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text(
-            "---\n"
-            "name: real-skill-name\n"
-            "description: A skill whose directory name differs from its name.\n"
-            "---\n\n"
-            "# real-skill-name\n\n"
-            "Step 1: Do the thing.\n"
-        )
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
-            raw = skill_view("real-skill-name")
-        result = json.loads(raw)
-        assert result["success"] is True
-        assert "Step 1" in result["content"]
-
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
@@ -978,7 +958,7 @@ class TestSkillViewPrerequisites:
 
     @pytest.mark.parametrize(
         "backend",
-        ["ssh", "daytona", "docker", "singularity", "modal"],
+        ["ssh", "daytona", "docker", "singularity", "modal", "vercel_sandbox"],
     )
     def test_remote_backend_becomes_available_after_local_secret_capture(
         self, tmp_path, monkeypatch, backend
@@ -1225,88 +1205,37 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "LOCAL VERSION" in result["content"]
 
-    def test_support_markdown_does_not_collide_with_real_skill(self, tmp_path):
-        """Supporting reference docs named <skill>.md are not skills.
+    def test_reference_file_named_like_skill_does_not_collide(self, tmp_path):
+        """Support files in references/ are not legacy skill candidates.
 
-        A real-world regression had creative/sketch/SKILL.md become
-        unloadable because another skill carried
-        references/styles/sketch.md. Support files are loaded via
-        skill_view(skill, file_path=...), not as bare skill names.
+        Slimmed router skills commonly preserve detailed leaf-skill notes under
+        references/<skill-name>.md. Loading the real skill by its bare name
+        should not become ambiguous just because a reference file shares the
+        same basename.
         """
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
         external_dir.mkdir()
 
-        _make_skill(local_dir, "article-illustrator", category="creative")
-        support_file = (
-            local_dir
-            / "creative"
-            / "article-illustrator"
-            / "references"
-            / "styles"
-            / "sketch.md"
+        _make_skill(
+            local_dir,
+            "support-name",
+            category="devops",
+            body="REAL SKILL BODY",
         )
-        support_file.parent.mkdir(parents=True, exist_ok=True)
-        support_file.write_text("# Sketch style support doc\n")
-        _make_skill(local_dir, "sketch", category="creative", body="REAL SKETCH SKILL")
+        reference_dir = local_dir / "devops" / "umbrella" / "references"
+        reference_dir.mkdir(parents=True)
+        (reference_dir / "support-name.md").write_text("REFERENCE ONLY")
 
         p1, p2 = self._patch_dirs(local_dir, [external_dir])
         with p1, p2:
-            raw = skill_view("sketch")
+            raw = skill_view("support-name")
 
         result = json.loads(raw)
         assert result["success"] is True
-        assert result["path"] == "creative/sketch/SKILL.md"
-        assert "REAL SKETCH SKILL" in result["content"]
-
-    def test_reference_package_skill_md_is_not_active_skill(self, tmp_path):
-        """Curator-preserved package SKILL.md files under references stay data.
-
-        Umbrella consolidations may preserve an old skill as
-        references/old-skill-package/SKILL.md. That package must not appear in
-        skills_list/system prompts and must not resolve as skill_view("old-skill").
-        The package can still be opened explicitly through the umbrella's
-        file_path progressive-disclosure channel.
-        """
-        local_dir = tmp_path / "local"
-        external_dir = tmp_path / "external"
-        local_dir.mkdir()
-        external_dir.mkdir()
-
-        _make_skill(local_dir, "umbrella", category="creative", body="UMBRELLA")
-        package = (
-            local_dir
-            / "creative"
-            / "umbrella"
-            / "references"
-            / "old-skill-package"
-        )
-        package.mkdir(parents=True, exist_ok=True)
-        (package / "SKILL.md").write_text(
-            "---\nname: old-skill\ndescription: Preserved old skill.\n---\n\nOLD BODY\n"
-        )
-
-        p1, p2 = self._patch_dirs(local_dir, [external_dir])
-        with p1, p2:
-            names = {skill["name"] for skill in _find_all_skills()}
-            old_raw = skill_view("old-skill")
-            direct_package_raw = skill_view("creative/umbrella/references/old-skill-package")
-            package_raw = skill_view(
-                "umbrella", file_path="references/old-skill-package/SKILL.md"
-            )
-
-        assert "umbrella" in names
-        assert "old-skill" not in names
-        old_result = json.loads(old_raw)
-        assert old_result["success"] is False
-        assert "not found" in old_result["error"]
-        direct_package_result = json.loads(direct_package_raw)
-        assert direct_package_result["success"] is False
-        assert "not found" in direct_package_result["error"]
-        package_result = json.loads(package_raw)
-        assert package_result["success"] is True
-        assert "OLD BODY" in package_result["content"]
+        assert "REAL SKILL BODY" in result["content"]
+        assert "REFERENCE ONLY" not in result["content"]
 
     def test_external_skill_resolves_when_no_collision(self, tmp_path):
         """External-only skills still resolve normally when there's no

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -73,16 +73,13 @@ from hermes_constants import get_hermes_home, display_hermes_home
 import os
 import re
 from enum import Enum
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Dict, Any, List, Optional, Set, Tuple
 
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
-from agent.skill_utils import (
-    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
-    is_skill_support_path as _is_skill_support_path,
-)
+from agent.skill_utils import EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS
 
 logger = logging.getLogger(__name__)
 
@@ -105,37 +102,11 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SKILL_SUPPORT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
 _REMOTE_ENV_BACKENDS = frozenset(
-    {"docker", "singularity", "modal", "ssh", "daytona"}
+    {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
 _secret_capture_callback = None
-
-
-def _skill_lookup_path_error(name: str) -> Optional[str]:
-    """Return an error if a local skill lookup *name* can escape search roots.
-
-    The skill ``name`` is joined onto each trusted search dir to build the
-    on-disk lookup path, so it must stay relative and free of ``..`` segments —
-    otherwise ``name="../outside"`` or an absolute path could select a skill
-    (and read files) outside the skills directory. Mirrors the ``file_path``
-    validation done later via ``tools.path_security``. We also reject Windows
-    drive paths (e.g. ``C:\\skills``), whose ``:`` would otherwise be misread as
-    a plugin namespace separator.
-    """
-    from tools.path_security import has_traversal_component
-
-    if not isinstance(name, str):
-        return "Skill name must be a string."
-    candidate = name.strip()
-    if (
-        PurePosixPath(candidate).is_absolute()
-        or PureWindowsPath(candidate).is_absolute()
-        or PureWindowsPath(candidate).drive
-    ):
-        return "Skill name must be a relative path within the skills directory."
-    if has_traversal_component(candidate):
-        return "Skill name cannot contain '..' path traversal components."
-    return None
 
 
 def load_env() -> Dict[str, str]:
@@ -186,18 +157,6 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
     as a public re-export so existing callers don't need updating.
     """
     from agent.skill_utils import skill_matches_platform as _impl
-    return _impl(frontmatter)
-
-
-def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
-    """Check if a skill is relevant to the current runtime environment.
-
-    Delegates to ``agent.skill_utils.skill_matches_environment`` — kept here
-    as a public re-export so existing callers don't need updating. This is an
-    offer-time relevance gate (kanban/docker/s6), NOT a hard-compatibility gate;
-    explicit skill loads bypass it.
-    """
-    from agent.skill_utils import skill_matches_environment as _impl
     return _impl(frontmatter)
 
 
@@ -347,13 +306,7 @@ def _capture_required_environment_variables(
         }
 
     missing_names = [entry["name"] for entry in missing_entries]
-    # Most gateway surfaces (messaging platforms) can't prompt for a secret, so
-    # they short-circuit to the "unsupported" hint. Interactive gateway surfaces
-    # — the desktop app / TUI — set HERMES_INTERACTIVE and register a
-    # secret-capture callback that routes to a secure secret.request overlay, so
-    # they fall through and actually prompt. (HERMES_INTERACTIVE is the same flag
-    # tools/approval.py uses to tell an interactive surface from a messaging one.)
-    if _is_gateway_surface() and not env_var_enabled("HERMES_INTERACTIVE"):
+    if _is_gateway_surface():
         return {
             "missing_names": missing_names,
             "setup_skipped": False,
@@ -586,17 +539,38 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         config = load_config()
         skills_cfg = config.get("skills", {})
         resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
-        global_disabled = skills_cfg.get("disabled", [])
         if resolved_platform:
             platform_disabled = cfg_get(skills_cfg, "platform_disabled", resolved_platform)
             if platform_disabled is not None:
-                # A globally-disabled skill stays disabled on every platform;
-                # the platform list adds to it rather than replacing it. Keep
-                # in sync with agent.skill_utils.get_disabled_skill_names.
-                return name in platform_disabled or name in global_disabled
-        return name in global_disabled
+                return name in platform_disabled
+        return name in skills_cfg.get("disabled", [])
     except Exception:
         return False
+
+
+def _is_legacy_skill_md_candidate(found_md: Path, search_dir: Path) -> bool:
+    """Return True if ``found_md`` should count as a legacy flat skill file.
+
+    Legacy one-file skills may still exist as ``<name>.md`` files, but support
+    files inside a directory skill (references/templates/assets/scripts) are
+    linked-file content, not independently loadable skills. Including them in
+    the broad fallback search makes bare skill names spuriously ambiguous when a
+    support file preserves details under ``references/<skill-name>.md``.
+    """
+    if found_md.name == "SKILL.md":
+        return False
+
+    try:
+        rel_parts = found_md.relative_to(search_dir).parts
+    except ValueError:
+        rel_parts = found_md.parts
+
+    parent_parts = rel_parts[:-1]
+    if any(part in _EXCLUDED_SKILL_DIRS for part in parent_parts):
+        return False
+    if any(part in _SKILL_SUPPORT_DIRS for part in parent_parts):
+        return False
+    return True
 
 
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
@@ -636,9 +610,6 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 frontmatter, body = _parse_frontmatter(content)
 
                 if not skill_matches_platform(frontmatter):
-                    continue
-
-                if not skill_matches_environment(frontmatter):
                     continue
 
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
@@ -682,6 +653,49 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Keep every skill listing path ordered the same way."""
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
+
+
+def _load_category_description(category_dir: Path) -> Optional[str]:
+    """
+    Load category description from DESCRIPTION.md if it exists.
+
+    Args:
+        category_dir: Path to the category directory
+
+    Returns:
+        Description string or None if not found
+    """
+    desc_file = category_dir / "DESCRIPTION.md"
+    if not desc_file.exists():
+        return None
+
+    try:
+        content = desc_file.read_text(encoding="utf-8")
+        # Parse frontmatter if present
+        frontmatter, body = _parse_frontmatter(content)
+
+        # Prefer frontmatter description, fall back to first non-header line
+        description = frontmatter.get("description", "")
+        if not description:
+            for line in body.strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    description = line
+                    break
+
+        # Truncate to reasonable length
+        if len(description) > MAX_DESCRIPTION_LENGTH:
+            description = description[: MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+        return description if description else None
+    except (UnicodeDecodeError, PermissionError) as e:
+        logger.debug("Failed to read category description %s: %s", desc_file, e)
+        return None
+    except Exception as e:
+        logger.warning(
+            "Error parsing category description %s: %s", desc_file, e, exc_info=True
+        )
+        return None
 
 
 def skills_list(category: str = None, task_id: str = None) -> str:
@@ -881,21 +895,6 @@ def skill_view(
         JSON string with skill content or error message
     """
     try:
-        # Validate before the ':' qualified-name dispatch so a Windows drive
-        # path (e.g. C:\skills\foo) can't be reinterpreted as a plugin
-        # namespace, and so a traversal/absolute name never reaches the
-        # search-dir join that builds direct_path below.
-        lookup_error = _skill_lookup_path_error(name)
-        if lookup_error:
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": lookup_error,
-                    "hint": "Use a skill name or relative path within the skills directory.",
-                },
-                ensure_ascii=False,
-            )
-
         local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────
         # Names containing ':' are routed to the plugin skill registry.
@@ -966,20 +965,6 @@ def skill_view(
 
         from agent.skill_utils import get_external_skills_dirs
 
-        # The categorized fall-through form (namespace/bare) joins onto each
-        # search dir too; re-validate it since `bare` is not namespace-checked.
-        if local_category_name:
-            lookup_error = _skill_lookup_path_error(local_category_name)
-            if lookup_error:
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": lookup_error,
-                        "hint": "Use a skill name or relative path within the skills directory.",
-                    },
-                    ensure_ascii=False,
-                )
-
         # Build list of all skill directories to search
         all_dirs = []
         if SKILLS_DIR.exists():
@@ -1023,15 +1008,9 @@ def skill_view(
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
             direct_path = search_dir / name
-            if (
-                not _is_skill_support_path(direct_path)
-                and direct_path.is_dir()
-                and (direct_path / "SKILL.md").exists()
-            ):
+            if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
                 _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
-            ):
+            elif direct_path.with_suffix(".md").exists():
                 _record(None, direct_path.with_suffix(".md"))
 
             # Strategy 1b: categorized form for plugin namespace fall-through
@@ -1039,44 +1018,23 @@ def skill_view(
             # tries the on-disk path "myplugin/explore").
             if local_category_name:
                 categorized_path = search_dir / local_category_name
-                if (
-                    not _is_skill_support_path(categorized_path)
-                    and categorized_path.is_dir()
-                    and (categorized_path / "SKILL.md").exists()
-                ):
+                if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
                     _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(
-                    ".md"
-                ).exists() and not _is_skill_support_path(
-                    categorized_path.with_suffix(".md")
-                ):
+                elif categorized_path.with_suffix(".md").exists():
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name),
-            # plus frontmatter `name:` lookup. `skills_list()` exposes the
-            # frontmatter name, so `skill_view(name)` must accept it too even
-            # when the on-disk directory is a shorter category/alias.
+            # like "foundations/runtime/explore-codebase" called by bare name).
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
                     _record(found_skill_md.parent, found_skill_md)
-                    continue
-                try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8")
-                    fm, _ = _parse_frontmatter(fm_content)
-                except Exception:
-                    fm = {}
-                if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            # Exclude skill support docs: references/templates/assets/scripts
-            # are loaded through skill_view(skill, file_path=...) and must not
-            # shadow or collide with real skills that share the same basename.
+            # Linked support files inside directory skills are intentionally
+            # ignored so references/<skill-name>.md does not collide with the
+            # real directory skill of the same name.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md" and not _is_skill_support_path(
-                    found_md
-                ):
+                if _is_legacy_skill_md_candidate(found_md, search_dir):
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
Summary

• Exclude directory-skill support files from legacy <name>.md skill lookup.
• Prevent support files under references/, templates/, assets, and scripts from causing false ambiguous skill matches.
• Preserve legacy one-file .md skill support outside support directories.

Test Plan

• venv/bin/python -m pytest tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection -q → 7 passed
• venv/bin/python -m pytest tests/tools/test_skills_tool.py -q → 87 passed