### PR TITLE
fix(qqbot): surface cached file attachments to agents

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1620,11 +1620,17 @@ class QQAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache image: %s", self._log_tag, exc)
             else:
-                # Other attachments (video, file, etc.): record as text.
+                # Other attachments (video, file, etc.): keep the text marker
+                # and pass the cached local path through the normal media_urls
+                # channel so downstream tools can open the file.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(
+                        url, ct, original_filename=filename
+                    )
                     if cached_path:
                         other_attachments.append(f"[Attachment: {filename or ct}]")
+                        image_urls.append(cached_path)
+                        image_media_types.append(ct)
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
 
@@ -1636,7 +1642,12 @@ class QQAdapter(BasePlatformAdapter):
             "attachment_info": attachment_info,
         }
 
-    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
+    async def _download_and_cache(
+            self,
+            url: str,
+            content_type: str,
+            original_filename: str = "",
+    ) -> Optional[str]:
         """Download a URL and cache it locally."""
         from tools.url_safety import is_safe_url
 
@@ -1668,7 +1679,11 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = Path(urlparse(url).path).name or "qq_attachment"
+            filename = (
+                original_filename.strip()
+                or Path(urlparse(url).path).name
+                or "qq_attachment"
+            )
             return cache_document_from_bytes(data, filename)
 
     @staticmethod

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -236,6 +236,60 @@ class TestQQWebSocketProxy:
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
 
+
+class TestQQAttachmentProcessing:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_process_attachments_surfaces_cached_documents_to_agent(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._download_and_cache = mock.AsyncMock(return_value="/tmp/report.xlsx")  # type: ignore[method-assign]
+
+        out = await adapter._process_attachments([
+            {
+                "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "url": "https://grouptalk.c2c.qq.com/files/qqdownloadftnv5",
+                "filename": "成绩表.xlsx",
+            }
+        ])
+
+        assert out["image_urls"] == ["/tmp/report.xlsx"]
+        assert out["image_media_types"] == [
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ]
+        assert out["attachment_info"] == "[Attachment: 成绩表.xlsx]"
+        adapter._download_and_cache.assert_awaited_once_with(
+            "https://grouptalk.c2c.qq.com/files/qqdownloadftnv5",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            original_filename="成绩表.xlsx",
+        )
+
+    @pytest.mark.asyncio
+    async def test_download_and_cache_prefers_original_filename_for_documents(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+
+        response = mock.Mock()
+        response.content = b"spreadsheet-bytes"
+        response.raise_for_status = mock.Mock()
+        adapter._http_client = mock.AsyncMock()
+        adapter._http_client.get = mock.AsyncMock(return_value=response)
+
+        with mock.patch("tools.url_safety.is_safe_url", return_value=True), \
+                mock.patch(
+                    "gateway.platforms.qqbot.adapter.cache_document_from_bytes",
+                    return_value="/tmp/成绩表.xlsx",
+                ) as cache_doc:
+            cached = await adapter._download_and_cache(
+                "https://grouptalk.c2c.qq.com/files/qqdownloadftnv5",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                original_filename="成绩表.xlsx",
+            )
+
+        assert cached == "/tmp/成绩表.xlsx"
+        cache_doc.assert_called_once_with(b"spreadsheet-bytes", "成绩表.xlsx")
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes QQ Bot document attachments so Hermes keeps the original filename and passes the cached local file path into the agent event instead of dropping the file after download.

## Related Issue

Fixes #26399

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `gateway/platforms/qqbot/adapter.py` so non-image/non-voice attachments append their cached local path into the normal `media_urls` / `media_types` pipeline instead of only emitting a text marker.
- Pass QQ attachment metadata `filename` into `_download_and_cache()` and prefer it over the CDN URL basename when caching documents.
- Add regression tests in `tests/gateway/test_qqbot.py` covering both cached document surfacing and original-filename preservation.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/gateway/test_qqbot.py`.
2. Verify document attachments now keep the original filename in cache and surface a local path through the QQ adapter attachment pipeline.
3. Optionally reproduce with a QQ document attachment and confirm the agent can see a local cached file path instead of only `[Attachment: ...]` text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/gateway/test_qqbot.py` → `146 passed, 1 warning in 4.19s`
- `python3 -m py_compile gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`
- `git diff --check`
- Attempted repo-wide gate via `uv run --extra dev --extra acp python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -x`, but the environment is missing optional test dependencies outside this change (`fastapi` on branch, `aiohttp` on clean `origin/main`).
