### PR TITLE
fix(delegate): tool_trace false-positive error detection for short outputs

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1649,7 +1649,7 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(content and "error" in content[:80].lower())
+                    is_error = _looks_like_error_output(content)
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",


### PR DESCRIPTION
Closes #26369

## Bug

The  logic in  flagged successful tool calls as errors when their output was short JSON containing . The heuristic  matched the JSON key itself within the first 80 chars.

## Fix

Replace the substring heuristic with the existing  function, which properly checks:
- JSON  key is truthy (null/false/empty strings don't trigger)
- JSON  field for error/failed/timeout
- First-line error markers (error:, traceback, exception:, failed:)

## Testing

Verified against the existing test suite in .