### PR TITLE
fix(cli): /reload-skills Tab completion update + _skill_commands sync

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2412,6 +2412,7 @@ def _looks_like_slash_command(text: str) -> bool:
 
 from agent.skill_commands import (
     scan_skill_commands,
+    get_skill_commands,
     build_skill_invocation_message,
     build_preloaded_skills_prompt,
 )
@@ -9598,12 +9599,18 @@ class HermesCLI:
         prompt caching intact.
         """
         try:
-            from agent.skill_commands import reload_skills
+            from agent.skill_commands import reload_skills, get_skill_commands
 
             if not self._command_running:
                 print("🔄 Reloading skills...")
 
             result = reload_skills()
+
+            # Sync cli.py's module-level _skill_commands so all consumers
+            # (help display, command dispatch, Tab-completion lambda) see the
+            # updated dict without needing to restart the session.
+            global _skill_commands
+            _skill_commands = get_skill_commands()
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)
@@ -12606,7 +12613,7 @@ class HermesCLI:
 
 
         _completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: _skill_commands,
+            skill_commands_provider=lambda: get_skill_commands(),
             command_filter=cli_ref._command_available,
         )
         input_area = TextArea(


### PR DESCRIPTION
Closes #26441

## Bug

After running `/reload-skills`, the Tab-completion menu for slash commands still showed the old list of skills. The lambda `lambda: _skill_commands` captured the module-level `_skill_commands` snapshot at startup, so newly installed skills were never visible in Tab completion.

## Changes

1. **Tab-completion lambda** (`cli.py:12609`): Changed from `lambda: _skill_commands` to `lambda: get_skill_commands()`. The latter calls the getter which returns the freshly-updated `_skill_commands` from `agent.skill_commands` (updated by `reload_skills()`), without needing any restart.

2. **`reload_skills` sync** (`cli.py:9601-9613`): After calling `reload_skills()`, now also syncs cli.py's module-level `_skill_commands` via `get_skill_commands()`. This ensures help display, command dispatch, and any other direct `_skill_commands` readers also reflect the updated skills after a reload.