### PR TITLE
fix(delegate): move heartbeat thread start inside try block to prevent orphan

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1431,7 +1431,6 @@ def _run_single_child(
                 pass
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
-    _heartbeat_thread.start()
 
     # Register the live agent in the module-level registry so the TUI can
     # target it by subagent_id (kill, pause, status queries).  Unregistered
@@ -1462,6 +1461,7 @@ def _run_single_child(
         )
 
     try:
+        _heartbeat_thread.start()
         if child_progress_cb:
             try:
                 child_progress_cb("subagent.start", preview=goal)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the heartbeat thread in `_run_single_child()` could become an orphan if an exception was raised between `_heartbeat_thread.start()` and the `try` block, causing it to keep calling `_touch_activity()` on the parent agent and incorrectly resetting gateway timeout counters.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Root Cause

```python
# Before — .start() is OUTSIDE the try/finally block
_heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
_heartbeat_thread.start()  # ← started here

# ... _register_subagent() and other code that can raise ...

try:
    ...
finally:
    _heartbeat_stop.set()   # ← never reached if exception above!
    _heartbeat_thread.join(timeout=5)
```

```python
# After — .start() is INSIDE the try block
_heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)

try:
    _heartbeat_thread.start()  # ← always covered by finally
    ...
finally:
    _heartbeat_stop.set()   # ← always runs
    _heartbeat_thread.join(timeout=5)
```

## Impact

If `_register_subagent()` or surrounding code raises before the `try` block, the heartbeat thread runs indefinitely as a daemon thread, continuously calling `_touch_activity()` on the parent agent. This incorrectly resets gateway inactivity timeout counters, potentially keeping sessions alive longer than intended.

## Changes Made

**`tools/delegate_tool.py`** — `_run_single_child()`:
- Move `_heartbeat_thread.start()` from before the `try` block to the first line inside it
- No other changes — `Thread()` creation stays in place, `finally` block unchanged

## Checklist
- [x] Code follows project style
- [x] No new dependencies introduced
- [x] Minimal change — 1 line moved