### PR TITLE
fix(gateway): force-release HTTP clients on shutdown to unstick orphaned subagents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6202,6 +6202,27 @@ class GatewayRunner:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
 
+                # Force-release HTTP clients on any agent still mid-turn —
+                # ``interrupt()`` only flips a flag checked between iterations,
+                # so a subagent blocked inside an LLM API socket read waits
+                # the OS-level connection timeout (12+ min, #26315) until the
+                # client is closed underneath it. ``release_clients()``
+                # recursively closes ``_active_children`` clients too, so a
+                # single parent-level pass cascades to every depth of
+                # delegation.
+                for _sk, _agent in list(self._running_agents.items()):
+                    if _agent is _AGENT_PENDING_SENTINEL:
+                        continue
+                    if not hasattr(_agent, "release_clients"):
+                        continue
+                    try:
+                        _agent.release_clients()
+                    except Exception as _e:
+                        logger.debug(
+                            "release_clients failed for %s during shutdown: %s",
+                            _sk, _e,
+                        )
+
                 # Kill lingering tool subprocesses NOW, before we spend more
                 # budget on adapter disconnect / session DB close.  Under
                 # systemd (TimeoutStopSec bounded by drain_timeout+headroom),

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -245,3 +245,143 @@ async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch
 
     # Only the final catch-all fires on the graceful path.
     assert kill_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_force_releases_clients_after_interrupt_grace(monkeypatch):
+    """On drain timeout, after interrupting and the 5s grace window, any agent
+    still in ``_running_agents`` must have ``release_clients()`` called so
+    delegate subagents blocked on long-running LLM API network reads get
+    unstuck. Without this, a subagent inside ``client.chat.completions.create()``
+    only checks the interrupt flag between iterations — not during the network
+    read itself — and waits for the OS-level connection timeout (12+ minutes
+    observed in #26315) before the interrupt actually takes effect.
+
+    ``release_clients()`` closes the OpenAI/httpx client AND recursively
+    releases each ``_active_children`` subagent's client, so this single
+    parent-level call cascades to every depth of delegation.
+
+    The test deliberately leaves ``_running_agents`` populated through the
+    5s grace wait — that simulates the stuck-subagent case the fix targets.
+    The test takes ~5s as a result, but xdist parallelism amortizes that
+    across the suite.
+    """
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01  # force timeout path
+    adapter.disconnect = AsyncMock()
+
+    running_agent = MagicMock()
+    runner._running_agents = {"session": running_agent}
+
+    import tools.process_registry as _pr
+    import tools.terminal_tool as _tt
+    import tools.browser_tool as _bt
+    monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 0)
+    monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+    monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    # Both must run on the timeout path: interrupt sets the flag, then the
+    # forced release breaks any in-flight network reads.
+    running_agent.interrupt.assert_called_once()
+    running_agent.release_clients.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_does_not_release_clients_on_graceful_path():
+    """Graceful shutdown — drain finishes inside the timeout — must NOT call
+    ``release_clients()`` on agents. The forced release exists only as a
+    timeout-path safety net for stuck delegate subagents; calling it on the
+    graceful path would close clients out from under agents that finished
+    normally and could break any post-turn finalization that still needs the
+    HTTP client (e.g. a final telemetry POST).
+    """
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+
+    running_agent = MagicMock()
+    runner._running_agents = {"session": running_agent}
+
+    async def finish_agent():
+        await asyncio.sleep(0.05)
+        runner._running_agents.clear()
+
+    asyncio.create_task(finish_agent())
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    running_agent.interrupt.assert_not_called()
+    running_agent.release_clients.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_release_clients_failure_does_not_break_shutdown(monkeypatch):
+    """If one agent's ``release_clients()`` raises, the shutdown sequence must
+    keep going so other agents and the rest of the teardown still run. The
+    forced-release loop is a best-effort safety net, not a hard prerequisite.
+    """
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    disconnect_mock = AsyncMock()
+    adapter.disconnect = disconnect_mock
+
+    bad_agent = MagicMock()
+    bad_agent.release_clients.side_effect = RuntimeError("client already closed")
+    good_agent = MagicMock()
+
+    runner._running_agents = {"bad": bad_agent, "good": good_agent}
+
+    import tools.process_registry as _pr
+    import tools.terminal_tool as _tt
+    import tools.browser_tool as _bt
+    monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 0)
+    monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+    monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    # Both attempted; bad agent's failure didn't prevent the good one's release.
+    bad_agent.release_clients.assert_called_once()
+    good_agent.release_clients.assert_called_once()
+    # Adapter disconnect still ran — shutdown completed despite the per-agent
+    # failure.
+    disconnect_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_skips_release_clients_for_pending_sentinel(monkeypatch):
+    """Sentinel entries in ``_running_agents`` represent sessions whose
+    AIAgent hasn't been instantiated yet (the slot is reserved during the
+    build window). They have no ``release_clients`` to call. The forced-
+    release loop must skip them rather than blow up — same pattern that
+    ``_interrupt_running_agents`` already uses for the sentinel.
+    """
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.01
+    adapter.disconnect = AsyncMock()
+
+    real_agent = MagicMock()
+    runner._running_agents = {
+        "pending": _AGENT_PENDING_SENTINEL,
+        "real": real_agent,
+    }
+
+    import tools.process_registry as _pr
+    import tools.terminal_tool as _tt
+    import tools.browser_tool as _bt
+    monkeypatch.setattr(_pr.process_registry, "kill_all", lambda task_id=None: 0)
+    monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+    monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    # Real agent got the forced release; sentinel was skipped (no AttributeError
+    # raised because the loop returned early via the sentinel guard).
+    real_agent.release_clients.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Closes #26315 — gateway restart leaves delegate subagents blocked on LLM API socket reads for 12+ minutes after the restart signal. Adds a post-interrupt forced-release pass that closes each remaining agent's HTTP client, which cascades recursively to every depth of subagent via the existing `release_clients()` recursion over `_active_children`.

