### PR TITLE
fix(delegate): honor api mode for direct endpoints

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3658,6 +3658,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
+        # Not all channel-like objects expose ``history``. Forum parents,
+        # voice channels, and custom proxies in tests can lack it.
+        if not hasattr(channel, "history"):
+            return ""
+
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
         include_other_bots = allow_bots_raw != "none"

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -802,6 +802,22 @@ async def test_fetch_channel_context_ignores_stale_cache(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_channel_context_returns_empty_when_channel_lacks_history(adapter, monkeypatch):
+    """Channel-like objects without ``.history`` should not break backfill."""
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    channel = SimpleNamespace(id=123, name="general")
+
+    result = await adapter._fetch_channel_context(
+        channel,
+        before=SimpleNamespace(id=42),
+    )
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_discord_shared_channel_backfill_prepends_context(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -252,8 +252,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -344,14 +348,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -922,6 +922,20 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    def test_direct_endpoint_detects_deepseek_anthropic_api_mode(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-pro",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/anthropic",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "deepseek-v4-pro")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://api.deepseek.com/anthropic")
+        self.assertIsNone(creds["api_key"])
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -936,6 +936,32 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["api_mode"], "anthropic_messages")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_direct_endpoint_uses_configured_provider_api_mode(self, mock_resolve):
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "https://open.bigmodel.cn/api/custom",
+            "api_key": "provider-key",
+            "api_mode": "anthropic_messages",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "glm-4.6",
+            "provider": "ccr",
+            "base_url": "https://open.bigmodel.cn/api/custom",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        mock_resolve.assert_called_once_with(
+            requested="ccr",
+            explicit_api_key=None,
+            explicit_base_url="https://open.bigmodel.cn/api/custom",
+            target_model="glm-4.6",
+        )
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://open.bigmodel.cn/api/custom")
+        self.assertIsNone(creds["api_key"])
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2371,6 +2371,17 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         base_lower = configured_base_url.lower()
         provider = "custom"
         api_mode = "chat_completions"
+        try:
+            from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+            detected_api_mode = _detect_api_mode_for_url(configured_base_url)
+        except Exception as exc:
+            logger.debug(
+                "Could not infer delegation API mode from base_url '%s': %s",
+                configured_base_url,
+                exc,
+            )
+            detected_api_mode = None
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"
             and "/backend-api/codex" in base_lower
@@ -2383,6 +2394,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"
+        elif detected_api_mode:
+            api_mode = detected_api_mode
 
         return {
             "model": configured_model,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2371,17 +2371,38 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         base_lower = configured_base_url.lower()
         provider = "custom"
         api_mode = "chat_completions"
-        try:
-            from hermes_cli.runtime_provider import _detect_api_mode_for_url
+        detected_api_mode = None
+        if configured_provider:
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
 
-            detected_api_mode = _detect_api_mode_for_url(configured_base_url)
-        except Exception as exc:
-            logger.debug(
-                "Could not infer delegation API mode from base_url '%s': %s",
-                configured_base_url,
-                exc,
-            )
-            detected_api_mode = None
+                runtime = resolve_runtime_provider(
+                    requested=configured_provider,
+                    explicit_api_key=configured_api_key,
+                    explicit_base_url=configured_base_url,
+                    target_model=configured_model,
+                )
+                runtime_api_mode = runtime.get("api_mode")
+                if isinstance(runtime_api_mode, str) and runtime_api_mode.strip():
+                    detected_api_mode = runtime_api_mode.strip()
+            except Exception as exc:
+                logger.debug(
+                    "Could not resolve delegation provider '%s' for direct base_url '%s': %s",
+                    configured_provider,
+                    configured_base_url,
+                    exc,
+                )
+        if not detected_api_mode:
+            try:
+                from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+                detected_api_mode = _detect_api_mode_for_url(configured_base_url)
+            except Exception as exc:
+                logger.debug(
+                    "Could not infer delegation API mode from base_url '%s': %s",
+                    configured_base_url,
+                    exc,
+                )
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"
             and "/backend-api/codex" in base_lower


### PR DESCRIPTION
## Summary
- honor the configured delegation provider's resolved `api_mode` when `delegation.base_url` is also set
- fall back to the shared runtime URL detector for direct endpoints such as `https://api.deepseek.com/anthropic`
- keep direct endpoint API-key inheritance unchanged when `delegation.api_key` is omitted

Fixes #26210.

## Test plan
- `python -m pytest -o addopts= tests\tools\test_delegate.py -q --tb=short`
- `python -m pytest -o addopts= tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format tests\gateway\test_discord_free_response.py::test_fetch_channel_context_returns_empty_when_channel_lacks_history tests\e2e\test_discord_adapter.py -q --tb=short`
- `python -m ruff check tools\delegate_tool.py tests\tools\test_delegate.py tests\run_agent\test_provider_parity.py tests\gateway\test_discord_free_response.py tests\e2e\test_discord_adapter.py gateway\platforms\discord.py`
- `git diff --check origin/main..HEAD`