### PR TITLE
fix(doctor): flag missing OpenRouter credentials

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -105,6 +105,28 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _has_openrouter_credentials() -> bool:
+    """Return True when OpenRouter can resolve an API credential."""
+    try:
+        from hermes_cli.auth import has_usable_secret
+    except Exception:  # pragma: no cover - import failure fallback
+        def has_usable_secret(value: object) -> bool:
+            return bool(str(value or "").strip())
+
+    if any(
+        has_usable_secret(os.getenv(key, ""))
+        for key in ("OPENROUTER_API_KEY", "OPENAI_API_KEY")
+    ):
+        return True
+
+    try:
+        from agent.credential_pool import load_pool
+
+        return bool(load_pool("openrouter").entries())
+    except Exception:
+        return False
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -625,7 +647,18 @@ def run_doctor(args):
             # own env-var checks elsewhere in doctor, and get_auth_status()
             # returns a bare {logged_in: False} for anything it doesn't
             # explicitly dispatch, which would produce false positives.
-            if runtime_provider and runtime_provider not in {"auto", "custom", "openrouter"}:
+            if runtime_provider == "openrouter":
+                if not _has_openrouter_credentials():
+                    check_fail(
+                        "model.provider 'openrouter' is set but no API key is configured",
+                        "(set OPENROUTER_API_KEY or OPENAI_API_KEY)",
+                    )
+                    issues.append(
+                        "No credentials found for provider 'openrouter'. "
+                        f"Set OPENROUTER_API_KEY or OPENAI_API_KEY in {_DHH}/.env, "
+                        "or switch providers with 'hermes config set model.provider <name>'"
+                    )
+            elif runtime_provider and runtime_provider not in {"auto", "custom"}:
                 try:
                     from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
                     pconfig = PROVIDER_REGISTRY.get(runtime_provider)
@@ -1282,7 +1315,11 @@ def run_doctor(args):
     _probes: list = []  # list of (label, callable) submitted in display order
 
     def _probe_openrouter() -> _ConnectivityResult:
-        key = os.getenv("OPENROUTER_API_KEY")
+        key_name = "OPENROUTER_API_KEY"
+        key = os.getenv(key_name)
+        if not key:
+            key_name = "OPENAI_API_KEY"
+            key = os.getenv(key_name)
         if not key:
             return _ConnectivityResult(
                 "OpenRouter API",
@@ -1308,7 +1345,7 @@ def run_doctor(args):
                     "OpenRouter API",
                     [(color("✗", Colors.RED), "OpenRouter API",
                       color("(invalid API key)", Colors.DIM))],
-                    ["Check OPENROUTER_API_KEY in .env"],
+                    [f"Check {key_name} in .env"],
                 )
             if r.status_code == 402:
                 return _ConnectivityResult(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -490,7 +490,7 @@ def _run_doctor_with_openrouter_config(monkeypatch, tmp_path):
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
     monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-    doctor_mod._APIKEY_PROVIDERS_CACHE = []
+    monkeypatch.setattr(doctor_mod, "_APIKEY_PROVIDERS_CACHE", [])
 
     fake_model_tools = types.SimpleNamespace(
         check_tool_availability=lambda *a, **kw: ([], []),

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -474,6 +474,94 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def _run_doctor_with_openrouter_config(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("TERMINAL_ENV=local\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n"
+        "  default: anthropic/claude-sonnet-4.6\n",
+        encoding="utf-8",
+    )
+
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    doctor_mod._APIKEY_PROVIDERS_CACHE = []
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.bedrock_adapter",
+        types.SimpleNamespace(
+            has_aws_credentials=lambda: False,
+            resolve_aws_auth_env_var=lambda: "",
+            resolve_bedrock_region=lambda: "",
+        ),
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: SimpleNamespace(entries=lambda: []))
+    monkeypatch.setattr(doctor_mod, "_check_gateway_service_linger", lambda issues: None)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+def test_run_doctor_flags_active_openrouter_without_credentials(monkeypatch, tmp_path):
+    for key in tuple(doctor_mod._PROVIDER_ENV_HINTS) + (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    out = _run_doctor_with_openrouter_config(monkeypatch, tmp_path)
+
+    assert "model.provider 'openrouter' is set but no API key is configured" in out
+    assert "No credentials found for provider 'openrouter'" in out
+    assert "Set OPENROUTER_API_KEY or OPENAI_API_KEY" in out
+
+
+def test_run_doctor_accepts_active_openrouter_with_openai_fallback_key(monkeypatch, tmp_path):
+    for key in tuple(doctor_mod._PROVIDER_ENV_HINTS) + (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai-fallback")
+
+    try:
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: SimpleNamespace(status_code=200))
+    except Exception:
+        pass
+
+    out = _run_doctor_with_openrouter_config(monkeypatch, tmp_path)
+
+    assert "model.provider 'openrouter' is set but no API key is configured" not in out
+    assert "No credentials found for provider 'openrouter'" not in out
+
+
 @pytest.mark.parametrize(
     ("provider", "default_model"),
     [

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- make doctor treat active model.provider=openrouter with no OpenRouter-compatible credential as a summary issue
- accept either OPENROUTER_API_KEY, OPENAI_API_KEY fallback, or an OpenRouter credential-pool entry
- make the OpenRouter connectivity probe report which fallback key was checked
- include the current Discord/Nous CI stabilizers used by this repo

Fixes #26436.

## Tests
- python -m pytest -o addopts= tests\\hermes_cli\\test_doctor.py::test_run_doctor_flags_active_openrouter_without_credentials tests\\hermes_cli\\test_doctor.py::test_run_doctor_accepts_active_openrouter_with_openai_fallback_key -q --tb=short
- python -m pytest -o addopts= tests\\hermes_cli\\test_doctor.py::TestProviderEnvDetection tests\\hermes_cli\\test_doctor_dedicated_provider_skip.py -q --tb=short
- python -m pytest -o addopts= tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m pytest -o addopts= tests\\run_agent\\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m ruff check hermes_cli\\doctor.py tests\\hermes_cli\\test_doctor.py tests\\e2e\\conftest.py tests\\run_agent\\test_provider_parity.py