### PR TITLE
test(ci): stabilize Discord e2e and Nous Portal parity tests

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
Summary:
- pass an explicit GPT-5 model into Nous Portal provider parity tests so they do not initialize AIAgent with an empty/default model
- skip Discord history backfill when a channel-like object does not expose history, matching the regression covered by #26301
- add a small regression test for the missing-history Discord path

Tests:
- python -m pytest -o addopts= tests\\run_agent\\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m pytest -o addopts= tests\\gateway\\test_discord_free_response.py::test_fetch_channel_context_returns_empty_when_channel_lacks_history -q --tb=short
- python -m pytest -o addopts= tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m ruff check gateway\\platforms\\discord.py tests\\gateway\\test_discord_free_response.py tests\\run_agent\\test_provider_parity.py
- git diff --check