### PR TITLE
fix(file): verify file exists after write to prevent silent failures in long conversations

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -127,6 +127,27 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     return p.resolve()
 
 
+def _verify_file_written(filepath: str, task_id: str = "default") -> str | None:
+    """Verify a file exists at the resolved absolute path after writing.
+
+    Uses the task's live terminal CWD to resolve *filepath*, then checks
+    whether the resulting path exists on the filesystem.  Returns the
+    resolved path on failure (write targeted a different CWD than expected)
+    or ``None`` on success.
+
+    This detects CWD drift (from ``cd`` commands or environment cleanup +
+    recreation) that causes ``write_file`` to silently place files in an
+    unexpected directory.
+    """
+    try:
+        resolved = str(_resolve_path_for_task(filepath, task_id))
+    except Exception:
+        return filepath
+    if os.path.exists(resolved):
+        return None
+    return resolved
+
+
 def _is_blocked_device(filepath: str) -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
 
@@ -817,6 +838,18 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             _update_read_timestamp(path, task_id)
+            # Post-write verification: ensure the file exists at the expected
+            # absolute path.  The write may have targeted a different CWD than
+            # the user expects (e.g. after environment cleanup + recreation or
+            # CWD drift from cd commands in long conversations).
+            if not result_dict.get("error"):
+                _verify_path = _verify_file_written(path, task_id)
+                if _verify_path:
+                    result_dict["_warning"] = (
+                        f"File was written but could not be verified at the expected "
+                        f"location. It may exist at a different path. "
+                        f"Use an absolute path to avoid CWD-dependent writes."
+                    )
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
@@ -838,6 +871,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
+                # Post-write verification: check the resolved path exists.
+                _verify_path = _verify_file_written(path, task_id)
+                if _verify_path:
+                    result_dict["_warning"] = (
+                        f"File was written but could not be verified at the expected "
+                        f"location ({_resolved}). It may exist at a different path. "
+                        f"Use an absolute path to avoid CWD-dependent writes."
+                    )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):


### PR DESCRIPTION
# [PR] Fix: Silent File Write Failures in Long Conversations (#26211)

## What does this PR do?
In long-running conversations, the `write_file` tool reports successful file creation (e.g., "7,681 bytes"), but the file does not actually exist at the expected location when checked via `ls` or Finder. 

**Key Findings:**
* **Reproducibility:** 100% reproducible in long sessions.
* **Behavior:** New conversations work fine; long conversations fail silently without error codes.

---

## 🔍 Root Cause
The terminal environment's **CWD (Current Working Directory)** drifts during long conversations due to:
1. **Manual Drift:** The agent executing `cd` commands over many turns.
2. **Environment Recycling:** The cleanup thread (5-minute inactivity timeout) killing idle environments and recreating them with a different default CWD.

This causes relative path writes to land in unexpected locations or volatile backend containers while the tool incorrectly reports success.

---

## 🛠️ Fix
Added a verification layer in `tools/file_tools.py`:
* **`_verify_file_written()`**: A new helper function that resolves the file path against the task's **live** terminal CWD.
* **Post-Write Check:** It performs an `os.path.exists()` check on the resulting absolute path immediately after a "successful" write.
* **Warning Attachment:** If the file is not found where expected, it attaches a `_warning` to the tool result instead of returning a silent success.

---

## 📑 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)

---

## 📂 Changes Made
- **`tools/file_tools.py`**: 
    - Added `_verify_file_written()` helper for post-write path verification.
    - Updated `write_file_tool()` to trigger verification and handle warning attachments.

---

## 🧪 How to Test
1. Start a long conversation and run `cd /tmp` via terminal.
2. Call `write_file(path="test.txt", content="hello")`.
3. **Observe:** A warning should appear in the result if the file is not at the expected path.
4. Call `write_file(path="/tmp/test.txt", content="hello")` using an **absolute path**.
5. **Observe:** Clean success without warnings.

---

## ✅ Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: WSL (Ubuntu)

---

**Fixes #26211**
