### PR TITLE
feat(providers): DigitalOcean Gradient serverless inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,16 @@
 # NOVITA_BASE_URL=https://api.novita.ai/openai/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (DigitalOcean Gradient / Inference)
+# =============================================================================
+# Serverless inference — OpenAI-compatible https://inference.do-ai.run/v1
+# Bearer token: use a model access key (recommended) or a DigitalOcean PAT
+# (broader account scope — rotate carefully). See:
+# https://docs.digitalocean.com/products/inference/how-to/si-endpoints/
+# DIGITALOCEAN_GRADIENT_API_KEY=
+# DIGITALOCEAN_GRADIENT_BASE_URL=https://inference.do-ai.run/v1  # Optional override
+
+# =============================================================================
 # LLM PROVIDER (Google AI Studio / Gemini)
 # =============================================================================
 # Native Gemini API via Google's OpenAI-compatible endpoint.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,6 +48,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba", "novita",
+    "digitalocean-gradient", "do-gradient", "digitalocean",
     "qwen-oauth",
     "xiaomi",
     "arcee",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -453,6 +453,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    # DigitalOcean Inference serverless — curated defaults favor newer flagship tiers;
+    # live `/v1/models` remains authoritative when a key is configured.
+    "digitalocean-gradient": [
+        "anthropic-claude-4.6-sonnet",
+        "kimi-k2.6",
+        "deepseek-v4-pro",
+        "qwen3-coder-flash",
+        "alibaba-qwen3-32b",
+    ],
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -1025,6 +1034,8 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "novita-ai": "novita",
     "novitaai": "novita",
+    "do-gradient": "digitalocean-gradient",
+    "digitalocean": "digitalocean-gradient",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
     "tencent": "tencent-tokenhub",

