### PR TITLE
feat(message-bus): Hermes Internal Message Bus (MQTT + SQLite)

### DIFF
--- a/agent/escalation.py
+++ b/agent/escalation.py
@@ -1,0 +1,149 @@
+"""Escalation publisher — thin wrapper over the Hermes Internal Message Bus.
+
+All escalations go through hermes_event_bus.publish_event() which:
+  1. Writes durably to SQLite FIRST
+  2. Publishes to MQTT for real-time delivery
+
+This module is kept as a compatibility shim so existing call sites
+(credential_pool.py, auxiliary_client.py, etc.) continue to work
+without modification.
+
+Usage:
+    from agent.escalation import escalate
+    escalate(summary="OpenRouter 402", severity="high", category="payment")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_agent() -> str:
+    """Best-effort agent name detection."""
+    explicit = os.getenv("HERMES_PROFILE", "").strip()
+    if explicit:
+        return explicit
+    cwd = os.getcwd()
+    if ".hermes/profiles/" in cwd:
+        parts = cwd.split(".hermes/profiles/")
+        if len(parts) > 1:
+            return parts[1].split("/")[0]
+    return "unknown"
+
+
+def _severity_to_priority(severity: str) -> int:
+    """Map escalation severity to bus priority."""
+    mapping = {"critical": 1, "high": 2, "medium": 3, "low": 5}
+    return mapping.get(severity.lower(), 3)
+
+
+def _category_to_bus_category(category: str) -> str:
+    """Map old escalation category to bus category."""
+    mapping = {
+        "payment": "system",
+        "auth": "guardrail",
+        "platform": "system",
+        "model": "capability",
+        "tool": "guardrail",
+    }
+    return mapping.get(category.lower(), "system")
+
+
+def escalate(
+    summary: str,
+    *,
+    severity: str = "medium",
+    category: str = "unknown",
+    details: str = "",
+    user_request: str = "",
+    attempted: Optional[List[str]] = None,
+    log_path: str = "",
+    skill_path: str = "",
+    custom: Optional[Dict[str, Any]] = None,
+    agent: Optional[str] = None,
+) -> Optional[int]:
+    """
+    Publish an escalation to the Hermes Internal Message Bus.
+
+    Returns the event row id on success, None on failure.
+    """
+    _agent = (agent or _detect_agent()).strip() or "unknown"
+
+    payload: Dict[str, Any] = {
+        "summary": summary,
+        "details": details,
+        "user_request": user_request,
+        "attempted": attempted or [],
+        "log_path": log_path,
+        "skill_path": skill_path,
+        "legacy_severity": severity,
+        "legacy_category": category,
+    }
+    if custom:
+        payload.update(custom)
+
+    try:
+        from hermes_event_bus import publish_event
+        event_id = publish_event(
+            category=_category_to_bus_category(category),
+            event_type="escalation",
+            source_agent=_agent,
+            target_agent="phoenix",
+            priority=_severity_to_priority(severity),
+            payload=payload,
+        )
+        return event_id
+    except Exception as exc:
+        logger.warning("Escalation publish failed: %s", exc)
+        return None
+
+
+# Convenience wrappers
+
+def escalate_payment(
+    summary: str,
+    details: str = "",
+    attempted: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Optional[int]:
+    return escalate(summary, severity="high", category="payment", details=details, attempted=attempted, **kwargs)
+
+
+def escalate_auth(
+    summary: str,
+    details: str = "",
+    attempted: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Optional[int]:
+    return escalate(summary, severity="high", category="auth", details=details, attempted=attempted, **kwargs)
+
+
+def escalate_platform(
+    summary: str,
+    details: str = "",
+    attempted: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Optional[int]:
+    return escalate(summary, severity="critical", category="platform", details=details, attempted=attempted, **kwargs)
+
+
+def escalate_model(
+    summary: str,
+    details: str = "",
+    attempted: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Optional[int]:
+    return escalate(summary, severity="high", category="model", details=details, attempted=attempted, **kwargs)
+
+
+def escalate_tool(
+    summary: str,
+    details: str = "",
+    attempted: Optional[List[str]] = None,
+    **kwargs: Any,
+) -> Optional[int]:
+    return escalate(summary, severity="medium", category="tool", details=details, attempted=attempted, **kwargs)

--- a/agent/message_subscriber.py
+++ b/agent/message_subscriber.py
@@ -1,0 +1,252 @@
+"""
+Hermes Message Subscriber — MQTT listener for the orchestrator (Phoenix).
+
+Subscribes to:
+  hermes/+/+/phoenix     — events directed at Phoenix
+  hermes/+/+/broadcast   — global broadcasts
+
+When MQTT delivers a message, triage logic decides:
+  - DROP: resolve immediately, no action needed
+  - DELIVER: urgent, needs Phoenix attention in real-time
+  - HOLD: store in pending queue for next Phoenix session
+
+All messages are already durably stored in SQLite by the publisher.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+BROKER = "127.0.0.1"
+PORT = 1883
+KEEPALIVE = 15
+
+# Topics Phoenix listens to
+SUBSCRIBE_TOPICS = [
+    ("hermes/+/+/phoenix", 1),
+    ("hermes/+/+/broadcast", 1),
+]
+
+_HAS_PAHO: bool = False
+try:
+    import paho.mqtt.client as mqtt
+    _HAS_PAHO = True
+except Exception:
+    logger.warning("paho-mqtt not available; message subscriber disabled")
+
+
+# Threading state
+_subscriber_thread: threading.Thread | None = None
+_client: Any = None
+_shutdown_event = threading.Event()
+_handler: Optional[Callable[[Dict[str, Any]], None]] = None
+
+# Pending escalations that need active Phoenix attention
+_pending_lock = threading.Lock()
+_pending_escalations: List[Dict[str, Any]] = []
+
+
+def get_pending_escalations(clear: bool = True) -> List[Dict[str, Any]]:
+    """
+    Return pending escalations that need Phoenix attention.
+    Called by the gateway or agent turn logic to surface unresolved events.
+    If clear=True, empties the queue after returning.
+    """
+    with _pending_lock:
+        copy = list(_pending_escalations)
+        if clear:
+            _pending_escalations.clear()
+        return copy
+
+
+def _resolve_event(event_id: int, status: str, resolution_time_ms: int = 0) -> None:
+    """Resolve an event in the SQLite event log."""
+    try:
+        import hermes_event_bus as bus
+        bus.resolve_event(event_id, status=status, resolution_time_ms=resolution_time_ms)
+    except Exception as exc:
+        logger.debug("Failed to resolve event %s: %s", event_id, exc)
+
+
+def _triage_event(payload: Dict[str, Any]) -> str:
+    """
+    Triage an incoming event.
+
+    Returns one of: DROP, DELIVER, HOLD
+      DROP   — resolve immediately, no action needed (known noise, low priority)
+      DELIVER — urgent, needs immediate attention (priority 1, auth failures)
+      HOLD   — queue for next Phoenix session (priority 2-3 tool failures)
+    """
+    priority = payload.get("priority", 5)
+    category = payload.get("_category", "system")
+    event_type = payload.get("event_type", "unknown")
+    event_id = payload.get("event_id", 0)
+    source = payload.get("_source", "?")
+    recurrence_hash = payload.get("recurrence_hash", "")
+
+    # Priority 1: auth/permission/credential failures — always DELIVER
+    if priority <= 1:
+        return "DELIVER"
+
+    # Category-specific rules
+    if category == "guardrail" and event_type == "tool_failure":
+        # Priority 2: programming errors (AttributeError, TypeError, etc.)
+        # These are usually one-off bugs. Resolve and HOLD for batch review.
+        _resolve_event(event_id, status="resolved", resolution_time_ms=0)
+        return "HOLD"
+
+    if category == "system" and event_type == "cron_output":
+        # Cron outputs: resolve immediately unless they are failure alerts
+        inner = payload.get("payload", {})
+        content = inner.get("content", "")
+        is_failure = content and content.lstrip().startswith("⚠")
+        if is_failure:
+            return "DELIVER"
+        _resolve_event(event_id, status="resolved", resolution_time_ms=0)
+        return "DROP"
+
+    if category == "lifecycle":
+        # Agent lifecycle events (start, stop, crash) — HOLD for review
+        _resolve_event(event_id, status="resolved", resolution_time_ms=0)
+        return "HOLD"
+
+    # Default: medium priority, just log and resolve
+    _resolve_event(event_id, status="resolved", resolution_time_ms=0)
+    return "DROP"
+
+
+def _phoenix_triage_handler(payload: Dict[str, Any]) -> None:
+    """
+    Main handler for Phoenix. Triage every incoming MQTT message.
+    """
+    category = payload.get("_category", "?")
+    event_type = payload.get("event_type", "?")
+    source = payload.get("_source", "?")
+    target = payload.get("_target", "?")
+    priority = payload.get("priority", "?")
+    event_id = payload.get("event_id", 0)
+    recurrence_hash = payload.get("recurrence_hash", "?")
+
+    decision = _triage_event(payload)
+
+    if decision == "DROP":
+        logger.info(
+            "[Bus DROP] %s/%s from %s (id=%s, hash=%s)",
+            category, event_type, source, event_id, recurrence_hash,
+        )
+        return
+
+    if decision == "DELIVER":
+        logger.warning(
+            "[Bus URGENT] %s/%s from %s (prio=%s, id=%s, hash=%s) — needs immediate attention",
+            category, event_type, source, priority, event_id, recurrence_hash,
+        )
+        with _pending_lock:
+            _pending_escalations.append(payload)
+        return
+
+    if decision == "HOLD":
+        logger.info(
+            "[Bus HOLD] %s/%s from %s (prio=%s, id=%s, hash=%s) — queued for review",
+            category, event_type, source, priority, event_id, recurrence_hash,
+        )
+        with _pending_lock:
+            _pending_escalations.append(payload)
+        return
+
+
+def _on_connect(client, userdata, flags, rc, properties=None):
+    if rc == 0:
+        logger.info("Message subscriber connected to MQTT broker")
+        for topic, qos in SUBSCRIBE_TOPICS:
+            client.subscribe(topic, qos=qos)
+            logger.info("Subscribed to %s (qos=%s)", topic, qos)
+    else:
+        logger.error("Message subscriber connect failed, rc=%s", rc)
+
+
+def _on_message(client, userdata, msg):
+    try:
+        payload = json.loads(msg.payload.decode("utf-8"))
+        topic = msg.topic
+        # Inject topic metadata for handler context
+        payload["_topic"] = topic
+        parts = topic.split("/")
+        if len(parts) == 4:
+            payload["_category"] = parts[1]
+            payload["_source"] = parts[2]
+            payload["_target"] = parts[3]
+
+        handler = _handler or _phoenix_triage_handler
+        try:
+            handler(payload)
+        except Exception as exc:
+            logger.exception("Message handler failed for %s: %s", topic, exc)
+    except Exception as exc:
+        logger.exception("Failed to handle message on %s: %s", msg.topic, exc)
+
+
+def _on_disconnect(client, userdata, disconnect_flags, rc, properties=None):
+    logger.warning("Message subscriber disconnected, rc=%s", rc)
+
+
+def start_message_subscriber(
+    handler: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> bool:
+    """
+    Start the MQTT message subscriber in a background daemon thread.
+
+    Args:
+        handler: Optional override callback. If None, uses the built-in
+                 Phoenix triage handler.
+
+    Returns:
+        True if started, False if paho-mqtt is missing or broker unreachable.
+    """
+    global _subscriber_thread, _client, _handler, _shutdown_event
+
+    if not _HAS_PAHO:
+        logger.warning("Message subscriber: paho-mqtt not available")
+        return False
+
+    if _subscriber_thread is not None and _subscriber_thread.is_alive():
+        logger.debug("Message subscriber already running")
+        return True
+
+    _handler = handler
+    _shutdown_event.clear()
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.on_connect = _on_connect
+    client.on_message = _on_message
+    client.on_disconnect = _on_disconnect
+
+    try:
+        client.connect(BROKER, PORT, KEEPALIVE)
+    except Exception as exc:
+        logger.warning("Message subscriber: broker unreachable (%s)", exc)
+        return False
+
+    def _run():
+        client.loop_start()
+        logger.info("Message subscriber thread started")
+        _shutdown_event.wait()
+        client.loop_stop()
+        client.disconnect()
+        logger.info("Message subscriber thread stopped")
+
+    _client = client
+    _subscriber_thread = threading.Thread(
+        target=_run, daemon=True, name="hermes-message-subscriber"
+    )
+    _subscriber_thread.start()
+    return True
+
+
+def stop_message_subscriber() -> None:
+    """Signal the message subscriber to stop."""
+    _shutdown_event.set()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -664,6 +664,30 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     if delivery_errors:
         return "; ".join(delivery_errors)
+
+    # -----------------------------------------------------------------
+    # Publish to Hermes Internal Message Bus for durable logging and reactive
+    # delivery via MQTT. Runs after adaptive delivery succeeds.
+    # -----------------------------------------------------------------
+    try:
+        from hermes_event_bus import publish_event
+        priority = 2 if content and content.lstrip().startswith("⚠") else 5
+        publish_event(
+            category="system",
+            event_type="cron_output",
+            priority=priority,
+            payload={
+                "content": content,
+                "job_id": job.get("id", ""),
+                "job_name": job.get("name", ""),
+                "targets": targets,
+                "delivery_method": "legacy",
+            },
+            target_agent="phoenix" if targets else "broadcast",
+        )
+    except Exception:
+        pass  # fail-open
+
     return None
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7606,6 +7606,33 @@ class GatewayRunner:
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
+            # -----------------------------------------------------------------
+            # Surface pending Message Bus escalations to Phoenix context.
+            # Any DELIVER or HOLD events that arrived via MQTT while Phoenix
+            # was idle get injected as a system note before this turn.
+            # -----------------------------------------------------------------
+            try:
+                from agent.message_subscriber import get_pending_escalations
+                pending = get_pending_escalations(clear=True)
+                if pending:
+                    lines = ["[System note: The following events need attention from other agents:]"]
+                    for evt in pending[:5]:  # cap at 5 to avoid context bloat
+                        cat = evt.get("category", "?")
+                        etype = evt.get("event_type", "?")
+                        src = evt.get("source_agent", "?")
+                        prio = evt.get("priority", "?")
+                        hash_prefix = evt.get("recurrence_hash", "?")[:8]
+                        inner = evt.get("payload", {})
+                        detail = inner.get("error", "") or inner.get("content", "") or inner.get("summary", "")
+                        detail = str(detail)[:120]
+                        lines.append(f"  • {cat}/{etype} from {src} (prio={prio}, hash={hash_prefix}): {detail}")
+                    if len(pending) > 5:
+                        lines.append(f"  ... and {len(pending) - 5} more event(s)")
+                    context_prompt += "\n\n" + "\n".join(lines)
+            except Exception as exc:
+                import logging as _logging
+                _logging.getLogger(__name__).debug("Failed to surface pending escalations: %s", exc)
+
             # Run the agent
             agent_result = await self._run_agent(
                 message=message_text,
@@ -16807,6 +16834,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
+
+    # Start Message Bus subscriber (Phoenix only).
+    # Subscribes to hermes/+/+/phoenix and hermes/+/+/broadcast via MQTT
+    # and triages events: DROP, DELIVER, or HOLD.
+    _message_subscriber_started = False
+    try:
+        _profile_name = _hermes_home.name
+        if _profile_name == "phoenix":
+            from agent.message_subscriber import start_message_subscriber
+            _message_subscriber_started = start_message_subscriber()
+            logger.info("Message subscriber started")
+    except Exception as e:
+        logger.debug("Message subscriber startup failed: %s", e)
     
     # Wait for shutdown
     await runner.wait_for_shutdown()

--- a/hermes_event_bus.py
+++ b/hermes_event_bus.py
@@ -1,0 +1,489 @@
+"""
+Hermes Internal Message Bus v1.0
+
+Unified MQTT + SQLite event bus for all agent-to-agent and system events.
+Replaces notification_bus.py and notification_consumer.py.
+
+Design:
+  1. SQLite is the source of truth — every event is written synchronously.
+  2. MQTT is the real-time transport — best-effort fire-and-forget.
+  3. Phoenix subscribes to hermes/+/+/phoenix and hermes/+/+/broadcast
+     and receives callbacks in real time during active sessions.
+  4. All agents publish via publish_event() which writes to SQLite FIRST,
+     then publishes to MQTT.
+
+Topic hierarchy:
+    hermes/{category}/{source_agent}/{target_agent}
+
+Categories: lifecycle, task, guardrail, capability, user, system
+Target: agent name or "broadcast"
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+HERMES_HOME = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+DB_PATH = Path(HERMES_HOME) / "shared" / "hermes_event_bus.db"
+BROKER = "127.0.0.1"
+PORT = 1883
+KEEPALIVE = 15
+
+# ---------------------------------------------------------------------------
+# Global state
+# ---------------------------------------------------------------------------
+_CONNECTION: sqlite3.Connection | None = None
+_CONNECTION_LOCK = threading.Lock()
+
+_MQTT_CLIENT: Any = None  # paho-mqtt client, lazy-initialised
+_MQTT_LOCK = threading.Lock()
+_HAS_PAHO: bool = False
+
+try:
+    import paho.mqtt.client as mqtt
+    _HAS_PAHO = True
+except Exception:
+    logger.warning("paho-mqtt not available; MQTT transport disabled")
+
+# ---------------------------------------------------------------------------
+# Dynamic field stripping for recurrence hashing
+# ---------------------------------------------------------------------------
+_DYNAMIC_KEYS = frozenset({
+    "timestamp", "created_at", "processed_at", "received_at", "resolved_at",
+    "session_id", "task_id", "message_id", "id", "uuid", "correlation_id",
+    "turn_id", "run_id", "seq", "sequence", "epoch", "ts", "time",
+    "user_message", "user_text", "content", "text",  # user-specific text
+    "agent", "source_agent", "target_agent", "model",  # identity — pattern is in structure
+})
+
+_DYNAMIC_SUFFIXES = ("_at", "_id", "_ts", "_time", "_uuid")
+
+
+def _is_dynamic_key(key: str) -> bool:
+    """Return True if a payload key is considered dynamic for recurrence hashing."""
+    k = key.lower()
+    if k in _DYNAMIC_KEYS:
+        return True
+    for suffix in _DYNAMIC_SUFFIXES:
+        if k.endswith(suffix):
+            return True
+    return False
+
+
+def _strip_dynamic(obj: Any) -> Any:
+    """Recursively strip dynamic fields from a payload for recurrence hashing."""
+    if isinstance(obj, dict):
+        return {
+            k: _strip_dynamic(v)
+            for k, v in obj.items()
+            if not _is_dynamic_key(k)
+        }
+    if isinstance(obj, list):
+        return [_strip_dynamic(item) for item in obj]
+    if isinstance(obj, str):
+        # Normalise whitespace and lowercase
+        return " ".join(obj.lower().split())
+    return obj
+
+
+def _canonical_json(obj: Any) -> str:
+    """Deterministic JSON representation with sorted keys."""
+    return json.dumps(obj, sort_keys=True, ensure_ascii=True, separators=(",", ":"), default=str)
+
+
+def compute_recurrence_hash(payload: dict) -> str:
+    """
+    Strip dynamic values, normalise, and compute a 16-char SHA256 prefix.
+    Identical recurring issues will share this hash regardless of timestamps
+    or session-specific identifiers.
+    """
+    stripped = _strip_dynamic(payload)
+    canonical = _canonical_json(stripped)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# SQLite schema and connection
+# ---------------------------------------------------------------------------
+def _init_db(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS event (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_agent TEXT NOT NULL,
+            target_agent TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            category TEXT NOT NULL,
+            priority INTEGER DEFAULT 5 NOT NULL,
+            payload TEXT NOT NULL,
+            task_id TEXT DEFAULT '',
+            session_id TEXT DEFAULT '',
+            model TEXT DEFAULT '',
+            resolution_status TEXT DEFAULT 'pending',
+            resolution_time_ms INTEGER DEFAULT 0,
+            recurrence_hash TEXT DEFAULT '',
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            processed_at TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_event_unresolved
+        ON event(resolution_status, priority, id)
+        WHERE resolution_status != 'resolved'
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_event_category
+        ON event(category, event_type)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_event_recurrence
+        ON event(recurrence_hash, created_at)
+        WHERE recurrence_hash != ''
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_event_source_target
+        ON event(source_agent, target_agent)
+    """)
+
+
+def _connection() -> sqlite3.Connection:
+    global _CONNECTION
+    if _CONNECTION is None:
+        with _CONNECTION_LOCK:
+            if _CONNECTION is None:
+                DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+                _CONNECTION = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+                _CONNECTION.row_factory = sqlite3.Row
+                _init_db(_CONNECTION)
+    return _CONNECTION
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Core public API: publish_event
+# ---------------------------------------------------------------------------
+def publish_event(
+    category: str,
+    event_type: str,
+    payload: dict,
+    source_agent: str | None = None,
+    target_agent: str = "broadcast",
+    priority: int = 5,
+    task_id: str = "",
+    session_id: str = "",
+    model: str = "",
+) -> int:
+    """
+    Publish an event to the Hermes Internal Message Bus.
+
+    Steps:
+      1. Write synchronously to SQLite (source of truth).
+      2. Compute recurrence hash.
+      3. Publish to MQTT for real-time delivery.
+
+    Returns the SQLite event row id.
+    """
+    # Resolve source agent
+    if source_agent is None:
+        source_agent = os.environ.get("HERMES_PROFILE", "unknown").strip()
+
+    # Validate category
+    valid_categories = {"lifecycle", "task", "guardrail", "capability", "user", "system"}
+    if category not in valid_categories:
+        logger.warning("Invalid category %r, defaulting to 'system'", category)
+        category = "system"
+
+    # Recurrence hash
+    recurrence_hash = compute_recurrence_hash(payload)
+
+    # Serialize payload
+    payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+
+    # 1. SQLite write (synchronous, always succeeds)
+    conn = _connection()
+    created_at = _now_iso()
+    cursor = conn.execute(
+        """
+        INSERT INTO event (
+            source_agent, target_agent, event_type, category, priority,
+            payload, task_id, session_id, model, recurrence_hash, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            source_agent, target_agent, event_type, category, priority,
+            payload_json, task_id, session_id, model, recurrence_hash, created_at,
+        ),
+    )
+    conn.commit()
+    event_id = cursor.lastrowid or 0
+
+    # 2. MQTT publish (best-effort, fire-and-forget, never blocks)
+    if _HAS_PAHO:
+        try:
+            _mqtt_publish(
+                category=category,
+                source_agent=source_agent,
+                target_agent=target_agent,
+                payload={
+                    "event_id": event_id,
+                    "event_type": event_type,
+                    "priority": priority,
+                    "payload": payload,
+                    "recurrence_hash": recurrence_hash,
+                    "task_id": task_id,
+                    "session_id": session_id,
+                    "model": model,
+                    "created_at": created_at,
+                },
+            )
+        except Exception as exc:
+            logger.debug("MQTT publish failed (event still durable in SQLite): %s", exc)
+
+    return event_id
+
+
+# ---------------------------------------------------------------------------
+# Resolution API (Phoenix owns this)
+# ---------------------------------------------------------------------------
+def resolve_event(
+    event_id: int,
+    status: str = "resolved",
+    resolution_time_ms: int = 0,
+) -> bool:
+    """
+    Mark an event as resolved (or other resolution status).
+    Called by Phoenix when an event has been handled.
+    """
+    valid_statuses = {"pending", "resolved", "dropped", "escalated", "hold"}
+    if status not in valid_statuses:
+        logger.warning("Invalid resolution status %r", status)
+        return False
+
+    conn = _connection()
+    conn.execute(
+        """
+        UPDATE event
+        SET resolution_status = ?, resolution_time_ms = ?, processed_at = ?
+        WHERE id = ?
+        """,
+        (status, resolution_time_ms, _now_iso(), event_id),
+    )
+    conn.commit()
+    return True
+
+
+def get_event(event_id: int) -> dict | None:
+    """Retrieve a single event by id."""
+    conn = _connection()
+    row = conn.execute("SELECT * FROM event WHERE id = ?", (event_id,)).fetchone()
+    if row is None:
+        return None
+    return _row_to_dict(row)
+
+
+def poll_unresolved(
+    target_agent: str | None = None,
+    category: str | None = None,
+    limit: int = 50,
+) -> List[dict]:
+    """
+    Poll unresolved events from SQLite.
+    Used by Phoenix at startup to catch anything that arrived while idle.
+    """
+    conn = _connection()
+    query = "SELECT * FROM event WHERE resolution_status = 'pending'"
+    params: List[str] = []
+
+    if target_agent:
+        query += " AND target_agent = ?"
+        params.append(target_agent)
+
+    if category:
+        query += " AND category = ?"
+        params.append(category)
+
+    query += " ORDER BY priority ASC, id ASC"
+    if limit > 0:
+        query += f" LIMIT {limit}"
+
+    cursor = conn.execute(query, params)
+    return [_row_to_dict(row) for row in cursor.fetchall()]
+
+
+def get_recurrence_stats(
+    since_hours: int = 24,
+    min_count: int = 3,
+) -> List[dict]:
+    """
+    Return recurrence hashes that have occurred >= min_count times
+    in the last since_hours hours, with latest event details.
+    """
+    conn = _connection()
+    cursor = conn.execute(
+        """
+        SELECT recurrence_hash, COUNT(*) as cnt,
+               MAX(created_at) as latest,
+               (SELECT event_type FROM event e2
+                WHERE e2.recurrence_hash = e1.recurrence_hash
+                ORDER BY created_at DESC LIMIT 1) as latest_type,
+               (SELECT source_agent FROM event e3
+                WHERE e3.recurrence_hash = e1.recurrence_hash
+                ORDER BY created_at DESC LIMIT 1) as latest_source
+        FROM event e1
+        WHERE recurrence_hash != ''
+          AND created_at > datetime('now', '-{} hours')
+        GROUP BY recurrence_hash
+        HAVING cnt >= ?
+        ORDER BY cnt DESC
+        """.format(since_hours),
+        (min_count,),
+    )
+    return [
+        {
+            "recurrence_hash": row["recurrence_hash"],
+            "count": row["cnt"],
+            "latest_at": row["latest"],
+            "latest_type": row["latest_type"],
+            "latest_source": row["latest_source"],
+        }
+        for row in cursor.fetchall()
+    ]
+
+
+def get_stats() -> dict:
+    """Return event bus statistics for diagnostics."""
+    conn = _connection()
+    total = conn.execute("SELECT COUNT(*) FROM event").fetchone()[0]
+    pending = conn.execute(
+        "SELECT COUNT(*) FROM event WHERE resolution_status = 'pending'"
+    ).fetchone()[0]
+    by_category = conn.execute(
+        "SELECT category, COUNT(*) FROM event WHERE resolution_status = 'pending' GROUP BY category"
+    ).fetchall()
+    by_type = conn.execute(
+        "SELECT event_type, COUNT(*) FROM event WHERE resolution_status = 'pending' GROUP BY event_type"
+    ).fetchall()
+    return {
+        "total": total,
+        "pending": pending,
+        "by_category": {row[0]: row[1] for row in by_category},
+        "by_type": {row[0]: row[1] for row in by_type},
+    }
+
+
+def close() -> None:
+    """Close the shared SQLite connection."""
+    global _CONNECTION
+    if _CONNECTION:
+        with _CONNECTION_LOCK:
+            if _CONNECTION:
+                _CONNECTION.commit()
+                _CONNECTION.close()
+                _CONNECTION = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    payload = {}
+    try:
+        payload = json.loads(row["payload"] or "{}")
+    except Exception:
+        pass
+    return {
+        "id": row["id"],
+        "source_agent": row["source_agent"] or "",
+        "target_agent": row["target_agent"] or "",
+        "event_type": row["event_type"] or "",
+        "category": row["category"] or "",
+        "priority": row["priority"],
+        "payload": payload,
+        "task_id": row["task_id"] or "",
+        "session_id": row["session_id"] or "",
+        "model": row["model"] or "",
+        "resolution_status": row["resolution_status"] or "pending",
+        "resolution_time_ms": row["resolution_time_ms"] or 0,
+        "recurrence_hash": row["recurrence_hash"] or "",
+        "created_at": row["created_at"] or "",
+        "processed_at": row["processed_at"] or "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# MQTT transport (private)
+# ---------------------------------------------------------------------------
+def _ensure_mqtt_client() -> Any:
+    """Lazy-initialise the MQTT publisher client."""
+    global _MQTT_CLIENT
+    if _MQTT_CLIENT is not None:
+        return _MQTT_CLIENT
+
+    with _MQTT_LOCK:
+        if _MQTT_CLIENT is not None:
+            return _MQTT_CLIENT
+
+        if not _HAS_PAHO:
+            raise RuntimeError("paho-mqtt not available")
+
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+        try:
+            client.connect(BROKER, PORT, KEEPALIVE)
+            client.loop_start()
+            _MQTT_CLIENT = client
+            logger.info("MQTT publisher connected to %s:%s", BROKER, PORT)
+        except Exception as exc:
+            logger.warning("MQTT broker unreachable (%s); events remain durable in SQLite", exc)
+            raise
+
+    return _MQTT_CLIENT
+
+
+def _mqtt_publish(
+    category: str,
+    source_agent: str,
+    target_agent: str,
+    payload: dict,
+    qos: int = 1,
+) -> None:
+    """Publish a message to MQTT. Fire-and-forget in a daemon thread."""
+    topic = f"hermes/{category}/{source_agent}/{target_agent}"
+    payload_json = json.dumps(payload, ensure_ascii=False, default=str)
+
+    def _do():
+        try:
+            client = _ensure_mqtt_client()
+            client.publish(topic, payload_json, qos=qos)
+            logger.debug("Published to %s", topic)
+        except Exception as exc:
+            logger.debug("MQTT publish to %s failed: %s", topic, exc)
+
+    # Always fire-and-forget so SQLite write never blocks on network
+    threading.Thread(target=_do, daemon=True, name=f"mqtt-pub-{category}").start()
+
+
+def _mqtt_disconnect() -> None:
+    """Clean disconnect for shutdown."""
+    global _MQTT_CLIENT
+    if _MQTT_CLIENT is not None:
+        try:
+            _MQTT_CLIENT.loop_stop()
+            _MQTT_CLIENT.disconnect()
+        except Exception:
+            pass
+        _MQTT_CLIENT = None

--- a/model_tools.py
+++ b/model_tools.py
@@ -819,6 +819,46 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # -------------------------------------------------------------
+        # Auto-escalate handled tool errors to the Hermes Internal Message Bus.
+        # Detects {"error": "..."} results that registry.dispatch() and
+        # tool_error() emit for caught exceptions. Runs after all hooks
+        # so we observe the final canonical result. Fail-open.
+        # -------------------------------------------------------------
+        try:
+            parsed = json.loads(result)
+            if isinstance(parsed, dict) and "error" in parsed:
+                import os as _os
+                profile = _os.environ.get("HERMES_PROFILE", "unknown")
+                if profile != "phoenix":
+                    from hermes_event_bus import publish_event
+                    err_text = str(parsed.get("error", ""))
+                    priority = 3
+                    if any(k in err_text.lower() for k in ("auth", "permission", "forbidden")):
+                        priority = 1
+                    elif any(k in err_text for k in ("AttributeError", "TypeError", "KeyError", "IndexError", "ValueError", "NameError", "RuntimeError")):
+                        priority = 2
+                    publish_event(
+                        category="guardrail",
+                        event_type="tool_failure",
+                        priority=priority,
+                        payload={
+                            "error": err_text,
+                            "tool": function_name,
+                            "args": function_args,
+                            "agent": profile,
+                            "session_id": session_id or "",
+                            "tool_call_id": tool_call_id or "",
+                            "duration_ms": duration_ms,
+                        },
+                        target_agent="phoenix",
+                        task_id=task_id or "",
+                        session_id=session_id or "",
+                        source_agent=profile,
+                    )
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:


### PR DESCRIPTION
## Summary

This PR introduces the Hermes Internal Message Bus, a unified event routing system that replaces the earlier notification_bus + notification_consumer approach with a durable SQLite-backed store and real-time MQTT pub/sub.

### Key components

- **hermes_event_bus.py** — Central bus API: `publish_event()`, `resolve_event()`, `poll_unresolved()`, `get_recurrence_stats()`. Events are written to SQLite first, then published to MQTT asynchronously so the bus is resilient when the broker is down.
- **agent/message_subscriber.py** — Phoenix MQTT subscriber with triage engine: `DROP` (system/cron), `DELIVER` (priority-1 or held events), `HOLD` (guardrail/tool failures). Exposes `get_pending_escalations()` for context injection.
- **agent/escalation.py** — Backward-compatible shim so existing callers (`credential_pool.py`, `auxiliary_client.py`) work without changes.

### Integration points

- **model_tools.py** — After `transform_tool_result` hooks, detects `{"error": "..."}` payloads and auto-escalates with priority mapping (auth = 1, TypeError = 2, generic = 3). Self-escalation excluded for Phoenix.
- **cron/scheduler.py** — After adaptive delivery succeeds, publishes a `system/cron_output` event. Fail-open try/except so cron never breaks on bus failure.
- **gateway/run.py** — Starts the message subscriber at gateway boot (Phoenix profile only). Injects up to 5 pending DELIVER/HOLD events into the turn's `context_prompt` before `_run_agent()`.

### Pattern deduplication

`compute_recurrence_hash()` strips dynamic fields using a global frozenset (`timestamp`, `session_id`, `task_id`, `uuid`, etc.) plus suffix-based stripping (`_at`, `_id`, `_ts`, `_time`, `_uuid`). Normalized values are SHA256'd for stable incident identifiers.

### OS agnosticism

DB path uses `$HERMES_HOME` env var with a `~/.hermes` fallback, avoiding hardcoded macOS paths. All three new files verified clean of macOS-isms (brew, launchd, /Users/, etc.).

## Test Plan

- [x] All six modified/created files compile cleanly (`py_compile`)
- [x] End-to-end test: publish, subscribe, triage (DROP/DELIVER/HOLD), context injection, escalation shim
- [x] Recurrence hash: identical errors with different session IDs produce same hash
- [x] Orphaned modules confirmed deleted and unimported
