### PR TITLE
fix(cron): rewrite script and workdir paths on skill consolidation

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1137,6 +1137,33 @@ def rewrite_skill_refs(
             job["skill"] = new_skills[0] if new_skills else None
             changed = True
 
+            # Also rewrite skill directory paths in script and workdir fields.
+            # When a skill is consolidated from X into Y, paths like
+            # ~/.hermes/skills/.../X/scripts/foo.py need to become
+            # ~/.hermes/skills/.../Y/scripts/foo.py.  Only rewrite when
+            # the target path actually exists to avoid creating broken refs.
+            script_rewrites: Dict[str, str] = {}
+            for old_name, new_name in mapped.items():
+                for field in ("script", "workdir"):
+                    val = job.get(field)
+                    if not isinstance(val, str) or old_name not in val:
+                        continue
+                    candidate = val.replace(old_name, new_name)
+                    # Only apply if the target path exists (or the field
+                    # is workdir which is validated separately at run time).
+                    _cand_path = os.path.expanduser(candidate) if field == "workdir" else None
+                    if field == "workdir" and _cand_path and os.path.isdir(_cand_path):
+                        job[field] = candidate
+                        script_rewrites[field] = candidate
+                    elif field == "script":
+                        # For script, check if the file part resolves
+                        _script_path = candidate.split()[-1] if candidate else ""
+                        # Resolve ~ and $HOME
+                        _script_path = os.path.expanduser(_script_path)
+                        if os.path.isfile(_script_path):
+                            job[field] = candidate
+                            script_rewrites[field] = candidate
+
             rewrites.append({
                 "job_id": job.get("id"),
                 "job_name": job.get("name") or job.get("id"),
@@ -1144,6 +1171,7 @@ def rewrite_skill_refs(
                 "after": list(new_skills),
                 "mapped": mapped,
                 "dropped": dropped,
+                "path_rewrites": script_rewrites,
             })
 
         if changed:


### PR DESCRIPTION
## Summary
Fix `rewrite_skill_refs()` to also update `script` and `workdir` paths when the auto-curator consolidates skills, preventing cron jobs from silently breaking.

## Problem
When the auto-curator consolidates skill X into umbrella Y, `rewrite_skill_refs()` in `cron/jobs.py` correctly updated the `skills` array but **missed `script` and `workdir` fields**. Cron jobs with script paths like:
```
~/.hermes/skills/productivity/school-teen-radar/scripts/jacob_digest.py
```
silently broke because the path was deleted during consolidation. The job would run with "skill not found, skipping" warnings.

From the curator run log:
```json
"cron_rewrites": {"rewrites": [], "jobs_updated": 0, "jobs_scanned": 0}
```

Closes #26326

## Solution
In `rewrite_skill_refs()`, after updating the `skills` list for each affected job:

1. Scan the `script` and `workdir` fields for old skill directory names
2. Generate candidate paths by replacing old name with umbrella name
3. Only apply the rewrite when the target path **actually exists** (prevents creating new broken references)
4. Record path rewrites in a `path_rewrites` field in the report for curator logging

## Files Changed
| File | Change |
|---|---|
| `cron/jobs.py` | +28 lines: path rewriting for `script` and `workdir` fields in `rewrite_skill_refs()` |

## Test Results
- Syntax check passed
- Existing `rewrite_skill_refs()` skills-array logic unchanged
- New path rewriting is additive (only fires when `mapped` is non-empty)

## Design Decisions
- **Existence check before rewrite**: Prevents creating broken paths if the umbrella skill has a different directory structure
- **`path_rewrites` in report**: Lets the curator log show exactly which script/workdir paths were updated, matching the existing `mapped`/`dropped` report pattern
- **`os.path.expanduser` for path resolution**: Handles `~` in paths which is the most common pattern in cron job configs