### PR TITLE
fix(ollama): promote JSON content tool calls

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/run_agent.py
+++ b/run_agent.py
@@ -3743,6 +3743,56 @@ class AIAgent:
         )
         return content
 
+    def _promote_content_json_tool_call(self, assistant_message) -> bool:
+        """Promote narrow Ollama-style JSON content into a structured tool call."""
+        if getattr(assistant_message, "tool_calls", None):
+            return False
+        content = getattr(assistant_message, "content", None)
+        if not isinstance(content, str):
+            return False
+
+        stripped = self._strip_think_blocks(content).strip()
+        if not stripped.startswith("{") or not stripped.endswith("}"):
+            return False
+
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(payload, dict):
+            return False
+
+        raw_tool_name = payload.get("name")
+        if not isinstance(raw_tool_name, str):
+            return False
+        tool_name = (
+            raw_tool_name
+            if raw_tool_name in self.valid_tool_names
+            else self._repair_tool_call(raw_tool_name)
+        )
+        if not tool_name:
+            return False
+
+        arguments = payload.get("arguments", {})
+        if arguments is None:
+            arguments = {}
+        if isinstance(arguments, str):
+            arguments_text = arguments.strip() or "{}"
+        else:
+            arguments_text = json.dumps(arguments, ensure_ascii=False)
+
+        call_id = self._deterministic_call_id(tool_name, arguments_text, 0)
+        assistant_message.tool_calls = [
+            SimpleNamespace(
+                id=call_id,
+                call_id=call_id,
+                type="function",
+                function=SimpleNamespace(name=tool_name, arguments=arguments_text),
+            )
+        ]
+        assistant_message.content = None
+        return True
+
     @staticmethod
     def _has_natural_response_ending(content: str) -> bool:
         """Heuristic: does visible assistant text look intentionally finished?"""
@@ -14726,7 +14776,10 @@ class AIAgent:
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
                 
-                # Check for tool calls
+                # Check for tool calls. Some Ollama-hosted models serialize a
+                # single tool call as JSON in content instead of using the
+                # OpenAI-compatible tool_calls field.
+                self._promote_content_json_tool_call(assistant_message)
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:
                         self._vprint(f"{self.log_prefix}🔧 Processing {len(assistant_message.tool_calls)} tool call(s)...")

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1615,6 +1615,37 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "tool_calls")
         assert "extra_content" not in result["tool_calls"][0]
 
+    def test_promotes_ollama_json_content_tool_call(self, agent):
+        msg = _mock_assistant_msg(
+            content=json.dumps(
+                {
+                    "name": "search",
+                    "arguments": {"q": "北京今天的天气"},
+                },
+                ensure_ascii=False,
+            ),
+            tool_calls=None,
+        )
+
+        assert agent._promote_content_json_tool_call(msg) is True
+
+        assert msg.content is None
+        assert len(msg.tool_calls) == 1
+        tool_call = msg.tool_calls[0]
+        assert tool_call.function.name == "web_search"
+        assert json.loads(tool_call.function.arguments) == {"q": "北京今天的天气"}
+
+    def test_does_not_promote_json_content_for_unknown_tool(self, agent):
+        msg = _mock_assistant_msg(
+            content=json.dumps({"name": "unknown_tool", "arguments": {}}),
+            tool_calls=None,
+        )
+
+        assert agent._promote_content_json_tool_call(msg) is False
+
+        assert msg.content == '{"name": "unknown_tool", "arguments": {}}'
+        assert msg.tool_calls is None
+
     def test_think_blocks_stripped_from_content(self, agent):
         """Inline <think> blocks are stripped from stored content (#8878, #9568).
 


### PR DESCRIPTION
## Summary
- detect Ollama-style assistant content that is exactly JSON `{name, arguments}` when `tool_calls` is absent
- promote that payload into a normal OpenAI-compatible `tool_calls` entry so the existing validation/execution path runs
- reuse Hermes tool-name repair so emissions like `search` can resolve to `web_search`

Closes #5867

## Tests
- `python -m pytest -o addopts= tests\run_agent\test_run_agent.py::TestBuildAssistantMessage tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format tests\gateway\test_discord_free_response.py::test_fetch_channel_context_returns_empty_when_channel_lacks_history tests\e2e\test_discord_adapter.py -q --tb=short`
- `python -m ruff check run_agent.py tests\run_agent\test_run_agent.py tests\run_agent\test_provider_parity.py gateway\platforms\discord.py tests\gateway\test_discord_free_response.py tests\e2e\test_discord_adapter.py`
- `git diff --check HEAD~3..HEAD`