### PR TITLE
feat(tts): auto-select voices by language

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_tts_auto_lang.py
+++ b/tests/tools/test_tts_auto_lang.py
@@ -1,0 +1,101 @@
+"""Tests for TTS automatic language-to-voice selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from tools import tts_tool
+
+
+def test_detect_tts_language_from_unicode_scripts():
+    assert tts_tool._detect_tts_language("Hello world") == "en"
+    assert tts_tool._detect_tts_language("Привет мир") == "ru"
+    assert tts_tool._detect_tts_language("你好世界") == "zh"
+    assert tts_tool._detect_tts_language("こんにちは") == "ja"
+
+
+def test_auto_lang_global_voice_map_applies_provider_voice():
+    config = {
+        "auto_lang": True,
+        "voices": {
+            "en": "alloy",
+            "zh": "nova",
+            "fallback": "echo",
+        },
+    }
+
+    updated = tts_tool._with_auto_lang_voice(config, "openai", "你好")
+
+    assert updated["openai"]["voice"] == "nova"
+    assert "openai" not in config
+
+
+def test_auto_lang_provider_voice_map_overrides_global_map():
+    config = {
+        "auto_lang": True,
+        "voices": {"ru": "global-ru"},
+        "edge": {
+            "voices": {
+                "ru": "ru-RU-SvetlanaNeural",
+                "fallback": "en-US-AvaNeural",
+            },
+        },
+    }
+
+    updated = tts_tool._with_auto_lang_voice(config, "edge", "Привет")
+
+    assert updated["edge"]["voice"] == "ru-RU-SvetlanaNeural"
+
+
+def test_auto_lang_updates_command_provider_voice_without_mutating_original():
+    config = {
+        "provider": "local-tts",
+        "auto_lang": True,
+        "voices": {"zh": "zh-voice", "fallback": "en-voice"},
+        "providers": {
+            "local-tts": {
+                "type": "command",
+                "command": "local-tts --voice {voice}",
+            },
+        },
+    }
+
+    updated = tts_tool._with_auto_lang_voice(config, "local-tts", "你好")
+
+    assert updated["providers"]["local-tts"]["voice"] == "zh-voice"
+    assert "voice" not in config["providers"]["local-tts"]
+
+
+def test_text_to_speech_tool_selects_edge_voice_from_language(
+    tmp_path,
+    monkeypatch,
+):
+    config = {
+        "provider": "edge",
+        "auto_lang": True,
+        "voices": {
+            "ru": "ru-RU-SvetlanaNeural",
+            "fallback": "en-US-AvaNeural",
+        },
+    }
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+    monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", lambda _path: None)
+
+    mock_comm = MagicMock()
+
+    async def save_audio(path):
+        Path(path).write_bytes(b"mp3")
+
+    mock_comm.save = AsyncMock(side_effect=save_audio)
+    mock_edge = MagicMock()
+    mock_edge.Communicate = MagicMock(return_value=mock_comm)
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: mock_edge)
+
+    result = json.loads(tts_tool.text_to_speech_tool("Привет мир"))
+
+    assert result["success"] is True
+    assert mock_edge.Communicate.call_args.args[0] == "Привет мир"
+    assert mock_edge.Communicate.call_args.kwargs["voice"] == "ru-RU-SvetlanaNeural"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -54,6 +54,7 @@ from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
 from hermes_constants import display_hermes_home
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -417,6 +418,146 @@ def _resolve_command_provider_config(
     if _is_command_provider_config(config):
         return config
     return None
+
+
+def _detect_tts_language(text: str) -> Optional[str]:
+    """Detect a broad language family from Unicode script distribution."""
+    counts: Dict[str, int] = {}
+    for ch in text:
+        cp = ord(ch)
+        lang: Optional[str] = None
+        if 0x0400 <= cp <= 0x052F or 0x2DE0 <= cp <= 0x2DFF or 0xA640 <= cp <= 0xA69F:
+            lang = "ru"
+        elif 0x3040 <= cp <= 0x30FF or 0x31F0 <= cp <= 0x31FF:
+            lang = "ja"
+        elif 0xAC00 <= cp <= 0xD7AF or 0x1100 <= cp <= 0x11FF:
+            lang = "ko"
+        elif (
+            0x4E00 <= cp <= 0x9FFF
+            or 0x3400 <= cp <= 0x4DBF
+            or 0x20000 <= cp <= 0x2A6DF
+            or 0x2A700 <= cp <= 0x2B73F
+            or 0x2B740 <= cp <= 0x2B81F
+            or 0x2B820 <= cp <= 0x2CEAF
+        ):
+            lang = "zh"
+        elif 0x0600 <= cp <= 0x06FF or 0x0750 <= cp <= 0x077F or 0x08A0 <= cp <= 0x08FF:
+            lang = "ar"
+        elif 0x0590 <= cp <= 0x05FF:
+            lang = "he"
+        elif 0x0900 <= cp <= 0x097F:
+            lang = "hi"
+        elif 0x0E00 <= cp <= 0x0E7F:
+            lang = "th"
+        elif 0x0370 <= cp <= 0x03FF:
+            lang = "el"
+        elif (
+            0x0041 <= cp <= 0x005A
+            or 0x0061 <= cp <= 0x007A
+            or 0x00C0 <= cp <= 0x024F
+        ):
+            lang = "en"
+        if lang:
+            counts[lang] = counts.get(lang, 0) + 1
+    if not counts:
+        return None
+    winner, winner_count = max(counts.items(), key=lambda item: item[1])
+    if sum(1 for value in counts.values() if value == winner_count) > 1:
+        return None
+    return winner
+
+
+_TTS_VOICE_CONFIG_KEYS = {
+    "edge": "voice",
+    "openai": "voice",
+    "gemini": "voice",
+    "kittentts": "voice",
+    "piper": "voice",
+    "elevenlabs": "voice_id",
+    "minimax": "voice_id",
+    "mistral": "voice_id",
+    "xai": "voice_id",
+}
+
+
+def _get_auto_lang_voice_map(
+    tts_config: Dict[str, Any],
+    provider: str,
+) -> Dict[str, Any]:
+    """Return provider-specific auto-lang voices, falling back to tts.voices."""
+    provider_section: Dict[str, Any]
+    if provider.lower() in BUILTIN_TTS_PROVIDERS:
+        provider_section = _get_provider_section(tts_config, provider.lower())
+    else:
+        provider_section = _get_named_provider_config(tts_config, provider.lower())
+
+    provider_voices = provider_section.get("voices")
+    if isinstance(provider_voices, dict):
+        return provider_voices
+    voices = tts_config.get("voices")
+    return voices if isinstance(voices, dict) else {}
+
+
+def _select_auto_lang_voice(
+    text: str,
+    provider: str,
+    tts_config: Dict[str, Any],
+) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(language, voice)`` for tts.auto_lang, or ``(None, None)``."""
+    if not is_truthy_value(tts_config.get("auto_lang"), default=False):
+        return None, None
+    voices = _get_auto_lang_voice_map(tts_config, provider)
+    if not voices:
+        return None, None
+    detected = _detect_tts_language(text)
+    raw_voice = voices.get(detected) if detected else None
+    if raw_voice is None:
+        raw_voice = voices.get("fallback") or voices.get("default")
+    if raw_voice is None:
+        return detected, None
+    voice = str(raw_voice).strip()
+    if not voice:
+        return detected, None
+    return detected or "fallback", voice
+
+
+def _with_auto_lang_voice(
+    tts_config: Dict[str, Any],
+    provider: str,
+    text: str,
+) -> Dict[str, Any]:
+    """Return config with the auto-lang voice applied when configured."""
+    language, voice = _select_auto_lang_voice(text, provider, tts_config)
+    if not voice:
+        return tts_config
+
+    key = _TTS_VOICE_CONFIG_KEYS.get(provider.lower(), "voice")
+    updated = dict(tts_config)
+
+    if provider.lower() in BUILTIN_TTS_PROVIDERS:
+        section = dict(_get_provider_section(updated, provider.lower()))
+        section[key] = voice
+        if provider.lower() == "xai" and language not in {None, "fallback"}:
+            section["language"] = language
+        updated[provider.lower()] = section
+    else:
+        providers = updated.get("providers")
+        if isinstance(providers, dict):
+            providers_copy = dict(providers)
+            for name, config in providers.items():
+                if isinstance(name, str) and name.lower() == provider.lower() and isinstance(config, dict):
+                    config_copy = dict(config)
+                    config_copy["voice"] = voice
+                    providers_copy[name] = config_copy
+                    updated["providers"] = providers_copy
+                    logger.info("TTS auto_lang selected %s voice for %s", language, provider)
+                    return updated
+        section = dict(_get_provider_section(updated, provider))
+        section["voice"] = voice
+        updated[provider] = section
+
+    logger.info("TTS auto_lang selected %s voice for %s", language, provider)
+    return updated
 
 
 def _iter_command_providers(tts_config: Dict[str, Any]):
