### PR TITLE
fix(run_agent): detect kimi models via model name for reasoning pad

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10127,12 +10127,16 @@ class AIAgent:
         Kimi ``/coding`` and Moonshot thinking mode both require
         ``reasoning_content`` on every assistant tool-call message; omitting
         it causes the next replay to fail with HTTP 400.
+
+        Also detects Kimi models served through third-party providers (e.g.
+        ollama-cloud) by matching ``kimi`` in the model name.
         """
         return (
             self.provider in {"kimi-coding", "kimi-coding-cn"}
             or base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
+            or "kimi" in (self.model or "").lower()
         )
 
     def _needs_deepseek_tool_reasoning(self) -> bool:


### PR DESCRIPTION
**Provider**: ollama-cloud
**Model**: kimi-k2.6
**Base URL**: https://ollama.com/v1

## Bug

 in  only checked provider ID and base URL. When  is served via , provider is  and base URL is  — both miss the checks. This causes  pad to **not** be injected on assistant messages. Ollama Cloud's Go backend then rejects the replay with:



## Fix

Add model-name detection () so any route serving a kimi model gets the required  echo-back. Same pattern already used elsewhere for model-family detection.

## Test

- Configure , 
- Send messages that trigger tool calls
- Subsequent turns should no longer fail with 400

This also fixes the Telegram 400/401 cascade where kimi-k2.6 via ollama-cloud consistently failed after tool-call turns, causing OpenRouter fallback to activate and fail with 401.