### PR TITLE
feat(kanban): add lifecycle hook seam

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1746,21 +1746,27 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
 def _preview_text(value: Any, *, limit: int = _KANBAN_EVENT_PREVIEW_CHARS) -> str:
     text = "" if value is None else str(value)
     text = text.strip().replace("\r", " ").replace("\n", " ")
+    try:
+        from agent.redact import redact_sensitive_text
+
+        text = redact_sensitive_text(text)
+    except Exception:
+        pass
     return text[:limit]
 
 
-def _bounded_jsonish(value: Any) -> Any:
-    """Return a small JSON-ish value for lifecycle hook payloads."""
+def _bounded_lifecycle_value(value: Any) -> Any:
+    """Return a bounded JSON-compatible value for allowlisted lifecycle fields."""
     if value is None or isinstance(value, (bool, int, float)):
         return value
     if isinstance(value, str):
         return _preview_text(value)
     if isinstance(value, (list, tuple)):
-        return [_bounded_jsonish(v) for v in value[:20]]
+        return [_bounded_lifecycle_value(v) for v in value[:20]]
     if isinstance(value, set):
-        return [_bounded_jsonish(v) for v in itertools.islice(value, 20)]
+        return [_bounded_lifecycle_value(v) for v in itertools.islice(value, 20)]
     if isinstance(value, dict):
-        return {str(k): _bounded_jsonish(v) for k, v in itertools.islice(value.items(), 20)}
+        return {str(k): _bounded_lifecycle_value(v) for k, v in itertools.islice(value.items(), 20)}
     return _preview_text(value)
 
 
