### PR TITLE
fix(gateway): interrupt delegated subagents on shutdown

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2731,6 +2731,21 @@ class GatewayRunner:
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
+        GatewayRunner._interrupt_active_subagents(self, reason)
+
+    def _interrupt_active_subagents(self, reason: str) -> None:
+        """Best-effort process-wide interrupt for delegated child agents."""
+        try:
+            from tools.delegate_tool import interrupt_all_subagents
+
+            count = interrupt_all_subagents(reason)
+            if count:
+                logger.debug(
+                    "Interrupted %d active delegated subagent(s) during shutdown",
+                    count,
+                )
+        except Exception as e:
+            logger.debug("Failed interrupting delegated subagents during shutdown: %s", e)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
@@ -5010,6 +5025,12 @@ class GatewayRunner:
                     logger.error("Failed to launch detached gateway restart: %s", e)
 
             self._finalize_shutdown_agents(active_agents)
+            GatewayRunner._interrupt_active_subagents(
+                self,
+                _INTERRUPT_REASON_GATEWAY_RESTART
+                if self._restart_requested
+                else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+            )
 
             # Also shut down memory providers on idle cached agents.
             # _finalize_shutdown_agents only handles agents that were

--- a/tests/agent/test_delegate_shutdown_interrupt.py
+++ b/tests/agent/test_delegate_shutdown_interrupt.py
@@ -1,0 +1,114 @@
+import threading
+from unittest.mock import MagicMock
+
+import gateway.run as gateway_run
+from tools import delegate_tool
+
+
+def _clear_active_subagents():
+    with delegate_tool._active_subagents_lock:
+        delegate_tool._active_subagents.clear()
+
+
+def test_interrupt_all_subagents_interrupts_registered_children():
+    _clear_active_subagents()
+    child_a = MagicMock()
+    child_b = MagicMock()
+
+    try:
+        with delegate_tool._active_subagents_lock:
+            delegate_tool._active_subagents["sa-a"] = {"agent": child_a}
+            delegate_tool._active_subagents["sa-b"] = {"agent": child_b}
+
+        count = delegate_tool.interrupt_all_subagents("Gateway restarting")
+
+        assert count == 2
+        child_a.interrupt.assert_called_once_with("Gateway restarting")
+        child_b.interrupt.assert_called_once_with("Gateway restarting")
+    finally:
+        _clear_active_subagents()
+
+
+def test_run_single_child_returns_when_parent_is_interrupted(monkeypatch):
+    _clear_active_subagents()
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 5.0)
+
+    released = threading.Event()
+
+    class Parent:
+        _interrupt_requested = True
+        _current_task_id = None
+
+    class Child:
+        tool_progress_callback = None
+        _delegate_saved_tool_names = []
+        _credential_pool = None
+        _subagent_id = "sa-parent-interrupt"
+        _delegate_depth = 1
+        _parent_subagent_id = None
+        _delegate_role = "leaf"
+        model = "test-model"
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_estimated_cost_usd = 0.0
+        session_reasoning_tokens = 0
+
+        def __init__(self):
+            self.interrupt_message = None
+            self.closed = False
+
+        def run_conversation(self, user_message, task_id):
+            released.wait(timeout=5)
+            return {
+                "final_response": "",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 0,
+                "messages": [],
+            }
+
+        def interrupt(self, message=None):
+            self.interrupt_message = message
+            released.set()
+
+        def close(self):
+            self.closed = True
+
+        def get_activity_summary(self):
+            return {"api_call_count": 0, "max_iterations": 1, "current_tool": None}
+
+    parent = Parent()
+    child = Child()
+
+    try:
+        result = delegate_tool._run_single_child(
+            0,
+            "do work",
+            child=child,
+            parent_agent=parent,
+        )
+    finally:
+        released.set()
+        _clear_active_subagents()
+
+    assert result["status"] == "interrupted"
+    assert result["exit_reason"] == "interrupted"
+    assert child.interrupt_message == "Parent agent interrupted"
+    assert child.closed is True
+
+
+def test_gateway_interrupt_running_agents_also_interrupts_registered_subagents(monkeypatch):
+    calls = []
+
+    def _fake_interrupt_all(reason):
+        calls.append(reason)
+        return 1
+
+    monkeypatch.setattr(delegate_tool, "interrupt_all_subagents", _fake_interrupt_all)
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._running_agents = {}
+
+    gateway_run.GatewayRunner._interrupt_running_agents(runner, "Gateway restarting")
+
+    assert calls == ["Gateway restarting"]

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -203,6 +203,29 @@ def interrupt_subagent(subagent_id: str) -> bool:
     return True
 
 
