### PR TITLE
docs(mcp): show multi-header HTTP config

### DIFF
--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -43,7 +43,7 @@ mcp_servers:
 | `args` | list | stdio | Arguments for the subprocess |
 | `env` | mapping | stdio | Environment passed to the subprocess |
 | `url` | string | HTTP | Remote MCP endpoint |
-| `headers` | mapping | HTTP | Headers for remote server requests |
+| `headers` | mapping | HTTP | Free-form headers for remote server requests. Include all vendor-required headers. |
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout |
 | `connect_timeout` | number | both | Initial connection timeout |
@@ -176,6 +176,20 @@ mcp_servers:
     tools:
       exclude: [delete_customer, refund_payment]
 ```
+
+### HTTP server with vendor-specific headers
+
+```yaml
+mcp_servers:
+  plane:
+    url: "https://mcp.plane.so/http/api-key/mcp"
+    headers:
+      Authorization: "Bearer <plane-api-token>"
+      X-Workspace-slug: "<workspace-slug>"
+```
+
+Some hosted MCP providers require more than a bearer token. `headers` accepts
+any HTTP header names the provider documents.
 
 ### Resource-only docs server
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -126,6 +126,24 @@ mcp_servers:
       Authorization: "Bearer ***"
 ```
 
+### HTTP server with multiple headers
+
+`headers` is a free-form map. Some hosted MCP providers require additional
+vendor-specific headers beyond `Authorization`; include each required header in
+the same block and check the provider's MCP docs for the exact names.
+
+For example, Plane Cloud's hosted MCP endpoint requires both the API token and
+workspace slug:
+
+```yaml
+mcp_servers:
+  plane:
+    url: "https://mcp.plane.so/http/api-key/mcp"
+    headers:
+      Authorization: "Bearer <plane-api-token>"
+      X-Workspace-slug: "<workspace-slug>"
+```
+
 ## How Hermes registers MCP tools
 
 Hermes prefixes MCP tools so they do not collide with built-in names:


### PR DESCRIPTION
## Summary
- clarify that MCP HTTP `headers` is a free-form map
- add a multi-header HTTP MCP example using Plane Cloud's `X-Workspace-slug`
- mirror the example in the MCP config reference

Closes #25478

## Testing
- `git diff --check`