### PR TITLE
fix(kanban): make `diagnostics --severity` an "at or above" threshold

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1405,12 +1405,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         # request must also surface `error` and `critical`).
         sev = getattr(args, "severity", None)
         if sev:
-            threshold = kd.SEVERITY_ORDER.index(sev)
+            severity_rank = {s: i for i, s in enumerate(kd.SEVERITY_ORDER)}
+            threshold = severity_rank[sev]
             for tid in list(diags_by_task.keys()):
                 kept = [
                     d for d in diags_by_task[tid]
-                    if d.severity in kd.SEVERITY_ORDER
-                    and kd.SEVERITY_ORDER.index(d.severity) >= threshold
+                    if severity_rank.get(d.severity, -1) >= threshold
                 ]
                 if kept:
                     diags_by_task[tid] = kept

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1399,11 +1399,19 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                     if dl:
                         diags_by_task[tid] = dl
 
-        # Severity filter.
+        # Severity filter. argparse limits ``sev`` to one of
+        # ``SEVERITY_ORDER``; comparing by index implements the
+        # documented "at or above" semantics (a `--severity warning`
+        # request must also surface `error` and `critical`).
         sev = getattr(args, "severity", None)
         if sev:
+            threshold = kd.SEVERITY_ORDER.index(sev)
             for tid in list(diags_by_task.keys()):
-                kept = [d for d in diags_by_task[tid] if d.severity == sev]
+                kept = [
+                    d for d in diags_by_task[tid]
+                    if d.severity in kd.SEVERITY_ORDER
+                    and kd.SEVERITY_ORDER.index(d.severity) >= threshold
+                ]
                 if kept:
                     diags_by_task[tid] = kept
                 else:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from pathlib import Path
 
 import pytest
 
 from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_diagnostics as kd
 
 
 @pytest.fixture
@@ -414,10 +416,7 @@ def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def _seed_three_severity_diagnostics(kanban_home, monkeypatch):
-    from hermes_cli import kanban_diagnostics as kd
-
     out = kc.run_slash("create 'noisy task' --assignee alice")
