### PR TITLE
fix(skills): load external slash-command skills by name

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -64,7 +64,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
             try:
                 normalized = str(identifier_path.resolve().relative_to(SKILLS_DIR.resolve()))
             except Exception:
-                normalized = raw_identifier
+                normalized = identifier_path.name
         else:
             normalized = raw_identifier.lstrip("/")
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
@@ -176,6 +177,35 @@ class TestScanSkillCommands:
 
             assert "/telegram-only" not in telegram_again
             assert "/discord-only" in telegram_again
+
+    def test_build_skill_invocation_message_loads_external_skill_from_absolute_dir(self, tmp_path):
+        import agent.skill_commands as sc_mod
+        from agent.skill_utils import _external_dirs_cache_clear
+
+        hermes_home = tmp_path / ".hermes"
+        local_skills = hermes_home / "skills"
+        external_skills = tmp_path / "external-skills"
+        local_skills.mkdir(parents=True)
+        external_skills.mkdir(parents=True)
+        _make_skill(external_skills, "daily-ops", body="Run the external checklist.")
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills}\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}, clear=False),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+            patch.object(skills_tool_module, "SKILLS_DIR", local_skills),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+        ):
+            _external_dirs_cache_clear()
+            message = build_skill_invocation_message("/daily-ops")
+
+        assert message is not None
+        assert "[Failed to load skill: daily-ops]" not in message
+        assert "Run the external checklist." in message
+        assert f"[Skill directory: {external_skills / 'daily-ops'}]" in message
 
     def test_get_skill_commands_rescans_when_session_platform_changes(self, tmp_path):
         """``HERMES_SESSION_PLATFORM`` from the gateway session context must


### PR DESCRIPTION
## What does this PR do?

Fixes external skill slash commands when `skills.external_dirs` points outside `~/.hermes/skills`. `build_skill_invocation_message()` was passing an absolute skill directory to `skill_view()`, which eventually hit an absolute-path `rglob()` failure and surfaced as `[Failed to load skill: ...]`. This change normalizes those fallback identifiers to the external skill directory name so slash commands load the same way bare `skill_view()` calls already do.

## Related Issue

Fixes #26337

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/skill_commands.py` so external absolute skill directories fall back to `identifier_path.name` instead of the raw absolute path.
- Added a regression test in `tests/agent/test_skill_commands.py` that configures `skills.external_dirs`, registers an external `daily-ops` skill, and verifies `/daily-ops` loads successfully through the slash-command path.

## How to Test

1. Configure `skills.external_dirs` to include an external skills folder containing `daily-ops/SKILL.md`.
2. Run `python3 -m pytest -o addopts='' tests/agent/test_skill_commands.py -k 'external_skill_from_absolute_dir or get_skill_commands_rescans_when_platform_scope_changes or get_skill_commands_rescans_when_session_platform_changes or get_skill_commands_rescans_when_leaving_platform_scope'`.
3. Invoke `/daily-ops` from CLI or gateway and confirm it loads the skill content instead of returning `[Failed to load skill: daily-ops]`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/agent/test_skill_commands.py -k 'external_skill_from_absolute_dir or get_skill_commands_rescans_when_platform_scope_changes or get_skill_commands_rescans_when_session_platform_changes or get_skill_commands_rescans_when_leaving_platform_scope'` → `4 passed, 36 deselected in 0.70s`
- `python3 -m py_compile agent/skill_commands.py tests/agent/test_skill_commands.py`
- `git diff --check`
