### PR TITLE
fix(kanban): stop forcing dashboard text to all caps

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1418,7 +1418,7 @@
     return h("div", { className: "hermes-kanban-boardswitcher" },
       h("div", { className: "hermes-kanban-boardswitcher-inner" },
         h("div", { className: "flex flex-col gap-0.5" },
-          h("div", { className: "text-[11px] uppercase tracking-wider text-muted-foreground" },
+          h("div", { className: "text-[11px] tracking-wider text-muted-foreground" },
             tx(t, "board", "Board")),
           h("div", { className: "flex items-center gap-2" },
             h(Select, Object.assign({

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -457,7 +457,6 @@
 .hermes-kanban-section-head {
   font-size: 0.72rem;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--color-muted-foreground);
 }
@@ -603,7 +602,6 @@
 }
 .hermes-kanban-deps-label {
   font-size: 0.68rem;
-  text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-muted-foreground);
   min-width: 4rem;
@@ -683,7 +681,6 @@
   border: 0;
   color: var(--color-muted-foreground);
   font-size: 0.7rem;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   cursor: pointer;
   padding: 0;
@@ -861,7 +858,6 @@
 .hermes-kanban-run-outcome {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-foreground);
 }
@@ -921,7 +917,6 @@
 .hermes-kanban-run-meta-label {
   font-size: 0.65rem;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--color-muted-foreground);
   padding-bottom: 0.15rem;


### PR DESCRIPTION
## What does this PR do?

Fixes the Kanban dashboard's forced ALL-CAPS presentation for user-facing text.

The WebUI was uppercasing several frequently repeated labels and status fields, which made the board noisier to scan and obscured the exact casing of stored values. This patch removes those uppercase transforms from the built dashboard assets so the UI renders in normal case by default.

## Related Issue

Fixes #26408

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed the `uppercase` Tailwind class from the board switcher label in `plugins/kanban/dashboard/dist/index.js`.
- Removed `text-transform: uppercase` from repeated Kanban dashboard text treatments in `plugins/kanban/dashboard/dist/style.css`, including section headers, dependency labels, edit links, run outcomes, and run metadata labels.

## How to Test

1. Open the Kanban dashboard and inspect the board switcher, task sections, dependency editor labels, run history outcomes, and run metadata labels.
2. Confirm these UI elements now render in normal case instead of forced ALL CAPS.
3. Run:
   - `node --check plugins/kanban/dashboard/dist/index.js`
   - `rg -n "uppercase|text-transform:\\s*uppercase" plugins/kanban/dashboard/dist`
   - `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not included. This change is limited to removing uppercase styling from existing dashboard text treatments.
