### PR TITLE
fix(ssh): support macOS tar during file sync

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -133,6 +134,133 @@ class TestControlSocketPath:
         assert SSHEnvironment(host="h", user="u", port=23).control_socket != base
         assert SSHEnvironment(host="h", user="v", port=22).control_socket != base
         assert SSHEnvironment(host="g", user="u", port=22).control_socket != base
+
+
+class TestSSHBulkUploadTarCompatibility:
+    def _make_env(self, supports_no_overwrite_dir):
+        env = object.__new__(SSHEnvironment)
+        env.host = "h"
+        env.user = "u"
+        env.port = 22
+        env.key_path = ""
+        env.control_socket = Path("/tmp/hermes-test.sock")
+        env._remote_home = "/Users/devhub"
+        env._build_ssh_command = lambda extra_args=None: ["ssh"] + (extra_args or [])
+        env._remote_tar_supports_no_overwrite_dir = lambda: supports_no_overwrite_dir
+        return env
+
+    def _fake_popen(self, calls):
+        class Proc:
+            def __init__(self, args):
+                self.args = args
+                self.returncode = 0
+                self.stdout = MagicMock()
+                self.stderr = MagicMock()
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return (b"", b"")
+
+            def wait(self):
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        def _popen(args, **kwargs):
+            calls.append(args)
+            return Proc(args)
+
+        return _popen
+
+    def test_bulk_upload_uses_gnu_no_overwrite_dir_when_supported(self, tmp_path, monkeypatch):
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        env = self._make_env(supports_no_overwrite_dir=True)
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", lambda *a, **k: subprocess.CompletedProcess([], 0))
+        popen_calls = []
+        monkeypatch.setattr("tools.environments.ssh.subprocess.Popen", self._fake_popen(popen_calls))
+
+        env._ssh_bulk_upload([(str(src), "/Users/devhub/.hermes/file.txt")])
+
+        assert any("tar xf - --no-overwrite-dir -C /Users/devhub/.hermes" in call for call in popen_calls)
+
+    def test_bulk_upload_falls_back_for_bsd_tar_without_no_overwrite_dir(self, tmp_path, monkeypatch):
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        env = self._make_env(supports_no_overwrite_dir=False)
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", lambda *a, **k: subprocess.CompletedProcess([], 0))
+        popen_calls = []
+        monkeypatch.setattr("tools.environments.ssh.subprocess.Popen", self._fake_popen(popen_calls))
+
+        env._ssh_bulk_upload([(str(src), "/Users/devhub/.hermes/file.txt")])
+
+        assert any("tar xmf - -C /Users/devhub/.hermes" in call for call in popen_calls)
+        assert not any("--no-overwrite-dir" in " ".join(call) for call in popen_calls)
+
+    def test_bulk_upload_archives_files_not_staging_root(self, tmp_path, monkeypatch):
+        src = tmp_path / "file.txt"
+        src.write_text("data")
+        env = self._make_env(supports_no_overwrite_dir=False)
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", lambda *a, **k: subprocess.CompletedProcess([], 0))
+        popen_calls = []
+        monkeypatch.setattr("tools.environments.ssh.subprocess.Popen", self._fake_popen(popen_calls))
+
+        env._ssh_bulk_upload([(str(src), "/Users/devhub/.hermes/nested/file.txt")])
+
+        tar_cmd = popen_calls[0]
+        assert tar_cmd[:4] == ["tar", "-chf", "-", "-C"]
+        assert tar_cmd[-1] == "nested/file.txt"
+        assert "." not in tar_cmd[5:]
+
+    def _make_probe_env(self):
+        env = object.__new__(SSHEnvironment)
+        env._remote_tar_no_overwrite_dir_support = None
+        env._build_ssh_command = lambda extra_args=None: ["ssh"] + (extra_args or [])
+        return env
+
+    def test_remote_tar_support_probe_caches_success(self, monkeypatch):
+        env = self._make_probe_env()
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", fake_run)
+
+        assert env._remote_tar_supports_no_overwrite_dir() is True
+        assert env._remote_tar_supports_no_overwrite_dir() is True
+        assert len(calls) == 1
+        assert calls[0][0][-1] == "tar --no-overwrite-dir --help >/dev/null 2>&1"
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+    def test_remote_tar_support_probe_caches_failure(self, monkeypatch):
+        env = self._make_probe_env()
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 1)
+
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", fake_run)
+
+        assert env._remote_tar_supports_no_overwrite_dir() is False
+        assert env._remote_tar_supports_no_overwrite_dir() is False
+        assert len(calls) == 1
+
+    def test_remote_tar_support_probe_falls_back_on_exception(self, monkeypatch):
+        env = self._make_probe_env()
+
+        def fake_run(*args, **kwargs):
+            raise OSError("ssh failed")
+
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", fake_run)
+
+        assert env._remote_tar_supports_no_overwrite_dir() is False
+        assert env._remote_tar_no_overwrite_dir_support is False
 
 
 class TestTerminalToolConfig:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -49,6 +49,7 @@ class SSHEnvironment(BaseEnvironment):
         self.user = user
         self.port = port
         self.key_path = key_path
