### PR TITLE
fix(kanban): preserve dashboard text casing

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -8,6 +8,13 @@
 .hermes-kanban {
   width: 100%;
 }
+.hermes-kanban,
+.hermes-kanban-drawer {
+  /* The dashboard shell uses uppercase as part of its visual language.
+   * Kanban displays case-sensitive task IDs, profile IDs, paths, and user
+   * content, so reset inherited casing at the plugin boundary. */
+  text-transform: none;
+}
 
 /* ---- Code/pre reset (theme-immune default) --------------------------- *
  *
@@ -457,8 +464,7 @@
 .hermes-kanban-section-head {
   font-size: 0.72rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.03em;
   color: var(--color-muted-foreground);
 }
 
@@ -603,8 +609,7 @@
 }
 .hermes-kanban-deps-label {
   font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.03em;
   color: var(--color-muted-foreground);
   min-width: 4rem;
 }
@@ -683,8 +688,7 @@
   border: 0;
   color: var(--color-muted-foreground);
   font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
   cursor: pointer;
   padding: 0;
 }
@@ -861,8 +865,7 @@
 .hermes-kanban-run-outcome {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
   color: var(--color-foreground);
 }
 .hermes-kanban-run-profile {
@@ -921,8 +924,7 @@
 .hermes-kanban-run-meta-label {
   font-size: 0.65rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.03em;
   color: var(--color-muted-foreground);
   padding-bottom: 0.15rem;
 }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -164,6 +164,32 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
     assert "[boardData, tenantFilter, assigneeFilter, search]" in js
 
 
+def _css_block(css: str, selector: str) -> str:
+    start = css.index(selector)
+    open_brace = css.index("{", start)
+    close_brace = css.index("}", open_brace)
+    return css[open_brace:close_brace]
+
+
+def test_dashboard_kanban_preserves_user_entered_case():
+    """Kanban must opt out of dashboard-wide uppercase styling."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert ".hermes-kanban,\n.hermes-kanban-drawer" in css
+    assert "text-transform: none;" in _css_block(css, ".hermes-kanban,")
+
+    for selector in (
+        ".hermes-kanban-section-head",
+        ".hermes-kanban-deps-label",
+        ".hermes-kanban-edit-link",
+        ".hermes-kanban-run-outcome",
+        ".hermes-kanban-run-meta-label",
+    ):
+        assert "text-transform: uppercase" not in _css_block(css, selector)
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
Fixes #26408

Summary:
- reset inherited dashboard uppercase styling at the Kanban plugin boundary
- remove forced uppercase transforms from Kanban drawer labels, dependency labels, edit links, run outcome labels, and metadata labels
- keep task IDs, task titles, profile IDs, paths, and user-entered content rendered with their stored casing
- add a regression test that checks the Kanban CSS opts out of inherited uppercase and avoids forcing uppercase on these Kanban UI surfaces
- include CI test stabilizers for the existing Discord mock and Nous provider parity failures

Tests:
- python -m pytest -o addopts= tests\plugins\test_kanban_dashboard_plugin.py::test_dashboard_kanban_preserves_user_entered_case -q --tb=short
- python -m pytest -o addopts= tests\e2e\test_discord_adapter.py -q --tb=short
- python -m pytest -o addopts= tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m ruff check tests\plugins\test_kanban_dashboard_plugin.py tests\e2e\conftest.py tests\run_agent\test_provider_parity.py