### PR TITLE
fix(wecom): bound outbound local media paths

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -37,6 +37,7 @@ import logging
 import mimetypes
 import os
 import re
+import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
@@ -67,6 +68,10 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    get_audio_cache_dir,
+    get_document_cache_dir,
+    get_image_cache_dir,
+    get_video_cache_dir,
 )
 
 logger = logging.getLogger(__name__)
@@ -1089,6 +1094,28 @@ class WeComAdapter(BasePlatformAdapter):
         parsed = urlparse(str(media_source or ""))
         return parsed.scheme in {"http", "https"}
 
+    @staticmethod
+    def _allowed_outbound_media_dirs() -> List[Path]:
+        """Directories whose local files may be uploaded as outbound media."""
+        return [
+            get_image_cache_dir().resolve(),
+            get_audio_cache_dir().resolve(),
+            get_video_cache_dir().resolve(),
+            get_document_cache_dir().resolve(),
+            Path(tempfile.gettempdir()).resolve(),
+        ]
+
+    @classmethod
+    def _validate_outbound_media_path(cls, local_path: Path) -> Path:
+        """Resolve and require ``local_path`` to stay inside media-safe dirs."""
+        resolved = local_path.resolve()
+        for allowed_dir in cls._allowed_outbound_media_dirs():
+            if resolved.is_relative_to(allowed_dir):
+                return resolved
+        raise PermissionError(
+            "Outbound WeCom media path is outside allowed media directories"
+        )
+
     async def _load_outbound_media(
         self,
         media_source: str,
@@ -1109,12 +1136,17 @@ class WeComAdapter(BasePlatformAdapter):
             return data, content_type, resolved_name
 
         if parsed.scheme == "file":
+            if parsed.netloc and parsed.netloc not in {"localhost", "127.0.0.1"}:
+                raise ValueError(
+                    f"Unsupported file URL host for WeCom media: {parsed.netloc}"
+                )
             local_path = Path(unquote(parsed.path)).expanduser()
         else:
             local_path = Path(source).expanduser()
 
         if not local_path.is_absolute():
-            local_path = (Path.cwd() / local_path).resolve()
+            local_path = Path.cwd() / local_path
+        local_path = self._validate_outbound_media_path(local_path)
 
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -353,6 +353,85 @@ class TestMediaHelpers:
         with pytest.raises(ValueError, match="placeholder was not replaced"):
             await adapter._load_outbound_media("<path>")
 
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_allows_file_inside_media_dir(self, tmp_path, monkeypatch):
+        from gateway.platforms.wecom import WeComAdapter
+
+        allowed_dir = tmp_path / "media-cache"
+        allowed_dir.mkdir()
+        media_file = allowed_dir / "report.txt"
+        media_file.write_bytes(b"wecom report")
+
+        monkeypatch.setattr(
+            WeComAdapter,
+            "_allowed_outbound_media_dirs",
+            staticmethod(lambda: [allowed_dir.resolve()]),
+        )
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        data, content_type, resolved_name = await adapter._load_outbound_media(
+            media_file.as_uri()
+        )
+
+        assert data == b"wecom report"
+        assert content_type == "text/plain"
+        assert resolved_name == "report.txt"
+
+    @pytest.mark.asyncio
+    async def test_load_outbound_media_rejects_file_outside_media_dirs(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from gateway.platforms.wecom import WeComAdapter
+
+        allowed_dir = tmp_path / "media-cache"
+        allowed_dir.mkdir()
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("do not upload", encoding="utf-8")
+
+        monkeypatch.setattr(
+            WeComAdapter,
+            "_allowed_outbound_media_dirs",
+            staticmethod(lambda: [allowed_dir.resolve()]),
+        )
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        with pytest.raises(
+            PermissionError,
+            match="outside allowed media directories",
+        ):
+            await adapter._load_outbound_media(secret_file.as_uri())
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.name == "nt", reason="symlink permissions vary on Windows")
+    async def test_load_outbound_media_rejects_symlink_escape(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from gateway.platforms.wecom import WeComAdapter
+
+        allowed_dir = tmp_path / "media-cache"
+        allowed_dir.mkdir()
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("do not upload", encoding="utf-8")
+        symlink_path = allowed_dir / "linked-secret.txt"
+        symlink_path.symlink_to(secret_file)
+
+        monkeypatch.setattr(
+            WeComAdapter,
+            "_allowed_outbound_media_dirs",
+            staticmethod(lambda: [allowed_dir.resolve()]),
+        )
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        with pytest.raises(
+            PermissionError,
+            match="outside allowed media directories",
+        ):
+            await adapter._load_outbound_media(symlink_path.as_uri())
+
 
 class TestMediaUpload:
     @pytest.mark.asyncio
@@ -830,4 +909,3 @@ class TestWeComZombieSessionFix:
         adapter._send_request.assert_awaited_once()
         cmd = adapter._send_request.await_args.args[0]
         assert cmd == APP_CMD_SEND
-


### PR DESCRIPTION
## What does this PR do?

Fixes WeCom outbound local media loading so `file://` and plain local path sources are resolved and checked before `read_bytes()`. Local media uploads are now limited to Hermes media cache directories and the system temp directory, which blocks arbitrary local file reads while preserving generated/cached media delivery.

HTTP/HTTPS media sources still use the existing `_download_remote_bytes()` path with `tools.url_safety.is_safe_url()` SSRF protection.

I found this while following up on the OpenClaw/Hermes runtime and security-hardening work after the Oracle zip contribution, and kept the patch intentionally narrow to the public WeCom issue.

## Related Issue

Fixes #8733

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/wecom.py`: add a resolved allowlist for outbound local media roots: image/audio/video/document caches plus `tempfile.gettempdir()`.
- `gateway/platforms/wecom.py`: validate every local/file URL outbound media source before existence checks and `read_bytes()`.
- `gateway/platforms/wecom.py`: reject non-local `file://host/...` media URLs.
- `tests/gateway/test_wecom.py`: cover allowed media-cache files, blocked arbitrary local files, and symlink escape attempts.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_wecom.py`
2. `git diff --check`
3. `.venv/bin/python -m ruff check gateway/platforms/wecom.py tests/gateway/test_wecom.py`
4. `.venv/bin/python -m py_compile gateway/platforms/wecom.py tests/gateway/test_wecom.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS Darwin 25.3.0 arm64, Python 3.11.13

Focused WeCom tests and touched-file checks passed; full `pytest tests/ -q` was not run because this is a narrow platform-adapter fix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_wecom.py
45 passed in 3.46s

.venv/bin/python -m ruff check gateway/platforms/wecom.py tests/gateway/test_wecom.py
All checks passed!

git diff --check
# no output

.venv/bin/python -m py_compile gateway/platforms/wecom.py tests/gateway/test_wecom.py
# no output
```