### PR TITLE
docs(setup): clarify custom endpoint provider choice

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -106,9 +106,21 @@ Good defaults:
 | **GitHub Copilot** | GitHub Copilot subscription (GPT-5.x, Claude, Gemini, etc.) | OAuth via `hermes model`, or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` |
 | **GitHub Copilot ACP** | Copilot ACP agent backend (spawns local `copilot` CLI) | `hermes model` (requires `copilot` CLI + `copilot login`) |
 | **Vercel AI Gateway** | Vercel AI Gateway routing | Set `AI_GATEWAY_API_KEY` |
-| **Custom Endpoint** | VLLM, SGLang, Ollama, or any OpenAI-compatible API | Set base URL + API key |
+| **Custom Endpoint** | vLLM, SGLang, Ollama, llama.cpp, or another OpenAI-compatible API | Set base URL + API key |
 
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.
+
+:::tip Custom endpoint vs direct provider
+Choose **Custom Endpoint** only when your server speaks the OpenAI-compatible
+API (`/v1/chat/completions`, usually `/v1/models`). That covers local servers
+such as Ollama, vLLM, SGLang, llama.cpp, LM Studio, or proxies like LiteLLM.
+
+Choose a named provider such as **Anthropic**, **Google / Gemini**, **AWS
+Bedrock**, **GitHub Copilot**, or **DeepSeek** when you want Hermes to use that
+provider's native auth, model catalog, request format, and capability handling.
+Those entries may still be "direct" APIs, but they are not the generic custom
+OpenAI-compatible path.
+:::
 
 :::caution Minimum context: 64K tokens
 Hermes Agent requires a model with at least **64,000 tokens** of context. Models with smaller windows cannot maintain enough working memory for multi-step tool-calling workflows and will be rejected at startup. Most hosted models (Claude, GPT, Gemini, Qwen, DeepSeek) meet this easily. If you're running a local model, set its context size to at least 64K (e.g. `--ctx-size 65536` for llama.cpp or `-c 65536` for Ollama).

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -41,9 +41,27 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
 | **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
-| **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
+| **Custom Endpoint** | `hermes model` → choose "Custom endpoint" for an OpenAI-compatible base URL (saved in `config.yaml`) |
 
 For the official API-key path, see the dedicated [Google Gemini guide](/docs/guides/google-gemini).
+
+:::tip Which custom option should I choose?
+**Custom Endpoint** means "generic OpenAI-compatible endpoint." Pick it for
+Ollama, vLLM, SGLang, llama.cpp, LM Studio, LiteLLM, or a hosted proxy that
+accepts OpenAI-style chat-completions requests. You will provide:
+
+- a base URL, usually ending in `/v1`
+- a model id from that server
+- an API key if the server requires one
+
+Named providers such as **Anthropic**, **Google / Gemini**, **AWS Bedrock**,
+**GitHub Copilot**, **DeepSeek**, **Kimi**, and **MiniMax** are direct provider
+integrations. Pick the named provider when you want Hermes to use
+provider-specific auth, native request formats, live model discovery, and
+capability metadata. Do not use Custom Endpoint for a native Anthropic, Gemini,
+Bedrock, or Copilot endpoint unless you are intentionally routing through an
+OpenAI-compatible proxy.
+:::
 
 :::tip Model key alias
 In the `model:` config section, you can use either `default:` or `model:` as the key name for your model ID. Both `model: { default: my-model }` and `model: { model: my-model }` work identically.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -159,7 +159,7 @@ Use this when you want to:
 - log into OAuth-backed providers (Anthropic, Copilot, Codex, Nous Portal)
 - enter or update API keys
 - pick from provider-specific model lists
-- configure a custom/self-hosted endpoint
+- configure a custom/self-hosted OpenAI-compatible endpoint
 - save the new default into config
 
 :::warning hermes model vs /model — know the difference
@@ -168,6 +168,14 @@ Use this when you want to:
 **`/model`** (typed inside an active Hermes chat session) can only **switch between providers and models you've already set up**. It cannot add new providers, run OAuth, or prompt for API keys.
 
 **If you need to add a new provider:** Exit your Hermes session first (`Ctrl+C` or `/quit`), then run `hermes model` from your terminal prompt.
+:::
+
+:::tip Custom endpoint means OpenAI-compatible
+In `hermes model`, choose **Custom endpoint** for local or proxy servers that
+implement OpenAI-style `/v1/chat/completions`, such as Ollama, vLLM, SGLang,
+llama.cpp, LM Studio, or LiteLLM. Choose a named provider instead when the
+service has a native Hermes integration, such as Anthropic, Gemini, Bedrock,
+Copilot, DeepSeek, Kimi, or MiniMax.
 :::
 
 ### `/model` slash command (mid-session)


### PR DESCRIPTION
## Summary
- clarify that Custom Endpoint means an OpenAI-compatible base URL
- distinguish generic custom endpoints from named direct provider integrations
- add the guidance to Quickstart, AI Providers, and the CLI command reference

Closes #25832

## Verification
- git diff --cached --check