### PR TITLE
docs(cron): document name-based job lookup from #26231

### DIFF
--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -125,6 +125,10 @@ Jobs with a `workdir` run sequentially on the scheduler tick, not in the paralle
 
 You do not need to delete and recreate jobs just to change them.
 
+:::tip Job reference
+The `<job_id>` placeholder below (and in [Lifecycle actions](#lifecycle-actions)) also accepts the job's name (case-insensitive) — handy when you remember `morning-digest` but not the hex ID. An exact job ID takes precedence over name matches; if the reference is not an ID and a name matches more than one job, the command refuses and prints the candidate IDs so you can disambiguate.
+:::
+
 ### Chat
 
 ```bash


### PR DESCRIPTION
## Summary

#26231 (merged ~16h ago) made `hermes cron edit|pause|resume|run|remove` and the agent `cronjob` tool accept a job's name (case-insensitive) in addition to the hex ID, but `website/docs/user-guide/features/cron.md` still uses the `<job_id>` placeholder everywhere without telling users names work.

This adds a small `:::tip` admonition right under "Editing jobs" that:

- mentions both Editing and Lifecycle command groups (anchor link to `#lifecycle-actions`)
- documents the resolver precedence (exact ID wins over name) to match `resolve_job_ref()` in `cron/jobs.py`
- documents the `AmbiguousJobReference` user-facing surface (commands refuse and print candidate IDs rather than silently picking one)

Single file, +4 lines. No placeholder rewrites elsewhere — keeps the diff narrow and lets the admonition do the work.

If this has already landed via separate patch or you'd prefer different placement, feel free to close + mark accordingly.