### PR TITLE
chore(release): map brian@dralth.com to btorresgil

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -265,6 +265,7 @@ AUTHOR_MAP = {
     "yuxiangl490@gmail.com": "y0shua1ee",
     "manmit0x@gmail.com": "0xDevNinja",
     "stevekelly622@gmail.com": "steezkelly",
+    "brian@dralth.com": "btorresgil",
     "momowind@gmail.com": "momowind",
     "clockwork-codex@users.noreply.github.com": "misery-hl",
     "207811921+misery-hl@users.noreply.github.com": "misery-hl",


### PR DESCRIPTION
## What does this PR do?

Adds `brian@dralth.com → btorresgil` to `AUTHOR_MAP` in `scripts/release.py`.

@btorresgil authors commits as `Brian Conklin <brian@dralth.com>` (git config carries a different name/email than the GitHub account). GitHub's commit-author mapping correctly attributes these commits to @btorresgil based on the public-key registration, but Hermes' release attribution audit reads the raw commit email, not the GitHub mapping. Without this entry, `scripts/contributor_audit.py` strict mode would fail when releasing.

## Why now

Prerequisite for the langfuse trace fix salvage that cherry-picks @btorresgil's commits from #22345 onto current main. That salvage PR will reference this one as a hard dependency.

## Verification

```python
import sys; sys.path.insert(0, "scripts")
import release
assert release.AUTHOR_MAP["brian@dralth.com"] == "btorresgil"
```

## Type of Change

- [x] 🧹 Chore (release housekeeping)
