### PR TITLE
fix(delegate): honor custom provider api mode for direct endpoints

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -922,6 +922,55 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    @patch("hermes_cli.config.load_config")
+    def test_direct_endpoint_uses_named_custom_provider_api_mode(self, mock_load_config):
+        parent = _make_mock_parent(depth=0)
+        mock_load_config.return_value = {
+            "custom_providers": [
+                {
+                    "name": "ccr",
+                    "base_url": "https://open.bigmodel.cn/api/anthropic",
+                    "api_mode": "anthropic_messages",
+                }
+            ]
+        }
+        cfg = {
+            "model": "glm-4.6",
+            "provider": "ccr",
+            "base_url": "https://open.bigmodel.cn/api/anthropic",
+            "api_key": "custom-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
+    @patch("hermes_cli.config.load_config")
+    def test_direct_endpoint_uses_provider_schema_api_mode_by_base_url(
+        self,
+        mock_load_config,
+    ):
+        parent = _make_mock_parent(depth=0)
+        mock_load_config.return_value = {
+            "providers": {
+                "zhipu-anthropic": {
+                    "base_url": "https://open.bigmodel.cn/api/anthropic",
+                    "transport": "anthropic_messages",
+                }
+            }
+        }
+        cfg = {
+            "model": "glm-4.6",
+            "base_url": "https://open.bigmodel.cn/api/anthropic/",
+            "api_key": "custom-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2333,6 +2333,54 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
+_DIRECT_ENDPOINT_API_MODES = frozenset(
+    {
+        "chat_completions",
+        "codex_responses",
+        "anthropic_messages",
+        "bedrock_converse",
+        "codex_app_server",
+    }
+)
+
+
+def _configured_direct_endpoint_api_mode(
+    configured_provider: Optional[str],
+    configured_base_url: str,
+) -> Optional[str]:
+    """Return api_mode declared for a matching custom provider, if any."""
+    provider_key = (configured_provider or "").strip().lower()
+    base_url = (configured_base_url or "").strip().rstrip("/").lower()
+    if not provider_key and not base_url:
+        return None
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+
+        providers = get_compatible_custom_providers(load_config())
+    except Exception as exc:
+        logger.debug("Could not inspect custom providers for delegation api_mode: %s", exc)
+        return None
+
+    for entry in providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_names = {
+            str(entry.get("provider_key") or "").strip().lower(),
+            str(entry.get("name") or "").strip().lower(),
+        }
+        entry_base_url = str(entry.get("base_url") or "").strip().rstrip("/").lower()
+        provider_matches = provider_key and provider_key in entry_names
+        base_matches = base_url and entry_base_url == base_url
+        if not provider_matches and not base_matches:
+            continue
+
+        api_mode = str(entry.get("api_mode") or "").strip().lower()
+        if api_mode in _DIRECT_ENDPOINT_API_MODES:
+            return api_mode
+    return None
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -2383,6 +2431,17 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"
+        # A configured delegation.base_url is still a direct endpoint, but
+        # users often point it at a named custom provider that already declares
+        # its transport. Honor that explicit api_mode before falling back to
+        # the URL heuristics above.
+        api_mode = (
+            _configured_direct_endpoint_api_mode(
+                configured_provider,
+                configured_base_url,
+            )
+            or api_mode
+        )
 
         return {
             "model": configured_model,


### PR DESCRIPTION
Closes #26210.\n\n## Summary\n- when delegation.base_url is configured, look up matching custom provider metadata before falling back to URL heuristics\n- honor api_mode from both legacy custom_providers and the newer providers schema\n- add regression coverage for Anthropic-compatible custom endpoints\n\n## Tests\n- python -m pytest -o addopts= tests\\tools\\test_delegate.py::TestDelegationCredentialResolution -q --tb=short\n- python -m pytest -o addopts= tests\\tools\\test_delegate.py -q --tb=short\n- python -m ruff check tools\\delegate_tool.py tests\\tools\\test_delegate.py\n- git diff --check