+def interrupt_all_subagents(message: str = "Parent agent interrupted") -> int:
+    """Request every currently registered subagent to stop.
+
+    This is intentionally best-effort. It is used by gateway shutdown/restart
+    paths as a process-wide safety net in addition to parent-agent interrupt
+    propagation.
+    """
+    with _active_subagents_lock:
+        records = list(_active_subagents.items())
+
+    interrupted = 0
+    for subagent_id, record in records:
+        agent = record.get("agent") if isinstance(record, dict) else None
+        if agent is None:
+            continue
+        try:
+            agent.interrupt(message)
+            interrupted += 1
+        except Exception as exc:
+            logger.debug("interrupt_all_subagents(%s) failed: %s", subagent_id, exc)
+    return interrupted
+
+
 def list_active_subagents() -> List[Dict[str, Any]]:
     """Snapshot of the currently running subagent tree.
 
@@ -517,6 +540,10 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+
+
+class _ParentInterruptedError(Exception):
+    """Raised when delegate_task should stop waiting for a child agent."""
 
 
 # ---------------------------------------------------------------------------
@@ -1506,23 +1533,46 @@ def _run_single_child(
 
         _child_future = _timeout_executor.submit(_run_with_thread_capture)
         try:
-            result = _child_future.result(timeout=child_timeout)
+            deadline = time.monotonic() + child_timeout
+            while True:
+                if getattr(parent_agent, "_interrupt_requested", False) is True:
+                    raise _ParentInterruptedError("Parent agent interrupted")
+
+                remaining = deadline - time.monotonic()
+                try:
+                    result = _child_future.result(timeout=max(0.0, min(0.5, remaining)))
+                    break
+                except FuturesTimeoutError:
+                    if remaining <= 0:
+                        raise
         except Exception as _timeout_exc:
+            is_interrupted = isinstance(_timeout_exc, _ParentInterruptedError)
+            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
             # Signal the child to stop so its thread can exit cleanly.
             try:
                 if hasattr(child, "interrupt"):
-                    child.interrupt()
+                    interrupt_message = str(_timeout_exc) if is_interrupted else None
+                    if interrupt_message is None:
+                        child.interrupt()
+                    else:
+                        try:
+                            child.interrupt(interrupt_message)
+                        except TypeError:
+                            child.interrupt()
                 elif hasattr(child, "_interrupt_requested"):
                     child._interrupt_requested = True
             except Exception:
                 pass
 
-            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
                 task_index,
-                "timed out" if is_timeout else f"raised {type(_timeout_exc).__name__}",
+                (
+                    "interrupted by parent"
+                    if is_interrupted
+                    else "timed out" if is_timeout else f"raised {type(_timeout_exc).__name__}"
+                ),
                 duration,
             )
 
@@ -1557,16 +1607,40 @@ def _run_single_child(
                     child_progress_cb(
                         "subagent.complete",
                         preview=(
-                            f"Timed out after {duration}s"
+                            "Interrupted by parent agent"
+                            if is_interrupted
+                            else f"Timed out after {duration}s"
                             if is_timeout
                             else str(_timeout_exc)
                         ),
-                        status="timeout" if is_timeout else "error",
+                        status=(
+                            "interrupted"
+                            if is_interrupted
+                            else "timeout" if is_timeout else "error"
+                        ),
                         duration_seconds=duration,
                         summary="",
                     )
                 except Exception:
                     pass
+
+            try:
+                _child_future.cancel()
+            except Exception:
+                pass
+
+            if is_interrupted:
+                return {
+                    "task_index": task_index,
+                    "status": "interrupted",
+                    "summary": None,
+                    "error": "Parent agent interrupted -- child was asked to stop",
+                    "exit_reason": "interrupted",
+                    "api_calls": child_api_calls,
+                    "duration_seconds": duration,
+                    "_child_role": getattr(child, "_delegate_role", None),
+                    "diagnostic_path": diagnostic_path,
+                }
 
             if is_timeout:
                 if child_api_calls == 0:
@@ -1601,7 +1675,10 @@ def _run_single_child(
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
-            _timeout_executor.shutdown(wait=False)
+            try:
+                _timeout_executor.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                _timeout_executor.shutdown(wait=False)
 
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, "_flush"):
@@ -2089,7 +2166,9 @@ def delegate_task(
         completed_count = 0
         spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
 
-        with ThreadPoolExecutor(max_workers=max_children) as executor:
+        executor = ThreadPoolExecutor(max_workers=max_children)
+        abandon_pending = False
+        try:
             futures = {}
             for i, t, child in children:
                 future = executor.submit(
@@ -2147,6 +2226,12 @@ def delegate_task(
                             }
                         results.append(entry)
                         completed_count += 1
+                    for f in pending:
+                        try:
+                            f.cancel()
+                        except Exception:
+                            pass
+                    abandon_pending = True
                     break
 
                 from concurrent.futures import wait as _cf_wait, FIRST_COMPLETED
@@ -2199,6 +2284,12 @@ def delegate_task(
                             )
                         except Exception as e:
                             logger.debug("Spinner update_text failed: %s", e)
+
+        finally:
+            try:
+                executor.shutdown(wait=not abandon_pending, cancel_futures=abandon_pending)
+            except TypeError:
+                executor.shutdown(wait=not abandon_pending)
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])


### PR DESCRIPTION
Closes #26315.\n\n## Summary\n- add a process-wide helper to interrupt registered delegated subagents\n- have gateway shutdown/restart call that helper as a safety net before adapter teardown\n- make delegate_task stop waiting for child futures when the parent agent is interrupted, including batch delegation\n\n## Tests\n- python -m pytest -o addopts= tests\\agent\\test_delegate_shutdown_interrupt.py -q --tb=short\n- python -m pytest -o addopts= tests\\gateway\\test_session_race_guard.py::test_shutdown_skips_sentinel tests\\gateway\\test_shutdown_cache_cleanup.py -q --tb=short\n- python -m pytest -o addopts= tests\\agent\\test_subagent_stop_hook.py tests\\cli\\test_cli_interrupt_subagent.py -q --tb=short\n- python -m ruff check tools\\delegate_tool.py gateway\\run.py tests\\agent\\test_delegate_shutdown_interrupt.py\n- git diff --check