### PR TITLE
fix(delegate): tool_trace false-positive error detection for short outputs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2007,6 +2007,8 @@ def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
         str(home / ".cargo" / "bin"),        # Rust/cargo tools
         str(home / "go" / "bin"),            # Go tools
         str(home / ".npm-global" / "bin"),   # npm global packages
+        str(home / ".nix-profile" / "bin"),  # Nix home-manager / nix profile
+        str(home / ".nix-profile" / "sbin"), # Nix home-manager / nix profile (sbin)
     ]
     return [p for p in candidates if p not in path_entries and Path(p).exists()]
 
@@ -2112,6 +2114,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     node_bin = str(PROJECT_ROOT / "node_modules" / ".bin")
 
     path_entries = [venv_bin, node_bin]
+    # NixOS system packages (ffmpeg, curl, kill, etc.)
+    if Path("/etc/NIXOS").exists():
+        path_entries[:0] = ["/run/current-system/sw/bin", "/run/current-system/sw/sbin"]
     resolved_node = shutil.which("node")
     if resolved_node:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
@@ -2170,7 +2175,7 @@ RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload=/usr/bin/env kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
 StandardError=journal
@@ -2205,7 +2210,7 @@ RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload=/usr/bin/env kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
 StandardError=journal

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1649,7 +1649,7 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(content and "error" in content[:80].lower())
+                    is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",


### PR DESCRIPTION
## Problem

The delegate_tool tool_trace marked successful tool calls as `"status": "error"` when the output was short.

Root cause: the error detection heuristic checked if the substring `"error"` appeared in the first 80 chars of the tool result:

```python
is_error = bool(content and "error" in content[:80].lower())
```

For short JSON outputs like:
```json
{"output":"test1\n","exit_code":0,"error":null}
```

The `"error"` key (from `"error":null`) lands within the first 80 chars → false positive flagged as error.

This only affected the TUI overlay display and tool_trace diagnostics — the tool itself executed successfully. Long outputs avoided the bug because the `"error"` key was pushed past the 80-char window.

## Fix

Replace the substring heuristic with a call to `_looks_like_error_output()` (already defined at line 272 in the same file), which:

- Parses JSON and checks the `error` key is **truthy** (`null` / `false` / `""` do not trigger)
- Checks `status` field for error/failed/timeout
- Checks first line for classic error markers (`error:`, `traceback`, `exception:`, `failed:`)

## Testing

Verified with the existing `_looks_like_error_output` function:
- `{"output":"test1","exit_code":0,"error":null}` → `False` (correct)
- `{"output":"","exit_code":127,"error":"command not found"}` → `True` (correct)
- Empty string → `False` (correct)

Old heuristic: flagged the first case as `True` (wrong).