### PR TITLE
fix(cli): restore resize history without truncating input or banner state

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2992,22 +2992,22 @@ class HermesCLI:
         those old-width rows remain visible and the next live redraw can look
         like duplicated input/status/output boxes.
 
-        Clear the visible screen and scrollback, reset prompt_toolkit's
-        cached screen/cursor state, replay Hermes-owned recent output
-        history, then let prompt_toolkit recalculate/redraw the live prompt
-        for the new size.  Clearing scrollback is intentional here: without
-        ESC[3J, every resize replay appends another copy of the previous
-        transcript to the terminal's real scrollback, making the visible
-        history grow longer on each resize.  Resume panels are stored as
-        width-aware history entries, so ``hermes -c`` can re-render them at
-        the current width instead of keeping the stale startup width.
+        Clear the visible screen, reset prompt_toolkit's cached screen/cursor
+        state, replay Hermes-owned recent output history, then let
+        prompt_toolkit recalculate/redraw the live prompt for the new size.
+        Do not clear the terminal emulator's real scrollback here: Hermes only
+        records a bounded recent history for replay, so ESC[3J would discard
+        older user-visible transcript that Hermes cannot restore.  Resume
+        panels are stored as width-aware history entries, so ``hermes -c`` can
+        re-render them at the current width instead of keeping the stale
+        startup width.
 
-        The visible screen/scrollback clear removes the stale-width input
-        chrome too, so the live prompt should be redrawn immediately at the
-        new width instead of being suppressed until the next keystroke.
+        The visible-screen clear removes stale-width input chrome from the
+        active viewport, so the live prompt should be redrawn immediately at
+        the new width instead of being suppressed until the next keystroke.
         """
         self._status_bar_suppressed_after_resize = False
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
+        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
         _replay_output_history()
         original_on_resize()
         try:

--- a/cli.py
+++ b/cli.py
@@ -1814,19 +1814,33 @@ def _cprint(text: str):
 
     # Cross-thread emission: ask the app's event loop to schedule a
     # ``run_in_terminal`` that wraps ``_pt_print``.  This hides the
-    # prompt, prints, and redraws.  Fire-and-forget — if scheduling
-    # fails we fall back to a direct print so the line isn't lost.
+    # prompt, prints, and redraws.  Wait briefly for the scheduled
+    # terminal print to complete so the next prompt_toolkit redraw cannot
+    # expose an empty prompt before the Hermes scrollback box lands.
+    import threading as _threading
+    done = _threading.Event()
+
     def _schedule():
         try:
-            run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            future = run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            if hasattr(future, "add_done_callback"):
+                future.add_done_callback(lambda _f: done.set())
+            else:
+                done.set()
         except Exception:
             try:
                 _pt_print(_PT_ANSI(text))
             except Exception:
                 pass
+            finally:
+                done.set()
 
     try:
         loop.call_soon_threadsafe(_schedule)
+        # The callback itself is very small.  If the app loop is wedged,
+        # do not block the agent/tool thread indefinitely; the scheduled
+        # print may still run later, and direct fallback would duplicate it.
+        done.wait(timeout=1.0)
     except Exception:
         try:
             _pt_print(_PT_ANSI(text))
@@ -3250,17 +3264,14 @@ class HermesCLI:
 
     @staticmethod
     def _scrollback_box_width(width: Optional[int] = None) -> int:
-        """Return the full viewport width for printed scrollback box rules.
+        """Return the target width for scrollback boxes.
 
-        Previously this clamped to ``max(32, min(width, 56))`` as a defense
-        against terminal-emulator reflow on column-shrink (#25975, salvaging
-        #24403).  That clamp made response/reasoning borders look stubby on
-        any modern wide terminal.  We now trust the prompt_toolkit
-        ``_output_screen_diff`` monkey-patch landed in #26137 (salvaging
-        #25981) to keep chrome out of scrollback in the first place, and
-        accept that an aggressive column-shrink may visually reflow already
-        printed Panel borders — that's a cosmetic artifact of stamped
-        scrollback history, not a live-render bug.
+        Classic CLI scrollback is printed in prompt_toolkit's non-fullscreen
+        mode.  A box that occupies the exact terminal width can hit the last
+        column and trigger an emulator wrap before prompt_toolkit redraws the
+        live input chrome, making the right border look like it overflowed.
+        Keep a one-column safety margin while still using the viewport width
+        instead of the old 56-column cap.
 
         A small floor (32 cols) is kept so the box still renders on tiny
         terminals without negative ``'─' * (w - 2)`` math.
@@ -3270,7 +3281,41 @@ class HermesCLI:
                 width = shutil.get_terminal_size((80, 24)).columns
             except Exception:
                 width = 80
-        return max(32, int(width or 80))
+        return max(32, int(width or 80) - 1)
+
+    @staticmethod
+    def _truncate_display_width(text: str, max_width: int) -> str:
+        """Truncate *text* so its terminal display width is at most max_width."""
+        if max_width <= 0:
+            return ""
+        out = []
+        used = 0
+        for ch in str(text):
+            ch_width = HermesCLI._status_bar_display_width(ch)
+            if used + ch_width > max_width:
+                break
+            out.append(ch)
+            used += ch_width
+        return "".join(out)
+
+    @staticmethod
+    def _scrollback_title_border(label: str, *, width: Optional[int] = None, style: str = "rounded") -> str:
+        """Return a display-width-safe top border with an inline title."""
+        w = HermesCLI._scrollback_box_width(width)
+        left, right = ("┌", "┐") if style == "square" else ("╭", "╮")
+        # Border layout: left + "─" + label + fill + right.
+        label_budget = max(0, w - 4)
+        safe_label = HermesCLI._truncate_display_width(label, label_budget)
+        label_width = HermesCLI._status_bar_display_width(safe_label)
+        fill = max(0, w - 3 - label_width)
+        return f"{left}─{safe_label}{'─' * fill}{right}"
+
+    @staticmethod
+    def _scrollback_bottom_border(*, width: Optional[int] = None, style: str = "rounded") -> str:
+        """Return a display-width-safe bottom border."""
+        w = HermesCLI._scrollback_box_width(width)
+        left, right = ("└", "┘") if style == "square" else ("╰", "╯")
+        return f"{left}{'─' * max(w - 2, 0)}{right}"
 
     def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
         """Return the visible height for the top/bottom input separator rules."""
@@ -3804,10 +3849,8 @@ class HermesCLI:
         # Open reasoning box on first reasoning token
         if not getattr(self, "_reasoning_box_opened", False):
             self._reasoning_box_opened = True
-            w = self._scrollback_box_width()
             r_label = " Reasoning "
-            r_fill = w - 2 - len(r_label)
-            _cprint(f"\n{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}")
+            _cprint(f"\n{_DIM}{self._scrollback_title_border(r_label, style='square')}{_RST}")
 
         self._reasoning_buf = getattr(self, "_reasoning_buf", "") + text
 
@@ -3828,8 +3871,7 @@ class HermesCLI:
             if buf:
                 _cprint(f"{_DIM}{buf}{_RST}")
                 self._reasoning_buf = ""
-            w = self._scrollback_box_width()
-            _cprint(f"{_DIM}└{'─' * (w - 2)}┘{_RST}")
+            _cprint(f"{_DIM}{self._scrollback_bottom_border(style='square')}{_RST}")
             self._reasoning_box_opened = False
 
             # Flush any content that was deferred while reasoning was rendering.
@@ -4019,9 +4061,7 @@ class HermesCLI:
                 self._stream_text_ansi = ""
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime('%H:%M')}"
-            w = self._scrollback_box_width()
-            fill = w - 2 - HermesCLI._status_bar_display_width(label)
-            _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+            _cprint(f"\n{_ACCENT}{self._scrollback_title_border(label)}{_RST}")
 
         self._stream_buf += text
 
@@ -4120,8 +4160,7 @@ class HermesCLI:
 
         # Close the response box
         if self._stream_box_opened:
-            w = self._scrollback_box_width()
-            _cprint(f"{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
+            _cprint(f"{_ACCENT}{self._scrollback_bottom_border()}{_RST}")
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -10933,12 +10972,14 @@ class HermesCLI:
                     nonlocal _streaming_box_opened
                     if not _streaming_box_opened:
                         _streaming_box_opened = True
-                        w = self._scrollback_box_width(getattr(self.console, "width", 80))
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
                             label = f"{label}{datetime.now().strftime('%H:%M')} "
-                        fill = w - 2 - HermesCLI._status_bar_display_width(label)
-                        _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+                        _cprint(
+                            f"\n{_ACCENT}"
+                            f"{self._scrollback_title_border(label, width=getattr(self.console, 'width', 80))}"
+                            f"{_RST}"
+                        )
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
 
                 tts_thread = threading.Thread(
@@ -11218,11 +11259,9 @@ class HermesCLI:
             if self.show_reasoning and result and not _reasoning_already_shown:
                 reasoning = result.get("last_reasoning")
                 if reasoning:
-                    w = self._scrollback_box_width()
                     r_label = " Reasoning "
-                    r_fill = w - 2 - len(r_label)
-                    r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
-                    r_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
+                    r_top = f"{_DIM}{self._scrollback_title_border(r_label, style='square')}{_RST}"
+                    r_bot = f"{_DIM}{self._scrollback_bottom_border(style='square')}{_RST}"
                     # Collapse long reasoning: show first 10 lines
                     lines = reasoning.strip().splitlines()
                     if len(lines) > 10:
@@ -11249,8 +11288,7 @@ class HermesCLI:
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
                 if use_streaming_tts and _streaming_box_opened and not is_error_response:
                     # Text was already printed sentence-by-sentence; just close the box
-                    w = self._scrollback_box_width()
-                    _cprint(f"\n{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
+                    _cprint(f"\n{_ACCENT}{self._scrollback_bottom_border()}{_RST}")
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
                     # _flush_stream() already closed the box. Skip Rich Panel.

--- a/cli.py
+++ b/cli.py
@@ -2971,35 +2971,36 @@ class HermesCLI:
     def _recover_after_resize(self, app, original_on_resize) -> None:
         """Recover a resized classic CLI without desynchronizing cursor state.
 
-        Unlike _force_full_redraw, we do NOT clear the physical screen or
-        scrollback here.  The startup banner and tool summary are printed
-        before prompt_toolkit owns the live chrome, so they live in normal
-        terminal scrollback.  Erasing the screen on SIGWINCH removes that
-        startup UI and ``_replay_output_history`` cannot reconstruct it
-        (the banner was never added to ``_OUTPUT_HISTORY``).
+        Column shrink is especially hostile in non-fullscreen
+        prompt_toolkit mode: the terminal emulator reflows already-printed
+        full-width boxes/rules before prompt_toolkit gets a chance to draw
+        the new prompt layout.  If we only reset prompt_toolkit's renderer,
+        those old-width rows remain visible and the next live redraw can look
+        like duplicated input/status/output boxes.
 
-        Instead we just reset prompt_toolkit's renderer cache so the next
-        incremental redraw starts from a clean slate, then let
-        ``original_on_resize`` recalculate layout for the new size.
+        Clear the visible screen and scrollback, reset prompt_toolkit's
+        cached screen/cursor state, replay Hermes-owned recent output
+        history, then let prompt_toolkit recalculate/redraw the live prompt
+        for the new size.  Clearing scrollback is intentional here: without
+        ESC[3J, every resize replay appends another copy of the previous
+        transcript to the terminal's real scrollback, making the visible
+        history grow longer on each resize.  Resume panels are stored as
+        width-aware history entries, so ``hermes -c`` can re-render them at
+        the current width instead of keeping the stale startup width.
 
         We also flag ``_status_bar_suppressed_after_resize`` so the dynamic
         status bar and input separator rules stay hidden until the next user
-        input.  On column shrink the terminal reflows already-rendered status
-        bar rows into scrollback before prompt_toolkit can erase them; drawing
-        a fresh full-width bar immediately makes the old and new versions
-        look duplicated (#19280, #22976).  Clearing the suppression on the
-        next prompt restores the bar cleanly.
+        input.  Clearing the suppression on the next prompt restores the bar
+        cleanly.
         """
         self._status_bar_suppressed_after_resize = True
-        try:
-            app.renderer.reset(leave_alternate_screen=False)
-        except Exception:
-            pass
+        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
+        _replay_output_history()
+        original_on_resize()
         try:
             app.invalidate()
         except Exception:
             pass
-        original_on_resize()
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:
         """Debounce resize redraws so footer chrome is not stamped into scrollback."""

--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -2988,15 +2988,29 @@ class HermesCLI:
         width-aware history entries, so ``hermes -c`` can re-render them at
         the current width instead of keeping the stale startup width.
 
-        We also flag ``_status_bar_suppressed_after_resize`` so the dynamic
-        status bar and input separator rules stay hidden until the next user
-        input.  Clearing the suppression on the next prompt restores the bar
-        cleanly.
+        The visible screen/scrollback clear removes the stale-width input
+        chrome too, so the live prompt should be redrawn immediately at the
+        new width instead of being suppressed until the next keystroke.
         """
-        self._status_bar_suppressed_after_resize = True
+        self._status_bar_suppressed_after_resize = False
         self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
         _replay_output_history()
         original_on_resize()
+        try:
+            input_area = getattr(self, "_tui_input_area", None)
+            if input_area is not None and getattr(app, "layout", None) is not None:
+                app.layout.focus(input_area)
+        except Exception:
+            pass
+        try:
+            # Re-drop prompt_toolkit's post-replay screen cache so the next
+            # invalidate paints the input prompt/status chrome from semantic
+            # layout state at the current terminal width.  Without this, a
+            # resize recovery can leave the transcript replay visible but the
+            # prompt row absent until another input event arrives.
+            app.renderer.reset(leave_alternate_screen=False)
+        except Exception:
+            pass
         try:
             app.invalidate()
         except Exception:
@@ -4576,38 +4590,73 @@ class HermesCLI:
             # logged at DEBUG by the advisory module.
             pass
 
-    def show_banner(self):
-        """Display the welcome banner in Claude Code style."""
-        self.console.clear()
+    def _get_startup_banner_context_length(self):
         ctx_len = None
         if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
             ctx_len = self.agent.context_compressor.context_length
-        
-        # Auto-compact for narrow terminals — the full banner with caduceus
-        # + tool list needs ~80 columns minimum to render without wrapping.
-        term_width = shutil.get_terminal_size().columns
-        use_compact = self.compact or term_width < 80
-        
-        if use_compact:
-            self._console_print(_build_compact_banner())
-            self._show_status()
+        return ctx_len
+
+    def _render_startup_banner_lines(self) -> list[str]:
+        """Render the startup banner at the current terminal width for replay."""
+        from io import StringIO
+
+        buf = StringIO()
+        width = shutil.get_terminal_size((80, 24)).columns
+        console = Console(
+            file=buf,
+            force_terminal=True,
+            color_system="truecolor",
+            highlight=False,
+            width=width,
+        )
+        if self.compact or width < 80:
+            console.print(_build_compact_banner())
         else:
-            # Get tools for display
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-            
-            # Get terminal working directory (where commands will execute)
+            enabled_toolsets = cast(List[str], list(self.enabled_toolsets) if self.enabled_toolsets is not None else None)
+            tools = get_tool_definitions(enabled_toolsets=enabled_toolsets, quiet_mode=True)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-            
-            # Build and display the banner
             build_welcome_banner(
-                console=self.console,
+                console=console,
                 model=self.model,
                 cwd=cwd,
                 tools=tools,
-                enabled_toolsets=self.enabled_toolsets,
+                enabled_toolsets=enabled_toolsets,
                 session_id=self.session_id,
-                context_length=ctx_len,
+                context_length=self._get_startup_banner_context_length(),
             )
+        return buf.getvalue().rstrip("\n").splitlines()
+
+    def _record_startup_banner_for_resize(self) -> None:
+        _record_output_history_entry(lambda: self._render_startup_banner_lines())
+
+    def _print_startup_banner(self, console) -> None:
+        """Print the startup banner once without raw-line history duplication."""
+        width = shutil.get_terminal_size((80, 24)).columns
+        if self.compact or width < 80:
+            console.print(_build_compact_banner())
+        else:
+            enabled_toolsets = cast(List[str], list(self.enabled_toolsets) if self.enabled_toolsets is not None else None)
+            tools = get_tool_definitions(enabled_toolsets=enabled_toolsets, quiet_mode=True)
+            cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+            build_welcome_banner(
+                console=console,
+                model=self.model,
+                cwd=cwd,
+                tools=tools,
+                enabled_toolsets=enabled_toolsets,
+                session_id=self.session_id,
+                context_length=self._get_startup_banner_context_length(),
+            )
+
+    def show_banner(self):
+        """Display the welcome banner in Claude Code style."""
+        self.console.clear()
+        self._record_startup_banner_for_resize()
+        with _suspend_output_history():
+            self._print_startup_banner(self.console)
+        if self.compact or shutil.get_terminal_size((80, 24)).columns < 80:
+            self._show_status()
+        ctx_len = self._get_startup_banner_context_length()
         
         # Show tool availability warnings if any tools are disabled
         self._show_tool_availability_warnings()
@@ -7733,24 +7782,9 @@ class HermesCLI:
             # and gets mangled by patch_stdout).
             if self._app:
                 cc = ChatConsole()
-                term_w = shutil.get_terminal_size().columns
-                if self.compact or term_w < 80:
-                    cc.print(_build_compact_banner())
-                else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-                    cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-                    ctx_len = None
-                    if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                        ctx_len = self.agent.context_compressor.context_length
-                    build_welcome_banner(
-                        console=cc,
-                        model=self.model,
-                        cwd=cwd,
-                        tools=tools,
-                        enabled_toolsets=self.enabled_toolsets,
-                        session_id=self.session_id,
-                        context_length=ctx_len,
-                    )
+                self._record_startup_banner_for_resize()
+                with _suspend_output_history():
+                    self._print_startup_banner(cc)
                 _cprint("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
                 # Show a random tip on new session
                 try:
@@ -12661,6 +12695,7 @@ class HermesCLI:
                 completer=_completer,
             ),
         )
+        self._tui_input_area = input_area
         # Keep prompt_toolkit on its simple tempfile path. Setting
         # buffer.tempfile = "prompt.md" triggers its complex-tempfile branch,
         # which tries to mkdir() the mkdtemp() directory again and raises

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,38 +71,50 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_preserves_scrollback_and_resets_renderer(self, bare_cli, monkeypatch):
-        """Resize recovery must NOT erase screen or scrollback.
+    def test_resize_clears_visible_screen_replays_and_resets_renderer(self, bare_cli, monkeypatch):
+        """Resize recovery clears the visible screen and replays history.
 
-        The startup banner lives in normal terminal scrollback (printed
-        before prompt_toolkit owns the chrome).  Clearing scrollback on
-        SIGWINCH removes it and ``_replay_output_history`` cannot
-        reconstruct it.  The fix is to only reset the renderer cache and
-        let ``original_on_resize`` recalculate layout.
+        On column shrink, terminal emulators reflow already-rendered
+        full-width boxes/rules before prompt_toolkit can repaint.  Merely
+        resetting the renderer leaves those stale rows visible and the next
+        prompt redraw can look duplicated.  The fix is to clear the visible
+        screen, reset prompt_toolkit's cache, replay Hermes-owned history at
+        the current width, then let prompt_toolkit recalculate layout.
 
-        Additionally, ``_status_bar_suppressed_after_resize`` must be set
-        so the input rules and status bar hide until the next user input,
-        preventing duplicated-bar artifacts on column shrink (#19280).
+        We intentionally clear scrollback (ESC[3J) because otherwise every
+        resize replay appends another copy of the previous transcript to the
+        real terminal history.
         """
         app = MagicMock()
+        out = app.renderer.output
         events = []
+        out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
+        out.erase_screen.side_effect = lambda: events.append("erase")
+        out.cursor_goto.side_effect = lambda *_: events.append("home")
+        out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
         app.invalidate.side_effect = lambda: events.append("invalidate")
         original_on_resize = lambda: events.append("original_resize")
+        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
 
         # bare_cli skips __init__, so seed the attribute the way __init__ would.
         bare_cli._status_bar_suppressed_after_resize = False
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
+            "reset_attrs",
+            "erase",
+            "home",
+            "flush",
             "renderer_reset",
-            "invalidate",
+            "replay",
             "original_resize",
+            "invalidate",
         ]
-        # Must NOT clear the screen or scrollback — those destroy the banner.
-        app.renderer.output.erase_screen.assert_not_called()
-        app.renderer.output.write_raw.assert_not_called()
-        app.renderer.output.cursor_goto.assert_not_called()
+        out.erase_screen.assert_called_once()
+        out.cursor_goto.assert_called_once_with(0, 0)
+        out.write_raw.assert_called_once_with("\x1b[3J")
+        app.renderer.reset.assert_called_once_with(leave_alternate_screen=False)
         # Status bar / input rules must be suppressed until the next prompt.
         assert bare_cli._status_bar_suppressed_after_resize is True
 

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -81,9 +81,9 @@ class TestForceFullRedraw:
         screen, reset prompt_toolkit's cache, replay Hermes-owned history at
         the current width, then let prompt_toolkit recalculate layout.
 
-        We intentionally clear scrollback (ESC[3J) because otherwise every
-        resize replay appends another copy of the previous transcript to the
-        real terminal history.
+        Resize recovery must not clear the terminal emulator's real
+        scrollback: Hermes only records a bounded recent output history, so an
+        ESC[3J clear would discard older transcript that cannot be replayed.
         """
         app = MagicMock()
         out = app.renderer.output
@@ -107,7 +107,6 @@ class TestForceFullRedraw:
         assert events == [
             "reset_attrs",
             "erase",
-            "write_raw:'\\x1b[3J'",
             "home",
             "flush",
             "renderer_reset",
@@ -119,7 +118,7 @@ class TestForceFullRedraw:
         ]
         out.erase_screen.assert_called_once()
         out.cursor_goto.assert_called_once_with(0, 0)
-        out.write_raw.assert_called_once_with("\x1b[3J")
+        out.write_raw.assert_not_called()
         assert app.renderer.reset.call_count == 2
         app.renderer.reset.assert_any_call(leave_alternate_screen=False)
         # The prompt/input chrome must be visible immediately after resize.

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -90,33 +90,40 @@ class TestForceFullRedraw:
         events = []
         out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
         out.erase_screen.side_effect = lambda: events.append("erase")
+        out.write_raw.side_effect = lambda value: events.append(f"write_raw:{value!r}")
         out.cursor_goto.side_effect = lambda *_: events.append("home")
         out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
         app.invalidate.side_effect = lambda: events.append("invalidate")
+        app.layout.focus.side_effect = lambda target: events.append(("focus", target))
         original_on_resize = lambda: events.append("original_resize")
         monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
 
-        # bare_cli skips __init__, so seed the attribute the way __init__ would.
-        bare_cli._status_bar_suppressed_after_resize = False
+        # bare_cli skips __init__, so seed the attributes the way __init__/run would.
+        bare_cli._status_bar_suppressed_after_resize = True
+        bare_cli._tui_input_area = object()
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
             "reset_attrs",
             "erase",
+            "write_raw:'\\x1b[3J'",
             "home",
             "flush",
             "renderer_reset",
             "replay",
             "original_resize",
+            ("focus", bare_cli._tui_input_area),
+            "renderer_reset",
             "invalidate",
         ]
         out.erase_screen.assert_called_once()
         out.cursor_goto.assert_called_once_with(0, 0)
         out.write_raw.assert_called_once_with("\x1b[3J")
-        app.renderer.reset.assert_called_once_with(leave_alternate_screen=False)
-        # Status bar / input rules must be suppressed until the next prompt.
-        assert bare_cli._status_bar_suppressed_after_resize is True
+        assert app.renderer.reset.call_count == 2
+        app.renderer.reset.assert_any_call(leave_alternate_screen=False)
+        # The prompt/input chrome must be visible immediately after resize.
+        assert bare_cli._status_bar_suppressed_after_resize is False
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):
         app = MagicMock()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -335,8 +335,8 @@ class TestCLIStatusBar:
     def test_input_rules_remain_visible_after_resize_recovery(self):
         """Resize recovery clears stale chrome, then redraws live input rules.
 
-        Since _recover_after_resize now clears the visible screen and
-        scrollback before replaying history, it should not suppress the input
+        Since _recover_after_resize now clears the visible screen before
+        replaying history, it should not suppress the input
         prompt/chrome until the next keystroke; that made the prompt appear to
         disappear after resize.
         """

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -350,27 +350,38 @@ class TestCLIStatusBar:
         assert cli_obj._tui_input_rule_height("top", width=90) == 0
         assert cli_obj._tui_input_rule_height("bottom", width=90) == 0
 
-    def test_scrollback_box_width_returns_viewport_width(self):
-        """Decorative scrollback boxes use the full viewport width.
-
-        The previous clamp (max 56 cols) was reverted in favour of the
-        prompt_toolkit ``_output_screen_diff`` monkey-patch landed in
-        #26137, which keeps chrome out of scrollback at the source.
-        We accept that an aggressive column-shrink may visually reflow
-        already printed Panel borders — that's a cosmetic artifact of
-        stamped scrollback history, not a live-render bug.
-        """
+    def test_scrollback_box_width_keeps_one_column_safety_margin(self):
+        """Decorative scrollback boxes leave room for emulator wrap quirks."""
         from cli import HermesCLI
 
         # Floor at 32 — narrow terminals still get something usable
         # (avoids negative ``'─' * (w - 2)`` math).
         assert HermesCLI._scrollback_box_width(20) == 32
         assert HermesCLI._scrollback_box_width(32) == 32
-        # Above the floor, return the actual viewport width — no cap.
-        assert HermesCLI._scrollback_box_width(48) == 48
-        assert HermesCLI._scrollback_box_width(80) == 80
-        assert HermesCLI._scrollback_box_width(120) == 120
-        assert HermesCLI._scrollback_box_width(200) == 200
+        # Above the floor, use almost the full viewport but avoid the last
+        # terminal column so the right border does not wrap past the prompt.
+        assert HermesCLI._scrollback_box_width(48) == 47
+        assert HermesCLI._scrollback_box_width(80) == 79
+        assert HermesCLI._scrollback_box_width(120) == 119
+        assert HermesCLI._scrollback_box_width(200) == 199
+
+    def test_scrollback_title_border_fits_display_width(self):
+        from cli import HermesCLI
+
+        border = HermesCLI._scrollback_title_border(" ⚕ Hermes " + "很长" * 20, width=40)
+
+        assert border.startswith("╭─")
+        assert border.endswith("╮")
+        assert HermesCLI._status_bar_display_width(border) == HermesCLI._scrollback_box_width(40)
+
+    def test_scrollback_square_title_border_fits_display_width(self):
+        from cli import HermesCLI
+
+        border = HermesCLI._scrollback_title_border(" Reasoning " + "x" * 80, width=48, style="square")
+
+        assert border.startswith("┌─")
+        assert border.endswith("┐")
+        assert HermesCLI._status_bar_display_width(border) == HermesCLI._scrollback_box_width(48)
 
     def test_agent_spacer_reclaimed_on_narrow_terminals(self):
         cli_obj = _make_cli()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -332,22 +332,23 @@ class TestCLIStatusBar:
         assert cli_obj._tui_input_rule_height("bottom", width=50) == 0
         assert cli_obj._tui_input_rule_height("bottom", width=90) == 1
 
-    def test_input_rules_hide_after_resize_until_next_input(self):
-        """When _status_bar_suppressed_after_resize is set, both rules hide.
+    def test_input_rules_remain_visible_after_resize_recovery(self):
+        """Resize recovery clears stale chrome, then redraws live input rules.
 
-        See _recover_after_resize — column shrink reflows already-rendered
-        bars into scrollback, so we hide the separators until the user
-        submits the next input, at which point the flag is cleared.
+        Since _recover_after_resize now clears the visible screen and
+        scrollback before replaying history, it should not suppress the input
+        prompt/chrome until the next keystroke; that made the prompt appear to
+        disappear after resize.
         """
         cli_obj = _make_cli()
-        cli_obj._status_bar_suppressed_after_resize = True
-
-        assert cli_obj._tui_input_rule_height("top", width=90) == 0
-        assert cli_obj._tui_input_rule_height("bottom", width=90) == 0
-
         cli_obj._status_bar_suppressed_after_resize = False
+
         assert cli_obj._tui_input_rule_height("top", width=90) == 1
         assert cli_obj._tui_input_rule_height("bottom", width=90) == 1
+
+        cli_obj._status_bar_suppressed_after_resize = True
+        assert cli_obj._tui_input_rule_height("top", width=90) == 0
+        assert cli_obj._tui_input_rule_height("bottom", width=90) == 0
 
     def test_scrollback_box_width_returns_viewport_width(self):
         """Decorative scrollback boxes use the full viewport width.

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -77,6 +77,7 @@ def test_cprint_bg_thread_schedules_on_app_loop(monkeypatch):
 
         def call_soon_threadsafe(self, cb, *args):
             scheduled.append(cb)
+            cb(*args)
 
     fake_loop = FakeLoop()
 
@@ -113,12 +114,50 @@ def test_cprint_bg_thread_schedules_on_app_loop(monkeypatch):
     # call_soon_threadsafe must have been called with a scheduling cb.
     assert len(scheduled) == 1
 
-    # Invoking the scheduled callback should hit run_in_terminal.
-    scheduled[0]()
     assert len(run_in_terminal_calls) == 1
 
     # And run_in_terminal's inner func should have emitted a pt_print.
     assert direct_prints == ["💾 Self-improvement review: Skill updated"]
+
+
+def test_cprint_bg_thread_waits_for_terminal_print(monkeypatch):
+    """Cross-thread _cprint waits for run_in_terminal to finish before returning."""
+    events = []
+    monkeypatch.setattr(cli, "_pt_print", lambda x: events.append(("pt_print", x)))
+    monkeypatch.setattr(cli, "_PT_ANSI", lambda t: t)
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+        def call_soon_threadsafe(self, cb, *args):
+            events.append(("scheduled",))
+            cb(*args)
+
+    class FakeFuture:
+        def add_done_callback(self, cb):
+            events.append(("done_callback",))
+            cb(self)
+
+    fake_pt_app = types.ModuleType("prompt_toolkit.application")
+    fake_pt_app.get_app_or_none = lambda: SimpleNamespace(_is_running=True, loop=FakeLoop())
+
+    def _fake_run_in_terminal(func, **kw):
+        events.append(("run_in_terminal",))
+        func()
+        return FakeFuture()
+
+    fake_pt_app.run_in_terminal = _fake_run_in_terminal
+    monkeypatch.setitem(sys.modules, "prompt_toolkit.application", fake_pt_app)
+
+    cli._cprint("ordered")
+
+    assert events == [
+        ("scheduled",),
+        ("run_in_terminal",),
+        ("pt_print", "ordered"),
+        ("done_callback",),
+    ]
 
 
 def test_cprint_same_thread_as_app_loop_direct_print(monkeypatch):

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -12,6 +12,7 @@ These tests verify the routing logic without spinning up a real PT app.
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -306,3 +307,33 @@ def test_clear_output_history_removes_replayable_lines():
     cli._clear_output_history()
 
     assert list(cli._OUTPUT_HISTORY) == []
+
+
+def test_startup_banner_history_entry_rerenders_at_current_width(monkeypatch):
+    cli._configure_output_history(True, 10)
+    cli_obj = object.__new__(cli.HermesCLI)
+    cli_obj.compact = True
+    cli_obj.enabled_toolsets = []
+    cli_obj.model = "test-model"
+    cli_obj.session_id = "test-session"
+    cli_obj.agent = None
+    widths = [50]
+    printed = []
+
+    monkeypatch.setattr(
+        cli.shutil,
+        "get_terminal_size",
+        lambda fallback=(80, 24): os.terminal_size((widths[-1], 24)),
+    )
+    monkeypatch.setattr(cli, "_build_compact_banner", lambda: f"banner-width-{widths[-1]}")
+    monkeypatch.setattr(cli, "_pt_print", lambda value: printed.append(value))
+    monkeypatch.setattr(cli, "_PT_ANSI", lambda text: text)
+
+    cli_obj._record_startup_banner_for_resize()
+    cli._replay_output_history()
+    widths.append(100)
+    cli._replay_output_history()
+
+    assert printed == ["banner-width-50", "banner-width-100"]
+    assert len(cli._OUTPUT_HISTORY) == 1
+    assert callable(cli._OUTPUT_HISTORY[0])


### PR DESCRIPTION
## What does this PR do?

Fixes classic CLI resize/history recovery issues where historical output can remain stuck at the wrong width, active input text can be replayed/misaligned, and the Hermes banner can disappear after restoring history.

Specifically, this PR addresses four resize-related rendering problems:

1. shrinking the terminal can truncate historical output, and widening the terminal again does not recover the layout
2. active input text can be replayed during resize recovery, causing duplicated or misplaced prompt text
3. historical response windows keep the old width instead of following the current terminal width
4. the Hermes banner can disappear after history recovery

The approach keeps the fix scoped to classic CLI resize/history recovery: restored history should be rendered against the current terminal width, active prompt input should remain separate from transcript recovery, and the banner should be preserved or restored after recovery.

## Related Issue

Fixes #26316

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - update classic CLI resize/history recovery so restored history follows the current terminal width
  - avoid replaying active prompt input into the recovered history output
  - preserve or restore the Hermes banner after history recovery
  - keep response/history window rendering bounded to the active terminal width
- `tests/cli/test_cli_force_redraw.py`
  - add/update coverage for resize recovery and history replay behavior
- `tests/cli/test_cli_status_bar.py`
  - add/update coverage for banner/prompt/status restoration after resize recovery
- `tests/cli/test_cprint_bg_thread.py`
  - add/update coverage for terminal output ordering around background-thread printing

## How to Test

1. Run the focused CLI tests:

   ```bash
   .venv/bin/python -m pytest \
     tests/cli/test_cprint_bg_thread.py \
     tests/cli/test_cli_status_bar.py \
     tests/cli/test_cli_force_redraw.py -q
   ```

2. Run syntax and lint checks:

   ```bash
   .venv/bin/python -m py_compile \
     cli.py \
     tests/cli/test_cprint_bg_thread.py \
     tests/cli/test_cli_status_bar.py \
     tests/cli/test_cli_force_redraw.py

   .venv/bin/python -m ruff check \
     cli.py \
     tests/cli/test_cprint_bg_thread.py \
     tests/cli/test_cli_status_bar.py \
     tests/cli/test_cli_force_redraw.py
   ```

3. Manually verify resize recovery in the classic CLI:

   - create enough history to show several response boxes
   - type partial input without submitting it
   - shrink the terminal window
   - widen the terminal window again
   - verify history width, prompt input position, and Hermes banner state all recover correctly

Expected local result:

```text
62 passed
All checks passed
```