### PR TITLE
fix(open-webui): add bootstrap dry-run and confirmation

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/scripts/setup_open_webui.sh
+++ b/scripts/setup_open_webui.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 #
 # Usage:
 #   bash scripts/setup_open_webui.sh
+#   bash scripts/setup_open_webui.sh --dry-run
+#   bash scripts/setup_open_webui.sh --yes
 #
 # Optional environment overrides:
 #   OPEN_WEBUI_PORT=8080
@@ -29,6 +31,7 @@ OPEN_WEBUI_HOST="${OPEN_WEBUI_HOST:-127.0.0.1}"
 OPEN_WEBUI_NAME="${OPEN_WEBUI_NAME:-Hermes Agent WebUI}"
 OPEN_WEBUI_ENABLE_SIGNUP="${OPEN_WEBUI_ENABLE_SIGNUP:-true}"
 OPEN_WEBUI_ENABLE_SERVICE="${OPEN_WEBUI_ENABLE_SERVICE:-auto}"
+OPEN_WEBUI_ASSUME_YES="${OPEN_WEBUI_ASSUME_YES:-false}"
 OPEN_WEBUI_VENV="${OPEN_WEBUI_VENV:-$HOME/.local/open-webui-venv}"
 OPEN_WEBUI_DATA_DIR="${OPEN_WEBUI_DATA_DIR:-$HOME/.local/share/open-webui/data}"
 HERMES_ENV_FILE="${HERMES_ENV_FILE:-$HOME/.hermes/.env}"
@@ -39,9 +42,116 @@ HERMES_API_MODEL_NAME="${HERMES_API_MODEL_NAME:-Hermes Agent}"
 HERMES_API_BASE_URL="http://${HERMES_API_CONNECT_HOST}:${HERMES_API_PORT}/v1"
 LAUNCHER_PATH="$HOME/.local/bin/start-open-webui-hermes.sh"
 LOG_DIR="$HOME/.hermes/logs"
+OPEN_WEBUI_DRY_RUN=false
 
 log() {
   printf '[open-webui-bootstrap] %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/setup_open_webui.sh [--dry-run] [--yes]
+
+Options:
+  --dry-run   Print planned file/env/service changes and exit.
+  --yes, -y   Apply without the interactive confirmation prompt.
+  --help, -h  Show this help text.
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        OPEN_WEBUI_DRY_RUN=true
+        ;;
+      --yes|-y)
+        OPEN_WEBUI_ASSUME_YES=true
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+    shift
+  done
+}
+
+is_truthy() {
+  case "$1" in
+    1|true|TRUE|yes|YES|y|Y|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+require_confirmation() {
+  local prompt="$1"
+
+  if is_truthy "$OPEN_WEBUI_ASSUME_YES"; then
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    echo "Refusing to apply changes without an interactive confirmation." >&2
+    echo "Re-run with --dry-run to preview or --yes to apply non-interactively." >&2
+    exit 1
+  fi
+
+  local answer
+  read -r -p "${prompt} [y/N] " answer
+  case "$answer" in
+    y|Y|yes|YES)
+      ;;
+    *)
+      log "Cancelled before making changes."
+      exit 0
+      ;;
+  esac
+}
+
+validate_service_mode() {
+  case "$OPEN_WEBUI_ENABLE_SERVICE" in
+    true|auto|false)
+      ;;
+    *)
+      echo "OPEN_WEBUI_ENABLE_SERVICE must be one of: auto, true, false" >&2
+      exit 1
+      ;;
+  esac
+}
+
+print_plan() {
+  local api_key_plan="$1"
+
+  log "Plan:"
+  printf '  - Update %s with API_SERVER_ENABLED=true, API_SERVER_HOST=%s, API_SERVER_PORT=%s, API_SERVER_MODEL_NAME=%s, and %s.\n' \
+    "$HERMES_ENV_FILE" "$HERMES_API_HOST" "$HERMES_API_PORT" "$HERMES_API_MODEL_NAME" "$api_key_plan"
+  printf '  - chmod 600 %s.\n' "$HERMES_ENV_FILE"
+  printf '  - Restart Hermes gateway, then verify http://%s:%s/health.\n' \
+    "$HERMES_API_CONNECT_HOST" "$HERMES_API_PORT"
+  printf '  - Install or update Open WebUI in %s.\n' "$OPEN_WEBUI_VENV"
+  printf '  - Write launcher %s using data dir %s and API base %s.\n' \
+    "$LAUNCHER_PATH" "$OPEN_WEBUI_DATA_DIR" "$HERMES_API_BASE_URL"
+  case "$OPEN_WEBUI_ENABLE_SERVICE" in
+    auto)
+      printf '  - Install a user service when launchd/systemd-user is available; otherwise print the launcher command.\n'
+      ;;
+    true)
+      printf '  - Install and start a user service with launchd or systemd-user.\n'
+      ;;
+    false)
+      printf '  - Skip service installation and print the launcher command.\n'
+      ;;
+  esac
 }
 
 require_cmd() {
@@ -287,17 +397,30 @@ start_foreground_hint() {
 }
 
 main() {
-  require_cmd hermes
-  require_cmd curl
+  parse_args "$@"
+  validate_service_mode
   require_cmd python3
 
-  install_macos_dependencies
-
-  local api_key
+  local api_key api_key_plan
   api_key="$(get_env_value API_SERVER_KEY "$HERMES_ENV_FILE")"
   if [[ -z "$api_key" ]]; then
     api_key="$(generate_secret)"
+    api_key_plan="generate a new API_SERVER_KEY"
+  else
+    api_key_plan="preserve the existing API_SERVER_KEY"
   fi
+
+  print_plan "$api_key_plan"
+  if [[ "$OPEN_WEBUI_DRY_RUN" == "true" ]]; then
+    log "Dry run complete. No files, services, or gateway processes were changed."
+    return 0
+  fi
+
+  require_confirmation "Apply this Open WebUI bootstrap plan?"
+  require_cmd hermes
+  require_cmd curl
+
+  install_macos_dependencies
 
   log 'Ensuring Hermes API server is configured...'
   upsert_env API_SERVER_ENABLED true "$HERMES_ENV_FILE"
@@ -334,10 +457,6 @@ main() {
       ;;
     false)
       start_foreground_hint
-      ;;
-    *)
-      echo "OPEN_WEBUI_ENABLE_SERVICE must be one of: auto, true, false" >&2
-      exit 1
       ;;
   esac
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
﻿## Summary

Follow-up to #25276. PR #25286 covers the documentation side; this adds a small code guardrail to the bootstrap itself.

- add `--dry-run` to print the exact env/file/service/gateway plan before touching the machine
- add `--yes` / `OPEN_WEBUI_ASSUME_YES=true` for automation
- require an interactive confirmation before applying the plan, updating `~/.hermes/.env`, restarting the gateway, installing Open WebUI, or installing a user service
- validate `OPEN_WEBUI_ENABLE_SERVICE` before any changes are applied

## Verification

- `C:\Program Files\Git\bin\bash.exe -n scripts/setup_open_webui.sh`
- `scripts/setup_open_webui.sh --dry-run` via Git Bash with a local `python3` shim; printed the plan and exited without changes
- non-interactive run without `--yes` printed the plan and refused before changes
- `python -m pytest -o addopts= tests\e2e\test_discord_adapter.py -q --tb=short`
- `python -m pytest -o addopts= tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short`
- `python -m ruff check tests\e2e\conftest.py tests\run_agent\test_provider_parity.py`

Refs #25276
