### PR TITLE
fix(cli): include profile in resume hints

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6396,7 +6396,12 @@ class HermesCLI:
                 }, f, indent=2, ensure_ascii=False)
             print(f"(^_^)v Conversation snapshot saved to: {path}")
             if self.session_id:
-                print(f"       Resume the live session with: hermes --resume {self.session_id}")
+                try:
+                    from hermes_cli.resume_hints import build_resume_command
+                    resume_hint = build_resume_command(self.session_id)
+                except Exception:
+                    resume_hint = f"hermes --resume {self.session_id}"
+                print(f"       Resume the live session with: {resume_hint}")
         except Exception as e:
             print(f"(x_x) Failed to save: {e}")
     
@@ -11297,10 +11302,16 @@ class HermesCLI:
                 except Exception:
                     pass
 
+            try:
+                from hermes_cli.resume_hints import build_continue_command, build_resume_command
+            except Exception:
+                build_resume_command = lambda session_id: f"hermes --resume {session_id}"
+                build_continue_command = lambda title: f'hermes -c "{title}"'
+
             print("Resume this session with:")
-            print(f"  hermes --resume {self.session_id}")
+            print(f"  {build_resume_command(self.session_id)}")
             if session_title:
-                print(f"  hermes -c \"{session_title}\"")
+                print(f"  {build_continue_command(session_title)}")
             print()
             print(f"Session:        {self.session_id}")
             if session_title:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -864,11 +864,17 @@ def _print_tui_exit_summary(
         if db is not None:
             db.close()
 
+    try:
+        from hermes_cli.resume_hints import build_continue_command, build_resume_command
+    except Exception:
+        build_resume_command = lambda session_id, tui=False: f"hermes --tui --resume {session_id}"
+        build_continue_command = lambda title, tui=False: f'hermes --tui -c "{title}"'
+
     print()
     print("Resume this session with:")
-    print(f"  hermes --tui --resume {target}")
+    print(f"  {build_resume_command(target, tui=True)}")
     if title:
-        print(f'  hermes --tui -c "{title}"')
+        print(f"  {build_continue_command(title, tui=True)}")
     print()
     print(f"Session:        {target}")
     if title:

--- a/hermes_cli/resume_hints.py
+++ b/hermes_cli/resume_hints.py
@@ -8,26 +8,14 @@ default profile and report ``Session not found``.
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Iterable
 
 
-def _shell_double_quote(value: str) -> str:
-    """Return a double-quoted shell token, preserving existing hint style.
-
-    Inside double quotes, POSIX shells still expand ``$...`` and backticks, so
-    escape those too.  Newlines are rendered as spaces to keep the hint a
-    single copy/pasteable command line.
-    """
-    escaped = (
-        value.replace("\r", " ")
-        .replace("\n", " ")
-        .replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("$", "\\$")
-        .replace("`", "\\`")
-    )
-    return '"' + escaped + '"'
+def _shell_quote(value: str) -> str:
+    """Return a POSIX-shell-safe token for a single-line hint command."""
+    return shlex.quote(value.replace("\r", " ").replace("\n", " "))
 
 
 def _active_profile_name_for_cli_hint() -> str | None:
@@ -54,8 +42,28 @@ def _active_profile_name_for_cli_hint() -> str | None:
     return None
 
 
+def _active_custom_home_for_cli_hint() -> Path | None:
+    """Return HERMES_HOME for non-profile custom homes that need an env hint."""
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.profiles import _get_default_hermes_home
+
+        hermes_home = get_hermes_home().resolve()
+        default_home = _get_default_hermes_home().resolve()
+        native_default_home = (Path.home() / ".hermes").resolve()
+        if hermes_home == default_home and hermes_home != native_default_home:
+            return hermes_home
+    except Exception:
+        return None
+    return None
+
+
 def _base_command_parts(*, tui: bool = False) -> list[str]:
-    parts = ["hermes"]
+    parts: list[str] = []
+    custom_home = _active_custom_home_for_cli_hint()
+    if custom_home is not None:
+        parts.append(f"HERMES_HOME={_shell_quote(str(custom_home))}")
+    parts.append("hermes")
     profile_name = _active_profile_name_for_cli_hint()
     if profile_name:
         parts.extend(["-p", profile_name])
@@ -75,4 +83,4 @@ def build_resume_command(session_id: str, *, tui: bool = False) -> str:
 
 def build_continue_command(title: str, *, tui: bool = False) -> str:
     """Build a profile-aware resume-by-title command."""
-    return _join_parts([*_base_command_parts(tui=tui), "-c", _shell_double_quote(str(title))])
+    return _join_parts([*_base_command_parts(tui=tui), "-c", _shell_quote(str(title))])

--- a/hermes_cli/resume_hints.py
+++ b/hermes_cli/resume_hints.py
@@ -1,0 +1,78 @@
+"""Helpers for shell-visible session resume hints.
+
+The command printed at the end of a session must recreate the same profile
+context that produced the session.  Named profiles store their sessions under a
+profile-specific HERMES_HOME, so a plain ``hermes --resume <id>`` may look in the
+default profile and report ``Session not found``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+def _shell_double_quote(value: str) -> str:
+    """Return a double-quoted shell token, preserving existing hint style.
+
+    Inside double quotes, POSIX shells still expand ``$...`` and backticks, so
+    escape those too.  Newlines are rendered as spaces to keep the hint a
+    single copy/pasteable command line.
+    """
+    escaped = (
+        value.replace("\r", " ")
+        .replace("\n", " ")
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+    return '"' + escaped + '"'
+
+
+def _active_profile_name_for_cli_hint() -> str | None:
+    """Return the active named profile for ``hermes -p ...`` hints, if any.
+
+    We intentionally derive this from the active HERMES_HOME path rather than
+    only from ``get_active_profile_name()``: that function returns ``"custom"``
+    for unrecognized homes, which is ambiguous with a real named profile called
+    ``custom``.  A profile flag is only safe when HERMES_HOME is exactly one
+    child under the profiles root.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.profiles import _PROFILE_ID_RE, _get_profiles_root
+
+        hermes_home = get_hermes_home().resolve()
+        profiles_root = _get_profiles_root().resolve()
+        rel = hermes_home.relative_to(profiles_root)
+        parts = rel.parts
+        if len(parts) == 1 and _PROFILE_ID_RE.match(parts[0]):
+            return parts[0]
+    except Exception:
+        return None
+    return None
+
+
+def _base_command_parts(*, tui: bool = False) -> list[str]:
+    parts = ["hermes"]
+    profile_name = _active_profile_name_for_cli_hint()
+    if profile_name:
+        parts.extend(["-p", profile_name])
+    if tui:
+        parts.append("--tui")
+    return parts
+
+
+def _join_parts(parts: Iterable[str]) -> str:
+    return " ".join(parts)
+
+
+def build_resume_command(session_id: str, *, tui: bool = False) -> str:
+    """Build a profile-aware ``hermes --resume`` command."""
+    return _join_parts([*_base_command_parts(tui=tui), "--resume", str(session_id)])
+
+
+def build_continue_command(title: str, *, tui: bool = False) -> str:
+    """Build a profile-aware resume-by-title command."""
+    return _join_parts([*_base_command_parts(tui=tui), "-c", _shell_double_quote(str(title))])

--- a/tests/cli/test_exit_summary_profile_resume.py
+++ b/tests/cli/test_exit_summary_profile_resume.py
@@ -1,0 +1,104 @@
+"""Regression tests for profile-aware classic CLI resume hints."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class _FakeSessionDB:
+    def __init__(self, title: str | None = "demo title"):
+        self.title = title
+
+    def get_session_title(self, _session_id: str) -> str | None:
+        return self.title
+
+
+def _reset_profile_modules():
+    for name in list(sys.modules):
+        if name in {"cli", "hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"}:
+            sys.modules.pop(name, None)
+
+
+def _stub_cli(session_id: str = "20260409_000001_abc123", title: str | None = "demo title"):
+    return SimpleNamespace(
+        conversation_history=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+        session_id=session_id,
+        session_start=datetime.now() - timedelta(seconds=3),
+        _session_db=_FakeSessionDB(title),
+    )
+
+
+def test_exit_summary_default_profile_keeps_existing_resume_hint(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    _reset_profile_modules()
+
+    import cli
+
+    cli.HermesCLI._print_exit_summary(_stub_cli())
+    out = capsys.readouterr().out
+
+    assert "  hermes --resume 20260409_000001_abc123" in out
+    assert '  hermes -c "demo title"' in out
+    assert "hermes -p" not in out
+
+
+def test_exit_summary_named_profile_includes_profile_flag(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_profile_modules()
+
+    import cli
+
+    cli.HermesCLI._print_exit_summary(_stub_cli())
+    out = capsys.readouterr().out
+
+    assert "  hermes -p coder --resume 20260409_000001_abc123" in out
+    assert '  hermes -p coder -c "demo title"' in out
+
+
+def test_exit_summary_named_custom_profile_is_not_treated_as_unknown_custom_home(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / ".hermes" / "profiles" / "custom"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_profile_modules()
+
+    import cli
+
+    cli.HermesCLI._print_exit_summary(_stub_cli())
+    out = capsys.readouterr().out
+
+    assert "  hermes -p custom --resume 20260409_000001_abc123" in out
+    assert '  hermes -p custom -c "demo title"' in out
+
+
+def test_exit_summary_custom_home_falls_back_to_plain_resume_hint(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    custom_home = tmp_path / "standalone-hermes-home"
+    custom_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    _reset_profile_modules()
+
+    import cli
+
+    cli.HermesCLI._print_exit_summary(_stub_cli())
+    out = capsys.readouterr().out
+
+    assert "  hermes --resume 20260409_000001_abc123" in out
+    assert '  hermes -c "demo title"' in out
+    assert "hermes -p" not in out

--- a/tests/cli/test_exit_summary_profile_resume.py
+++ b/tests/cli/test_exit_summary_profile_resume.py
@@ -47,7 +47,7 @@ def test_exit_summary_default_profile_keeps_existing_resume_hint(tmp_path, monke
     out = capsys.readouterr().out
 
     assert "  hermes --resume 20260409_000001_abc123" in out
-    assert '  hermes -c "demo title"' in out
+    assert "  hermes -c 'demo title'" in out
     assert "hermes -p" not in out
 
 
@@ -64,7 +64,7 @@ def test_exit_summary_named_profile_includes_profile_flag(tmp_path, monkeypatch,
     out = capsys.readouterr().out
 
     assert "  hermes -p coder --resume 20260409_000001_abc123" in out
-    assert '  hermes -p coder -c "demo title"' in out
+    assert "  hermes -p coder -c 'demo title'" in out
 
 
 def test_exit_summary_named_custom_profile_is_not_treated_as_unknown_custom_home(
@@ -82,14 +82,14 @@ def test_exit_summary_named_custom_profile_is_not_treated_as_unknown_custom_home
     out = capsys.readouterr().out
 
     assert "  hermes -p custom --resume 20260409_000001_abc123" in out
-    assert '  hermes -p custom -c "demo title"' in out
+    assert "  hermes -p custom -c 'demo title'" in out
 
 
-def test_exit_summary_custom_home_falls_back_to_plain_resume_hint(
+def test_exit_summary_custom_home_includes_hermes_home_env(
     tmp_path, monkeypatch, capsys
 ):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    custom_home = tmp_path / "standalone-hermes-home"
+    custom_home = tmp_path / "standalone hermes home"
     custom_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(custom_home))
     _reset_profile_modules()
@@ -99,6 +99,7 @@ def test_exit_summary_custom_home_falls_back_to_plain_resume_hint(
     cli.HermesCLI._print_exit_summary(_stub_cli())
     out = capsys.readouterr().out
 
-    assert "  hermes --resume 20260409_000001_abc123" in out
-    assert '  hermes -c "demo title"' in out
+    env_prefix = f"HERMES_HOME='{custom_home}'"
+    assert f"  {env_prefix} hermes --resume 20260409_000001_abc123" in out
+    assert f"  {env_prefix} hermes -c 'demo title'" in out
     assert "hermes -p" not in out

--- a/tests/cli/test_save_conversation_location.py
+++ b/tests/cli/test_save_conversation_location.py
@@ -132,3 +132,39 @@ def test_save_conversation_named_profile_resume_hint_includes_profile_flag(
     out = capsys.readouterr().out
     assert (profile_home / "sessions" / "saved").is_dir()
     assert "Resume the live session with: hermes -p coder --resume 20260101_120000_abc123" in out
+
+
+def test_save_conversation_custom_home_resume_hint_includes_env(
+    tmp_path, monkeypatch, capsys
+):
+    custom_home = tmp_path / "standalone hermes home"
+    custom_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    for mod in [
+        m
+        for m in sys.modules
+        if m in {"cli", "hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"}
+    ]:
+        sys.modules.pop(mod, None)
+
+    import cli
+
+    stub = _make_stub_cli([
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ])
+
+    cli.HermesCLI.save_conversation(stub)
+
+    out = capsys.readouterr().out
+    assert (custom_home / "sessions" / "saved").is_dir()
+    env_prefix = f"HERMES_HOME='{custom_home}'"
+    assert (
+        f"Resume the live session with: {env_prefix} hermes --resume 20260101_120000_abc123"
+        in out
+    )

--- a/tests/cli/test_save_conversation_location.py
+++ b/tests/cli/test_save_conversation_location.py
@@ -100,3 +100,35 @@ def test_save_conversation_empty_history_does_nothing(hermes_home, capsys):
     assert not saved_dir.exists() or not list(saved_dir.iterdir())
     out = capsys.readouterr().out
     assert "No conversation to save" in out
+
+
+def test_save_conversation_named_profile_resume_hint_includes_profile_flag(
+    tmp_path, monkeypatch, capsys
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    for mod in [
+        m
+        for m in sys.modules
+        if m in {"cli", "hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"}
+    ]:
+        sys.modules.pop(mod, None)
+
+    import cli
+
+    stub = _make_stub_cli([
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ])
+
+    cli.HermesCLI.save_conversation(stub)
+
+    out = capsys.readouterr().out
+    assert (profile_home / "sessions" / "saved").is_dir()
+    assert "Resume the live session with: hermes -p coder --resume 20260101_120000_abc123" in out

--- a/tests/hermes_cli/test_resume_hints.py
+++ b/tests/hermes_cli/test_resume_hints.py
@@ -1,0 +1,97 @@
+"""Tests for profile-aware resume hint command builders."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _reset_modules():
+    for name in list(sys.modules):
+        if name in {"hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"}:
+            sys.modules.pop(name, None)
+
+
+def test_resume_command_default_profile_has_no_profile_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_resume_command
+
+    assert build_resume_command("sess123") == "hermes --resume sess123"
+    assert build_resume_command("sess123", tui=True) == "hermes --tui --resume sess123"
+
+
+def test_resume_command_named_profile_adds_global_profile_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_continue_command, build_resume_command
+
+    assert build_resume_command("sess123") == "hermes -p coder --resume sess123"
+    assert build_resume_command("sess123", tui=True) == "hermes -p coder --tui --resume sess123"
+    assert build_continue_command("demo title") == 'hermes -p coder -c "demo title"'
+    assert build_continue_command("demo title", tui=True) == 'hermes -p coder --tui -c "demo title"'
+
+
+def test_resume_command_named_custom_profile_is_preserved(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / ".hermes" / "profiles" / "custom"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_resume_command
+
+    assert build_resume_command("sess123") == "hermes -p custom --resume sess123"
+
+
+def test_resume_command_unrecognized_custom_home_falls_back_to_plain_command(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    custom_home = tmp_path / "custom-home"
+    custom_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_resume_command
+
+    assert build_resume_command("sess123") == "hermes --resume sess123"
+
+
+def test_resume_command_custom_root_named_profile_adds_profile_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / "opt" / "data" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_resume_command
+
+    assert build_resume_command("sess123") == "hermes -p coder --resume sess123"
+
+
+def test_continue_command_escapes_double_quoted_shell_expansions(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _reset_modules()
+
+    from hermes_cli.resume_hints import build_continue_command
+
+    command = build_continue_command(r'say "hi" \ $HOME `whoami` $(date)')
+
+    assert command.startswith('hermes -p coder -c "')
+    assert r'\"hi\"' in command
+    assert r'\\' in command
+    assert r'\$HOME' in command
+    assert r'\`whoami\`' in command
+    assert r'\$(date)' in command

--- a/tests/hermes_cli/test_resume_hints.py
+++ b/tests/hermes_cli/test_resume_hints.py
@@ -36,8 +36,8 @@ def test_resume_command_named_profile_adds_global_profile_flag(tmp_path, monkeyp
 
     assert build_resume_command("sess123") == "hermes -p coder --resume sess123"
     assert build_resume_command("sess123", tui=True) == "hermes -p coder --tui --resume sess123"
-    assert build_continue_command("demo title") == 'hermes -p coder -c "demo title"'
-    assert build_continue_command("demo title", tui=True) == 'hermes -p coder --tui -c "demo title"'
+    assert build_continue_command("demo title") == "hermes -p coder -c 'demo title'"
+    assert build_continue_command("demo title", tui=True) == "hermes -p coder --tui -c 'demo title'"
 
 
 def test_resume_command_named_custom_profile_is_preserved(tmp_path, monkeypatch):
@@ -52,18 +52,21 @@ def test_resume_command_named_custom_profile_is_preserved(tmp_path, monkeypatch)
     assert build_resume_command("sess123") == "hermes -p custom --resume sess123"
 
 
-def test_resume_command_unrecognized_custom_home_falls_back_to_plain_command(
+def test_resume_command_unrecognized_custom_home_includes_hermes_home_env(
     tmp_path, monkeypatch
 ):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    custom_home = tmp_path / "custom-home"
+    custom_home = tmp_path / "custom home"
     custom_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(custom_home))
     _reset_modules()
 
-    from hermes_cli.resume_hints import build_resume_command
+    from hermes_cli.resume_hints import build_continue_command, build_resume_command
 
-    assert build_resume_command("sess123") == "hermes --resume sess123"
+    env_prefix = f"HERMES_HOME='{custom_home}'"
+    assert build_resume_command("sess123") == f"{env_prefix} hermes --resume sess123"
+    assert build_resume_command("sess123", tui=True) == f"{env_prefix} hermes --tui --resume sess123"
+    assert build_continue_command("demo title") == f"{env_prefix} hermes -c 'demo title'"
 
 
 def test_resume_command_custom_root_named_profile_adds_profile_flag(tmp_path, monkeypatch):
@@ -78,7 +81,7 @@ def test_resume_command_custom_root_named_profile_adds_profile_flag(tmp_path, mo
     assert build_resume_command("sess123") == "hermes -p coder --resume sess123"
 
 
-def test_continue_command_escapes_double_quoted_shell_expansions(tmp_path, monkeypatch):
+def test_continue_command_shell_quotes_expansion_and_history_characters(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     profile_home = tmp_path / ".hermes" / "profiles" / "coder"
     profile_home.mkdir(parents=True)
@@ -87,11 +90,7 @@ def test_continue_command_escapes_double_quoted_shell_expansions(tmp_path, monke
 
     from hermes_cli.resume_hints import build_continue_command
 
-    command = build_continue_command(r'say "hi" \ $HOME `whoami` $(date)')
+    title = "say 'hi' $HOME `whoami` $(date)!\nnext"
+    command = build_continue_command(title)
 
-    assert command.startswith('hermes -p coder -c "')
-    assert r'\"hi\"' in command
-    assert r'\\' in command
-    assert r'\$HOME' in command
-    assert r'\`whoami\`' in command
-    assert r'\$(date)' in command
+    assert command == "hermes -p coder -c 'say '\"'\"'hi'\"'\"' $HOME `whoami` $(date)! next'"

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -553,7 +553,7 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
 
     assert "Resume this session with:" in out
     assert "hermes --tui --resume 20260409_000001_abc123" in out
-    assert 'hermes --tui -c "demo title"' in out
+    assert "hermes --tui -c 'demo title'" in out
     assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
 
 
@@ -633,7 +633,7 @@ def test_print_tui_exit_summary_named_profile_includes_profile_flag(
     out = capsys.readouterr().out
 
     assert "hermes -p coder --tui --resume 20260409_000001_abc123" in out
-    assert 'hermes -p coder --tui -c "demo title"' in out
+    assert "hermes -p coder --tui -c 'demo title'" in out
 
 
 def test_print_tui_exit_summary_custom_profile_includes_profile_flag(
@@ -675,7 +675,7 @@ def test_print_tui_exit_summary_custom_profile_includes_profile_flag(
     assert "hermes -p custom --tui --resume 20260409_000001_abc123" in out
 
 
-def test_print_tui_exit_summary_custom_home_keeps_plain_resume_hint(
+def test_print_tui_exit_summary_custom_home_includes_hermes_home_env(
     monkeypatch, capsys, tmp_path
 ):
     import hermes_cli.main as main_mod
@@ -698,7 +698,7 @@ def test_print_tui_exit_summary_custom_home_keeps_plain_resume_hint(
         def close(self):
             return None
 
-    custom_home = tmp_path / "standalone-hermes-home"
+    custom_home = tmp_path / "standalone hermes home"
     custom_home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(custom_home))
@@ -711,5 +711,7 @@ def test_print_tui_exit_summary_custom_home_keeps_plain_resume_hint(
     main_mod._print_tui_exit_summary("20260409_000001_abc123")
     out = capsys.readouterr().out
 
-    assert "hermes --tui --resume 20260409_000001_abc123" in out
+    env_prefix = f"HERMES_HOME='{custom_home}'"
+    assert f"{env_prefix} hermes --tui --resume 20260409_000001_abc123" in out
+    assert f"{env_prefix} hermes --tui -c 'custom home title'" in out
     assert "hermes -p" not in out

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -594,3 +594,122 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(
     assert seen == ["actual_session"]
     assert "hermes --tui --resume actual_session" in out
     assert "startup_resume" not in out
+
+
+def test_print_tui_exit_summary_named_profile_includes_profile_flag(
+    monkeypatch, capsys, tmp_path
+):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {
+                "message_count": 2,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+        def get_session_title(self, _session_id):
+            return "demo title"
+
+        def close(self):
+            return None
+
+    profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    for name in ["hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"]:
+        sys.modules.pop(name, None)
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "hermes -p coder --tui --resume 20260409_000001_abc123" in out
+    assert 'hermes -p coder --tui -c "demo title"' in out
+
+
+def test_print_tui_exit_summary_custom_profile_includes_profile_flag(
+    monkeypatch, capsys, tmp_path
+):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {
+                "message_count": 1,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+        def get_session_title(self, _session_id):
+            return "custom profile title"
+
+        def close(self):
+            return None
+
+    profile_home = tmp_path / ".hermes" / "profiles" / "custom"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    for name in ["hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"]:
+        sys.modules.pop(name, None)
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "hermes -p custom --tui --resume 20260409_000001_abc123" in out
+
+
+def test_print_tui_exit_summary_custom_home_keeps_plain_resume_hint(
+    monkeypatch, capsys, tmp_path
+):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {
+                "message_count": 1,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+        def get_session_title(self, _session_id):
+            return "custom home title"
+
+        def close(self):
+            return None
+
+    custom_home = tmp_path / "standalone-hermes-home"
+    custom_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    for name in ["hermes_constants", "hermes_cli.profiles", "hermes_cli.resume_hints"]:
+        sys.modules.pop(name, None)
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "hermes --tui --resume 20260409_000001_abc123" in out
+    assert "hermes -p" not in out


### PR DESCRIPTION
## What does this PR do?

Fixes printed resume hints for sessions created outside the default Hermes profile.

Sessions are profile-local, so a hint like `hermes --resume <session>` can look in the default profile and report `Session not found` when the session actually belongs to a named profile or a standalone/custom `HERMES_HOME`. This PR centralizes resume hint construction and makes the hints preserve the context that created the session:

- classic CLI exit summary
- TUI exit summary
- `/save` live-session hint

This is related to the issue covered by #9652 and #10419, but it intentionally goes beyond the original one-line classic CLI fix:

- covers **TUI** resume hints
- covers **`/save`** live-session hints
- preserves a real named profile called `custom`
- handles standalone/custom `HERMES_HOME` by printing an env-prefixed command instead of an unsafe `-p` alias
- uses POSIX shell quoting for resume-by-title hints so titles containing `$`, backticks, `!`, quotes, or newlines stay copy/pasteable
- adds regression tests for all of the above

Examples:

```text
# default profile: unchanged
hermes --resume <session>

# named profile
hermes -p coder --resume <session>

# named profile + TUI
hermes -p coder --tui --resume <session>

# standalone/custom HERMES_HOME
HERMES_HOME='/path/to/hermes home' hermes --resume <session>
```

## Related Issue

No separate issue found. Related prior PRs: #9652, #10419.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (small helper extraction to share behavior)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/resume_hints.py`: shared helpers for profile/custom-home-aware `--resume` and `-c` hint commands.
- `cli.py`: uses the helper for classic CLI exit summaries and `/save` live-session hints.
- `hermes_cli/main.py`: uses the helper for TUI exit summaries.
- `tests/hermes_cli/test_resume_hints.py`: covers default profile, named profile, real `custom` profile, standalone/custom `HERMES_HOME`, TUI ordering, and shell quoting.
- `tests/cli/test_exit_summary_profile_resume.py`: covers classic CLI profile-aware exit summaries.
- `tests/hermes_cli/test_tui_resume_flow.py`: covers TUI profile-aware exit summaries.
- `tests/cli/test_save_conversation_location.py`: covers `/save` profile/custom-home-aware live-session hints.

## How to Test

Focused regression suite run locally:

```text
HOME=/home/ddeok /home/ddeok/.hermes/hermes-agent/venv/bin/pytest -q \
  tests/hermes_cli/test_resume_hints.py \
  tests/cli/test_exit_summary_profile_resume.py \
  tests/cli/test_save_conversation_location.py \
  tests/hermes_cli/test_tui_resume_flow.py \
  -p no:cacheprovider

36 passed in 2.97s
```

Additional local checks:

```text
git diff --check

# Contributor attribution gate logic, locally reproduced:
NEW_EMAILS=15044917+dd3ok@users.noreply.github.com
attribution_check_local=pass
```

Full test suite was also attempted:

```text
HOME=/home/ddeok scripts/run_tests.sh -q

10 failed, 23140 passed, 52 skipped, 233 warnings in 584.04s (0:09:44)
```

The 10 failures were outside the files touched by this PR and appear unrelated to resume hints:

```text
FAILED tests/agent/lsp/test_broken_set.py::test_mark_broken_handles_no_workspace_silently
FAILED tests/agent/lsp/test_service.py::test_service_skips_files_outside_workspace
FAILED tests/agent/lsp/test_workspace.py::test_find_git_worktree_returns_none_outside_repo
FAILED tests/agent/lsp/test_workspace.py::test_resolve_workspace_for_file_no_repo_returns_none
FAILED tests/agent/lsp/test_workspace.py::test_resolve_workspace_falls_back_to_file_location
FAILED tests/cli/test_resume_display.py::TestDisplayResumedHistory::test_panel_is_stored_as_resize_aware_history_entry
FAILED tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal
FAILED tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags
FAILED tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format
FAILED tests/test_ipv4_preference.py::TestApplyIPv4Preference::test_patches_getaddrinfo_when_forced
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Related PRs #9652/#10419 cover the same symptom, but this PR includes broader runtime coverage and tests as described above.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Full suite attempted locally; unrelated failures listed above. Focused regression suite passes.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: user-facing CLI hint behavior is covered by tests and helper docstrings.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys added.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture/workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Uses `pathlib` and string formatting only; no platform-specific syscalls. The emitted command is POSIX-shell-oriented, matching the current CLI hint style.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool behavior changed.

## For New Skills

N/A — this PR does not add a skill.
