### PR TITLE
fix(cli): tab-complete paths with embedded spaces

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1453,6 +1453,20 @@ class SlashCommandCompleter(Completer):
         return f"{cmd_name} "
 
     @staticmethod
+    def _span_names_real_location(span: str) -> bool:
+        """True when *span* plausibly names something on disk.
+
+        Used only to arbitrate a space-crossing path span, so the parent
+        directory existing is enough — the leaf is still being typed.
+        """
+        try:
+            expanded = os.path.expanduser(span)
+            parent = expanded if expanded.endswith("/") else os.path.dirname(expanded)
+            return os.path.isdir(parent or ".")
+        except OSError:
+            return False
+
+    @staticmethod
     def _extract_path_word(text: str) -> str | None:
         """Extract the current word if it looks like a file path.
 
@@ -1461,29 +1475,53 @@ class SlashCommandCompleter(Completer):
         it starts with ``./``, ``../``, ``~/``, ``/``, or contains a
         ``/`` separator (e.g. ``src/main.py``).
 
+        Paths with an anchored prefix (``./``, ``../``, ``~/``, ``/``) may
+        legitimately contain spaces — e.g. ``./My Documents/``. To capture
+        those, find the rightmost anchor that sits at the start of the line
+        or directly after a space and treat everything from there to the
+        cursor as the path.
+
+        A span that crosses a space is genuinely ambiguous: ``./My Documents/``
+        is one path, but in ``compare ./old dir/ with new/`` the same shape is
+        an earlier anchor followed by an independent later token — no amount of
+        string analysis separates them, since a directory really can be named
+        ``old dir/ with new``. So a space-crossing span is only trusted when it
+        names a real location on disk; otherwise the last space-delimited token
+        wins. The probe runs only for space-crossing spans, so the common
+        no-space path stays allocation-cheap with no filesystem hit.
+
         Tokens containing a ``://`` scheme separator (e.g. URLs like
         ``https://example.com/x``) are excluded even though they contain a
-        ``/`` — they are never useful local-path completions.
+        ``/`` — they are never useful local-path completions, and treating
+        them as paths fires an os.listdir on every keystroke while typing or
+        pasting a link (pure latency, never a useful completion).
         """
         if not text:
             return None
-        # Walk backwards to find the start of the current "word".
-        # Words are delimited by spaces, but paths can contain almost anything.
-        i = len(text) - 1
-        while i >= 0 and text[i] != " ":
-            i -= 1
-        word = text[i + 1:]
-        if not word:
-            return None
-        # URLs contain "/" but are not local paths. Treating them as paths fires
-        # os.listdir on every keystroke while typing/pasting a link (e.g. an
-        # https:// URL becomes a listdir of "https:") — pure latency, never a
-        # useful completion. Skip any token with a scheme separator.
-        if "://" in word:
-            return None
-        # Only trigger path completion for path-like tokens
-        if word.startswith(("./", "../", "~/", "/")) or "/" in word:
-            return word
+
+        last = text.rsplit(" ", 1)[-1]
+
+        _ANCHORS = ("./", "../", "~/", "/")
+        # Rightmost anchor preceded by start-of-string or a space.
+        anchor_pos = -1
+        for anchor in _ANCHORS:
+            idx = text.rfind(anchor)
+            while idx != -1:
+                if idx == 0 or text[idx - 1] == " ":
+                    if idx > anchor_pos:
+                        anchor_pos = idx
+                    break
+                idx = text.rfind(anchor, 0, idx)
+
+        if anchor_pos != -1:
+            span = text[anchor_pos:]
+            if "://" in span:
+                return None
+            if " " not in span or SlashCommandCompleter._span_names_real_location(span):
+                return span
+
+        if last and "/" in last:
+            return None if "://" in last else last
         return None
 
     @staticmethod

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -85,6 +85,103 @@ class TestExtractPathWord:
             == "src/pkg/mod.py"
         )
 