@@ -1645,6 +1786,7 @@ def text_to_speech_tool(
 
     tts_config = _load_tts_config()
     provider = _get_provider(tts_config)
+    tts_config = _with_auto_lang_voice(tts_config, provider, text)
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -45,6 +45,12 @@ Convert text to speech with ten providers:
 tts:
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
+  auto_lang: false              # Auto-select a voice from tts.voices by detected language
+  voices:
+    en: "en-US-AvaNeural"
+    ru: "ru-RU-SvetlanaNeural"
+    zh: "zh-CN-XiaoxiaoNeural"
+    fallback: "en-US-AvaNeural"
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
     speed: 1.0                  # Converted to rate percentage (+/-%)
@@ -97,6 +103,20 @@ tts:
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
 
+**Automatic language voices**: Set `tts.auto_lang: true` with a `tts.voices` map to pick a voice from the text's Unicode script before synthesis. Hermes supports lightweight built-in detection for Latin (`en`), Cyrillic (`ru`), Chinese (`zh`), Japanese (`ja`), Korean (`ko`), Arabic (`ar`), Hebrew (`he`), Hindi/Devanagari (`hi`), Thai (`th`), and Greek (`el`). If the detected language is not mapped, `fallback` is used.
+
+Provider-specific maps can override the global map:
+
+```yaml
+tts:
+  provider: openai
+  auto_lang: true
+  openai:
+    voices:
+      en: alloy
+      zh: nova
+      fallback: alloy
+```
 
 ### Input length limits
 


### PR DESCRIPTION
## Summary
- add `tts.auto_lang` voice selection using lightweight Unicode-script detection
- support global `tts.voices` and provider-specific voice maps, including command providers
- document multilingual TTS voice configuration
- include CI fixture stabilizers for existing Discord/NouS Portal test failures

Fixes #26377

## Tests
- `python -m pytest -o addopts= tests\tools\test_tts_auto_lang.py tests\tools\test_tts_speed.py tests\tools\test_tts_command_providers.py tests\e2e\test_discord_adapter.py tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short`
- `python -m ruff check tools\tts_tool.py tests\tools\test_tts_auto_lang.py tests\e2e\conftest.py tests\run_agent\test_provider_parity.py`