### PR TITLE
fix(slack): dedupe rich text bang commands

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -207,6 +207,24 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
     return "\n".join(parts)
 
 
+def _dedupe_slack_block_text(blocks_text: str, *plain_text_candidates: str) -> str:
+    """Drop Slack's authored-text echo while preserving quoted block extras."""
+    text = (blocks_text or "").strip()
+    if not text:
+        return ""
+
+    for candidate in plain_text_candidates:
+        candidate = (candidate or "").strip()
+        if not candidate:
+            continue
+        if text == candidate:
+            return ""
+        prefix = f"{candidate}\n"
+        if text.startswith(prefix):
+            return text[len(prefix) :].lstrip("\n").strip()
+    return text
+
+
 def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> str:
     """Return a compact, redacted JSON view of the current message's Block Kit payload."""
     if not blocks:
@@ -2620,6 +2638,14 @@ class SlackAdapter(BasePlatformAdapter):
             return
 
         original_text = event.get("text", "")
+        raw_original_text = original_text
+        team_hint = event.get("team") or event.get("team_id") or ""
+        bot_uid_hint = self._team_bot_user_ids.get(team_hint, self._bot_user_id)
+        command_probe_text = original_text.strip()
+        if bot_uid_hint:
+            mention_token = f"<@{bot_uid_hint}>"
+            if command_probe_text.startswith(mention_token):
+                command_probe_text = command_probe_text[len(mention_token) :].lstrip()
 
         # Slack blocks native slash commands inside threads ("/queue is not
         # supported in threads. Sorry!").  As a workaround, recognise a
@@ -2628,11 +2654,11 @@ class SlackAdapter(BasePlatformAdapter):
         # gateway dispatcher) handles it like a normal slash command.  Only
         # rewrite when the first token resolves to a known gateway command
         # so casual messages like "!nice work" pass through unchanged.
-        if original_text.startswith("!"):
+        if command_probe_text.startswith("!"):
             try:
                 from hermes_cli.commands import is_gateway_known_command
 
-                first_token = original_text[1:].split(maxsplit=1)[0]
+                first_token = command_probe_text[1:].split(maxsplit=1)[0]
                 # Strip "@suffix" the same way get_command() does, so
                 # forms like ``!stop@hermes`` still resolve.
                 cmd_name = first_token.split("@", 1)[0].lower()
@@ -2641,25 +2667,26 @@ class SlackAdapter(BasePlatformAdapter):
                     and "/" not in cmd_name
                     and is_gateway_known_command(cmd_name)
                 ):
-                    original_text = "/" + original_text[1:]
+                    command_probe_text = "/" + command_probe_text[1:]
             except Exception:  # pragma: no cover - defensive
                 pass
 
-        text = original_text
+        is_command_text = command_probe_text.startswith("/")
+        text = command_probe_text if is_command_text else original_text
 
-        # Extract quoted/forwarded content from Slack blocks.
-        # Slack's modern composer embeds forwarded messages in the ``blocks``
-        # array as ``rich_text_quote`` elements, which are NOT reflected in
-        # the plain ``text`` field.  Merge block text so the agent sees the
-        # full message content.
+        # Command payloads are authoritative. Slack mirrors authored text in
+        # blocks and may add unfurls, files, or fetched thread context later;
+        # none of those may become command arguments.
         blocks = event.get("blocks")
-        if blocks:
+        if blocks and not is_command_text:
             blocks_text = _extract_text_from_slack_blocks(blocks)
             if blocks_text:
