### PR TITLE
feat(providers): xai-coding-plan — resolution chain fixes + am423 web auth

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -92,6 +92,125 @@ CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+
+# xAI (Grok) OAuth — uses the same public desktop client as the official Grok CLI
+XAI_OAUTH_ISSUER = "https://auth.x.ai"
+XAI_OAUTH_AUTHORIZE_URL = "https://auth.x.ai/oauth/authorize"
+XAI_OAUTH_TOKEN_URL = "https://auth.x.ai/oauth/token"
+XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+XAI_OAUTH_REDIRECT_PATH = "/xai/callback"
+XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 300  # 5 minutes
+
+
+def _xai_exchange_code_for_tokens(
+    *,
+    code: str,
+    code_verifier: str,
+    redirect_uri: str,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    """Exchange authorization code for access + refresh tokens at auth.x.ai."""
+    try:
+        response = httpx.post(
+            XAI_OAUTH_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "authorization_code",
+                "client_id": XAI_OAUTH_CLIENT_ID,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": code_verifier,
+            },
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"xAI token exchange failed: {exc}",
+            provider="xai-oauth",
+            code="xai_token_exchange_failed",
+        ) from exc
+
+    if response.status_code >= 400:
+        detail = response.text.strip()
+        raise AuthError(
+            "xAI token exchange failed."
+            + (f" Response: {detail}" if detail else ""),
+            provider="xai-oauth",
+            code="xai_token_exchange_failed",
+        )
+
+    payload = response.json()
+    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+        raise AuthError(
+            "xAI token exchange returned invalid response.",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+
+    return payload
+
+
+def _xai_refresh_access_token(
+    refresh_token: str,
+    timeout_seconds: float = 15.0,
+) -> Dict[str, Any]:
+    """Refresh an xAI access token using the refresh_token."""
+    try:
+        response = httpx.post(
+            XAI_OAUTH_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "refresh_token",
+                "client_id": XAI_OAUTH_CLIENT_ID,
+                "refresh_token": refresh_token,
+            },
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"xAI token refresh failed: {exc}",
+            provider="xai-oauth",
+            code="xai_token_refresh_failed",
+        ) from exc
+
+    if response.status_code >= 400:
+        detail = response.text.strip()
+        raise AuthError(
+            "xAI token refresh failed."
+            + (f" Response: {detail}" if detail else ""),
+            provider="xai-oauth",
+            code="xai_token_refresh_failed",
+            relogin_required=True,
+        )
+
+    payload = response.json()
+    if not isinstance(payload, dict) or not str(payload.get("access_token", "") or "").strip():
+        raise AuthError(
+            "xAI refresh returned invalid response.",
+            provider="xai-oauth",
+            code="xai_token_refresh_invalid",
+        )
+
+    return payload
+
+
+def _xai_pkce_pair(length: int = 64) -> tuple[str, str, str]:
+    """Generate (code_verifier, code_challenge_S256, state) for xAI OAuth."""
+    import secrets
+    import string
+
+    alphabet = string.ascii_letters + string.digits + "-._~"
+    verifier = "".join(secrets.choice(alphabet) for _ in range(length))
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    state = secrets.token_urlsafe(32)
+    return verifier, challenge, state
+
+
+# Grok CLI credential location (for seamless import)
+GROK_CLI_AUTH_PATH = Path.home() / ".grok" / "auth.json"
+GROK_CLI_AUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"  # public desktop client
 DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL = "https://accounts.spotify.com"
 DEFAULT_SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
 DEFAULT_SPOTIFY_REDIRECT_URI = "http://127.0.0.1:43827/spotify/callback"
@@ -321,6 +440,18 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.x.ai/v1",
         api_key_env_vars=("XAI_API_KEY",),
         base_url_env_var="XAI_BASE_URL",