-    import re
     tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
 
     diags = [
@@ -454,9 +453,6 @@ def test_diagnostics_severity_filter_is_threshold_not_exact_match(
 
     out = kc.run_slash(f"diagnostics {flag} --json".strip())
     payload = json.loads(out)
-    if not expected_severities:
-        assert payload == []
-        return
     assert len(payload) == 1
     assert payload[0]["task_id"] == tid
     got = {d["severity"] for d in payload[0]["diagnostics"]}
@@ -466,10 +462,7 @@ def test_diagnostics_severity_filter_is_threshold_not_exact_match(
 def test_diagnostics_severity_filter_drops_task_when_no_match(
     kanban_home, monkeypatch,
 ):
-    from hermes_cli import kanban_diagnostics as kd
-
     out = kc.run_slash("create 'warning only' --assignee alice")
-    import re
     tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
 
     def fake_compute(task, events, runs, *, now=None, config=None):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -402,3 +402,84 @@ def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
     kc.run_slash("--board alpha list")
 
     assert os.environ.get("HERMES_KANBAN_BOARD") == "beta"
+
+
+# ---------------------------------------------------------------------------
+# diagnostics --severity filter (regression for #26379)
+#
+# `--severity X` is documented as "at or above X", but the implementation
+# used to be an exact-match equality. That silently dropped higher-severity
+# diagnostics under `--severity warning`, breaking monitoring scripts that
+# treated warning as a catch-all threshold.
+# ---------------------------------------------------------------------------
+
+def _seed_three_severity_diagnostics(kanban_home, monkeypatch):
+    from hermes_cli import kanban_diagnostics as kd
+
+    out = kc.run_slash("create 'noisy task' --assignee alice")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+
+    diags = [
+        kd.Diagnostic(kind="x_warn", severity="warning",
+                      title="warn", detail="w"),
+        kd.Diagnostic(kind="x_err", severity="error",
+                      title="err", detail="e"),
+        kd.Diagnostic(kind="x_crit", severity="critical",
+                      title="crit", detail="c"),
+    ]
+
+    def fake_compute(task, events, runs, *, now=None, config=None):
+        if task["id"] == tid:
+            return list(diags)
+        return []
+
+    monkeypatch.setattr(kd, "compute_task_diagnostics", fake_compute)
+    return tid
+
+
+@pytest.mark.parametrize(
+    "flag,expected_severities",
+    [
+        ("",                    {"warning", "error", "critical"}),
+        ("--severity warning",  {"warning", "error", "critical"}),
+        ("--severity error",    {"error", "critical"}),
+        ("--severity critical", {"critical"}),
+    ],
+)
+def test_diagnostics_severity_filter_is_threshold_not_exact_match(
+    kanban_home, monkeypatch, flag, expected_severities,
+):
+    tid = _seed_three_severity_diagnostics(kanban_home, monkeypatch)
+
+    out = kc.run_slash(f"diagnostics {flag} --json".strip())
+    payload = json.loads(out)
+    if not expected_severities:
+        assert payload == []
+        return
+    assert len(payload) == 1
+    assert payload[0]["task_id"] == tid
+    got = {d["severity"] for d in payload[0]["diagnostics"]}
+    assert got == expected_severities
+
+
+def test_diagnostics_severity_filter_drops_task_when_no_match(
+    kanban_home, monkeypatch,
+):
+    from hermes_cli import kanban_diagnostics as kd
+
+    out = kc.run_slash("create 'warning only' --assignee alice")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+
+    def fake_compute(task, events, runs, *, now=None, config=None):
+        if task["id"] == tid:
+            return [kd.Diagnostic(kind="x", severity="warning",
+                                  title="w", detail="w")]
+        return []
+
+    monkeypatch.setattr(kd, "compute_task_diagnostics", fake_compute)
+
+    out = kc.run_slash("diagnostics --severity critical --json")
+    payload = json.loads(out)
+    assert payload == []


### PR DESCRIPTION
## Summary

`hermes kanban diagnostics --severity X` is documented as **"at or above X"** but the filter was implemented as an exact-match equality, silently dropping higher-severity diagnostics. Replace with a `SEVERITY_ORDER`-index threshold comparison so the implementation matches the documented (and intuitive) semantics.

Fixes #26379.

## The bug

`hermes_cli/kanban.py:1406` (before):

```python
kept = [d for d in diags_by_task[tid] if d.severity == sev]
```

Argparse help text (`hermes_cli/kanban.py:360`) and the issue reporter's expectation:

> "Only show diagnostics at or above this severity"

Live reproduction from the issue, on a board with two `error`-severity diagnostics:

| Filter | Returned | Expected |
|---|---|---|
| (none) | 2 | 2 |
| `--severity warning` | **0** | 2 |
| `--severity error` | 2 | 2 |
| `--severity critical` | 0 | 0 |

`warning` returned 0 — the silent failure mode. Watchdog cron scripts that use `--severity warning` as a catch-all gate get false-confidence runs while real `error`/`critical` issues go undetected.

## The fix

`hermes_cli/kanban_diagnostics.py` already defines the ordering and uses it for sort/highest:

```python
SEVERITY_ORDER = ("warning", "error", "critical")
```

The filter now uses the same constant to compute a threshold index. `argparse(choices=["warning", "error", "critical"])` already constrains the flag, and the inner `d.severity in SEVERITY_ORDER` guard tolerates any future rule-produced severity that isn't in the canonical tuple without crashing the filter (same pattern used by `severity_of_highest()`).

## Test plan

- [x] Focused regression test: `tests/hermes_cli/test_kanban_cli.py::test_diagnostics_severity_filter_is_threshold_not_exact_match` — parametrized over `(no filter | warning | error | critical)`, asserts kept severities match the threshold semantics.
- [x] Edge case: `test_diagnostics_severity_filter_drops_task_when_no_match` — task whose only diagnostic is below the requested threshold is dropped from output (preserves the existing "no match → drop task" behavior).
- [x] Regression guard: with the original exact-match code, the `--severity warning` and `--severity error` cases fail (because they expect higher-severity diags to be included). With the threshold fix, all 5 pass.
- [x] Adjacent suite: `tests/hermes_cli/test_kanban_cli.py` + `tests/hermes_cli/test_kanban_diagnostics.py` (73 tests). 72 pass; 1 unrelated failure (`test_run_slash_missing_required_arg_friendly_error`) reproduces on clean `origin/main` and is not in the touched code.

## Notes for reviewers

Single-file production change (~10 lines including a why-comment) plus regression tests. The `severity in SEVERITY_ORDER` guard inside the comprehension is intentional defense — rule authors could in principle ship a `Diagnostic(severity="info")` and that should silently skip a `--severity warning` threshold rather than ValueError-crash the CLI.