### PR TITLE
fix(delegate): tool_trace false-positive error detection for short outputs

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1649,7 +1649,7 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(content and "error" in content[:80].lower())
+                    is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",


### PR DESCRIPTION
## Problem

The delegate_tool tool_trace marked successful tool calls as `"status": "error"` when the output was short.

Root cause: the error detection heuristic checked if the substring `"error"` appeared in the first 80 chars of the tool result:

```python
is_error = bool(content and "error" in content[:80].lower())
```

For short JSON outputs like:
```json
{"output":"test1\n","exit_code":0,"error":null}
```

The `"error"` key (from `"error":null`) lands within the first 80 chars → false positive flagged as error.

This only affected the TUI overlay display and tool_trace diagnostics — the tool itself executed successfully. Long outputs avoided the bug because the `"error"` key was pushed past the 80-char window.

## Fix

Replace the substring heuristic with a call to `_looks_like_error_output()` (already defined at line 272 in the same file), which:

- Parses JSON and checks the `error` key is truthy (`null` / `false` / `""` do not trigger)
- Checks `status` field for error/failed/timeout
- Checks first line for classic error markers (`error:`, `traceback`, `exception:`, `failed:`)

## Testing

Verified with the existing `_looks_like_error_output` function:
- `{"output":"test1","exit_code":0,"error":null}` → `False` (correct)
- `{"output":"","exit_code":127,"error":"command not found"}` → `True` (correct)
- Empty string → `False` (correct)

Old heuristic: flagged the first case as `True` (wrong).