### PR TITLE
fix(agent): auto-deduplicate session titles on collision

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -126,6 +126,22 @@ def auto_title_session(
                 title_callback(title)
             except Exception:
                 logger.debug("Auto-title callback failed", exc_info=True)
+    except ValueError as e:
+        # Title already in use — auto-deduplicate with #N suffix
+        # so repeated greetings / identical first exchanges don't
+        # silently leave sessions untitled (issue: title uniqueness).
+        logger.debug("Title collision for %s: %s", session_id, e)
+        try:
+            unique_title = session_db.get_next_title_in_lineage(title)
+            session_db.set_session_title(session_id, unique_title)
+            logger.debug("Auto-generated deduplicated session title: %s", unique_title)
+            if title_callback is not None:
+                try:
+                    title_callback(unique_title)
+                except Exception:
+                    logger.debug("Auto-title callback failed", exc_info=True)
+        except Exception as fallback_err:
+            logger.debug("Failed to set deduplicated title for %s: %s", session_id, fallback_err)
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1079,6 +1079,7 @@ AUTHOR_MAP = {
     "nidhi2894@gmail.com": "nidhi-singh02",  # PR #2752 salvage (slack whitespace-only IndexError guard)
     "38173192+nidhi-singh02@users.noreply.github.com": "nidhi-singh02",
     "Jaaneek@users.noreply.github.com": "Jaaneek",  # PR #26457 (xAI Grok OAuth provider)
+    "02356abc@users.noreply.github.com": "02356abc",  # PR #26389 (auto-deduplicate session titles on collision)
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where auto-generated session titles silently failed when the
LLM produced a title already in use by another session, leaving the new
session untitled.

## Related Issue

No existing issue found. This is a standalone bug fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`agent/title_generator.py\`: In \`auto_title_session\`, catch the
  \`ValueError\` from \`set_session_title\` when the title collides, and
  fall back to \`get_next_title_in_lineage()\` which appends a \`#N\`
  suffix (e.g. \"Hermes Agent Intro #2\").

## Bug Report (Reproduction)

**Observed behavior:**
1. Start session A with \"Who are you?\" → auto-title: \"Hermes Agent Intro\"
2. Start session B with \"Who are you?\" → title generation succeeds but
   \`set_session_title\` raises \`ValueError: Title already in use\`
3. Session B remains untitled (title = null)

**Root cause:** \`SessionDB\` enforces a uniqueness constraint on session
titles (\`idx_sessions_title_unique\`). The auto-title generator did not
handle collisions, so repeated greetings or identical first exchanges
would silently leave sessions untitled.

**Analysis:** The codebase already has infrastructure for handling
duplicate titles:
- \`resolve_session_by_title()\` searches for \"title #N\" variants and
  returns the latest one
- \`get_next_title_in_lineage()\` computes the next available \`#N\` suffix

However, the auto-title path (\`auto_title_session\`) was not using this
infrastructure — it simply gave up when \`set_session_title\` failed.

**Fix:** When a collision is detected, automatically append a \`#N\`
suffix using the existing \`get_next_title_in_lineage()\` helper. This
aligns the auto-title behaviour with \`resolve_session_by_title()\` and
makes the title-unique constraint workable instead of silently broken.

## How to Test

1. Start two sessions with the same first message (e.g. \"Who are you?\")
2. Both sessions should receive auto-generated titles
3. The second session's title should have a \"#2\" suffix

## Checklist

- [x] pytest tests/agent/test_title_generator.py -v (20 passed)
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix