### PR TITLE
fix(cli): honor legacy minimal toolset config

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -101,6 +101,17 @@ _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
 }
 
 
+_DETERMINISTIC_TOOLSET_ALIASES: Dict[str, List[str]] = {
+    # Users often reach for these datagen distribution names when trying to
+    # shrink local-runtime payloads. Expand the deterministic ones into the
+    # actual runtime toolsets they represent.
+    "minimal": ["web"],
+    "terminal_only": ["terminal", "file"],
+    "terminal_web": ["terminal", "file", "web"],
+    "browser_only": ["browser"],
+}
+
+
 def _toolset_allowed_for_platform(ts_key: str, platform: str) -> bool:
     """Return True if ``ts_key`` is configurable on ``platform``.
 
@@ -144,6 +155,38 @@ def _get_plugin_toolset_keys() -> set:
         return {ts_key for ts_key, _, _ in get_plugin_toolsets()}
     except Exception:
         return set()
+
+
+def _normalize_configured_toolset_names(raw: object) -> Optional[List[str]]:
+    """Normalize a config value into a runtime toolset-name list."""
+    if raw is None:
+        return None
+
+    if isinstance(raw, str):
+        raw_items = [part.strip() for part in raw.split(",")]
+    elif isinstance(raw, (list, tuple, set)):
+        raw_items = [str(part).strip() for part in raw]
+    else:
+        return None
+
+    normalized: List[str] = []
+    for item in raw_items:
+        if not item:
+            continue
+        normalized.extend(_DETERMINISTIC_TOOLSET_ALIASES.get(item, [item]))
+    return normalized
+
+
+def _get_legacy_cli_toolset_names(config: dict) -> Optional[List[str]]:
+    """Back-compat for legacy CLI-wide toolset config keys."""
+    legacy_toolsets = _normalize_configured_toolset_names(config.get("toolsets"))
+    if legacy_toolsets is not None:
+        return legacy_toolsets
+
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        return _normalize_configured_toolset_names(model_cfg.get("toolsets"))
+    return None
 
 # Platform display config — derived from the canonical registry so every
 # module shares the same data.  Kept as dict-of-dicts for backward
@@ -990,13 +1033,18 @@ def _get_platform_tools(
     toolset_names = platform_toolsets.get(platform)
 
     if toolset_names is None or not isinstance(toolset_names, list):
+        if platform == "cli":
+            legacy_toolsets = _get_legacy_cli_toolset_names(config)
+            if legacy_toolsets is not None:
+                toolset_names = legacy_toolsets
         plat_info = PLATFORMS.get(platform)
-        if plat_info:
-            default_ts = plat_info["default_toolset"]
-        else:
-            # Plugin platform — derive toolset name from platform key
-            default_ts = f"hermes-{platform}"
-        toolset_names = [default_ts]
+        if toolset_names is None:
+            if plat_info:
+                default_ts = plat_info["default_toolset"]
+            else:
+                # Plugin platform — derive toolset name from platform key
+                default_ts = f"hermes-{platform}"
+            toolset_names = [default_ts]
 
     # YAML may parse bare numeric names (e.g. ``12306:``) as int.
     # Normalise to str so downstream sorted() never mixes types.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -74,6 +74,49 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
+def test_get_platform_tools_uses_top_level_toolsets_for_cli():
+    config = {"toolsets": ["terminal", "file"]}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" in enabled
+    assert "file" in enabled
+    assert "web" not in enabled
+
+
+def test_get_platform_tools_uses_model_toolsets_for_cli_when_platform_unset():
+    config = {"model": {"toolsets": ["terminal", "file"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" in enabled
+    assert "file" in enabled
+    assert "web" not in enabled
+
+
+def test_get_platform_tools_expands_minimal_alias_for_cli():
+    config = {"model": {"toolsets": "minimal"}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "web" in enabled
+    assert "terminal" not in enabled
+    assert "file" not in enabled
+
+
+def test_get_platform_tools_platform_config_wins_over_model_toolsets():
+    config = {
+        "model": {"toolsets": ["terminal", "file"]},
+        "platform_toolsets": {"cli": ["web"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "web" in enabled
+    assert "terminal" not in enabled
+    assert "file" not in enabled
+
+
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 


### PR DESCRIPTION
## What does this PR do?

Fixes legacy CLI toolset config fallback so users can actually shrink the runtime tool payload for local endpoints like Ollama. When `platform_toolsets.cli` is unset, Hermes now honors top-level `toolsets`, falls back to `model.toolsets` for compatibility, and expands deterministic aliases like `minimal` into the runtime toolsets they represent instead of silently reverting to the full default CLI payload.

## Related Issue

Fixes #26339

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added legacy CLI toolset normalization in `hermes_cli/tools_config.py` so `_get_platform_tools(..., "cli")` falls back to top-level `toolsets` before defaulting to `hermes-cli`.
- Added a compatibility fallback for `model.toolsets` when `platform_toolsets.cli` is unset.
- Expanded deterministic narrowing aliases like `minimal`, `terminal_only`, `terminal_web`, and `browser_only` into concrete runtime toolsets.
- Added regression tests in `tests/hermes_cli/test_tools_config.py` covering top-level fallback, `model.toolsets`, `minimal`, and `platform_toolsets.cli` precedence.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/hermes_cli/test_tools_config.py`.
2. Run `python3 -m pytest -o addopts='' tests/tools/test_kanban_tools.py -k 'toolset_config or worker_with_kanban_toolset'`.
3. Set `model.toolsets: minimal` or `toolsets: [terminal, file]` in a CLI profile with no `platform_toolsets.cli`, then confirm the resulting enabled runtime toolsets narrow instead of falling back to the full default CLI set.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_tools_config.py` → `70 passed in 2.27s`
- `python3 -m pytest -o addopts='' tests/tools/test_kanban_tools.py -k 'toolset_config or worker_with_kanban_toolset'` → `2 passed, 56 deselected in 0.73s`
