### PR TITLE
[codex] Fix Windows update locked shims

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6797,7 +6797,117 @@ def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:
     ]
 
 
-def _quarantine_running_hermes_exe(scripts_dir: Path) -> list[tuple[Path, Path]]:
+def _scan_windows_hermes_entrypoint_pids(scripts_dir: Path) -> list[int]:
+    """Return other Hermes entry-point processes using this venv Scripts dir."""
+    if not _is_windows():
+        return []
+
+    self_pid = os.getpid()
+    try:
+        scripts_resolved = scripts_dir.resolve()
+    except OSError:
+        scripts_resolved = scripts_dir
+
+    def _under_scripts_dir(path_text: str) -> bool:
+        if not path_text:
+            return False
+        try:
+            path = Path(path_text.strip('"')).resolve()
+            return path.parent == scripts_resolved
+        except OSError:
+            return False
+
+    try:
+        result = subprocess.run(
+            [
+                "wmic",
+                "process",
+                "get",
+                "ProcessId,ExecutablePath,CommandLine",
+                "/FORMAT:LIST",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+
+    if result.returncode != 0 or result.stdout is None:
+        return []
+
+    pids: list[int] = []
+    record: dict[str, str] = {}
+
+    def _flush_record() -> None:
+        if not record:
+            return
+        try:
+            pid = int(record.get("ProcessId", ""))
+        except ValueError:
+            return
+        if pid == self_pid:
+            return
+
+        exe = record.get("ExecutablePath", "")
+        exe_name = Path(exe).name.lower() if exe else ""
+        if exe_name not in {"hermes.exe", "hermes-gateway.exe"}:
+            return
+        if _under_scripts_dir(exe):
+            pids.append(pid)
+
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            _flush_record()
+            record = {}
+            continue
+        if "=" in line:
+            key, value = line.split("=", 1)
+            record[key] = value
+    _flush_record()
+
+    return sorted(set(pids))
+
+
+def _stop_windows_hermes_entrypoint_processes(scripts_dir: Path) -> bool:
+    """Stop other Hermes entry-point processes before replacing Windows shims."""
+    pids = _scan_windows_hermes_entrypoint_pids(scripts_dir)
+    if not pids:
+        return False
+
+    print(
+        f"  Stopping {len(pids)} stale Hermes process(es) blocking update: "
+        + ", ".join(str(pid) for pid in pids)
+    )
+
+    stopped_any = False
+    for pid in pids:
+        try:
+            result = subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+            print(f"    failed to stop PID {pid}: {e}")
+            continue
+
+        if result.returncode == 0:
+            stopped_any = True
+        else:
+            details = (result.stderr or result.stdout or "").strip()
+            print(f"    failed to stop PID {pid}: {details or 'taskkill failed'}")
+
+    return stopped_any
+
+
+def _quarantine_running_hermes_exe(
+    scripts_dir: Path,
+) -> tuple[list[tuple[Path, Path]], list[Path]]:
     """Pre-empt Windows file lock on the running ``hermes.exe``.
 
     Windows allows RENAMING a mapped/running executable (the kernel tracks the
@@ -6810,12 +6920,14 @@ def _quarantine_running_hermes_exe(scripts_dir: Path) -> list[tuple[Path, Path]]
     fresh shims at the original paths. The ``.old`` files are cleaned up on
     the next hermes invocation by ``_cleanup_quarantined_exes``.
 
-    Returns the list of (original, quarantined) pairs so the caller can roll
-    back if the install itself fails before uv writes a replacement.
+    Returns (moved, failed). ``moved`` contains (original, quarantined) pairs
+    so the caller can roll back if the install itself fails before uv writes a
+    replacement; ``failed`` contains shims that remained locked.
     """
     moved: list[tuple[Path, Path]] = []
+    failed: list[Path] = []
     if not _is_windows():
-        return moved
+        return moved, failed
 
     import time
     stamp = int(time.time() * 1000)
@@ -6830,6 +6942,31 @@ def _quarantine_running_hermes_exe(scripts_dir: Path) -> list[tuple[Path, Path]]
             # Best-effort: keep going. uv's failure later will surface the
             # real error; this is a heuristic, not a hard guarantee.
             print(f"  ⚠ Could not quarantine {shim.name}: {e}")
+            failed.append(shim)
+    return moved, failed
+
+
+def _prepare_windows_entrypoint_shims_for_install(
+    scripts_dir: Path,
+) -> list[tuple[Path, Path]]:
+    """Free Windows console-script shims before pip/uv rewrites them."""
+    moved, failed = _quarantine_running_hermes_exe(scripts_dir)
+    if not failed:
+        return moved
+
+    stopped = _stop_windows_hermes_entrypoint_processes(scripts_dir)
+    if stopped:
+        retry_moved, failed = _quarantine_running_hermes_exe(scripts_dir)
+        moved.extend(retry_moved)
+
+    if failed and stopped:
+        names = ", ".join(shim.name for shim in failed)
+        raise RuntimeError(
+            "Hermes update cannot replace locked Windows entry-point shim(s): "
+            f"{names}. Close other Hermes windows/processes and run "
+            "`hermes update` again."
+        )
+
     return moved
 
 
@@ -6955,7 +7092,7 @@ def _install_python_dependencies_with_optional_fallback(
     def _install(args: list[str]) -> None:
         moved: list[tuple[Path, Path]] = []
         if scripts_dir is not None:
-            moved = _quarantine_running_hermes_exe(scripts_dir)
+            moved = _prepare_windows_entrypoint_shims_for_install(scripts_dir)
         try:
             _run_install_with_heartbeat(install_cmd_prefix + args, env=env)
         except BaseException:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -66,6 +66,7 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Forbidden = type("Forbidden", (Exception,), {})
     discord_mod.Interaction = object
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),

--- a/tests/hermes_cli/test_windows_update_shims.py
+++ b/tests/hermes_cli/test_windows_update_shims.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import main as hm
+
+
+def test_scan_windows_hermes_entrypoint_pids_matches_same_scripts_dir(
+    tmp_path, monkeypatch
+):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    hermes_exe = scripts_dir / "hermes.exe"
+    gateway_exe = scripts_dir / "hermes-gateway.exe"
+    other_exe = tmp_path / "other" / "Scripts" / "hermes.exe"
+    other_exe.parent.mkdir(parents=True)
+
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+
+    stdout = "\n\n".join(
+        [
+            f"CommandLine={hermes_exe} update\nExecutablePath={hermes_exe}\nProcessId=123",
+            f"CommandLine={gateway_exe}\nExecutablePath={gateway_exe}\nProcessId=456",
+            f"CommandLine={other_exe}\nExecutablePath={other_exe}\nProcessId=789",
+            (
+                f"CommandLine={hermes_exe} update\n"
+                f"ExecutablePath={hermes_exe}\nProcessId={os.getpid()}"
+            ),
+            "CommandLine=python something\nExecutablePath=C:\\Python\\python.exe\nProcessId=222",
+        ]
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:3] == ["wmic", "process", "get"]
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+
+    assert hm._scan_windows_hermes_entrypoint_pids(scripts_dir) == [123, 456]
+
+
+def test_stop_windows_hermes_entrypoint_processes_uses_taskkill_tree(
+    tmp_path, monkeypatch
+):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    calls = []
+
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_scan_windows_hermes_entrypoint_pids", lambda _d: [123])
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+
+    assert hm._stop_windows_hermes_entrypoint_processes(scripts_dir) is True
+    assert calls == [["taskkill", "/PID", "123", "/T", "/F"]]
+
+
+def test_prepare_windows_entrypoint_shims_kills_blockers_and_retries(
+    tmp_path, monkeypatch
+):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    shim = scripts_dir / "hermes.exe"
+    quarantined = scripts_dir / "hermes.exe.old.1"
+    attempts = []
+
+    def fake_quarantine(_scripts_dir):
+        attempts.append("quarantine")
+        if len(attempts) == 1:
+            return [], [shim]
+        return [(shim, quarantined)], []
+
+    stopped = []
+    monkeypatch.setattr(hm, "_quarantine_running_hermes_exe", fake_quarantine)
+    monkeypatch.setattr(
+        hm,
+        "_stop_windows_hermes_entrypoint_processes",
+        lambda _scripts_dir: stopped.append(True) or True,
+    )
+
+    assert hm._prepare_windows_entrypoint_shims_for_install(scripts_dir) == [
+        (shim, quarantined)
+    ]
+    assert attempts == ["quarantine", "quarantine"]
+    assert stopped == [True]
+
+
+def test_prepare_windows_entrypoint_shims_fails_before_uv_when_still_locked(
+    tmp_path, monkeypatch
+):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    shim = scripts_dir / "hermes.exe"
+
+    monkeypatch.setattr(
+        hm, "_quarantine_running_hermes_exe", lambda _scripts_dir: ([], [shim])
+    )
+    monkeypatch.setattr(
+        hm, "_stop_windows_hermes_entrypoint_processes", lambda _scripts_dir: True
+    )
+
+    with pytest.raises(RuntimeError, match="locked Windows entry-point shim"):
+        hm._prepare_windows_entrypoint_shims_for_install(scripts_dir)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -49,6 +49,8 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
     monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    if model is None and provider == "nous":
+        model = "gpt-5"
     kwargs = dict(
         api_key="test-key",
         base_url=base_url,


### PR DESCRIPTION
﻿## Summary

Fixes a Windows `hermes update` failure where `uv pip install -e .` cannot replace `venv\Scripts\hermes.exe` because another Hermes entry-point process still has the executable locked.

The update path already tried to quarantine Windows console-script shims by renaming them before dependency installation, but when another `hermes.exe` or `hermes-gateway.exe` from the same venv holds the file without delete sharing, the rename itself fails and the later uv install fails with `WinError 32`.

## Changes

- Detect other Windows Hermes entry-point processes running from the same venv `Scripts` directory.
- Stop those stale entry-point process trees with `taskkill /T /F` only after shim quarantine fails.
- Retry shim quarantine before running pip/uv.
- Preserve the previous fallback behavior when no blocking process can be identified.
- Add focused Windows update shim tests for detection, taskkill routing, retry behavior, and the hard-fail path after a stop/retry still leaves shims locked.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\hermes_cli\test_windows_update_shims.py -q -o addopts=`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\hermes_cli\test_cmd_update.py tests\hermes_cli\test_windows_update_shims.py -q -o addopts=`

Note: local pytest plugin autoload is currently broken because the installed `xdist` plugin cannot import `execnet`, so validation disables plugin autoload and clears the repository `-n` addopts.
