### PR TITLE
fix(cron): rewrite skill path refs after curator consolidation

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -13,11 +13,12 @@ import tempfile
 import threading
 import os
 import re
+import shlex
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,216 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     normalized["skills"] = skills
     normalized["skill"] = skills[0] if skills else None
     return normalized
+
+
+def _find_skill_dir_for_rewrite(skill_name: str) -> Optional[Path]:
+    """Find an installed skill directory by its leaf directory name."""
+    name = str(skill_name or "").strip()
+    if not name:
+        return None
+
+    skills_root = HERMES_DIR / "skills"
+    if not skills_root.exists():
+        return None
+
+    candidates: List[Path] = [skills_root / name]
+    try:
+        candidates.extend(
+            child / name for child in skills_root.iterdir() if child.is_dir()
+        )
+    except OSError:
+        pass
+
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+
+    try:
+        for skill_file in skills_root.rglob("SKILL.md"):
+            if skill_file.parent.name == name:
+                return skill_file.parent
+    except OSError:
+        pass
+
+    return None
+
+
+def _skill_segment_index(parts: List[str], skill_name: str) -> Optional[int]:
+    """Return the segment index for skill_name when it appears under skills/."""
+    for index, part in enumerate(parts):
+        if part != skill_name:
+            continue
+        if "skills" in parts[:index]:
+            return index
+    return None
+
+
+def _skill_root_index(parts: List[str], before_index: int) -> Optional[int]:
+    for index in range(before_index - 1, -1, -1):
+        if parts[index] == "skills":
+            return index
+    return None
+
+
+def _rewrite_skill_path_token(
+    token: str,
+    consolidated: Dict[str, str],
+    pruned_set: Set[str],
+    *,
+    require_target_exists: bool,
+) -> Dict[str, Any]:
+    """Rewrite one path-like token that may point inside a skill directory."""
+    raw = str(token or "").strip()
+    if not raw:
+        return {"matched": False}
+
+    normalized = raw.replace("\\", "/")
+    parts = normalized.split("/")
+
+    for old_name, target_name in consolidated.items():
+        old_index = _skill_segment_index(parts, old_name)
+        if old_index is None:
+            continue
+
+        skills_index = _skill_root_index(parts, old_index)
+        target_dir = _find_skill_dir_for_rewrite(target_name)
+        if skills_index is None or target_dir is None:
+            return {
+                "matched": True,
+                "changed": False,
+                "old": old_name,
+                "target": target_name,
+                "reason": f"target skill directory not found: {target_name}",
+            }
+
+        suffix = parts[old_index + 1:]
+        target_path = target_dir.joinpath(*suffix)
+        if require_target_exists and not target_path.exists():
+            return {
+                "matched": True,
+                "changed": False,
+                "old": old_name,
+                "target": target_name,
+                "reason": f"target path does not exist: {target_path}",
+            }
+
+        try:
+            target_rel_parts = list(target_dir.relative_to(HERMES_DIR).parts)
+            new_parts = parts[:skills_index] + target_rel_parts + suffix
+            separator = "\\" if "\\" in raw and "/" not in raw else "/"
+            new_token = separator.join(new_parts)
+        except ValueError:
+            new_token = str(target_path)
+
+        return {
+            "matched": True,
+            "changed": new_token != raw,
+            "old": old_name,
+            "target": target_name,
+            "new": new_token,
+        }
+
+    for old_name in pruned_set:
+        old_index = _skill_segment_index(parts, old_name)
+        if old_index is not None:
+            return {
+                "matched": True,
+                "changed": True,
+                "old": old_name,
+                "target": None,
+                "new": None,
+            }
+
+    return {"matched": False}
+
+
+def _path_tokens_to_scan(value: str) -> List[str]:
+    """Extract path-like tokens from a cron script/workdir field."""
+    raw = str(value or "").strip()
+    if not raw:
+        return []
+    if not any(ch.isspace() for ch in raw):
+        return [raw]
+
+    if "\\" in raw:
+        tokens = raw.split()
+    else:
+        try:
+            tokens = shlex.split(raw)
+        except ValueError:
+            tokens = raw.split()
+
+    if not tokens:
+        tokens = raw.split()
+
+    return [
+        token for token in tokens
+        if "skills" in token.replace("\\", "/").split("/")
+    ]
+
+
+def _rewrite_cron_path_field(
+    value: Any,
+    consolidated: Dict[str, str],
+    pruned_set: Set[str],
+    *,
+    field: str,
+    require_target_exists: bool,
+) -> Dict[str, Any]:
+    """Rewrite script/workdir strings that reference consolidated skills."""
+    raw = str(value or "").strip()
+    if not raw:
+        return {"changed": False, "unresolved": []}
+
+    rewritten = raw
+    mapped: Dict[str, str] = {}
+    dropped: List[str] = []
+    unresolved: List[Dict[str, Any]] = []
+
+    for token in _path_tokens_to_scan(raw):
+        outcome = _rewrite_skill_path_token(
+            token,
+            consolidated,
+            pruned_set,
+            require_target_exists=require_target_exists,
+        )
+        if not outcome.get("matched"):
+            continue
+
+        old_name = outcome.get("old")
+        target_name = outcome.get("target")
+        if not outcome.get("changed"):
+            unresolved.append({
+                "field": field,
+                "skill": old_name,
+                "target": target_name,
+                "value": raw,
+                "reason": outcome.get("reason") or "reference could not be rewritten",
+            })
+            continue
+
+        new_token = outcome.get("new")
+        if new_token is None:
+            dropped.append(str(old_name))
+            return {
+                "changed": True,
+                "value": None,
+                "mapped": mapped,
+                "dropped": dropped,
+                "unresolved": unresolved,
+            }
+
+        rewritten = rewritten.replace(token, str(new_token), 1)
+        if old_name and target_name:
+            mapped[str(old_name)] = str(target_name)
+
+    return {
+        "changed": rewritten != raw,
+        "value": rewritten,
+        "mapped": mapped,
+        "dropped": dropped,
+        "unresolved": unresolved,
+    }
 
 
 def _coerce_job_text(value: Any, fallback: str = "") -> str:
