### PR TITLE
feat: add restricted MCP bridge task interface

### DIFF
--- a/gateway/mcp_bridge.py
+++ b/gateway/mcp_bridge.py
@@ -1,0 +1,678 @@
+"""Minimal local-first MCP bridge task store.
+
+This module intentionally does not execute tasks. It validates task
+contracts, records accepted/refused submissions under HERMES_HOME, and
+returns stored status/result records for a future orchestrator to consume.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+REQUIRED_SUBMIT_FIELDS = (
+    "title",
+    "project",
+    "mode",
+    "task_contract",
+    "allowed_actions",
+    "forbidden_actions",
+    "return_format",
+)
+
+SCOPE_FIELDS = ("repo_scope", "worktree_scope")
+
+_UNCLEAR_CONTRACTS = {
+    "do it",
+    "do stuff",
+    "fix it",
+    "make changes",
+    "whatever",
+    "help",
+}
+
+_HARD_REFUSAL_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "approval bypass or safety-disable requests are refused",
+        re.compile(
+            r"\b(bypass|skip|disable|turn\s+off|ignore)\s+"
+            r"(?:the\s+)?(?:approval|approvals|safety|safeguards?|policy|gatekeeper)\b",
+            re.I,
+        ),
+    ),
+    ("run_shell is not exposed by this bridge", re.compile(r"\brun[_ -]?shell\b", re.I)),
+    (
+        "raw shell access is not exposed by this bridge",
+        re.compile(
+            r"\b(raw\s+shell|shell\s+access|direct\s+command\s+execution|run[_ -]?shell)\b|"
+            r"\b(?:add|expose|provide|enable|create|publish|surface|make)\b.{0,80}"
+            r"\b(raw\s+shell|shell\s+access|direct\s+command\s+execution|run[_ -]?shell)\b|"
+            r"\b(raw\s+shell|shell\s+access|direct\s+command\s+execution)\b.{0,80}"
+            r"\b(?:through|as|via|on|to)\s+(?:the\s+)?(?:bridge|mcp|public\s+mcp|workers?)\b",
+            re.I,
+        ),
+    ),
+    (
+        "secret/env/token/auth file access is refused",
+        re.compile(
+            r"\b(read[_ -]?secret|secret[s]?|\.env|token[s]?|credential[s]?|"
+            r"key\s+material|auth\s+file[s]?)\b",
+            re.I,
+        ),
+    ),
+    (
+        "git_push is not exposed by this bridge",
+        re.compile(r"\bgit[_-]push\b", re.I),
+    ),
+    (
+        "external_service_import is not exposed by this bridge",
+        re.compile(r"\bexternal[_ -]?service[_ -]?import\b", re.I),
+    ),
+    (
+        "docker_run is not exposed by this bridge",
+        re.compile(r"\bdocker[_ -]?run\b|\bdocker\s+run\b", re.I),
+    ),
+    (
+        "direct external code agent calls are not exposed by this bridge",
+        re.compile(
+            r"\bexternal[_ -]?code[_ -]?agent[_ -]?direct\b|"
+            r"\bdirect\s+external\s+code\s+agent\b",
+            re.I,
+        ),
+    ),
+    (
+        "MCP tool changes are refused by this bridge",
+        re.compile(
+            r"\b(add|remove|install|delete|change|expose|publish|surface|create)\s+"
+            r"(?:an?\s+)?(?:public\s+)?mcp\s+tools?\b|"
+            r"\bmcp\s+tools?\s+(?:add|remove|install|delete|change|expose|publish|surface|create)s?\b",
+            re.I,
+        ),
+    ),
+)
+
+_APPROVAL_REQUIRED_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "local file writes require human approval before routing",
+        re.compile(r"\b(write[_ -]?file|direct\s+write[_ -]?file|local\s+writes?)\b", re.I),
+    ),
+    (
+        "destructive git operations require human approval before routing",
+        re.compile(
+            r"\bgit\s+(reset|clean|merge|rebase|switch|stash|tag|fetch|pull|push)\b|"
+            r"\bforce\s+push\b|\bdestructive\s+git\b",
+            re.I,
+        ),
+    ),
+    (
+        "external service writes require human approval before routing",
+        re.compile(
+            r"\bexternal\s+service\s+(write|mutation|update|import|delete)\b",
+            re.I,
+        ),
+    ),
+    (
+        "production actions require human approval before routing",
+        re.compile(
+            r"\bprod(?:uction)?\s+(deploy|release|write|mutation|update|delete)\b|"
+            r"\bdeploy\s+to\s+prod(?:uction)?\b",
+            re.I,
+        ),
+    ),
+    (
+        "paid API use requires human approval before routing",
+        re.compile(
+            r"\bpaid[_ -]?api[_ -]?call\b|\bpaid\s+(?:model\s+provider\s+)?api\b",
+            re.I,
+        ),
+    ),
+    (
+        "service restart/reload requires human approval before routing",
+        re.compile(r"\b(restart|reload|refresh)\s+(?:service[s]?|gateway|bridge|server[s]?|process(?:es)?)\b", re.I),
+    ),
+    (
+        "real submit_task reproduction requires human approval before routing",
+        re.compile(r"\bsubmit[_ -]?task\b", re.I),
+    ),
+)
+
+_NETWORK_PATTERN = re.compile(
+    r"\b(network|internet|external\s+api|curl|wget|http[s]?://)\b",
+    re.I,
+)
+_EXACT_ENDPOINT_PATTERN = re.compile(
+    r"\b(?:https?://(?:[A-Za-z0-9.-]+|localhost|127(?:\.\d{1,3}){3}|\[[0-9A-Fa-f:.]+\])"
+    r"(?::\d{1,5})?(?:/[^\s,;]*)?|"
+    r"(?:host|origin|endpoint)s?\s+(?:is|are|named|outside|against|for|to)?\s*"
+    r"(?:[A-Za-z0-9.-]+|localhost|127(?:\.\d{1,3}){3})(?::\d{1,5})?)\b",
+    re.I,
+)
+_BOUNDED_DIAGNOSTIC_PATTERN = re.compile(
+    r"\b(read[-\s]?only|diagnos(?:e|tic)|health|status|inventory|list[_ -]?tools|"
+    r"process\s+status|local/public\s+tunnel|exact\s+(?:host|origin|endpoint))\b",
+    re.I,
+)
+_MUTATION_PATTERN = re.compile(
+    r"\b(write|mutation|mutate|modify|delete|deploy|release|settings?\s+change|"
+    r"tool\s+change|restart|reload|submit[_ -]?task)\b",
+    re.I,
+)
+_TASK_ID_PATTERN = re.compile(r"\bmcp_[A-Za-z0-9_-]+\b")
+_FULL_CODE_PATTERN = re.compile(
+    r"\b(?:HERMES-BRIDGE-)?([0-9]{3,}[A-Z]{2,}(?:-[A-Z0-9]+)*)\b"
+)
+_LEADING_CODE_PATTERN = re.compile(
+    r"\b(?:HERMES-BRIDGE-)?([0-9]{3,}[A-Z]{2,})(?:-[A-Z0-9-]+)?\b"
+)
+_BROAD_SCOPE_PATTERN = re.compile(
+    r"\b(all|any|multiple|every)\s+(repo|repos|repository|repositories|worktree|worktrees)\b|"
+    r"\bcross[-\s]?repo\b|\bentire\s+filesystem\b",
+    re.I,
+)
+_INFRASTRUCTURE_ERROR_RESPONSE_PATTERN = re.compile(
+    r"\bhttp\s*401\b|"
+    r"\btoken[_\s-]invalidated\b|"
+    r"\btoken[_\s-]revoked\b|"
+    r"\binvalidated\s+oauth\b|"
+    r"\bauthentication\s+token\s+invalidated\b|"
+    r"\bprovider\s+authentication\s+failed\b|"
+    r"\bno\s+credentials\s+stored\b|"
+    r"\brefresh[_\s-]token[_\s-]reused\b",
+    re.I,
+)
+_NEGATION_PATTERN = re.compile(
+    r"\b(do\s+not|don't|dont|no|without|forbid(?:den)?|refuse|avoid|must\s+not|never)\b",
+    re.I,
+)
+_PROHIBITION_FIELDS = {
+    "forbidden_actions",
+    "safety_statement",
+    "risk_boundary",
+    "risk_boundaries",
+    "training_notes",
+    "stop_conditions",
+}
+_POSITIVE_FIELDS = {
+    "title",
+    "project",
+    "mode",
+    "task_contract",
+    "allowed_actions",
+    "approvals",
+    "allowed_commands",
+    "commands",
+    "repo_scope",
+    "worktree_scope",
+    "worker_selection_guidance",
+    "expected_branch",
+    "expected_head",
+}
+
+
+class MCPBridgeError(ValueError):
+    """Raised when a bridge operation cannot be completed."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bridge_home() -> Path:
+    """Return the bridge task-store home without changing global HERMES_HOME.
+
+    A dedicated task store must be selected explicitly with
+    HERMES_MCP_BRIDGE_HOME or HERMES_MCP_BRIDGE_TASKS_DIR. Otherwise the
+    bridge uses the active Hermes home.
+    """
+    explicit_home = os.getenv("HERMES_MCP_BRIDGE_HOME")
+    if explicit_home:
+        return Path(explicit_home).expanduser()
+    return get_hermes_home()
+
+
+def _task_dir() -> Path:
+    explicit_tasks_dir = os.getenv("HERMES_MCP_BRIDGE_TASKS_DIR")
+    if explicit_tasks_dir:
+        return Path(explicit_tasks_dir).expanduser()
+    return _bridge_home() / "mcp_bridge_tasks"
+
+
+def _record_path(task_id: str) -> Path:
+    if not re.match(r"^mcp_[A-Za-z0-9_-]+$", task_id or ""):
+        raise MCPBridgeError("invalid task_id")
+    return _task_dir() / f"{task_id}.json"
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def _flatten(value: Any, *, skip_keys: set[str] | None = None) -> str:
+    skip_keys = skip_keys or set()
+    parts: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key) in skip_keys:
+                continue
+            parts.append(str(key))
+            parts.append(_flatten(item, skip_keys=skip_keys))
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            parts.append(_flatten(item, skip_keys=skip_keys))
+    elif value is not None:
+        parts.append(str(value))
+    return " ".join(p for p in parts if p)
+
+
+def _is_non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _missing_submit_fields(payload: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for field in REQUIRED_SUBMIT_FIELDS:
+        if field == "forbidden_actions":
+            if field not in payload or not isinstance(payload.get(field), list):
+                missing.append(field)
+        elif not _is_non_empty(payload.get(field)):
+            missing.append(field)
+    return missing
+
+
+def _is_negated(text: str, start: int) -> bool:
+    window = text[max(0, start - 40):start]
+    return bool(_NEGATION_PATTERN.search(window))
+
+
+def _flatten_selected(payload: dict[str, Any], fields: set[str]) -> str:
+    return _flatten({field: payload.get(field) for field in fields if field in payload})
+
+
+def _flatten_positive_surface(payload: dict[str, Any]) -> str:
+    positive_payload = {field: payload.get(field) for field in _POSITIVE_FIELDS if field in payload}
+    return _flatten(positive_payload, skip_keys=_PROHIBITION_FIELDS).strip()
+
+
+def _allows_bounded_read_only_network(payload: dict[str, Any], text: str) -> bool:
+    """Permit exact-scope read-only health diagnostics, not broad network access."""
+    positive_text = _flatten_positive_surface(payload)
+    combined_text = f"{positive_text} {_flatten_selected(payload, _PROHIBITION_FIELDS)}"
+    if not _EXACT_ENDPOINT_PATTERN.search(positive_text):
+        return False
+    if not _BOUNDED_DIAGNOSTIC_PATTERN.search(positive_text):
+        return False
+
+    for match in _MUTATION_PATTERN.finditer(text):
+        if not _is_negated(text, match.start()):
+            return False
+
+    required_prohibitions = ("submit", "restart", "reload", "mutation")
+    lowered = combined_text.lower()
+    return all(word in lowered for word in required_prohibitions)
+
+
+def _find_hard_refusal(payload: dict[str, Any]) -> str | None:
+    missing = _missing_submit_fields(payload)
+    if not any(_is_non_empty(payload.get(field)) for field in SCOPE_FIELDS):
+        missing.append("repo_scope or worktree_scope")
+    if missing:
+        return f"missing required field(s): {', '.join(missing)}"
+
+    contract = payload.get("task_contract")
+    contract_text = _flatten(contract).strip()
+    if not contract_text:
+        return "unclear task contract: task_contract is empty"
+    if contract_text.lower() in _UNCLEAR_CONTRACTS or len(contract_text) < 12:
+        return "unclear task contract: provide concrete objective and boundaries"
+
+    scope_text = _flatten({field: payload.get(field) for field in SCOPE_FIELDS})
+    if _BROAD_SCOPE_PATTERN.search(scope_text):
+        return "broad cross-repo mutation is refused; provide one repo_scope or worktree_scope"
+
+    allowed_text = _flatten(payload.get("allowed_actions"))
+    checked_text = _flatten_positive_surface(payload)
+    for reason, pattern in _HARD_REFUSAL_PATTERNS:
+        for match in pattern.finditer(allowed_text):
+            if not _is_negated(allowed_text, match.start()):
+                return reason
+        for match in pattern.finditer(checked_text):
+            if not _is_negated(checked_text, match.start()):
+                return reason
+    return None
+
+
+def _find_approval_required(payload: dict[str, Any]) -> str | None:
+    allowed_text = _flatten(payload.get("allowed_actions"))
+    checked_text = _flatten_positive_surface(payload)
+
+    for reason, pattern in _APPROVAL_REQUIRED_PATTERNS:
+        for match in pattern.finditer(allowed_text):
+            if not _is_negated(allowed_text, match.start()):
+                return reason
+        for match in pattern.finditer(checked_text):
+            if not _is_negated(checked_text, match.start()):
+                return reason
+
+    for text in (allowed_text, checked_text):
+        for match in _NETWORK_PATTERN.finditer(text):
+            if not _is_negated(text, match.start()):
+                if _allows_bounded_read_only_network(payload, text):
+                    continue
+                return "network access with unclear scope requires human approval before routing"
+    return None
+
+
+def _write_record(record: dict[str, Any]) -> None:
+    directory = _task_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = _record_path(record["task_id"])
+    tmp = path.with_suffix(f".{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_record(task_id: str) -> dict[str, Any]:
+    path = _record_path(task_id)
+    if not path.exists():
+        raise MCPBridgeError(f"task {task_id} not found")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _is_infrastructure_error_response(response: str) -> bool:
+    """Return True for provider/auth failures that are not task reports."""
+    return bool(_INFRASTRUCTURE_ERROR_RESPONSE_PATTERN.search(str(response or "")))
+
+
+def submit_task(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate and record a bridge task without executing it."""
+    if not isinstance(payload, dict):
+        raise MCPBridgeError("submit_task payload must be an object")
+
+    task_id = "mcp_" + uuid.uuid4().hex
+    created_at = _now_iso()
+    refusal = _find_hard_refusal(payload)
+    approval_required_reason = None if refusal else _find_approval_required(payload)
+    status = "refused" if refusal else "approval_required" if approval_required_reason else "accepted"
+    execution_state = "approval_required" if approval_required_reason else "not_executed"
+    execution_message = (
+        "Recorded for Hermes approval routing; no task runner was invoked."
+        if approval_required_reason
+        else "Recorded for future Hermes orchestration; no task runner was invoked."
+    )
+    record = {
+        "task_id": task_id,
+        "status": status,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "project": _jsonable(payload.get("project")),
+        "title": _jsonable(payload.get("title")),
+        "mode": _jsonable(payload.get("mode")),
+        "repo_scope": _jsonable(payload.get("repo_scope")),
+        "worktree_scope": _jsonable(payload.get("worktree_scope")),
+        "payload": _jsonable(payload),
+        "refusal_reason": refusal,
+        "approval_required_reason": approval_required_reason,
+        "execution": {
+            "state": execution_state,
+            "message": execution_message,
+        },
+        "result": None,
+    }
+    _write_record(record)
+    return {
+        "ok": refusal is None,
+        "task_id": task_id,
+        "status": status,
+        "refusal_reason": refusal,
+        "approval_required_reason": approval_required_reason,
+    }
+
+
+def get_task_status(task_id: str) -> dict[str, Any]:
+    record = _read_record(task_id)
+    return {
+        "ok": True,
+        "task_id": record["task_id"],
+        "status": record["status"],
+        "created_at": record["created_at"],
+        "updated_at": record["updated_at"],
+        "refusal_reason": record.get("refusal_reason"),
+        "approval_required_reason": record.get("approval_required_reason"),
+        "execution": record.get("execution"),
+    }
+
+
+def get_task_result(task_id: str) -> dict[str, Any]:
+    record = _read_record(task_id)
+    return {
+        "ok": True,
+        "task_id": record["task_id"],
+        "status": record["status"],
+        "result": record.get("result"),
+        "refusal_reason": record.get("refusal_reason"),
+        "approval_required_reason": record.get("approval_required_reason"),
+        "execution": record.get("execution"),
+        "record": record,
+    }
+
+
+def update_task_lifecycle(
+    task_id: str,
+    *,
+    status: str | None = None,
+    execution_state: str | None = None,
+    result: dict[str, Any] | None = None,
+    execution_updates: dict[str, Any] | None = None,
+) -> bool:
+    """Update canonical task lifecycle fields without changing task metadata.
+
+    This helper is intentionally internal to the bridge module and is not part
+    of the MCP tool facade. It preserves the original contract/payload and any
+    unknown record metadata by touching only status, result, execution, and
+    updated_at. Refused records are terminal and cannot be promoted to
+    completed by mirror flows.
+    """
+    record = _read_record(task_id)
+    if record.get("status") == "refused" and status == "completed":
+        return False
+
+    updated = dict(record)
+    if status is not None:
+        updated["status"] = str(status)
+
+    if result is not None:
+        updated["result"] = _jsonable(result)
+
+    if execution_state is not None or execution_updates:
+        execution = updated.get("execution")
+        if not isinstance(execution, dict):
+            execution = {}
+        else:
+            execution = dict(execution)
+        if execution_state is not None:
+            execution["state"] = str(execution_state)
+        if execution_updates:
+            for key, value in execution_updates.items():
+                execution[str(key)] = _jsonable(value)
+        updated["execution"] = execution
+
+    if updated == record:
+        return True
+
+    updated["updated_at"] = _now_iso()
+    _write_record(updated)
+    return True
+
+
+def mirror_task_result(
+    task_id: str,
+    response: str,
+    *,
+    platform: str = "discord",
+    source: str = "discord_gateway_final_response",
+) -> bool:
+    """Internally mirror a delivered gateway final response into a task record.
+
+    This is deliberately not exposed as an MCP tool. It updates only the
+    lifecycle/result fields so the submitted contract and metadata remain
+    intact.
+    """
+    response = str(response or "").strip()
+    if not response:
+        return False
+    if _is_infrastructure_error_response(response):
+        return False
+
+    result = {
+        "source": str(source or "discord_gateway_final_response"),
+        "platform": platform,
+        "response": response,
+    }
+    return update_task_lifecycle(
+        task_id,
+        status="completed",
+        execution_state="completed",
+        result=result,
+        execution_updates={
+            "result_mirrored_by": "Hermes",
+            "message": "Final Discord response mirrored to bridge record.",
+        },
+    )
+
+
+def _matching_task_ids_for_code(recent: list[dict[str, Any]], code: str) -> list[str]:
+    code = str(code or "").upper().strip()
+    if not code:
+        return []
+    bridge_prefix = f"HERMES-BRIDGE-{code}"
+    matches = [
+        task
+        for task in recent
+        if str(task.get("title") or "").upper().startswith((code, bridge_prefix))
+    ]
+    active_matches = [task for task in matches if task.get("status") != "refused"]
+    if active_matches:
+        matches = active_matches
+    return [str(task.get("task_id") or "") for task in matches if task.get("task_id")]
+
+
+def _resolve_unique_code_candidates(
+    recent: list[dict[str, Any]], codes: list[str]
+) -> tuple[str | None, bool]:
+    candidates: set[str] = set()
+    for code in codes:
+        matches = _matching_task_ids_for_code(recent, code)
+        if len(matches) == 1:
+            candidates.add(matches[0])
+        elif len(matches) > 1:
+            return None, True
+
+    if len(candidates) == 1:
+        return next(iter(candidates)), False
+    if len(candidates) > 1:
+        return None, True
+    return None, False
+
+
+def resolve_task_id_from_text(text: str, *, limit: int = 100) -> str | None:
+    """Resolve a bridge task reference from gateway-visible text.
+
+    Exact ``mcp_...`` ids win. Otherwise, full work codes such as
+    ``002DV-B2`` or ``HERMES-BRIDGE-002DW-A`` are tried before broad base
+    codes such as ``002DV``. Code references resolve only when exactly one
+    recent bridge task title starts with that code (or the canonical
+    ``HERMES-BRIDGE-<code>`` prefix).
+    """
+    text = str(text or "")
+    if not text.strip():
+        return None
+
+    exact_ids: list[str] = []
+    for task_id in dict.fromkeys(_TASK_ID_PATTERN.findall(text)):
+        try:
+            _read_record(task_id)
+            exact_ids.append(task_id)
+        except MCPBridgeError:
+            continue
+    if len(exact_ids) == 1:
+        return exact_ids[0]
+    if len(exact_ids) > 1:
+        return None
+
+    full_codes = list(
+        dict.fromkeys(match.group(1).upper() for match in _FULL_CODE_PATTERN.finditer(text))
+    )
+    broad_codes = list(
+        dict.fromkeys(match.group(1).upper() for match in _LEADING_CODE_PATTERN.finditer(text))
+    )
+    if not full_codes and not broad_codes:
+        return None
+
+    try:
+        recent = list_recent_tasks(limit=limit).get("tasks", [])
+    except MCPBridgeError:
+        return None
+
+    specific_codes = [code for code in full_codes if "-" in code]
+    resolved, ambiguous = _resolve_unique_code_candidates(recent, specific_codes)
+    if resolved or ambiguous:
+        return resolved
+
+    resolved, ambiguous = _resolve_unique_code_candidates(recent, broad_codes)
+    if resolved or ambiguous:
+        return resolved
+    return None
+
+
+def list_recent_tasks(limit: int = 20) -> dict[str, Any]:
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        raise MCPBridgeError("limit must be an integer") from None
+    if limit < 1 or limit > 100:
+        raise MCPBridgeError("limit must be between 1 and 100")
+
+    directory = _task_dir()
+    records: list[dict[str, Any]] = []
+    if directory.exists():
+        for path in directory.glob("mcp_*.json"):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            records.append(record)
+    records.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
+    return {
+        "ok": True,
+        "tasks": [
+            {
+                "task_id": record.get("task_id"),
+                "status": record.get("status"),
+                "created_at": record.get("created_at"),
+                "updated_at": record.get("updated_at"),
+                "project": record.get("project"),
+                "title": record.get("title"),
+                "refusal_reason": record.get("refusal_reason"),
+                "approval_required_reason": record.get("approval_required_reason"),
+            }
+            for record in records[:limit]
+        ],
+    }

--- a/gateway/mcp_bridge_tools.py
+++ b/gateway/mcp_bridge_tools.py
@@ -1,0 +1,198 @@
+"""Task-level tool facade for the local Hermes MCP bridge MVP."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.mcp_bridge import (
+    MCPBridgeError,
+    get_task_result as _get_task_result,
+    get_task_status as _get_task_status,
+    list_recent_tasks as _list_recent_tasks,
+    submit_task as _submit_task,
+)
+
+
+SUBMIT_TASK_SCHEMA = {
+    "name": "submit_task",
+    "description": (
+        "Validate and record a local Hermes task contract for future "
+        "orchestration. This tool does not execute tasks or expose shell, "
+        "filesystem mutation, secrets, network, Docker, external code agent, "
+        "paid API, external service, production deployment, or "
+        "git push/reset/clean capabilities. The canonical "
+        "contract is the top-level object below; the FastMCP wrapper also "
+        "accepts exactly one remote-client compatibility envelope named "
+        "payload, args, or arguments containing that same object."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "project": {"type": "string"},
+            "mode": {"type": "string"},
+            "repo_scope": {"type": ["string", "object"]},
+            "worktree_scope": {"type": ["string", "object"]},
+            "task_contract": {"type": ["string", "object"]},
+            "allowed_actions": {"type": "array", "items": {"type": "string"}},
+            "forbidden_actions": {"type": "array", "items": {"type": "string"}},
+            "return_format": {"type": ["string", "object"]},
+            "approvals": {"type": ["array", "object"]},
+            "expected_branch": {"type": "string"},
+            "expected_head": {"type": "string"},
+            "stop_conditions": {"type": ["array", "object", "string"]},
+            "worker_selection_guidance": {"type": ["object", "string"]},
+            "training_notes": {"type": ["object", "string"]},
+        },
+        "required": [
+            "title",
+            "project",
+            "mode",
+            "task_contract",
+            "allowed_actions",
+            "forbidden_actions",
+            "return_format",
+        ],
+        "anyOf": [
+            {"required": ["repo_scope"]},
+            {"required": ["worktree_scope"]},
+        ],
+    },
+}
+
+GET_TASK_STATUS_SCHEMA = {
+    "name": "get_task_status",
+    "description": "Return the stored status for a local bridge task.",
+    "parameters": {
+        "type": "object",
+        "properties": {"task_id": {"type": "string"}},
+        "required": ["task_id"],
+    },
+}
+
+GET_TASK_RESULT_SCHEMA = {
+    "name": "get_task_result",
+    "description": "Return the stored result/refusal/accepted record for a local bridge task.",
+    "parameters": {
+        "type": "object",
+        "properties": {"task_id": {"type": "string"}},
+        "required": ["task_id"],
+    },
+}
+
+LIST_RECENT_TASKS_SCHEMA = {
+    "name": "list_recent_tasks",
+    "description": "List recently recorded local bridge tasks. No task execution is performed.",
+    "parameters": {
+        "type": "object",
+        "properties": {"limit": {"type": "integer", "minimum": 1, "maximum": 100}},
+    },
+}
+
+TOOL_SCHEMAS = (
+    SUBMIT_TASK_SCHEMA,
+    GET_TASK_STATUS_SCHEMA,
+    GET_TASK_RESULT_SCHEMA,
+    LIST_RECENT_TASKS_SCHEMA,
+)
+
+
+_SUBMIT_TASK_ENVELOPE_KEYS = ("payload", "args", "arguments")
+_SUBMIT_TASK_TOP_LEVEL_KEYS = frozenset(SUBMIT_TASK_SCHEMA["parameters"]["properties"])
+
+
+def _compact_mapping(values: dict[str, Any]) -> dict[str, Any]:
+    """Drop only None values while preserving empty lists/dicts/strings for validation."""
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def normalize_submit_task_arguments(args: dict[str, Any]) -> dict[str, Any]:
+    """Normalize supported local/remote submit_task argument shapes.
+
+    Local MCP clients call the FastMCP wrapper with the task fields as top-level
+    keyword arguments. Some remote clients wrap tool arguments under an envelope
+    key such as ``payload``, ``args``, or ``arguments``. Accept exactly one safe
+    envelope or the existing top-level shape, but fail closed on ambiguous or
+    malformed containers before the core bridge persists a record.
+    """
+    if not isinstance(args, dict):
+        raise MCPBridgeError("submit_task arguments must be an object")
+
+    compact_args = _compact_mapping(args)
+    present_envelopes = [key for key in _SUBMIT_TASK_ENVELOPE_KEYS if key in args]
+    if len(present_envelopes) > 1:
+        raise MCPBridgeError("submit_task arguments include multiple envelopes")
+
+    if present_envelopes:
+        envelope_key = present_envelopes[0]
+        top_level_keys = set(compact_args) - {envelope_key}
+        if top_level_keys:
+            raise MCPBridgeError("submit_task envelope cannot be mixed with top-level fields")
+        envelope = args[envelope_key]
+        if not isinstance(envelope, dict):
+            raise MCPBridgeError(f"submit_task {envelope_key} envelope must be an object")
+        normalized = _compact_mapping(envelope)
+    else:
+        normalized = compact_args
+
+    if not normalized:
+        raise MCPBridgeError("submit_task arguments must include task fields")
+
+    nested_envelopes = set(normalized) & set(_SUBMIT_TASK_ENVELOPE_KEYS)
+    if nested_envelopes:
+        keys = ", ".join(sorted(nested_envelopes))
+        raise MCPBridgeError(f"submit_task nested envelopes are not supported: {keys}")
+
+    unknown_keys = set(normalized) - _SUBMIT_TASK_TOP_LEVEL_KEYS
+    if unknown_keys:
+        keys = ", ".join(sorted(unknown_keys))
+        raise MCPBridgeError(f"submit_task arguments include unknown fields: {keys}")
+
+    return normalized
+
+
+def _error(exc: Exception) -> dict[str, Any]:
+    return {"ok": False, "error": str(exc)}
+
+
+def submit_task(args: dict[str, Any]) -> dict[str, Any]:
+    try:
+        return _submit_task(normalize_submit_task_arguments(args))
+    except MCPBridgeError as exc:
+        return _error(exc)
+
+
+def get_task_status(args: dict[str, Any]) -> dict[str, Any]:
+    try:
+        if not isinstance(args, dict):
+            raise MCPBridgeError("get_task_status arguments must be an object")
+        return _get_task_status(str(args.get("task_id", "")))
+    except MCPBridgeError as exc:
+        return _error(exc)
+
+
+def get_task_result(args: dict[str, Any]) -> dict[str, Any]:
+    try:
+        if not isinstance(args, dict):
+            raise MCPBridgeError("get_task_result arguments must be an object")
+        return _get_task_result(str(args.get("task_id", "")))
+    except MCPBridgeError as exc:
+        return _error(exc)
+
+
+def list_recent_tasks(args: dict[str, Any] | None = None) -> dict[str, Any]:
+    args = args or {}
+    try:
+        if not isinstance(args, dict):
+            raise MCPBridgeError("list_recent_tasks arguments must be an object")
+        return _list_recent_tasks(args.get("limit", 20))
+    except MCPBridgeError as exc:
+        return _error(exc)
+
+
+TOOL_HANDLERS = {
+    "submit_task": submit_task,
+    "get_task_status": get_task_status,
+    "get_task_result": get_task_result,
+    "list_recent_tasks": list_recent_tasks,
+}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11108,10 +11108,13 @@ Examples:
         "mcp",
         help="Manage MCP servers and run Hermes as an MCP server",
         description=(
-            "Manage MCP server connections and run Hermes as an MCP server.\n\n"
+            "Manage MCP server connections and run Hermes MCP surfaces.\n\n"
             "MCP servers provide additional tools via the Model Context Protocol.\n"
-            "Use 'hermes mcp add' to connect to a new server, or\n"
-            "'hermes mcp serve' to expose Hermes conversations over MCP."
+            "Use 'hermes mcp add' to connect to a new server. Use\n"
+            "'hermes mcp bridge-http' for the restricted Streamable HTTP\n"
+            "task-contract surface at /mcp. 'hermes mcp serve' is the\n"
+            "full/shared surface and must not be used as the ChatGPT/default\n"
+            "external config unless full/shared exposure is explicitly approved."
         ),
     )
     mcp_sub = mcp_parser.add_subparsers(dest="mcp_action")
