### PR TITLE
fix(gateway): keep Discord docs out of photo vision routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -766,16 +766,33 @@ def _build_media_placeholder(event) -> str:
     """
     parts = []
     media_urls = getattr(event, "media_urls", None) or []
-    media_types = getattr(event, "media_types", None) or []
     for i, url in enumerate(media_urls):
-        mtype = media_types[i] if i < len(media_types) else ""
-        if mtype.startswith("image/") or getattr(event, "message_type", None) == MessageType.PHOTO:
+        if _event_media_is_image(event, i):
             parts.append(f"[User sent an image: {url}]")
-        elif mtype.startswith("audio/"):
+        elif _event_media_is_audio(event, i):
             parts.append(f"[User sent audio: {url}]")
         else:
             parts.append(f"[User sent a file: {url}]")
     return "\n".join(parts)
+
+
+def _event_media_type_at(event, index: int) -> str:
+    media_types = getattr(event, "media_types", None) or []
+    return media_types[index] if index < len(media_types) else ""
+
+
+def _event_media_is_image(event, index: int) -> bool:
+    mtype = _event_media_type_at(event, index)
+    if mtype:
+        return mtype.startswith("image/")
+    return getattr(event, "message_type", None) == MessageType.PHOTO
+
+
+def _event_media_is_audio(event, index: int) -> bool:
+    mtype = _event_media_type_at(event, index)
+    if mtype:
+        return mtype.startswith("audio/")
+    return getattr(event, "message_type", None) in {MessageType.VOICE, MessageType.AUDIO}
 
 
 def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
@@ -6819,10 +6836,9 @@ class GatewayRunner:
             image_paths = []
             audio_paths = []
             for i, path in enumerate(event.media_urls):
-                mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
+                if _event_media_is_image(event, i):
                     image_paths.append(path)
-                if mtype.startswith("audio/") or event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+                if _event_media_is_audio(event, i):
                     audio_paths.append(path)
 
             if image_paths:

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -2,7 +2,7 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _build_media_placeholder
 from gateway.session import SessionSource, build_session_key
 
 
@@ -77,3 +77,42 @@ async def test_native_image_buffer_not_cleared_by_other_sessions_without_images(
 
     assert runner._consume_pending_native_image_paths(build_session_key(source_a)) == ["/tmp/a.png"]
     assert runner._consume_pending_native_image_paths(build_session_key(source_b)) == []
+
+
+@pytest.mark.asyncio
+async def test_native_image_buffer_excludes_document_attachments_from_photo_messages():
+    runner = _make_runner()
+    source = _source("chat-mixed")
+    event = MessageEvent(
+        text="see both",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/picture.png", "/tmp/notes.md"],
+        media_types=["image/png", "text/markdown"],
+    )
+
+    await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == [
+        "/tmp/picture.png"
+    ]
+
+
+def test_media_placeholder_respects_per_attachment_media_types():
+    source = _source("chat-placeholder")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/picture.png", "/tmp/notes.md"],
+        media_types=["image/png", "text/markdown"],
+    )
+
+    assert _build_media_placeholder(event) == (
+        "[User sent an image: /tmp/picture.png]\n"
+        "[User sent a file: /tmp/notes.md]"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the mixed-attachment half of #25935. When a Discord message contains both images and documents, Hermes currently treats every attachment as an image if the message-level type is `PHOTO`. That causes non-image files like `.md` to be forwarded into the vision image path and can trigger provider-side `Could not process image` 400s.

This patch narrows the fallback: Hermes now trusts each attachment's own MIME type first, and only falls back to the message-level `PHOTO` classification when that attachment has no per-file MIME metadata.

## Related Issue

Addresses #25935

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `gateway/run.py` to classify inbound media per attachment, so document attachments on Discord photo messages no longer enter the image routing / vision path.
- Reuse the same per-attachment classification for busy-session media placeholders, so queued mixed attachments keep image/file distinctions.
- Add regressions in `tests/gateway/test_native_image_buffer_isolation.py` covering mixed image+document photo messages.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/gateway/test_native_image_buffer_isolation.py`.
2. Verify a `MessageType.PHOTO` event with `media_types=["image/png", "text/markdown"]` only buffers the image path for native vision delivery.
3. Verify the busy placeholder renders the image attachment as an image and the `.md` attachment as a file, instead of marking both as images.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/gateway/test_native_image_buffer_isolation.py` → `4 passed in 0.35s`
- `python3 -m py_compile gateway/run.py tests/gateway/test_native_image_buffer_isolation.py`
- `git diff --check`
- Broader `tests/gateway/test_discord_document_handling.py` is red in this environment before/after the patch because current Discord attachment tests hit existing SSRF URL blocking against `https://cdn.discordapp.com/attachments/fake/file`; not caused by this change.