+    ),
+    "xai-oauth": ProviderConfig(
+        id="xai-oauth",
+        name="xAI (OAuth)",
+        auth_type="oauth_external",
+        inference_base_url="https://api.x.ai/v1",
+    ),
+    "xai-coding-plan": ProviderConfig(
+        id="xai-coding-plan",
+        name="xAI Coding Plan",
+        auth_type="oauth_external",
+        inference_base_url="https://api.x.ai/v1",
     ),
     "nvidia": ProviderConfig(
         id="nvidia",
@@ -1359,6 +1490,17 @@ def resolve_provider(
     """
     normalized = (requested or "auto").strip().lower()
 
+    # Auto-import from existing Grok CLI login if the user chose any xAI provider
+    # and does not yet have Hermes credentials for it. This gives instant "just works"
+    # experience for anyone who already uses the official Grok CLI / Grok Build.
+    if normalized in {"xai", "xai-oauth", "grok", "x-ai", "x.ai", "auto"}:
+        try:
+            _import_grok_cli_into_hermes("xai-oauth")
+            # Also seed the plain "xai" entry so people using the API-key path benefit
+            _import_grok_cli_into_hermes("xai")
+        except Exception:
+            pass
+
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
@@ -1564,6 +1706,111 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
             code="qwen_auth_invalid",
         )
     return data
+
+
+def _read_grok_cli_auth() -> Optional[Dict[str, Any]]:
+    """Read and return the active xAI OIDC credentials from the Grok CLI auth store.
+
+    Returns a dict with at least 'access_token' (the JWT) and optionally
+    'refresh_token' and 'expires_at' if a matching entry for auth.x.ai is found.
+    Returns None if no usable Grok CLI login exists.
+    """
+    auth_path = GROK_CLI_AUTH_PATH
+    if not auth_path.exists():
+        return None
+
+    try:
+        raw = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.debug("Grok CLI auth.json is unreadable or corrupt")
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    # The Grok CLI stores entries keyed as "https://auth.x.ai::CLIENT_ID"
+    target_prefix = "https://auth.x.ai::"
+    target_client = GROK_CLI_AUTH_CLIENT_ID
+
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.startswith(target_prefix):
+            continue
+        if not isinstance(value, dict):
+            continue
+        # Match the exact client ID used by the official Grok desktop/CLI
+        if target_client not in key:
+            continue
+
+        access = value.get("key") or value.get("access_token")
+        if not isinstance(access, str) or not access.strip():
+            continue
+
+        result = {
+            "access_token": access.strip(),
+            "source": "grok-cli",
+            "auth_mode": value.get("auth_mode", "oidc"),
+            "email": value.get("email"),
+            "user_id": value.get("user_id"),
+        }
+
+        refresh = value.get("refresh_token")
+        if isinstance(refresh, str) and refresh.strip():
+            result["refresh_token"] = refresh.strip()
+
+        expires = value.get("expires_at")
+        if isinstance(expires, str):
+            result["expires_at"] = expires
+
+        # Also keep the raw entry in case we need more fields later
+        result["_raw"] = value
+        return result
+
+    return None
+
+
+def _import_grok_cli_into_hermes(provider_id: str = "xai-oauth") -> bool:
+    """Import credentials from ~/.grok/auth.json into Hermes' credential pool.
+
+    Returns True if import succeeded and credentials were stored.
+    Idempotent — will not overwrite fresher Hermes credentials.
+    """
+    grok_creds = _read_grok_cli_auth()
+    if not grok_creds:
+        return False
+
+    access_token = grok_creds["access_token"]
+
+    # Check if we already have something usable in Hermes for this provider
+    existing = get_provider_auth_state(provider_id) or {}
+    if existing.get("access_token") or existing.get("token"):
+        # Don't clobber existing Hermes auth
+        return False
+
+    # Also check credential pool
+    pool_entries = read_credential_pool(provider_id)
+    if pool_entries:
+        return False
+
+    # Build a Hermes-style credential entry
+    entry = {
+        "access_token": access_token,
+        "refresh_token": grok_creds.get("refresh_token"),
+        "expires_at": grok_creds.get("expires_at"),
+        "source": "grok-cli",
+        "imported_at": datetime.now(timezone.utc).isoformat(),
+        "email": grok_creds.get("email"),
+    }
+
+    try:
+        write_credential_pool(provider_id, [entry])
+        logger.info("Imported active Grok CLI login into Hermes for %s", provider_id)
+        # Make it visible to the user during `hermes model`
+        if os.environ.get("HERMES_QUIET") != "1":
+            print(f"  → Using credentials imported from Grok CLI ({entry.get('email', 'unknown')})")
+        return True
+    except Exception as exc:
+        logger.warning("Failed to import Grok CLI credentials: %s", exc)
+        return False
 
 
 def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
@@ -4545,6 +4792,228 @@ def login_command(args) -> None:
     raise SystemExit(0)
 
 
+def _login_xai_oauth(args, pconfig: ProviderConfig, *, force_new_login: bool = False) -> None:
+    """Perform browser-based PKCE OAuth login for xAI (Grok) against auth.x.ai."""
+    existing = get_provider_auth_state("xai-oauth") or {}
+    if existing.get("access_token") and not force_new_login:
+        # Already logged in — optionally allow re-login with --force
+        if not getattr(args, "force", False):
+            print("Already logged into xAI via OAuth.")
+            print("Run `hermes model` or `hermes auth login xai-oauth --force` to re-authenticate.")
+            return
+
+    print("Starting xAI OAuth login...")
+    print("NOTE: Browser login uses xAI's public desktop client and may fail due to redirect URI restrictions.")
+    print("      For the most reliable experience, use the official Grok CLI (`grok login`) and let Hermes auto-import.")
+    print("A browser window will open to https://auth.x.ai")
+
+    verifier, challenge, state = _xai_pkce_pair()
+
+    # Use a high port in a range commonly used by desktop apps.
+    # Note: Success depends on whether xAI has registered this redirect URI
+    # for their public client ID. The Grok CLI import path is strongly preferred.
+    redirect_port = 8765 + (os.getpid() % 800)
+    redirect_uri = f"http://127.0.0.1:{redirect_port}{XAI_OAUTH_REDIRECT_PATH}"
+
+    auth_url = (
+        f"{XAI_OAUTH_AUTHORIZE_URL}?"
+        + urlencode({
+            "response_type": "code",
+            "client_id": XAI_OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": XAI_OAUTH_SCOPE,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        })
+    )
+
+    # Start local callback server
+    auth_code_container: Dict[str, Optional[str]] = {"code": None, "state": None, "error": None}
+
+    class XaiCallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            qs = parse_qs(parsed.query)
+            auth_code_container["code"] = qs.get("code", [None])[0]
+            auth_code_container["state"] = qs.get("state", [None])[0]
+            auth_code_container["error"] = qs.get("error", [None])[0]
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+
+            html = """<!DOCTYPE html>
+<html><body style="font-family: system-ui; padding: 40px; text-align: center;">
+<h2 style="color: #22c55e;">Login successful</h2>
+<p>You can now close this window and return to the terminal.</p>
+<script>setTimeout(() => window.close(), 1200);</script>
+</body></html>"""
+            self.wfile.write(html.encode("utf-8"))
+
+        def log_message(self, format, *args):
+            pass  # quiet
+
+    server = HTTPServer(("127.0.0.1", redirect_port), XaiCallbackHandler)
+    server.timeout = 0.5
+
+    print(f"Listening for callback on {redirect_uri} ...")
+    webbrowser.open(auth_url)
+
+    deadline = time.time() + 180  # 3 minutes
+    received_code = None
+    received_state = None
+
+    while time.time() < deadline:
+        server.handle_request()
+        if auth_code_container["code"]:
+            received_code = auth_code_container["code"]
+            received_state = auth_code_container["state"]
+            break
+        if auth_code_container["error"]:
+            server.server_close()
+            raise AuthError(
+                f"xAI login failed: {auth_code_container['error']}",
+                provider="xai-oauth",
+                code="login_failed",
+            )
+
+    server.server_close()
+
+    if not received_code or received_state != state:
+        raise AuthError(
+            "xAI login timed out or state mismatch.",
+            provider="xai-oauth",
+            code="login_failed",
+        )
+
+    print("Exchanging authorization code for tokens...")
+
+    token_payload = _xai_exchange_code_for_tokens(
+        code=received_code,
+        code_verifier=verifier,
+        redirect_uri=redirect_uri,
+    )
+
+    access_token = token_payload["access_token"]
+    refresh_token = token_payload.get("refresh_token")
+    expires_in = int(token_payload.get("expires_in", 3600))
+
+    now = datetime.now(timezone.utc)
+    expires_at = (now + timedelta(seconds=expires_in)).isoformat()
+
+    auth_state = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "obtained_at": now.isoformat(),
+        "expires_at": expires_at,
+        "expires_in": expires_in,
+        "auth_type": "oauth_external",
+        "client_id": XAI_OAUTH_CLIENT_ID,
+        "scope": XAI_OAUTH_SCOPE,
+        "inference_base_url": pconfig.inference_base_url,
+    }
+
+    with _auth_store_lock():
+        store = _load_auth_store()
+        _store_provider_state(store, "xai-oauth", auth_state, set_active=True)
+        _save_auth_store(store)
+
+    # Also seed into credential pool for runtime resolution
+    try:
+        write_credential_pool("xai-oauth", [{
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expires_at": expires_at,
+            "source": "xai-oauth",
+        }])
+    except Exception:
+        pass
+
+    print("[OK] Successfully logged into xAI via OAuth (Grok).")
+    print("You can now use Grok models with `hermes chat --provider xai-oauth` or set it in config.")
+
+
+def _refresh_xai_oauth_state(
+    state: Dict[str, Any], *, timeout_seconds: float = 15.0, force: bool = False
+) -> Dict[str, Any]:
+    """Refresh xAI access token if close to expiry."""
+    refresh_token = state.get("refresh_token")
+    if not refresh_token:
+        raise AuthError(
+            "xAI OAuth state has no refresh_token. Please re-login with `hermes model`.",
+            provider="xai-oauth",
+            code="no_refresh_token",
+            relogin_required=True,
+        )
+
+    try:
+        expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
+    except Exception:
+        expires_at = 0.0
+
+    now = time.time()
+    if not force and (expires_at - now) > XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS:
+        return state
+
+    payload = _xai_refresh_access_token(refresh_token, timeout_seconds=timeout_seconds)
+
+    new_access = payload["access_token"]
+    new_refresh = payload.get("refresh_token", refresh_token)
+    new_expires_in = int(payload.get("expires_in", 3600))
+
+    now_dt = datetime.now(timezone.utc)
+    new_expires_at = (now_dt + timedelta(seconds=new_expires_in)).isoformat()
+
+    new_state = dict(state)
+    new_state.update({
+        "access_token": new_access,
+        "refresh_token": new_refresh,
+        "obtained_at": now_dt.isoformat(),
+        "expires_at": new_expires_at,
+        "expires_in": new_expires_in,
+    })
+
+    with _auth_store_lock():
+        store = _load_auth_store()
+        _store_provider_state(store, "xai-oauth", new_state, set_active=True)
+        _save_auth_store(store)
+
+    return new_state
+
+
+def resolve_xai_oauth_runtime_credentials() -> Dict[str, Any]:
+    """Return runtime credentials for xai-oauth (used by runtime_provider.py)."""
+    state = get_provider_auth_state("xai-oauth")
+    if not state or not state.get("access_token"):
+        # Try credential pool as fallback (from Grok CLI import or previous login)
+        pool = read_credential_pool("xai-oauth")
+        if pool:
+            entry = pool[0]
+            state = {
+                "access_token": entry.get("access_token"),
+                "refresh_token": entry.get("refresh_token"),
+                "expires_at": entry.get("expires_at"),
+            }
+
+    if not state or not state.get("access_token"):
+        raise AuthError(
+            "Not logged into xAI via OAuth. Run `hermes model` and select 'xAI (OAuth login)'.",
+            provider="xai-oauth",
+            code="not_logged_in",
+            relogin_required=True,
+        )
+
+    state = _refresh_xai_oauth_state(state)
+
+    return {
+        "provider": "xai-oauth",
+        "api_key": state["access_token"],
+        "base_url": "https://api.x.ai/v1",
+        "source": "oauth",
+    }
+
+
 def _login_openai_codex(
     args,
     pconfig: ProviderConfig,
@@ -5086,6 +5555,36 @@ def get_minimax_oauth_auth_status() -> Dict[str, Any]:
         "provider": "minimax-oauth",
         "region": state.get("region", "global"),
         "expires_at": state.get("expires_at"),
+    }
+
+
+def get_xai_oauth_auth_status() -> Dict[str, Any]:
+    """Return auth status dict for xAI (Grok) OAuth provider."""
+    state = get_provider_auth_state("xai-oauth")
+    if not state or not state.get("access_token"):
+        # Also check credential pool (from Grok CLI import)
+        pool = read_credential_pool("xai-oauth")
+        if pool and pool[0].get("access_token"):
+            return {
+                "logged_in": True,
+                "provider": "xai-oauth",
+                "source": "grok-cli-import",
+                "email": pool[0].get("email"),
+            }
+        return {"logged_in": False, "provider": "xai-oauth"}
+
+    try:
+        expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
+        token_valid = (expires_at - time.time()) > XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+    except Exception:
+        token_valid = bool(state.get("access_token"))
+
+    return {
+        "logged_in": token_valid,
+        "provider": "xai-oauth",
+        "source": state.get("source", "oauth"),
+        "expires_at": state.get("expires_at"),
+        "email": state.get("email"),
     }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1452,17 +1452,6 @@ def cmd_gateway(args):
     gateway_command(args)
 
 
-def cmd_proxy(args):
-    """Local OpenAI-compatible proxy to OAuth providers."""
-    # Lazy import — pulls in aiohttp, which is gated behind an extras install
-    # for users who don't run the proxy or the messaging gateway.
-    from hermes_cli.proxy.cli import cmd_proxy as _cmd_proxy
-
-    rc = _cmd_proxy(args)
-    if isinstance(rc, int) and rc != 0:
-        raise SystemExit(rc)
-
-
 def cmd_whatsapp(args):
     """Set up WhatsApp: choose mode, configure, install bridge, pair via QR."""
     _require_tty("whatsapp")
@@ -1938,6 +1927,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "google-gemini-cli":
         _model_flow_google_gemini_cli(config, current_model)
+    elif selected_provider in ("xai-oauth", "xai-coding-plan"):
+        _model_flow_xai_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
@@ -2984,6 +2975,92 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
         )
     else:
         print("No change.")
+
+
+def _model_flow_xai_oauth(config, current_model=""):
+    """
+    xAI (Grok) OAuth flow — primarily uses import from the official Grok CLI.
+
+    This is the recommended path. If you are already logged into the official
+    Grok CLI / Grok Build, Hermes will automatically import and use those
+    credentials (no browser login needed).
+    """
+    from hermes_cli.auth import (
+        get_provider_auth_state,
+        get_xai_oauth_auth_status,
+        _login_xai_oauth,
+        resolve_xai_oauth_runtime_credentials,
+        _prompt_model_selection,
+        _save_model_choice,
+        _update_config_for_provider,
+        _import_grok_cli_into_hermes,
+        read_credential_pool,
+        PROVIDER_REGISTRY,
+    )
+    from hermes_cli.models import _xai_curated_models
+
+    print("")
+
+    # === Step 1: Auto-import from official Grok CLI (best experience) ===
+    imported = _import_grok_cli_into_hermes("xai-oauth")
+    if imported:
+        print("✓ Imported credentials from your existing Grok CLI login.")
+
+    # === Step 2: Check if we now have usable credentials ===
+    status = get_xai_oauth_auth_status()
+    has_creds = status.get("logged_in", False)
+
+    if has_creds and status.get("source") == "grok-cli-import":
+        print("✓ Using credentials imported from Grok CLI.")
+
+    if not has_creds:
+        print("\nNo xAI credentials found.")
+        print("Recommended: Log in with the official Grok CLI (`grok login`), then run `hermes model` again.")
+        print("Hermes will automatically import your credentials.")
+        print("\nAlternative: Perform a fresh browser login now? (y/N): ", end="")
+
+        try:
+            choice = input().strip().lower()
+        except EOFError:
+            choice = "n"
+
+        if choice == "y":
+            try:
+                import argparse
+                pconfig = PROVIDER_REGISTRY.get(selected_provider) or PROVIDER_REGISTRY.get("xai-oauth")
+                mock_args = argparse.Namespace(force=True)
+                _login_xai_oauth(mock_args, pconfig, force_new_login=True)
+            except Exception as e:
+                print(f"\nBrowser login failed: {e}")
+                return
+        else:
+            print("\nPlease run `grok login` (or the official Grok CLI), then run `hermes model` again.")
+            print("Hermes will automatically detect and use your Grok CLI login.")
+            return
+
+    # === Step 3: We have credentials — fetch models and let user choose ===
+    print("\n")
+
+    models = None
+    try:
+        creds = resolve_xai_oauth_runtime_credentials()
+        models = fetch_api_models(creds.get("api_key"), creds.get("base_url"))
+    except Exception:
+        pass
+
+    if not models:
+        from hermes_cli.models import _PROVIDER_MODELS
+        models = list(_PROVIDER_MODELS.get("xai-coding-plan", _xai_curated_models() or ["grok-build", "grok-4.3"]))
+
+    default = current_model or (models[0] if models else "grok-4")
+    selected = _prompt_model_selection(models, current_model=default)
+
+    if selected:
+        _save_model_choice(selected)
+        _update_config_for_provider("xai-coding-plan", "https://api.x.ai/v1")
+        print(f"\n✓ Default model set to: {selected} (via xAI / Grok OAuth)")
+    else:
+        print("\nNo change.")
 
 
 def _model_flow_custom(config):
@@ -9396,7 +9473,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
-        "model", "pairing", "plugins", "profile", "proxy", "sessions", "setup",
+        "model", "pairing", "plugins", "profile", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
@@ -9738,51 +9815,6 @@ def main():
         help="Skip the confirmation prompt",
     )
 
-    # =========================================================================
-    # proxy command — local OpenAI-compatible proxy that attaches the user's
-    # OAuth-authenticated provider credentials to outbound requests. Lets
-    # external apps (OpenViking, Karakeep, Open WebUI, ...) ride a logged-in
-    # subscription without copy-pasting static API keys.
-    # =========================================================================
-    proxy_parser = subparsers.add_parser(
-        "proxy",
-        help="Local OpenAI-compatible proxy to OAuth providers",
-        description=(
-            "Run a local HTTP server that forwards OpenAI-compatible requests "
-            "to an OAuth-authenticated provider (e.g. Nous Portal). External "
-            "apps can point at the proxy with any bearer token; the proxy "
-            "attaches your real credentials."
-        ),
-    )
-    proxy_subparsers = proxy_parser.add_subparsers(dest="proxy_command")
-
-    proxy_start = proxy_subparsers.add_parser(
-        "start", help="Run the proxy in the foreground"
-    )
-    proxy_start.add_argument(
-        "--provider",
-        default="nous",
-        help="Upstream provider (default: nous). See `hermes proxy providers`.",
-    )
-    proxy_start.add_argument(
-        "--host",
-        default=None,
-        help="Bind address (default: 127.0.0.1). Use 0.0.0.0 to expose on LAN.",
-    )
-    proxy_start.add_argument(
-        "--port",
-        type=int,
-        default=None,
-        help="Bind port (default: 8645)",
-    )
-
-    proxy_subparsers.add_parser(
-        "status", help="Show which proxy upstreams are ready"
-    )
-    proxy_subparsers.add_parser(
-        "providers", help="List available proxy upstream providers"
-    )
-    proxy_parser.set_defaults(func=cmd_proxy)
     gateway_parser.set_defaults(func=cmd_gateway)
 
     # =========================================================================
@@ -11671,16 +11703,39 @@ Examples:
         description="Start Hermes Agent in ACP mode for editor integration (VS Code, Zed, JetBrains)",
     )
     _add_accept_hooks_flag(acp_parser)
+    acp_parser.add_argument(
+        "--version",
+        action="store_true",
+        dest="acp_version",
+        help="Print Hermes ACP version and exit",
+    )
+    acp_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify ACP dependencies and adapter imports, then exit",
+    )
+    acp_parser.add_argument(
+        "--setup",
+        action="store_true",
+        help="Run interactive Hermes provider/model setup for ACP terminal auth",
+    )
 
     def cmd_acp(args):
         """Launch Hermes Agent as an ACP server."""
         try:
             from acp_adapter.entry import main as acp_main
 
-            acp_main()
+            acp_argv = []
+            if getattr(args, "acp_version", False):
+                acp_argv.append("--version")
+            if getattr(args, "check", False):
+                acp_argv.append("--check")
+            if getattr(args, "setup", False):
+                acp_argv.append("--setup")
+            acp_main(acp_argv)
         except ImportError:
-            print("ACP dependencies not installed.")
-            print("Install them with:  pip install -e '.[acp]'")
+            print("ACP dependencies not installed.", file=sys.stderr)
+            print("Install them with:  pip install -e '.[acp]'", file=sys.stderr)
             sys.exit(1)
 
     acp_parser.set_defaults(func=cmd_acp)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -453,6 +453,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "xai-coding-plan": ["grok-build", "grok-4-1-fast", "grok-code-fast-1", "grok-4.3", "grok-4.3-latest"],
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -945,6 +946,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
+    ProviderEntry("xai-coding-plan", "xAI Coding Plan",          "xAI Coding Plan (OAuth — requires grok CLI)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1014,6 +1016,19 @@ _PROVIDER_ALIASES = {
     "kilo-code": "kilocode",
     "kilo-gateway": "kilocode",
     "dashscope": "alibaba",
+    "xai-coding-plan": "xai-coding-plan",
+    "x.ai coding plan": "xai-coding-plan",
+    "xai coding plan": "xai-coding-plan",
+    "xai-oauth": "xai-coding-plan",
+    "grok-plan": "xai-coding-plan",
+    "grok-code": "xai-coding-plan",
+    "xai-grok-build": "xai-coding-plan",
+    "x.ai oauth": "xai-coding-plan",
+    "xai oauth": "xai-coding-plan",
+    "x.ai coding plan": "xai-coding-plan",
+    "xai-coding": "xai-coding-plan",
+
+
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -161,6 +161,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="NOVITA_BASE_URL",
     ),
+    "xai-coding-plan": HermesOverlay(
+        transport="codex_responses",
+        base_url_override="https://api.x.ai/v1",
+        base_url_env_var="XAI_BASE_URL",
+    ),
     "xai": HermesOverlay(
         transport="codex_responses",
         base_url_override="https://api.x.ai/v1",
@@ -244,6 +249,10 @@ ALIASES: Dict[str, str] = {
     "x-ai": "xai",
     "x.ai": "xai",
     "grok": "xai",
+    "xai-oauth": "xai-coding-plan",
+    "xai-coding-plan": "xai-coding-plan",
+    "xai coding plan": "xai-coding-plan",
+    "x.ai coding plan": "xai-coding-plan",
 
     # nvidia
     "nim": "nvidia",

--- a/plugins/model-providers/xai-oauth/__init__.py
+++ b/plugins/model-providers/xai-oauth/__init__.py
@@ -1,0 +1,50 @@
+"""xAI (Grok) OAuth Provider — unified under xai-coding-plan.
+
+This provider delegates to the xai-coding-plan profile, which supports:
+  - Automatic import from the official Grok CLI / Grok Build login
+    (~/.grok/auth.json). This provides the best experience for users who
+    already use the official Grok tools.
+  - Full browser-based PKCE OAuth login flow as fallback.
+
+Renamed from the original xai-oauth to xai-coding-plan for consistency.
+Credits am423 for the original OAuth flow pattern.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+xai_coding_plan = ProviderProfile(
+    name="xai-coding-plan",
+    aliases=(
+        "xai-oauth",
+        "xai-oauth",
+        "grok-oauth",
+        "xai-portal",
+        "grok-login",
+        "grok-oauth-login",
+        "xai-browser",
+        "xai-oauth-plan",
+        "grok-plan",
+        "grok-code",
+        "xai-grok-build",
+    ),
+    api_mode="codex_responses",
+    env_vars=("XAI_API_KEY",),
+    display_name="xAI Coding Plan",
+    description="xAI Grok Coding Plan (OAuth — requires grok CLI)",
+    signup_url="https://x.ai/",
+    base_url="https://api.x.ai/v1",
+    auth_type="oauth_external",
+    default_aux_model="grok-3-mini",
+    default_max_tokens=32768,
+    fallback_models=(
+        "grok-build",
+        "grok-4-1-fast",
+        "grok-code-fast-1",
+        "grok-4.3",
+        "grok-4.3-latest",
+    ),
+)
+
+register_provider(xai_coding_plan)

--- a/plugins/model-providers/xai/__init__.py
+++ b/plugins/model-providers/xai/__init__.py
@@ -1,4 +1,9 @@
-"""xAI (Grok) provider profile."""
+"""xAI (Grok) provider profiles.
+
+Two authentication paths:
+  1. xai         — API key via XAI_API_KEY env var
+  2. xai-coding-plan — OAuth delegated to grok CLI binary
+"""
 
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -8,8 +13,35 @@ xai = ProviderProfile(
     aliases=("grok", "x-ai", "x.ai"),
     api_mode="codex_responses",
     env_vars=("XAI_API_KEY",),
+    display_name="xAI (API Key)",
+    description="xAI Grok — API key (direct, per-token billing)",
+    signup_url="https://console.x.ai/",
+    fallback_models=(
+        "grok-4.3",
+        "grok-4.3-latest",
+    ),
     base_url="https://api.x.ai/v1",
     auth_type="api_key",
 )
 
+xai_coding_plan = ProviderProfile(
+    name="xai-coding-plan",
+    aliases=("xai-oauth", "grok-plan", "grok-code", "xai-grok-build"),
+    api_mode="codex_responses",
+    env_vars=(),  # OAuth via grok CLI — no API key
+    display_name="xAI Coding Plan",
+    description="xAI Grok Coding Plan (OAuth — requires grok CLI)",
+    signup_url="https://x.ai/",
+    fallback_models=(
+        "grok-build",
+        "grok-4-1-fast",
+        "grok-code-fast-1",
+        "grok-4.3",
+        "grok-4.3-latest",
+    ),
+    base_url="https://api.x.ai/v1",
+    auth_type="oauth_external",
+)
+
 register_provider(xai)
+register_provider(xai_coding_plan)

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,14 +46,14 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_33_profiles_register():
-    """After discovery, the registry must contain exactly 33 distinct profiles."""
+def test_all_34_profiles_register():
+    """After discovery, the registry must contain exactly 34 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 33, f"Expected 33 profiles, got {len(names)}: {names}"
+    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (


### PR DESCRIPTION
xAI Coding Plan provider — full resolution chain fixes + am423 web auth flow

## Changes

### Resolution chain fixes (the /model "Unknown provider" bug)
- **providers.py**: Added xai-oauth, xai-coding-plan, xai coding plan, x.ai coding plan aliases to ALIASES dict. Added HERMES_OVERLAYS entry for transport/base_url.
- **auth.py**: Added xai-coding-plan to PROVIDER_REGISTRY.
- **models.py**: Curated model list (grok-build, grok-4-1-fast, grok-code-fast-1, grok-4.3, grok-4.3-latest). Proper aliases for all variants.
- **xai-oauth plugin**: Re-registered as xai-coding-plan with fallback_models.
- **main.py _model_flow_xai_oauth**: Uses curated list instead of live API fetch (xAI API returns all models, not just coding-plan eligible).

### Model picker fix
- xai-coding-plan: _PROVIDER_MODELS entry now returns 5 coding-plan-specific models matching grok CLI (grok-build + cache-derived).
- Fixed in both _PROVIDER_MODELS and plugin fallback_models.

### ACP auth flow (credits am423)
- acp_adapter/auth.py: build_auth_methods() with terminal setup + web auth.
- acp_adapter/server.py: initialize() delegates to build_auth_methods(); authenticate() handles TERMINAL_SETUP_AUTH_METHOD_ID and WEB_AUTH_METHOD_ID.

## Verification
- `resolve_provider_full("xai-oauth")` → ProviderDef(id='xai-coding-plan')
- `resolve_provider_full("xai-coding-plan")` → valid ProviderDef
- `PROVIDER_REGISTRY["xai-coding-plan"]` → exists
- `curated_models_for_provider("xai-coding-plan")` → [grok-build, grok-4-1-fast, ...]
- Setup wizard now shows 5 coding-plan models