--- a/plugins/model-providers/digitalocean-gradient/README.md
+++ b/plugins/model-providers/digitalocean-gradient/README.md
@@ -1,0 +1,32 @@
+# DigitalOcean Gradient (serverless inference)
+
+Hermes profile for [DigitalOcean Inference](https://docs.digitalocean.com/products/inference/) **serverless** endpoints: OpenAI-compatible `POST /v1/chat/completions` and `GET /v1/models` on `https://inference.do-ai.run/v1`.
+
+## Credentials
+
+HTTP requests use **`Authorization: Bearer <token>`**. Per [Serverless Inference API Endpoints](https://docs.digitalocean.com/products/inference/how-to/si-endpoints/), DigitalOcean accepts either:
+
+1. **Model access key** (recommended for inference-only scope) — create under **Inference → Model access keys** in the [DigitalOcean control panel](https://cloud.digitalocean.com/), or follow [Manage model access keys](https://docs.digitalocean.com/products/inference/how-to/manage-model-access-keys/).
+2. **Personal access token (PAT)** — also works as the Bearer token; PATs are broader account credentials (rotate carefully, least-privilege scopes).
+
+Set the key in Hermes as:
+
+- `DIGITALOCEAN_GRADIENT_API_KEY` — primary env var (Hermes naming; not the same string as DO’s console label, but the value is the key or PAT).
+
+Optional override:
+
+- `DIGITALOCEAN_GRADIENT_BASE_URL` — defaults to `https://inference.do-ai.run/v1` if unset.
+
+## Provider id and aliases
+
+- Canonical: `digitalocean-gradient`
+- Aliases: `do-gradient`, `digitalocean` (CLI / config normalization)
+
+## Compatibility caveats
+
+OpenAI-compatible does not mean full OpenAI feature parity. See [Inference limits](https://docs.digitalocean.com/products/inference/details/limits/) for caveats, tool/plugin support, and rate limits (documented defaults include **5000 requests/hour** and **250 requests/minute** on applicable operations per the [API reference](https://docs.digitalocean.com/reference/api/reference/serverless-inference/)).
+
+## Further reading
+
+- [Use serverless inference](https://docs.digitalocean.com/products/gradient-ai-platform/how-to/use-serverless-inference/)
+- [Available models](https://docs.digitalocean.com/products/inference/details/models/)

--- a/plugins/model-providers/digitalocean-gradient/__init__.py
+++ b/plugins/model-providers/digitalocean-gradient/__init__.py
@@ -1,0 +1,31 @@
+"""DigitalOcean Gradient serverless inference (OpenAI-compatible) profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+digitalocean_gradient = ProviderProfile(
+    name="digitalocean-gradient",
+    aliases=("do-gradient", "digitalocean"),
+    display_name="DigitalOcean Gradient",
+    description=(
+        "DigitalOcean Inference — serverless chat via OpenAI-compatible "
+        "https://inference.do-ai.run (model access key or PAT as Bearer)"
+    ),
+    signup_url=(
+        "https://docs.digitalocean.com/products/inference/how-to/manage-model-access-keys/"
+    ),
+    env_vars=("DIGITALOCEAN_GRADIENT_API_KEY", "DIGITALOCEAN_GRADIENT_BASE_URL"),
+    base_url="https://inference.do-ai.run/v1",
+    auth_type="api_key",
+    default_aux_model="anthropic-claude-4.6-sonnet",
+    fallback_models=(
+        "anthropic-claude-4.6-sonnet",
+        "kimi-k2.6",
+        "deepseek-v4-pro",
+        "qwen3-coder-flash",
+        "alibaba-qwen3-32b",
+    ),
+)
+
+register_provider(digitalocean_gradient)

--- a/plugins/model-providers/digitalocean-gradient/plugin.yaml
+++ b/plugins/model-providers/digitalocean-gradient/plugin.yaml
@@ -1,0 +1,5 @@
+name: digitalocean-gradient-provider
+kind: model-provider
+version: 1.0.0
+description: DigitalOcean Gradient serverless inference (OpenAI-compatible)
+author: DigitalOcean

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ AUTHOR_MAP = {
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",
     "m@mobrienv.dev": "mikeyobrien",
+    "mmercado@digitalocean.com": "mamercad",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "nidhi2894@gmail.com": "nidhi-singh02",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1253,6 +1253,142 @@ class TestNovitaProvider:
 
 
 # =============================================================================
+# DigitalOcean Gradient / Inference (serverless OpenAI-compatible)
+# =============================================================================
+
+class TestDigitalOceanGradientProvider:
+    """DigitalOcean Inference serverless — OpenAI-compatible Bearer key API."""
+
+    def test_profile_loads(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("digitalocean-gradient")
+        assert profile is not None
+        assert profile.name == "digitalocean-gradient"
+        assert profile.display_name == "DigitalOcean Gradient"
+        assert profile.base_url == "https://inference.do-ai.run/v1"
+        assert "DIGITALOCEAN_GRADIENT_API_KEY" in profile.env_vars
+        assert profile.default_aux_model == "anthropic-claude-4.6-sonnet"
+
+    def test_aliases_on_profile(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("digitalocean-gradient")
+        assert "do-gradient" in profile.aliases
+        assert "digitalocean" in profile.aliases
+
+    def test_alias_resolves(self):
+        assert resolve_provider("do-gradient") == "digitalocean-gradient"
+        assert resolve_provider("digitalocean") == "digitalocean-gradient"
+
+    def test_in_provider_registry(self):
+        assert "digitalocean-gradient" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["digitalocean-gradient"]
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.id == "digitalocean-gradient"
+        assert pconfig.inference_base_url == "https://inference.do-ai.run/v1"
+        assert pconfig.api_key_env_vars == ("DIGITALOCEAN_GRADIENT_API_KEY",)
+        assert pconfig.base_url_env_var == "DIGITALOCEAN_GRADIENT_BASE_URL"
+
+    def test_aliases_in_registry(self):
+        assert "do-gradient" in PROVIDER_REGISTRY
+        assert "digitalocean" in PROVIDER_REGISTRY
+
+    def test_main_and_models_provider_models_match(self):
+        from hermes_cli.main import _PROVIDER_MODELS as main_models
+        from hermes_cli.models import _PROVIDER_MODELS as models_models
+
+        assert "digitalocean-gradient" in main_models
+        assert main_models["digitalocean-gradient"] == models_models["digitalocean-gradient"]
+
+    def test_models_use_do_catalog_ids(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        for model in _PROVIDER_MODELS["digitalocean-gradient"]:
+            assert model, "empty model id"
+            assert "/" not in model, (
+                f"DigitalOcean serverless ids are hyphenated, not org/name: {model!r}"
+            )
+
+    def test_aliases_in_models_py(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+
+        assert _PROVIDER_ALIASES.get("do-gradient") == "digitalocean-gradient"
+        assert _PROVIDER_ALIASES.get("digitalocean") == "digitalocean-gradient"
+
+    def test_label_via_auto_canonical(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+
+        assert "digitalocean-gradient" in _PROVIDER_LABELS
+
+    def test_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+
+        assert "digitalocean-gradient" in _PROVIDER_PREFIXES
+        assert "do-gradient" in _PROVIDER_PREFIXES
+        assert "digitalocean" in _PROVIDER_PREFIXES
+
+    def test_url_to_provider_hostname(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+
+        assert _URL_TO_PROVIDER.get("inference.do-ai.run") == "digitalocean-gradient"
+
+    def test_strip_provider_prefix(self):
+        from agent.model_metadata import _strip_provider_prefix
+
+        assert (
+            _strip_provider_prefix("digitalocean-gradient:qwen3-coder-flash")
+            == "qwen3-coder-flash"
+        )
+        assert _strip_provider_prefix("do-gradient:kimi-k2.5") == "kimi-k2.5"
+
+    def test_provider_model_ids_without_key_returns_fallback(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.delenv("DIGITALOCEAN_GRADIENT_API_KEY", raising=False)
+        monkeypatch.delenv("DIGITALOCEAN_GRADIENT_BASE_URL", raising=False)
+        ids = provider_model_ids("digitalocean-gradient")
+        assert ids == [
+            "anthropic-claude-4.6-sonnet",
+            "kimi-k2.6",
+            "deepseek-v4-pro",
+            "qwen3-coder-flash",
+            "alibaba-qwen3-32b",
+        ]
+
+    def test_provider_model_ids_live_fetch_mocked(self, monkeypatch):
+        import json as _json
+        import urllib.request
+
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("DIGITALOCEAN_GRADIENT_API_KEY", "do-test-key")
+        monkeypatch.setenv(
+            "DIGITALOCEAN_GRADIENT_BASE_URL",
+            "https://inference.do-ai.run/v1",
+        )
+
+        payload = {"data": [{"id": "zeta-fast"}, {"id": "alpha-pro"}]}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return _json.dumps(payload).encode()
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        ids = provider_model_ids("digitalocean-gradient")
+        assert sorted(ids) == ["alpha-pro", "zeta-fast"]
+
+
+# =============================================================================
 # MiniMax OAuth provider tests (added by feat/minimax-oauth-provider)
 # =============================================================================
 

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,20 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "digitalocean-gradient",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -155,6 +155,7 @@ Look at these bundled plugins for idioms:
 | `plugins/model-providers/nous/` | Attribution tags, "omit reasoning when disabled" |
 | `plugins/model-providers/custom/` | Ollama `num_ctx` + `think: false` quirks |
 | `plugins/model-providers/bedrock/` | `api_mode="bedrock_converse"`, `fetch_models` returns None (no REST endpoint) |
+| `plugins/model-providers/digitalocean-gradient/` | Declarative `api_key` + default `fetch_models` for `inference.do-ai.run` |
 
 ## User overrides — replace a built-in without editing the repo
 


### PR DESCRIPTION
## Summary

- Bundled `digitalocean-gradient` model-provider plugin for DigitalOcean Inference serverless (`inference.do-ai.run`, OpenAI-compatible chat + models).
- CLI catalog, aliases, `model_metadata` URL/prefix wiring, `.env.example`, tests, docs hook table row.
- `scripts/release.py` `AUTHOR_MAP`: `mmercado@digitalocean.com` → `mamercad`.

## Test plan

- [ ] `scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py::TestDigitalOceanGradientProvider -q`
- [ ] `scripts/run_tests.sh tests/providers/test_plugin_discovery.py -q`


Made with [Cursor](https://cursor.com)