### PR TITLE
feat(feishu): render markdown tables as JSON 2.0 cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4179,8 +4179,16 @@ class FeishuAdapter(BasePlatformAdapter):
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            # JSON 2.0 card renders markdown tables natively with borders and alignment.
+            card = {
+                "schema": "2.0",
+                "body": {
+                    "elements": [
+                        {"tag": "markdown", "content": content}
+                    ]
+                },
+            }
+            return "interactive", json.dumps(card, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
## Problem

Feishu messages with markdown tables render as ugly plain text with pipe characters (`|`) because the adapter sends them as `msg_type: "text"` which does not support table syntax.

## Solution

When the content contains a markdown table, send it as an **interactive card with `schema: "2.0"`** instead. Feishu JSON 2.0 cards natively render markdown tables with:

- Proper borders and cell alignment
- Header row styling
- Pagination for large tables (max 5 data rows per page)
- Up to 4 tables per markdown component

## Change

In `gateway/platforms/feishu.py`, `_build_outbound_payload()`:

**Before:** table content → `msg_type: "text"` (ugly plain text)
**After:** table content → `msg_type: "interactive"` with card JSON 2.0 (native table rendering)

```python
if _MARKDOWN_TABLE_RE.search(content):
    card = {
        "schema": "2.0",
        "body": {
            "elements": [
                {"tag": "markdown", "content": content}
            ]
        },
    }
    return "interactive", json.dumps(card, ensure_ascii=False)
```

## Testing

- Verified on Feishu desktop client: tables now render with proper borders and alignment
- Non-table markdown messages continue to use existing `post` / `text` paths (no behavior change)
- The `_MARKDOWN_TABLE_RE` regex detection is unchanged — only the rendering path is affected

## References

- [Feishu Card JSON 2.0 Rich Text Component](https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-json-v2-components/content-components/rich-text) — documents table support in JSON 2.0 structure