### PR TITLE
fix(telegram): propagate nested extra config to adapter

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1053,6 +1053,12 @@ def load_gateway_config() -> GatewayConfig:
                             extra = {}
                             plat_data["extra"] = extra
                         extra[_telegram_extra_key] = telegram_cfg[_telegram_extra_key]
+                if _telegram_extra:
+                    _plat_data, _plat_extra = _ensure_platform_extra_dict(
+                        platforms_data, Platform.TELEGRAM.value
+                    )
+                    for _telegram_extra_key, _telegram_extra_value in _telegram_extra.items():
+                        _plat_extra.setdefault(_telegram_extra_key, _telegram_extra_value)
 
             whatsapp_cfg = yaml_cfg.get("whatsapp", {})
             if isinstance(whatsapp_cfg, dict):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -547,6 +547,26 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["disable_link_previews"] is True
 
+    def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  extra:\n"
+            "    base_url: https://custom-proxy.example.com/bot\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.TELEGRAM].extra["base_url"]
+            == "https://custom-proxy.example.com/bot"
+        )
+
     def test_bridges_notice_delivery_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram config resolution so `telegram.extra.base_url` and other nested `telegram.extra.*` keys actually reach `platforms.telegram.extra` at runtime. The adapter side already reads `self.config.extra["base_url"]`, but the config bridge only forwarded a couple of hard-coded top-level flags, so custom Bot API endpoints were silently dropped.

## Related Issue

Fixes #26359

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a generic `telegram.extra` propagation step in `gateway/config.py` so keys like `base_url` survive YAML config resolution
- Kept existing explicit top-level Telegram overrides intact by only filling missing keys from `telegram.extra`
- Added a regression test in `tests/gateway/test_config.py` covering `telegram.extra.base_url`

## How to Test

1. Add `telegram.extra.base_url: https://custom-proxy.example.com/bot` to `config.yaml`
2. Run `python3 -m pytest -o addopts='' tests/gateway/test_config.py -k 'telegram_extra_base_url or telegram_disable_link_previews'`
3. Start Hermes and confirm `load_gateway_config().platforms[Platform.TELEGRAM].extra["base_url"]` is populated and Telegram uses the custom Bot API endpoint

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/gateway/test_config.py -k 'telegram_extra_base_url or telegram_disable_link_previews'` -> `2 passed, 45 deselected in 0.53s`
- `python3 -m py_compile gateway/config.py tests/gateway/test_config.py`
- `git diff --check`
