### PR TITLE
fix(api_server): propagate cache/reasoning tokens to OpenAI-compat responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -464,6 +464,71 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+def _openai_chat_usage(usage: Dict[str, int]) -> Dict[str, Any]:
+    """Build an OpenAI Chat Completions ``usage`` block from the internal
+    counter dict produced by the agent loop.
+
+    Maps ``input_tokens``/``output_tokens``/``total_tokens`` to the
+    canonical ``prompt_tokens``/``completion_tokens``/``total_tokens``
+    fields and — when the agent reported cache or reasoning tokens —
+    attaches ``prompt_tokens_details.cached_tokens`` and
+    ``completion_tokens_details.reasoning_tokens`` so OpenAI-compatible
+    clients can read those values without an out-of-band probe. The
+    nested ``*_tokens_details`` are only emitted when non-zero so we
+    don't bloat responses for providers that don't report them.
+    """
+    block: Dict[str, Any] = {
+        "prompt_tokens": usage.get("input_tokens", 0),
+        "completion_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("total_tokens", 0),
+    }
+    cache_read = usage.get("cache_read_tokens") or 0
+    cache_write = usage.get("cache_write_tokens") or 0
+    if cache_read or cache_write:
+        details: Dict[str, int] = {}
+        if cache_read:
+            details["cached_tokens"] = cache_read
+        if cache_write:
+            # OpenAI uses ``cache_creation_input_tokens`` in their
+            # streaming Responses API; mirror that name here so the
+            # field is recognizable by clients written against OpenAI.
+            details["cache_creation_input_tokens"] = cache_write
+        block["prompt_tokens_details"] = details
+    reasoning = usage.get("reasoning_tokens") or 0
+    if reasoning:
+        block["completion_tokens_details"] = {"reasoning_tokens": reasoning}
+    return block
+
+
+def _openai_responses_usage(usage: Dict[str, int]) -> Dict[str, Any]:
+    """Build a Responses-API-style ``usage`` block.
+
+    Same fields as Chat Completions but using the input/output naming
+    convention (``input_tokens``/``output_tokens``) — and the
+    ``input_tokens_details.cached_tokens`` nesting Responses clients
+    expect, with ``output_tokens_details.reasoning_tokens`` for
+    reasoning models.
+    """
+    block: Dict[str, Any] = {
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("total_tokens", 0),
+    }
+    cache_read = usage.get("cache_read_tokens") or 0
+    cache_write = usage.get("cache_write_tokens") or 0
+    if cache_read or cache_write:
+        details: Dict[str, int] = {}
+        if cache_read:
+            details["cached_tokens"] = cache_read
+        if cache_write:
+            details["cache_creation_input_tokens"] = cache_write
+        block["input_tokens_details"] = details
+    reasoning = usage.get("reasoning_tokens") or 0
+    if reasoning:
+        block["output_tokens_details"] = {"reasoning_tokens": reasoning}
+    return block
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -1286,11 +1351,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "finish_reason": finish_reason,
                 }
             ],
