### PR TITLE
feat(email): isolate sessions by subject

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1443,6 +1443,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
+        email_session_by_subject = os.getenv("EMAIL_SESSION_BY_SUBJECT")
+        if email_session_by_subject is not None:
+            config.platforms[Platform.EMAIL].extra["session_by_subject"] = _coerce_bool(
+                email_session_by_subject,
+                default=False,
+            )
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -315,7 +315,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _subject_thread_id(self, subject: str) -> Optional[str]:
         """Return a normalized subject thread id when subject isolation is enabled."""
-        if not self._session_by_subject:
+        if not getattr(self, "_session_by_subject", False):
             return None
         normalized = _normalize_email_subject(subject)
         return normalized or None
@@ -323,7 +323,7 @@ class EmailAdapter(BasePlatformAdapter):
     def _thread_context_key(self, address: str, thread_id: Optional[str] = None) -> str:
         """Build the key used for email reply context."""
         normalized_address = address.lower()
-        if self._session_by_subject and thread_id:
+        if getattr(self, "_session_by_subject", False) and thread_id:
             return f"{normalized_address}{_THREAD_CONTEXT_SEPARATOR}{thread_id}"
         return normalized_address
 

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -13,6 +13,7 @@ Environment variables:
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    EMAIL_SESSION_BY_SUBJECT — Isolate sessions by normalized email subject
 """
 
 import asyncio
@@ -42,6 +43,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -64,6 +66,13 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+# Prefixes stripped when EMAIL_SESSION_BY_SUBJECT builds an email thread id.
+_SUBJECT_REPLY_PREFIX_RE = re.compile(
+    r"^(?:(?:re|fw|fwd)\s*:\s*|(?:答复|回复|转发)\s*:\s*)+",
+    re.IGNORECASE,
+)
+_THREAD_CONTEXT_SEPARATOR = "\0"
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
@@ -182,6 +191,13 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
+def _normalize_email_subject(subject: str) -> str:
+    """Normalize a subject for optional email session isolation."""
+    normalized = str(subject or "").strip()
+    normalized = _SUBJECT_REPLY_PREFIX_RE.sub("", normalized).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
@@ -262,13 +278,17 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        session_by_subject = os.getenv("EMAIL_SESSION_BY_SUBJECT")
+        if session_by_subject is None:
+            session_by_subject = extra.get("session_by_subject")
+        self._session_by_subject = is_truthy_value(session_by_subject, default=False)
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
+        # Map chat/session key -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
@@ -292,6 +312,31 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _subject_thread_id(self, subject: str) -> Optional[str]:
+        """Return a normalized subject thread id when subject isolation is enabled."""
+        if not self._session_by_subject:
+            return None
+        normalized = _normalize_email_subject(subject)
+        return normalized or None
+
+    def _thread_context_key(self, address: str, thread_id: Optional[str] = None) -> str:
+        """Build the key used for email reply context."""
+        normalized_address = address.lower()
+        if self._session_by_subject and thread_id:
+            return f"{normalized_address}{_THREAD_CONTEXT_SEPARATOR}{thread_id}"
+        return normalized_address
+
+    def _context_key_from_metadata(
+        self,
+        address: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Map outbound metadata back to the inbound email thread context."""
+        thread_id = (metadata or {}).get("thread_id")
+        if thread_id is not None:
+            thread_id = str(thread_id)
+        return self._thread_context_key(address, thread_id)
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
@@ -456,6 +501,7 @@ class EmailAdapter(BasePlatformAdapter):
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
         attachments = msg_data["attachments"]
+        subject_thread_id = self._subject_thread_id(subject)
 
         # Build message text: include subject as context
         text = body
@@ -474,7 +520,8 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.PHOTO
 
         # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
+        context_key = self._thread_context_key(sender_addr, subject_thread_id)
+        self._thread_context[context_key] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
         }
@@ -485,6 +532,7 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=subject_thread_id,
         )
 
         event = MessageEvent(
@@ -510,8 +558,9 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email reply to the given address."""
         try:
             loop = asyncio.get_running_loop()
+            context_key = self._context_key_from_metadata(chat_id, metadata)
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, context_key
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -523,6 +572,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        context_key: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -530,7 +580,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(context_key or to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -571,11 +621,12 @@ class EmailAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image URL as part of an email body."""
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata=metadata)
 
     async def send_multiple_images(
         self,
@@ -615,6 +666,7 @@ class EmailAdapter(BasePlatformAdapter):
             return
 
         body = "\n\n".join(body_parts)
+        context_key = self._context_key_from_metadata(chat_id, metadata)
 
         try:
             loop = asyncio.get_running_loop()
@@ -624,6 +676,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                context_key,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -634,13 +687,14 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        context_key: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(context_key or to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -691,11 +745,13 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:
             loop = asyncio.get_running_loop()
+            context_key = self._context_key_from_metadata(chat_id, metadata)
             message_id = await loop.run_in_executor(
                 None,
                 self._send_email_with_attachment,
@@ -703,6 +759,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                context_key,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -715,13 +772,14 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        context_key: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(context_key or to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -47,6 +47,19 @@ class TestConfigEnvOverrides(unittest.TestCase):
         "EMAIL_PASSWORD": "secret",
         "EMAIL_IMAP_HOST": "imap.test.com",
         "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SESSION_BY_SUBJECT": "true",
+    }, clear=False)
+    def test_email_session_by_subject_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertTrue(config.platforms[Platform.EMAIL].extra["session_by_subject"])
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
         "EMAIL_HOME_ADDRESS": "user@test.com",
     }, clear=False)
     def test_email_home_channel_loaded(self):
