### PR TITLE
docs(slack): document bot-to-bot mode

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -269,6 +269,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `SLACK_BOT_TOKEN` | Slack bot token (`xoxb-...`) |
 | `SLACK_APP_TOKEN` | Slack app-level token (`xapp-...`, required for Socket Mode) |
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs |
+| `SLACK_ALLOW_BOTS` | Bot-to-bot message handling: `none` (default), `mentions`, or `all` |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |
 | `GOOGLE_CHAT_PROJECT_ID` | GCP project hosting the Pub/Sub topic (falls back to `GOOGLE_CLOUD_PROJECT`) |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -197,6 +197,7 @@ SLACK_ALLOWED_USERS=U01ABC2DEF3              # Comma-separated Member IDs
 # Optional
 SLACK_HOME_CHANNEL=C01234567890              # Default channel for cron/scheduled messages
 SLACK_HOME_CHANNEL_NAME=general              # Human-readable name for the home channel (optional)
+SLACK_ALLOW_BOTS=mentions                    # Bot-to-bot mode: none, mentions, or all
 ```
 
 Or run the interactive setup:
@@ -389,6 +390,29 @@ Set this to `true` in busy workspaces where Slack's default "the bot remembers t
 Slack supports both patterns: `@mention` required to start a conversation by default, but you can opt specific channels out via `SLACK_FREE_RESPONSE_CHANNELS` (comma-separated channel IDs) or `slack.free_response_channels` in `config.yaml`. Once the bot has an active session in a thread, subsequent thread replies do not require a mention. In DMs the bot always responds without needing a mention.
 :::
 
+### Bot-to-Bot Messaging
+
+By default Hermes ignores messages sent by other Slack bots. Enable bot-to-bot messaging when Hermes needs to participate in multi-agent Slack threads or receive notifications from another bot.
+
+```bash
+SLACK_ALLOW_BOTS=mentions   # default: none
+```
+
+| Value | Behavior |
+|-------|----------|
+| `none` | Ignore all messages from other bots (default). |
+| `mentions` | Accept peer bot messages only when they @mention Hermes. |
+| `all` | Accept every peer bot message except Hermes' own messages. |
+
+You can also set this in `~/.hermes/config.yaml`:
+
+```yaml
+slack:
+  allow_bots: "mentions"
+```
+
+`SLACK_ALLOW_BOTS` takes precedence when both are set. Use `mentions` for the safest multi-agent setup: peer bots can wake Hermes explicitly without letting every bot message in the workspace start or continue a Hermes session.
+
 ### Unauthorized User Handling
 
 ```yaml
@@ -427,6 +451,7 @@ stt_enabled: true
 # Slack-specific settings
 slack:
   require_mention: true
+  allow_bots: "none"  # Set to "mentions" for bot-to-bot Slack threads
   unauthorized_dm_behavior: "pair"
 
 # Platform config


### PR DESCRIPTION
## Summary
- document `SLACK_ALLOW_BOTS` in the Slack setup guide
- add the `slack.allow_bots` config example and behavior table
- list `SLACK_ALLOW_BOTS` in the environment variable reference

Closes #26184

## Testing
- `git diff --check`
- `npm run build` (blocked locally: E: drive hit ENOSPC during Docusaurus asset emit; prebuild also could not find Python on PATH)