### PR TITLE
feat(providers): add Aether API support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,14 @@
 # ARCEE_BASE_URL=                                 # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Aether)
+# =============================================================================
+# Aether provides an OpenAI-compatible inference API.
+# Get your key at: https://aetherapi.dev/
+# AETHER_API_KEY=
+# AETHER_BASE_URL=https://api.aetherapi.dev/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (MiniMax)
 # =============================================================================
 # MiniMax provides access to MiniMax models (global endpoint)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -275,6 +275,7 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "aether": "",
 }
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -52,6 +52,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xiaomi",
     "arcee",
     "gmi",
+    "aether",
     "tencent-tokenhub",
     "custom", "local",
     # Common aliases
@@ -364,6 +365,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
+    "api.aetherapi.dev": "aether",
     "api.novita.ai": "novita",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -330,6 +330,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("NVIDIA_API_KEY",),
         base_url_env_var="NVIDIA_BASE_URL",
     ),
+    "aether": ProviderConfig(
+        id="aether",
+        name="Aether",
+        auth_type="api_key",
+        inference_base_url="https://api.aetherapi.dev/v1",
+        api_key_env_vars=("AETHER_API_KEY",),
+        base_url_env_var="AETHER_BASE_URL",
+    ),
     "ai-gateway": ProviderConfig(
         id="ai-gateway",
         name="Vercel AI Gateway",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1984,6 +1984,7 @@ def select_provider_and_model(args=None):
         "xiaomi",
         "arcee",
         "gmi",
+        "aether",
         "nvidia",
         "ollama-cloud",
         "tencent-tokenhub",
@@ -9404,7 +9405,7 @@ def _build_provider_choices() -> list[str]:
             "anthropic", "gemini", "google-gemini-cli", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",
-            "nvidia", "deepseek", "alibaba", "qwen-oauth", "opencode-zen", "opencode-go",
+            "nvidia", "aether", "deepseek", "alibaba", "qwen-oauth", "opencode-zen", "opencode-go",
         ]
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -453,6 +453,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "aether": [],
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -921,6 +922,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)"),
     ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview — direct API via tokenhub.tencentmaas.com)"),
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)"),
+    ProviderEntry("aether",         "Aether",                   "Aether (OpenAI-compatible inference API)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
@@ -1013,6 +1015,7 @@ _PROVIDER_ALIASES = {
     "kilo": "kilocode",
     "kilo-code": "kilocode",
     "kilo-gateway": "kilocode",
+    "aetherapi": "aether",
     "dashscope": "alibaba",
     "aliyun": "alibaba",
     "qwen": "alibaba",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -190,6 +190,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "aether": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://api.aetherapi.dev/v1",
+        base_url_env_var="AETHER_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="OLLAMA_BASE_URL",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -43,6 +43,7 @@ class TestProviderRegistry:
         ("ai-gateway", "Vercel AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
         ("gmi", "GMI Cloud", "api_key"),
+        ("aether", "Aether", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -67,6 +68,12 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("NVIDIA_API_KEY",)
         assert pconfig.base_url_env_var == "NVIDIA_BASE_URL"
         assert pconfig.inference_base_url == "https://integrate.api.nvidia.com/v1"
+
+    def test_aether_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["aether"]
+        assert pconfig.api_key_env_vars == ("AETHER_API_KEY",)
+        assert pconfig.base_url_env_var == "AETHER_BASE_URL"
+        assert pconfig.inference_base_url == "https://api.aetherapi.dev/v1"
 
     def test_copilot_env_vars(self):
         pconfig = PROVIDER_REGISTRY["copilot"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -27,6 +27,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **Aether** | `AETHER_API_KEY` in `~/.hermes/.env` (provider: `aether`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **Alibaba Cloud** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -40,6 +40,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `AETHER_API_KEY` | Aether API key ([aetherapi.dev](https://aetherapi.dev/)) |
+| `AETHER_BASE_URL` | Override Aether base URL (default: `https://api.aetherapi.dev/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
Adds Aether (https://api.aetherapi.dev/v1) as a native OpenAI-compatible inference provider.

Users can authenticate with `AETHER_API_KEY` and use `--provider aether` or `aether:model` syntax.

Changes:
- Register provider across CLI auth, models, runtime overlays, and main flow
- Add provider prefix and hostname mapping for model metadata resolution
- Add aux-model fallback entry
- Add `AETHER_API_KEY` / `AETHER_BASE_URL` to `.env.example`
- Update provider docs and env-var reference
- Add registry and env-var assertions to existing API-key provider tests