### PR TITLE
fix(install): avoid publishing uv-managed python shims

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -470,7 +470,7 @@ check_python() {
 
     # Python not found — use uv to install it (no sudo needed!)
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
-    if "$UV_CMD" python install "$PYTHON_VERSION"; then
+    if "$UV_CMD" python install --no-bin "$PYTHON_VERSION"; then
         PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -155,7 +155,7 @@ else
         echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION found"
     else
         echo -e "${CYAN}→${NC} Python $PYTHON_VERSION not found, installing via uv..."
-        $UV_CMD python install "$PYTHON_VERSION"
+        $UV_CMD python install --no-bin "$PYTHON_VERSION"
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
         PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} $PYTHON_FOUND_VERSION installed"

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,7 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         agent.model = "gpt-5"
         messages = [
             {"role": "system", "content": "You are helpful."},
@@ -346,14 +351,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -13,7 +13,7 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def test_install_script_skips_playwright_download_when_system_browser_exists() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     assert "find_system_browser()" in text
     assert "google-chrome google-chrome-stable chromium chromium-browser chrome" in text
@@ -21,14 +21,14 @@ def test_install_script_skips_playwright_download_when_system_browser_exists() -
 
 
 def test_install_script_persists_system_browser_for_agent_browser() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     assert "configure_browser_env_from_system_browser()" in text
     assert "AGENT_BROWSER_EXECUTABLE_PATH=$browser_path" in text
 
 
 def test_playwright_installs_are_timeout_guarded() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     assert "run_browser_install_with_timeout()" in text
     assert "run_browser_install_with_timeout 600 npx playwright install chromium" in text
@@ -41,7 +41,7 @@ def test_playwright_installs_are_timeout_guarded() -> None:
 
 def test_install_script_supports_skip_browser_flag() -> None:
     """--skip-browser (and --no-playwright alias) skips the Playwright install."""
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     assert "--skip-browser|--no-playwright)" in text
     assert "SKIP_BROWSER=true" in text
@@ -51,7 +51,7 @@ def test_install_script_supports_skip_browser_flag() -> None:
 
 def test_install_script_skips_with_deps_when_no_sudo() -> None:
     """Non-sudo users on apt distros must not block on an interactive sudo prompt."""
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     # The apt branch must gate --with-deps behind a sudo capability check
     # (root or non-interactive sudo), otherwise the installer hangs for

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -16,6 +16,7 @@ in ``command_link_dir`` and the venv entry point is left intact.
 from __future__ import annotations
 
 import re
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -29,7 +30,7 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 def _extract_setup_path_shim_block() -> str:
     """Return the install.sh shim-write block used by setup_path()."""
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
     match = re.search(
         r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
         text,
@@ -89,11 +90,18 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
     shim_path.symlink_to(pip_entry)
     assert shim_path.is_symlink()
 
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the install.sh shim block")
+    probe = subprocess.run([bash, "-c", "true"], capture_output=True, text=True)
+    if probe.returncode != 0:
+        pytest.skip("bash is not usable in this environment")
+
     block = _extract_setup_path_shim_block()
     # Drive the block with the real env vars setup_path() sets.
     script = f'set -e\nHERMES_BIN={pip_entry!s}\ncommand_link_dir={command_link_dir!s}\n{block}\n'
     result = subprocess.run(
-        ["bash", "-c", script],
+        [bash, "-c", script],
         capture_output=True,
         text=True,
         cwd=tmp_path,

--- a/tests/test_install_uv_python_no_bin.py
+++ b/tests/test_install_uv_python_no_bin.py
@@ -1,0 +1,22 @@
+"""Regression guard for uv-managed Python installs in shell installers."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_HERMES_SH = REPO_ROOT / "setup-hermes.sh"
+
+
+def test_install_sh_does_not_publish_uv_python_to_global_bin() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert '"$UV_CMD" python install --no-bin "$PYTHON_VERSION"' in text
+    assert '"$UV_CMD" python install "$PYTHON_VERSION"' not in text
+
+
+def test_setup_hermes_does_not_publish_uv_python_to_global_bin() -> None:
+    text = SETUP_HERMES_SH.read_text(encoding="utf-8")
+
+    assert '$UV_CMD python install --no-bin "$PYTHON_VERSION"' in text
+    assert '$UV_CMD python install "$PYTHON_VERSION"' not in text


### PR DESCRIPTION
## Summary
- install uv-managed Python with `--no-bin` so Hermes can create its 3.11 venv without publishing `python`/`python3` shims into a global bin directory
- apply the same behavior to `setup-hermes.sh`
- make installer script tests read UTF-8 explicitly and skip the bash behavioral test when bash is not usable on Windows

Fixes #22054.

## Test plan
- `python -m pytest -o addopts= tests\test_install_sh_symlink_stomp.py tests\test_install_sh_browser_install.py tests\test_install_uv_python_no_bin.py -q --tb=short`
- `python -m ruff check tests\test_install_sh_symlink_stomp.py tests\test_install_sh_browser_install.py tests\test_install_uv_python_no_bin.py`
- `git diff --check`