`_interrupt_running_agents` sets a per-thread/per-child interrupt flag on the parent + every child, and `interrupt()` already propagates to subagents via `_active_children`. That works for paths that *check* the flag — between iterations, inside tools — but a subagent already inside `client.chat.completions.create(...)` is blocked on a network read. The OpenAI/httpx client doesn't poll the interrupt flag mid-request. The flag only takes effect when the client returns from the network read, which means the subagent waits for the OS-level connection timeout — 757s, 765s, and 968s observed in the issue's gateway log — before noticing it should stop. Every gateway restart with in-flight delegate work leaves orphaned subagents lingering behind the restart for 12-16 minutes.

The fix: after the existing 5-second post-interrupt grace window in `GatewayRunner.stop()`, walk `_running_agents` once more and call `agent.release_clients()` on anything still alive. `release_clients()` (`run_agent.py:5764+`) iterates `_active_children` and calls `child.release_clients()` recursively, then closes the OpenAI/httpx client itself, which forcibly closes the underlying socket. Any `client.chat.completions.create(...)` call blocked on the network read returns immediately with a connection error, and the agent's existing interrupted-during-API-call cleanup path runs. The 5-second grace stays, so agents that can honor `interrupt()` cleanly still get the chance to do so before we forcibly cut their clients.

## Related Issue

Fixes #26315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — after the 5-second post-interrupt grace window in `GatewayRunner.stop()`, iterate `_running_agents` and call `release_clients()` on anything still alive. Skip `_AGENT_PENDING_SENTINEL` slots (matches `_interrupt_running_agents`). Per-agent failures are caught so one bad release doesn't break shutdown.
- `tests/gateway/test_gateway_shutdown.py` — 4 new cases: forced-release fires on timeout, does NOT fire on graceful path, per-agent failure doesn't break shutdown, sentinel slots are skipped.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_gateway_shutdown.py -v`
2. Expected: 13 passed (4 new + 9 pre-existing).
3. Adjacent: `tests/gateway/test_restart_drain.py test_restart_resume_pending.py test_shutdown_cache_cleanup.py test_shutdown_memory_provider_messages.py test_clean_shutdown_marker.py` — 118 passed total.
4. Regression guard: revert `gateway/run.py` change — the 3 new timeout-path tests fail with `AssertionError: Expected 'release_clients' to have been called once. Called 0 times.` Restore — green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (13/13 + 118 adjacent)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — socket-level cleanup is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #26315 — bug report with timeout evidence (757s, 765s, 968s).
- #12029 — earlier session-leak issue across restart/exception paths (different surface, same family).
- #25966 — gateway restart force-kill races cleanup tail (different timing window, complementary).

## Contract Protected

**Invariant**: every agent the gateway tried to interrupt (via `_interrupt_running_agents`) must have its HTTP clients forcibly released before the gateway proceeds with adapter disconnect, so no subagent at any depth of delegation can stay blocked on a network read past the shutdown sequence.

| Coverage | Test |
|---|---|
| Forced-release fires on the timeout path | `test_gateway_stop_force_releases_clients_after_interrupt_grace` |
| Forced-release does NOT fire on the graceful path | `test_gateway_stop_does_not_release_clients_on_graceful_path` |
| Per-agent failure doesn't break shutdown | `test_gateway_stop_release_clients_failure_does_not_break_shutdown` |
| `_AGENT_PENDING_SENTINEL` slots are skipped | `test_gateway_stop_skips_release_clients_for_pending_sentinel` |

> Sibling code paths that may need the same fix: `tools/transcription_tools.py` and other places that block on httpx network reads while honoring an interrupt flag — the same "flag set ≠ socket closed" gap exists for any long-running API call. Intentionally left out of this PR's scope to keep the diff narrow — happy to widen if preferred.
