### PR TITLE
feat(send-message): support trigger_agent handoffs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1862,6 +1862,58 @@ async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None
         )
 
 
+def trigger_agent_message(platform: Platform, chat_id: str, text: str, thread_id: str | None = None) -> dict:
+    """Wake a destination gateway session from send_message(trigger_agent=True).
+
+    This is intentionally runner-bound: active handoffs only work in the live
+    gateway process where the destination adapter and event loop exist. Other
+    processes (CLI/cron/tests without a runner) get a stable sanitized error
+    instead of silently claiming an agent was triggered.
+    """
+    runner = _gateway_runner_ref()
+    if runner is None:
+        return {"trigger_error": "no live gateway runner"}
+
+    adapter = runner.adapters.get(platform)
+    if adapter is None:
+        return {"trigger_error": "no live adapter"}
+
+    source = adapter.build_source(
+        chat_id=str(chat_id),
+        chat_type="thread" if thread_id else "channel",
+        thread_id=str(thread_id) if thread_id else None,
+        is_bot=True,
+    )
+    event = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+
+    async def _run_trigger() -> None:
+        await adapter.handle_message(event)
+
+    def _schedule_on_loop() -> None:
+        task = asyncio.create_task(_run_trigger())
+        runner._background_tasks.add(task)
+        task.add_done_callback(runner._background_tasks.discard)
+
+    loop = getattr(runner, "_gateway_loop", None)
+    if loop is not None and loop.is_running():
+        loop.call_soon_threadsafe(_schedule_on_loop)
+    else:
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return {"trigger_error": "no live gateway runner"}
+        task = running_loop.create_task(_run_trigger())
+        runner._background_tasks.add(task)
+        task.add_done_callback(runner._background_tasks.discard)
+
+    return {"triggered": True}
+
+
 class GatewayRunner(GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -455,6 +455,155 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_passive_default_does_not_trigger_agent(self):
+        config, _telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("tools.send_message_tool._trigger_gateway_agent") as trigger_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["mirrored"] is True
+        trigger_mock.assert_not_called()
+        mirror_mock.assert_called_once()
+
+    def test_trigger_agent_sends_suppresses_mirror_and_calls_helper(self):
+        config, telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("tools.send_message_tool._trigger_gateway_agent", return_value={"triggered": True}) as trigger_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345:678",
+                        "message": "hello",
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["triggered"] is True
+        assert "mirrored" not in result
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_cfg,
+            "12345",
+            "hello",
+            thread_id="678",
+            media_files=[],
+            force_document=False,
+        )
+        trigger_mock.assert_called_once_with(Platform.TELEGRAM, "12345", "678", "hello")
+        mirror_mock.assert_not_called()
+
+    def test_trigger_agent_string_false_is_passive(self):
+        config, _telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("tools.send_message_tool._trigger_gateway_agent") as trigger_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "hello",
+                        "trigger_agent": "false",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["mirrored"] is True
+        trigger_mock.assert_not_called()
+        mirror_mock.assert_called_once()
+
+    def test_trigger_agent_no_live_runner_returns_sanitized_error(self):
+        config, _telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.run._gateway_runner_ref", lambda: None), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "hello",
+                        "trigger_agent": True,
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["trigger_error"] == "no live gateway runner"
+        mirror_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trigger_agent_message_schedules_internal_event(self):
+        from gateway.run import trigger_agent_message
+
+        source = SimpleNamespace(chat_id="12345", thread_id="678", is_bot=True)
+        adapter = SimpleNamespace(
+            build_source=MagicMock(return_value=source),
+            handle_message=AsyncMock(),
+        )
+        runner = SimpleNamespace(
+            adapters={Platform.TELEGRAM: adapter},
+            _background_tasks=set(),
+            _gateway_loop=None,
+        )
+
+        with patch("gateway.run._gateway_runner_ref", lambda: runner):
+            result = trigger_agent_message(Platform.TELEGRAM, "12345", "hello", thread_id="678")
+            await asyncio.sleep(0)
+
+        assert result == {"triggered": True}
+        adapter.build_source.assert_called_once_with(
+            chat_id="12345",
+            chat_type="thread",
+            thread_id="678",
+            is_bot=True,
+        )
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "hello"
+        assert event.source is source
+        assert event.internal is True
+
+    def test_trigger_agent_missing_adapter_returns_sanitized_error(self):
+        from gateway.run import trigger_agent_message
+
+        runner = SimpleNamespace(adapters={})
+        with patch("gateway.run._gateway_runner_ref", lambda: runner):
+            result = trigger_agent_message(Platform.TELEGRAM, "12345", "hello")
+
+        assert result == {"trigger_error": "no live adapter"}
+
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
         leaked = "very-secret-query-token-123456"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -148,6 +148,10 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+            },