@@ -1068,6 +1279,10 @@ def rewrite_skill_refs(
       forwarding target.
     - Ordering and other skills in the list are preserved.
     - The legacy ``skill`` field is realigned via ``_apply_skill_fields``.
+    - ``script`` and ``workdir`` fields that point inside a consolidated
+      skill directory are rewritten to the absorbing skill directory when
+      the target path exists. Pruned skill path references are cleared.
+      References that cannot be resolved are reported but left untouched.
 
     Args:
         consolidated: mapping of ``old_skill_name -> umbrella_skill_name``.
@@ -1090,6 +1305,7 @@ def rewrite_skill_refs(
             ],
             "jobs_updated": N,
             "jobs_scanned": M,
+            "jobs_with_unresolved": U,
         }
 
     Best-effort: exceptions from loading/saving propagate to the caller so
@@ -1109,12 +1325,13 @@ def rewrite_skill_refs(
         jobs = load_jobs()
         rewrites: List[Dict[str, Any]] = []
         changed = False
+        updated_count = 0
+        unresolved_count = 0
 
         for job in jobs:
             skills_before = _normalize_skill_list(job.get("skill"), job.get("skills"))
-            if not skills_before:
-                continue
-
+            script_before = job.get("script")
+            workdir_before = job.get("workdir")
             mapped: Dict[str, str] = {}
             dropped: List[str] = []
             new_skills: List[str] = []
@@ -1130,30 +1347,81 @@ def rewrite_skill_refs(
                 elif name not in new_skills:
                     new_skills.append(name)
 
-            if not mapped and not dropped:
+            script_rewrite = _rewrite_cron_path_field(
+                job.get("script"),
+                consolidated,
+                pruned_set,
+                field="script",
+                require_target_exists=True,
+            )
+            workdir_rewrite = _rewrite_cron_path_field(
+                job.get("workdir"),
+                consolidated,
+                pruned_set,
+                field="workdir",
+                require_target_exists=True,
+            )
+
+            unresolved = (
+                script_rewrite.get("unresolved", [])
+                + workdir_rewrite.get("unresolved", [])
+            )
+
+            skills_changed = bool(mapped or dropped)
+            paths_changed = bool(
+                script_rewrite.get("changed") or workdir_rewrite.get("changed")
+            )
+            if not skills_changed and not paths_changed and not unresolved:
                 continue
 
-            job["skills"] = new_skills
-            job["skill"] = new_skills[0] if new_skills else None
-            changed = True
+            if skills_changed:
+                job["skills"] = new_skills
+                job["skill"] = new_skills[0] if new_skills else None
 
-            rewrites.append({
+            if script_rewrite.get("changed"):
+                job["script"] = script_rewrite.get("value")
+
+            if workdir_rewrite.get("changed"):
+                job["workdir"] = workdir_rewrite.get("value")
+
+            if skills_changed or paths_changed:
+                changed = True
+                updated_count += 1
+
+            if unresolved:
+                unresolved_count += 1
+
+            entry = {
                 "job_id": job.get("id"),
                 "job_name": job.get("name") or job.get("id"),
                 "before": list(skills_before),
-                "after": list(new_skills),
+                "after": list(new_skills) if skills_changed else list(skills_before),
                 "mapped": mapped,
                 "dropped": dropped,
-            })
+            }
+            if script_rewrite.get("changed"):
+                entry["script_before"] = script_before
+                entry["script_after"] = script_rewrite.get("value")
+                entry["script_mapped"] = script_rewrite.get("mapped", {})
+                entry["script_dropped"] = script_rewrite.get("dropped", [])
+            if workdir_rewrite.get("changed"):
+                entry["workdir_before"] = workdir_before
+                entry["workdir_after"] = workdir_rewrite.get("value")
+                entry["workdir_mapped"] = workdir_rewrite.get("mapped", {})
+                entry["workdir_dropped"] = workdir_rewrite.get("dropped", [])
+            if unresolved:
+                entry["unresolved"] = unresolved
+            rewrites.append(entry)
 
         if changed:
             save_jobs(jobs)
             logger.info(
-                "Curator rewrote skill references in %d cron job(s)", len(rewrites)
+                "Curator rewrote skill references in %d cron job(s)", updated_count
             )
 
         return {
             "rewrites": rewrites,
-            "jobs_updated": len(rewrites),
+            "jobs_updated": updated_count,
             "jobs_scanned": len(jobs),
+            "jobs_with_unresolved": unresolved_count,
         }

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/tests/cron/test_rewrite_skill_refs.py
+++ b/tests/cron/test_rewrite_skill_refs.py
@@ -37,6 +37,17 @@ def cron_env(tmp_path, monkeypatch):
     return hermes_home
 
 
+def _make_skill(hermes_home: Path, category: str, name: str, files: dict[str, str] | None = None) -> Path:
+    skill_dir = hermes_home / "skills" / category / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+    for rel_path, content in (files or {}).items():
+        path = skill_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return skill_dir
+
+
 class TestRewriteSkillRefsNoop:
     """No jobs, no rewrites, no map — every combination of empty inputs."""
 
@@ -255,6 +266,117 @@ class TestRewriteSkillRefsMultipleJobs:
         loaded = get_job(job["id"])
         assert loaded["skills"] == ["umbrella"]
         assert loaded["skill"] == "umbrella"
+
+
+class TestRewriteSkillRefsPathFields:
+    """Cron script/workdir fields can also point inside skill directories."""
+
+    def test_script_command_path_rewritten_when_target_file_exists(self, cron_env):
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        old_dir = _make_skill(cron_env, "productivity", "school-teen-radar")
+        target_dir = _make_skill(
+            cron_env,
+            "productivity",
+            "automated-industry-briefing",
+            {"scripts/jacob_digest.py": "print('ok')\n"},
+        )
+        old_script = old_dir / "scripts" / "jacob_digest.py"
+        script_command = f"python3 {old_script} --days 1 --compact"
+
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            skills=["school-teen-radar", "google-workspace"],
+            script=script_command,
+        )
+        report = rewrite_skill_refs(
+            consolidated={"school-teen-radar": "automated-industry-briefing"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        expected_script = target_dir / "scripts" / "jacob_digest.py"
+        assert loaded["skills"] == ["automated-industry-briefing", "google-workspace"]
+        assert loaded["script"] == f"python3 {expected_script} --days 1 --compact"
+        assert report["jobs_updated"] == 1
+        entry = report["rewrites"][0]
+        assert entry["script_before"] == script_command
+        assert entry["script_after"] == loaded["script"]
+        assert entry["script_mapped"] == {
+            "school-teen-radar": "automated-industry-briefing",
+        }
+
+    def test_workdir_rewritten_to_absorbing_skill_dir(self, cron_env):
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        old_dir = _make_skill(cron_env, "productivity", "school-teen-radar")
+        target_dir = _make_skill(cron_env, "productivity", "automated-industry-briefing")
+
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            workdir=str(old_dir),
+        )
+        report = rewrite_skill_refs(
+            consolidated={"school-teen-radar": "automated-industry-briefing"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert loaded["workdir"] == str(target_dir)
+        assert report["jobs_updated"] == 1
+        assert report["rewrites"][0]["workdir_before"] == str(old_dir)
+        assert report["rewrites"][0]["workdir_after"] == str(target_dir)
+
+    def test_missing_target_script_is_reported_without_rewrite(self, cron_env):
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        old_dir = _make_skill(cron_env, "productivity", "school-teen-radar")
+        _make_skill(cron_env, "productivity", "automated-industry-briefing")
+        old_script = old_dir / "scripts" / "jacob_digest.py"
+        script_command = f"python3 {old_script} --days 1"
+
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            script=script_command,
+        )
+        report = rewrite_skill_refs(
+            consolidated={"school-teen-radar": "automated-industry-briefing"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert loaded["script"] == script_command
+        assert report["jobs_updated"] == 0
+        assert report["jobs_with_unresolved"] == 1
+        unresolved = report["rewrites"][0]["unresolved"][0]
+        assert unresolved["field"] == "script"
+        assert unresolved["skill"] == "school-teen-radar"
+        assert "target path does not exist" in unresolved["reason"]
+
+    def test_pruned_skill_path_refs_are_cleared(self, cron_env):
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        old_dir = _make_skill(cron_env, "productivity", "school-teen-radar")
+        old_script = old_dir / "scripts" / "digest.py"
+
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            script=str(old_script),
+            workdir=str(old_dir),
+        )
+        report = rewrite_skill_refs(consolidated={}, pruned=["school-teen-radar"])
+
+        loaded = get_job(job["id"])
+        assert loaded.get("script") is None
+        assert loaded.get("workdir") is None
+        assert report["jobs_updated"] == 1
+        entry = report["rewrites"][0]
+        assert entry["script_dropped"] == ["school-teen-radar"]
+        assert entry["workdir_dropped"] == ["school-teen-radar"]
 
 
 class TestRewriteSkillRefsPersistence:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- extend curator cron rewrites beyond skills[] so script/workdir fields that point into a consolidated skill directory follow the absorbing skill
- only rewrite script/workdir paths when the target file or directory exists; otherwise report the unresolved reference in the rewrite payload
- clear script/workdir fields that still point at pruned skill directories

Closes #26326.

## Tests
- python -m pytest -o addopts= tests\\cron\\test_rewrite_skill_refs.py tests\\cron\\test_cron_script.py::TestJobScriptField -q --tb=short
- python -m ruff check cron\\jobs.py tests\\cron\\test_rewrite_skill_refs.py
- git diff --check