### PR TITLE
fix(agent): preserve continuation output cap after truncation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3626,6 +3626,21 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    @staticmethod
+    def _requested_output_cap_from_api_kwargs(api_kwargs: Any) -> Optional[int]:
+        """Extract the outgoing response token cap from a prepared request."""
+        if not isinstance(api_kwargs, dict):
+            return None
+        for key in ("max_output_tokens", "max_completion_tokens", "max_tokens"):
+            raw = api_kwargs.get(key)
+            try:
+                value = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                return value
+        return None
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any reasoning/thinking blocks.
@@ -14534,9 +14549,16 @@ class AIAgent:
                 # Progressively boost the output token budget on each retry.
                 # Retry 1 → 2× base, retry 2 → 3× base, capped at 32 768.
                 # Applies to all providers via _ephemeral_max_output_tokens.
+                # If the original request already used a larger provider/model
+                # default budget, keep that floor so continuation retries do
+                # not accidentally downshift to a much smaller cap.
                 _boost_base = self.max_tokens if self.max_tokens else 4096
                 _boost = _boost_base * (length_continue_retries + 1)
-                self._ephemeral_max_output_tokens = min(_boost, 32768)
+                _requested_cap = self._requested_output_cap_from_api_kwargs(api_kwargs)
+                if _requested_cap is not None:
+                    _boost = max(_boost, _requested_cap)
+                _boost_cap = max(32768, _requested_cap or 0)
+                self._ephemeral_max_output_tokens = min(_boost, _boost_cap)
                 continue
 
             # Guard: if all retries exhausted without a successful response

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3101,6 +3101,36 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
+        """Continuation retries must not shrink a higher provider default cap."""
+        self._setup_agent(agent)
+        agent.max_tokens = None
+        requested_caps = []
+
+        def _fake_build_api_kwargs(api_messages):
+            ephemeral = getattr(agent, "_ephemeral_max_output_tokens", None)
+            if ephemeral is not None:
+                agent._ephemeral_max_output_tokens = None
+            cap = ephemeral if ephemeral is not None else 65536
+            requested_caps.append(cap)
+            return {"model": agent.model, "messages": api_messages, "max_tokens": cap}
+
+        first = _mock_response(content="Part 1 ", finish_reason="length")
+        second = _mock_response(content="Part 2", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_build_api_kwargs", side_effect=_fake_build_api_kwargs),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Part 1 Part 2"
+        assert requested_caps == [65536, 65536]
+
     def test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation(self, agent):
         """Ollama-hosted GLM responses can misreport truncated output as stop."""
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Fixes continuation retries for long responses so Hermes does not accidentally shrink the output budget after the first `finish_reason='length'` turn.

The current continuation path boosts from `self.max_tokens or 4096` and caps at `32768`. When the initial request relied on a higher provider/model default output cap, the retry path can unintentionally downshift that request to `8K/12K/16K`, making truncation much more likely even in fresh sessions with large-output models.

This patch preserves the original request's effective output cap as a floor for continuation retries. Hermes still uses the existing progressive retry path, but it no longer retries with a much smaller token budget than the truncated request just used.

## Related Issue

Fixes #26425

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: added a small helper to read the outgoing response token cap from prepared API kwargs.
- `run_agent.py`: updated the length-continuation restart path to preserve the original request cap as a floor instead of always dropping back to `self.max_tokens or 4096`.
- `tests/run_agent/test_run_agent.py`: added a regression test proving a large provider-default cap is preserved across continuation retries.

## How to Test

1. `python3 -m pytest -o addopts='' tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_continuation_preserves_large_provider_default_output_cap or length_thinking_exhausted_skips_continuation or length_empty_content_without_think_tags_retries_normally or truncated_tool_call_retries_once_before_refusing'`
2. `python3 -m py_compile run_agent.py tests/run_agent/test_run_agent.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 / Python 3.10.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
python3 -m pytest -o addopts='' tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_continuation_preserves_large_provider_default_output_cap or length_thinking_exhausted_skips_continuation or length_empty_content_without_think_tags_retries_normally or truncated_tool_call_retries_once_before_refusing'
5 passed, 321 deselected in 12.79s

python3 -m py_compile run_agent.py tests/run_agent/test_run_agent.py
# no output

git diff --check
# no output
```
