### PR TITLE
fix(cron): append delivery hint after prompt and detect send_message contradictions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -917,10 +917,13 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
                 # silent skip — do not pollute the prompt with error messages
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
+    # Cron delivery guidance — appended (not prepended) so it appears after
+    # user prompt and skill content.  Models are recency-biased; placing
+    # the hint last makes it the final instruction the model sees,
+    # preventing user prompts from overriding the "do NOT use send_message"
+    # directive.
     cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
+        "\n\n[IMPORTANT: You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
@@ -928,9 +931,8 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more.]"
     )
-    prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []
@@ -939,7 +941,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     skill_names = [str(name).strip() for name in skills if str(name).strip()]
     if not skill_names:
-        return _scan_assembled_cron_prompt(prompt, job)
+        return _scan_assembled_cron_prompt(prompt + cron_hint, job)
 
     from tools.skills_tool import skill_view
     from tools.skill_usage import bump_use
@@ -982,6 +984,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
+    parts.append(cron_hint)
     return _scan_assembled_cron_prompt("\n".join(parts), job)
 
 
@@ -1761,6 +1764,29 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 if success and not final_response:
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+                # Detect when the model produced a delivery-failure message
+                # instead of actual content.  This happens when the prompt
+                # instructs the agent to call send_message (unavailable in
+                # cron context) and the model retries until it gives up.
+                if success and final_response:
+                    _lower = final_response.lower()
+                    _delivery_failure_markers = (
+                        "tool \"send_message\" does not exist",
+                        "tool 'send_message' does not exist",
+                        "send_message is not available",
+                        "couldn't deliver",
+                        "failed to send",
+                        "max retries (3) for invalid tool calls exceeded",
+                    )
+                    if any(m in _lower for m in _delivery_failure_markers):
+                        success = False
+                        error = (
+                            "Agent produced delivery-failure output instead of content "
+                            "(prompt likely instructs send_message — set 'deliver' field "
+                            "and let the agent produce content only)"
+                        )
+                        logger.warning("Job '%s': %s", job.get("id"), error)
 
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 return True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -65,6 +65,15 @@ _CRON_EXFIL_COMMAND_PATTERNS = [
     (rf'curl\s+[^\n]*(?:-H|--header)\s+["\']Authorization:\s*(?:Bearer|token)\s+{_CRON_SECRET_VAR_RE}["\']', "exfil_curl_auth_header"),
 ]
 
+# Patterns that indicate the prompt is trying to use send_message,
+# which contradicts the cron delivery model.  Not blocked (user may
+# have a reason), but a warning is logged so operators can investigate.
+_CRON_SEND_MESSAGE_PATTERNS = [
+    r'send_message\s*\(',
+    r'(?:call|invoke|use)\s+send_message',
+    r'(?:send|deliver|forward)\s+(?:this|the|a)\s+message\s+to\s+(?:discord|telegram|slack)',
+]
+
 _CRON_INVISIBLE_CHARS = {
     '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
     '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
@@ -93,6 +102,18 @@ def _scan_cron_prompt(prompt: str) -> str:
     for pattern, pid in _CRON_EXFIL_COMMAND_PATTERNS:
         if re.search(pattern, prompt_to_scan, re.IGNORECASE):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."
+    # Warn (don't block) if the prompt contains send_message instructions.
+    # The cron delivery model handles routing; prompts should only produce content.
+    for pattern in _CRON_SEND_MESSAGE_PATTERNS:
+        if re.search(pattern, prompt, re.IGNORECASE):
+            logger.warning(
+                "Cron prompt contains send_message instruction (pattern: %r). "
+                "Cron delivery is automatic via the 'deliver' field — prompts "
+                "should not call send_message. Hint: set 'deliver' to the "
+                "target and let the agent produce content only.",
+                pattern,
+            )
+            break
     return ""
 
 


### PR DESCRIPTION
## Problem

Cron delivery hint (`do NOT use send_message`) is prepended before user prompt and skill content. Models are recency-biased, so a user prompt that says `send_message(target=...)` overrides the hint. The model tries to call an unavailable tool, retries 3 times, fails, and the cron system marks the run as `ok` while delivering a garbage error message.

## Changes

**1. Hint ordering: prepend → append** (`cron/scheduler.py`)

Move the cron delivery hint to the end of the assembled prompt (after user prompt + skill content). Both code paths are updated:
- No-skills path: `prompt + cron_hint`
- Skills path: `parts.append(cron_hint)` after all skill/user content

**2. Send_message detection at creation time** (`tools/cronjob_tools.py`)

Add `_CRON_SEND_MESSAGE_PATTERNS` regex list that matches `send_message(`, `call send_message`, and natural-language delivery instructions. Logs a warning at job creation/update time (non-blocking — user may have a reason).

**3. Delivery-failure output detection** (`cron/scheduler.py`)

After the agent runs, scan `final_response` for markers like `Tool 'send_message' does not exist` and `max retries (3) for invalid tool calls exceeded`. When detected, mark the run as failed with a descriptive error instead of `ok`.

## Testing

- Verified on a 1GB VPS running hermes-agent `77276070` with a cron job that previously hit this issue
- Hint now appears at the end of the assembled prompt
- Warning fires correctly on prompt creation with send_message instructions
- Run status correctly reflects delivery-failure output

Closes the issue identified in session analysis of cron delivery contradictions.