@@ -57,7 +70,10 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertIsNotNone(home)
         self.assertEqual(home.chat_id, "user@test.com")
 
-    @patch.dict(os.environ, {}, clear=True)
+    @patch.dict(os.environ, {
+        "HOME": os.path.expanduser("~"),
+        "USERPROFILE": os.path.expanduser("~"),
+    }, clear=True)
     def test_email_not_loaded_without_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
         config = GatewayConfig()
@@ -123,6 +139,13 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertEqual(
             _extract_email_address("John@Example.COM"),
             "john@example.com"
+        )
+
+    def test_normalize_email_subject_strips_reply_prefixes(self):
+        from gateway.platforms.email import _normalize_email_subject
+        self.assertEqual(
+            _normalize_email_subject(" RE: Fwd: 答复:  Project   Plan "),
+            "Project Plan",
         )
 
     def test_strip_html_basic(self):
@@ -425,6 +448,38 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
 
+    @patch.dict(os.environ, {
+        "EMAIL_SESSION_BY_SUBJECT": "true",
+    }, clear=False)
+    def test_session_by_subject_sets_thread_id(self):
+        """When enabled, sessions are isolated by normalized subject."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        msg_data = {
+            "uid": b"7",
+            "sender_addr": "john@example.com",
+            "sender_name": "John Doe",
+            "subject": "RE: Fwd: 答复: Project   Plan",
+            "message_id": "<msg7@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        event = captured_events[0]
+        self.assertEqual(event.source.chat_id, "john@example.com")
+        self.assertEqual(event.source.thread_id, "Project Plan")
+        self.assertIn("john@example.com\0Project Plan", adapter._thread_context)
+
     def test_non_allowlisted_sender_dropped(self):
         """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""
         import asyncio
@@ -606,6 +661,38 @@ class TestThreadContext(unittest.TestCase):
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
             self.assertIn("Date", send_call)
+
+    @patch.dict(os.environ, {
+        "EMAIL_SESSION_BY_SUBJECT": "true",
+    }, clear=False)
+    def test_reply_uses_subject_thread_metadata(self):
+        """Outbound replies should use the context for the matching subject."""
+        import asyncio
+        adapter = self._make_adapter()
+        budget_key = adapter._thread_context_key("user@test.com", "Budget")
+        roadmap_key = adapter._thread_context_key("user@test.com", "Roadmap")
+        adapter._thread_context[budget_key] = {
+            "subject": "Budget",
+            "message_id": "<budget@test.com>",
+        }
+        adapter._thread_context[roadmap_key] = {
+            "subject": "Roadmap",
+            "message_id": "<roadmap@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            asyncio.run(adapter.send(
+                "user@test.com",
+                "Approved.",
+                metadata={"thread_id": "Budget"},
+            ))
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Budget")
+            self.assertEqual(send_call["In-Reply-To"], "<budget@test.com>")
 
 
 class TestSendMethods(unittest.TestCase):

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -433,10 +433,11 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths, context_key = mock_send.call_args.args
         assert to_addr == "user@example.com"
         assert len(file_paths) == 3
         assert "alt 0" in body
+        assert context_key == "user@example.com"
 
     def test_remote_urls_linked_in_body(self, adapter, tmp_path):
         """Remote URL images get their URL appended to the body, no attachment."""
@@ -450,10 +451,11 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths, context_key = mock_send.call_args.args
         assert file_paths == []
         assert "https://x.com/a.png" in body
         assert "https://x.com/b.png" in body
+        assert context_key == "user@example.com"
 
     def test_empty_noop(self, adapter):
         with patch.object(

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -314,6 +314,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_ALLOWED_USERS` | Comma-separated email addresses allowed to message the bot |
 | `EMAIL_HOME_ADDRESS` | Default recipient for proactive email delivery |
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
+| `EMAIL_SESSION_BY_SUBJECT` | Isolate email sessions by sender plus normalized subject |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -72,6 +72,7 @@ EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+EMAIL_SESSION_BY_SUBJECT=false         # Isolate sessions per sender + subject
 ```
 
 ---
@@ -99,6 +100,7 @@ The adapter polls the IMAP inbox for UNSEEN messages at a configurable interval 
 
 - **Subject line** is included as context (e.g., `[Subject: Deploy to production]`)
 - **Reply emails** (subject starting with `Re:`) skip the subject prefix — the thread context is already established
+- **Optional subject-based sessions** can isolate one sender's conversations by normalized subject with `EMAIL_SESSION_BY_SUBJECT=true`
 - **Attachments** are cached locally:
   - Images (JPEG, PNG, GIF, WebP) → available to the vision tool
   - Documents (PDF, ZIP, etc.) → available for file access
@@ -187,4 +189,5 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
+| `EMAIL_SESSION_BY_SUBJECT` | No | `false` | Use sender + normalized subject as the session key |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |


### PR DESCRIPTION
Closes #26277.

Summary:
- add optional EMAIL_SESSION_BY_SUBJECT support for per-sender, per-subject email sessions
- normalize reply/forward prefixes before using the subject as the session thread id
- preserve outbound reply context by using thread metadata for email sends, including multi-image and document paths
- document the new environment variable

Tests:
- python -m pytest -o addopts= tests\\gateway\\test_email.py
- python -m pytest -o addopts= tests\\gateway\\test_session.py
- python -m pytest -o addopts= tests\\gateway\\test_send_multiple_images.py::TestEmailMultiImage -q --tb=short
- python -m ruff check gateway\\platforms\\email.py gateway\\config.py tests\\gateway\\test_email.py tests\\gateway\\test_send_multiple_images.py
- git diff --check