### PR TITLE
fix(discord): skip history backfill when channel lacks `.history`

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3768,6 +3768,15 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history`` — Forum parent
+        # channels, voice channels, and custom proxies in tests can lack it.
+        # Skip rather than raise: the outer ``except`` swallows ``discord.Forbidden``
+        # only when ``discord`` is the real library, so an AttributeError that
+        # leaks past would surface as a TypeError under mocked-discord test
+        # setups (the except clause can't evaluate a MagicMock as an exception).
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,28 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` (Forum parents, custom proxies,
+    test mocks) must not raise — backfill quietly returns empty.
+
+    Regression for the discord e2e adapter tests that broke after history
+    backfill defaulted on: the SimpleNamespace channel fixtures have no
+    ``.history`` and the outer ``except discord.Forbidden`` cannot catch the
+    resulting AttributeError under mocked-discord test setups.
+    """
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")  # no ``history`` attribute
+
+    result = await adapter._fetch_channel_context(
+        channel, before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)


### PR DESCRIPTION
## What does this PR do?

Adds a defensive `hasattr(channel, "history")` guard at the start of `_fetch_channel_context` in `gateway/platforms/discord.py`. Restores 4 e2e tests in `tests/e2e/test_discord_adapter.py` that have been failing on every open PR since commit `4abfb6bc2` (`feat(discord): default history backfill on, expand to per-user + threads`). Adds a focused regression test in `tests/gateway/test_discord_free_response.py`.

Root cause: the `_handle_message` path added by `4abfb6bc2` unconditionally calls `_fetch_channel_context` for non-DM channels, which jumps straight into `async for msg in channel.history(...)`. Channel-like objects that don't implement `history` — Forum parent channels, voice channels in some deployments, and the `SimpleNamespace` channel proxies used by `tests/e2e/test_discord_adapter.py` — raise `AttributeError`. The outer `except discord.Forbidden:` at `gateway/platforms/discord.py:3730` cannot catch it cleanly: under mocked-discord test setups `discord` is a `MagicMock`, so Python evaluates `discord.Forbidden` as the except class *before* matching, which raises `TypeError: catching classes that do not inherit from BaseException is not allowed`. That `TypeError` then masks the original `AttributeError` and bubbles past the broader `except Exception` handler.

## Related Issue

Follow-up to commit `4abfb6bc2`. No standalone bug issue — surfaced as 4 e2e regressions on every open PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` — early return `""` from `_fetch_channel_context` when the channel doesn't expose `history`. Same end state as a real fetch that yielded zero usable messages.
- `tests/gateway/test_discord_free_response.py` — new `test_fetch_channel_context_returns_empty_when_channel_lacks_history` covering a bare `SimpleNamespace` channel, asserting empty-string return and no exception.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_discord_free_response.py tests/e2e/test_discord_adapter.py -v`
2. Expected: 41/41 passing (35 free-response + 6 e2e).
3. Regression guard: temporarily revert the production line; the new test fails with the exact `TypeError: catching classes that do not inherit from BaseException is not allowed` from CI logs. Restore the fix — all 6 `_fetch_channel_context` unit tests pass.

The 4 previously-failing e2e tests now restored:

- `TestMentionStrippedCommandDispatch::test_mention_then_command`
- `TestMentionStrippedCommandDispatch::test_nickname_mention_then_command`
- `TestMentionStrippedCommandDispatch::test_text_before_command_not_detected`
- `TestAutoThreadingPreservesCommand::test_command_detected_after_auto_thread`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (41/41)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — defensive guard is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Follow-up to commit `4abfb6bc2` (`feat(discord): default history backfill on, expand to per-user + threads`).
- No other open PR touches `_fetch_channel_context` or `channel.history` (verified via `gh search prs`).

> Audited siblings: `gateway/platforms/discord.py` has no other call sites of `channel.history(...)` — the guard is appropriately localised. No widening needed.
