### PR TITLE
fix(gateway): release evicted cached agents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13845,11 +13845,28 @@ class GatewayRunner:
             self._release_running_agent_state(session_key)
 
     def _evict_cached_agent(self, session_key: str) -> None:
-        """Remove a cached agent for a session (called on /new, /model, etc)."""
+        """Remove a cached agent for a session and release soft client state."""
+        evicted_agent = None
         _lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            return
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                entry = _cache.pop(session_key, None)
+        else:
+            entry = _cache.pop(session_key, None)
+        if isinstance(entry, tuple) and entry:
+            evicted_agent = entry[0]
+        else:
+            evicted_agent = entry
+        if evicted_agent is not None:
+            threading.Thread(
+                target=self._release_evicted_agent_soft,
+                args=(evicted_agent,),
+                daemon=True,
+                name=f"agent-cache-evict-{str(session_key)[:24]}",
+            ).start()
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -13885,6 +13902,9 @@ class GatewayRunner:
         try:
             if hasattr(agent, "release_clients"):
                 agent.release_clients()
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, (list, dict, set)):
+                    session_messages.clear()
             else:
                 # Older agent instance (shouldn't happen in practice) —
                 # fall back to the legacy full-close path.

--- a/model_tools.py
+++ b/model_tools.py
@@ -250,6 +250,7 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_TOOL_DEFS_CACHE_MAX_SIZE = 8
 
 
 def _clear_tool_defs_cache() -> None:
@@ -318,6 +319,8 @@ def get_tool_definitions(
         # agent inits and providers that enforce unique tool names
         # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
         # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
+        if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX_SIZE:
+            _tool_defs_cache.clear()
         _tool_defs_cache[cache_key] = result
         return list(result)
     return result

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -386,6 +386,36 @@ class TestAgentCacheLifecycle:
         with runner._agent_cache_lock:
             assert session_key not in runner._agent_cache
 
+    def test_evict_on_session_reset_soft_releases_clients(self):
+        """Direct eviction should release cached client state without closing tools."""
+        from gateway import run as gw_run
+
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        agent = MagicMock()
+        agent._session_messages = [{"role": "user", "content": "old"}]
+
+        class ImmediateThread:
+            def __init__(self, *, target, args=(), kwargs=None, **_thread_kwargs):
+                self._target = target
+                self._args = args
+                self._kwargs = kwargs or {}
+
+            def start(self):
+                self._target(*self._args, **self._kwargs)
+
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (agent, "sig123")
+
+        with patch.object(gw_run.threading, "Thread", ImmediateThread):
+            runner._evict_cached_agent(session_key)
+
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+        agent.release_clients.assert_called_once()
+        agent.close.assert_not_called()
+        assert agent._session_messages == []
+
     def test_evict_does_not_affect_other_sessions(self):
         """Evicting one session leaves other sessions cached."""
         runner = _make_runner()
@@ -570,6 +600,17 @@ class TestAgentCacheBoundedGrowth:
         assert new_agent not in release_calls
         # Hard-cleanup path must NOT have fired — that's for session expiry only.
         assert cleanup_calls == []
+
+    def test_soft_release_clears_retained_session_messages(self):
+        """Soft cache release should drop large model histories from memory."""
+        runner = self._bounded_runner()
+        agent = self._fake_agent()
+        agent._session_messages = [{"role": "tool", "content": "large output"}]
+
+        runner._release_evicted_agent_soft(agent)
+
+        agent.release_clients.assert_called_once()
+        assert agent._session_messages == []
 
     def test_idle_ttl_sweep_evicts_stale_agents(self, monkeypatch):
         """_sweep_idle_cached_agents removes agents idle past the TTL."""

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -40,6 +40,19 @@ class TestHandleFunctionCall:
         assert len(parsed["error"]) > 0
         assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
 
+    def test_tool_definition_cache_is_bounded(self, monkeypatch):
+        """Config-mtime churn must not grow the quiet-mode schema cache forever."""
+        import model_tools
+
+        model_tools._tool_defs_cache.clear()
+        for idx in range(model_tools._TOOL_DEFS_CACHE_MAX_SIZE):
+            model_tools._tool_defs_cache[(idx,)] = []
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", lambda *a, **kw: [])
+        model_tools.get_tool_definitions(enabled_toolsets=["web"], quiet_mode=True)
+
+        assert len(model_tools._tool_defs_cache) == 1
+
     def test_tool_hooks_receive_session_and_tool_call_ids(self):
         with (
             patch("model_tools.registry.dispatch", return_value='{"ok":true}'),


### PR DESCRIPTION
## Summary

Addresses the main cache-retention paths from #25315:

- soft-release cached `AIAgent` instances when `_evict_cached_agent()` removes them from the gateway cache
- clear retained `_session_messages` during soft release after client cleanup
- bound `model_tools._tool_defs_cache` so config timestamp churn cannot grow it forever
- add regression coverage for direct eviction cleanup, retained message clearing, and bounded tool-definition cache size

This keeps soft eviction distinct from full `close()` teardown, preserving terminal/browser/task resources for resumable sessions while releasing LLM clients and large message histories.

## Tests

- `uv run --with pytest --with pytest-xdist python -m pytest tests/gateway/test_agent_cache.py -q`
- `uv run --with pytest --with pytest-xdist python -m pytest tests/test_model_tools.py -q`
- `uv run --with pytest --with pytest-xdist python -m pytest tests/tools/test_zombie_process_cleanup.py::TestGatewayCleanupWiring::test_evict_does_not_call_close -q`
- `git diff --check`