@@ -1831,7 +1837,7 @@ def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[s
         elif key in sensitive_or_large:
             sanitized[f"{key}_present"] = value is not None
         elif key in passthrough:
-            sanitized[key] = _bounded_jsonish(value)
+            sanitized[key] = _bounded_lifecycle_value(value)
         else:
             # Fail closed for future payload keys: don't leak arbitrary text or
             # object reprs just because a new producer forgot to classify the

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import re
 import secrets
@@ -86,6 +87,9 @@ from typing import Any, Iterable, Optional
 from toolsets import get_toolset_names
 
 
+logger = logging.getLogger(__name__)
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -94,6 +98,31 @@ VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "arch
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
+
+_KANBAN_LIFECYCLE_HOOK = "on_kanban_event"
+_KANBAN_EVENT_SCHEMA_VERSION = 1
+_KANBAN_EVENT_PREVIEW_CHARS = 300
+_KANBAN_TXN_PENDING_EVENTS: dict[int, list[dict[str, Any]]] = {}
+_KANBAN_EVENT_TYPES = {
+    "created": "kanban.task_created",
+    "assigned": "kanban.task_assigned",
+    "linked": "kanban.dependency_linked",
+    "unlinked": "kanban.dependency_unlinked",
+    "commented": "kanban.comment_added",
+    "promoted": "kanban.task_promoted",
+    "claimed": "kanban.task_claimed",
+    "spawned": "kanban.worker_spawned",
+    "completed": "kanban.task_completed",
+    "blocked": "kanban.task_blocked",
+    "unblocked": "kanban.task_unblocked",
+    "archived": "kanban.task_archived",
+    "reclaimed": "kanban.run_reclaimed",
+    "timed_out": "kanban.run_failed",
+    "crashed": "kanban.run_failed",
+    "spawn_failed": "kanban.run_failed",
+    "gave_up": "kanban.run_failed",
+    "protocol_violation": "kanban.run_failed",
+}
 
 # A running task's claim is valid for 15 minutes; after that the next
 # dispatcher tick reclaims it.  Workers that outlive this window should call
@@ -1178,14 +1207,31 @@ def write_txn(conn: sqlite3.Connection):
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
     """
-    conn.execute("BEGIN IMMEDIATE")
+    pending_events: list[dict[str, Any]] = []
+    conn_key = id(conn)
+    previous_pending = _KANBAN_TXN_PENDING_EVENTS.get(conn_key)
+    _KANBAN_TXN_PENDING_EVENTS[conn_key] = pending_events
+
+    committed = False
     try:
-        yield conn
-    except Exception:
-        conn.execute("ROLLBACK")
-        raise
-    else:
-        conn.execute("COMMIT")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        else:
+            conn.execute("COMMIT")
+            committed = True
+    finally:
+        if previous_pending is not None:
+            _KANBAN_TXN_PENDING_EVENTS[conn_key] = previous_pending
+        else:
+            _KANBAN_TXN_PENDING_EVENTS.pop(conn_key, None)
+
+    if committed:
+        for event in pending_events:
+            _emit_kanban_event(event)
 
 
 # ---------------------------------------------------------------------------
@@ -1503,7 +1549,12 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             )
         else:
             conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
-        _append_event(conn, task_id, "assigned", {"assignee": profile})
+        _append_event(
+            conn,
+            task_id,
+            "assigned",
+            {"previous_assignee": row["assignee"], "assignee": profile},
+        )
         return True
 
 
@@ -1638,8 +1689,14 @@ def add_comment(
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
-        _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
-        return int(cur.lastrowid or 0)
+        comment_id = int(cur.lastrowid or 0)
+        _append_event(
+            conn,
+            task_id,
+            "commented",
+            {"comment_id": comment_id, "author": author, "len": len(body)},
+        )
+        return comment_id
 
 
 def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
@@ -1683,6 +1740,181 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
     return out
 
 
+def _preview_text(value: Any, *, limit: int = _KANBAN_EVENT_PREVIEW_CHARS) -> str:
+    text = "" if value is None else str(value)
+    text = text.strip().replace("\r", " ").replace("\n", " ")
+    return text[:limit]
+
+
+def _bounded_jsonish(value: Any) -> Any:
+    """Return a small JSON-ish value for lifecycle hook payloads."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _preview_text(value)
+    if isinstance(value, (list, tuple, set)):
+        return [_bounded_jsonish(v) for v in list(value)[:20]]
+    if isinstance(value, dict):
+        return {str(k): _bounded_jsonish(v) for k, v in list(value.items())[:20]}
+    return _preview_text(value)
+
+
+def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[str, Any]:
+    raw = dict(payload or {})
+    sanitized: dict[str, Any] = {}
+    sensitive_or_large = {
+        "body",
+        "command",
+        "env",
+        "logs",
+        "metadata",
+        "pid",
+        "reason",
+        "result",
+        "summary",
+        "workspace_path",
+    }
+    passthrough = {
+        "assignee",
+        "status",
+        "previous_assignee",
+        "parent",
+        "child",
+        "parents",
+        "tenant",
+        "skills",
+        "run_id",
+        "expires",
+        "verified_cards",
+        "phantom_cards",
+        "phantom_refs",
+        "result_len",
+        "len",
+        "comment_id",
+        "author",
+        "failure_count",
+        "failure_limit",
+        "auto_blocked",
+        "retryable",
+        "elapsed_seconds",
+        "limit_seconds",
+        "sigkill",
+        "exit_kind",
+        "exit_code",
+    }
+
+    for key, value in raw.items():
+        if key == "pid":
+            sanitized["pid_present"] = value is not None
+        elif key == "lock":
+            sanitized["claimer"] = _preview_text(value, limit=120)
+        elif key == "reason":
+            sanitized["reason_len"] = len(str(value or ""))
+            sanitized["reason_preview"] = _preview_text(value)
+        elif key == "summary":
+            sanitized["summary_preview"] = _preview_text(value)
+        elif key == "result":
+            sanitized["result_len"] = len(str(value or ""))
+        elif key == "error":
+            sanitized["error_preview"] = _preview_text(value)
+        elif key == "metadata" and isinstance(value, dict):
+            sanitized["metadata_keys"] = sorted(str(k) for k in value.keys())[:50]
+        elif key in sensitive_or_large:
+            sanitized[f"{key}_present"] = value is not None
+        elif key in passthrough:
+            sanitized[key] = _bounded_jsonish(value)
+        else:
+            sanitized[key] = _bounded_jsonish(value)
+
+    if kind in {"timed_out", "crashed", "spawn_failed", "gave_up", "protocol_violation"}:
+        sanitized.setdefault("outcome", kind)
+    if kind == "commented" and "len" in sanitized:
+        sanitized["body_len"] = sanitized.pop("len")
+    if kind in {"linked", "unlinked"}:
+        sanitized.setdefault("parent_id", sanitized.pop("parent", None))
+        sanitized.setdefault("child_id", sanitized.pop("child", None))
+    return sanitized
+
+
+def _build_kanban_lifecycle_event(
+    conn: sqlite3.Connection,
+    *,
+    event_id: int,
+    task_id: str,
+    kind: str,
+    payload: Optional[dict],
+    run_id: Optional[int],
+    created_at: int,
+) -> Optional[dict[str, Any]]:
+    event_type = _KANBAN_EVENT_TYPES.get(kind)
+    if event_type is None:
+        return None
+
+    task = conn.execute(
+        "SELECT id, title, assignee, status, tenant, created_by, "
+        "priority, workspace_kind FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    title_preview = _preview_text(task["title"] if task else "")
+    assignee = task["assignee"] if task else None
+    status = task["status"] if task else None
+    tenant = task["tenant"] if task else None
+
+    relationships: list[dict[str, Any]] = []
+    if assignee:
+        relationships.append(
+            {
+                "subject_type": "profile",
+                "subject_id": assignee,
+                "relation": kind,
+                "object_type": "task",
+                "object_id": task_id,
+            }
+        )
+
+    sanitized_payload = _sanitize_kanban_event_payload(kind, payload)
+    if task:
+        sanitized_payload.setdefault("title_preview", title_preview)
+        sanitized_payload.setdefault("workspace_kind", task["workspace_kind"])
+        sanitized_payload.setdefault("priority", task["priority"])
+
+    return {
+        "schema_version": _KANBAN_EVENT_SCHEMA_VERSION,
+        "event_id": event_id,
+        "event_type": event_type,
+        "emitted_at": created_at,
+        "board": get_current_board(),
+        "tenant": tenant,
+        "task_id": task_id,
+        "run_id": run_id,
+        "source": "kanban_db",
+        "actor": None,
+        "origin_plugin": None,
+        "correlation_id": None,
+        "status_before": None,
+        "status_after": status,
+        "assignee_before": sanitized_payload.get("previous_assignee"),
+        "assignee_after": assignee,
+        "relationships": relationships,
+        "payload": sanitized_payload,
+    }
+
+
+def _emit_kanban_event(event: dict[str, Any]) -> None:
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        invoke_hook(_KANBAN_LIFECYCLE_HOOK, event=event)
+    except Exception as exc:
+        logger.warning(
+            "Kanban lifecycle hook delivery failed for %s event_id=%s task_id=%s: %s",
+            event.get("event_type"),
+            event.get("event_id"),
+            event.get("task_id"),
+            exc,
+        )
+
+
 def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
@@ -1690,8 +1922,12 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
-) -> None:
-    """Record an event row.  Called from within an already-open txn.
+) -> int:
+    """Record an event row and queue a sanitized lifecycle hook event.
+
+    Called from within an already-open txn. Hook delivery is deferred until
+    :func:`write_txn` commits, so observers see committed state and hook
+    failures cannot roll back the Kanban mutation.
 
     ``run_id`` is optional: pass the current run id so UIs can group
     events by attempt. For events that aren't scoped to a single run
@@ -1700,11 +1936,28 @@ def _append_event(
     """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+    event_id = int(cur.lastrowid or 0)
+    event = _build_kanban_lifecycle_event(
+        conn,
+        event_id=event_id,
+        task_id=task_id,
+        kind=kind,
+        payload=payload,
+        run_id=run_id,
+        created_at=now,
+    )
+    if event is not None:
+        pending = _KANBAN_TXN_PENDING_EVENTS.get(id(conn))
+        if pending is not None:
+            pending.append(event)
+        else:
+            _emit_kanban_event(event)
+    return event_id
 
 
 def _end_run(
@@ -2476,6 +2729,9 @@ def complete_task(
         completed_payload: dict = {
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
+            "metadata_keys": sorted(str(k) for k in metadata.keys())[:50]
+            if isinstance(metadata, dict)
+            else [],
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1815,13 +1815,15 @@ def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[s
             sanitized["claimer"] = _preview_text(value, limit=120)
         elif key == "reason":
             sanitized["reason_len"] = len(str(value or ""))
-            sanitized["reason_preview"] = _preview_text(value)
+            sanitized["reason_present"] = value is not None
         elif key == "summary":
-            sanitized["summary_preview"] = _preview_text(value)
+            sanitized["summary_len"] = len(str(value or ""))
+            sanitized["summary_present"] = value is not None
         elif key == "result":
             sanitized["result_len"] = len(str(value or ""))
         elif key == "error":
-            sanitized["error_preview"] = _preview_text(value)
+            sanitized["error_len"] = len(str(value or ""))
+            sanitized["error_present"] = value is not None
         elif key == "metadata" and isinstance(value, dict):
             sanitized["metadata_keys"] = sorted(str(k) for k in value.keys())[:50]
         elif key in sensitive_or_large:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -103,10 +103,12 @@ _IS_WINDOWS = sys.platform == "win32"
 _KANBAN_LIFECYCLE_HOOK = "on_kanban_event"
 _KANBAN_EVENT_SCHEMA_VERSION = 1
 _KANBAN_EVENT_PREVIEW_CHARS = 300
-# sqlite3.Connection is not weak-referenceable on CPython, so keep the
-# short-lived association keyed by the connection object itself and clean it up
-# in write_txn's finally block instead of relying on id(conn) reuse safety.
+# sqlite3.Connection is not weak-referenceable on CPython. Transaction-local
+# pending events are cleaned up in write_txn's finally block; board identity is
+# remembered per open connection so explicit connect(board=...) calls do not
+# fall back to the ambient current-board setting during hook emission.
 _KANBAN_TXN_PENDING_EVENTS: dict[sqlite3.Connection, list[dict[str, Any]]] = {}
+_KANBAN_CONNECTION_BOARDS: dict[sqlite3.Connection, str] = {}
 _KANBAN_EVENT_TYPES = {
     "created": "kanban.task_created",
     "assigned": "kanban.task_assigned",
@@ -923,6 +925,34 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 
 
+def _board_for_db_path(db_path: Path) -> str:
+    """Best-effort board slug for an explicit kanban DB path."""
+    try:
+        resolved = db_path.expanduser().resolve()
+        if resolved == (kanban_home() / "kanban.db").resolve():
+            return DEFAULT_BOARD
+        root = boards_root().resolve()
+        relative = resolved.relative_to(root)
+        if len(relative.parts) >= 2 and relative.parts[1] == "kanban.db":
+            return _normalize_board_slug(relative.parts[0]) or DEFAULT_BOARD
+    except (OSError, ValueError):
+        pass
+    return get_current_board()
+
+
+def _board_for_connection(conn: sqlite3.Connection) -> str:
+    board = _KANBAN_CONNECTION_BOARDS.get(conn)
+    if board:
+        return board
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        if row and row[2]:
+            return _board_for_db_path(Path(row[2]))
+    except sqlite3.Error:
+        pass
+    return get_current_board()
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -948,12 +978,17 @@ def connect(
     """
     if db_path is not None:
         path = db_path
+        resolved_board = _board_for_db_path(path)
     else:
-        path = kanban_db_path(board=board)
+        resolved_board = _normalize_board_slug(board)
+        if resolved_board is None:
+            resolved_board = get_current_board()
+        path = kanban_db_path(board=resolved_board)
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
     needs_init = resolved not in _INITIALIZED_PATHS
     conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    _KANBAN_CONNECTION_BOARDS[conn] = resolved_board
     conn.row_factory = sqlite3.Row
     # WAL doesn't work on network filesystems (NFS/SMB/FUSE).  Shared helper
     # falls back to DELETE with one WARNING so kanban stays usable there.
@@ -1906,7 +1941,7 @@ def _build_kanban_lifecycle_event(
         "event_id": event_id,
         "event_type": event_type,
         "emitted_at": created_at,
-        "board": get_current_board(),
+        "board": _board_for_connection(conn),
         "tenant": tenant,
         "task_id": task_id,
         "run_id": run_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1924,8 +1924,11 @@ def _build_kanban_lifecycle_event(
 
 def _emit_kanban_event(event: dict[str, Any]) -> None:
     try:
-        from hermes_cli.plugins import invoke_hook
+        from hermes_cli.plugins import discover_plugins, invoke_hook
 
+        # Kanban mutations also happen from direct CLI commands, not only the
+        # agent/gateway startup paths that already discover plugins.
+        discover_plugins()
         invoke_hook(_KANBAN_LIFECYCLE_HOOK, event=event)
     except Exception as exc:
         logger.warning(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1697,7 +1697,7 @@ def add_comment(
             conn,
             task_id,
             "commented",
-            {"comment_id": comment_id, "author": author, "len": len(body)},
+            {"comment_id": comment_id, "author": author, "body_len": len(body)},
         )
         return comment_id
 
@@ -1751,7 +1751,7 @@ def _preview_text(value: Any, *, limit: int = _KANBAN_EVENT_PREVIEW_CHARS) -> st
 
         text = redact_sensitive_text(text)
     except Exception:
-        pass
+        logger.debug("Kanban lifecycle preview redaction failed", exc_info=True)
     return text[:limit]
 
 
@@ -1801,6 +1801,7 @@ def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[s
         "phantom_refs",
         "metadata_keys",
         "pid_present",
+        "body_len",
         "result_len",
         "len",
         "comment_id",
@@ -2148,6 +2149,10 @@ def claim_task(
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
+
+    ``claimer`` is copied into the claim lock and exposed to lifecycle
+    observers as a redacted/truncated ``payload.claimer`` value; callers
+    should not put secrets or raw user content in it.
     """
     now = int(time.time())
     lock = claimer or _claimer_id()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import itertools
 import json
 import logging
 import os
@@ -102,7 +103,10 @@ _IS_WINDOWS = sys.platform == "win32"
 _KANBAN_LIFECYCLE_HOOK = "on_kanban_event"
 _KANBAN_EVENT_SCHEMA_VERSION = 1
 _KANBAN_EVENT_PREVIEW_CHARS = 300
-_KANBAN_TXN_PENDING_EVENTS: dict[int, list[dict[str, Any]]] = {}
+# sqlite3.Connection is not weak-referenceable on CPython, so keep the
+# short-lived association keyed by the connection object itself and clean it up
+# in write_txn's finally block instead of relying on id(conn) reuse safety.
+_KANBAN_TXN_PENDING_EVENTS: dict[sqlite3.Connection, list[dict[str, Any]]] = {}
 _KANBAN_EVENT_TYPES = {
     "created": "kanban.task_created",
     "assigned": "kanban.task_assigned",
@@ -1208,9 +1212,8 @@ def write_txn(conn: sqlite3.Connection):
     atomic -- at most one concurrent writer can succeed.
     """
     pending_events: list[dict[str, Any]] = []
-    conn_key = id(conn)
-    previous_pending = _KANBAN_TXN_PENDING_EVENTS.get(conn_key)
-    _KANBAN_TXN_PENDING_EVENTS[conn_key] = pending_events
+    previous_pending = _KANBAN_TXN_PENDING_EVENTS.get(conn)
+    _KANBAN_TXN_PENDING_EVENTS[conn] = pending_events
 
     committed = False
     try:
@@ -1225,9 +1228,9 @@ def write_txn(conn: sqlite3.Connection):
             committed = True
     finally:
         if previous_pending is not None:
-            _KANBAN_TXN_PENDING_EVENTS[conn_key] = previous_pending
+            _KANBAN_TXN_PENDING_EVENTS[conn] = previous_pending
         else:
-            _KANBAN_TXN_PENDING_EVENTS.pop(conn_key, None)
+            _KANBAN_TXN_PENDING_EVENTS.pop(conn, None)
 
     if committed:
         for event in pending_events:
@@ -1752,10 +1755,12 @@ def _bounded_jsonish(value: Any) -> Any:
         return value
     if isinstance(value, str):
         return _preview_text(value)
-    if isinstance(value, (list, tuple, set)):
-        return [_bounded_jsonish(v) for v in list(value)[:20]]
+    if isinstance(value, (list, tuple)):
+        return [_bounded_jsonish(v) for v in value[:20]]
+    if isinstance(value, set):
+        return [_bounded_jsonish(v) for v in itertools.islice(value, 20)]
     if isinstance(value, dict):
-        return {str(k): _bounded_jsonish(v) for k, v in list(value.items())[:20]}
+        return {str(k): _bounded_jsonish(v) for k, v in itertools.islice(value.items(), 20)}
     return _preview_text(value)
 
 
@@ -1934,6 +1939,10 @@ def _append_event(
     (task created/edited/archived, dependency promotion) leave it None
     and the row carries NULL.
     """
+    pending = _KANBAN_TXN_PENDING_EVENTS.get(conn)
+    if pending is None:
+        raise RuntimeError("Kanban lifecycle events must be appended inside write_txn")
+
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
     cur = conn.execute(
@@ -1952,11 +1961,7 @@ def _append_event(
         created_at=now,
     )
     if event is not None:
-        pending = _KANBAN_TXN_PENDING_EVENTS.get(id(conn))
-        if pending is not None:
-            pending.append(event)
-        else:
-            _emit_kanban_event(event)
+        pending.append(event)
     return event_id
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1793,6 +1793,8 @@ def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[s
         "verified_cards",
         "phantom_cards",
         "phantom_refs",
+        "metadata_keys",
+        "pid_present",
         "result_len",
         "len",
         "comment_id",
@@ -1831,7 +1833,14 @@ def _sanitize_kanban_event_payload(kind: str, payload: Optional[dict]) -> dict[s
         elif key in passthrough:
             sanitized[key] = _bounded_jsonish(value)
         else:
-            sanitized[key] = _bounded_jsonish(value)
+            # Fail closed for future payload keys: don't leak arbitrary text or
+            # object reprs just because a new producer forgot to classify the
+            # field for the lifecycle wire schema.
+            sanitized[f"{key}_present"] = value is not None
+            if isinstance(value, str):
+                sanitized[f"{key}_len"] = len(value)
+            elif isinstance(value, (dict, list, tuple, set)):
+                sanitized[f"{key}_count"] = len(value)
 
     if kind in {"timed_out", "crashed", "spawn_failed", "gave_up", "protocol_violation"}:
         sanitized.setdefault("outcome", kind)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -143,6 +143,10 @@ VALID_HOOKS: Set[str] = {
     "on_session_finalize",
     "on_session_reset",
     "subagent_stop",
+    # Kanban lifecycle observer hook. Fired after committed Kanban DB
+    # mutations with a bounded/sanitized event dict. Observer only:
+    # return values are ignored and callbacks cannot veto lifecycle writes.
+    "on_kanban_event",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -195,7 +195,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        # Lifecycle events are appended under write_txn so hook delivery
+        # observes committed state and rollback suppression semantics.
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -220,7 +223,8 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         # Second crash — same task, same dispatcher (or a respawn). Append
         # another event to simulate the dispatcher firing crashed a second
         # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -195,8 +195,6 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         # First crash — fired by the dispatcher when the worker PID dies.
-        # Lifecycle events are appended under write_txn so hook delivery
-        # observes committed state and rollback suppression semantics.
         with kb.write_txn(conn):
             kb._append_event(conn, tid, kind="crashed")
     finally:

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -1,0 +1,183 @@
+"""Focused tests for the Kanban lifecycle plugin hook seam."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import plugins
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    events: list[dict] = []
+
+    def fake_invoke_hook(name: str, **kwargs):
+        assert name == "on_kanban_event"
+        events.append(kwargs["event"])
+        return []
+
+    monkeypatch.setattr(plugins, "invoke_hook", fake_invoke_hook)
+    return events
+
+
+def test_valid_hooks_contains_kanban_lifecycle_hook():
+    assert "on_kanban_event" in plugins.VALID_HOOKS
+
+
+def test_create_task_emits_after_commit_and_uses_task_event_id(kanban_home, monkeypatch):
+    observed: list[tuple[dict, str]] = []
+
+    def fake_invoke_hook(name: str, **kwargs):
+        assert name == "on_kanban_event"
+        event = kwargs["event"]
+        with kb.connect() as read_conn:
+            committed = kb.get_task(read_conn, event["task_id"])
+        assert committed is not None
+        observed.append((event, committed.status))
+        return []
+
+    monkeypatch.setattr(plugins, "invoke_hook", fake_invoke_hook)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="hook me",
+            body="raw task body must not enter hook payload",
+            assignee="worker",
+        )
+        row_event = kb.list_events(conn, tid)[0]
+
+    assert len(observed) == 1
+    event, committed_status = observed[0]
+    assert committed_status == "ready"
+    assert event["schema_version"] == 1
+    assert event["event_type"] == "kanban.task_created"
+    assert event["event_id"] == row_event.id
+    assert event["task_id"] == tid
+    assert event["status_after"] == "ready"
+    assert event["assignee_after"] == "worker"
+    assert event["payload"]["title_preview"] == "hook me"
+    assert "raw task body" not in json.dumps(event)
+
+
+def test_hook_failure_does_not_break_lifecycle_operations(kanban_home, monkeypatch, caplog):
+    calls: list[str] = []
+
+    def failing_hook(name: str, **kwargs):
+        calls.append(kwargs["event"]["event_type"])
+        raise RuntimeError("observer exploded")
+
+    monkeypatch.setattr(plugins, "invoke_hook", failing_hook)
+
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = kb.create_task(conn, title="child", assignee="worker")
+        kb.link_tasks(conn, parent, child)
+        kb.add_comment(conn, parent, "reviewer", "looks okay")
+        assert kb.block_task(conn, parent, reason="needs review")
+        assert kb.complete_task(conn, parent, summary="done", result="finished")
+        assert kb.get_task(conn, parent).status == "done"
+
+    assert "kanban.task_created" in calls
+    assert "kanban.dependency_linked" in calls
+    assert "kanban.comment_added" in calls
+    assert "kanban.task_blocked" in calls
+    assert "kanban.task_completed" in calls
+    assert "Kanban lifecycle hook delivery failed" in caplog.text
+
+
+def test_failed_mutation_does_not_emit_lifecycle_success(kanban_home, captured_events):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b")
+        kb.link_tasks(conn, a, b)
+        count_after_success = len(captured_events)
+        with pytest.raises(ValueError):
+            kb.link_tasks(conn, b, a)
+
+    assert len(captured_events) == count_after_success
+    assert [e["event_type"] for e in captured_events].count("kanban.dependency_linked") == 1
+
+
+def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_events):
+    big_body = "body-secret-" + "x" * 5000
+    big_comment = "comment-secret-" + "y" * 5000
+    big_result = "result-secret-" + "z" * 5000
+    metadata = {"token": "metadata-secret", "count": 1}
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="redaction", body=big_body, assignee="worker")
+        kb.add_comment(conn, tid, "human", big_comment)
+        assert kb.block_task(conn, tid, reason="waiting on reviewer " + "r" * 1000)
+        assert kb.complete_task(conn, tid, summary="summary " + "s" * 1000, result=big_result, metadata=metadata)
+
+    serialized = "\n".join(json.dumps(event, sort_keys=True) for event in captured_events)
+    assert "body-secret" not in serialized
+    assert "comment-secret" not in serialized
+    assert "result-secret" not in serialized
+    assert "metadata-secret" not in serialized
+    assert "token" in serialized  # metadata keys are useful; values are not.
+    for event in captured_events:
+        assert len(json.dumps(event)) < 4096
+
+    blocked = next(e for e in captured_events if e["event_type"] == "kanban.task_blocked")
+    assert blocked["payload"]["reason_len"] > len("waiting on reviewer")
+    assert len(blocked["payload"]["reason_preview"]) <= 300
+    completed = next(e for e in captured_events if e["event_type"] == "kanban.task_completed")
+    assert completed["payload"]["result_len"] == len(big_result)
+    assert completed["payload"]["metadata_keys"] == ["count", "token"]
+
+
+def test_assignment_dependency_and_run_events_include_core_ids(
+    kanban_home, captured_events, all_assignees_spawnable
+):
+    def spawn(_task, _workspace):
+        return 12345
+
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="alpha")
+        child = kb.create_task(conn, title="child", assignee="alpha")
+        kb.link_tasks(conn, parent, child)
+        assert kb.assign_task(conn, child, "beta")
+        assert kb.complete_task(conn, parent, summary="parent done")
+        kb.dispatch_once(conn, spawn_fn=spawn)
+
+    assigned = next(e for e in captured_events if e["event_type"] == "kanban.task_assigned")
+    assert assigned["assignee_before"] == "alpha"
+    assert assigned["assignee_after"] == "beta"
+    assert assigned["payload"]["previous_assignee"] == "alpha"
+    assert assigned["payload"]["assignee"] == "beta"
+
+    linked = next(e for e in captured_events if e["event_type"] == "kanban.dependency_linked")
+    assert linked["payload"]["parent_id"] == parent
+    assert linked["payload"]["child_id"] == child
+
+    promoted = next(e for e in captured_events if e["event_type"] == "kanban.task_promoted")
+    assert promoted["task_id"] == child
+
+    claimed = next(e for e in captured_events if e["event_type"] == "kanban.task_claimed")
+    assert claimed["task_id"] == child
+    assert isinstance(claimed["run_id"], int)
+    assert claimed["payload"]["run_id"] == claimed["run_id"]
+
+    spawned = next(e for e in captured_events if e["event_type"] == "kanban.worker_spawned")
+    assert spawned["task_id"] == child
+    assert spawned["run_id"] == claimed["run_id"]
+    assert spawned["payload"]["pid_present"] is True
+    assert "pid" not in spawned["payload"]

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -160,21 +160,26 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
         tid = kb.create_task(conn, title="redaction", body=big_body, assignee="worker")
         kb.add_comment(conn, tid, "human", big_comment)
         assert kb.block_task(conn, tid, reason="waiting on reviewer " + "r" * 1000)
-        assert kb.complete_task(conn, tid, summary="summary " + "s" * 1000, result=big_result, metadata=metadata)
+        assert kb.complete_task(conn, tid, summary="summary-secret " + "s" * 1000, result=big_result, metadata=metadata)
 
     serialized = "\n".join(json.dumps(event, sort_keys=True) for event in captured_events)
     assert "body-secret" not in serialized
     assert "comment-secret" not in serialized
     assert "result-secret" not in serialized
     assert "metadata-secret" not in serialized
+    assert "summary-secret" not in serialized
     assert "token" in serialized  # metadata keys are useful; values are not.
     for event in captured_events:
         assert len(json.dumps(event)) < 4096
 
     blocked = next(e for e in captured_events if e["event_type"] == "kanban.task_blocked")
     assert blocked["payload"]["reason_len"] > len("waiting on reviewer")
-    assert len(blocked["payload"]["reason_preview"]) <= 300
+    assert blocked["payload"]["reason_present"] is True
+    assert "reason_preview" not in blocked["payload"]
     completed = next(e for e in captured_events if e["event_type"] == "kanban.task_completed")
+    assert completed["payload"]["summary_len"] > len("summary")
+    assert completed["payload"]["summary_present"] is True
+    assert "summary_preview" not in completed["payload"]
     assert completed["payload"]["result_len"] == len(big_result)
     assert completed["payload"]["metadata_keys"] == ["count", "token"]
 

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -132,22 +132,22 @@ def test_append_event_requires_write_txn_for_after_commit_guarantee(kanban_home,
         assert len(captured_events) == hook_count
 
 
-def test_bounded_jsonish_does_not_process_items_beyond_cap():
+def test_bounded_lifecycle_value_does_not_process_items_beyond_cap():
     class ExplodingRepr:
         def __str__(self):
             raise AssertionError("item past the cap should not be stringified")
 
     big: dict[str, object] = {f"k{i}": i for i in range(20)}
     big["k20"] = ExplodingRepr()
-    bounded = kb._bounded_jsonish(big)
+    bounded = kb._bounded_lifecycle_value(big)
     assert len(bounded) == 20
     assert list(bounded) == [f"k{i}" for i in range(20)]
 
     values = list(range(20)) + [ExplodingRepr()]
-    assert kb._bounded_jsonish(values) == list(range(20))
+    assert kb._bounded_lifecycle_value(values) == list(range(20))
 
     large_set = set(range(1000))
-    assert len(kb._bounded_jsonish(large_set)) == 20
+    assert len(kb._bounded_lifecycle_value(large_set)) == 20
 
 
 def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_events):

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -85,6 +85,18 @@ def test_create_task_emits_after_commit_and_uses_task_event_id(kanban_home, monk
     assert "raw task body" not in json.dumps(event)
 
 
+def test_lifecycle_event_uses_explicit_connection_board(kanban_home, captured_events):
+    kb.create_board("side-board")
+
+    with kb.connect(board="side-board") as conn:
+        tid = kb.create_task(conn, title="side board task")
+
+    assert captured_events
+    event = captured_events[-1]
+    assert event["task_id"] == tid
+    assert event["board"] == "side-board"
+
+
 def test_hook_failure_does_not_break_lifecycle_operations(kanban_home, monkeypatch, caplog):
     calls: list[str] = []
 

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -27,6 +27,8 @@ def kanban_home(tmp_path, monkeypatch):
 def captured_events(monkeypatch):
     events: list[dict] = []
 
+    monkeypatch.setattr(plugins, "discover_plugins", lambda force=False: None)
+
     def fake_invoke_hook(name: str, **kwargs):
         assert name == "on_kanban_event"
         events.append(kwargs["event"])
@@ -42,8 +44,13 @@ def test_valid_hooks_contains_kanban_lifecycle_hook():
 
 def test_create_task_emits_after_commit_and_uses_task_event_id(kanban_home, monkeypatch):
     observed: list[tuple[dict, str]] = []
+    call_order: list[str] = []
+
+    def fake_discover_plugins(force: bool = False):
+        call_order.append("discover")
 
     def fake_invoke_hook(name: str, **kwargs):
+        call_order.append("invoke")
         assert name == "on_kanban_event"
         event = kwargs["event"]
         with kb.connect() as read_conn:
@@ -52,6 +59,7 @@ def test_create_task_emits_after_commit_and_uses_task_event_id(kanban_home, monk
         observed.append((event, committed.status))
         return []
 
+    monkeypatch.setattr(plugins, "discover_plugins", fake_discover_plugins)
     monkeypatch.setattr(plugins, "invoke_hook", fake_invoke_hook)
 
     with kb.connect() as conn:
@@ -64,6 +72,7 @@ def test_create_task_emits_after_commit_and_uses_task_event_id(kanban_home, monk
         row_event = kb.list_events(conn, tid)[0]
 
     assert len(observed) == 1
+    assert call_order == ["discover", "invoke"]
     event, committed_status = observed[0]
     assert committed_status == "ready"
     assert event["schema_version"] == 1
@@ -83,6 +92,7 @@ def test_hook_failure_does_not_break_lifecycle_operations(kanban_home, monkeypat
         calls.append(kwargs["event"]["event_type"])
         raise RuntimeError("observer exploded")
 
+    monkeypatch.setattr(plugins, "discover_plugins", lambda force=False: None)
     monkeypatch.setattr(plugins, "invoke_hook", failing_hook)
 
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -161,6 +161,13 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
         kb.add_comment(conn, tid, "human", big_comment)
         assert kb.block_task(conn, tid, reason="waiting on reviewer " + "r" * 1000)
         assert kb.complete_task(conn, tid, summary="summary-secret " + "s" * 1000, result=big_result, metadata=metadata)
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                tid,
+                "commented",
+                {"author": "human", "len": 7, "new_future_field": "future-secret"},
+            )
 
     serialized = "\n".join(json.dumps(event, sort_keys=True) for event in captured_events)
     assert "body-secret" not in serialized
@@ -168,6 +175,7 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
     assert "result-secret" not in serialized
     assert "metadata-secret" not in serialized
     assert "summary-secret" not in serialized
+    assert "future-secret" not in serialized
     assert "token" in serialized  # metadata keys are useful; values are not.
     for event in captured_events:
         assert len(json.dumps(event)) < 4096
@@ -182,6 +190,10 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
     assert "summary_preview" not in completed["payload"]
     assert completed["payload"]["result_len"] == len(big_result)
     assert completed["payload"]["metadata_keys"] == ["count", "token"]
+    future = [e for e in captured_events if e["event_type"] == "kanban.comment_added"][-1]
+    assert future["payload"]["new_future_field_present"] is True
+    assert future["payload"]["new_future_field_len"] == len("future-secret")
+    assert "new_future_field" not in future["payload"]
 
 
 def test_assignment_dependency_and_run_events_include_core_ids(

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -176,7 +176,7 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
                 conn,
                 tid,
                 "commented",
-                {"author": "human", "len": 7, "new_future_field": "future-secret"},
+                {"author": "human", "body_len": 7, "new_future_field": "future-secret"},
             )
 
     serialized = "\n".join(json.dumps(event, sort_keys=True) for event in captured_events)
@@ -201,9 +201,33 @@ def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_even
     assert completed["payload"]["result_len"] == len(big_result)
     assert completed["payload"]["metadata_keys"] == ["count", "token"]
     future = [e for e in captured_events if e["event_type"] == "kanban.comment_added"][-1]
+    assert future["payload"]["body_len"] == 7
     assert future["payload"]["new_future_field_present"] is True
     assert future["payload"]["new_future_field_len"] == len("future-secret")
     assert "new_future_field" not in future["payload"]
+
+
+def test_failure_events_share_run_failed_type_and_keep_outcome(
+    kanban_home, captured_events
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="crash me", assignee="worker")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                tid,
+                "crashed",
+                {"pid": 4242, "error": "secret stack trace"},
+            )
+
+    failed = [e for e in captured_events if e["event_type"] == "kanban.run_failed"][-1]
+    assert failed["task_id"] == tid
+    assert failed["payload"]["outcome"] == "crashed"
+    assert failed["payload"]["pid_present"] is True
+    assert failed["payload"]["error_present"] is True
+    assert failed["payload"]["error_len"] == len("secret stack trace")
+    assert "pid" not in failed["payload"]
+    assert "error" not in failed["payload"]
 
 
 def test_assignment_dependency_and_run_events_include_core_ids(

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -115,6 +115,41 @@ def test_failed_mutation_does_not_emit_lifecycle_success(kanban_home, captured_e
     assert [e["event_type"] for e in captured_events].count("kanban.dependency_linked") == 1
 
 
+def test_append_event_requires_write_txn_for_after_commit_guarantee(kanban_home, captured_events):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="manual txn guard")
+        event_count = len(kb.list_events(conn, tid))
+        hook_count = len(captured_events)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            with pytest.raises(RuntimeError, match="write_txn"):
+                kb._append_event(conn, tid, "commented", {"author": "tester", "len": 1})
+        finally:
+            conn.execute("ROLLBACK")
+
+        assert len(kb.list_events(conn, tid)) == event_count
+        assert len(captured_events) == hook_count
+
+
+def test_bounded_jsonish_does_not_process_items_beyond_cap():
+    class ExplodingRepr:
+        def __str__(self):
+            raise AssertionError("item past the cap should not be stringified")
+
+    big: dict[str, object] = {f"k{i}": i for i in range(20)}
+    big["k20"] = ExplodingRepr()
+    bounded = kb._bounded_jsonish(big)
+    assert len(bounded) == 20
+    assert list(bounded) == [f"k{i}" for i in range(20)]
+
+    values = list(range(20)) + [ExplodingRepr()]
+    assert kb._bounded_jsonish(values) == list(range(20))
+
+    large_set = set(range(1000))
+    assert len(kb._bounded_jsonish(large_set)) == 20
+
+
 def test_lifecycle_payloads_are_sanitized_and_bounded(kanban_home, captured_events):
     big_body = "body-secret-" + "x" * 5000
     big_comment = "comment-secret-" + "y" * 5000

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -94,8 +94,6 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     try:
         tid = kb.create_task(conn, title=f"test {kind} task", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
-        # Lifecycle events are appended under write_txn so hook delivery
-        # observes committed state and rollback suppression semantics.
         with kb.write_txn(conn):
             kb._append_event(conn, tid, kind=kind)
     finally:

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -94,7 +94,10 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     try:
         tid = kb.create_task(conn, title=f"test {kind} task", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
-        kb._append_event(conn, tid, kind=kind)
+        # Lifecycle events are appended under write_txn so hook delivery
+        # observes committed state and rollback suppression semantics.
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind=kind)
     finally:
         conn.close()
 

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -523,7 +523,7 @@ All callbacks should accept `**kwargs` for forward compatibility. If a hook call
 
 ### `pre_llm_call` context injection
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+`pre_llm_call` is the context-injection hook. When a callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
 
 #### Return format
 

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -498,6 +498,7 @@ def register(ctx):
     ctx.register_hook("pre_llm_call", inject_memory)
     ctx.register_hook("on_session_start", on_new_session)
     ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_kanban_event", on_kanban_event)
 ```
 
 ### Hook reference
@@ -506,7 +507,7 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 
 | Hook | Fires when | Callback signature | Returns |
 |------|-----------|-------------------|---------|
-| [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
+| [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | block directive to veto |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
 | [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
@@ -514,8 +515,9 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 | [`on_session_end`](/docs/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/docs/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/docs/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`on_kanban_event`](/docs/user-guide/features/hooks#on_kanban_event) | A Kanban task/run lifecycle event commits | `event: dict` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. Exceptions include `pre_tool_call`, which can block a tool; `pre_llm_call`, which can inject context into the conversation; gateway dispatch hooks, which can skip/rewrite/allow; and transform hooks, which can replace text/result values. See the hook reference before relying on a return value.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -505,7 +505,7 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. Its return value can inject context into the current turn's user message.
 
 **Callback signature:**
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -361,13 +361,14 @@ def register(ctx):
     ctx.register_hook("post_llm_call", my_sync_callback)
     ctx.register_hook("on_session_start", my_init_callback)
     ctx.register_hook("on_session_end", my_cleanup_callback)
+    ctx.register_hook("on_kanban_event", my_kanban_observer)
 ```
 
 **General rules for all hooks:**
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Return values are ignored unless a hook's section explicitly documents an action/transform contract. Observer hooks are fire-and-forget.
 
 ### Quick reference
 
@@ -382,6 +383,7 @@ def register(ctx):
 | [`on_session_finalize`](#on_session_finalize) | CLI/gateway tears down an active session (flush, save, stats) | ignored |
 | [`on_session_reset`](#on_session_reset) | Gateway swaps in a fresh session key (e.g. `/new`, `/reset`) | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
+| [`on_kanban_event`](#on_kanban_event) | A Kanban task/run lifecycle event commits | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
 | [`pre_approval_request`](#pre_approval_request) | Dangerous command needs user approval, before the prompt/notification is sent | ignored |
 | [`post_approval_response`](#post_approval_response) | User responded to an approval prompt (or it timed out) | ignored |
@@ -850,6 +852,132 @@ def register(ctx):
 :::info
 With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `subagent_stop` fires many times per turn. Keep your callback fast; push expensive work to a background queue.
 :::
+
+---
+
+### `on_kanban_event`
+
+Fires after a Kanban task/run lifecycle event is written and the surrounding Kanban write transaction commits. This is an observer hook for plugins that maintain external indexes, relationship graphs, notifications, or dashboards from the Kanban board.
+
+**Callback signature:**
+
+```python
+def my_callback(event: dict, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `event` | `dict` | Versioned, sanitized lifecycle event envelope. See schema below. |
+
+**Fires:** In `hermes_cli/kanban_db.py`, after `write_txn()` commits. Event rows are appended inside the transaction, then delivered after commit. Failed mutations and rollbacks do not emit this hook. Hook failures are logged and do not roll back the Kanban write.
+
+**Return value:** Ignored. This hook is observer-only; plugins cannot veto, rewrite, or delay Kanban state changes.
+
+**Delivery contract:** This is an in-process notification hook, not a durable event bus. If the process exits after committing the Kanban DB row but before invoking plugin callbacks, the hook may be missed. Plugins that require durable catch-up should keep their own cursor over Kanban `task_events` and treat `on_kanban_event` as the fast path.
+
+**Schema:**
+
+```jsonc
+{
+  "schema_version": 1,
+  "event_id": 123,
+  "event_type": "kanban.task_completed",
+  "emitted_at": 1760000000,
+  "board": "default",
+  "tenant": null,
+  "task_id": "t_abcd1234",
+  "run_id": 456,
+  "source": "kanban_db",
+  "actor": null,
+  "origin_plugin": null,
+  "correlation_id": null,
+  "status_before": null,
+  "status_after": "done",
+  "assignee_before": null,
+  "assignee_after": "reviewer",
+  "relationships": [
+    {
+      "subject_type": "profile",
+      "subject_id": "reviewer",
+      "relation": "completed",
+      "object_type": "task",
+      "object_id": "t_abcd1234"
+    }
+  ],
+  "payload": {
+    "title_preview": "Fix failing integration test",
+    "workspace_kind": "worktree",
+    "priority": 0,
+    "summary_len": 240,
+    "summary_present": true,
+    "result_len": 1200,
+    "metadata_keys": ["checks", "pr_url"]
+  }
+}
+```
+
+Top-level fields with no known value yet, such as `actor`, `origin_plugin`, `correlation_id`, and `status_before`, are nullable reserved fields for future attribution and causality support.
+
+**Event types:**
+
+| Event type | Meaning |
+|------------|---------|
+| `kanban.task_created` | Task row was created. |
+| `kanban.task_assigned` | Task assignee changed. |
+| `kanban.dependency_linked` / `kanban.dependency_unlinked` | Parent/child task dependency changed. |
+| `kanban.comment_added` | Comment row was added. |
+| `kanban.task_promoted` | Task became dispatchable after dependencies cleared. |
+| `kanban.task_claimed` | Worker claimed a task attempt. |
+| `kanban.worker_spawned` | Dispatcher spawned a worker process for the task. |
+| `kanban.task_completed` | Task reached `done`. |
+| `kanban.task_blocked` / `kanban.task_unblocked` | Task blocked state changed. |
+| `kanban.task_archived` | Task was archived. |
+| `kanban.run_reclaimed` | Stale run claim was reclaimed. |
+| `kanban.run_failed` | Run ended due to timeout, crash, spawn failure, give-up, or protocol violation. Check `payload.outcome` for the specific failure kind. |
+
+**Privacy and boundedness:**
+
+The event payload is designed for routing and indexing, not raw content replication. Task bodies, comments, results, summaries, block reasons, metadata values, process IDs, logs, environment values, commands, and workspace paths are not exposed as raw text. Prefer length/presence fields and metadata keys when building downstream indexes.
+
+`title_preview` is intentionally included as bounded display text so dashboards and graph plugins can label events. Treat task titles as visible operational metadata; do not put secrets in Kanban titles.
+
+**Example — enqueue Kanban events for background processing:**
+
+```python
+import json
+import queue
+import threading
+from pathlib import Path
+
+_events = queue.Queue(maxsize=1000)
+
+
+def _worker():
+    path = Path.home() / ".hermes" / "kanban-events.jsonl"
+    while True:
+        event = _events.get()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event, sort_keys=True) + "\n")
+        finally:
+            _events.task_done()
+
+
+def on_kanban_event(event, **kwargs):
+    try:
+        _events.put_nowait(event)
+    except queue.Full:
+        # Never block Kanban writes on a slow observer.
+        pass
+
+
+def register(ctx):
+    threading.Thread(target=_worker, daemon=True).start()
+    ctx.register_hook("on_kanban_event", on_kanban_event)
+```
+
+**Use cases:** Relationship-memory plugins, assignment analytics, external notification bridges, dashboard/event-log replication, durable catch-up workers keyed by `(board, event_id)`.
 
 ---
 


### PR DESCRIPTION
## Diff footprint

Against `upstream/main`:

| Area | Files | Lines |
|---|---:|---:|
| Runtime code | 2 | +303 / -13 |
| Tests | 3 | +275 / -3 |
| Documentation | 2 | +134 / -4 |
| **Total** | **7** | **+712 / -20** |

Runtime code is limited to `hermes_cli/kanban_db.py` and `hermes_cli/plugins.py`; docs are limited to the plugin/hook guides.

## Summary

Adds one atomic Kanban plugin seam: `on_kanban_event(event)`.

- Registers `on_kanban_event` as a valid plugin hook.
- Emits a versioned, sanitized Kanban lifecycle envelope after successful `write_txn` commit.
- Documents the hook contract in the plugin/hook docs.

## Contract

This hook is intentionally narrow:

- **Observer-only:** return values are ignored; plugins cannot veto Kanban writes.
- **Post-commit:** rollback/failed mutations do not emit plugin events.
- **Fail-open:** plugin exceptions are logged and do not roll back task mutations.
- **Sanitized:** raw bodies, comments, results, summaries, reasons, metadata values, commands, logs, PIDs, env values, and paths are not exposed.
- **Not a durable event bus:** plugins that need guaranteed catch-up should keep a cursor over Kanban `task_events` and treat the hook as the fast path.

## Why

Plugin authors need a stable observer seam for Kanban lifecycle facts without scraping logs or reading raw task/comment/result payloads. This is the minimal core primitive needed for downstream graph, memory, notification, and bridge plugins.

## Related

This PR does not close the broader requests below, but it gives them a shared primitive to build on:

- https://github.com/NousResearch/hermes-agent/issues/23961 — asks for Kanban dispatcher/tick style hooks; this PR adds committed lifecycle observation, not periodic tick dispatch.
- https://github.com/NousResearch/hermes-agent/issues/9405 — multi-agent observer / relationship-memory direction.
- https://github.com/NousResearch/hermes-agent/issues/19932 — Kanban bridge plugin direction.
- https://github.com/NousResearch/hermes-agent/issues/16102 — original Kanban RFC/context.

## Verification

- `./scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_lifecycle_hooks.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_plugins.py -q` — 94 passed
- `./scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py tests/gateway/test_kanban_notifier.py -q` — 16 passed after final doc/comment cleanup
- `git diff --check` — passed
- `codex exec review --base upstream/main --ephemeral` — no discrete correctness, security, or maintainability issue found after fixes
- `claude -p ...` maintainer-style PR review — initial verdict COMMENT with no blocking findings; follow-up verdict APPROVE after addressing the targeted non-blocking review items
- `npm --prefix website ci && npm --prefix website run build` — completed; build reports existing unrelated docs warnings/broken links, with no new failure from this hook docs section.
