### PR TITLE
fix(codex): rotate credential pool on usage-limit 429

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5037,7 +5037,7 @@ class AIAgent:
         if isinstance(body, dict):
             payload = body.get("error") if isinstance(body.get("error"), dict) else body
         if isinstance(payload, dict):
-            reason = payload.get("code") or payload.get("error")
+            reason = payload.get("code") or payload.get("type") or payload.get("error")
             if isinstance(reason, str) and reason.strip():
                 context["reason"] = reason.strip()
             message = payload.get("message") or payload.get("error_description")
@@ -7404,7 +7404,15 @@ class AIAgent:
             return False, has_retried_429
 
         if effective_reason == FailoverReason.rate_limit:
-            if not has_retried_429:
+            usage_limit_reached = False
+            if error_context:
+                context_reason = str(error_context.get("reason") or "").lower()
+                context_message = str(error_context.get("message") or "").lower()
+                usage_limit_reached = (
+                    "usage_limit_reached" in context_reason
+                    or "usage limit has been reached" in context_message
+                )
+            if not has_retried_429 and not usage_limit_reached:
                 return False, True
             rotate_status = status_code if status_code is not None else 429
             next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3692,6 +3692,37 @@ class TestCredentialPoolRecovery:
         assert retry_same is False
         agent._swap_credential.assert_called_once_with(next_entry)
 
+    def test_recover_with_pool_rotates_usage_limit_429_immediately(self, agent):
+        next_entry = SimpleNamespace(label="secondary")
+        captured = {}
+
+        class _Pool:
+            def current(self):
+                return SimpleNamespace(label="primary")
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                captured["status_code"] = status_code
+                captured["error_context"] = error_context
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+            },
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        assert captured["status_code"] == 429
+        assert captured["error_context"]["reason"] == "usage_limit_reached"
+        agent._swap_credential.assert_called_once_with(next_entry)
+
 
     def test_recover_with_pool_refreshes_on_401(self, agent):
         """401 with successful refresh should swap to refreshed credential."""
@@ -3777,6 +3808,22 @@ class TestCredentialPoolRecovery:
         assert context["reason"] == "device_code_exhausted"
         assert context["message"] == "Weekly credits exhausted."
         assert context["reset_at"] == "2026-04-12T10:30:00Z"
+
+    def test_extract_api_error_context_uses_type_as_reason(self, agent):
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "usage_limit_reached"
+        assert context["message"] == "The usage limit has been reached"
 
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")


### PR DESCRIPTION
## What does this PR do?

Codex can return HTTP 429 with `error.type = "usage_limit_reached"` and message `The usage limit has been reached`. Hermes currently drops the `type` field while extracting error context, so the recovery path sees only a generic 429 `rate_limit` and intentionally retries the same credential once before rotating.

For Codex account quota windows, that first retry is wasted: the current OAuth profile is exhausted until reset, while another same-provider pool entry may still be usable. This PR preserves the structured `type` value and rotates immediately for the known `usage_limit_reached` signal.

## Related Issue

Fixes #26388

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: include `payload["type"]` when extracting structured API error context.
- `run_agent.py`: skip the first same-credential retry for Codex-style `usage_limit_reached` 429s and immediately call `mark_exhausted_and_rotate()`.
- `tests/run_agent/test_run_agent.py`: regression coverage for extracting `usage_limit_reached` from `type` and rotating on the first 429 for that reason.

## Similar Issues / PRs Checked

This is narrower than the current related work:

- #26149 rotates immediately only when the current entry is already marked exhausted; it does not handle a fresh `usage_limit_reached` body on the first 429.
- #25733 aligns credential pools with runtime/fallback state; it does not change `usage_limit_reached` classification/recovery behavior.
- #25277 loads pools during `/model` switch; different entry path.
- #24173 handles Codex Responses soft failures where HTTP status is 200 with `response.status=failed`; this PR handles the HTTP exception path.
- #19608 fixes concurrent auth-store stale writes; different persistence race.
- #22778/#22792 fixed auxiliary-client cache pinning; this PR is the main agent recovery path.

Searches included `usage_limit_reached` with `first 429`, `second 429`, `retry same credential`, `rotate immediately`, and `The usage limit has been reached` + `credential pool` across open and closed issues/PRs.

## How to Test

1. Unit repro before the fix: call `_recover_with_credential_pool(status_code=429, has_retried_429=False, error_context={"reason": "usage_limit_reached"})`; it returns `(False, True)` and does not rotate.
2. With this PR, the same call returns `(True, False)` and swaps to the next pool entry.
3. Run tests:

```shell
pytest -o addopts='' tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery -q
pytest -o addopts='' tests/run_agent/test_run_agent.py tests/agent/test_credential_pool.py -q
```

Local results:

```shell
10 passed in 9.99s
370 passed in 226.47s
```

I also ran:

```shell
pytest -o addopts='' tests/run_agent/test_run_agent.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py -q
```

That reached `379 passed` and failed one CLI-routing test at import time because this clean local worktree environment is missing the `fire` package (`ModuleNotFoundError: No module named 'fire'`). The failure happens while importing `cli.py`, not in the changed recovery code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Known provider message:

```shell
HTTP 429: The usage limit has been reached
```

Known structured body field now preserved:

```shell
error.type = usage_limit_reached
```