+            "trigger_agent": {
+                "type": "boolean",
+                "description": "When true, a successful platform send also schedules an internal inbound event for the live destination gateway agent. Defaults false for passive notifications and loop prevention."
             }
         },
         "required": []
@@ -178,6 +182,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    trigger_agent = args.get("trigger_agent") is True
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -325,30 +330,50 @@ def _handle_send(args):
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
-        # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:
-            try:
-                from gateway.mirror import mirror_to_session
-                from gateway.session_context import get_session_env
-                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
-                user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
-                if mirror_to_session(
-                    platform_name,
-                    chat_id,
-                    mirror_text,
-                    source_label=source_label,
-                    thread_id=thread_id,
-                    user_id=user_id,
-                ):
-                    result["mirrored"] = True
-            except Exception:
-                pass
+            if trigger_agent:
+                result.update(_trigger_gateway_agent(platform, chat_id, thread_id, mirror_text))
+            else:
+                # Mirror the sent message into the target's gateway session.
+                try:
+                    from gateway.mirror import mirror_to_session
+                    from gateway.session_context import get_session_env
+                    source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
+                    user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+                    if mirror_to_session(
+                        platform_name,
+                        chat_id,
+                        mirror_text,
+                        source_label=source_label,
+                        thread_id=thread_id,
+                        user_id=user_id,
+                    ):
+                        result["mirrored"] = True
+                except Exception:
+                    pass
 
         if isinstance(result, dict) and "error" in result:
             result["error"] = _sanitize_error_text(result["error"])
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _trigger_gateway_agent(platform, chat_id: str, thread_id: str | None, text: str) -> dict:
+    """Schedule an active destination-agent wake-up through the live gateway."""
+    try:
+        from gateway.run import trigger_agent_message
+        trigger_result = trigger_agent_message(platform, chat_id, text, thread_id=thread_id)
+    except Exception as exc:
+        return {"trigger_error": _sanitize_error_text(str(exc))}
+
+    if not isinstance(trigger_result, dict):
+        return {"trigger_error": "invalid trigger result"}
+    if trigger_result.get("error") and "trigger_error" not in trigger_result:
+        trigger_result = {"trigger_error": trigger_result.get("error")}
+    if "trigger_error" in trigger_result:
+        trigger_result["trigger_error"] = _sanitize_error_text(str(trigger_result["trigger_error"]))
+    return trigger_result
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):


### PR DESCRIPTION
## Summary
- add an explicit `trigger_agent` option to the `send_message` tool schema
- preserve existing passive mirror behavior by default
- when `trigger_agent=True`, wake the live destination gateway session by scheduling a synthetic internal `MessageEvent`
- report sanitized trigger errors instead of claiming success when no live gateway runner/adapter exists
- cover passive, active, no-runner, missing-adapter, strict boolean, and internal event scheduling behavior

## Motivation
Cross-platform delivery and cross-channel agent handoff are different operations. Before this change, a source session could visibly send a message into another Hermes channel while the destination agent stayed idle. This patch keeps normal human notifications passive, while giving explicit agent-to-agent handoffs a safe opt-in wake-up path.

## Test Plan
- [x] `python -m pytest tests/tools/test_send_message_tool.py::TestSendMessageTool -q -o 'addopts='`
- [x] `python -m pytest tests/tools/test_send_message_tool.py -q -o 'addopts='`
- [x] `python -m py_compile tools/send_message_tool.py gateway/run.py tests/tools/test_send_message_tool.py`
- [x] `git diff --check origin/main..HEAD`

## Review Focus
- the passive-vs-active handoff split and default `trigger_agent=False` behavior
- live-runner-bound scheduling through `GatewayRunner._gateway_loop`
- whether the returned `trigger_error` strings are appropriate for CLI/no-runner contexts
