### PR TITLE
fix(gateway): cancel in-flight delegate subagents during shutdown/restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4929,6 +4929,28 @@ class GatewayRunner:
                 _phase_elapsed(),
             )
 
+            # Interrupt ALL in-flight delegate subagents before draining
+            # parent agents.  Without this, subagents whose parents finish
+            # the drain gracefully continue running on stale API connections
+            # until they hit the 12+ minute provider idle timeout.
+            # (See #26315 — gateway restart orphans delegate subagents.)
+            try:
+                from tools.delegate_tool import interrupt_all_subagents
+                _reason = (
+                    "Gateway restart — interrupting in-flight subagents"
+                    if self._restart_requested
+                    else "Gateway shutdown — interrupting in-flight subagents"
+                )
+                _n_interrupted = interrupt_all_subagents(_reason)
+                if _n_interrupted:
+                    logger.info(
+                        "Shutdown phase: interrupted %d orphan-prone subagent(s) at +%.2fs",
+                        _n_interrupted,
+                        _phase_elapsed(),
+                    )
+            except Exception as _e:
+                logger.debug("interrupt_all_subagents during shutdown: %s", _e)
+
             timeout = self._restart_drain_timeout
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -216,6 +216,41 @@ def list_active_subagents() -> List[Dict[str, Any]]:
         ]
 
 
+def interrupt_all_subagents(reason: str = "Gateway shutdown") -> int:
+    """Interrupt ALL currently running subagents.
+
+    Called during gateway shutdown/restart to prevent orphaned subagents
+    that would otherwise time out after 12+ minutes.  Iterates the global
+    _active_subagents registry and sends interrupt() to each child agent,
+    which also cascades into grandchildren via AIAgent.interrupt().
+
+    Returns the number of subagents that were interrupted.
+    Safe to call from any thread.
+    """
+    with _active_subagents_lock:
+        records = list(_active_subagents.values())
+
+    interrupted = 0
+    for record in records:
+        agent = record.get("agent")
+        if agent is None:
+            continue
+        try:
+            agent.interrupt(reason)
+            interrupted += 1
+        except Exception as exc:
+            logger.debug(
+                "interrupt_all_subagents failed for %s: %s",
+                record.get("subagent_id", "?"), exc,
+            )
+    if interrupted:
+        logger.info(
+            "interrupt_all_subagents: sent interrupt to %d subagent(s)",
+            interrupted,
+        )
+    return interrupted
+
+
 def _extract_output_tail(
     result: Dict[str, Any],
     *,


### PR DESCRIPTION
## Summary
Cancel in-flight delegate subagents during gateway shutdown/restart to prevent 12+ minute orphaned timeouts.

## Problem
When the gateway restarts (`hermes gateway restart` or launchd KeepAlive), delegate_task subagents running in ThreadPoolExecutor workers are not cancelled. They lose API connections and time out after 12–16 minutes. Users see "No response from provider for 968s" and "Interrupted during API call" errors.

Root cause: `_stop_impl()` in `gateway/run.py` only interrupts parent agents tracked in `self._running_agents`. While `agent.interrupt()` does propagate to children via `_active_children`, subagents whose parents completed the drain gracefully continued running on stale connections.

Closes #26315

## Solution
1. **`tools/delegate_tool.py`** — Add `interrupt_all_subagents()` function that iterates the global `_active_subagents` registry and sends `interrupt()` to every active child agent (cascading to grandchildren via `AIAgent.interrupt()`).

2. **`gateway/run.py`** — Call `interrupt_all_subagents()` in `_stop_impl()` after `_notify_active_sessions_of_shutdown()` but before `_drain_active_agents()`. This ensures all subagents receive the interrupt signal before the drain begins.

## Files Changed
| File | Change |
|---|---|
| `tools/delegate_tool.py` | +35 lines: new `interrupt_all_subagents()` function |
| `gateway/run.py` | +22 lines: call `interrupt_all_subagents()` in shutdown path |

## Test Results
- Syntax check passed for both files
- Function signature verified via AST parsing
- Existing `agent.interrupt()` child-propagation logic unchanged (lines 5327-5330 in `run_agent.py`)

## Design Decisions
- **Why not modify `_interrupt_running_agents`?** That method only knows about `_running_agents` (parent agents). Subagents are tracked separately in `_active_subagents` global registry. A separate function is cleaner.
- **Why before drain, not after?** Sending interrupts before drain gives subagents the full drain window to unwind gracefully, rather than racing against the drain timeout.
- **Why `try/except` wrapper?** The import may fail if delegate_tool isn't available (unlikely but defensive). Shutdown must never fail due to subagent cleanup issues.