### PR TITLE
fix(gateway/status): catch SystemError from os.kill on Windows

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -496,8 +496,11 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError, OSError):
-                # Windows raises OSError with WinError 87 for invalid pid check
+            except (ProcessLookupError, PermissionError, OSError, SystemError):
+                # Windows raises OSError with WinError 87 for invalid pid check.
+                # CPython on Windows sometimes wraps that as SystemError
+                # ("<class 'OSError'> returned a result with an exception set")
+                # when probing a definitely-gone pid - treat both as "process is gone".
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -736,6 +739,10 @@ def get_running_pid(
         try:
             os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
         except ProcessLookupError:
+            continue
+        except SystemError:
+            # CPython on Windows can surface as SystemError when os.kill
+            # gets a definitely-invalid pid; treat as process-gone.
             continue
         except PermissionError:
             # The process exists but belongs to another user/service scope.


### PR DESCRIPTION
## Summary

On Windows, CPython's `os.kill(pid, 0)` can raise `SystemError` instead of `OSError` when probing a definitely-gone PID:

```
SystemError: <class 'OSError'> returned a result with an exception set
```

This propagates out of `acquire_scoped_lock()` during gateway startup. PM2 restarts the gateway, the stale lock file still points at the dead PID, the gateway crashes again on the next startup — infinite restart loop until something manually clears `~/.hermes/gateway.lock` or the OS recycles enough PIDs that the stale PID number gets reused by a non-Hermes process.

## Fix

Treat `SystemError` the same as `OSError`/`ProcessLookupError` in both `os.kill(pid, 0)` probe sites in `gateway/status.py` (`acquire_scoped_lock` and `get_running_pid`): if it raises, the probed process is gone.

## Repro

Reproduced on Windows 11 + Python 3.11 + PM2 after a Mac→Windows migration where the stale `~/.hermes/gateway.lock` contained a PID number from the old MacBook host. Gateway logs filled with:

```
File "gateway/platforms/base.py", line 1000, in _acquire_platform_lock
    acquired, existing = acquire_scoped_lock(...)
File "gateway/status.py", line 498, in acquire_scoped_lock
    os.kill(existing_pid, 0)
SystemError: <class 'OSError'> returned a result with an exception set
ERROR gateway.run: Gateway failed to connect any configured messaging platform: telegram
```

The bot logged 78 restarts in ~4h before stabilizing (presumably once a successful Python worker happened to win the race against the lock probe, or the system PID space rolled over). On lower-end hardware or with sticky stale PIDs the loop could be unbounded.

## Test Plan
- [x] Live patch applied to my install, gateway no longer crashes on startup.
- [ ] No automated test added — this is a Windows-specific CPython quirk path; would need a Windows CI runner + ability to inject a SystemError to test cleanly.

## Notes
Same fix pattern as the existing `OSError` catch with the Windows-specific WinError 87 comment. Just adds `SystemError` to the tuple in both spots.