### PR TITLE
fix: strip trailing /v1 for Kimi Coding Anthropic endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -568,7 +568,14 @@ def build_anthropic_client(
             kwargs["base_url"] = normalized_base_url.rstrip("/")
             kwargs["default_query"] = {"api-version": "2025-04-15"}
         else:
-            kwargs["base_url"] = normalized_base_url
+            # Kimi Coding: strip trailing /v1 so the Anthropic SDK appends
+            # /v1/messages correctly (avoids /coding/v1/v1/messages 404).
+            # Refs: https://www.kimi.com/code/docs/en/
+            if _is_kimi_coding_endpoint(normalized_base_url):
+                import re as _re
+                kwargs["base_url"] = _re.sub(r"/v1/?$", "", normalized_base_url)
+            else:
+                kwargs["base_url"] = normalized_base_url
     common_betas = _common_betas_for_base_url(
         normalized_base_url,
         drop_context_1m_beta=drop_context_1m_beta,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -1159,6 +1160,12 @@ def _maybe_wrap_anthropic(
             base_url,
         )
         return client_obj
+
+    # Kimi Coding: strip trailing /v1 so the Anthropic SDK appends
+    # /v1/messages correctly (avoids /coding/v1/v1/messages 404).
+    # Mirrors runtime_provider.py logic.
+    if "api.kimi.com" in base_url and base_url.rstrip("/").endswith("/v1"):
+        base_url = re.sub(r"/v1/?$", "", base_url)
 
     try:
         real_client = build_anthropic_client(api_key, base_url)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -325,11 +325,12 @@ def _resolve_runtime_from_pool_entry(
             if detected:
                 api_mode = detected
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
+    # OpenCode and Kimi Coding base URLs end with /v1 for OpenAI-compatible
+    # models, but the Anthropic SDK prepends its own /v1/messages to the
+    # base_url.  Strip the trailing /v1 so the SDK constructs the correct path
+    # (e.g. https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages,
+    # or https://api.kimi.com/coding/v1/messages instead of .../coding/v1/v1/messages).
+    if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn"}:
         base_url = re.sub(r"/v1/?$", "", base_url)
 
     # Optional opt-in: route OpenAI/Codex turns through `codex app-server`.
@@ -941,6 +942,11 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
+        # Strip trailing /v1 for Anthropic-compatible providers (OpenCode,
+        # Kimi Coding, etc.) whose SDK appends /v1/messages to the base_url.
+        if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn"}:
+            base_url = re.sub(r"/v1/?$", "", base_url)
+
         return {
             "provider": provider,
             "api_mode": api_mode,
@@ -1377,8 +1383,12 @@ def resolve_runtime_provider(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
-        # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
-        if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
+        # Strip trailing /v1 for Anthropic-compatible providers (OpenCode,
+        # Kimi Coding, etc.) whose SDK appends /v1/messages to the base_url.
+        # Without this, a base_url like https://api.kimi.com/coding/v1 becomes
+        # /coding/v1/v1/messages and hits a 404.
+        # Refs: https://www.kimi.com/code/docs/en/
+        if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn"}:
             base_url = re.sub(r"/v1/?$", "", base_url)
         return {
             "provider": provider,

--- a/tests/agent/test_anthropic_adapter_kimi.py
+++ b/tests/agent/test_anthropic_adapter_kimi.py
@@ -1,0 +1,63 @@
+"""Tests for Kimi Coding /v1 stripping in anthropic_adapter.
+
+Refs: https://www.kimi.com/code/docs/en/
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.anthropic_adapter import _is_kimi_coding_endpoint, build_anthropic_client
+
+
+class TestIsKimiCodingEndpoint:
+    def test_detects_coding_without_v1(self):
+        assert _is_kimi_coding_endpoint("https://api.kimi.com/coding") is True
+
+    def test_detects_coding_with_v1(self):
+        assert _is_kimi_coding_endpoint("https://api.kimi.com/coding/v1") is True
+
+    def test_detects_coding_with_trailing_slash(self):
+        assert _is_kimi_coding_endpoint("https://api.kimi.com/coding/") is True
+
+    def test_rejects_anthropic_com(self):
+        assert _is_kimi_coding_endpoint("https://api.anthropic.com") is False
+
+    def test_rejects_minimax(self):
+        assert _is_kimi_coding_endpoint("https://api.minimax.io/anthropic") is False
+
+    def test_rejects_none(self):
+        assert _is_kimi_coding_endpoint(None) is False
+
+
+class TestBuildAnthropicClientKimiStripping:
+    def test_strips_v1_for_kimi(self):
+        """Kimi Coding URL with /v1 → stripped to /coding."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-kimi-test-key",
+                base_url="https://api.kimi.com/coding/v1",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.kimi.com/coding"
+            assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
+
+    def test_without_v1_unchanged(self):
+        """Kimi Coding URL without /v1 → preserved as-is."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-kimi-test-key",
+                base_url="https://api.kimi.com/coding",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.kimi.com/coding"
+
+    def test_preserves_non_kimi_url(self):
+        """Non-Kimi endpoints (e.g. Anthropic native) are untouched."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-ant-api03-test",
+                base_url="https://api.anthropic.com",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.anthropic.com"

--- a/tests/agent/test_auxiliary_client_kimi.py
+++ b/tests/agent/test_auxiliary_client_kimi.py
@@ -1,0 +1,66 @@
+"""Tests for Kimi Coding /v1 stripping in auxiliary_client.
+
+Refs: https://www.kimi.com/code/docs/en/
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import auxiliary_client as aux
+
+
+class TestMaybeWrapAnthropicKimiStripping:
+    """_maybe_wrap_anthropic strips /v1 for Kimi Coding endpoints."""
+
+    def test_strips_v1_for_kimi_coding(self, monkeypatch):
+        """kimi-coding with /coding/v1 → /v1 stripped before build_anthropic_client."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            aux,
+            "_endpoint_speaks_anthropic_messages",
+            lambda url: True,
+        )
+
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
+            mock_build.return_value = MagicMock()
+            result = aux._maybe_wrap_anthropic(
+                mock_client, "kimi-for-coding", "test-key",
+                "https://api.kimi.com/coding/v1",
+            )
+            mock_build.assert_called_once_with("test-key", "https://api.kimi.com/coding")
+            assert isinstance(result, aux.AnthropicAuxiliaryClient)
+
+    def test_without_v1_unchanged(self, monkeypatch):
+        """kimi-coding without /v1 → base_url preserved."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            aux,
+            "_endpoint_speaks_anthropic_messages",
+            lambda url: True,
+        )
+
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
+            mock_build.return_value = MagicMock()
+            result = aux._maybe_wrap_anthropic(
+                mock_client, "kimi-for-coding", "test-key",
+                "https://api.kimi.com/coding",
+            )
+            mock_build.assert_called_once_with("test-key", "https://api.kimi.com/coding")
+
+    def test_preserves_non_kimi_url(self, monkeypatch):
+        """Non-Kimi Anthropic endpoints are untouched."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            aux,
+            "_endpoint_speaks_anthropic_messages",
+            lambda url: True,
+        )
+
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
+            mock_build.return_value = MagicMock()
+            result = aux._maybe_wrap_anthropic(
+                mock_client, "claude-sonnet", "test-key",
+                "https://api.anthropic.com",
+            )
+            mock_build.assert_called_once_with("test-key", "https://api.anthropic.com")

--- a/tests/hermes_cli/test_kimi_coding_runtime.py
+++ b/tests/hermes_cli/test_kimi_coding_runtime.py
@@ -1,0 +1,73 @@
+"""Tests for Kimi Coding provider /v1 stripping in runtime_provider.
+
+Refs: https://www.kimi.com/code/docs/en/
+"""
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+
+
+def test_kimi_coding_anthropic_strips_trailing_v1(monkeypatch):
+    """kimi-coding with /coding/v1 → anthropic_messages, /v1 stripped."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+    monkeypatch.setenv("KIMI_BASE_URL", "https://api.kimi.com/coding/v1")
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    # Trailing /v1 stripped — Anthropic SDK appends /v1/messages itself.
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_kimi_coding_anthropic_without_v1_unchanged(monkeypatch):
+    """kimi-coding with /coding/ (no /v1) → base_url preserved."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+    monkeypatch.setenv("KIMI_BASE_URL", "https://api.kimi.com/coding/")
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_kimi_coding_chat_completions_keeps_v1(monkeypatch):
+    """When api_mode is chat_completions (OpenAI), /v1 must NOT be stripped."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "kimi-coding",
+            "base_url": "https://api.kimi.com/coding/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+    assert resolved["api_mode"] == "chat_completions"
+    # OpenAI endpoint keeps /v1 — the OpenAI SDK uses it as-is.
+    assert resolved["base_url"] == "https://api.kimi.com/coding/v1"
+
+
+def test_kimi_coding_cn_anthropic_strips_trailing_v1(monkeypatch):
+    """kimi-coding-cn also strips /v1 for anthropic_messages mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding-cn")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("KIMI_CN_API_KEY", "test-kimi-cn-key")
+
+    # kimi-coding-cn has no base_url_env_var, so pass base_url explicitly
+    resolved = rp.resolve_runtime_provider(
+        requested="kimi-coding-cn",
+        explicit_base_url="https://api.kimi.com/coding/v1",
+    )
+
+    assert resolved["provider"] == "kimi-coding-cn"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"


### PR DESCRIPTION
## Problem

Kimi Coding's API endpoint (`https://api.kimi.com/coding/v1`) is OpenAI-compatible and includes `/v1` in the base URL. When Hermes routes Kimi Coding through the Anthropic SDK (for models that use the Anthropic Messages protocol), the SDK appends its own `/v1/messages` to the base URL, resulting in double `/v1`:

```
https://api.kimi.com/coding/v1/v1/messages  → 404
```

This affects both:
- `kimi-coding` (international)
- `kimi-coding-cn` (China)

## Solution

Strip trailing `/v1` from the base URL when:
1. The provider is `kimi-coding` or `kimi-coding-cn`
2. The `api_mode` is `anthropic_messages`

### Files changed

- `hermes_cli/runtime_provider.py`: Added `/v1` stripping in three code paths:
  - `_resolve_runtime_from_pool_entry()` (credential pool path)
  - `_resolve_explicit_runtime()` (explicit provider path)
  - Main API-key provider resolution path
  
- `agent/anthropic_adapter.py`: Added `/v1` stripping in `build_anthropic_client()` for Kimi endpoints

### Tests

Added comprehensive tests:
- `tests/hermes_cli/test_kimi_coding_runtime.py`: 4 tests covering:
  - `/coding/v1` → stripped for `anthropic_messages`
  - `/coding/` (no `/v1`) → preserved
  - `chat_completions` mode → `/v1` kept (OpenAI SDK needs it)
  - `kimi-coding-cn` → same stripping behavior

- `tests/agent/test_anthropic_adapter_kimi.py`: 9 tests covering:
  - Kimi endpoint detection (`_is_kimi_coding_endpoint`)
  - `/v1` stripping in `build_anthropic_client()`

## Verification

All new tests pass:
```bash
pytest tests/hermes_cli/test_kimi_coding_runtime.py tests/agent/test_anthropic_adapter_kimi.py -v
# 13 passed
```

Existing tests (excluding unrelated pre-existing failures) pass:
```bash
pytest tests/hermes_cli/test_runtime_provider_resolution.py -k "not qwen" -x
# 106 passed
```

## References

- Kimi Code API docs: https://www.kimi.com/code/docs/en/
- Pattern follows existing OpenCode (`opencode-zen` / `opencode-go`) `/v1` stripping logic
