### PR TITLE
test(dashboard): cover analytics session token auth

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/hermes_cli/test_dashboard_browser_safe_imports.py
+++ b/tests/hermes_cli/test_dashboard_browser_safe_imports.py
@@ -14,3 +14,20 @@ def test_dashboard_does_not_import_nous_ui_root_barrel():
                 offenders.append(str(path.relative_to(WEB_SRC)))
 
     assert offenders == []
+
+
+def test_dashboard_api_client_injects_session_token_header():
+    source = (WEB_SRC / "lib" / "api.ts").read_text(encoding="utf-8")
+
+    required_snippets = [
+        'const SESSION_HEADER = "X-Hermes-Session-Token";',
+        "const headers = new Headers(init?.headers);",
+        "const token = window.__HERMES_SESSION_TOKEN__;",
+        "setSessionHeader(headers, token);",
+        "fetch(`${BASE}${url}`, { ...init, headers })",
+        "fetchJSON<AnalyticsResponse>(`/api/analytics/usage?days=${days}`)",
+        "fetchJSON<ModelsAnalyticsResponse>(`/api/analytics/models?days=${days}`)",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in source]
+    assert missing == []

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -972,6 +972,28 @@ class TestNewEndpoints:
             "top_skills": [],
         }
 
+    def test_analytics_models(self):
+        resp = self.client.get("/api/analytics/models?days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "models" in data
+        assert "totals" in data
+        assert "distinct_models" in data["totals"]
+        assert data["period_days"] == 7
+
+    def test_analytics_routes_require_session_token(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+
+        for path in (
+            "/api/analytics/usage?days=7",
+            "/api/analytics/models?days=7",
+        ):
+            resp = unauth_client.get(path)
+            assert resp.status_code == 401
+
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB
 

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- add regression coverage that analytics API routes stay protected by the dashboard session token
- cover /api/analytics/models with an authenticated request
- add a static dashboard API-client check that analytics fetches continue to go through fetchJSON with X-Hermes-Session-Token
- include the current Discord/Nous CI stabilizers used by this repo

Refs #25275.

## Tests
- python -m pytest -o addopts= tests\\hermes_cli\\test_dashboard_browser_safe_imports.py tests\\hermes_cli\\test_web_server.py::TestNewEndpoints::test_analytics_usage tests\\hermes_cli\\test_web_server.py::TestNewEndpoints::test_analytics_models tests\\hermes_cli\\test_web_server.py::TestNewEndpoints::test_analytics_routes_require_session_token -q --tb=short
- python -m pytest -o addopts= tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m pytest -o addopts= tests\\run_agent\\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m ruff check tests\\hermes_cli\\test_dashboard_browser_safe_imports.py tests\\hermes_cli\\test_web_server.py tests\\e2e\\conftest.py tests\\run_agent\\test_provider_parity.py