### PR TITLE
fix(codex-runtime): advertise strict hermes-tools MCP schemas

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -105,6 +105,97 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 )
 
 
+def _strict_mcp_input_schema(schema: Any) -> dict[str, Any]:
+    """Return an MCP input schema compatible with strict JSON Schema clients.
+
+    Hermes tool definitions are authored for chat-completion function calling.
+    When we expose them through MCP, clients such as Codex/OpenAI strict-mode
+    validators expect object schemas to declare ``additionalProperties: false``.
+    Add that recursively without mutating the source tool definition.
+    """
+    if not isinstance(schema, dict):
+        schema = {}
+    normalized = json.loads(json.dumps(schema))
+    if not isinstance(normalized, dict):
+        normalized = {}
+    if normalized.get("type") != "object" and "properties" not in normalized:
+        normalized = {"type": "object", "properties": {}}
+    normalized.setdefault("type", "object")
+    normalized.setdefault("properties", {})
+    _add_strict_additional_properties(normalized)
+    return normalized
+
+
+def _add_strict_additional_properties(node: Any) -> None:
+    if isinstance(node, list):
+        for item in node:
+            _add_strict_additional_properties(item)
+        return
+    if not isinstance(node, dict):
+        return
+
+    node_type = node.get("type")
+    node_types = set(node_type) if isinstance(node_type, list) else {node_type}
+    if "object" in node_types or "properties" in node:
+        node.setdefault("additionalProperties", False)
+
+    for key in (
+        "properties",
+        "$defs",
+        "definitions",
+        "patternProperties",
+        "dependentSchemas",
+    ):
+        child_map = node.get(key)
+        if isinstance(child_map, dict):
+            for child in child_map.values():
+                _add_strict_additional_properties(child)
+
+    for key in ("items", "additionalProperties", "not", "if", "then", "else"):
+        _add_strict_additional_properties(node.get(key))
+
+    for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
+        _add_strict_additional_properties(node.get(key))
+
+
+def _register_tool_with_schema(
+    mcp: Any,
+    handler: Any,
+    *,
+    name: str,
+    description: str,
+    input_schema: dict[str, Any],
+) -> None:
+    """Register a FastMCP tool while preserving Hermes' JSON schema.
+
+    Current FastMCP releases derive schema from Python signatures and do not
+    accept an ``input_schema`` argument on ``FastMCP.add_tool``. Hermes tools are
+    discovered dynamically, so their authoritative schema lives in
+    ``model_tools``. Use the tool manager when available so the advertised MCP
+    schema matches the Hermes tool schema.
+    """
+    tool_manager = getattr(mcp, "_tool_manager", None)
+    manager_add_tool = getattr(tool_manager, "add_tool", None)
+    if callable(manager_add_tool):
+        tool = manager_add_tool(
+            handler,
+            name=name,
+            description=description,
+        )
+        if hasattr(tool, "parameters"):
+            tool.parameters = input_schema
+        return
+
+    try:
+        mcp.add_tool(handler, name=name, description=description)
+    except TypeError:
+        handler = mcp.tool(name=name, description=description)(handler)
+    tool_map = getattr(tool_manager, "_tools", None)
+    tool = tool_map.get(name) if isinstance(tool_map, dict) else None
+    if tool is not None and hasattr(tool, "parameters"):
+        tool.parameters = input_schema
+
+
 def _build_server() -> Any:
     """Create the FastMCP server with Hermes tools attached. Lazy imports
     so the module can be imported without the mcp package installed
@@ -152,13 +243,12 @@ def _build_server() -> Any:
             continue
 
         description = spec.get("description") or f"Hermes {name} tool"
-        params_schema = spec.get("parameters") or {"type": "object", "properties": {}}
+        params_schema = _strict_mcp_input_schema(spec.get("parameters"))
 
         # FastMCP wants a Python callable. Build a closure that takes the
         # arguments dict, dispatches via handle_function_call, and returns
-        # the result string. We use add_tool() for full control over the
-        # input schema (FastMCP's @tool() decorator inspects type hints,
-        # which we can't get from a JSON schema at runtime).
+        # the result string. The schema is attached after registration because
+        # FastMCP derives schemas from Python signatures by default.
         def _make_handler(tool_name: str):
             def _dispatch(**kwargs: Any) -> str:
                 try:
@@ -170,19 +260,13 @@ def _build_server() -> Any:
             _dispatch.__doc__ = description
             return _dispatch
 
-        try:
-            mcp.add_tool(
-                _make_handler(name),
-                name=name,
-                description=description,
-                # FastMCP accepts JSON schema directly via the
-                # input_schema parameter on newer versions; older
-                # versions use parameters_schema. Try both for compat.
-            )
-        except TypeError:
-            # Older mcp SDK signature — fall back to decorator-style.
-            handler = _make_handler(name)
-            handler = mcp.tool(name=name, description=description)(handler)
+        _register_tool_with_schema(
+            mcp,
+            _make_handler(name),
+            name=name,
+            description=description,
+            input_schema=params_schema,
+        )
 
         exposed_count += 1
 

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -8,6 +8,9 @@ build helper assembles a server when the SDK is present.
 
 from __future__ import annotations
 
+import sys
+import types
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -97,6 +100,102 @@ class TestModuleSurface:
             assert orch_tool in EXPOSED_TOOLS, (
                 f"{orch_tool!r} missing from codex callback"
             )
+
+
+class TestStrictSchemas:
+    def test_strict_mcp_input_schema_adds_additional_properties_recursively(self):
+        import agent.transports.hermes_tools_mcp_server as m
+
+        source = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {"type": "integer"},
+                    },
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                },
+                "mode": {
+                    "anyOf": [
+                        {"type": "object", "properties": {"fast": {"type": "boolean"}}},
+                        {"type": "string"},
+                    ],
+                },
+            },
+        }
+
+        strict = m._strict_mcp_input_schema(source)
+
+        assert strict["additionalProperties"] is False
+        assert strict["properties"]["options"]["additionalProperties"] is False
+        assert strict["properties"]["filters"]["items"]["additionalProperties"] is False
+        assert strict["properties"]["mode"]["anyOf"][0]["additionalProperties"] is False
+        assert "additionalProperties" not in source
+
+    def test_build_server_attaches_hermes_schema_to_fastmcp_tool(self, monkeypatch):
+        import agent.transports.hermes_tools_mcp_server as m
+
+        class FakeToolManager:
+            def __init__(self):
+                self.tools = {}
+
+            def add_tool(self, fn, name=None, description=None, **kwargs):
+                tool = SimpleNamespace(
+                    fn=fn,
+                    name=name,
+                    description=description,
+                    parameters={"type": "object", "properties": {"kwargs": {}}},
+                )
+                self.tools[name] = tool
+                return tool
+
+        class FakeFastMCP:
+            def __init__(self, *args, **kwargs):
+                self._tool_manager = FakeToolManager()
+
+        fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+        fake_fastmcp.FastMCP = FakeFastMCP
+        monkeypatch.setitem(sys.modules, "mcp", types.ModuleType("mcp"))
+        monkeypatch.setitem(sys.modules, "mcp.server", types.ModuleType("mcp.server"))
+        monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+        fake_model_tools = types.ModuleType("model_tools")
+        fake_model_tools.get_tool_definitions = lambda quiet_mode=True: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "options": {
+                                "type": "object",
+                                "properties": {"limit": {"type": "integer"}},
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+        fake_model_tools.handle_function_call = lambda name, args: "ok"
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        server = m._build_server()
+
+        tool = server._tool_manager.tools["web_search"]
+        assert tool.parameters["properties"]["query"]["type"] == "string"
+        assert tool.parameters["additionalProperties"] is False
+        assert tool.parameters["properties"]["options"]["additionalProperties"] is False
 
 
 class TestMain:


### PR DESCRIPTION
## Summary

- Preserve Hermes' authoritative tool parameter schema when exposing tools through the codex-runtime `hermes-tools` MCP callback.
- Normalize advertised MCP input schemas for strict clients by recursively adding `additionalProperties: false` to object schemas.
- Add focused unit coverage for the schema normalizer and FastMCP registration path.

Refs #26010 (T15).

## Verification

- `python3 -m py_compile agent/transports/hermes_tools_mcp_server.py tests/agent/transports/test_hermes_tools_mcp_server.py`
- `../hermes-pr-8733-wecom-media-path-boundary/.venv/bin/python -m py_compile agent/transports/hermes_tools_mcp_server.py tests/agent/transports/test_hermes_tools_mcp_server.py`
- `../hermes-pr-8733-wecom-media-path-boundary/.venv/bin/python -m pytest -o addopts='' tests/agent/transports/test_hermes_tools_mcp_server.py -q` — 11 passed
- `../hermes-pr-8733-wecom-media-path-boundary/.venv/bin/python -m ruff check agent/transports/hermes_tools_mcp_server.py tests/agent/transports/test_hermes_tools_mcp_server.py`
- `git diff --check`

## Real behavior proof

Behavior addressed: `hermes-tools` MCP callback tools now advertise Hermes' original JSON parameter schema with strict object metadata instead of FastMCP's generic `**kwargs`-derived schema.

Real environment tested: Local macOS checkout using the existing sibling Hermes `.venv` because this new worktree did not have its own virtualenv. No live Codex turn was required for the schema advertisement proof.

Exact steps or command run after this patch:

```bash
../hermes-pr-8733-wecom-media-path-boundary/.venv/bin/python - <<'PY'
import asyncio
from agent.transports.hermes_tools_mcp_server import _build_server

async def main():
    server = _build_server()
    tools = await server.list_tools()
    print('tool_count', len(tools))
    names = [tool.name for tool in tools]
    print('tool_names', ','.join(names))
    tool = tools[0]
    schema = tool.inputSchema
    print('sample_tool', tool.name)
    print('sample_root_additionalProperties', schema.get('additionalProperties'))
    print('sample_has_properties', isinstance(schema.get('properties'), dict))

asyncio.run(main())
PY
```

Evidence after fix: The server registered 13 available local tools and `browser_navigate` advertised an object input schema with `additionalProperties` set to `False` and a real `properties` object.

Observed result after fix: A local MCP list-tools path sees strict schema metadata on advertised Hermes callback tools. The optional local environment was missing `websockets`, so some browser-dialog dependent tools were skipped by existing discovery behavior, but the server still registered available tools and exposed strict schemas for them.

What was not tested: A full live Codex app-server MCP call was not run, and the full repository test suite was not run.