### PR TITLE
fix(bedrock): install boto3 on first use via lazy_deps

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -37,6 +37,19 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Ensure boto3/botocore are installed before any code in this module runs.
+# Upstream removed boto3 from [all] extras (PRs #24220, #24515); lazy_deps
+# handles on-demand installation so the Bedrock provider still works in the
+# EKS deployment without baking boto3 into the base image.
+# ---------------------------------------------------------------------------
+try:
+    from tools.lazy_deps import ensure
+    ensure("provider.bedrock", prompt=False)
+except Exception:
+    pass  # lazy_deps unavailable or install failed — let downstream imports surface the real error
+
+
+# ---------------------------------------------------------------------------
 # Lazy boto3 import — only loaded when the Bedrock provider is actually used.
 # This keeps startup fast for users who don't use Bedrock.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`agent/bedrock_adapter.py` already defers `import boto3` until the provider is actually used, but on a base install (no `[all]` extras) that deferred import just raises `ModuleNotFoundError` — there's nothing that actually *installs* boto3.

`tools/lazy_deps.py` already registers a `provider.bedrock` entry pointing at `boto3==1.42.89`. This PR wires the adapter to call `lazy_deps.ensure("provider.bedrock")` at module load, so the first import of the Bedrock adapter triggers the install.

The `ensure()` call is wrapped in `try / except Exception: pass` so that:
- Environments where `lazy_deps` isn't importable (test stubs, etc.) don't break
- An install failure surfaces as the real downstream `ImportError` from the existing lazy import block, not a confusing lazy_deps stack

After #24220 / #24515 removed `boto3` from the `[all]` extras, users on a base install hit `ModuleNotFoundError: No module named 'boto3'` the first time the Bedrock provider is touched, even though the lazy_deps registration was already in place to handle exactly this case.

## Related Issue

No open issue — surfaced as a regression after the boto3-from-extras removal in #24220 / #24515.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/bedrock_adapter.py` — 13-line `try / except` block at the top of the module that calls `lazy_deps.ensure("provider.bedrock", prompt=False)` so boto3 is installed on first import. Pinned version (`boto3==1.42.89`) comes from the existing `tools/lazy_deps.py` registration — not changed here.

## How to Test

On a clean venv with `pip install hermes-agent` (no extras):

1. Confirm the regression on `main`:
   ```python
   python -c "from agent.bedrock_adapter import BedrockAdapter"
   # ModuleNotFoundError: No module named 'boto3'
   ```
2. Apply this PR.
3. Re-run the same import:
   ```python
   python -c "from agent.bedrock_adapter import BedrockAdapter"
   # lazy_deps installs boto3==1.42.89, import succeeds
   ```
4. Run the existing test suite:
   ```
   pytest tests/ -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`chore(deps):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single 13-line addition to one file)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — N/A (this is a deps-bootstrap shim that runs at import time; behavior is "lazy_deps installs the package", which is already covered by lazy_deps' own tests)
- [x] I've tested on my platform: Ubuntu 24.04 (Amazon Linux 2023 runtime)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal bootstrap shim; user-visible behavior is unchanged)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `lazy_deps` is the existing cross-platform install path; no new platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
