### PR TITLE
fix(kanban): honor severity thresholds in diagnostics

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_diagnostics as kd
 
 
 # ---------------------------------------------------------------------------
@@ -1403,7 +1404,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         sev = getattr(args, "severity", None)
         if sev:
             for tid in list(diags_by_task.keys()):
-                kept = [d for d in diags_by_task[tid] if d.severity == sev]
+                kept = [d for d in diags_by_task[tid] if kd.severity_at_or_above(d.severity, sev)]
                 if kept:
                     diags_by_task[tid] = kept
                 else:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -41,6 +41,15 @@ import time
 SEVERITY_ORDER = ("warning", "error", "critical")
 
 
+def severity_at_or_above(severity: Optional[str], threshold: Optional[str]) -> bool:
+    """Return True when ``severity`` meets or exceeds ``threshold``."""
+    if threshold is None:
+        return True
+    if severity not in SEVERITY_ORDER or threshold not in SEVERITY_ORDER:
+        return False
+    return SEVERITY_ORDER.index(severity) >= SEVERITY_ORDER.index(threshold)
+
+
 @dataclass
 class DiagnosticAction:
     """A single recovery action attached to a diagnostic.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -49,6 +49,7 @@ from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconn
 from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
+from hermes_cli import kanban_diagnostics as kd
 
 log = logging.getLogger(__name__)
 
@@ -946,7 +947,7 @@ def list_diagnostics(
         if severity:
             filtered: dict[str, list[dict]] = {}
             for tid, dl in diags_by_task.items():
-                keep = [d for d in dl if d.get("severity") == severity]
+                keep = [d for d in dl if kd.severity_at_or_above(d.get("severity"), severity)]
                 if keep:
                     filtered[tid] = keep
             diags_by_task = filtered

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -67,6 +67,17 @@ def _run(outcome="completed", run_id=1, error=None):
 # ---------------------------------------------------------------------------
 
 
+def test_severity_at_or_above_uses_threshold_semantics():
+    assert kd.severity_at_or_above("warning", "warning") is True
+    assert kd.severity_at_or_above("error", "warning") is True
+    assert kd.severity_at_or_above("critical", "warning") is True
+    assert kd.severity_at_or_above("critical", "error") is True
+    assert kd.severity_at_or_above("warning", "error") is False
+    assert kd.severity_at_or_above("error", "critical") is False
+    assert kd.severity_at_or_above("mystery", "warning") is False
+    assert kd.severity_at_or_above("warning", None) is True
+
+
 def test_hallucinated_cards_fires_on_blocked_event():
     task = _task(status="ready")
     events = [

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1543,7 +1543,7 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
 
 
 def test_diagnostics_endpoint_severity_filter(client):
-    """Warning-severity filter excludes error-severity entries."""
+    """Severity filter keeps diagnostics at or above the requested level."""
     conn = kb.connect()
     try:
         # A warning-severity diagnostic (prose phantom) on one task.
@@ -1564,8 +1564,8 @@ def test_diagnostics_endpoint_severity_filter(client):
     r = client.get("/api/plugins/kanban/diagnostics?severity=warning")
     assert r.status_code == 200
     data = r.json()
-    assert data["count"] == 1
-    assert data["diagnostics"][0]["task_id"] == p1
+    assert data["count"] == 2
+    assert {row["task_id"] for row in data["diagnostics"]} == {p1, p2}
 
     r = client.get("/api/plugins/kanban/diagnostics?severity=error")
     data = r.json()


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes kanban diagnostics --severity` filter so it matches the documented "at or above" threshold semantics instead of exact severity matching. The CLI path and the Kanban dashboard diagnostics endpoint now both use the same threshold helper, so `warning` includes `warning`, `error`, and `critical`, while `error` includes `error` and `critical`.

## Related Issue

Fixes #26379

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `severity_at_or_above()` in `hermes_cli/kanban_diagnostics.py` to centralize severity ordering.
- Updated `hermes_cli/kanban.py` so CLI diagnostics filtering uses threshold semantics.
- Updated `plugins/kanban/dashboard/plugin_api.py` so dashboard diagnostics filtering matches the CLI behavior.
- Added a unit test for the helper in `tests/hermes_cli/test_kanban_diagnostics.py`.
- Updated `tests/plugins/test_kanban_dashboard_plugin.py` to assert threshold behavior instead of exact-match behavior.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/hermes_cli/test_kanban_diagnostics.py -k 'severity_at_or_above_uses_threshold_semantics'`
2. Run `python3 -m pytest -o addopts='' tests/plugins/test_kanban_dashboard_plugin.py -k 'diagnostics_endpoint_severity_filter'`
3. Confirm both tests pass and that `warning` returns both warning-level and higher-severity diagnostics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/hermes_cli/test_kanban_diagnostics.py -k 'severity_at_or_above_uses_threshold_semantics'`
- `python3 -m pytest -o addopts='' tests/plugins/test_kanban_dashboard_plugin.py -k 'diagnostics_endpoint_severity_filter'`
