### PR TITLE
fix(config): write runtime aliases into model config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2768,6 +2768,15 @@ def _set_nested(config, dotted_key: str, value):
         current[last] = value
 
 
+_CONFIG_SET_KEY_ALIASES = {
+    "model": "model.default",
+    "provider": "model.provider",
+    "base_url": "model.base_url",
+    "api_mode": "model.api_mode",
+    "context_length": "model.context_length",
+}
+
+
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
@@ -5043,6 +5052,7 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
+    key = _CONFIG_SET_KEY_ALIASES.get(key, key)
     _set_nested(user_config, key, value)
     
     # Write only user config back (not the full merged defaults)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch, call
 
 import pytest
+import yaml
 
 from hermes_cli.config import set_config_value, config_command
 
@@ -99,9 +100,21 @@ class TestConfigYamlRouting:
 
     def test_simple_key(self, _isolated_hermes_home):
         set_config_value("model", "gpt-4o")
-        config = _read_config(_isolated_hermes_home)
-        assert "gpt-4o" in config
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["model"]["default"] == "gpt-4o"
         assert "model" not in _read_env(_isolated_hermes_home)
+
+    def test_model_runtime_aliases_write_canonical_model_section(self, _isolated_hermes_home):
+        set_config_value("provider", "openai-codex")
+        set_config_value("model", "gpt-5.5")
+        set_config_value("base_url", "https://api.example.com/v1")
+
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["model"]["provider"] == "openai-codex"
+        assert config["model"]["default"] == "gpt-5.5"
+        assert config["model"]["base_url"] == "https://api.example.com/v1"
+        assert "provider" not in config
+        assert "base_url" not in config
 
     def test_nested_key(self, _isolated_hermes_home):
         set_config_value("terminal.backend", "docker")
@@ -149,8 +162,8 @@ class TestFalsyValues:
     def test_empty_string_routes_to_config(self, _isolated_hermes_home):
         """Blanking a config key should write an empty string to config.yaml."""
         set_config_value("model", "")
-        config = _read_config(_isolated_hermes_home)
-        assert "model: ''" in config or "model: \"\"" in config
+        config = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert config["model"]["default"] == ""
 
     def test_zero_routes_to_config(self, _isolated_hermes_home):
         """Setting a config key to '0' should write 0 to config.yaml."""

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,7 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         agent.model = "gpt-5"
         messages = [
             {"role": "system", "content": "You are helpful."},
@@ -346,14 +351,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- Route shorthand runtime config keys from `hermes config set` into the canonical `model.*` section.
- Keep `hermes config set model ...` and `hermes config set provider ...` aligned with what interactive chat reads.
- Add regression coverage for the alias writes.

Fixes #24433

## Testing
- `python -m pytest -o addopts= tests\hermes_cli\test_set_config_value.py -q --tb=short`
- `python -m ruff check hermes_cli\config.py tests\hermes_cli\test_set_config_value.py`
- `git diff --check`