### PR TITLE
fix(gateway): preserve spaced unicode media paths from tool output

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -86,6 +86,22 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
 
 
+def _extract_media_paths_from_tool_content(content: str) -> tuple[list[str], bool]:
+    """Extract MEDIA paths from persisted tool output.
+
+    Tool outputs are often JSON strings, so a simple ``MEDIA:(\\S+)`` regex
+    truncates paths containing spaces before BasePlatformAdapter gets a chance
+    to deliver them. Reuse the platform extractor here so Unicode filenames and
+    local paths with spaces round-trip through the post-run media scan.
+    """
+    if not isinstance(content, str) or "MEDIA:" not in content:
+        return [], False
+    media, _cleaned = BasePlatformAdapter.extract_media(content)
+    paths = [path for path, _is_voice in media if path]
+    has_voice = any(is_voice for _path, is_voice in media)
+    return paths, has_voice
+
+
 # Only auto-continue interrupted gateway turns while the interruption is fresh.
 # Stale tool-tail/resume markers can otherwise revive an unrelated old task
 # after a gateway restart when the user's next message starts new work.
@@ -15499,8 +15515,7 @@ class GatewayRunner:
                 if _hm.get("role") in {"tool", "function"}:
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
-                        for _match in re.finditer(r'MEDIA:(\S+)', _hc):
-                            _p = _match.group(1).strip().rstrip('",}')
+                        for _p in _extract_media_paths_from_tool_content(_hc)[0]:
                             if _p:
                                 _history_media_paths.add(_p)
             
@@ -15788,11 +15803,11 @@ class GatewayRunner:
                     if msg.get("role") in {"tool", "function"}:
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
-                            for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
+                            paths, has_voice = _extract_media_paths_from_tool_content(content)
+                            for path in paths:
                                 if path and path not in _history_media_paths:
                                     media_tags.append(f"MEDIA:{path}")
-                            if "[[audio_as_voice]]" in content:
+                            if has_voice:
                                 has_voice_directive = True
                 
                 if media_tags:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -7,8 +7,12 @@ This prevents voice messages from accumulating and being sent multiple
 times per reply. (Regression test for #160)
 """
 
-import pytest
+import json
 import re
+
+import pytest
+
+from gateway.run import _extract_media_paths_from_tool_content
 
 
 def extract_media_tags_fixed(result_messages, history_len):
@@ -178,6 +182,30 @@ class TestMediaExtraction:
         seen = set()
         unique = [t for t in tags if t not in seen and not seen.add(t)]
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
+
+    def test_tool_media_parser_preserves_unicode_paths_with_spaces(self):
+        """Real gateway extraction must keep non-ASCII filenames intact.
+
+        The old MEDIA:(\\S+) scan truncated this at the first space, leaving
+        Telegram with a path like /tmp/<first-word> instead of the .ogg file.
+        """
+        filename = (
+            "\u0433\u043e\u043b\u043e\u0441\u043e\u0432\u0430\u044f "
+            "\u0437\u0430\u043f\u0438\u0441\u044c.ogg"
+        )
+        path = f"/tmp/{filename}"
+        content = json.dumps(
+            {
+                "success": True,
+                "media_tag": f"[[audio_as_voice]]\nMEDIA:{path}",
+            },
+            ensure_ascii=False,
+        )
+
+        paths, has_voice = _extract_media_paths_from_tool_content(content)
+
+        assert paths == [path]
+        assert has_voice is True
 
 
 if __name__ == "__main__":

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary

Addresses the novel MEDIA extraction part of #26355: gateway tool-output scanning now preserves local media paths that contain spaces and non-ASCII filenames instead of truncating them with `MEDIA:(\S+)`.

## Changes

- Reuse `BasePlatformAdapter.extract_media()` when scanning persisted tool output for MEDIA paths.
- Apply the same extraction to history de-duplication and current-turn media forwarding.
- Add a regression test for a Cyrillic `.ogg` filename with a space inside a JSON tool result.

Addresses #26355 (Bug 1: Cyrillic/spaced MEDIA paths lost during extraction)

## Tests

- `python -m pytest -o addopts= tests\gateway\test_media_extraction.py tests\gateway\test_platform_base.py::TestExtractMedia tests\gateway\test_tts_media_routing.py -q --tb=short`
- `python -m ruff check gateway\run.py tests\gateway\test_media_extraction.py`
- `git diff --check`