+        self._remote_tar_no_overwrite_dir_support: bool | None = None
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -220,6 +221,7 @@ class SSHEnvironment(BaseEnvironment):
         # that specific error and fall back to a plain copy; all other
         # OSErrors (e.g. disk full, bad path) are re-raised as normal.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
+            staged_relatives: list[str] = []
             for host_path, remote_path in files:
                 try:
                     rel_remote = os.path.relpath(remote_path, base)
@@ -234,6 +236,7 @@ class SSHEnvironment(BaseEnvironment):
                     )
 
                 staged = os.path.join(staging, rel_remote)
+                staged_relatives.append(rel_remote)
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
                 try:
                     os.symlink(os.path.abspath(host_path), staged)
@@ -244,13 +247,27 @@ class SSHEnvironment(BaseEnvironment):
                     else:
                         raise
 
-            tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
+            # Do not archive the staging root itself.  The remote parents are
+            # created above, and including ``.`` lets tar apply the local
+            # staging directory's permissions to an existing remote sync root.
+            # GNU tar's --no-overwrite-dir guards that, but bsdtar has no
+            # equivalent flag; sending only file entries keeps both paths from
+            # clobbering existing directory metadata.
+            tar_cmd = ["tar", "-chf", "-", "-C", staging, *staged_relatives]
             ssh_cmd = self._build_ssh_command()
-            # --no-overwrite-dir prevents tar from overwriting the mode of
-            # existing directories (e.g. /home/<user>) with the staging
-            # directory's mode.  Without this, a umask 002 produces 0775
-            # dirs which breaks sshd StrictModes (refuses authorized_keys).
-            ssh_cmd.append(f"tar xf - --no-overwrite-dir -C {shlex.quote(base)}")
+            # GNU tar supports --no-overwrite-dir, but macOS ships bsdtar,
+            # which rejects that flag. Detect support on the remote side so
+            # SSH workers targeting macOS can still run without a persistent
+            # file-sync warning on every tool call. Keep the safer GNU-tar
+            # flag where available to avoid clobbering directory modes.
+            quoted_base = shlex.quote(base)
+            tar_extract_cmd = f"tar xf - --no-overwrite-dir -C {quoted_base}"
+            if not self._remote_tar_supports_no_overwrite_dir():
+                # bsdtar on macOS also tries to restore mtimes on existing
+                # directories from the archive and exits non-zero when that
+                # is not permitted. -m skips mtime restoration.
+                tar_extract_cmd = f"tar xmf - -C {quoted_base}"
+            ssh_cmd.append(tar_extract_cmd)
 
             tar_proc = subprocess.Popen(
                 tar_cmd,
@@ -299,6 +316,32 @@ class SSHEnvironment(BaseEnvironment):
                 )
 
         logger.debug("SSH: bulk-uploaded %d file(s) via tar pipe", len(files))
+
+    def _remote_tar_supports_no_overwrite_dir(self) -> bool:
+        """Return whether remote tar accepts GNU tar's --no-overwrite-dir."""
+        cached = getattr(self, "_remote_tar_no_overwrite_dir_support", None)
+        if cached is not None:
+            return cached
+
+        cmd = self._build_ssh_command()
+        cmd.append("tar --no-overwrite-dir --help >/dev/null 2>&1")
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                stdin=subprocess.DEVNULL,
+            )
+            supported = result.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            logger.debug(
+                "SSH: remote tar --no-overwrite-dir probe failed; using portable extraction",
+                exc_info=True,
+            )
+            supported = False
+        self._remote_tar_no_overwrite_dir_support = supported
+        return supported
 
     def _ssh_bulk_download(self, dest: Path) -> None:
         """Download remote .hermes/ as a tar archive."""


### PR DESCRIPTION
## Summary
- detect whether the remote `tar` supports GNU `--no-overwrite-dir` before SSH bulk upload extraction
- keep the existing GNU tar behavior when supported
- fall back to macOS/bsdtar-compatible `tar xmf - -C /` when the GNU flag is unavailable
- cache the probe result per SSH environment and cover success/failure/exception paths

## Test Plan
- [x] `python -m pytest tests/tools/test_ssh_environment.py::TestSSHBulkUploadTarCompatibility -q -o 'addopts='`
- [x] `python -m pytest tests/tools/test_ssh_environment.py -q -o 'addopts='`
- [x] `python -m py_compile tools/environments/ssh.py tests/tools/test_ssh_environment.py`
- [x] `git diff --check origin/main..HEAD`

Note: the full SSH environment test file passes with existing pytest thread warnings from older mocked process tests; no new failures were observed.

## Review Focus
- whether `tar xmf - -C /` is the right portable fallback for bsdtar/macOS targets
- whether the per-instance probe cache is acceptable for SSH environment lifetime
