### PR TITLE
Add Canon gateway platform adapter

### DIFF
--- a/plugins/platforms/canon/__init__.py
+++ b/plugins/platforms/canon/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/canon/adapter.py
+++ b/plugins/platforms/canon/adapter.py
@@ -1,0 +1,1226 @@
+"""
+Canon platform adapter for Hermes Agent.
+
+This bundled plugin connects Hermes to Canon agent conversations using the
+same public surface as Canon's TypeScript SDK:
+
+* REST endpoints for identity, conversation discovery, sends, and typing.
+* Server-sent events from /agents/stream?events=messages for inbound messages.
+
+The adapter is intentionally dependency-light: Hermes already depends on
+httpx, so we do not need a Node sidecar or a runtime dependency on
+@canonmsg/* packages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import mimetypes
+import os
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Deque, Dict, Optional
+
+import httpx
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
+    cache_video_from_bytes,
+    safe_url_for_log,
+    _ssrf_redirect_guard,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_BASE_URL = "https://api-6m6mlelskq-uc.a.run.app"
+DEFAULT_STREAM_URL = "https://canon-agent-stream-195218560334.us-central1.run.app"
+DEFAULT_HISTORY_LIMIT = 50
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_SEEN_MESSAGE_IDS = 1024
+MAX_MEDIA_BYTES = 10 * 1024 * 1024
+
+AUDIO_EXTS = {".m4a", ".mp3", ".ogg", ".opus", ".wav", ".webm", ".flac"}
+IMAGE_EXTS = {".gif", ".jpeg", ".jpg", ".png", ".webp"}
+VIDEO_EXTS = {".avi", ".mkv", ".mov", ".mp4", ".webm", ".3gp"}
+
+TURN_COMPLETE_METADATA = {
+    "turnSemantics": "turn_complete",
+    "turnComplete": True,
+}
+
+
+class CanonApiError(Exception):
+    """HTTP error from Canon's agent API."""
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body.strip()
+        super().__init__(f"Canon API returned {status_code}: {self.body[:500]}")
+
+    @property
+    def retryable(self) -> bool:
+        return self.status_code in {408, 425, 429} or self.status_code >= 500
+
+
+@dataclass
+class CanonStreamFrame:
+    event: str
+    data: Any
+    event_id: Optional[str] = None
+
+
+class CanonHttpClient:
+    """Small async client for the Canon agent REST and SSE APIs."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        stream_url: str = DEFAULT_STREAM_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.stream_url = stream_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout),
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
+
+    def _headers(self, *, accept: Optional[str] = None) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        if accept:
+            headers["Accept"] = accept
+        return headers
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        res = await self._client.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=params,
+            json=json_body,
+        )
+        if res.status_code >= 400:
+            raise CanonApiError(res.status_code, res.text)
+        if not res.content:
+            return {}
+        return res.json()
+
+    async def get_me(self) -> dict[str, Any]:
+        data = await self._request_json("GET", "/agents/me")
+        return data if isinstance(data, dict) else {}
+
+    async def get_conversations(self) -> list[dict[str, Any]]:
+        data = await self._request_json("GET", "/conversations")
+        conversations = data.get("conversations") if isinstance(data, dict) else data
+        return conversations if isinstance(conversations, list) else []
+
+    async def get_messages(
+        self, conversation_id: str, *, limit: int = DEFAULT_HISTORY_LIMIT
+    ) -> list[dict[str, Any]]:
+        data = await self._request_json(
+            "GET",
+            f"/conversations/{conversation_id}/messages",
+            params={"limit": str(limit)},
+        )
+        messages = data.get("messages") if isinstance(data, dict) else data
+        return messages if isinstance(messages, list) else []
+
+    async def send_message(
+        self,
+        conversation_id: str,
+        text: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        options: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "text": text,
+        }
+        if options:
+            body.update(options)
+        if reply_to:
+            body["replyTo"] = reply_to
+        if metadata:
+            body["metadata"] = metadata
+
+        data = await self._request_json("POST", "/messages/send", json_body=body)
+        return data if isinstance(data, dict) else {}
+
+    async def upload_media(
+        self,
+        conversation_id: str,
+        data: str,
+        mime_type: str,
+        *,
+        file_name: Optional[str] = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "data": data,
+            "mimeType": mime_type,
+        }
+        if file_name:
+            body["fileName"] = file_name
+        result = await self._request_json("POST", "/media/upload", json_body=body)
+        return result if isinstance(result, dict) else {}
+
+    async def download_media(self, url: str) -> tuple[bytes, Optional[str]]:
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(url):
+            raise ValueError(
+                f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}"
+            )
+
+        res = await self._client.get(
+            url,
+            headers={"User-Agent": "HermesAgent/CanonPlatform"},
+            follow_redirects=True,
+        )
+        if res.status_code >= 400:
+            raise CanonApiError(res.status_code, res.text)
+        if len(res.content) > MAX_MEDIA_BYTES:
+            raise ValueError("Canon media attachment exceeds 10MB")
+        return res.content, res.headers.get("content-type")
+
+    async def set_typing(
+        self,
+        conversation_id: str,
+        typing: bool,
+        status: Optional[str] = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "typing": typing,
+        }
+        if status in {"typing", "thinking"}:
+            body["status"] = status
+        await self._request_json("POST", "/typing", json_body=body)
+
+    async def stream_events(
+        self,
+        *,
+        last_event_id: Optional[str] = None,
+    ) -> AsyncIterator[CanonStreamFrame]:
+        url = f"{self.stream_url}/agents/stream"
+        headers = self._headers(accept="text/event-stream")
+        if last_event_id:
+            headers["Last-Event-ID"] = last_event_id
+
+        async with self._client.stream(
+            "GET",
+            url,
+            headers=headers,
+            params={"events": "messages"},
+            timeout=None,
+        ) as res:
+            if res.status_code >= 400:
+                body = await res.aread()
+                raise CanonApiError(
+                    res.status_code, body.decode("utf-8", errors="replace")
+                )
+
+            buffer = ""
+            async for chunk in res.aiter_text():
+                if not chunk:
+                    continue
+                buffer += chunk.replace("\r\n", "\n").replace("\r", "\n")
+                while "\n\n" in buffer:
+                    frame, buffer = buffer.split("\n\n", 1)
+                    parsed = _parse_sse_frame(frame)
+                    if parsed is not None:
+                        yield parsed
+
+
+class CanonAdapter(BasePlatformAdapter):
+    """Hermes gateway adapter for Canon conversations."""
+
+    def __init__(self, config, **_: Any) -> None:
+        super().__init__(config=config, platform=Platform("canon"))
+
+        self.api_key = _config_value(config, "api_key", "CANON_API_KEY")
+        self.base_url = _config_value(
+            config, "base_url", "CANON_BASE_URL", DEFAULT_BASE_URL
+        )
+        self.stream_url = _config_value(
+            config, "stream_url", "CANON_STREAM_URL", DEFAULT_STREAM_URL
+        )
+        self.history_limit = _config_int(
+            config, "history_limit", "CANON_HISTORY_LIMIT", DEFAULT_HISTORY_LIMIT
+        )
+
+        self._client: Optional[CanonHttpClient] = None
+        self._agent_id: Optional[str] = None
+        self._stream_task: Optional[asyncio.Task] = None
+        self._stream_stop: Optional[asyncio.Event] = None
+        self._last_event_id: Optional[str] = None
+        self._conversation_cache: dict[str, dict[str, Any]] = {}
+        self._seen_message_ids: set[str] = set()
+        self._seen_message_order: Deque[str] = deque()
+
+    @property
+    def name(self) -> str:
+        return "Canon"
+
+    async def connect(self) -> bool:
+        if not self.api_key:
+            self._set_fatal_error(
+                "missing_api_key",
+                "CANON_API_KEY or config.api_key is required for the Canon platform",
+                retryable=False,
+            )
+            return False
+
+        self._client = self._make_client()
+        self._stream_stop = asyncio.Event()
+
+        try:
+            ctx = await self._client.get_me()
+            self._agent_id = _first_string(ctx, "agentId", "id", "userId")
+            await self._refresh_conversations()
+            self._mark_connected()
+            self._stream_task = asyncio.create_task(
+                self._stream_loop(), name="canon-platform-stream"
+            )
+            logger.info(
+                "Canon platform connected as agent %s", self._agent_id or "<unknown>"
+            )
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._set_fatal_error(
+                "connect_failed", _safe_error(exc), retryable=_is_retryable(exc)
+            )
+            await self._close_client()
+            return False
+
+    async def disconnect(self) -> None:
+        stop = self._stream_stop
+        if stop is not None:
+            stop.set()
+
+        task = self._stream_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Canon stream task raised during disconnect", exc_info=True
+                )
+
+        self._stream_task = None
+        self._stream_stop = None
+        await self._close_client()
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+
+        try:
+            canon_options, message_metadata = _split_canon_metadata(metadata)
+            message_metadata.update(TURN_COMPLETE_METADATA)
+            data = await client.send_message(
+                chat_id,
+                content,
+                reply_to=reply_to,
+                metadata=message_metadata,
+                options=canon_options,
+            )
+            message_id = _first_string(data, "messageId", "id")
+            return SendResult(
+                success=True,
+                message_id=message_id,
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False,
+                error=_safe_error(exc),
+                retryable=_is_retryable(exc),
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        return await self._send_attachment(
+            chat_id,
+            caption or "",
+            content_type="image",
+            attachment={"kind": "image", "url": image_url},
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="image",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            audio_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="audio",
+            mime_hint=kwargs.get("mime_type"),
+            duration_ms=kwargs.get("duration_ms"),
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="file",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_media_file(
+            chat_id,
+            file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+            content_type="file",
+            mime_hint=kwargs.get("mime_type"),
+        )
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        if not self.api_key:
+            return
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            status = "thinking"
+            if isinstance(metadata, dict) and metadata.get("status") in {
+                "typing",
+                "thinking",
+            }:
+                status = metadata["status"]
+            await client.set_typing(chat_id, True, status)
+        except Exception:
+            logger.debug("Canon typing indicator failed", exc_info=True)
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def stop_typing(self, chat_id: str) -> None:
+        if not self.api_key:
+            return
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            await client.set_typing(chat_id, False)
+        except Exception:
+            logger.debug("Canon typing clear failed", exc_info=True)
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        convo = self._conversation_cache.get(str(chat_id))
+        if convo is None and self._client is not None:
+            await self._refresh_conversations()
+            convo = self._conversation_cache.get(str(chat_id))
+        return {
+            "id": str(chat_id),
+            "name": _conversation_name(convo) if convo else str(chat_id),
+            "type": _chat_type_from_conversation(convo),
+        }
+
+    def _make_client(self) -> CanonHttpClient:
+        return CanonHttpClient(
+            self.api_key,
+            base_url=self.base_url,
+            stream_url=self.stream_url,
+        )
+
+    async def _close_client(self) -> None:
+        client = self._client
+        self._client = None
+        if client is not None:
+            await client.close()
+
+    async def _refresh_conversations(self) -> None:
+        if self._client is None:
+            return
+        conversations = await self._client.get_conversations()
+        for convo in conversations:
+            convo_id = _first_string(convo, "id", "conversationId")
+            if convo_id:
+                self._conversation_cache[convo_id] = convo
+
+    async def _send_media_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        *,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        content_type: str,
+        mime_hint: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        path = Path(file_path).expanduser()
+        if not path.exists():
+            return SendResult(success=False, error=f"Media file not found: {file_path}")
+        if path.stat().st_size > MAX_MEDIA_BYTES:
+            return SendResult(success=False, error="Canon media upload limit is 10MB")
+
+        client = self._client or self._make_client()
+        owns_client = self._client is None
+        try:
+            media_bytes = path.read_bytes()
+            mime_type = _guess_mime_type(str(path), mime_hint)
+            uploaded = await client.upload_media(
+                chat_id,
+                base64.b64encode(media_bytes).decode("ascii"),
+                mime_type,
+                file_name=file_name or path.name,
+            )
+            attachment = dict(uploaded.get("attachment") or {})
+            if not attachment:
+                attachment = {
+                    "kind": _canon_attachment_kind_for_mime(mime_type),
+                    "url": uploaded.get("url"),
+                    "mimeType": mime_type,
+                    "fileName": file_name or path.name,
+                    "sizeBytes": len(media_bytes),
+                }
+            if duration_ms and attachment.get("kind") == "audio":
+                attachment["durationMs"] = int(duration_ms)
+            if mime_type.startswith("video/"):
+                content_type = "file"
+            elif attachment.get("kind") in {"image", "audio"}:
+                content_type = str(attachment["kind"])
+
+            return await self._send_attachment(
+                chat_id,
+                caption or "",
+                content_type=content_type,
+                attachment=attachment,
+                reply_to=reply_to,
+                metadata=metadata,
+                client=client,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False, error=_safe_error(exc), retryable=_is_retryable(exc)
+            )
+        finally:
+            if owns_client:
+                await client.close()
+
+    async def _send_attachment(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        content_type: str,
+        attachment: dict[str, Any],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        client: Optional[CanonHttpClient] = None,
+    ) -> SendResult:
+        if not self.api_key:
+            return SendResult(
+                success=False, error="Canon API key is not configured", retryable=False
+            )
+
+        active_client = client or self._client or self._make_client()
+        owns_client = client is None and self._client is None
+        try:
+            canon_options, message_metadata = _split_canon_metadata(metadata)
+            message_metadata.update(TURN_COMPLETE_METADATA)
+            canon_options.update({
+                "contentType": content_type,
+                "attachments": [attachment],
+            })
+            data = await active_client.send_message(
+                chat_id,
+                text,
+                reply_to=reply_to,
+                metadata=message_metadata,
+                options=canon_options,
+            )
+            return SendResult(
+                success=True,
+                message_id=_first_string(data, "messageId", "id"),
+                raw_response=data,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return SendResult(
+                success=False, error=_safe_error(exc), retryable=_is_retryable(exc)
+            )
+        finally:
+            if owns_client:
+                await active_client.close()
+
+    async def _stream_loop(self) -> None:
+        assert self._client is not None
+        backoff = 1.0
+
+        while self._stream_stop is not None and not self._stream_stop.is_set():
+            try:
+                async for frame in self._client.stream_events(
+                    last_event_id=self._last_event_id
+                ):
+                    if frame.event_id:
+                        self._last_event_id = frame.event_id
+                    await self._handle_stream_frame(frame)
+                backoff = 1.0
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if self._stream_stop is not None and self._stream_stop.is_set():
+                    break
+                logger.warning("Canon stream disconnected: %s", _safe_error(exc))
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def _handle_stream_frame(self, frame: CanonStreamFrame) -> None:
+        if frame.event == "agent.context" and isinstance(frame.data, dict):
+            self._agent_id = (
+                _first_string(frame.data, "agentId", "id", "userId") or self._agent_id
+            )
+            return
+        if frame.event == "conversation.updated" and isinstance(frame.data, dict):
+            convo_id = _first_string(frame.data, "conversationId", "id")
+            if convo_id:
+                cached = self._conversation_cache.setdefault(convo_id, {"id": convo_id})
+                changes = frame.data.get("changes")
+                if isinstance(changes, dict):
+                    cached.update(changes)
+            return
+        if frame.event != "message.created":
+            return
+        if isinstance(frame.data, dict):
+            await self._handle_message_payload(frame.data)
+
+    async def _handle_message_payload(self, payload: dict[str, Any]) -> None:
+        message = payload.get("message")
+        if not isinstance(message, dict):
+            return
+
+        sender_id = _first_string(message, "senderId")
+        if self._agent_id and sender_id == self._agent_id:
+            return
+
+        message_id = _first_string(message, "id")
+        if message_id and self._already_seen(message_id):
+            return
+
+        conversation_id = _first_string(payload, "conversationId")
+        if not conversation_id:
+            return
+
+        conversation = payload.get("conversation")
+        if isinstance(conversation, dict):
+            self._conversation_cache[conversation_id] = conversation
+        conversation = self._conversation_cache.get(
+            conversation_id, conversation if isinstance(conversation, dict) else None
+        )
+
+        text = _message_text(message)
+        if not text:
+            return
+
+        (
+            media_urls,
+            media_types,
+            media_message_type,
+        ) = await self._materialize_attachments(message)
+
+        source = self.build_source(
+            chat_id=conversation_id,
+            chat_name=_conversation_name(conversation),
+            chat_type=_chat_type_from_conversation(conversation),
+            user_id=sender_id,
+            user_name=_first_string(message, "senderName"),
+            message_id=message_id,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=_message_type_for_text_and_media(text, media_message_type),
+            source=source,
+            raw_message=payload,
+            message_id=message_id,
+            media_urls=media_urls,
+            media_types=media_types,
+            reply_to_message_id=_first_string(message, "replyTo"),
+        )
+        await self.handle_message(event)
+
+    async def _materialize_attachments(
+        self,
+        message: dict[str, Any],
+    ) -> tuple[list[str], list[str], Optional[MessageType]]:
+        attachments = message.get("attachments")
+        if not isinstance(attachments, list) or not attachments:
+            return [], [], None
+        if self._client is None:
+            return [], [], None
+
+        media_urls: list[str] = []
+        media_types: list[str] = []
+        message_type: Optional[MessageType] = None
+
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            url = _first_string(attachment, "url")
+            if not url:
+                continue
+
+            try:
+                data, response_mime = await self._client.download_media(url)
+                mime_type = _attachment_mime_type(attachment, response_mime)
+                local_path, local_message_type = _cache_canon_media(
+                    attachment, data, mime_type
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to materialize Canon media attachment", exc_info=True
+                )
+                continue
+
+            media_urls.append(local_path)
+            media_types.append(mime_type)
+            message_type = _prefer_media_message_type(message_type, local_message_type)
+
+        return media_urls, media_types, message_type
+
+    def _already_seen(self, message_id: str) -> bool:
+        if message_id in self._seen_message_ids:
+            return True
+        self._seen_message_ids.add(message_id)
+        self._seen_message_order.append(message_id)
+        while len(self._seen_message_order) > MAX_SEEN_MESSAGE_IDS:
+            old = self._seen_message_order.popleft()
+            self._seen_message_ids.discard(old)
+        return False
+
+
+def _parse_sse_frame(frame: str) -> Optional[CanonStreamFrame]:
+    event: Optional[str] = None
+    event_id: Optional[str] = None
+    data_lines: list[str] = []
+
+    for line in frame.split("\n"):
+        if not line or line.startswith(":"):
+            continue
+        if line.startswith("id:"):
+            event_id = line[3:].strip()
+        elif line.startswith("event:"):
+            event = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].strip())
+
+    if not event or not data_lines:
+        return None
+
+    raw_data = "\n".join(data_lines)
+    try:
+        data: Any = json.loads(raw_data)
+    except json.JSONDecodeError:
+        data = raw_data
+    return CanonStreamFrame(event=event, data=data, event_id=event_id)
+
+
+def _config_value(config: Any, key: str, env_name: str, default: str = "") -> str:
+    env_value = os.getenv(env_name)
+    if env_value:
+        return env_value.strip()
+
+    if key == "api_key":
+        for attr in ("api_key", "token"):
+            value = getattr(config, attr, None)
+            if value:
+                return str(value).strip()
+
+    extra = getattr(config, "extra", {}) or {}
+    if isinstance(extra, dict):
+        for candidate in (key, env_name.lower(), env_name):
+            value = extra.get(candidate)
+            if value:
+                return str(value).strip()
+    return default
+
+
+def _config_int(config: Any, key: str, env_name: str, default: int) -> int:
+    raw = _config_value(config, key, env_name, "")
+    if raw == "":
+        return default
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _first_string(data: Any, *keys: str) -> Optional[str]:
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        value = data.get(key)
+        if value is not None and str(value) != "":
+            return str(value)
+    return None
+
+
+def _conversation_name(conversation: Optional[dict[str, Any]]) -> Optional[str]:
+    if not isinstance(conversation, dict):
+        return None
+    return _first_string(conversation, "name", "topic") or _first_string(
+        conversation, "id"
+    )
+
+
+def _chat_type_from_conversation(conversation: Optional[dict[str, Any]]) -> str:
+    if isinstance(conversation, dict) and conversation.get("type") == "group":
+        return "group"
+    return "dm"
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    text = message.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+
+    content_type = message.get("contentType")
+    if content_type == "contact_card":
+        card = message.get("contactCard")
+        name = (
+            _first_string(card, "displayName", "userId")
+            if isinstance(card, dict)
+            else None
+        )
+        return f"[Contact card: {name}]" if name else "[Contact card]"
+
+    attachments = message.get("attachments")
+    if isinstance(attachments, list) and attachments:
+        labels: list[str] = []
+        for item in attachments:
+            if not isinstance(item, dict):
+                continue
+            kind = _first_string(item, "kind") or content_type or "file"
+            name = _first_string(item, "fileName", "url")
+            labels.append(
+                f"{kind} attachment: {name}" if name else f"{kind} attachment"
+            )
+        if labels:
+            return "[" + "; ".join(labels) + "]"
+
+    if isinstance(content_type, str) and content_type != "text":
+        return f"[{content_type} message]"
+    return ""
+
+
+def _message_type_for_text_and_media(
+    text: str, media_type: Optional[MessageType]
+) -> MessageType:
+    if text.strip().startswith("/"):
+        return MessageType.COMMAND
+    return media_type or MessageType.TEXT
+
+
+def _prefer_media_message_type(
+    current: Optional[MessageType],
+    candidate: MessageType,
+) -> MessageType:
+    priority = {
+        MessageType.VOICE: 4,
+        MessageType.AUDIO: 4,
+        MessageType.VIDEO: 3,
+        MessageType.PHOTO: 2,
+        MessageType.DOCUMENT: 1,
+    }
+    if current is None:
+        return candidate
+    return (
+        candidate if priority.get(candidate, 0) > priority.get(current, 0) else current
+    )
+
+
+def _guess_mime_type(path_or_name: str, override: Optional[str] = None) -> str:
+    if override:
+        return override
+    guessed, _encoding = mimetypes.guess_type(path_or_name)
+    if guessed:
+        return guessed
+    ext = Path(path_or_name.split("?", 1)[0]).suffix.lower()
+    if ext in {".m4a"}:
+        return "audio/mp4"
+    if ext in {".opus"}:
+        return "audio/ogg"
+    if ext in VIDEO_EXTS:
+        return "video/mp4"
+    if ext in IMAGE_EXTS:
+        return "image/jpeg"
+    if ext in AUDIO_EXTS:
+        return "audio/mpeg"
+    return "application/octet-stream"
+
+
+def _canon_attachment_kind_for_mime(mime_type: str) -> str:
+    if mime_type.startswith("image/"):
+        return "image"
+    if mime_type.startswith("audio/"):
+        return "audio"
+    return "file"
+
+
+def _attachment_mime_type(
+    attachment: dict[str, Any],
+    response_mime: Optional[str] = None,
+) -> str:
+    explicit = _first_string(attachment, "mimeType")
+    if explicit:
+        return explicit.split(";", 1)[0].strip().lower()
+    if response_mime:
+        return response_mime.split(";", 1)[0].strip().lower()
+    name = _first_string(attachment, "fileName", "url") or ""
+    return _guess_mime_type(name)
+
+
+def _attachment_file_name(attachment: dict[str, Any], mime_type: str) -> str:
+    name = _first_string(attachment, "fileName")
+    if name:
+        return Path(name).name
+
+    url = _first_string(attachment, "url") or ""
+    url_name = Path(url.split("?", 1)[0]).name
+    if url_name and "." in url_name:
+        return url_name
+
+    ext = mimetypes.guess_extension(mime_type) or ".bin"
+    return f"canon-media{ext}"
+
+
+def _cache_canon_media(
+    attachment: dict[str, Any],
+    data: bytes,
+    mime_type: str,
+) -> tuple[str, MessageType]:
+    ext = Path(_attachment_file_name(attachment, mime_type)).suffix.lower()
+    if not ext:
+        ext = mimetypes.guess_extension(mime_type) or ".bin"
+
+    if mime_type.startswith("image/"):
+        return cache_image_from_bytes(
+            data, ext if ext in IMAGE_EXTS else ".jpg"
+        ), MessageType.PHOTO
+    if mime_type.startswith("audio/"):
+        return cache_audio_from_bytes(
+            data, ext if ext in AUDIO_EXTS else ".ogg"
+        ), MessageType.VOICE
+    if mime_type.startswith("video/"):
+        return cache_video_from_bytes(
+            data, ext if ext in VIDEO_EXTS else ".mp4"
+        ), MessageType.VIDEO
+    return cache_document_from_bytes(
+        data, _attachment_file_name(attachment, mime_type)
+    ), MessageType.DOCUMENT
+
+
+def _media_file_path(item: Any) -> str:
+    if isinstance(item, (list, tuple)) and item:
+        return str(item[0])
+    return str(item)
+
+
+def _split_canon_metadata(
+    metadata: Optional[Dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return {}, {}
+
+    options = metadata.get("canon_options")
+    canon_metadata = metadata.get("canon_metadata")
+
+    safe_options = dict(options) if isinstance(options, dict) else {}
+    safe_metadata = dict(canon_metadata) if isinstance(canon_metadata, dict) else {}
+
+    if not safe_metadata and metadata:
+        safe_metadata["hermes"] = metadata
+
+    return safe_options, safe_metadata
+
+
+def _safe_error(exc: Exception) -> str:
+    if isinstance(exc, CanonApiError):
+        return str(exc)
+    return str(exc) or exc.__class__.__name__
+
+
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, CanonApiError):
+        return exc.retryable
+    return isinstance(
+        exc,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.RemoteProtocolError,
+        ),
+    )
+
+
+def check_requirements() -> bool:
+    """Canon uses Hermes' core httpx dependency, so imports are the only check."""
+    return True
+
+
+def validate_config(config) -> bool:
+    return bool(_config_value(config, "api_key", "CANON_API_KEY"))
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> dict | None:
+    api_key = os.getenv("CANON_API_KEY", "").strip()
+    if not api_key:
+        return None
+
+    seed: dict[str, Any] = {"api_key": api_key}
+    if os.getenv("CANON_BASE_URL"):
+        seed["base_url"] = os.getenv("CANON_BASE_URL", "").strip()
+    if os.getenv("CANON_STREAM_URL"):
+        seed["stream_url"] = os.getenv("CANON_STREAM_URL", "").strip()
+    if os.getenv("CANON_HISTORY_LIMIT"):
+        seed["history_limit"] = os.getenv("CANON_HISTORY_LIMIT", "").strip()
+    if os.getenv("CANON_HOME_CHANNEL"):
+        seed["home_channel"] = {
+            "chat_id": os.getenv("CANON_HOME_CHANNEL", "").strip(),
+            "name": os.getenv("CANON_HOME_CHANNEL_NAME", "Canon Home"),
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document: bool = False,
+) -> dict:
+    api_key = _config_value(pconfig, "api_key", "CANON_API_KEY")
+    if not api_key:
+        return {
+            "error": "Canon standalone send failed: CANON_API_KEY is not configured"
+        }
+
+    target = chat_id or os.getenv("CANON_HOME_CHANNEL", "").strip()
+    if not target:
+        home = getattr(pconfig, "home_channel", None)
+        target = getattr(home, "chat_id", "") or ""
+    if not target:
+        return {"error": "Canon standalone send failed: no conversation ID provided"}
+
+    text = message or ""
+
+    client = CanonHttpClient(
+        api_key,
+        base_url=_config_value(pconfig, "base_url", "CANON_BASE_URL", DEFAULT_BASE_URL),
+        stream_url=_config_value(
+            pconfig, "stream_url", "CANON_STREAM_URL", DEFAULT_STREAM_URL
+        ),
+    )
+    try:
+        options: dict[str, Any] = {}
+        if media_files:
+            attachments: list[dict[str, Any]] = []
+            for item in media_files:
+                media_path = _media_file_path(item)
+                path = Path(media_path).expanduser()
+                if not path.exists():
+                    return {
+                        "error": f"Canon standalone send failed: media file not found: {media_path}"
+                    }
+                if path.stat().st_size > MAX_MEDIA_BYTES:
+                    return {
+                        "error": "Canon standalone send failed: Canon media upload limit is 10MB"
+                    }
+                mime_type = _guess_mime_type(str(path))
+                uploaded = await client.upload_media(
+                    target,
+                    base64.b64encode(path.read_bytes()).decode("ascii"),
+                    mime_type,
+                    file_name=path.name,
+                )
+                attachment = dict(uploaded.get("attachment") or {})
+                if not attachment:
+                    attachment = {
+                        "kind": _canon_attachment_kind_for_mime(mime_type),
+                        "url": uploaded.get("url"),
+                        "mimeType": mime_type,
+                        "fileName": path.name,
+                        "sizeBytes": path.stat().st_size,
+                    }
+                attachments.append(attachment)
+
+            if attachments:
+                first_kind = str(attachments[0].get("kind") or "file")
+                options["contentType"] = (
+                    first_kind if first_kind in {"image", "audio"} else "file"
+                )
+                options["attachments"] = attachments
+
+        data = await client.send_message(
+            target,
+            text,
+            reply_to=str(thread_id) if thread_id else None,
+            metadata=dict(TURN_COMPLETE_METADATA),
+            options=options or None,
+        )
+        return {"success": True, "message_id": _first_string(data, "messageId", "id")}
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return {"error": f"Canon standalone send failed: {_safe_error(exc)}"}
+    finally:
+        await client.close()
+
+
+def register(ctx):
+    """Plugin entry point: called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="canon",
+        label="Canon",
+        adapter_factory=lambda cfg: CanonAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["CANON_API_KEY"],
+        install_hint="Set CANON_API_KEY for your Canon agent",
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="CANON_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="CANON_ALLOWED_USERS",
+        allow_all_env="CANON_ALLOW_ALL_USERS",
+        max_message_length=8000,
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via Canon. Canon conversations can be direct or group chats. "
+            "Use concise conversational text; slash commands are preserved when users send them. "
+            "Messages sent by Hermes are marked as turn-complete for Canon's UI."
+        ),
+    )

--- a/plugins/platforms/canon/plugin.yaml
+++ b/plugins/platforms/canon/plugin.yaml
@@ -1,0 +1,38 @@
+name: canon-platform
+label: Canon
+kind: platform
+version: 0.1.0
+description: >
+  Canon gateway adapter for Hermes Agent. Connects Hermes to Canon agent
+  conversations over Canon's REST and SSE APIs.
+author: Hermes Agent contributors
+requires_env:
+  - name: CANON_API_KEY
+    description: "Canon agent API key"
+    prompt: "Canon API key"
+    password: true
+optional_env:
+  - name: CANON_BASE_URL
+    description: "Canon agent REST API base URL"
+    prompt: "Canon base URL"
+    password: false
+  - name: CANON_STREAM_URL
+    description: "Canon agent SSE stream base URL"
+    prompt: "Canon stream URL"
+    password: false
+  - name: CANON_HOME_CHANNEL
+    description: "Default Canon conversation ID for cron / notification delivery"
+    prompt: "Canon home conversation ID"
+    password: false
+  - name: CANON_ALLOWED_USERS
+    description: "Comma-separated Canon user IDs allowed to talk to Hermes"
+    prompt: "Allowed Canon user IDs"
+    password: false
+  - name: CANON_ALLOW_ALL_USERS
+    description: "Allow any Canon user to talk to Hermes"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: CANON_HISTORY_LIMIT
+    description: "Messages to fetch when hydrating Canon conversation context"
+    prompt: "Canon history limit"
+    password: false

--- a/tests/gateway/test_canon_adapter.py
+++ b/tests/gateway/test_canon_adapter.py
@@ -1,0 +1,538 @@
+"""Tests for the Canon platform adapter plugin."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_canon = load_plugin_adapter("canon")
+
+CanonAdapter = _canon.CanonAdapter
+CanonHttpClient = _canon.CanonHttpClient
+CanonStreamFrame = _canon.CanonStreamFrame
+DEFAULT_BASE_URL = _canon.DEFAULT_BASE_URL
+DEFAULT_STREAM_URL = _canon.DEFAULT_STREAM_URL
+TURN_COMPLETE_METADATA = _canon.TURN_COMPLETE_METADATA
+_env_enablement = _canon._env_enablement
+_parse_sse_frame = _canon._parse_sse_frame
+_standalone_send = _canon._standalone_send
+check_requirements = _canon.check_requirements
+register = _canon.register
+validate_config = _canon.validate_config
+
+
+def _config(**kwargs):
+    from gateway.config import PlatformConfig
+
+    return PlatformConfig(enabled=True, **kwargs)
+
+
+class TestCanonConfig:
+    def test_init_from_config_extra(self, monkeypatch):
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        cfg = _config(
+            extra={
+                "api_key": "config-key",
+                "base_url": "https://api.example.test",
+                "stream_url": "https://stream.example.test",
+                "history_limit": "25",
+            }
+        )
+
+        adapter = CanonAdapter(cfg)
+
+        assert adapter.api_key == "config-key"
+        assert adapter.base_url == "https://api.example.test"
+        assert adapter.stream_url == "https://stream.example.test"
+        assert adapter.history_limit == 25
+
+    def test_env_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_BASE_URL", "https://api.env.test")
+
+        adapter = CanonAdapter(
+            _config(api_key="config-key", extra={"base_url": "https://api.config.test"})
+        )
+
+        assert adapter.api_key == "env-key"
+        assert adapter.base_url == "https://api.env.test"
+
+    def test_validate_config_accepts_env_or_config(self, monkeypatch):
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+        assert not validate_config(_config())
+        assert validate_config(_config(api_key="config-key"))
+
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        assert validate_config(_config())
+
+    def test_env_enablement_seeds_extra_and_home_channel(self, monkeypatch):
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_BASE_URL", "https://api.env.test")
+        monkeypatch.setenv("CANON_STREAM_URL", "https://stream.env.test")
+        monkeypatch.setenv("CANON_HOME_CHANNEL", "convo-home")
+        monkeypatch.setenv("CANON_HISTORY_LIMIT", "75")
+
+        seed = _env_enablement()
+
+        assert seed["api_key"] == "env-key"
+        assert seed["base_url"] == "https://api.env.test"
+        assert seed["stream_url"] == "https://stream.env.test"
+        assert seed["history_limit"] == "75"
+        assert seed["home_channel"]["chat_id"] == "convo-home"
+
+    def test_requirements_are_core_dependency_only(self):
+        assert check_requirements() is True
+
+
+class TestCanonHttpClient:
+    @pytest.mark.asyncio
+    async def test_download_media_blocks_unsafe_url(self, monkeypatch):
+        client = CanonHttpClient("key")
+        client._client.get = AsyncMock()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: False)
+
+        try:
+            with pytest.raises(ValueError, match="SSRF"):
+                await client.download_media("http://127.0.0.1/private")
+
+            client._client.get.assert_not_called()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_download_media_uses_redirect_guard(self, monkeypatch):
+        client = CanonHttpClient("key")
+        monkeypatch.setattr(
+            "tools.url_safety.is_safe_url",
+            lambda url: url == "https://media.example/voice.m4a",
+        )
+        redirect_response = SimpleNamespace(
+            is_redirect=True,
+            next_request=SimpleNamespace(
+                url="http://169.254.169.254/latest/meta-data"
+            ),
+        )
+
+        try:
+            hooks = client._client.event_hooks["response"]
+            assert hooks
+            with pytest.raises(ValueError, match="Blocked redirect"):
+                await hooks[0](redirect_response)
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_download_media_returns_bytes_for_safe_url(self, monkeypatch):
+        response = SimpleNamespace(
+            status_code=200,
+            content=b"audio-bytes",
+            text="",
+            headers={"content-type": "audio/mp4"},
+        )
+        client = CanonHttpClient("key")
+        client._client.get = AsyncMock(return_value=response)
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda _url: True)
+
+        try:
+            data, content_type = await client.download_media(
+                "https://media.example/voice.m4a"
+            )
+
+            assert data == b"audio-bytes"
+            assert content_type == "audio/mp4"
+            client._client.get.assert_awaited_once_with(
+                "https://media.example/voice.m4a",
+                headers={"User-Agent": "HermesAgent/CanonPlatform"},
+                follow_redirects=True,
+            )
+        finally:
+            await client.close()
+
+
+class TestCanonInbound:
+    @pytest.mark.asyncio
+    async def test_message_created_normalizes_to_message_event(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter._conversation_cache["convo-1"] = {
+            "id": "convo-1",
+            "type": "group",
+            "name": "Research",
+        }
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-1",
+                "senderId": "human-1",
+                "senderName": "Ada",
+                "text": "/status please",
+                "contentType": "text",
+                "replyTo": "msg-parent",
+            },
+        })
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/status please"
+        assert event.message_type == MessageType.COMMAND
+        assert event.message_id == "msg-1"
+        assert event.reply_to_message_id == "msg-parent"
+        assert event.source.platform.value == "canon"
+        assert event.source.chat_id == "convo-1"
+        assert event.source.chat_type == "group"
+        assert event.source.chat_name == "Research"
+        assert event.source.user_id == "human-1"
+        assert event.source.user_name == "Ada"
+
+    @pytest.mark.asyncio
+    async def test_ignores_self_messages_and_duplicates(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._agent_id = "agent-1"
+        adapter.handle_message = AsyncMock()
+
+        payload = {
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-1",
+                "senderId": "agent-1",
+                "text": "own echo",
+                "contentType": "text",
+            },
+        }
+        await adapter._handle_message_payload(payload)
+        adapter.handle_message.assert_not_awaited()
+
+        payload["message"]["senderId"] = "human-1"
+        await adapter._handle_message_payload(payload)
+        await adapter._handle_message_payload(payload)
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_message_gets_text_placeholder(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-2",
+                "senderId": "human-1",
+                "contentType": "image",
+                "attachments": [{"kind": "image", "fileName": "plot.png"}],
+            },
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "[image attachment: plot.png]"
+        assert event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_audio_and_video_attachments_are_materialized(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        class FakeClient:
+            async def download_media(self, url):
+                if url.endswith("voice.m4a"):
+                    return b"audio-bytes", "audio/mp4"
+                return b"video-bytes", "video/mp4"
+
+        monkeypatch.setattr(
+            _canon,
+            "cache_audio_from_bytes",
+            lambda data, ext=".ogg": f"/tmp/canon-audio{ext}",
+        )
+        monkeypatch.setattr(
+            _canon,
+            "cache_video_from_bytes",
+            lambda data, ext=".mp4": f"/tmp/canon-video{ext}",
+        )
+
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._client = FakeClient()
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_message_payload({
+            "conversationId": "convo-1",
+            "message": {
+                "id": "msg-media",
+                "senderId": "human-1",
+                "text": "review these",
+                "contentType": "file",
+                "attachments": [
+                    {"kind": "audio", "url": "https://media.example/voice.m4a"},
+                    {"kind": "file", "url": "https://media.example/demo.mp4"},
+                ],
+            },
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.VOICE
+        assert event.media_urls == ["/tmp/canon-audio.m4a", "/tmp/canon-video.mp4"]
+        assert event.media_types == ["audio/mp4", "video/mp4"]
+
+
+class TestCanonOutbound:
+    class FakeClient:
+        def __init__(self):
+            self.sent = []
+            self.typing = []
+            self.uploads = []
+            self.closed = False
+
+        async def send_message(
+            self, conversation_id, text, *, reply_to=None, metadata=None, options=None
+        ):
+            self.sent.append({
+                "conversation_id": conversation_id,
+                "text": text,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "options": options,
+            })
+            return {"messageId": "msg-out"}
+
+        async def set_typing(self, conversation_id, typing, status=None):
+            self.typing.append((conversation_id, typing, status))
+
+        async def upload_media(
+            self, conversation_id, data, mime_type, *, file_name=None
+        ):
+            self.uploads.append((conversation_id, data, mime_type, file_name))
+            kind = "audio" if mime_type.startswith("audio/") else "file"
+            return {
+                "url": f"https://media.example/{file_name}",
+                "attachment": {
+                    "kind": kind,
+                    "url": f"https://media.example/{file_name}",
+                    "mimeType": mime_type,
+                    "fileName": file_name,
+                },
+            }
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_send_posts_turn_complete_metadata(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        result = await adapter.send(
+            "convo-1",
+            "hello",
+            reply_to="msg-parent",
+            metadata={
+                "canon_metadata": {"source": "test"},
+                "canon_options": {"mentions": ["u1"]},
+            },
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-out"
+        assert fake.sent == [
+            {
+                "conversation_id": "convo-1",
+                "text": "hello",
+                "reply_to": "msg-parent",
+                "metadata": {"source": "test", **TURN_COMPLETE_METADATA},
+                "options": {"mentions": ["u1"]},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_typing_is_best_effort(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+
+        await adapter.send_typing("convo-1")
+        await adapter.stop_typing("convo-1")
+
+        assert fake.typing == [
+            ("convo-1", True, "thinking"),
+            ("convo-1", False, None),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_voice_uploads_audio_attachment(self, tmp_path):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        audio_path = tmp_path / "reply.mp3"
+        audio_path.write_bytes(b"audio-bytes")
+
+        result = await adapter.send_voice(
+            "convo-1", str(audio_path), caption="voice reply"
+        )
+
+        assert result.success is True
+        assert fake.uploads[0][2] == "audio/mpeg"
+        sent = fake.sent[0]
+        assert sent["text"] == "voice reply"
+        assert sent["options"]["contentType"] == "audio"
+        assert sent["options"]["attachments"][0]["kind"] == "audio"
+        assert sent["metadata"] == TURN_COMPLETE_METADATA
+
+    @pytest.mark.asyncio
+    async def test_send_video_uploads_file_attachment_with_video_mime(self, tmp_path):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        adapter._client = fake
+        video_path = tmp_path / "demo.mp4"
+        video_path.write_bytes(b"video-bytes")
+
+        result = await adapter.send_video("convo-1", str(video_path))
+
+        assert result.success is True
+        assert fake.uploads[0][2] == "video/mp4"
+        sent = fake.sent[0]
+        assert sent["options"]["contentType"] == "file"
+        assert sent["options"]["attachments"][0]["mimeType"] == "video/mp4"
+
+
+class TestCanonLifecycle:
+    class FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def get_me(self):
+            return {"agentId": "agent-1", "displayName": "Hermes"}
+
+        async def get_conversations(self):
+            return [{"id": "convo-1", "type": "direct", "name": "Ada"}]
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_connect_hydrates_identity_and_conversations(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        fake = self.FakeClient()
+        block = asyncio.Event()
+
+        async def fake_stream_loop():
+            await block.wait()
+
+        adapter._make_client = lambda: fake
+        adapter._stream_loop = fake_stream_loop
+
+        assert await adapter.connect() is True
+        assert adapter.is_connected is True
+        assert adapter._agent_id == "agent-1"
+        assert adapter._conversation_cache["convo-1"]["name"] == "Ada"
+
+        block.set()
+        await adapter.disconnect()
+        assert fake.closed is True
+        assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_stream_frame_dispatches_message_created(self):
+        adapter = CanonAdapter(_config(extra={"api_key": "key"}))
+        adapter._handle_message_payload = AsyncMock()
+
+        frame = CanonStreamFrame(
+            event="message.created",
+            data={"conversationId": "convo-1", "message": {"id": "m1"}},
+            event_id="evt-1",
+        )
+        await adapter._handle_stream_frame(frame)
+
+        adapter._handle_message_payload.assert_awaited_once_with(frame.data)
+
+
+class TestCanonSSE:
+    def test_parse_sse_frame(self):
+        frame = _parse_sse_frame(
+            'id: evt-1\nevent: message.created\ndata: {"conversationId":"convo-1"}'
+        )
+
+        assert frame.event == "message.created"
+        assert frame.event_id == "evt-1"
+        assert frame.data == {"conversationId": "convo-1"}
+
+    def test_parse_sse_frame_ignores_comments(self):
+        frame = _parse_sse_frame(": keepalive\nevent: heartbeat\ndata: ok")
+
+        assert frame.event == "heartbeat"
+        assert frame.data == "ok"
+
+
+class TestCanonStandalone:
+    class FakeClient:
+        instances = []
+
+        def __init__(
+            self, api_key, *, base_url=DEFAULT_BASE_URL, stream_url=DEFAULT_STREAM_URL
+        ):
+            self.api_key = api_key
+            self.base_url = base_url
+            self.stream_url = stream_url
+            self.sent = []
+            self.closed = False
+            self.instances.append(self)
+
+        async def send_message(
+            self, conversation_id, text, *, reply_to=None, metadata=None, options=None
+        ):
+            self.sent.append((conversation_id, text, reply_to, metadata, options))
+            return {"messageId": "standalone-1"}
+
+        async def close(self):
+            self.closed = True
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_home_channel_and_closes(self, monkeypatch):
+        self.FakeClient.instances = []
+        monkeypatch.setattr(_canon, "CanonHttpClient", self.FakeClient)
+        monkeypatch.setenv("CANON_API_KEY", "env-key")
+        monkeypatch.setenv("CANON_HOME_CHANNEL", "convo-home")
+
+        result = await _standalone_send(_config(), "", "hello cron")
+
+        client = self.FakeClient.instances[0]
+        assert result == {"success": True, "message_id": "standalone-1"}
+        assert client.api_key == "env-key"
+        assert client.sent == [
+            ("convo-home", "hello cron", None, TURN_COMPLETE_METADATA, None)
+        ]
+        assert client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_errors_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("CANON_API_KEY", raising=False)
+
+        result = await _standalone_send(_config(), "convo-1", "hello")
+
+        assert "error" in result
+        assert "CANON_API_KEY" in result["error"]
+
+
+class TestCanonRegister:
+    def test_register_metadata(self):
+        recorded = {}
+
+        class Context:
+            def register_platform(self, **kwargs):
+                recorded.update(kwargs)
+
+        register(Context())
+
+        assert recorded["name"] == "canon"
+        assert recorded["label"] == "Canon"
+        assert recorded["required_env"] == ["CANON_API_KEY"]
+        assert recorded["cron_deliver_env_var"] == "CANON_HOME_CHANNEL"
+        assert recorded["standalone_sender_fn"] is _standalone_send
+        assert recorded["allowed_users_env"] == "CANON_ALLOWED_USERS"
+        assert recorded["allow_all_env"] == "CANON_ALLOW_ALL_USERS"
+        assert recorded["max_message_length"] == 8000


### PR DESCRIPTION
Adds a bundled Canon platform adapter for the Hermes gateway. For context, Canon is the agent messaging app/API at https://canonmail.com; this adapter talks to Canon’s existing agent REST/SSE surfaces instead of adding a Node sidecar or SDK dependency.

What changed:
- registers a `canon` platform plugin gated by `CANON_API_KEY`
- supports inbound SSE `message.created` events, conversation hydration, self-message filtering, and duplicate filtering
- sends text, typing indicators, image links, uploaded voice/audio, video/file attachments, and standalone cron delivery via `CANON_HOME_CHANNEL`
- materializes inbound image/audio/video/file attachments into Hermes media caches
- adds focused adapter and plugin-registration tests

Validation:
- `uv run --extra dev pytest tests/gateway/test_canon_adapter.py tests/gateway/test_plugin_platform_interface.py -q`
- `uv run --extra dev ruff check plugins/platforms/canon tests/gateway/test_canon_adapter.py`

Refs #25671.