-            "usage": {
-                "prompt_tokens": usage.get("input_tokens", 0),
-                "completion_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
+            "usage": _openai_chat_usage(usage),
         }
         if is_partial or is_failed or not completed:
             response_data["hermes"] = {
@@ -1415,11 +1476,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                "usage": {
-                    "prompt_tokens": usage.get("input_tokens", 0),
-                    "completion_tokens": usage.get("output_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                },
+                "usage": _openai_chat_usage(usage),
             }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
@@ -2310,11 +2367,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "created_at": created_at,
             "model": body.get("model", self._model_name),
             "output": output_items,
-            "usage": {
-                "input_tokens": usage.get("input_tokens", 0),
-                "output_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
+            "usage": _openai_responses_usage(usage),
         }
 
         # Store the complete response object for future chaining / GET retrieval
@@ -2745,6 +2798,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                # The chat completions transport already tracks these on the
+                # agent (see run_agent.py session_cache_*_tokens) — surface
+                # them so the OpenAI-compatible serializers below can
+                # populate ``prompt_tokens_details`` / ``completion_tokens_details``.
+                # Without this, clients that rely on the OpenAI cache fields
+                # (prompt cache hit ratio dashboards, etc.) get zero even
+                # when the upstream provider actually reported the numbers.
+                "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0) or 0,
+                "reasoning_tokens": getattr(agent, "session_reasoning_tokens", 0) or 0,
             }
             # Include the effective session ID in the result so callers
             # (e.g. X-Hermes-Session-Id header) can track compression-

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -410,6 +410,12 @@ class TestAgentExecution:
         mock_agent.session_prompt_tokens = 1
         mock_agent.session_completion_tokens = 2
         mock_agent.session_total_tokens = 3
+        # New cache + reasoning counters surfaced by _run_agent so OpenAI-
+        # compatible serializers can populate ``prompt_tokens_details``
+        # and ``completion_tokens_details`` downstream.
+        mock_agent.session_cache_read_tokens = 0
+        mock_agent.session_cache_write_tokens = 0
+        mock_agent.session_reasoning_tokens = 0
 
         with patch.object(adapter, "_create_agent", return_value=mock_agent):
             result, usage = await adapter._run_agent(
@@ -424,7 +430,14 @@ class TestAgentExecution:
         # here doesn't set an explicit session_id string so the guard skips
         # the annotation — header will fall back to the provided session_id.
         assert result["final_response"] == "ok"
-        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        assert usage == {
+            "input_tokens": 1,
+            "output_tokens": 2,
+            "total_tokens": 3,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        }
         mock_agent.run_conversation.assert_called_once_with(
             user_message="hello",
             conversation_history=[],


### PR DESCRIPTION
## Summary

The agent loop already tracks `session_cache_read_tokens`, `session_cache_write_tokens` and `session_reasoning_tokens` (see `run_agent.py:13241-13243`), populated by the chat_completions transport from provider responses. But the `api_server` adapter that serializes the `/v1/chat/completions` and `/v1/responses` bodies was only writing `prompt_tokens` / `completion_tokens` / `total_tokens` — the cached/reasoning counters were dropped before reaching the OpenAI-compatible response.

Effect: any client downstream of Hermes that consumed the canonical OpenAI fields (`prompt_tokens_details.cached_tokens`, `completion_tokens_details.reasoning_tokens`) saw zero / null even for providers that emit them faithfully. We hit this measuring prompt-cache hit rate after wiring `cache_control: ephemeral` on the static prefix — `cached_tokens` was always `null` regardless of the upstream provider's behavior.

## Changes

1. **`_run_agent`** surfaces three extra counters in the usage dict:
   - `cache_read_tokens` (from `agent.session_cache_read_tokens`)
   - `cache_write_tokens` (from `agent.session_cache_write_tokens`)
   - `reasoning_tokens` (from `agent.session_reasoning_tokens`)

2. **`_openai_chat_usage` / `_openai_responses_usage`** new helpers build the OpenAI usage block in the canonical shape:
   - Chat Completions: `prompt_tokens_details.cached_tokens` + `prompt_tokens_details.cache_creation_input_tokens` + `completion_tokens_details.reasoning_tokens`
   - Responses API: `input_tokens_details.cached_tokens` + `input_tokens_details.cache_creation_input_tokens` + `output_tokens_details.reasoning_tokens`
   - Nested objects only emitted when non-zero, so providers that don't report them keep the lean original shape.

3. The three call sites that serialized usage manually now use the helpers — non-streaming chat completion, streaming finish chunk, and Responses API.

## Test

`tests/gateway/test_api_server.py::test_run_agent_uses_session_id_as_task_id` updated to assert the additional zero-valued counters are present when the mock agent doesn't override them. Existing usage-shape tests in `test_responses_usage` keep passing because they pass `usage` dicts in directly without exercising `_run_agent`.

Compile-checked locally; full pytest run wasn't possible here (no provider creds), but the patch is mechanical — same three keys, same nesting OpenAI documents publicly.

## Motivation

Lets clients build prompt-cache hit dashboards on top of Hermes without an out-of-band probe path. Particularly useful for anyone running `cache_control: ephemeral` system prompts: the savings the cache provides are measurable directly from the chat completion response.