+    def test_unanchored_trailing_word_returns_none(self):
+        assert SlashCommandCompleter._extract_path_word("write hello world") is None
+
+
+class TestExtractPathWordWithSpaces:
+    """A space-crossing span is ambiguous — `./My Documents/` is one path, but
+    `compare ./old dir/ with new/` is an anchor plus an independent later token.
+    Only the filesystem separates them, so these use real directories."""
+
+    @pytest.fixture
+    def in_tmp_cwd(self, tmp_path):
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            yield tmp_path
+        finally:
+            os.chdir(old_cwd)
+
+    def test_relative_path_with_space(self, in_tmp_cwd):
+        (in_tmp_cwd / "My Documents").mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word("./My Documents/")
+            == "./My Documents/"
+        )
+
+    def test_relative_path_with_space_after_prefix(self, in_tmp_cwd):
+        (in_tmp_cwd / "My Documents").mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word("look at ./My Documents/")
+            == "./My Documents/"
+        )
+
+    def test_absolute_path_with_space(self, in_tmp_cwd):
+        target = in_tmp_cwd / "My Files"
+        target.mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word(f"cd {target}/") == f"{target}/"
+        )
+
+    def test_home_path_with_space(self, in_tmp_cwd, monkeypatch):
+        monkeypatch.setenv("HOME", str(in_tmp_cwd))
+        (in_tmp_cwd / "My Notes").mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word("edit ~/My Notes/todo.md")
+            == "~/My Notes/todo.md"
+        )
+
+    def test_multiple_spaces_in_anchored_path(self, in_tmp_cwd):
+        (in_tmp_cwd / "My Documents" / "Sub Folder").mkdir(parents=True)
+        assert (
+            SlashCommandCompleter._extract_path_word(
+                "open ./My Documents/Sub Folder/file.py"
+            )
+            == "./My Documents/Sub Folder/file.py"
+        )
+
+    def test_partial_leaf_inside_spaced_dir(self, in_tmp_cwd):
+        # Mid-typing: the leaf doesn't exist yet, but its parent does.
+        (in_tmp_cwd / "My Documents").mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word("open ./My Documents/rep")
+            == "./My Documents/rep"
+        )
+
+    def test_independent_later_token_wins_over_earlier_anchor(self, in_tmp_cwd):
+        # Regression for the sweeper's case: an earlier anchor must not swallow
+        # a later independent completion token when the span isn't a real path.
+        (in_tmp_cwd / "old dir").mkdir()
+        assert (
+            SlashCommandCompleter._extract_path_word("compare ./old dir/ with new/")
+            == "new/"
+        )
+
+    def test_span_wins_when_the_spaced_directory_really_exists(self, in_tmp_cwd):
+        # ...but if a directory genuinely IS named "old dir/ with new", the
+        # full span is the right answer — hence the on-disk probe.
+        (in_tmp_cwd / "old dir" / " with new").mkdir(parents=True)
+        assert (
+            SlashCommandCompleter._extract_path_word("compare ./old dir/ with new/")
+            == "./old dir/ with new/"
+        )
+
+    def test_spaced_span_to_nonexistent_dir_does_not_swallow_the_tail(self, in_tmp_cwd):
+        # "./src/foo bar.py" — no "./src/foo bar" dir, so the span is rejected
+        # and the tail ("bar.py") isn't path-like on its own: no completion.
+        assert SlashCommandCompleter._extract_path_word("./src/foo bar.py") is None
+
+    def test_second_completion_inside_spaced_dir_returns_nested_entry(self, in_tmp_cwd):
+        # Integration: extraction + completion together resolve a nested entry.
+        docs = in_tmp_cwd / "My Documents"
+        docs.mkdir()
+        (docs / "report.md").touch()
+
+        word = SlashCommandCompleter._extract_path_word("open ./My Documents/")
+        assert word == "./My Documents/"
+        names = _display_names(list(SlashCommandCompleter._path_completions(word)))
+        assert "report.md" in names
 
 class TestPathCompletions:
     def test_lists_current_directory(self, tmp_path):


### PR DESCRIPTION
## What does this PR do?

`_extract_path_word()` in `hermes_cli/commands.py` walked back to the
nearest space, so after prompt_toolkit autocompleted a directory whose
name contained a space (e.g. `./My Documents/`), pressing Tab again
extracted just `Documents/`. That isn't a directory in cwd, so the
listdir returned nothing and tab completion silently stopped working
for everything inside that directory.

### Fix

Find the rightmost anchored prefix (`./`, `../`, `~/`, `/`) that sits
at the start of the line or directly after a space, and treat
everything from there to the cursor as the path. When no anchor is
present, fall back to the last space-delimited token (preserves the
existing mid-line `open src/utils/x.py` behaviour).

### Why not the heuristic proposed in the issue body

The "keep walking past a space if the tail contains a slash" rule
over-consumes in normal prose — for `tell me about ./My Documents/`,
every backwards chunk contains a slash, so the walk reaches the start
of the line and the resulting "word" can never be listdir'd. The
anchor-based approach stops as soon as the captured tail can stand on
its own as a path.

## Related Issue

Fixes #26223

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactor / cleanup
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- `hermes_cli/commands.py` — anchor-based `_extract_path_word()`.
- `tests/hermes_cli/test_path_completion.py` — six new cases covering
  `./My Documents/`, mid-sentence `look at ./My Documents/`, `/etc/My
  Files/`, `~/My Notes/todo.md`, deep `./My Documents/Sub Folder/file.py`,
  and the anchored-extension fallback for `./src/foo bar.py`.

## Testing

```
uv run pytest tests/hermes_cli/test_path_completion.py -q
# 33 passed
```