-                # Only append if the blocks contain text not already present
-                # in the plain text field (avoids duplication).
-                stripped_blocks = blocks_text.strip()
-                if stripped_blocks and stripped_blocks not in text.strip():
+                stripped_blocks = _dedupe_slack_block_text(
+                    blocks_text,
+                    text,
+                    raw_original_text,
+                )
+                if stripped_blocks:
                     logger.debug(
                         "Slack: extracted additional text from blocks "
                         "(likely quoted/forwarded content): %s",
@@ -2676,7 +2703,7 @@ class SlackAdapter(BasePlatformAdapter):
         # fields like title, title_link/from_url, text, footer, and fallback.
         # Without reading these, the agent never sees shared link previews.
         slack_attachments = event.get("attachments") or []
-        if slack_attachments:
+        if slack_attachments and not is_command_text:
             att_parts: list[str] = []
             for att in slack_attachments:
                 att_title = att.get("title", "")
@@ -2885,7 +2912,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
+        if not is_command_text and is_thread_reply and not self._has_active_session_for_thread(
             channel_id=channel_id,
             thread_ts=event_thread_ts,
             user_id=user_id,
@@ -2901,7 +2928,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Determine message type
         msg_type = MessageType.TEXT
-        if (original_text or "").startswith("/"):
+        if is_command_text:
             msg_type = MessageType.COMMAND
 
         # Handle file attachments
@@ -3115,7 +3142,11 @@ class SlackAdapter(BasePlatformAdapter):
                     # cached path only (run.py emits a path-pointing note).
                     MAX_TEXT_INJECT_BYTES = 100 * 1024
                     _is_text = ext in _TEXT_INJECT_EXTENSIONS or (mimetype or "").startswith("text/")
-                    if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                    if (
+                        not is_command_text
+                        and _is_text
+                        and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES
+                    ):
                         try:
                             text_content = raw_bytes.decode("utf-8")
                             display_name = original_filename or f"document{ext or '.txt'}"
@@ -3141,7 +3172,7 @@ class SlackAdapter(BasePlatformAdapter):
                             exc_info=True,
                         )
 
-        if attachment_notices:
+        if attachment_notices and not is_command_text:
             notice_block = "[Slack attachment notice]\n" + "\n".join(
                 f"- {n}" for n in attachment_notices
             )
@@ -3952,6 +3983,21 @@ class SlackAdapter(BasePlatformAdapter):
             # gateway command dispatcher by prepending the slash.
             text = f"/{slash_name} {text}".strip()
 
+        # Preserve any thread context Slack includes so session-scoped commands
+        # key to the same conversation. Prefer an explicit parent thread over
+        # the command message timestamp fallback.
+        thread_id = command.get("thread_ts")
+        if not thread_id:
+            message_payload = command.get("message")
+            if isinstance(message_payload, dict):
+                thread_id = message_payload.get("thread_ts")
+        if not thread_id:
+            container_payload = command.get("container")
+            if isinstance(container_payload, dict):
+                thread_id = container_payload.get("thread_ts")
+        if not thread_id:
+            thread_id = command.get("message_ts")
+
         # Slack slash commands can originate from DMs or shared channels.
         # Preserve DM semantics only for DM channel IDs; shared channels must
         # keep group semantics so different users do not collide into one
@@ -3961,6 +4007,7 @@ class SlackAdapter(BasePlatformAdapter):
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
+            thread_id=thread_id or None,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -166,6 +166,77 @@ class TestSlashCommandSessionIsolation:
         assert event.source.chat_id == "D123"
         assert event.source.user_id == "U123"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "expected_thread_id"),
+        [
+            ({"thread_ts": "1700.1"}, "1700.1"),
+            ({"message": {"thread_ts": "1700.2"}}, "1700.2"),
+            ({"container": {"thread_ts": "1700.3"}}, "1700.3"),
+            ({"message_ts": "1700.4"}, "1700.4"),
+            (
+                {
+                    "message": {"thread_ts": "1700.5"},
+                    "container": {"thread_ts": "1700.6"},
+                    "message_ts": "1700.7",
+                },
+                "1700.5",
+            ),
+        ],
+    )
+    async def test_slash_command_preserves_thread_payload_variants(
+        self, adapter, payload, expected_thread_id
+    ):
+        command = {
+            "command": "/model",
+            "text": "sol",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+            **payload,
+        }
+
+        await adapter._handle_slash_command(command)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.thread_id == expected_thread_id
+
+    @pytest.mark.asyncio
+    async def test_slash_command_prefers_parent_thread_over_fallbacks(self, adapter):
+        command = {
+            "command": "/model",
+            "text": "sol",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+            "thread_ts": "1700.parent",
+            "message_ts": "1700.message",
+            "message": {"thread_ts": "1700.message-parent"},
+            "container": {"thread_ts": "1700.container-parent"},
+        }
+
+        await adapter._handle_slash_command(command)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.thread_id == "1700.parent"
+
+    @pytest.mark.asyncio
+    async def test_slash_command_ignores_malformed_nested_thread_payloads(self, adapter):
+        command = {
+            "command": "/model",
+            "text": "sol",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "team_id": "T123",
+            "message": "not-a-dict",
+            "container": ["not", "a", "dict"],
+        }
+
+        await adapter._handle_slash_command(command)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.source.thread_id is None
+
 
 # ---------------------------------------------------------------------------
 # TestAppMentionHandler
@@ -1159,6 +1230,186 @@ class TestBangPrefixCommands:
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.text.startswith("/model gpt-5.4")
         assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_bang_model_rich_text_echo_keeps_args_exact(self, adapter):