@@ -11127,6 +11130,37 @@ Examples:
         help="Enable verbose logging on stderr",
     )
     _add_accept_hooks_flag(mcp_serve_p)
+
+    mcp_bridge_http_p = mcp_sub.add_parser(
+        "bridge-http",
+        help="Run the restricted bridge-only MCP server over Streamable HTTP",
+        description=(
+            "Run Hermes as a restricted bridge-only MCP server over Streamable "
+            "HTTP. This exposes only the task-contract tools at /mcp."
+        ),
+    )
+    mcp_bridge_http_p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging on stderr",
+    )
+    mcp_bridge_http_p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind for Streamable HTTP (default: 127.0.0.1)",
+    )
+    mcp_bridge_http_p.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind for Streamable HTTP (default: 8000)",
+    )
+    mcp_bridge_http_p.add_argument(
+        "--path",
+        default="/mcp",
+        help="Streamable HTTP endpoint path (default: /mcp)",
+    )
 
     mcp_add_p = mcp_sub.add_parser(
         "add", help="Add an MCP server (discovery-first install)"

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -755,6 +755,16 @@ def mcp_command(args):
         run_mcp_server(verbose=getattr(args, "verbose", False))
         return
 
+    if action == "bridge-http":
+        from mcp_serve import run_bridge_http_mcp_server
+        run_bridge_http_mcp_server(
+            verbose=getattr(args, "verbose", False),
+            host=getattr(args, "host", "127.0.0.1"),
+            port=getattr(args, "port", 8000),
+            path=getattr(args, "path", "/mcp"),
+        )
+        return
+
     handlers = {
         "add": cmd_mcp_add,
         "remove": cmd_mcp_remove,
@@ -775,6 +785,7 @@ def mcp_command(args):
         cmd_mcp_list()
         print(color("  Commands:", Colors.CYAN))
         _info("hermes mcp serve                              Run as MCP server")
+        _info("hermes mcp bridge-http                        Run restricted Streamable HTTP MCP server at /mcp")
         _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
         _info("hermes mcp add <name> --preset <preset>       Add from a known preset")

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -1,7 +1,7 @@
 """
 Hermes MCP Server — expose messaging conversations as MCP tools.
 
-Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
+Starts a stdio MCP server that lets any MCP client (local coding agents,
 etc.) list conversations, read message history, send messages, poll for live
 events, and manage approval requests across all connected platforms.
 
@@ -38,9 +38,26 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("hermes.mcp_serve")
+
+MCP_TRANSPORT_STREAMABLE_HTTP = "streamable-http"
+MCP_BRIDGE_HTTP_DEFAULT_HOST = "127.0.0.1"
+MCP_BRIDGE_HTTP_DEFAULT_PORT = 8000
+MCP_BRIDGE_HTTP_DEFAULT_PATH = "/mcp"
+
+BRIDGE_ONLY_MCP_TOOLS = frozenset({
+    "submit_task",
+    "get_task_status",
+    "get_task_result",
+    "list_recent_tasks",
+})
+
+_MCP_HTTP_TRANSPORT_ALIASES = {
+    MCP_TRANSPORT_STREAMABLE_HTTP: MCP_TRANSPORT_STREAMABLE_HTTP,
+    "streamable_http": MCP_TRANSPORT_STREAMABLE_HTTP,
+}
 
 # ---------------------------------------------------------------------------
 # Lazy MCP SDK import
@@ -446,6 +463,179 @@ class EventBridge:
 # ---------------------------------------------------------------------------
 # MCP Server
 # ---------------------------------------------------------------------------
+
+def _register_mcp_bridge_tools(mcp: "FastMCP") -> None:
+    """Register the local task-level MCP bridge tools."""
+    from gateway.mcp_bridge import MCPBridgeError
+    from gateway.mcp_bridge_tools import (
+        TOOL_HANDLERS,
+        TOOL_SCHEMAS,
+        normalize_submit_task_arguments,
+    )
+
+    descriptions = {schema["name"]: schema["description"] for schema in TOOL_SCHEMAS}
+
+    @mcp.tool(description=descriptions["submit_task"])
+    def submit_task(
+        title: Optional[str] = None,
+        project: Optional[str] = None,
+        mode: Optional[str] = None,
+        task_contract: Optional[Any] = None,
+        allowed_actions: Optional[list[str]] = None,
+        forbidden_actions: Optional[list[str]] = None,
+        return_format: Optional[Any] = None,
+        repo_scope: Optional[Any] = None,
+        worktree_scope: Optional[Any] = None,
+        approvals: Optional[Any] = None,
+        expected_branch: Optional[str] = None,
+        expected_head: Optional[str] = None,
+        stop_conditions: Optional[Any] = None,
+        worker_selection_guidance: Optional[Any] = None,
+        training_notes: Optional[Any] = None,
+        payload: Optional[dict[str, Any]] = None,
+        args: Optional[dict[str, Any]] = None,
+        arguments: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Validate and record a local Hermes task contract for future orchestration."""
+        raw_arguments = {
+            "title": title,
+            "project": project,
+            "mode": mode,
+            "repo_scope": repo_scope,
+            "worktree_scope": worktree_scope,
+            "task_contract": task_contract,
+            "allowed_actions": allowed_actions,
+            "forbidden_actions": forbidden_actions,
+            "return_format": return_format,
+            "approvals": approvals,
+            "expected_branch": expected_branch,
+            "expected_head": expected_head,
+            "stop_conditions": stop_conditions,
+            "worker_selection_guidance": worker_selection_guidance,
+            "training_notes": training_notes,
+            "payload": payload,
+            "args": args,
+            "arguments": arguments,
+        }
+        compact_arguments = {
+            key: value for key, value in raw_arguments.items() if value is not None
+        }
+        try:
+            normalized_payload = normalize_submit_task_arguments(compact_arguments)
+            response = TOOL_HANDLERS["submit_task"](normalized_payload)
+        except MCPBridgeError as exc:
+            response = {"ok": False, "error": str(exc)}
+        return json.dumps(response, indent=2)
+
+    @mcp.tool(description=descriptions["get_task_status"])
+    def get_task_status(task_id: str) -> str:
+        """Return the stored status for a local bridge task."""
+        return json.dumps(TOOL_HANDLERS["get_task_status"]({"task_id": task_id}), indent=2)
+
+    @mcp.tool(description=descriptions["get_task_result"])
+    def get_task_result(task_id: str) -> str:
+        """Return the stored result/refusal/accepted record for a local bridge task."""
+        return json.dumps(TOOL_HANDLERS["get_task_result"]({"task_id": task_id}), indent=2)
+
+    @mcp.tool(description=descriptions["list_recent_tasks"])
+    def list_recent_tasks(limit: int = 20) -> str:
+        """List recently recorded local bridge tasks. No task execution is performed."""
+        return json.dumps(TOOL_HANDLERS["list_recent_tasks"]({"limit": limit}), indent=2)
+
+
+def create_bridge_only_mcp_server(
+    *,
+    host: str = MCP_BRIDGE_HTTP_DEFAULT_HOST,
+    port: int = MCP_BRIDGE_HTTP_DEFAULT_PORT,
+    path: str = MCP_BRIDGE_HTTP_DEFAULT_PATH,
+) -> "FastMCP":
+    """Create a restricted MCP server with only task-contract bridge tools.
+
+    This mode intentionally excludes messaging, approval, shell, filesystem,
+    secret, deployment, Docker, external code agent, paid API, external service,
+    and production deployment surfaces.
+    """
+    if not _MCP_SERVER_AVAILABLE:
+        raise ImportError(
+            "MCP server requires the 'mcp' package. "
+            f"Install with: {sys.executable} -m pip install 'mcp'"
+        )
+
+    path = _normalize_mcp_path(path)
+    mcp = FastMCP(
+        "hermes-bridge",
+        instructions=(
+            "Restricted Hermes task-contract MCP bridge. Records local task "
+            "contracts and status only; it does not execute tasks, send "
+            "messages, manage approvals, expose shell/files/secrets, or call "
+            "external code agent, paid API, Docker, external service, or "
+            "production deployment systems."
+        ),
+        host=host,
+        port=port,
+        streamable_http_path=path,
+    )
+    _register_mcp_bridge_tools(mcp)
+    return mcp
+
+
+def create_bridge_only_http_mcp_server(
+    *,
+    host: str = MCP_BRIDGE_HTTP_DEFAULT_HOST,
+    port: int = MCP_BRIDGE_HTTP_DEFAULT_PORT,
+    path: str = MCP_BRIDGE_HTTP_DEFAULT_PATH,
+) -> "FastMCP":
+    """Create the restricted Streamable HTTP MCP server without starting it."""
+    return create_bridge_only_mcp_server(host=host, port=port, path=path)
+
+
+def _normalize_bridge_http_transport(transport: str) -> str:
+    """Normalize the restricted HTTP transport selector.
+
+    Unknown transports fail closed so the bridge-only HTTP command cannot drift
+    into SSE, stdio, or any future transport with different exposure semantics.
+    """
+    if not isinstance(transport, str):
+        raise ValueError("MCP bridge HTTP transport must be a string")
+
+    normalized = transport.strip().lower()
+    if normalized not in _MCP_HTTP_TRANSPORT_ALIASES:
+        known = ", ".join(sorted(_MCP_HTTP_TRANSPORT_ALIASES))
+        raise ValueError(
+            f"Unknown MCP bridge HTTP transport: {transport!r}. "
+            f"Expected one of: {known}"
+        )
+    return _MCP_HTTP_TRANSPORT_ALIASES[normalized]
+
+
+def _normalize_mcp_path(path: str) -> str:
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("MCP bridge HTTP path must be a non-empty string")
+    normalized = path.strip()
+    if not normalized.startswith("/"):
+        raise ValueError("MCP bridge HTTP path must start with '/'")
+    return normalized
+
+
+def _mcp_tool_names(mcp: "FastMCP") -> set[str]:
+    """Return registered FastMCP tool names for pre-serve inventory checks."""
+    tool_manager = getattr(mcp, "_tool_manager", None)
+    if tool_manager is None or not hasattr(tool_manager, "list_tools"):
+        raise RuntimeError("Cannot inspect MCP tool inventory before serving")
+    return {tool.name for tool in tool_manager.list_tools()}
+
+
+def assert_bridge_only_tool_inventory(mcp: "FastMCP") -> None:
+    """Fail closed unless the restricted MCP server exposes exactly task tools."""
+    actual = _mcp_tool_names(mcp)
+    if actual != BRIDGE_ONLY_MCP_TOOLS:
+        missing = sorted(BRIDGE_ONLY_MCP_TOOLS - actual)
+        unexpected = sorted(actual - BRIDGE_ONLY_MCP_TOOLS)
+        raise RuntimeError(
+            "Restricted MCP bridge inventory mismatch before serving "
+            f"(missing={missing}, unexpected={unexpected})"
+        )
+
 
 def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     """Create and return the Hermes MCP server with all tools registered."""
@@ -895,3 +1085,37 @@ def run_mcp_server(verbose: bool = False) -> None:
         asyncio.run(_run())
     except KeyboardInterrupt:
         bridge.stop()
+
+
+def run_bridge_http_mcp_server(
+    *,
+    verbose: bool = False,
+    host: str = MCP_BRIDGE_HTTP_DEFAULT_HOST,
+    port: int = MCP_BRIDGE_HTTP_DEFAULT_PORT,
+    path: str = MCP_BRIDGE_HTTP_DEFAULT_PATH,
+    transport: str = MCP_TRANSPORT_STREAMABLE_HTTP,
+) -> None:
+    """Start the restricted bridge-only MCP server over Streamable HTTP."""
+    if not _MCP_SERVER_AVAILABLE:
+        print(
+            "Error: MCP server requires the 'mcp' package.\n"
+            f"Install with: {sys.executable} -m pip install 'mcp'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    normalized_transport = _normalize_bridge_http_transport(transport)
+    normalized_path = _normalize_mcp_path(path)
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+    else:
+        logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    server = create_bridge_only_http_mcp_server(
+        host=host,
+        port=port,
+        path=normalized_path,
+    )
+    assert_bridge_only_tool_inventory(server)
+    server.run(transport=normalized_transport)

--- a/tests/gateway/test_mcp_bridge.py
+++ b/tests/gateway/test_mcp_bridge.py
@@ -1,0 +1,758 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gateway import mcp_bridge
+from gateway import mcp_bridge_tools
+
+
+def _valid_payload() -> dict:
+    return {
+        "title": "Add focused local validation tests",
+        "project": "hermes-agent",
+        "mode": "local",
+        "worktree_scope": {
+            "path": "/tmp/hermes-worktree",
+            "expected_branch": "task/example",
+        },
+        "task_contract": {
+            "objective": "Implement focused validation around the local bridge without executing tasks.",
+            "acceptance_criteria": ["records accepted task", "returns stored status"],
+        },
+        "allowed_actions": ["read repo files", "edit scoped bridge files", "run targeted tests"],
+        "forbidden_actions": ["read_secret", "run_shell", "git_push", "docker_run"],
+        "return_format": {"sections": ["summary", "tests"]},
+    }
+
+
+def test_submit_task_records_accepted_without_execution(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    response = mcp_bridge.submit_task(_valid_payload())
+
+    assert response["ok"] is True
+    assert response["status"] == "accepted"
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["status"] == "accepted"
+    assert status["execution"]["state"] == "not_executed"
+
+    result = mcp_bridge.get_task_result(response["task_id"])
+    assert result["result"] is None
+    assert result["record"]["payload"]["title"] == "Add focused local validation tests"
+
+    stored = list((tmp_path / "hermes" / "mcp_bridge_tasks").glob("mcp_*.json"))
+    assert len(stored) == 1
+    assert json.loads(stored[0].read_text())["status"] == "accepted"
+
+
+def test_submit_task_refuses_missing_scope(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload.pop("worktree_scope")
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "repo_scope or worktree_scope" in response["refusal_reason"]
+
+
+def test_submit_task_refuses_missing_forbidden_actions_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload.pop("forbidden_actions")
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "missing required field(s): forbidden_actions" in response["refusal_reason"]
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "not_executed"
+
+
+def test_submit_task_accepts_empty_forbidden_actions_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["forbidden_actions"] = []
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "accepted"
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "not_executed"
+
+
+def test_submit_task_refuses_unsafe_allowed_actions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["allowed_actions"] = ["run_shell", "read repo files"]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "run_shell" in response["refusal_reason"]
+
+
+def test_submit_task_refuses_complete_unsafe_contract_with_empty_forbidden_actions(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["forbidden_actions"] = []
+    payload["task_contract"] = {
+        "objective": "Use run_shell to mutate local files without invoking bridge dispatch.",
+        "acceptance_criteria": ["unsafe capability is refused before execution"],
+    }
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "run_shell" in response["refusal_reason"]
+    assert "missing required field" not in response["refusal_reason"]
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "not_executed"
+
+
+def test_submit_task_routes_risky_local_write_for_approval(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": "Use a direct write_file operation for a scoped local bridge test fixture.",
+        "acceptance_criteria": ["task is routed for approval and remains unexecuted"],
+    }
+    payload["allowed_actions"] = ["direct write_file in scoped test fixture"]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "approval_required"
+    assert response["refusal_reason"] is None
+    assert "local file writes" in response["approval_required_reason"]
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "approval_required"
+
+
+@pytest.mark.parametrize(
+    ("allowed_action", "reason_fragment"),
+    [
+        ("raw shell access", "raw shell"),
+        ("read_secret", "secret"),
+        ("read .env token files", "secret"),
+        ("git_push", "git_push"),
+        ("external_service_import", "external_service_import"),
+        ("docker_run", "docker_run"),
+        ("external_code_agent_direct", "external code agent"),
+    ],
+)
+def test_submit_task_refuses_required_unsafe_requests(
+    tmp_path, monkeypatch, allowed_action, reason_fragment
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["allowed_actions"] = [allowed_action]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert reason_fragment in response["refusal_reason"]
+
+
+@pytest.mark.parametrize(
+    ("allowed_action", "reason_fragment"),
+    [
+        ("direct arbitrary write_file", "local file writes"),
+        ("git reset --hard", "destructive git"),
+        ("git push to task branch", "destructive git"),
+        ("external service write records", "external service writes"),
+        ("production deploy", "production actions"),
+        ("paid_api_call", "paid API"),
+        ("network access", "network access"),
+    ],
+)
+def test_submit_task_routes_required_risky_requests_for_approval(
+    tmp_path, monkeypatch, allowed_action, reason_fragment
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["allowed_actions"] = [allowed_action]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "approval_required"
+    assert response["refusal_reason"] is None
+    assert reason_fragment in response["approval_required_reason"]
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "approval_required"
+
+
+def test_submit_task_does_not_refuse_forbidden_unsafe_actions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["forbidden_actions"] = [
+        "run_shell",
+        "direct arbitrary write_file",
+        "read_secret",
+        "git reset",
+        "docker_run",
+        "paid_api_call",
+    ]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "accepted"
+    status = mcp_bridge.get_task_status(response["task_id"])
+    assert status["execution"]["state"] == "not_executed"
+
+
+def test_submit_task_accepts_classifier_calibration_prohibitions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["title"] = "Calibrate MCP bridge refusal classifier"
+    payload["task_contract"] = {
+        "objective": "Make the local classifier field-aware without weakening safety.",
+        "acceptance_criteria": ["dangerous terms in prohibition fields do not cause refusal"],
+        "safety_statement": "Do not expose direct command execution or raw shell access.",
+    }
+    payload["allowed_actions"] = ["read scoped bridge files", "edit classifier tests"]
+    payload["forbidden_actions"] = [
+        "run_shell",
+        "raw shell access",
+        "read .env token files",
+        "git reset --hard",
+        "external service write records",
+        "restart services",
+    ]
+    payload["stop_conditions"] = [
+        "Stop if direct command execution is requested.",
+        "Stop before any service restart or submit_task reproduction.",
+    ]
+    payload["training_notes"] = (
+        "Dangerous capabilities are examples of refused behavior only: docker_run, "
+        "paid_api_call, git_push, and read_secret."
+    )
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "accepted"
+
+
+def test_submit_task_accepts_bounded_read_only_health_diagnostic(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["title"] = "Inspect MCP bridge health diagnostics"
+    payload["task_contract"] = {
+        "objective": (
+            "Diagnose a local/public tunnel health issue for exact endpoint "
+            "https://bridge.example.test and local origin http://127.0.0.1:8765."
+        ),
+        "acceptance_criteria": [
+            "check process status only",
+            "list MCP tools only",
+            "inventory local status endpoints only",
+        ],
+    }
+    payload["allowed_actions"] = [
+        "read repo files",
+        "check process status for local bridge only",
+        "inventory exact endpoint https://bridge.example.test/health",
+        "list_tools against exact origin http://127.0.0.1:8765/mcp",
+    ]
+    payload["forbidden_actions"] = [
+        "submit_task",
+        "settings changes",
+        "tool changes",
+        "restart services",
+        "reload services",
+        "mutations",
+    ]
+    payload["stop_conditions"] = [
+        "Stop before any mutation, settings change, tool change, submit_task, restart, or reload.",
+        "Stop if a host outside bridge.example.test or 127.0.0.1 is needed.",
+    ]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "accepted"
+
+
+def test_submit_task_accepts_exact_scope_read_only_public_route_inventory_plan(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["title"] = "Inventory MCP public route exposure"
+    payload["task_contract"] = {
+        "objective": (
+            "Build a read-only inventory plan for public MCP route exposure at exact origin "
+            "https://bridge.example.test/mcp and local endpoint http://127.0.0.1:8765/mcp."
+        ),
+        "acceptance_criteria": [
+            "list route names only",
+            "record no setting changes",
+            "do not submit_task against the live bridge",
+        ],
+    }
+    payload["allowed_actions"] = [
+        "read repo route definitions",
+        "inventory exact endpoint https://bridge.example.test/mcp",
+        "list_tools for exact local endpoint http://127.0.0.1:8765/mcp",
+    ]
+    payload["forbidden_actions"] = ["submit_task", "restart services", "reload services", "mutations"]
+    payload["stop_conditions"] = [
+        "Stop before any mutation, settings change, tool change, submit_task, restart, or reload."
+    ]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] in {"accepted", "approval_required"}
+    assert response["refusal_reason"] is None
+
+
+def test_submit_task_refuses_direct_command_execution_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": "Expose direct command execution for workers through the bridge.",
+        "acceptance_criteria": ["raw shell access works"],
+    }
+    payload["allowed_actions"] = ["add direct command execution", "raw shell access"]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert "raw shell" in response["refusal_reason"] or "command execution" in response["refusal_reason"]
+
+
+def test_submit_task_refuses_direct_public_mcp_tool_exposure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": "Add public MCP tools for raw shell and direct write_file capabilities.",
+        "acceptance_criteria": ["new public MCP tools are visible"],
+    }
+    payload["allowed_actions"] = ["add public MCP tools", "expose raw shell through MCP"]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "MCP tool" in response["refusal_reason"] or "raw shell" in response["refusal_reason"]
+
+
+def test_submit_task_refuses_direct_approval_bypass_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": "Bypass approval and restart the bridge process immediately.",
+        "acceptance_criteria": ["approval gate is skipped"],
+    }
+    payload["allowed_actions"] = ["bypass approval", "restart bridge process"]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert response["status"] == "refused"
+    assert "approval" in response["refusal_reason"]
+
+
+@pytest.mark.parametrize(
+    ("contract_text", "allowed_action", "reason_fragment"),
+    [
+        ("Read protected private configuration material from user config.", "read .env token files", "secret"),
+        ("Add and remove MCP tools without exact approval.", "add MCP tools", "MCP tool"),
+        ("Restart services while bypassing approval.", "bypass approval", "approval"),
+    ],
+)
+def test_submit_task_refuses_required_safety_matrix(
+    tmp_path, monkeypatch, contract_text, allowed_action, reason_fragment
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": contract_text,
+        "acceptance_criteria": ["unsafe request is refused"],
+    }
+    payload["allowed_actions"] = [allowed_action]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert reason_fragment in response["refusal_reason"]
+
+
+@pytest.mark.parametrize(
+    ("contract_text", "allowed_action", "reason_fragment"),
+    [
+        ("Call network endpoints as needed to debug the bridge.", "network access", "network access"),
+        ("Run destructive git cleanup with approval routing.", "git reset --hard", "destructive git"),
+        ("Run destructive git cleanup without exact approval yet.", "git reset --hard", "destructive git"),
+        (
+            "Perform external service production writes with approval routing.",
+            "external service production write",
+            "production actions",
+        ),
+        (
+            "Perform external service production writes without exact approval yet.",
+            "external service production write",
+            "production actions",
+        ),
+        ("Restart and reload services after approval.", "restart services", "restart"),
+        ("Refresh tunnel process after approval.", "refresh bridge process", "restart/reload"),
+        ("Reproduce submit_task against a staged task store after approval.", "submit_task reproduction", "submit_task"),
+    ],
+)
+def test_submit_task_routes_required_safety_matrix_for_approval(
+    tmp_path, monkeypatch, contract_text, allowed_action, reason_fragment
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["task_contract"] = {
+        "objective": contract_text,
+        "acceptance_criteria": ["unsafe request is routed for approval"],
+    }
+    payload["allowed_actions"] = [allowed_action]
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is True
+    assert response["status"] == "approval_required"
+    assert response["refusal_reason"] is None
+    assert reason_fragment in response["approval_required_reason"]
+
+
+def test_submit_task_refuses_broad_cross_repo_scope(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _valid_payload()
+    payload["worktree_scope"] = "all repos under the user home"
+
+    response = mcp_bridge.submit_task(payload)
+
+    assert response["ok"] is False
+    assert "cross-repo" in response["refusal_reason"]
+
+
+def test_list_recent_tasks_is_local_and_limited(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    first = mcp_bridge.submit_task({**_valid_payload(), "title": "First local bridge task"})
+    second = mcp_bridge.submit_task({**_valid_payload(), "title": "Second local bridge task"})
+
+    listed = mcp_bridge.list_recent_tasks(limit=1)
+
+    assert listed["ok"] is True
+    assert len(listed["tasks"]) == 1
+    assert listed["tasks"][0]["task_id"] in {first["task_id"], second["task_id"]}
+
+
+def test_tool_facade_returns_errors_for_unknown_task(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    response = mcp_bridge_tools.get_task_status({"task_id": "mcp_missing"})
+
+    assert response["ok"] is False
+    assert "not found" in response["error"]
+
+
+def test_mirror_task_result_updates_only_result_execution_and_updated_at(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+    before = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+
+    mirrored = mcp_bridge.mirror_task_result(
+        submitted["task_id"],
+        "Final answer from Discord.",
+        platform="discord",
+    )
+
+    assert mirrored is True
+    after = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+    changed_keys = {key for key in after if after.get(key) != before.get(key)}
+    assert changed_keys == {"status", "result", "execution", "updated_at"}
+    assert after["payload"] == before["payload"]
+    assert after["status"] == "completed"
+    assert after["result"] == {
+        "source": "discord_gateway_final_response",
+        "platform": "discord",
+        "response": "Final answer from Discord.",
+    }
+    assert after["execution"]["state"] == "completed"
+    assert after["execution"]["result_mirrored_by"] == "Hermes"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "HTTP 401 from provider while sending final response.",
+        "token_invalidated",
+        "token-revoked during delivery",
+        "invalidated oauth credentials",
+        "authentication token invalidated",
+        "provider authentication failed",
+        "no credentials stored for Discord provider",
+        "refresh_token_reused",
+    ],
+)
+def test_mirror_task_result_rejects_infrastructure_errors_on_fresh_record(
+    tmp_path, monkeypatch, response
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+
+    mirrored = mcp_bridge.mirror_task_result(submitted["task_id"], response, platform="discord")
+
+    assert mirrored is False
+    record = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+    assert record["status"] == "accepted"
+    assert record["result"] is None
+    assert record["execution"]["state"] == "not_executed"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "HTTP 401",
+        "token_invalidated",
+        "provider authentication failed",
+        "no credentials stored",
+        "refresh_token_reused",
+    ],
+)
+def test_mirror_task_result_infrastructure_errors_do_not_overwrite_completed_result(
+    tmp_path, monkeypatch, response
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+    assert mcp_bridge.mirror_task_result(
+        submitted["task_id"],
+        "SUCCESS: meaningful completed task report.",
+        platform="discord",
+    )
+    before = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+
+    mirrored = mcp_bridge.mirror_task_result(submitted["task_id"], response, platform="discord")
+
+    assert mirrored is False
+    after = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+    assert after == before
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "SUCCESS: implemented source-only guard and targeted tests.",
+        "BLOCKED: stopped because the requested file was outside the allowed scope.",
+        "FAILED: validation found a real regression in the requested behavior.",
+    ],
+)
+def test_mirror_task_result_preserves_normal_task_reports(tmp_path, monkeypatch, response):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+
+    mirrored = mcp_bridge.mirror_task_result(submitted["task_id"], response, platform="discord")
+
+    assert mirrored is True
+    record = mcp_bridge.get_task_result(submitted["task_id"])["record"]
+    assert record["status"] == "completed"
+    assert record["execution"]["state"] == "completed"
+    assert record["result"]["response"] == response
+
+
+def test_resolve_task_id_from_text_matches_exact_mcp_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        f"please finish {submitted['task_id']} and report back"
+    )
+
+    assert resolved == submitted["task_id"]
+
+
+def test_resolve_task_id_from_text_matches_unique_leading_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(
+        {**_valid_payload(), "title": "002BV Discord mirror implementation"}
+    )
+
+    resolved = mcp_bridge.resolve_task_id_from_text("Please work on 002BV.")
+
+    assert resolved == submitted["task_id"]
+
+
+def test_resolve_task_id_from_text_ambiguous_prefix_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    first = mcp_bridge.submit_task({**_valid_payload(), "title": "002BV first task"})
+    second = mcp_bridge.submit_task({**_valid_payload(), "title": "002BV second task"})
+
+    resolved = mcp_bridge.resolve_task_id_from_text("Please work on 002BV.")
+
+    assert resolved is None
+    assert mcp_bridge.get_task_result(first["task_id"])["result"] is None
+    assert mcp_bridge.get_task_result(second["task_id"])["result"] is None
+
+
+def test_resolve_task_id_from_text_ignores_refused_duplicate_when_one_active_match(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    title = "002EA define accepted read-only diagnostic task classes"
+    refused_payload = {**_valid_payload(), "title": title}
+    refused_payload.pop("allowed_actions")
+    refused = mcp_bridge.submit_task(refused_payload)
+    active_payload = {**_valid_payload(), "title": title}
+    active_payload["task_contract"] = {
+        "objective": "Use a direct write_file operation for a scoped local bridge test fixture.",
+        "acceptance_criteria": ["task is routed for approval and remains unexecuted"],
+    }
+    active_payload["allowed_actions"] = ["direct write_file in scoped test fixture"]
+    active = mcp_bridge.submit_task(active_payload)
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        "Ю Одобрявам 002EA define accepted read-only diagnostic task classes"
+    )
+
+    assert refused["status"] == "refused"
+    assert active["status"] == "approval_required"
+    assert resolved == active["task_id"]
+
+
+def test_resolve_task_id_from_text_multiple_non_refused_matches_fail_closed(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    first = mcp_bridge.submit_task({**_valid_payload(), "title": "002EA first active task"})
+    second = mcp_bridge.submit_task({**_valid_payload(), "title": "002EA second active task"})
+    refused_payload = {**_valid_payload(), "title": "002EA refused duplicate"}
+    refused_payload.pop("allowed_actions")
+    refused = mcp_bridge.submit_task(refused_payload)
+
+    resolved = mcp_bridge.resolve_task_id_from_text("Please continue 002EA.")
+
+    assert refused["status"] == "refused"
+    assert resolved is None
+    assert mcp_bridge.get_task_result(first["task_id"])["result"] is None
+    assert mcp_bridge.get_task_result(second["task_id"])["result"] is None
+
+
+def test_resolve_task_id_from_text_without_marker_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task({**_valid_payload(), "title": "002BV bridge task"})
+
+    resolved = mcp_bridge.resolve_task_id_from_text("normal unrelated Discord chatter")
+
+    assert resolved is None
+    assert mcp_bridge.get_task_result(submitted["task_id"])["result"] is None
+
+
+def test_resolve_task_id_from_text_prefers_exact_mcp_id_over_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    code_task = mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-B2 code task"})
+    exact_task = mcp_bridge.submit_task({**_valid_payload(), "title": "unrelated exact task"})
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        f"Use 002DV-B2 but actually mirror {exact_task['task_id']}."
+    )
+
+    assert resolved == exact_task["task_id"]
+    assert resolved != code_task["task_id"]
+
+
+def test_resolve_task_id_from_text_matches_full_code_before_broad_ambiguity(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-A lifecycle helpers"})
+    mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-B1 local runner plan"})
+    b2 = mcp_bridge.submit_task(
+        {**_valid_payload(), "title": "002DV-B2 accepted read-only local runner source implementation tests"}
+    )
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        "Одобрявам 002DV-B2 accepted read-only local runner source implementation tests"
+    )
+
+    assert resolved == b2["task_id"]
+
+
+def test_resolve_task_id_from_text_matches_longer_full_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-B2 accepted read-only local runner"})
+    b2a = mcp_bridge.submit_task(
+        {**_valid_payload(), "title": "002DV-B2-A commit accepted read-only local runner source/tests"}
+    )
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        "002DV-B2-A commit accepted read-only local runner source/tests"
+    )
+
+    assert resolved == b2a["task_id"]
+
+
+def test_resolve_task_id_from_text_matches_hermes_bridge_full_code(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    dwa = mcp_bridge.submit_task(
+        {
+            **_valid_payload(),
+            "title": "HERMES-BRIDGE-002DW-A Discord approval continuation task_id preservation",
+        }
+    )
+    mcp_bridge.submit_task(
+        {**_valid_payload(), "title": "HERMES-BRIDGE-002DW-B follow-up bridge task"}
+    )
+
+    resolved = mcp_bridge.resolve_task_id_from_text(
+        "Approved HERMES-BRIDGE-002DW-A full-code resolver tests."
+    )
+
+    assert resolved == dwa["task_id"]
+
+
+def test_resolve_task_id_from_text_keeps_broad_code_ambiguous(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    first = mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-A lifecycle helpers"})
+    second = mcp_bridge.submit_task({**_valid_payload(), "title": "002DV-B2 local runner"})
+
+    resolved = mcp_bridge.resolve_task_id_from_text("Please continue 002DV.")
+
+    assert resolved is None
+    assert mcp_bridge.get_task_result(first["task_id"])["result"] is None
+    assert mcp_bridge.get_task_result(second["task_id"])["result"] is None
+
+
+def test_get_task_result_returns_mirrored_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    submitted = mcp_bridge.submit_task(_valid_payload())
+
+    mcp_bridge.mirror_task_result(submitted["task_id"], "Delivered response.")
+
+    result = mcp_bridge.get_task_result(submitted["task_id"])
+    assert result["result"]["response"] == "Delivered response."
+
+
+def test_mirror_helper_is_not_exposed_as_mcp_tool():
+    tool_names = {schema["name"] for schema in mcp_bridge_tools.TOOL_SCHEMAS}
+    handler_names = set(mcp_bridge_tools.TOOL_HANDLERS)
+    expected_tool_names = {
+        "submit_task",
+        "get_task_status",
+        "get_task_result",
+        "list_recent_tasks",
+    }
+
+    assert tool_names == expected_tool_names
+    assert handler_names == expected_tool_names
+    assert "mirror_task_result" not in tool_names
+    assert "resolve_task_id_from_text" not in tool_names
+    assert "mirror_task_result" not in handler_names
+    assert "resolve_task_id_from_text" not in handler_names

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -600,3 +600,39 @@ class TestMcpLogin:
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
 
+
+
+
+def test_mcp_bridge_http_dispatches_to_restricted_http_runner(monkeypatch):
+    """bridge-http must dispatch only to the restricted HTTP runner, not full serve."""
+    import sys
+    from hermes_cli.mcp_config import mcp_command
+
+    calls = []
+
+    def fake_run_bridge_http_mcp_server(**kwargs):
+        calls.append(kwargs)
+
+    def fake_run_mcp_server(*args, **kwargs):
+        raise AssertionError("bridge-http must not dispatch to run_mcp_server")
+
+    fake_mcp_serve = types.SimpleNamespace(
+        run_bridge_http_mcp_server=fake_run_bridge_http_mcp_server,
+        run_mcp_server=fake_run_mcp_server,
+    )
+    monkeypatch.setitem(sys.modules, "mcp_serve", fake_mcp_serve)
+
+    mcp_command(_make_args(
+        mcp_action="bridge-http",
+        verbose=True,
+        host="127.0.0.1",
+        port=8765,
+        path="/mcp",
+    ))
+
+    assert calls == [{
+        "verbose": True,
+        "host": "127.0.0.1",
+        "port": 8765,
+        "path": "/mcp",
+    }]

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -21,6 +21,39 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+BRIDGE_TASK_TOOLS = {
+    "submit_task",
+    "get_task_status",
+    "get_task_result",
+    "list_recent_tasks",
+}
+
+PRE_EXISTING_MESSAGING_APPROVAL_TOOLS = {
+    "conversations_list",
+    "conversation_get",
+    "messages_read",
+    "attachments_fetch",
+    "events_poll",
+    "events_wait",
+    "messages_send",
+    "permissions_list_open",
+    "permissions_respond",
+    "channels_list",
+}
+
+FORBIDDEN_RESTRICTED_TOOL_NAMES = PRE_EXISTING_MESSAGING_APPROVAL_TOOLS | {
+    "run_shell",
+    "write_file",
+    "read_secret",
+    "git_push",
+    "docker_run",
+    "external_code_agent_direct",
+    "paid_api_call",
+    "external_service_import",
+    "production_release",
+}
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -209,9 +242,9 @@ def mock_session_db(tmp_path, populated_sessions_dir):
 
 
 class _FakeTool:
-    def __init__(self, fn):
+    def __init__(self, fn, description=None):
         self.name = fn.__name__
-        self.description = inspect.getdoc(fn) or ""
+        self.description = description or inspect.getdoc(fn) or ""
         self.fn = fn
 
 
@@ -219,8 +252,8 @@ class _FakeToolManager:
     def __init__(self):
         self._tools = {}
 
-    def add_tool(self, fn):
-        self._tools[fn.__name__] = _FakeTool(fn)
+    def add_tool(self, fn, description=None):
+        self._tools[fn.__name__] = _FakeTool(fn, description=description)
 
     async def call_tool(self, name, args=None):
         return self._tools[name].fn(**(args or {}))
@@ -231,14 +264,20 @@ class _FakeToolManager:
 
 class _FakeFastMCP:
     def __init__(self, *args, **kwargs):
+        self.init_args = args
+        self.init_kwargs = kwargs
         self._tool_manager = _FakeToolManager()
+        self.run_calls = []
 
-    def tool(self):
+    def tool(self, **kwargs):
         def decorator(fn):
-            self._tool_manager.add_tool(fn)
+            self._tool_manager.add_tool(fn, description=kwargs.get("description"))
             return fn
 
         return decorator
+
+    def run(self, **kwargs):
+        self.run_calls.append(kwargs)
 
 
 @pytest.fixture
@@ -1237,3 +1276,147 @@ class TestEventBridgePollE2E:
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL
         assert POLL_INTERVAL == 0.2
+
+
+
+# ---------------------------------------------------------------------------
+# Restricted bridge-http MCP surface / no-start adapter tests
+# ---------------------------------------------------------------------------
+
+class TestRestrictedBridgeHttpAdapter:
+    def test_bridge_only_mode_exposes_exactly_task_tools(self, monkeypatch):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "FastMCP", _FakeFastMCP)
+
+        server = mcp_serve.create_bridge_only_mcp_server()
+        tool_names = {tool.name for tool in server._tool_manager.list_tools()}
+
+        assert tool_names == BRIDGE_TASK_TOOLS
+        assert PRE_EXISTING_MESSAGING_APPROVAL_TOOLS.isdisjoint(tool_names)
+        assert FORBIDDEN_RESTRICTED_TOOL_NAMES.isdisjoint(tool_names)
+
+    def test_bridge_http_factory_uses_bridge_only_factory_not_full_factory(self, monkeypatch):
+        import mcp_serve
+
+        calls = []
+
+        def fake_bridge_factory(**kwargs):
+            calls.append(kwargs)
+            server = _FakeFastMCP()
+            for name in BRIDGE_TASK_TOOLS:
+                server._tool_manager._tools[name] = _FakeTool(lambda: None)
+                server._tool_manager._tools[name].name = name
+            return server
+
+        def fail_full_factory(*args, **kwargs):
+            raise AssertionError("restricted HTTP path must not call create_mcp_server")
+
+        monkeypatch.setattr(mcp_serve, "create_bridge_only_mcp_server", fake_bridge_factory)
+        monkeypatch.setattr(mcp_serve, "create_mcp_server", fail_full_factory)
+
+        server = mcp_serve.create_bridge_only_http_mcp_server(
+            host="127.0.0.1",
+            port=8123,
+            path="/mcp",
+        )
+
+        assert server is not None
+        assert calls == [{"host": "127.0.0.1", "port": 8123, "path": "/mcp"}]
+
+    def test_bridge_http_inventory_is_exact_restricted_tool_set(self, monkeypatch):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "FastMCP", _FakeFastMCP)
+
+        server = mcp_serve.create_bridge_only_http_mcp_server(path="/mcp")
+        tool_names = {tool.name for tool in server._tool_manager.list_tools()}
+
+        assert tool_names == BRIDGE_TASK_TOOLS
+        assert PRE_EXISTING_MESSAGING_APPROVAL_TOOLS.isdisjoint(tool_names)
+        assert FORBIDDEN_RESTRICTED_TOOL_NAMES.isdisjoint(tool_names)
+        assert server.init_kwargs["streamable_http_path"] == "/mcp"
+
+    def test_run_bridge_http_uses_restricted_factory_and_streamable_http(self, monkeypatch):
+        import mcp_serve
+
+        server = _FakeFastMCP()
+        for name in BRIDGE_TASK_TOOLS:
+            server._tool_manager._tools[name] = _FakeTool(lambda: None)
+            server._tool_manager._tools[name].name = name
+        calls = []
+
+        def fake_bridge_http_factory(**kwargs):
+            calls.append(kwargs)
+            return server
+
+        def fail_stdio_runner(*args, **kwargs):
+            raise AssertionError("bridge-http must not call run_mcp_server")
+
+        def fail_full_factory(*args, **kwargs):
+            raise AssertionError("bridge-http must not call create_mcp_server")
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "create_bridge_only_http_mcp_server", fake_bridge_http_factory)
+        monkeypatch.setattr(mcp_serve, "run_mcp_server", fail_stdio_runner)
+        monkeypatch.setattr(mcp_serve, "create_mcp_server", fail_full_factory)
+
+        mcp_serve.run_bridge_http_mcp_server(
+            host="127.0.0.1",
+            port=8123,
+            path="/mcp",
+        )
+
+        assert calls == [{"host": "127.0.0.1", "port": 8123, "path": "/mcp"}]
+        assert server.run_calls == [{"transport": "streamable-http"}]
+
+    def test_bridge_http_inventory_guard_fails_closed_on_extra_tool(self, monkeypatch):
+        import mcp_serve
+
+        server = _FakeFastMCP()
+        for name in BRIDGE_TASK_TOOLS | {"messages_send"}:
+            server._tool_manager._tools[name] = _FakeTool(lambda: None)
+            server._tool_manager._tools[name].name = name
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(
+            mcp_serve,
+            "create_bridge_only_http_mcp_server",
+            lambda **kwargs: server,
+        )
+
+        with pytest.raises(RuntimeError, match="inventory mismatch"):
+            mcp_serve.run_bridge_http_mcp_server()
+
+        assert server.run_calls == []
+
+    def test_bridge_http_unknown_transport_values_fail_closed(self):
+        import mcp_serve
+
+        for transport in ["stdio", "sse", "http", "", None]:
+            with pytest.raises(ValueError, match="transport"):
+                mcp_serve._normalize_bridge_http_transport(transport)
+
+    def test_bridge_http_submit_task_wrapper_exposes_remote_envelope_parameters(self, monkeypatch):
+        import mcp_serve
+
+        monkeypatch.setattr(mcp_serve, "_MCP_SERVER_AVAILABLE", True)
+        monkeypatch.setattr(mcp_serve, "FastMCP", _FakeFastMCP)
+
+        server = mcp_serve.create_bridge_only_http_mcp_server(path="/mcp")
+        submit_fn = server._tool_manager._tools["submit_task"].fn
+        params = inspect.signature(submit_fn).parameters
+
+        assert {"payload", "args", "arguments"}.issubset(params)
+        for name in [
+            "title",
+            "project",
+            "mode",
+            "task_contract",
+            "allowed_actions",
+            "forbidden_actions",
+            "return_format",
+        ]:
+            assert params[name].default is None


### PR DESCRIPTION
## Summary
- Adds a restricted MCP bridge task interface with four public tools:
  - submit_task
  - get_task_status
  - get_task_result
  - list_recent_tasks
- Records submitted tasks for out-of-band processing instead of exposing execution primitives.
- Adds bridge-only HTTP serving/config support for the restricted task interface.

## Safety model
- Public bridge tool inventory is exact-four.
- The bridge exposes task-level records, not raw execution.
- The bridge does not expose raw shell, direct file writer, secret reader, source-control mutation, external-service write, production deployment, Docker execution, direct external code-agent, or paid API-call tools.
- Unsafe task contracts are classified for human review instead of being executed through MCP.

## Tests
- Covers restricted bridge tool schema and handler inventory.
- Covers task submission, status, result, and recent-task listing behavior.
- Covers safety classification for unsafe task contracts.
- Confirms exact-four public MCP bridge surface.