### PR TITLE
test(ci): stabilize provider and Discord fixtures

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -66,6 +66,7 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
     discord_mod.Interaction = object
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -59,8 +59,7 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
         skip_context_files=True,
         skip_memory=True,
     )
-    if model:
-        kwargs["model"] = model
+    kwargs["model"] = model or "openai/gpt-5"
     base_url="https://openrouter.ai/api/v1",
     api_key="test-key",
     base_url="https://openrouter.ai/api/v1",


### PR DESCRIPTION
## Summary
- give provider-parity test agents an explicit long-context model so Nous Portal init does not fail the 64K guard before assertions run
- make the e2e Discord mock expose `discord.Forbidden` as an exception class, matching discord.py and allowing the existing generic history-fetch fallback to run

## Verification
- `python -m pytest tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_mention_then_command tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_nickname_mention_then_command tests/e2e/test_discord_adapter.py::TestMentionStrippedCommandDispatch::test_text_before_command_not_detected tests/e2e/test_discord_adapter.py::TestAutoThreadingPreservesCommand::test_command_detected_after_auto_thread -q -o addopts=`
- `python -m pytest tests/run_agent/test_provider_parity.py tests/e2e/test_discord_adapter.py -q -o addopts=`