+        event = self._make_event("!model sol")
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": "!model sol"}],
+                    }
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_mentioned_bang_command_is_normalized_before_enrichment(self, adapter):
+        event = self._make_event(
+            "<@U_BOT> !model sol",
+            channel_type="channel",
+            channel="C123",
+        )
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "text", "text": "<@U_BOT> !model sol"}
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_bang_command_skips_blocks_and_unfurls(self, adapter):
+        event = self._make_event("!model sol")
+        event["blocks"] = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "block metadata"},
+            }
+        ]
+        event["attachments"] = [
+            {
+                "title": "Preview",
+                "title_link": "https://example.com/preview",
+                "text": "unfurl body",
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+
+    @pytest.mark.asyncio
+    async def test_bang_command_skips_fetched_thread_context(self, adapter):
+        event = self._make_event(
+            "!model sol",
+            thread_ts="1111111111.000001",
+            channel_type="channel",
+            channel="C123",
+        )
+        adapter._bot_message_ts.add("1111111111.000001")
+
+        with patch.object(
+            adapter,
+            "_fetch_thread_context",
+            new_callable=AsyncMock,
+            return_value="[Thread context]\nnoise\n\n",
+        ) as fetch_context:
+            await adapter._handle_slack_message(event)
+
+        fetch_context.assert_not_awaited()
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+
+    @pytest.mark.asyncio
+    async def test_bang_command_keeps_text_file_out_of_args(self, adapter):
+        event = self._make_event("!model sol")
+        event["files"] = [
+            {
+                "mimetype": "text/plain",
+                "name": "notes.txt",
+                "url_private_download": "https://files.slack.com/notes.txt",
+                "size": 11,
+            }
+        ]
+
+        with patch.object(
+            adapter,
+            "_download_slack_file_bytes",
+            new_callable=AsyncMock,
+            return_value=b"hello world",
+        ):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+        assert msg_event.media_types == ["text/plain"]
+
+    @pytest.mark.asyncio
+    async def test_bang_command_keeps_attachment_notice_out_of_args(self, adapter):
+        event = self._make_event("!model sol")
+        event["files"] = [
+            {
+                "id": "F123",
+                "file_access": "check_file_info",
+                "mimetype": "text/plain",
+                "name": "missing.txt",
+            }
+        ]
+        adapter._app.client.files_info.return_value = {
+            "ok": False,
+            "error": "file_not_found",
+        }
+
+        with patch.object(
+            adapter,
+            "_describe_slack_api_error",
+            return_value="Slack could not access missing.txt",
+        ):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "/model sol"
+        assert msg_event.get_command_args() == "sol"
+
+    @pytest.mark.asyncio
+    async def test_unknown_bang_text_dedupes_authored_echo_but_keeps_quote(self, adapter):
+        event = self._make_event("!nice work")
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": "!nice work"}],
+                    },
+                    {
+                        "type": "rich_text_quote",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": "Quoted line"}
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "!nice work\n> Quoted line"
+        assert msg_event.message_type != MessageType.COMMAND
 
     @pytest.mark.asyncio
     async def test_bang_works_inside_thread(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes Slack message handling for the `!command` fallback used where native slash commands are unavailable, especially inside thread replies.

Slack may mirror the authored `text` in `rich_text` blocks and add Block Kit payloads, link unfurls, fetched thread context, file snippets, or attachment notices. Once a message is recognized as a command, this PR keeps the normalized command text authoritative so none of those enrichment paths can become command arguments.

It also handles channel messages that mention the bot before the bang command, such as `<@bot> !model sol`, while retaining the raw Slack text for mention routing. Normal non-command messages still preserve quoted/forwarded rich-text extras without duplicating the authored text.

Native Slack command payloads now preserve thread context from `thread_ts`, `message.thread_ts`, `container.thread_ts`, or `message_ts`, with parent-thread IDs taking precedence.

## Related Issue

No issue filed. Bug reproduced on current `main` while using the Slack thread command fallback.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Detect and normalize known `!command` messages before enrichment.
  - Strip a leading bot mention for command parsing while retaining raw text for mention routing.
  - Keep command arguments isolated from rich text, Block Kit metadata, unfurls, fetched thread context, text-file injection, and attachment notices.
  - Deduplicate authored rich-text echoes for normal messages while preserving quoted extras.
  - Preserve native slash-command thread context with deterministic precedence and malformed-payload guards.
- `tests/gateway/test_slack.py`
  - Cover exact `/model` text and args across rich-text echoes, leading mentions, Block Kit payloads, unfurls, first-entry thread context, text files, and attachment failures.
  - Cover unknown `!` text and normal quote preservation.
  - Cover slash-command thread payload variants, precedence, and malformed nested payloads.

## Local verification

- `./scripts/run_tests.sh tests/gateway/test_slack.py` → 230 passed
- `python -m pytest tests/gateway/test_slack.py::TestBangPrefixCommands tests/gateway/test_slack.py::TestSlashCommandSessionIsolation -q -o addopts=''` → 22 passed
- `python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` → passed
- `git diff --check` → clean

## Checklist

- [x] I've read the Contributing Guide
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the bugfix
- [x] Documentation/config/tool schemas: N/A — this is Slack message parsing only
