### PR TITLE
docs(i18n): add Simplified Chinese (zh-Hans) translation for core documentation

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -1,0 +1,180 @@
+---
+sidebar_position: 2
+title: "安装"
+description: "在 Linux、macOS、WSL2、原生 Windows（早期测试版）或通过 Termux 的 Android 上安装 Hermes Agent"
+---
+
+# 安装
+
+通过一行安装脚本，在两分钟内让 Hermes Agent 运行起来。
+
+## 快速安装
+
+### Linux / macOS / WSL2
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+### Windows（原生 PowerShell）— 早期测试版
+
+:::warning Early BETA
+原生 Windows 支持仍处于 **早期测试版**。它可以在常见路径下安装并正常工作，但尚未像 POSIX 安装器那样经过广泛实测。遇到问题请 [提交 issue](https://github.com/NousResearch/hermes-agent/issues)。若想在 Windows 上获得最可靠的体验，建议在 **WSL2** 中使用上面的 Linux/macOS 一行脚本。
+:::
+
+打开 PowerShell 并运行：
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
+
+安装程序会处理 **所有** 内容：`uv`、Python 3.11、Node.js 22、`ripgrep`、`ffmpeg`，以及便携的 Git Bash（PortableGit —— 包含 `bash.exe` 与完整的 POSIX 工具链，Hermes 用于 shell 命令；在 32 位 Windows 上安装程序会回退到 MinGit，缺少 bash，终端工具 / agent-browser 功能将被禁用）。它会把仓库克隆到 `%LOCALAPPDATA%\hermes\hermes-agent`，创建 virtualenv，并将 `hermes` 加入 **用户 PATH**。安装后请重新打开终端（或新开一个 PowerShell 窗口）以使 PATH 更新。
+
+**Git 的处理方式：**
+1. 若系统已有 `git` 并在 PATH 中，安装程序直接使用该安装。
+2. 否则会下载便携的 **PortableGit**（约 50 MB，来自官方 `git-for-windows` 发布页）并解压到 `%LOCALAPPDATA%\hermes\git`。无需管理员权限。完全隔离——不会影响系统中任何 Git 安装（即使已损坏）。（在 32 位 Windows 上会回退到 MinGit，因为 PortableGit 只提供 64 位和 ARM64 资产，依赖 bash 的 Hermes 功能在 32 位主机上将不可用。）
+
+**为何不使用 winget？** 早期设计会通过 `winget install Git.Git` 自动安装 Git，但当系统中已有部分或损坏的 Git 时 winget 往往失败——恰恰是用户最需要安装程序正常工作的时刻。便携 Git 方案规避了 winget、Windows 安装程序注册表以及任何系统 Git。若 Hermes 自带的 Git 安装出现问题，只需 `Remove-Item %LOCALAPPDATA%\hermes\git` 并重新运行安装脚本——对系统毫无影响，也无需卸载烦恼。
+
+安装程序还会设置 `HERMES_GIT_BASH_PATH` 指向相应的 `bash.exe`，从而在全新 shell 中确定性地定位它。
+
+如果你更倾向使用 WSL2，上述 Linux 安装脚本同样可以在 WSL2 中运行；原生 Windows 与 WSL 安装可以并存（原生数据位于 `%LOCALAPPDATA%\hermes`，WSL 数据位于 `~/.hermes`）。
+
+### Android / Termux
+
+Hermes 现在也提供了适配 Termux 的安装路径：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+安装程序会自动检测 Termux 并切换到经过测试的 Android 流程：
+- 使用 Termux `pkg` 安装系统依赖（`git`、`python`、`nodejs`、`ripgrep`、`ffmpeg`、构建工具）
+- 通过 `python -m venv` 创建 virtualenv
+- 自动导出 `ANDROID_API_LEVEL` 以构建 Android wheel
+- 首选 `.[termux-all]` 扩展；若编译失败会回退到较小的 `.[termux]`，最终回退到基础安装
+- 默认跳过未经测试的浏览器 / WhatsApp 引导
+
+如果想查看更完整的步骤，请参考专门的 [Termux 指南](./termux.md)。
+
+:::note Windows 特性兼容性（早期测试版）
+原生 Windows 仍处于 **早期测试版**。除浏览器仪表盘聊天终端外，其他功能均可在 Windows 本地运行：
+- **CLI (`hermes chat`、`hermes setup`、`hermes gateway` …)** — 原生，使用默认终端
+- **网关（Telegram、Discord、Slack 等）** — 原生，作为后台 PowerShell 进程运行
+- **Cron 调度器** — 原生
+- **浏览器工具** — 原生（通过 Node.js 的 Chromium）
+- **MCP 服务器** — 原生（同时支持 stdio 与 HTTP 传输）
+- **仪表盘 `/chat` 终端窗格** — **仅限 WSL2**（使用 POSIX PTY；原生 Windows 暂无等价实现）。仪表盘的其他部分（会话、任务、指标）均可原生运行，仅嵌入的 PTY 终端标签受限。
+
+如果遇到编码相关的 bug，可在环境中设置 `HERMES_DISABLE_WINDOWS_UTF8=1`，以回退到传统的 cp1252 stdio 路径（便于定位问题）。
+:::
+
+### 安装程序的工作内容
+
+安装程序全自动完成所有依赖（Python、Node.js、ripgrep、ffmpeg）、仓库克隆、virtualenv 创建、全局 `hermes` 命令配置以及 LLM 提供商的初始化。完成后即可开始聊天。
+
+#### 安装布局
+
+实际文件放置位置取决于是普通用户安装还是 root 安装：
+
+| 安装方式 | 代码所在路径 | `hermes` 二进制 | 数据目录 |
+|---|---|---|---|
+| 普通用户（非 root） | `~/.hermes/hermes-agent/` | `~/.local/bin/hermes`（符号链接） | `~/.hermes/` |
+| root 模式（`sudo curl … | sudo bash`） | `/usr/local/lib/hermes-agent/` | `/usr/local/bin/hermes` | `/root/.hermes/`（或 `$HERMES_HOME`） |
+
+root 模式采用 **FHS 布局**（`/usr/local/lib/...`、`/usr/local/bin/hermes`），与 Linux 上其他系统级开发工具的放置位置一致。适用于共享机器的全局部署。每个用户的配置（认证信息、技能、会话等）仍然位于各自的 `~/.hermes/` 或显式的 `HERMES_HOME` 下。
+
+### 安装后
+
+重新加载 shell 并开始聊天：
+
+```bash
+source ~/.bashrc   # 或: source ~/.zshrc
+hermes             # 开始聊天！
+```
+
+以后若需单独配置某些设置，可使用相应命令：
+
+```bash
+hermes model          # 选择你的 LLM 提供商和模型
+hermes tools          # 配置启用的工具
+hermes gateway setup  # 设置消息平台
+hermes config set     # 设置单个配置项
+hermes setup          # 或运行完整的设置向导，一次性配置所有内容
+```
+
+---
+
+## 前置条件
+
+唯一的前置条件是 **Git**。安装程序会自动处理其余所有依赖：
+- **uv**（高速 Python 包管理器）
+- **Python 3.11**（通过 uv，无需 sudo）
+- **Node.js v22**（用于浏览器自动化和 WhatsApp 桥接）
+- **ripgrep**（快速文件搜索）
+- **ffmpeg**（音频格式转换，供 TTS 使用）
+
+:::info
+你 **不需要** 手动安装 Python、Node.js、ripgrep 或 ffmpeg。安装程序会检测缺失项并自动安装。只要系统中能运行 `git --version` 即可。
+:::
+
+:::tip Nix 用户
+如果你使用 Nix（在 NixOS、macOS 或 Linux 上），项目提供了专门的 Nix flake、声明式 NixOS 模块以及可选的容器模式。详见 **[Nix & NixOS 设置](./nix-setup.md)** 指南。
+:::
+
+---
+
+## 手动 / 开发者安装
+
+如果你想克隆仓库并从源码安装——例如进行贡献、切换到特定分支或完全控制 virtualenv——请参阅贡献指南中的 [开发者设置](../developer-guide/contributing.md#development-setup) 部分。
+
+---
+
+## 非 sudo / 系统服务用户安装
+
+在非特权用户（例如用于 systemd 服务的 `hermes` 用户，或任何没有 `sudo` 权限的用户）下运行 Hermes 是受支持的。唯一真正需要 root 权限的步骤是 Playwright 的 `--with-deps`，它会通过 `apt` 安装 Chromium 所需的共享库（`libnss3`、`libxkbcommon` 等）。安装程序会检测是否可以使用 sudo，并在不可用时优雅降级——它会把 Chromium 二进制放入该服务用户自己的 Playwright 缓存，并打印出管理员需要单独执行的命令。
+
+**在 Debian/Ubuntu 上的推荐做法：**
+
+1. **一次性，以拥有 sudo 的管理员用户**，为 Chromium 安装系统库：
+   ```bash
+   sudo npx playwright install-deps chromium
+   ```
+   （可以在任意目录执行，`npx` 会即时下载 Playwright。）
+
+2. **以非特权服务用户** 运行常规安装脚本。它会检测缺少 sudo，跳过 `--with-deps`，并把 Chromium 安装到用户本地的 Playwright 缓存中：
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+   ```
+
+   若想完全跳过 Playwright 步骤（例如只运行无头模式，不需要浏览器自动化），可以传入 `--skip-browser`：
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-browser
+   ```
+
+3. **让 `hermes` 在服务用户的 shell 中可用。** 安装程序会将启动器写入 `~/.local/bin/hermes`。系统服务账户的 PATH 通常不包含此目录。可以：
+   - 将其加入用户的环境配置；
+   - 或者在系统位置创建符号链接。
+   ```bash
+   # 方案 A — 添加到服务用户的 profile
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+   # 方案 B — 创建全局软链接（需要管理员）
+   sudo ln -s /home/hermes/.hermes/hermes-agent/venv/bin/hermes /usr/local/bin/hermes
+   ```
+
+4. **验证：**运行 `hermes doctor` 应当顺利。如果出现 `ModuleNotFoundError: No module named 'dotenv'`，说明你正在使用仓库中的 `hermes` 脚本（`~/.hermes/hermes-agent/hermes`）而不是 virtualenv 启动器（`~/.hermes/hermes-agent/venv/bin/hermes`），请修正第 3 步。
+
+相同模式同样适用于 Arch（installer 使用 pacman 并具备相同的 sudo 检测逻辑）、Fedora/RHEL、openSUSE——这些发行版根本不支持 `--with-deps`，因此管理员始终需要自行安装系统库。对应的 `dnf`/`zypper` 命令会由安装程序打印。
+
+---
+
+## 故障排查
+
+| 问题 | 解决方案 |
+|------|----------|
+| `hermes: command not found` | 重新加载 shell（`source ~/.bashrc`）或检查 PATH |
+| `API key not set` | 运行 `hermes model` 配置提供商，或 `hermes config set OPENROUTER_API_KEY your_key` |
+| 更新后缺少配置 | 运行 `hermes config check` 再 `hermes config migrate` |
+
+如需更详细的诊断信息，运行 `hermes doctor` ——它会准确指出缺失项并提供修复方案。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 3
+title: '学习路径'
+description: '根据您的经验水平和目标，在 Hermes Agent 文档中选择合适的学习路径。'
+---
+
+# 学习路径
+
+Hermes Agent 功能丰富——包括 CLI 助手、Telegram/Discord 机器人、任务自动化、强化学习（RL）训练等。本页帮助您根据经验水平和目标，确定从何处入手以及阅读顺序。
+
+:::tip 开始前
+如果您尚未安装 Hermes Agent，请先阅读[安装指南](/docs/getting-started/installation)，随后完成[快速入门](/docs/getting-started/quickstart)。以下内容默认您已经完成了可用的安装。
+:::
+
+## 如何使用本页
+
+- **已知自己的水平？** 跳转至[按经验水平划分](#按经验水平划分)的表格，按照对应层级的阅读顺序进行。
+- **有具体目标？** 前往[按使用场景](_#按使用场景)查找匹配的方案。
+- **随便浏览？** 查看[功能速览](_#功能速览)表格，快速了解 Hermes Agent 的全部能力。
+
+## 按经验水平划分
+
+| 等级 | 目标 | 推荐阅读 | 预计时间 |
+|---|---|---|---|
+| **初学者** | 快速上手、进行基本对话、使用内置工具 | [安装](/docs/getting-started/installation) → [快速入门](/docs/getting-started/quickstart) → [CLI 使用](/docs/user-guide/cli) → [配置](/docs/user-guide/configuration) | ~1 小时 |
+| **中级** | 部署消息机器人，使用记忆、定时任务（cron）和技能等高级功能 | [会话](/docs/user-guide/sessions) → [消息](/docs/user-guide/messaging) → [工具](/docs/user-guide/features/tools) → [技能](/docs/user-guide/features/skills) → [记忆](/docs/user-guide/features/memory) → [Cron](/docs/user-guide/features/cron) | ~2–3 小时 |
+| **高级** | 开发自定义工具、创建技能、使用强化学习训练模型、为项目贡献代码 | [架构](/docs/developer-guide/architecture) → [添加工具](/docs/developer-guide/adding-tools) → [创建技能](/docs/developer-guide/creating-skills) → [RL 训练](/docs/user-guide/features/rl-training) → [贡献指南](/docs/developer-guide/contributing) | ~4–6 小时 |
+
+## 按使用场景
+
+挑选与您需求相符的场景，每个场景都会按推荐顺序链接到相应文档。
+
+### “我想要一个 CLI 编码助手”
+
+使用 Hermes Agent 作为交互式终端助手，协助编写、审查、运行代码。
+
+1. [安装](/docs/getting-started/installation)
+2. [快速入门](/docs/getting-started/quickstart)
+3. [CLI 使用](/docs/user-guide/cli)
+4. [代码执行](/docs/user-guide/features/code-execution)
+5. [上下文文件](/docs/user-guide/features/context-files)
+6. [技巧与窍门](/docs/guides/tips)
+
+:::tip
+通过上下文文件直接将项目文件加入对话。Hermes Agent 能读取、编辑并运行代码。
+:::
+
+### “我想要一个 Telegram/Discord 机器人”
+
+将在您喜欢的即时通讯平台上部署 Hermes Agent 机器人。
+
+1. [安装](/docs/getting-started/installation)
+2. [配置](/docs/user-guide/configuration)
+3. [消息概览](/docs/user-guide/messaging)
+4. [Telegram 设置](/docs/user-guide/messaging/telegram)
+5. [Discord 设置](/docs/user-guide/messaging/discord)
+6. [语音模式](/docs/user-guide/features/voice-mode)
+7. [在 Hermes 中使用语音模式](/docs/guides/use-voice-mode-with-hermes)
+8. [安全](/docs/user-guide/security)
+
+完整项目示例请参见：
+- [每日简报机器人](/docs/guides/daily-briefing-bot)
+- [团队 Telegram 助手](/docs/guides/team-telegram-assistant)
+
+### “我想要自动化任务”
+
+安排周期性任务、运行批处理作业，或将多个 Agent 动作串联。
+
+1. [快速入门](/docs/getting-started/quickstart)
+2. [Cron 调度](/docs/user-guide/features/cron)
+3. [批处理](/docs/user-guide/features/batch-processing)
+4. [委派](/docs/user-guide/features/delegation)
+5. [钩子](/docs/user-guide/features/hooks)
+
+:::tip
+Cron 任务让 Hermes Agent 按计划运行——每日摘要、定时检查、自动报表等，无需人工干预。
+:::
+
+### “我想要构建自定义工具/技能”
+
+通过插件扩展 Hermes Agent，添加自己的工具和可复用的技能包。
+
+1. [插件](/docs/user-guide/features/plugins)
+2. [构建 Hermes 插件](/docs/guides/build-a-hermes-plugin)
+3. [工具概览](/docs/user-guide/features/tools)
+4. [技能概览](/docs/user-guide/features/skills)
+5. [MCP（模型上下文协议）](/docs/user-guide/features/mcp)
+6. [架构](/docs/developer-guide/architecture)
+7. [添加工具](/docs/developer-guide/adding-tools)
+8. [创建技能](/docs/developer-guide/creating-skills)
+
+:::tip
+大多数自定义工具请从插件入手。"添加工具"章节针对的是 Hermes 核心的内部开发，不是普通用户的路径。
+:::
+
+### “我想要训练模型”
+
+使用强化学习（RL）管道对模型行为进行微调。
+
+1. [快速入门](/docs/getting-started/quickstart)
+2. [配置](/docs/user-guide/configuration)
+3. [RL 训练](/docs/user-guide/features/rl-training)
+4. [提供商路由](/docs/user-guide/features/provider-routing)
+5. [架构](/docs/developer-guide/architecture)
+
+:::tip
+RL 训练在您已熟悉 Hermes Agent 的对话与工具调用机制后效果最佳。若是新手，请先走初学者路径。
+:::
+
+### “我想把它当作 Python 库使用”
+
+在自己的 Python 应用中以库的形式集成 Hermes Agent。
+
+1. [安装](/docs/getting-started/installation)
+2. [快速入门](/docs/getting-started/quickstart)
+3. [Python 库指南](/docs/guides/python-library)
+4. [架构](/docs/developer-guide/architecture)
+5. [工具](/docs/user-guide/features/tools)
+6. [会话](/docs/user-guide/sessions)
+
+## 功能速览
+
+不确定有哪些功能？下面是一览表，帮助您快速定位想要的特性。
+
+| 功能 | 作用 | 链接 |
+|---|---|---|
+| **Tools** | 内置工具（文件 I/O、搜索、Shell 等） | [Tools](/docs/user-guide/features/tools) |
+| **Skills** | 可安装的插件包，提供新能力 | [Skills](/docs/user-guide/features/skills) |
+| **Memory** | 跨会话的持久记忆 | [Memory](/docs/user-guide/features/memory) |
+| **Context Files** | 将文件或目录喂入对话上下文 | [Context Files](/docs/user-guide/features/context-files) |
+| **MCP** | 通过模型上下文协议连接外部工具服务器 | [MCP](/docs/user-guide/features/mcp) |
+| **Cron** | 定时任务调度 | [Cron](/docs/user-guide/features/cron) |
+| **Delegation** | 为并行工作生成子代理 | [Delegation](/docs/user-guide/features/delegation) |
+| **Code Execution** | 以编程方式运行 Python 脚本并调用 Hermes 工具 | [Code Execution](/docs/user-guide/features/code-execution) |
+| **Browser** | 网页浏览与抓取 | [Browser](/docs/user-guide/features/browser) |
+| **Hooks** | 事件回调与中间件 | [Hooks](/docs/user-guide/features/hooks) |
+| **Batch Processing** | 批量处理多个输入 | [Batch Processing](/docs/user-guide/features/batch-processing) |
+| **RL Training** | 使用强化学习微调模型 | [RL Training](/docs/user-guide/features/rl-training) |
+| **Provider Routing** | 在多个 LLM 提供商之间路由请求 | [Provider Routing](/docs/user-guide/features/provider-routing) |
+
+## 接下来阅读什么
+
+根据您当前所处阶段：
+
+- **刚完成安装？** → 前往[快速入门](/docs/getting-started/quickstart)开始第一次对话。
+- **完成快速入门？** → 阅读[CLI 使用](/docs/user-guide/cli)和[配置](/docs/user-guide/configuration)以自定义设置。
+- **已经掌握基础？** → 探索[工具]、[技能]、[记忆]等模块，充分发挥代理的能力。
+- **为团队部署？** → 查看[安全]和[会话]章节，了解访问控制和会话管理。
+- **准备动手开发？** → 进入[开发者指南](/docs/developer-guide/architecture)了解内部实现并开始贡献。
+- **想要实战案例？** → 前往[指南](/docs/guides/tips)获取真实项目和技巧。
+
+:::tip
+不必一次阅读完所有内容。选取符合您目标的路径，按顺序阅读链接，即可快速上手。之后随时回到本页寻找下一步。
+:::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -1,0 +1,335 @@
+---
+sidebar_position: 1
+title: "快速入门"
+description: "与 Hermes Agent 的首次对话——从安装到聊天，5 分钟搞定"
+---
+
+# 快速入门
+
+本指南帮助你从零开始搭建可在真实环境中使用的 Hermes，完成安装、选择**provider（供应商）**、验证聊天功能，并在出现问题时知道该如何处理。
+
+## 更喜欢观看视频？
+
+**Onchain AI Garage** 制作了一套完整的 Masterclass 视频，演示了安装、配置和基础指令的全过程——如果你更倾向于边看边学，可将其作为本页的补充。更多内容请查看完整的 [Hermes Agent 教程与使用案例](https://www.youtube.com/channel/UCqB1bhMwGsW-yefBxYwFCCg) 播放列表。
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1.5rem'}}>
+  <iframe
+    style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+    src="https://www.youtube-nocookie.com/embed/R3YOGfTBcQg"
+    title="Hermes Agent Masterclass: Installation, Setup, Basic Commands"
+    frameBorder="0"
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## 本指南适合谁
+
+- 完全新手，想要最快速地得到可运行的环境
+- 正在更换供应商，不想因配置错误浪费时间
+- 为团队、机器人或常驻工作流部署 Hermes
+- 对“一键安装，却无任何响应”感到厌倦
+
+## 最速路径
+
+挑选与你目标匹配的那一行：
+
+| 目标 | 首先要做的事 | 然后做什么 |
+|---|---|---|
+| 我只想在本机运行 Hermes | `hermes setup` | 运行一次真实聊天并确认有响应 |
+| 我已经知道要使用的 provider（供应商） | `hermes model` | 保存配置后开始聊天 |
+| 我想要机器人或常驻服务 | 在 CLI（命令行界面）工作正常后运行 `hermes gateway setup` | 连接 Telegram、Discord、Slack 或其他平台 |
+| 我想使用本地或自托管模型 | `hermes model` → 自定义端点 | 验证端点、模型名称以及上下文长度 |
+| 我想要多供应商兜底 | 先执行 `hermes model` | 确认基础聊天可用后再添加路由与兜底 |
+
+**经验法则**：如果 Hermes 还不能完成一次普通聊天，暂不要再添加功能。先让一次干净的对话跑通，然后再逐层加入网关、定时任务、技能、语音或路由。
+
+---
+
+## 1️⃣ 安装 Hermes Agent
+
+运行一行安装命令：
+
+```bash
+# Linux / macOS / WSL2 / Android (Termux)
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+:::tip Android / Termux
+如果在手机上安装，请参阅专门的 [Termux 指南](./termux.md)，了解经测试的手动步骤、支持的扩展以及当前的 Android 限制。
+:::
+
+:::tip Windows 用户
+先安装 [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)，再在 WSL2 终端中运行以上命令。
+:::
+
+完成后，重新加载 shell：
+
+```bash
+source ~/.bashrc   # 或者 source ~/.zshrc
+```
+
+想了解更详细的安装选项、前置需求和故障排查，请阅读 [安装指南](./installation.md)。
+
+## 2️⃣ 选择 Provider（供应商）
+
+这是唯一最关键的设置步骤。使用 `hermes model` 交互式完成选择：
+
+```bash
+hermes model
+```
+
+以下是常用的默认选项：
+
+| Provider | 说明 | 设置方式 |
+|----------|------|----------|
+| **Nous Portal** | 订阅制、零配置 | 在 `hermes model` 中通过 OAuth 登录 |
+| **OpenAI Codex** | ChatGPT OAuth，使用 Codex 模型 | 在 `hermes model` 中通过设备码认证 |
+| **Anthropic** | Claude 系列模型——需 Max 计划+额外使用额度（OAuth），或使用按 token 计费的 API Key | `hermes model` → OAuth 登录（需要 Max + 额度），或提供 Anthropic API Key |
+| **OpenRouter** | 多供应商路由，覆盖众多模型 | 填写 API Key |
+| **Z.AI** | GLM / Zhipu 托管模型 | 设置 `GLM_API_KEY` / `ZAI_API_KEY` |
+| **Kimi / Moonshot** | Moonshot 托管的编码与聊天模型 | 设置 `KIMI_API_KEY`（或专用于编码的 `KIMI_CODING_API_KEY`） |
+| **Kimi / Moonshot China** | 面向中国区的 Moonshot 接口 | 设置 `KIMI_CN_API_KEY` |
+| **Arcee AI** | Trinity 系列模型 | 设置 `ARCEEAI_API_KEY` |
+| **GMI Cloud** | 多模型直接 API 接入 | 设置 `GMI_API_KEY` |
+| **MiniMax (OAuth)** | MiniMax‑M2.7 浏览器 OAuth，无需 API Key | `hermes model` → MiniMax（OAuth） |
+| **MiniMax** | 国际版 MiniMax 接口 | 设置 `MINIMAX_API_KEY` |
+| **MiniMax China** | 中国区 MiniMax 接口 | 设置 `MINIMAX_CN_API_KEY` |
+| **Alibaba Cloud** | 通过 DashScope 调用 Qwen 系列模型 | 设置 `DASHSCOPE_API_KEY` |
+| **Hugging Face** | 通过统一路由访问 20+ 开源模型（Qwen、DeepSeek、Kimi 等） | 设置 `HF_TOKEN` |
+| **AWS Bedrock** | Claude、Nova、Llama、DeepSeek 等通过原生 Converse API 访问 | 采用 IAM 角色或执行 `aws configure`（[指南](../guides/aws-bedrock.md)） |
+| **Kilo Code** | KiloCode 托管模型 | 设置 `KILOCODE_API_KEY` |
+| **OpenCode Zen** | 按使用量付费的精选模型 | 设置 `OPENCODE_ZEN_API_KEY` |
+| **OpenCode Go** | 月付 $10 的开源模型订阅 | 设置 `OPENCODE_GO_API_KEY` |
+| **DeepSeek** | 直接对接 DeepSeek API | 设置 `DEEPSEEK_API_KEY` |
+| **NVIDIA NIM** | 通过 build.nvidia.com 或本地 NIM 调用 Nemotron 系列模型 | 设置 `NVIDIA_API_KEY`（可选 `NVIDIA_BASE_URL`） |
+| **GitHub Copilot** | GitHub Copilot 订阅（GPT‑5.x、Claude、Gemini 等） | 在 `hermes model` 中通过 OAuth 登录，或设置 `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` |
+| **GitHub Copilot ACP** | Copilot ACP 代理后端（需本地 `copilot` CLI） | `hermes model`（前提是已安装 `copilot` CLI 并完成 `copilot login`） |
+| **Vercel AI Gateway** | Vercel AI Gateway 路由 | 设置 `AI_GATEWAY_API_KEY` |
+| **Custom Endpoint** | VLLM、SGLang、Ollama 或任意兼容 OpenAI 的 API | 设置基础 URL + API Key |
+
+对于大多数首次使用者：选择一个 provider（供应商），除非明确知道自己在改什么，否则请接受默认值。完整的 provider 目录、对应的环境变量以及设置步骤请参见 [供应商列表](../integrations/providers.md)。
+
+:::caution Minimum context: 64K tokens
+Hermes Agent 至少需要 **64,000 token** 的上下文窗口。窗口小于该阈值的模型无法支撑多轮工具调用的工作记忆，在启动时会被拒绝。主流托管模型（Claude、GPT、Gemini、Qwen、DeepSeek）均已轻松满足。若自行部署本地模型，请将上下文长度调至至少 64K（例如在 llama.cpp 中使用 `--ctx-size 65536`，或在 Ollama 中使用 `-c 65536`）。
+:::
+
+:::tip
+随时可使用 `hermes model` 切换 provider（供应商）——不存在绑定限制。完整的 provider 支持列表及设置细节请查看 [AI 供应商](../integrations/providers.md)。
+:::
+
+### 设置如何存储
+
+Hermes 将 **机密信息** 与普通配置分离存放：
+
+- **机密和 token（令牌）** → `~/.hermes/.env`
+- **非机密设置** → `~/.hermes/config.yaml`
+
+最省事的方式是通过 CLI（命令行界面）进行设置：
+
+```bash
+hermes config set model anthropic/claude-opus-4.6
+hermes config set terminal.backend docker
+hermes config set OPENROUTER_API_KEY sk-or-...
+```
+
+系统会自动将对应值写入正确的文件。
+
+## 3️⃣ 运行你的首个聊天
+
+```bash
+hermes            # 经典 CLI（命令行界面）
+hermes --tui      # 现代 TUI（推荐）
+```
+
+启动后会显示包含模型、可用工具及已加载技能的欢迎横幅。请使用明确且易于验证的提示进行测试：
+
+:::tip 选择交互界面
+Hermes 提供两种终端交互方式：传统的 `prompt_toolkit` CLI 与更现代的 [TUI](../user-guide/tui.md)（支持模态覆盖、鼠标选择和非阻塞输入）。两者共享相同的 session（会话）、斜线指令和配置，任选其一即可体验。
+:::
+
+```
+Summarize this repo in 5 bullets and tell me what the main entrypoint is.
+```
+
+```
+Check my current directory and tell me what looks like the main project file.
+```
+
+```
+Help me set up a clean GitHub PR workflow for this codebase.
+```
+
+**成功的标志**：
+
+- 横幅显示你选定的模型/供应商
+- Hermes 能够无错误回复
+- 如需，可使用工具（终端、文件读取、网页搜索）
+- 对话能够顺畅进行多轮
+
+如果上述都正常，则已跨过最难的阶段。
+
+## 4️⃣ 验证 Session（会话）恢复
+
+在继续其他操作前，先确认会话恢复功能可用：
+
+```bash
+hermes --continue    # 恢复最近一次会话
+hermes -c            # 略写形式
+```
+
+这应当把你带回刚才的对话。如果没有，检查是否在同一 profile（配置文件）下，或会话是否真的已保存。这在后期切换机器或多套环境时尤为重要。
+
+## 5️⃣ 体验关键功能
+
+### 使用终端工具
+
+```
+❯ What's my disk usage? Show the top 5 largest directories.
+```
+
+Agent 会在你的机器上执行终端指令并返回结果。
+
+### 斜线指令（Slash commands）
+
+在聊天框输入 `/` 可弹出所有指令的自动补全列表：
+
+| 指令 | 功能 |
+|---------|-------------|
+| `/help` | 显示所有可用指令 |
+| `/tools` | 列出可用工具 |
+| `/model` | 交互式切换模型 |
+| `/personality pirate` | 尝试有趣的角色设定 |
+| `/save` | 保存当前对话 |
+
+### 多行输入
+
+使用 `Alt+Enter`、`Ctrl+J` 或 `Shift+Enter` 换行。`Shift+Enter` 需要终端能够将其识别为独立的键序列（默认支持 Kitty / foot / WezTerm / Ghostty；在 iTerm2 / Alacritty / VS Code 终端中开启 Kitty 键盘协议后亦可）。`Alt+Enter` 与 `Ctrl+J` 在所有终端均可使用。
+
+### 中断 Agent
+
+若 Agent 响应过慢，直接输入新消息并回车即可中断当前任务并切换指令。`Ctrl+C` 也能实现同样效果。
+
+## 6️⃣ 添加下一层功能
+
+仅在基础聊天正常后再继续。根据需求选择下面的扩展路径：
+
+### 机器人或共享助理
+
+```bash
+hermes gateway setup    # 交互式平台配置向导
+```
+
+可连接 [Telegram](/docs/user-guide/messaging/telegram)、[Discord](/docs/user-guide/messaging/discord)、[Slack](/docs/user-guide/messaging/slack)、[WhatsApp](/docs/user-guide/messaging/whatsapp)、[Signal](/docs/user-guide/messaging/signal)、[Email](/docs/user-guide/messaging/email)、[Home Assistant](/docs/user-guide/messaging/homeassistant)、[Microsoft Teams](/docs/user-guide/messaging/teams) 等平台。
+
+### 自动化与工具
+
+- `hermes tools` — 为不同平台微调工具访问权限
+- `hermes skills` — 浏览并安装可复用的工作流
+- 定时任务（Cron）— 仅在机器人或 CLI 稳定后使用
+
+### 沙箱终端
+
+为安全起见，可在 Docker 容器或远程服务器中运行 Agent：
+
+```bash
+hermes config set terminal.backend docker    # Docker 隔离
+hermes config set terminal.backend ssh       # 远程服务器
+```
+
+### 语音模式
+
+```bash
+# 在 Hermes 安装目录（curl 安装器会放在 ~/.hermes/hermes-agent）
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[voice]"
+# 包含 free local 的 faster-whisper 用于语音转文字
+```
+
+随后在 CLI 中使用 `/voice on` 启动。录音请按 `Ctrl+B`。更多请参见 [语音模式](../user-guide/features/voice-mode.md)。
+
+### Skills（技能）
+
+```bash
+hermes skills search kubernetes
+hermes skills install openai/skills/k8s
+```
+
+或在聊天中使用 `/skills`。
+
+### MCP 服务器
+
+```yaml
+# 添加到 ~/.hermes/config.yaml
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxx"
+```
+
+### 编辑器集成（ACP）
+
+ACP 支持已随 `[all]` extras 一同安装，curl 安装器默认已包含。直接运行：
+
+```bash
+hermes acp
+```
+
+（若未安装 `[all]`，请先执行 `cd ~/.hermes/hermes-agent && uv pip install -e ".[acp]"`。）
+
+详细请查看 [ACP 编辑器集成](../user-guide/features/acp.md)。
+
+---
+
+## 常见故障模式
+
+以下问题最容易让人浪费时间：
+
+| 症状 | 可能原因 | 解决方案 |
+|---|---|---|
+| Hermes 启动后返回空白或破碎的回复 | Provider（供应商）认证或模型选择错误 | 重新运行 `hermes model`，确认 provider、model 与 auth 正确 |
+| 自定义端点“能用”但返回乱码 | 基础 URL、模型名称错误，或并非真正的 OpenAI 兼容接口 | 先在独立客户端验证端点 |
+| Gateway 启动却无法收到消息 | 机器人 token、白名单或平台配置不完整 | 重新运行 `hermes gateway setup` 并检查 `hermes gateway status` |
+| `hermes --continue` 找不到旧 session（会话） | 切换了 profile，或会话根本未保存 | 查看 `hermes sessions list`，确认使用正确的 profile |
+| 模型不可用或出现异常回退行为 | Provider（供应商）路由或兜底设置过于激进 | 在基础 provider 稳定前关闭路由 |
+| `hermes doctor` 检测到配置问题 | 配置缺失或已过期 | 修复配置后先测试普通聊天，再添加其他功能 |
+
+## 恢复工具箱
+
+当感觉一切不对劲时，按以下顺序排查：
+
+1. `hermes doctor`
+2. `hermes model`
+3. `hermes setup`
+4. `hermes sessions list`
+5. `hermes --continue`
+6. `hermes gateway status`
+
+这样即可快速把系统从“坏掉的状态”恢复到已知的良好状态。
+
+---
+
+## 快速参考
+
+| 命令 | 描述 |
+|---------|-------------|
+| `hermes` | 开始聊天 |
+| `hermes model` | 选择 LLM provider（供应商）和模型 |
+| `hermes tools` | 为不同平台配置启用的工具 |
+| `hermes setup` | 完整设置向导（一次性配置所有内容） |
+| `hermes doctor` | 诊断问题 |
+| `hermes update` | 更新到最新版本 |
+| `hermes gateway` | 启动消息网关 |
+| `hermes --continue` | 恢复最近一次会话 |
+
+## 后续步骤
+
+- **[CLI 指南](../user-guide/cli.md)** — 精通终端交互
+- **[配置指南](../user-guide/configuration.md)** — 定制你的 Hermes
+- **[消息网关](../user-guide/messaging/index.md)** — 连接 Telegram、Discord、Slack、WhatsApp、Signal、Email、Home Assistant、Teams 等平台
+- **[工具与工具集](../user-guide/features/tools.md)** — 探索可用能力
+- **[AI 供应商](../integrations/providers.md)** — 完整供应商列表及配置细节
+- **[技能系统](../user-guide/features/skills.md)** — 可复用的工作流与知识库
+- **[技巧与最佳实践](../guides/tips.md)** — 高阶使用技巧

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/updating.md
@@ -1,0 +1,213 @@
+---
+sidebar_position: 3
+title: "更新与卸载"
+description: "如何将 Hermes Agent 更新到最新版本或卸载它"
+---
+
+# 更新与卸载
+
+## 更新
+
+使用单个命令更新到最新版本：
+
+```bash
+hermes update
+```
+
+此命令会拉取最新代码、更新依赖，并提示你配置自上次更新后新增的选项。
+
+:::tip
+`hermes update` 会自动检测新配置项并提示你添加。如果你错过了该提示，可以手动运行 `hermes config check` 查看缺失的选项，然后运行 `hermes config migrate` 交互式添加它们。
+:::
+
+### 更新期间会发生什么
+
+运行 `hermes update` 时，会执行以下步骤：
+
+1. **配对数据快照** — 在更新前保存轻量级的状态快照（覆盖 `~/.hermes/pairing/`、飞书评论规则以及其他运行时会修改的状态文件）。可通过[快照与回滚](../user-guide/checkpoints-and-rollback.md)章节描述的恢复流程恢复，或通过 Hermes 在 `~/.hermes/` 目录旁写入的最新快速快照 zip 文件进行提取。
+2. **Git 拉取** — 从 `main` 分支拉取最新代码并更新子模块。
+3. **依赖安装** — 运行 `uv pip install -e ".[all]"` 以获取新的或变更的依赖。
+4. **配置迁移** — 检测自你当前版本起新增的配置项并提示你设置。
+5. **网关自动重启** — 更新完成后会刷新正在运行的网关，使新代码立即生效。系统服务管理的网关（Linux 上的 systemd、macOS 上的 launchd）会通过服务管理器重启。手动启动的网关在 Hermes 能够将运行的 PID 映射回配置文件时会自动重新启动。
+
+### 仅预览：`hermes update --check`
+
+想在实际拉取之前先了解自己是否落后于 `origin/main`？运行 `hermes update --check` — 它会抓取远程信息，侧边打印本地提交与最新远程提交的对比，并在同步时退出码为 `0`，落后时为 `1`。此过程不修改文件，也不重启网关，适合在脚本和 cron 任务中用作 “是否有更新” 的判断。
+
+### 完整的更新前备份：`--backup`
+
+对于高价值的配置（生产网关、团队共享安装），可以在拉取前对整个 `HERMES_HOME`（配置、认证、会话、技能、配对数据）做完整备份：
+
+```bash
+hermes update --backup
+```
+
+或者将其设为每次运行的默认行为：
+
+```yaml
+# ~/.hermes/config.yaml
+updates:
+  pre_update_backup: true
+```
+
+`--backup` 在早期版本中是默认开启的，但在大型主目录上会导致更新耗时数分钟，因此现在改为可选。上述轻量级的配对数据快照仍然会无条件执行。
+
+预期的输出示例：
+
+```
+$ hermes update
+Updating Hermes Agent...
+📥 Pulling latest code...
+Already up to date.  (or: Updating abc1234..def5678)
+📦 Updating dependencies...
+✅ Dependencies updated
+🔍 Checking for new config options...
+✅ Config is up to date  (or: Found 2 new options — running migration...)
+🔄 Restarting gateways...
+✅ Gateway restarted
+✅ Hermes Agent updated successfully!
+```
+
+### 推荐的更新后验证
+
+`hermes update` 已处理大部分更新流程，但进行一次快速验证可以确保一切顺利：
+
+1. `git status --short` — 若工作树出现意外脏文件，请在继续前检查原因。
+2. `hermes doctor` — 检查配置、依赖和服务健康状态。
+3. `hermes --version` — 确认版本已如预期提升。
+4. 若使用网关：`hermes gateway status`
+5. 若 `doctor` 报告 npm audit 问题：在对应目录下运行 `npm audit fix`
+
+:::warning Dirty working tree after update
+如果在 `hermes update` 后 `git status --short` 显示意外的更改，请停止并检查这些更改再继续。这通常意味着本地修改被重新应用在更新的代码上，或依赖步骤重新生成了 lock 文件。
+:::
+
+### 当终端在更新途中断开连接时
+
+`hermes update` 已对意外的终端掉线做了保护：
+
+- 更新会忽略 `SIGHUP`，因此关闭 SSH 会话或终端窗口不再导致更新中途被杀死。`pip` 与 `git` 子进程会继承此保护，防止因掉线导致环境半装。
+- 所有输出会同步写入 `~/.hermes/logs/update.log`。如果终端消失，重新登录后查看日志即可判断更新是否完成以及网关重启是否成功：
+
+```bash
+tail -f ~/.hermes/logs/update.log
+```
+
+- `Ctrl‑C`（SIGINT）和系统关机（SIGTERM）仍然会被尊重——这些是有意的取消操作。
+
+因此你不再需要借助 `screen` 或 `tmux` 来确保更新过程的持续性。
+
+### 检查当前版本
+
+```bash
+hermes version
+```
+
+可与最新发布版本进行对比，最新发布页位于 [GitHub releases 页面](https://github.com/NousResearch/hermes-agent/releases)。
+
+### 从即时通讯平台更新
+
+你也可以直接在 Telegram、Discord、Slack、WhatsApp、Teams 等平台发送以下指令进行更新：
+
+```
+/update
+```
+
+这会拉取最新代码、更新依赖并重启正在运行的网关。更新期间机器人会短暂离线（通常 5–15 秒），随后恢复。
+
+### 手动更新
+
+如果你是手动安装（而非使用快速安装脚本），可按下列步骤自行更新：
+
+```bash
+cd /path/to/hermes-agent
+export VIRTUAL_ENV="$(pwd)/venv"
+
+# 拉取最新代码
+git pull origin main
+
+# 重新安装（获取新依赖）
+uv pip install -e ".[all]"
+
+# 检查新配置项
+hermes config check
+hermes config migrate   # 交互式添加缺失的选项
+```
+
+### 回滚说明
+
+若更新后出现问题，可回滚到先前的版本：
+
+```bash
+cd /path/to/hermes-agent
+
+# 查看最近的提交记录
+git log --oneline -10
+
+# 回滚到指定提交
+git checkout <commit-hash>
+git submodule update --init --recursive
+uv pip install -e ".[all]"
+
+# 若网关在运行，重启它
+hermes gateway restart
+```
+
+要回滚到特定的发布标签：
+
+```bash
+git checkout v0.6.0
+git submodule update --init --recursive
+uv pip install -e ".[all]"
+```
+
+:::warning
+回滚可能导致配置不兼容（因为新选项已被加入）。回滚后运行 `hermes config check`，若出现未识别的选项，请在 `config.yaml` 中移除它们以避免错误。
+:::
+
+### 对 Nix 用户的提示
+
+如果通过 Nix flake 安装，更新由 Nix 包管理器管理：
+
+```bash
+# 更新 flake 输入
+nix flake update hermes-agent
+
+# 或者直接使用最新的构建
+nix profile upgrade hermes-agent
+```
+
+Nix 安装是不可变的，回滚由 Nix 的 generation 系统处理：
+
+```bash
+nix profile rollback
+```
+
+更多细节请参阅 [Nix Setup](./nix-setup.md)。
+
+---
+
+## 卸载
+
+```bash
+hermes uninstall
+```
+
+卸载程序会询问是否保留配置文件 (`~/.hermes/`) 供以后重新安装使用。
+
+### 手动卸载
+
+```bash
+rm -f ~/.local/bin/hermes
+rm -rf /path/to/hermes-agent
+rm -rf ~/.hermes            # 如无重新安装计划，可选执行此步骤
+```
+
+:::info
+如果你将网关作为系统服务安装，请先停止并禁用它：
+```bash
+hermes gateway stop
+# Linux: systemctl --user disable hermes-gateway
+# macOS: launchctl remove ai.hermes.gateway
+```
+:::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.md
@@ -1,0 +1,84 @@
+---
+slug: /
+sidebar_position: 0
+title: "Hermes Agent 文档"
+description: "由 Nous Research 构建的自我改进 AI 代理。内置学习循环，可从经验中创建技能，在使用过程中改进，并在会话之间保持记忆。"
+hide_table_of_contents: true
+displayed_sidebar: docs
+---
+
+# Hermes Agent
+
+由 [Nous Research](https://nousresearch.com) 构建的自我改进 AI 代理。唯一拥有内置学习循环的代理——它从经验中创建技能，在使用过程中改进，主动推进记忆持久化，并在会话之间构建对用户的深度模型。
+
+<div style={{display: 'flex', gap: '1rem', marginBottom: '2rem', flexWrap: 'wrap'}}>
+  <a href="/docs/getting-started/installation" style={{display: 'inline-block', padding: '0.6rem 1.2rem', backgroundColor: '#FFD700', color: '#07070d', borderRadius: '8px', fontWeight: 600, textDecoration: 'none'}}>开始使用 →</a>
+  <a href="https://github.com/NousResearch/hermes-agent" style={{display: 'inline-block', padding: '0.6rem 1.2rem', border: '1px solid rgba(255,215,0,0.2)', borderRadius: '8px', textDecoration: 'none'}}>在 GitHub 上查看</a>
+</div>
+
+## 安装
+
+**Linux / macOS / WSL2**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+**Windows（原生 PowerShell）** — *早期测试版，[详情 →](/docs/user-guide/windows-native)*
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
+
+**Android（Termux）** — 与 Linux 相同的 curl 单行命令；安装程序会自动检测 Termux。
+
+完整的 **[安装指南](/docs/getting-started/installation)** 详细说明了安装程序的工作原理、用户与根目录布局以及 Windows 的特定注意事项。
+
+## 什么是 Hermes Agent？
+
+它并不是绑定在 IDE 上的编码助手，也不是围绕单一 API 的聊天机器人包装器。它是一个 **自主代理**，运行时间越长能力越强。它可以部署在任何地方——$5 的 VPS、GPU 集群，或几乎不占资源的无服务器基础设施（Daytona、Modal），在空闲时几乎不产生费用。你可以通过 Telegram 与它对话，而它在云端虚拟机上工作，你甚至不需要自行 SSH 登录。它不依赖你的笔记本电脑。
+
+## 快速链接
+
+| | |
+|---|---|
+| 🚀 **[安装](/docs/getting-started/installation)** | 在 Linux、macOS、WSL2 或原生 Windows（早期测试版）上 60 秒完成安装 |
+| 📖 **[快速入门教程](/docs/getting-started/quickstart)** | 第一次对话以及可尝试的关键功能 |
+| 🗺️ **[学习路径](/docs/getting-started/learning-path)** | 为你的经验水平找到合适的文档 |
+| ⚙️ **[配置](/docs/user-guide/configuration)** | 配置文件、提供商、模型以及各项选项 |
+| 💬 **[消息网关](/docs/user-guide/messaging)** | 设置 Telegram、Discord、Slack、WhatsApp、Teams 等平台 |
+| 🔧 **[工具与工具集](/docs/user-guide/features/tools)** | 超过 70 项内置工具及其配置方法 |
+| 🧠 **[记忆系统](/docs/user-guide/features/memory)** | 跨会话增长的持久记忆 |
+| 📚 **[技能系统](/docs/user-guide/features/skills)** | 代理创建并复用的过程性记忆 |
+| 🔌 **[MCP 集成](/docs/user-guide/features/mcp)** | 连接 MCP 服务器、过滤工具并安全扩展 Hermes |
+| 🧭 **[在 Hermes 中使用 MCP](/docs/guides/use-mcp-with-hermes)** | 实用的 MCP 配置模式、示例与教程 |
+| 🎙️ **[语音模式](/docs/user-guide/features/voice-mode)** | CLI、Telegram、Discord 与 Discord 语音频道的实时语音交互 |
+| 🗣️ **[在 Hermes 中使用语音模式](/docs/guides/use-voice-mode-with-hermes)** | Hermes 语音工作流的动手设置与使用模式 |
+| 🎭 **[人格 & SOUL.md](/docs/user-guide/features/personality)** | 使用全局 SOUL.md 定义 Hermes 的默认声音 |
+| 📄 **[上下文文件](/docs/user-guide/features/context-files)** | 影响每次对话的项目上下文文件 |
+| 🔒 **[安全性](/docs/user-guide/security)** | 命令批准、授权、容器隔离 |
+| 💡 **[技巧与最佳实践](/docs/guides/tips)** | 快速提升 Hermes 使用效果的技巧 |
+| 🏗️ **[架构](/docs/developer-guide/architecture)** | 底层工作原理 |
+| ❓ **[常见问题与故障排除](/docs/reference/faq)** | 常见问题及解决方案 |
+
+## 关键特性
+
+- **闭环学习** — 代理自行管理记忆并定期 nudging，自动创建技能，在使用过程中自行改进，利用 FTS5 跨会话召回并通过 LLM 摘要，配合 [Honcho](https://github.com/plastic-labs/honcho) 实现辩证用户建模。
+- **随处运行，不局限于笔记本** — 支持 6 种终端后端：本地、Docker、SSH、Daytona、Singularity、Modal。Daytona 与 Modal 提供无服务器持久化——空闲时环境进入休眠，费用几乎为零。
+- **随你所在之处而存活** — 支持 CLI、Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Mattermost、Email、SMS、钉钉、飞书、企业微信、微信、QQ Bot、元宝、BlueBubbles、Home Assistant、Microsoft Teams、Google Chat 等 20+ 平台的统一网关。
+- **模型训练者打造** — 由 [Nous Research](https://nousresearch.com) 构建，背后是 Hermes、Nomos 与 Psyche 系列模型。兼容 Nous Portal、OpenRouter、OpenAI 以及任何兼容的端点。
+- **计划任务** — 内置 cron，可将结果投递到任意平台。
+- **委派与并行** — 为并行工作流生成隔离子代理。通过 `execute_code` 的程序化工具调用，将多步骤流水线压缩为一次推理调用。
+- **开放标准技能** — 与 [agentskills.io](https://agentskills.io) 兼容。技能可移植、可共享，并通过 Skills Hub 社区贡献。
+- **完整的网页控制** — 搜索、提取、浏览、视觉、图像生成、文本转语音（TTS）。
+- **MCP 支持** — 连接任意 MCP 服务器以获得扩展工具功能。
+- **科研就绪** — 批处理、轨迹导出、使用 Atropos 进行强化学习训练。由 [Nous Research](https://nousresearch.com) 打造的实验平台。
+
+## 面向 LLM 和代码代理
+
+机器可读的文档入口点：
+
+- **[`/llms.txt`](/llms.txt)** — 每个文档页面的简要索引，约 17 KB，安全加载到 LLM 上下文。
+- **[`/llms-full.txt`](/llms-full.txt)** — 将所有文档页面合并为单一 markdown 文件，约 1.8 MB，适合一次性摄入。
+
+这两个文件也可以通过 `/docs/llms.txt` 与 `/docs/llms-full.txt` 访问。每次部署时都会重新生成。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -1,0 +1,436 @@
+---
+sidebar_position: 1
+title: "CLI 界面"
+description: "掌握 Hermes Agent 终端界面 —— 命令、快捷键、人格等"
+---
+
+# CLI 界面
+
+Hermes Agent 的 CLI 是完整的终端用户界面（TUI）——而不是网页 UI。它支持多行编辑、斜杠指令自动完成、对话历史、打断并重定向，以及流式工具输出。专为在终端中工作的用户打造。
+
+:::tip
+Hermes 还提供了带模态覆盖、鼠标选择和非阻塞输入的现代 TUI。使用 `hermes --tui` 启动——参见 [TUI](tui.md) 指南。
+:::
+
+## 运行 CLI
+
+```bash
+# 启动交互式会话（默认）
+hermes
+
+# 单次查询模式（非交互式）
+hermes chat -q "Hello"
+
+# 指定模型
+hermes chat --model "anthropic/claude-sonnet-4"
+
+# 指定提供商
+hermes chat --provider nous        # 使用 Nous Portal
+hermes chat --provider openrouter  # 强制使用 OpenRouter
+
+# 指定工具集
+hermes chat --toolsets "web,terminal,skills"
+
+# 启动时预加载一个或多个技能
+hermes -s hermes-agent-dev,github-auth
+hermes chat -s github-pr-workflow -q "open a draft PR"
+
+# 恢复先前会话
+hermes --continue             # 恢复最近的 CLI 会话（-c）
+hermes --resume <session_id>  # 按 ID 恢复指定会话
+
+# Verbose 模式（调试输出）
+hermes chat --verbose
+
+# 隔离的 git worktree（用于并行运行多个代理）
+hermes -w                         # 在 worktree 中交互模式
+hermes -w -q "Fix issue #123"     # 在 worktree 中单次查询
+```
+
+## 界面布局
+
+<img className="docs-terminal-figure" src="/img/docs/cli-layout.svg" alt="Hermes CLI 布局的艺术化预览，展示横幅、对话区域和固定输入提示。" />
+<p className="docs-figure-caption">Hermes CLI 横幅、对话流和固定输入提示，以稳定的文档图形方式呈现，而非易碎的文本艺术。</p>
+
+欢迎横幅一目了然地显示模型、终端后端、工作目录、可用工具以及已安装的技能。
+
+### 状态栏
+
+一个持久的状态栏位于输入区之上，实时更新：
+
+```
+ ⚕ claude-sonnet-4-20250514 │ 12.4K/200K │ [██████░░░░] 6% │ $0.06 │ 15m
+```
+
+| 元素 | 描述 |
+|------|------|
+| 模型名称 | 当前模型（若超过 26 字符则截断） |
+| 令牌计数 | 已使用的上下文令牌 / 最大上下文窗口 |
+| 上下文条 | 使用颜色编码阈值的可视化填充指示 |
+| 成本 | 估算的会话费用（若模型免费或未知则显示 `n/a`） |
+| 时长 | 会话已运行时间 |
+
+状态栏会根据终端宽度自适应——宽度 ≥ 76 列显示完整布局，52–75 列显示紧凑布局，<52 列仅显示模型 + 时长。
+
+**上下文颜色编码：**
+
+| 颜色 | 阈值 | 含义 |
+|------|------|------|
+| 绿色 | < 50% | 余量充足 |
+| 黄色 | 50–80% | 正在使用 |
+| 橙色 | 80–95% | 接近上限 |
+| 红色 | ≥ 95% | 接近溢出 —— 考虑使用 `/compress` |
+
+使用 `/usage` 可获取包括输入/输出令牌成本在内的详细拆分。
+
+### 会话恢复显示
+
+当通过 `hermes -c` 或 `hermes --resume <id>` 恢复先前会话时，会在横幅和输入提示之间出现“先前会话”面板，展示会话历史的紧凑回顾。详情请见 [Sessions — Conversation Recap on Resume](sessions.md#conversation-recap-on-resume)。
+
+## 快捷键
+
+| 键 | 操作 |
+|-----|------|
+| `Enter` | 发送消息 |
+| `Alt+Enter`、`Ctrl+J`、或 `Shift+Enter` | 换行（多行输入）。`Shift+Enter` 需要终端能区分此键——见下文。Windows Terminal 中 `Alt+Enter` 被终端捕获（全屏切换），请使用 `Ctrl+Enter` 或 `Ctrl+J` 替代。 |
+| `Alt+V` | 在支持的终端中从剪贴板粘贴图像 |
+| `Ctrl+V` | 粘贴文本并在可能时附加剪贴板图片 |
+| `Ctrl+B` | 在启用语音模式时开始/停止录音（`voice.record_key` 默认 `ctrl+b`） |
+| `Ctrl+G` | 在 `$EDITOR` 中打开当前输入缓冲区（vim/nvim/nano/VS Code 等）。保存并退出后将编辑后的文本作为下一条提示发送——适用于长段落提示。 |
+| `Ctrl+X Ctrl+E` | Emacs 风格的外部编辑器快捷键（同 `Ctrl+G`） |
+| `Ctrl+C` | 打断代理（在 2 秒内双击可强制退出） |
+| `Ctrl+D` | 退出 |
+| `Ctrl+Z` | 将 Hermes 挂起至后台（仅 Unix）。在 shell 中运行 `fg` 恢复。 |
+| `Tab` | 接受自动建议（幽灵文本）或自动完成斜杠指令 |
+
+**多行粘贴预览**：粘贴多行块时，CLI 会回显紧凑的单行预览（`[pasted: 47 lines, 1,842 chars — press Enter to send]`），而非将全部内容打印到滚动缓冲区。实际发送的仍是完整内容，仅为显示美化。
+
+**最终响应的 Markdown 处理**：CLI 会剥除最冗余的 Markdown 代码块以及 `**粗体**` / `*斜体*` 包装，使最终的终端回复成为可读的普通文字。代码块和列表会被保留。这不影响网关平台或工具结果——它们仍保留原始 Markdown 用于原生渲染。
+
+## 斜杠指令
+
+输入 `/` 可弹出自动完成下拉框。Hermes 支持大量 CLI 斜杠指令、动态技能指令以及用户自定义快捷指令。
+
+常用示例：
+
+| 指令 | 描述 |
+|------|------|
+| `/help` | 显示指令帮助 |
+| `/model` | 查看或更改当前模型 |
+| `/tools` | 列出当前可用工具 |
+| `/skills browse` | 浏览技能中心及官方可选技能 |
+| `/background <prompt>` | 在独立后台会话中运行提示 |
+| `/skin` | 查看或切换当前 CLI 皮肤 |
+| `/voice on` | 启用 CLI 语音模式（按 `Ctrl+B` 录音） |
+| `/voice tts` | 切换 Hermes 回复的语音播放 |
+| `/reasoning high` | 增强推理力度 |
+| `/title My Session` | 为当前会话命名 |
+
+完整的内置 CLI 与消息指令列表请参阅 [Slash Commands Reference](../reference/slash-commands.md)。
+
+关于设置、提供商、安静调校以及消息/Discord 语音使用，请参阅 [Voice Mode](features/voice-mode.md)。
+
+:::tip
+指令不区分大小写——`/HELP` 与 `/help` 等价。已安装的技能也会自动成为斜杠指令。
+:::
+
+## 快捷指令
+
+您可以定义自定义指令，在不调用 LLM 的情况下直接执行 shell 命令。这些指令在 CLI 与所有消息平台（Telegram、Discord 等）中均可使用。
+
+```yaml
+# ~/.hermes/config.yaml
+quick_commands:
+  status:
+    type: exec
+    command: systemctl status hermes-agent
+  gpu:
+    type: exec
+    command: nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
+```
+
+之后在任意聊天中输入 `/status`、`/gpu` 或 `/restart` 即可。更多示例请见 [配置指南](/docs/user-guide/configuration#quick-commands)。
+
+## 启动时预加载技能
+
+如果已经知道本次会话需要哪些技能，可在启动时一次性传入：
+
+```bash
+hermes -s hermes-agent-dev,github-auth
+hermes chat -s github-pr-workflow -s github-auth
+```
+
+Hermes 会在第一轮对话之前将每个指定技能加载进提示中。该标志在交互模式和单查询模式下均可使用。
+
+## 技能斜杠指令
+
+`~/.hermes/skills/` 中的每个已安装技能会自动注册为斜杠指令。技能名即指令名：
+
+```
+/gif-search funny cats
+/axolotl help me fine-tune Llama 3 on my dataset
+/github-pr-workflow create a PR for the auth refactor
+
+# 仅加载技能，让代理询问具体需求：
+/excalidraw
+```
+
+## 人格（Personalities）
+
+设置预定义人格以改变代理的语气：
+
+```
+/personality pirate
+/personality kawaii
+/personality concise
+```
+
+内置人格包括：`helpful`、`concise`、`technical`、`creative`、`teacher`、`kawaii`、`catgirl`、`pirate`、`shakespeare`、`surfer`、`noir`、`uwu`、`philosopher`、`hype`。
+
+您也可以在 `~/.hermes/config.yaml` 中自定义人格：
+
+```yaml
+personalities:
+  helpful: "You are a helpful, friendly AI assistant."
+  kawaii: "You are a kawaii assistant! Use cute expressions..."
+  pirate: "Arrr! Ye be talkin' to Captain Hermes..."
+  # 添加你的自定义人格
+```
+
+## 多行输入
+
+有两种方式输入多行消息：
+
+1. **`Alt+Enter`、`Ctrl+J` 或 `Shift+Enter`** — 插入新行
+2. **反斜杠续行** — 在行尾使用 `\` 继续，例如：
+
+```
+❯ Write a function that:\
+  1. Takes a list of numbers\
+  2. Returns the sum
+```
+
+:::info
+粘贴多行文本同样受支持——使用上述任意换行键，或直接粘贴内容。
+:::
+
+### Shift+Enter 兼容性
+
+大多数终端默认将 `Enter` 与 `Shift+Enter` 发送相同字节序列，导致应用无法区分。Hermes 仅在终端通过 [Kitty 键盘协议](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) 或 xterm 的 `modifyOtherKeys` 模式发送独立序列时才识别 `Shift+Enter`。
+
+| 终端 | 支持情况 |
+|------|----------|
+| Kitty、foot、WezTerm、Ghostty | 默认启用独立 `Shift+Enter` |
+| iTerm2（近期）、Alacritty、VS Code 终端、Warp | 在设置中启用 Kitty 协议后支持 |
+| Windows Terminal Preview 1.25+ | 在设置中启用 Kitty 协议后支持 |
+| macOS Terminal.app、官方 Windows Terminal（稳定版） | 不支持 —— `Shift+Enter` 与 `Enter` 无差别 |
+
+在终端无法区分时，`Alt+Enter` 与 `Ctrl+J` 仍可在所有环境中使用。**在 Windows Terminal 中，`Alt+Enter` 被终端捕获（切换全屏），请使用 `Ctrl+Enter`（等同于 `Ctrl+J`）或直接 `Ctrl+J` 换行。**
+
+## 中断代理
+
+您可以随时中断代理的执行：
+
+- **在代理工作时键入新消息并回车** —— 会中断当前任务并处理新指令
+- **`Ctrl+C`** —— 中断当前操作（双击 2 秒内强制退出）
+- 正在执行的终端命令会被立即终止（先 SIGTERM，1 秒后 SIGKILL）
+- 多条在中断期间键入的消息会合并为一次提示
+
+### 忙碌输入模式
+
+`display.busy_input_mode` 配置键决定在代理工作时按 Enter 的行为：
+
+| 模式 | 行为 |
+|------|------|
+| `"interrupt"`（默认） | 您的消息立即中断当前操作并被处理 |
+| `"queue"` | 您的消息静默排队，在代理完成后作为下一轮发送 |
+| `"steer"` | 您的消息通过 `/steer` 注入当前运行的工具调用后——不会中断，也不会生成新轮次 |
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  busy_input_mode: "steer"   # 可选 "queue" 或 "interrupt"
+```
+
+`"queue"` 适用于想准备后续消息却不想意外取消正在进行的工作。`"steer"` 适用于在代码编辑等任务中想在不打断的情况下指示额外操作，例如 “顺便检查测试”。未知值会回落到 `"interrupt"`。
+
+`"steer"` 有两种自动回退：如果代理尚未开始，或附带了图像，消息会退化为 `"queue"` 行为，确保信息不丢失。
+
+您也可以在 CLI 内动态切换：
+
+```text
+/busy queue
+/busy steer
+/busy interrupt
+/busy status
+```
+
+:::tip First‑touch hint
+第一次在 Hermes 工作时按 Enter，Hermes 会打印一行提醒解释 `/busy` 选项（"(tip) Your message interrupted the current run…"）。该提示仅在首次安装时出现——`config.yaml` 中的 `onboarding.seen.busy_input_prompt` 键会记录它。删除该键即可再次看到提示。
+:::
+
+## 挂起到后台（Unix）
+
+在 Unix 系统上，按 **`Ctrl+Z`** 可将 Hermes 挂起到后台——与任何终端进程的行为相同。Shell 会显示确认信息：
+
+```
+Hermes Agent has been suspended. Run `fg` to bring Hermes Agent back.
+```
+
+在 shell 中执行 `fg` 即可恢复会话，继续之前的交互。Windows 不支持此功能。
+
+## 工具进度显示
+
+CLI 会在代理工作时展示动画反馈：
+
+**思考动画（API 调用期间）**：
+```
+  ◜ (｡•́︿•̀｡) pondering... (1.2s)
+  ◠ (⊙_⊙) contemplating... (2.4s)
+  ✧٩(ˊᗜˋ*)و✧ got it! (3.1s)
+```
+
+**工具执行流**：
+```
+  ┊ 💻 terminal `ls -la` (0.3s)
+  ┊ 🔍 web_search (1.2s)
+  ┊ 📄 web_extract (2.1s)
+```
+
+使用 `/verbose` 在不同显示模式之间切换：`off → new → all → verbose`。此指令也可在消息平台上启用，参见 [配置](/docs/user-guide/configuration#display-settings)。
+
+### 工具预览长度
+
+`display.tool_preview_length` 配置键控制工具调用预览行的最大字符数（如文件路径、终端命令）。默认 `0` 表示不限制——完整路径和命令都会显示。
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  tool_preview_length: 80   # 将工具预览截断到 80 字符（0 为无限制）
+```
+
+在窄终端或参数包含超长路径时此设置非常有用。
+
+## 会话管理
+
+### 恢复会话
+
+退出 CLI 会话后，会打印恢复指令：
+
+```
+Resume this session with:
+  hermes --resume 20260225_143052_a1b2c3
+
+Session:        20260225_143052_a1b2c3
+Duration:       12m 34s
+Messages:       28 (5 user, 18 tool calls)
+```
+
+恢复选项：
+
+```bash
+hermes --continue                          # 恢复最近的 CLI 会话
+hermes -c                                  # 简写
+hermes -c "my project"                     # 恢复最近的同系列会话（按标题）
+hermes --resume 20260225_143052_a1b2c3     # 按 ID 恢复指定会话
+hermes --resume "refactoring auth"         # 按标题恢复
+hermes -r 20260225_143052_a1b2c3           # 简写
+```
+
+恢复会从 SQLite 中恢复完整对话历史。代理会看到所有先前的消息、工具调用以及响应——就像从未离开一样。
+
+使用 `/title My Session Name` 在聊天中为当前会话命名，或通过 `hermes sessions rename <id> <title>` 在命令行中重命名。`hermes sessions list` 可列出过去的会话。
+
+### 会话存储
+
+CLI 会话保存在 `~/.hermes/state.db` 的 SQLite 数据库中，包含：
+
+- 会话元数据（ID、标题、时间戳、令牌计数）
+- 消息历史
+- 跨压缩/恢复的会话血缘
+- `session_search` 使用的全文索引
+
+部分消息适配器也会在数据库旁边保存平台特定的转录文件，但 CLI 本身仅从 SQLite 恢复。
+
+### 上下文压缩
+
+当会话接近上下文限制时会自动摘要：
+
+```yaml
+# ~/.hermes/config.yaml
+compression:
+  enabled: true
+  threshold: 0.50    # 默认在 50% 上下文限制时触发压缩
+
+# 使用的摘要模型（在 auxiliary 中配置）
+auxiliary:
+  compression:
+    model: ""  # 空则使用主聊天模型（默认）。也可指定廉价快速模型，例如 "google/gemini-3-flash-preview"。
+```
+
+压缩触发后，会对中间回合进行摘要，而首 3 回合和最后 20 回合始终保留。
+
+## 后台会话
+
+使用斜杠指令在独立后台会话中运行提示，同时继续在前台使用 CLI：
+
+```
+/background Analyze the logs in /var/log and summarize any errors from today
+```
+
+Hermes 会立即确认任务并返回提示信息：
+
+```
+🔄 Background task #1 started: "Analyze the logs in /var/log and summarize..."
+   Task ID: bg_143022_a1b2c3
+```
+
+### 工作原理
+
+每个 `/background` 提示会在守护线程中生成一个 **完全独立的代理会话**：
+
+- **隔离对话** —— 背景代理不知晓当前会话的历史，仅收到该提示。
+- **相同配置** —— 继承当前会话的模型、提供商、工具集、推理设置等。
+- **非阻塞** —— 前台会话保持交互，可继续聊天、运行命令或启动更多后台任务。
+- **多任务** —— 可同时运行多个后台任务，每个任务都有编号 ID。
+
+### 结果展示
+
+后台任务完成后，结果会以面板形式出现在终端：
+
+```
+╭─ ⚕ Hermes (background #1) ──────────────────────────────────╮
+│ Found 3 errors in syslog from today:                         │
+│ 1. OOM killer invoked at 03:22 — killed process nginx        │
+│ 2. Disk I/O error on /dev/sda1 at 07:15                      │
+│ 3. Failed SSH login attempts from 192.168.1.50 at 14:30      │
+╰──────────────────────────────────────────────────────────────╯
+```
+
+若任务失败，将显示错误通知。如果 `display.bell_on_complete` 在配置中启用，任务完成时会响铃。
+
+### 使用场景
+
+- **长期研究** — `/background research the latest developments in quantum error correction` 与此同时继续编码。
+- **文件处理** — `/background analyze all Python files in this repo and list any security issues` 与此同时继续对话。
+- **并行调查** — 启动多个后台任务，同时探索不同角度。
+
+:::info
+后台会话不出现在主对话历史中。它们是拥有独立任务 ID（如 `bg_143022_a1b2c3`）的独立会话。
+:::
+
+## 安静模式（Quiet Mode）
+
+默认情况下，CLI 运行在安静模式下，
+- 抑制工具的详细日志
+- 启用可爱风格的动画反馈
+- 保持输出简洁友好
+
+如需调试输出：
+
+```bash
+hermes chat --verbose
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1,0 +1,1726 @@
+---
+sidebar_position: 2
+title: "配置"
+description: "Configure Hermes Agent — config.yaml, providers, models, API keys, and more"
+---
+
+# Configuration
+
+All settings are stored in the `~/.hermes/` directory for easy access.
+
+## Directory Structure
+
+```text
+~/.hermes/
+├── config.yaml     # Settings (model, terminal, TTS, compression, etc.)
+├── .env            # API keys and secrets
+├── auth.json       # OAuth provider credentials (Nous Portal, etc.)
+├── SOUL.md         # Primary agent identity (slot #1 in system prompt)
+├── memories/       # Persistent memory (MEMORY.md, USER.md)
+├── skills/         # Agent-created skills (managed via skill_manage tool)
+├── cron/           # Scheduled jobs
+├── sessions/       # Gateway sessions
+└── logs/           # Logs (errors.log, gateway.log — secrets auto-redacted)
+```
+
+## Managing Configuration
+
+```bash
+hermes config              # View current configuration
+hermes config edit         # Open config.yaml in your editor
+hermes config set KEY VAL  # Set a specific value
+hermes config check        # Check for missing options (after updates)
+hermes config migrate      # Interactively add missing options
+
+# Examples:
+hermes config set model anthropic/claude-opus-4
+hermes config set terminal.backend docker
+hermes config set OPENROUTER_API_KEY sk-or-...  # Saves to .env
+```
+
+:::tip
+The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`.
+:::
+
+## Configuration Precedence
+
+Settings are resolved in this order (highest priority first):
+
+1. **CLI arguments** — e.g., `hermes chat --model anthropic/claude-sonnet-4` (per-invocation override)
+2. **`~/.hermes/config.yaml`** — the primary config file for all non-secret settings
+3. **`~/.hermes/.env`** — fallback for env vars; **required** for secrets (API keys, tokens, passwords)
+4. **Built-in defaults** — hardcoded safe defaults when nothing else is set
+
+:::info Rule of Thumb
+Secrets (API keys, bot tokens, passwords) go in `.env`. Everything else (model, terminal backend, compression settings, memory limits, toolsets) goes in `config.yaml`. When both are set, `config.yaml` wins for non-secret settings.
+:::
+
+## Environment Variable Substitution
+
+You can reference environment variables in `config.yaml` using `${VAR_NAME}` syntax:
+
+```yaml
+auxiliary:
+  vision:
+    api_key: ${GOOGLE_API_KEY}
+    base_url: ${CUSTOM_VISION_URL}
+
+delegation:
+  api_key: ${DELEGATION_KEY}
+```
+
+Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a referenced variable is not set, the placeholder is kept verbatim (`${UNDEFINED_VAR}` stays as-is). Only the `${VAR}` syntax is supported — bare `$VAR` is not expanded.
+
+For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/docs/integrations/providers).
+
+### Provider Timeouts
+
+You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.
+
+You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming stale-call detector, plus `providers.<id>.models.<model>.stale_timeout_seconds` for a model-specific override. This wins over the legacy `HERMES_API_CALL_STALE_TIMEOUT` env var.
+
+Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=300`s, native Anthropic 900s). Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
+
+## Terminal Backend Configuration
+
+Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
+
+```yaml
+terminal:
+  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
+  timeout: 180      # Per-command timeout in seconds
+  env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
+  singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
+  modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
+  daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
+```
+
+For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
+
+### Backend Overview
+
+| Backend | Where commands run | Isolation | Best for |
+|---------|-------------------|-----------|----------|
+| **local** | Your machine directly | None | Development, personal use |
+| **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
+| **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
+| **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
+| **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
+| **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
+| **singularity** | Singularity/Apptainer container | Namespaces (--containall) | HPC clusters, shared machines |
+
+### Local Backend
+
+The default. Commands run directly on your machine with no isolation. No special setup required.
+
+```yaml
+terminal:
+  backend: local
+```
+
+:::warning
+The agent has the same filesystem access as your user account. Use `hermes tools` to disable tools you don't want, or switch to Docker for sandboxing.
+:::
+
+### Docker Backend
+
+Runs commands inside a Docker container with security hardening (all capabilities dropped, no privilege escalation, PID limits).
+
+**Single persistent container, not per-command.** Hermes starts ONE long-lived container on first use and routes every terminal, file, and `execute_code` call through `docker exec` into that same container — across sessions, `/new`, `/reset`, and `delegate_task` subagents — for the lifetime of the Hermes process. Working-directory changes, installed packages, and files in `/workspace` carry over from one tool call to the next, just like a local shell. The container is stopped and removed on shutdown. See **Container lifecycle** below for details.
+
+```yaml
+terminal:
+  backend: docker
+  docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
+  docker_mount_cwd_to_workspace: false  # Mount launch dir into /workspace
+  docker_run_as_host_user: false   # See "Running container as host user" below
+  docker_forward_env:              # Env vars to forward into container
+    - "GITHUB_TOKEN"
+  docker_volumes:                  # Host directory mounts
+    - "/home/user/projects:/workspace/projects"
+    - "/home/user/data:/data:ro"   # :ro for read-only
+
+  # Resource limits
+  container_cpu: 1                 # CPU cores (0 = unlimited)
+  container_memory: 5120           # MB (0 = unlimited)
+  container_disk: 51200            # MB (requires overlay2 on XFS+pquota)
+  container_persistent: true       # Persist /workspace and /root across sessions
+```
+
+**Requirements:** Docker Desktop or Docker Engine installed and running. Hermes probes `$PATH` plus common macOS install locations (`/usr/local/bin/docker`, `/opt/homebrew/bin/docker`, Docker Desktop app bundle). Podman is supported out of the box: set `HERMES_DOCKER_BINARY=podman` (or the full path) to force it when both are installed.
+
+**Container lifecycle:** Hermes reuses a single long-lived container (`docker run -d ... sleep 2h`) for every terminal and file-tool call, across sessions, `/new`, `/reset`, and `delegate_task` subagents, for the lifetime of the Hermes process. Commands run via `docker exec` with a login shell, so working-directory changes, installed packages, and files in `/workspace` all persist from one tool call to the next. The container is stopped and removed on Hermes shutdown (or when the idle-sweep reclaims it).
+
+Parallel subagents spawned via `delegate_task(tasks=[...])` share this one container — concurrent `cd`, env mutations, and writes to the same path will collide. If a subagent needs an isolated sandbox, it must register a per-task image override via `register_task_env_overrides()`, which RL and benchmark environments (TerminalBench2, HermesSweEnv, etc.) do automatically for their per-task Docker images.
+
+**Security hardening:**
+- `--cap-drop ALL` with only `DAC_OVERRIDE`, `CHOWN`, `FOWNER` added back
+- `--security-opt no-new-privileges`
+- `--pids-limit 256`
+- Size-limited tmpfs for `/tmp` (512MB), `/var/tmp` (256MB), `/run` (64MB)
+
+**Credential forwarding:** Env vars listed in `docker_forward_env` are resolved from your shell environment first, then `~/.hermes/.env`. Skills can also declare `required_environment_variables` which are merged automatically.
+
+### SSH Backend
+
+Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
+
+```yaml
+terminal:
+  backend: ssh
+  persistent_shell: true           # Keep a long-lived bash session (default: true)
+```
+
+**Required environment variables:**
+
+```bash
+TERMINAL_SSH_HOST=my-server.example.com
+TERMINAL_SSH_USER=ubuntu
+```
+
+**Optional:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TERMINAL_SSH_PORT` | `22` | SSH port |
+| `TERMINAL_SSH_KEY` | (system default) | Path to SSH private key |
+| `TERMINAL_SSH_PERSISTENT` | `true` | Enable persistent shell |
+
+**How it works:** Connects at init time with `BatchMode=yes` and `StrictHostKeyChecking=accept-new`. Persistent shell keeps a single `bash -l` process alive on the remote host, communicating via temporary files. Commands that need `stdin_data` or `sudo` automatically fall back to one-shot mode.
+
+### Modal Backend
+
+Runs commands in a [Modal](https://modal.com) cloud sandbox. Each task gets an isolated VM with configurable CPU, memory, and disk. Filesystem can be snapshot/restored across sessions.
+
+```yaml
+terminal:
+  backend: modal
+  container_cpu: 1                 # CPU cores
+  container_memory: 5120           # MB (5GB)
+  container_disk: 51200            # MB (50GB)
+  container_persistent: true       # Snapshot/restore filesystem
+```
+
+**Required:** Either `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` environment variables, or a `~/.modal.toml` config file.
+
+**Persistence:** When enabled, the sandbox filesystem is snapshotted on cleanup and restored on next session. Snapshots are tracked in `~/.hermes/modal_snapshots.json`. This preserves filesystem state, not live processes, PID space, or background jobs.
+
+**Credential files:** Automatically mounted from `~/.hermes/` (OAuth tokens, etc.) and synced before each command.
+
+### Daytona Backend
+
+Runs commands in a [Daytona](https://daytona.io) managed workspace. Supports stop/resume for persistence.
+
+```yaml
+terminal:
+  backend: daytona
+  container_cpu: 1                 # CPU cores
+  container_memory: 5120           # MB → converted to GiB
+  container_disk: 10240            # MB → converted to GiB (max 10 GiB)
+  container_persistent: true       # Stop/resume instead of delete
+```
+
+**Required:** `DAYTONA_API_KEY` environment variable.
+
+**Persistence:** When enabled, sandboxes are stopped (not deleted) on cleanup and resumed on next session. Sandbox names follow the pattern `hermes-{task_id}`.
+
+**Disk limit:** Daytona enforces a 10 GiB maximum. Requests above this are capped with a warning.
+
+### Vercel Sandbox Backend
+
+Runs commands in a [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) cloud microVM. Hermes uses the normal terminal and file tool surfaces; there are no Vercel-specific model-facing tools.
+
+```yaml
+terminal:
+  backend: vercel_sandbox
+  vercel_runtime: node24          # node24 | node22 | python3.13
+  cwd: /vercel/sandbox            # default workspace root
+  container_persistent: true      # Snapshot/restore filesystem
+  container_disk: 51200           # Shared default only; custom disk is unsupported
+```
+
+**Required install:** Install the optional SDK extra:
+
+```bash
+pip install 'hermes-agent[vercel]'
+```
+
+**Required authentication:** Configure access-token auth with all three of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. This is the supported setup for deployments and normal long-running Hermes processes on Render, Railway, Docker, and similar hosts.
+
+For one-off local development, Hermes also accepts short-lived Vercel OIDC tokens:
+
+```bash
+VERCEL_OIDC_TOKEN="$(vc project token <project-name>)" hermes chat
+```
+
+From a linked Vercel project directory, you can omit the project name:
+
+```bash
+VERCEL_OIDC_TOKEN="$(vc project token)" hermes chat
+```
+
+OIDC tokens are short-lived and should not be used as the documented deployment path.
+
+**Runtime:** `terminal.vercel_runtime` supports `node24`, `node22`, and `python3.13`. If unset, Hermes defaults to `node24`.
+
+**Persistence:** When `container_persistent: true`, Hermes snapshots the sandbox filesystem during cleanup and restores a later sandbox for the same task from that snapshot. Snapshot contents can include Hermes-synced credentials, skills, and cache files that were copied into the sandbox. This preserves filesystem state only; it does not preserve live sandbox identity, PID space, shell state, or running background processes.
+
+**Background commands:** `terminal(background=true)` uses Hermes' generic non-local background process flow. You can spawn, poll, wait, view logs, and kill processes through the normal process tool while the sandbox is alive. Hermes does not provide native Vercel detached-process recovery after cleanup or restart.
+
+**Disk sizing:** Vercel Sandbox does not currently support Hermes' `container_disk` resource knob. Leave `container_disk` unset or at the shared default `51200`; non-default values fail diagnostics and backend creation instead of being silently ignored.
+
+### Singularity/Apptainer Backend
+
+Runs commands in a [Singularity/Apptainer](https://apptainer.org) container. Designed for HPC clusters and shared machines where Docker isn't available.
+
+```yaml
+terminal:
+  backend: singularity
+  singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"
+  container_cpu: 1                 # CPU cores
+  container_memory: 5120           # MB
+  container_persistent: true       # Writable overlay persists across sessions
+```
+
+**Requirements:** `apptainer` or `singularity` binary in `$PATH`.
+
+**Image handling:** Docker URLs (`docker://...`) are automatically converted to SIF files and cached. Existing `.sif` files are used directly.
+
+**Scratch directory:** Resolved in order: `TERMINAL_SCRATCH_DIR` → `TERMINAL_SANDBOX_DIR/singularity` → `/scratch/$USER/hermes-agent` (HPC convention) → `~/.hermes/sandboxes/singularity`.
+
+**Isolation:** Uses `--containall --no-home` for full namespace isolation without mounting the host home directory.
+
+### Common Terminal Backend Issues
+
+If terminal commands fail immediately or the terminal tool is reported as disabled:
+
+- **Local** — No special requirements. The safest default when getting started.
+- **Docker** — Run `docker version` to verify Docker is working. If it fails, fix Docker or `hermes config set terminal.backend local`.
+- **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
+- **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.
+- **Daytona** — Needs `DAYTONA_API_KEY`. The Daytona SDK handles server URL configuration.
+- **Singularity** — Needs `apptainer` or `singularity` in `$PATH`. Common on HPC clusters.
+
+When in doubt, set `terminal.backend` back to `local` and verify that commands run there first.
+
+### Remote-to-Host File Sync on Teardown
+
+For the **SSH**, **Modal**, and **Daytona** backends (anywhere the agent's working tree lives on a different machine than the host running Hermes), Hermes tracks files the agent touched inside the remote sandbox and, on session teardown / sandbox cleanup, **syncs the modified files back to the host** under `~/.hermes/cache/remote-syncs/<session-id>/`.
+
+- Triggers on: session close, `/new`, `/reset`, gateway message timeout, `delegate_task` subagent completion when the child used a remote backend.
+- Covers the whole tree the agent modified, not just files it explicitly opened. Additions, edits, and deletions are all captured.
+- The remote sandbox may have been torn down by the time you go looking; the local `~/.hermes/cache/remote-syncs/…` copy is the authoritative record of what the agent changed.
+- Large binary outputs (model checkpoints, raw datasets) are capped by size — the sync skips files over `file_sync_max_mb` (default `100`). Bump that if you expect bigger artifacts to come back.
+
+```yaml
+terminal:
+  file_sync_max_mb: 100     # default — sync files up to 100 MB each
+  file_sync_enabled: true   # default — set false to skip the sync entirely
+```
+
+This is how you recover results from ephemeral cloud sandboxes that get destroyed after the session ends, without having to tell the agent to explicitly `scp` or `modal volume put` every artifact.
+
+### Docker Volume Mounts
+
+When using the Docker backend, `docker_volumes` lets you share host directories with the container. Each entry uses standard Docker `-v` syntax: `host_path:container_path[:options]`.
+
+```yaml
+terminal:
+  backend: docker
+  docker_volumes:
+    - "/home/user/projects:/workspace/projects"   # Read-write (default)
+    - "/home/user/datasets:/data:ro"              # Read-only
+    - "/home/user/.hermes/cache/documents:/output" # Gateway-visible exports
+```
+
+This is useful for:
+- **Providing files** to the agent (datasets, configs, reference code)
+- **Receiving files** from the agent (generated code, reports, exports)
+- **Shared workspaces** where both you and the agent access the same files
+
+If you use a messaging gateway and want the agent to send generated files via
+`MEDIA:/...`, prefer a dedicated host-visible export mount such as
+`/home/user/.hermes/cache/documents:/output`.
+
+- Write files inside Docker to `/output/...`
+- Emit the **host path** in `MEDIA:`, for example:
+  `MEDIA:/home/user/.hermes/cache/documents/report.txt`
+- Do **not** emit `/workspace/...` or `/output/...` unless that exact path also
+  exists for the gateway process on the host
+
+:::warning
+YAML duplicate keys silently override earlier ones. If you already have a
+`docker_volumes:` block, merge new mounts into the same list instead of adding
+another `docker_volumes:` key later in the file.
+:::
+
+Can also be set via environment variable: `TERMINAL_DOCKER_VOLUMES='["/host:/container"]'` (JSON array).
+
+### Docker Credential Forwarding
+
+By default, Docker terminal sessions do not inherit arbitrary host credentials. If you need a specific token inside the container, add it to `terminal.docker_forward_env`.
+
+```yaml
+terminal:
+  backend: docker
+  docker_forward_env:
+    - "GITHUB_TOKEN"
+    - "NPM_TOKEN"
+```
+
+Hermes resolves each listed variable from your current shell first, then falls back to `~/.hermes/.env` if it was saved with `hermes config set`.
+
+:::warning
+Anything listed in `docker_forward_env` becomes visible to commands run inside the container. Only forward credentials you are comfortable exposing to the terminal session.
+:::
+
+### Running the Container as Your Host User
+
+By default Docker containers run as `root` (UID 0). Files created inside `/workspace` or other bind-mounts end up owned by root on the host, so after a session you have to `sudo chown` them before you can edit them from your host editor. The `terminal.docker_run_as_host_user` flag fixes this:
+
+```yaml
+terminal:
+  backend: docker
+  docker_run_as_host_user: true   # default: false
+```
+
+When enabled, Hermes appends `--user $(id -u):$(id -g)` to the `docker run` command so files written into bind-mounted directories (`/workspace`, `/root`, anything in `docker_volumes`) are owned by your host user, not root. The trade-off: the container can no longer `apt install` or write to root-owned paths like `/root/.npm` — use a base image whose `HOME` is owned by a non-root user (or add your required tooling at image build time) if you need both.
+
+Leave this `false` (the default) for backwards-compatible behavior. Turn it on when your workflow is mostly "edit mounted host files" and you're tired of `sudo chown -R`.
+
+### Optional: Mount the Launch Directory into `/workspace`
+
+Docker sandboxes stay isolated by default. Hermes does **not** pass your current host working directory into the container unless you explicitly opt in.
+
+Enable it in `config.yaml`:
+
+```yaml
+terminal:
+  backend: docker
+  docker_mount_cwd_to_workspace: true
+```
+
+When enabled:
+- if you launch Hermes from `~/projects/my-app`, that host directory is bind-mounted to `/workspace`
+- the Docker backend starts in `/workspace`
+- file tools and terminal commands both see the same mounted project
+
+When disabled, `/workspace` stays sandbox-owned unless you explicitly mount something via `docker_volumes`.
+
+Security tradeoff:
+- `false` preserves the sandbox boundary
+- `true` gives the sandbox direct access to the directory you launched Hermes from
+
+Use the opt-in only when you intentionally want the container to work on live host files.
+
+### Persistent Shell
+
+By default, each terminal command runs in its own subprocess — working directory, environment variables, and shell variables reset between commands. When **persistent shell** is enabled, a single long-lived bash process is kept alive across `execute()` calls so that state survives between commands.
+
+This is most useful for the **SSH backend**, where it also eliminates per-command connection overhead. Persistent shell is **enabled by default for SSH** and disabled for the local backend.
+
+```yaml
+terminal:
+  persistent_shell: true   # default — enables persistent shell for SSH
+```
+
+To disable:
+
+```bash
+hermes config set terminal.persistent_shell false
+```
+
+**What persists across commands:**
+- Working directory (`cd /tmp` sticks for the next command)
+- Exported environment variables (`export FOO=bar`)
+- Shell variables (`MY_VAR=hello`)
+
+**Precedence:**
+
+| Level | Variable | Default |
+|-------|----------|---------|
+| Config | `terminal.persistent_shell` | `true` |
+| SSH override | `TERMINAL_SSH_PERSISTENT` | follows config |
+| Local override | `TERMINAL_LOCAL_PERSISTENT` | `false` |
+
+Per-backend environment variables take highest precedence. If you want persistent shell on the local backend too:
+
+```bash
+export TERMINAL_LOCAL_PERSISTENT=true
+```
+
+:::note
+Commands that require `stdin_data` or sudo automatically fall back to one-shot mode, since the persistent shell's stdin is already occupied by the IPC protocol.
+:::
+
+See [Code Execution](features/code-execution.md) and the [Terminal section of the README](features/tools.md) for details on each backend.
+
+## Skill Settings
+
+Skills can declare their own configuration settings via their SKILL.md frontmatter. These are non-secret values (paths, preferences, domain settings) stored under the `skills.config` namespace in `config.yaml`.
+
+```yaml
+skills:
+  config:
+    myplugin:
+      path: ~/myplugin-data   # Example — each skill defines its own keys
+```
+
+**How skill settings work:**
+
+- `hermes config migrate` scans all enabled skills, finds unconfigured settings, and offers to prompt you
+- `hermes config show` displays all skill settings under "Skill Settings" with the skill they belong to
+- When a skill loads, its resolved config values are injected into the skill context automatically
+
+**Setting values manually:**
+
+```bash
+hermes config set skills.config.myplugin.path ~/myplugin-data
+```
+
+For details on declaring config settings in your own skills, see [Creating Skills — Config Settings](/docs/developer-guide/creating-skills#config-settings-configyaml).
+
+### Guard on agent-created skill writes
+
+When the agent uses `skill_manage` to create, edit, patch, or delete a skill, Hermes can optionally scan the new/updated content for dangerous keyword patterns (credential harvesting, obvious prompt injection, exfil instructions). The scanner is **off by default** — real agent workflows that legitimately touch `~/.ssh/` or mention `$OPENAI_API_KEY` were tripping the heuristic too often. Turn it back on if you want the scanner to prompt you before the agent's skill writes land:
+
+```yaml
+skills:
+  guard_agent_created: true   # default: false
+```
+
+When on, any flagged `skill_manage` write surfaces as an approval prompt with the scanner's rationale. Accepted writes land; denied writes return an explanatory error to the agent.
+
+## Memory Configuration
+
+```yaml
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200   # ~800 tokens
+  user_char_limit: 1375     # ~500 tokens
+```
+
+## File Read Safety
+
+Controls how much content a single `read_file` call can return. Reads that exceed the limit are rejected with an error telling the agent to use `offset` and `limit` for a smaller range. This prevents a single read of a minified JS bundle or large data file from flooding the context window.
+
+```yaml
+file_read_max_chars: 100000  # default — ~25-35K tokens
+```
+
+Raise it if you're on a model with a large context window and frequently read big files. Lower it for small-context models to keep reads efficient:
+
+```yaml
+# Large context model (200K+)
+file_read_max_chars: 200000
+
+# Small local model (16K context)
+file_read_max_chars: 30000
+```
+
+The agent also deduplicates file reads automatically — if the same file region is read twice and the file hasn't changed, a lightweight stub is returned instead of re-sending the content. This resets on context compression so the agent can re-read files after their content is summarized away.
+
+## Tool Output Truncation Limits
+
+Three related caps control how much raw output a tool can return before Hermes truncates it:
+
+```yaml
+tool_output:
+  max_bytes: 50000        # terminal output cap (chars)
+  max_lines: 2000         # read_file pagination cap
+  max_line_length: 2000   # per-line cap in read_file's line-numbered view
+```
+
+- **`max_bytes`** — When a `terminal` command produces more than this many characters of combined stdout/stderr, Hermes keeps the first 40% and last 60% and inserts a `[OUTPUT TRUNCATED]` notice between them. Default `50000` (≈12-15K tokens across typical tokenisers).
+- **`max_lines`** — Upper bound on the `limit` parameter of a single `read_file` call. Requests above this are clamped so a single read can't flood the context window. Default `2000`.
+- **`max_line_length`** — Per-line cap applied when `read_file` emits the line-numbered view. Lines longer than this are truncated to this many chars followed by `... [truncated]`. Default `2000`.
+
+Raise the limits on models with large context windows that can afford more raw output per call. Lower them for small-context models to keep tool results compact:
+
+```yaml
+# Large context model (200K+)
+tool_output:
+  max_bytes: 150000
+  max_lines: 5000
+
+# Small local model (16K context)
+tool_output:
+  max_bytes: 20000
+  max_lines: 500
+```
+
+## Global Toolset Disable
+
+To suppress specific toolsets across the CLI and every gateway platform in one
+place, list their names under `agent.disabled_toolsets`:
+
+```yaml
+agent:
+  disabled_toolsets:
+    - memory       # hide memory tools + MEMORY_GUIDANCE injection
+    - web          # no web_search / web_extract anywhere
+```
+
+This applies **after** per-platform tool config (`platform_toolsets` written by
+`hermes tools`), so a toolset listed here is always removed — even if a
+platform's saved config still lists it. Use this when you want a single
+switch for "turn X off everywhere" rather than editing 15+ platform rows in
+the `hermes tools` UI.
+
+Leaving the list empty, or omitting the key, is a no-op.
+
+## Git Worktree Isolation
+
+Enable isolated git worktrees for running multiple agents in parallel on the same repo:
+
+```yaml
+worktree: true    # Always create a worktree (same as hermes -w)
+# worktree: false # Default — only when -w flag is passed
+```
+
+When enabled, each CLI session creates a fresh worktree under `.worktrees/` with its own branch. Agents can edit files, commit, push, and create PRs without interfering with each other. Clean worktrees are removed on exit; dirty ones are kept for manual recovery.
+
+You can also list gitignored files to copy into worktrees via `.worktreeinclude` in your repo root:
+
+```
+# .worktreeinclude
+.env
+.venv/
+node_modules/
+```
+
+## Context Compression
+
+Hermes automatically compresses long conversations to stay within your model's context window. The compression summarizer is a separate LLM call — you can point it at any provider or endpoint.
+
+All compression settings live in `config.yaml` (no environment variables).
+
+### Full reference
+
+```yaml
+compression:
+  enabled: true                                     # Toggle compression on/off
+  threshold: 0.50                                   # Compress at this % of context limit
+  target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
+  protect_last_n: 20                                # Min recent messages to keep uncompressed
+  hygiene_hard_message_limit: 400                   # Gateway safety valve — see below
+
+# The summarization model/provider is configured under auxiliary:
+auxiliary:
+  compression:
+    model: ""                                       # Empty = use main chat model. Override with e.g. "google/gemini-3-flash-preview" for cheaper/faster compression.
+    provider: "auto"                                # Provider: "auto", "openrouter", "nous", "codex", "main", etc.
+    base_url: null                                  # Custom OpenAI-compatible endpoint (overrides provider)
+```
+
+:::info Legacy config migration
+Older configs with `compression.summary_model`, `compression.summary_provider`, and `compression.summary_base_url` are automatically migrated to `auxiliary.compression.*` on first load (config version 17). No manual action needed.
+:::
+
+`hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+
+:::tip Gateway hot-reload of compression and context length
+As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
+:::
+
+### Common setups
+
+**Default (auto-detect) — no configuration needed:**
+```yaml
+compression:
+  enabled: true
+  threshold: 0.50
+```
+Uses your main provider and main model. Override per-task (e.g. `auxiliary.compression.provider: openrouter` + `model: google/gemini-2.5-flash`) if you want compression on a cheaper model than your main chat model.
+
+**Force a specific provider** (OAuth or API-key based):
+```yaml
+auxiliary:
+  compression:
+    provider: nous
+    model: gemini-3-flash
+```
+Works with any provider: `nous`, `openrouter`, `codex`, `anthropic`, `main`, etc.
+
+**Custom endpoint** (self-hosted, Ollama, zai, DeepSeek, etc.):
+```yaml
+auxiliary:
+  compression:
+    model: glm-4.7
+    base_url: https://api.z.ai/api/coding/paas/v4
+```
+Points at a custom OpenAI-compatible endpoint. Uses `OPENAI_API_KEY` for auth.
+
+### How the three knobs interact
+
+| `auxiliary.compression.provider` | `auxiliary.compression.base_url` | Result |
+|---------------------|---------------------|--------|
+| `auto` (default) | not set | Auto-detect best available provider |
+| `nous` / `openrouter` / etc. | not set | Force that provider, use its auth |
+| any | set | Use the custom endpoint directly (provider ignored) |
+
+:::warning Summary model context length requirement
+The summary model **must** have a context window at least as large as your main agent model's. The compressor sends the full middle section of the conversation to the summary model — if that model's context window is smaller than the main model's, the summarization call will fail with a context length error. When this happens, the middle turns are **dropped without a summary**, losing conversation context silently. If you override the model, verify its context length meets or exceeds your main model's.
+:::
+
+## Context Engine
+
+The context engine controls how conversations are managed when approaching the model's token limit. The built-in `compressor` engine uses lossy summarization (see [Context Compression](/docs/developer-guide/context-compression-and-caching)). Plugin engines can replace it with alternative strategies.
+
+```yaml
+context:
+  engine: "compressor"    # default — built-in lossy summarization
+```
+
+To use a plugin engine (e.g., LCM for lossless context management):
+
+```yaml
+context:
+  engine: "lcm"          # must match the plugin's name
+```
+
+Plugin engines are **never auto-activated** — you must explicitly set `context.engine` to the plugin name. Available engines can be browsed and selected via `hermes plugins` → Provider Plugins → Context Engine.
+
+See [Memory Providers](/docs/user-guide/features/memory-providers) for the analogous single-select system for memory plugins.
+
+## Iteration Budget Pressure
+
+When the agent is working on a complex task with many tool calls, it can burn through its iteration budget (default: 90 turns) without realizing it's running low. Budget pressure automatically warns the model as it approaches the limit:
+
+| Threshold | Level | What the model sees |
+|-----------|-------|---------------------|
+| **70%** | Caution | `[BUDGET: 63/90. 27 iterations left. Start consolidating.]` |
+| **90%** | Warning | `[BUDGET WARNING: 81/90. Only 9 left. Respond NOW.]` |
+
+Warnings are injected into the last tool result's JSON (as a `_budget_warning` field) rather than as separate messages — this preserves prompt caching and doesn't disrupt the conversation structure.
+
+```yaml
+agent:
+  max_turns: 90                # Max iterations per conversation turn (default: 90)
+  api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+```
+
+Budget pressure is enabled by default. The agent sees warnings naturally as part of tool results, encouraging it to consolidate its work and deliver a response before running out of iterations.
+
+When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`. If the budget runs out during active work, the agent generates a summary of what was accomplished before stopping.
+
+`agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/docs/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+
+### API Timeouts
+
+Hermes has separate timeout layers for streaming, plus a stale detector for non-streaming calls. The stale detectors auto-adjust for local providers only when you leave them at their implicit defaults.
+
+| Timeout | Default | Local providers | Config / env |
+|---------|---------|----------------|--------------|
+| Socket read timeout | 120s | Auto-raised to 1800s | `HERMES_STREAM_READ_TIMEOUT` |
+| Stale stream detection | 180s | Auto-disabled | `HERMES_STREAM_STALE_TIMEOUT` |
+| Stale non-stream detection | 300s | Auto-disabled when left implicit | `providers.<id>.stale_timeout_seconds` or `HERMES_API_CALL_STALE_TIMEOUT` |
+| API call (non-streaming) | 1800s | Unchanged | `providers.<id>.request_timeout_seconds` / `timeout_seconds` or `HERMES_API_TIMEOUT` |
+
+The **socket read timeout** controls how long httpx waits for the next chunk of data from the provider. Local LLMs can take minutes for prefill on large contexts before producing the first token, so Hermes raises this to 30 minutes when it detects a local endpoint. If you explicitly set `HERMES_STREAM_READ_TIMEOUT`, that value is always used regardless of endpoint detection.
+
+The **stale stream detection** kills connections that receive SSE keep-alive pings but no actual content. This is disabled entirely for local providers since they don't send keep-alive pings during prefill.
+
+The **stale non-stream detection** kills non-streaming calls that produce no response for too long. By default Hermes disables this on local endpoints to avoid false positives during long prefills. If you explicitly set `providers.<id>.stale_timeout_seconds`, `providers.<id>.models.<model>.stale_timeout_seconds`, or `HERMES_API_CALL_STALE_TIMEOUT`, that explicit value is honored even on local endpoints.
+
+## Context Pressure Warnings
+
+Separate from iteration budget pressure, context pressure tracks how close the conversation is to the **compaction threshold** — the point where context compression fires to summarize older messages. This helps both you and the agent understand when the conversation is getting long.
+
+| Progress | Level | What happens |
+|----------|-------|-------------|
+| **≥ 60%** to threshold | Info | CLI shows a cyan progress bar; gateway sends an informational notice |
+| **≥ 85%** to threshold | Warning | CLI shows a bold yellow bar; gateway warns compaction is imminent |
+
+In the CLI, context pressure appears as a progress bar in the tool output feed:
+
+```
+  ◐ context ████████████░░░░░░░░ 62% to compaction  48k threshold (50%) · approaching compaction
+```
+
+On messaging platforms, a plain-text notification is sent:
+
+```
+◐ Context: ████████████░░░░░░░░ 62% to compaction (threshold: 50% of window).
+```
+
+If auto-compression is disabled, the warning tells you context may be truncated instead.
+
+Context pressure is automatic — no configuration needed. It fires purely as a user-facing notification and does not modify the message stream or inject anything into the model's context.
+
+## Credential Pool Strategies
+
+When you have multiple API keys or OAuth tokens for the same provider, configure the rotation strategy:
+
+```yaml
+credential_pool_strategies:
+  openrouter: round_robin    # cycle through keys evenly
+  anthropic: least_used      # always pick the least-used key
+```
+
+Options: `fill_first` (default), `round_robin`, `least_used`, `random`. See [Credential Pools](/docs/user-guide/features/credential-pools) for full documentation.
+
+## Auxiliary Models
+
+Hermes uses "auxiliary" models for side tasks like image analysis, web page summarization, browser screenshot analysis, session-title generation, and context compression. By default (`auxiliary.*.provider: "auto"`), Hermes routes every auxiliary task to your **main chat model** — the same provider/model you picked in `hermes model`. You don't need to configure anything to get started, but be aware that on expensive reasoning models (Opus, MiniMax M2.7, etc.) auxiliary tasks add meaningful cost. If you want cheap-and-fast side tasks regardless of your main model, set `auxiliary.<task>.provider` and `auxiliary.<task>.model` explicitly (for example, Gemini Flash on OpenRouter for vision and web extraction).
+
+:::note Why "auto" uses your main model
+Earlier builds split aggregator users (OpenRouter, Nous Portal) onto a cheap provider-side default. That was surprising — users who paid for an aggregator subscription would see a different model handling their auxiliary traffic. `auto` now uses the main model for everyone, and per-task overrides in `config.yaml` still win (see [Full auxiliary config reference](#full-auxiliary-config-reference) below).
+:::
+
+### Configuring auxiliary models interactively
+
+Instead of hand-editing YAML, run `hermes model` and pick **"Configure auxiliary models"** from the menu. You'll get an interactive per-task picker:
+
+```
+$ hermes model
+→ Configure auxiliary models
+
+[ ] vision               currently: auto / main model
+[ ] web_extract          currently: auto / main model
+[ ] session_search       currently: openrouter / google/gemini-2.5-flash
+[ ] title_generation     currently: openrouter / google/gemini-3-flash-preview
+[ ] compression          currently: auto / main model
+[ ] approval             currently: auto / main model
+[ ] triage_specifier     currently: auto / main model
+```
+
+Select a task, pick a provider (OAuth flows open a browser; API-key providers prompt), pick a model. The change persists to `auxiliary.<task>.*` in `config.yaml`. Same machinery as the main-model picker — no extra syntax to learn.
+
+### Video Tutorial
+
+<div style={{position: 'relative', width: '100%', aspectRatio: '16 / 9', marginBottom: '1.5rem'}}>
+  <iframe
+    src="https://www.youtube.com/embed/NoF-YajElIM"
+    title="Hermes Agent — Auxiliary Models Tutorial"
+    style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', border: 0}}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  />
+</div>
+
+### The universal config pattern
+
+Every model slot in Hermes — auxiliary tasks, compression, fallback — uses the same three knobs:
+
+| Key | What it does | Default |
+|-----|-------------|---------|
+| `provider` | Which provider to use for auth and routing | `"auto"` |
+| `model` | Which model to request | provider's default |
+| `base_url` | Custom OpenAI-compatible endpoint (overrides provider) | not set |
+
+When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
+
+Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/docs/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+
+:::tip MiniMax OAuth
+`minimax-oauth` logs in via browser OAuth (no API key needed). Run `hermes model` and select **MiniMax (OAuth)** to authenticate. Auxiliary tasks use `MiniMax-M2.7-highspeed` automatically. See the [MiniMax OAuth guide](../guides/minimax-oauth.md).
+:::
+
+:::warning `"main"` is for auxiliary tasks only
+The `"main"` provider option means "use whatever provider my main agent uses" — it's only valid inside `auxiliary:`, `compression:`, and `fallback_model:` configs. It is **not** a valid value for your top-level `model.provider` setting. If you use a custom OpenAI-compatible endpoint, set `provider: custom` in your `model:` section. See [AI Providers](/docs/integrations/providers) for all main model provider options.
+:::
+
+### Full auxiliary config reference
+
+```yaml
+auxiliary:
+  # Image analysis (vision_analyze tool + browser screenshots)
+  vision:
+    provider: "auto"           # "auto", "openrouter", "nous", "codex", "main", etc.
+    model: ""                  # e.g. "openai/gpt-4o", "google/gemini-2.5-flash"
+    base_url: ""               # Custom OpenAI-compatible endpoint (overrides provider)
+    api_key: ""                # API key for base_url (falls back to OPENAI_API_KEY)
+    timeout: 120               # seconds — LLM API call timeout; vision payloads need generous timeout
+    download_timeout: 30       # seconds — image HTTP download; increase for slow connections
+
+  # Web page summarization + browser page text extraction
+  web_extract:
+    provider: "auto"
+    model: ""                  # e.g. "google/gemini-2.5-flash"
+    base_url: ""
+    api_key: ""
+    timeout: 360               # seconds (6min) — per-attempt LLM summarization
+
+  # Dangerous command approval classifier
+  approval:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30                # seconds
+
+  # Context compression timeout (separate from compression.* config)
+  compression:
+    timeout: 120               # seconds — compression summarizes long conversations, needs more time
+
+  # Session search — summarizes past session matches
+  session_search:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30
+    max_concurrency: 3       # Limit parallel summaries to reduce request-burst 429s
+    extra_body: {}           # Provider-specific OpenAI-compatible request fields
+
+  # Skills hub — skill matching and search
+  skills_hub:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30
+
+  # MCP tool dispatch
+  mcp:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30
+
+  # Kanban triage specifier — `hermes kanban specify <id>` (or the
+  # dashboard's ✨ Specify button on Triage-column cards) uses this
+  # slot to expand a one-liner into a concrete spec and promote the
+  # task to `todo`. Cheap fast models work well here; spec expansion
+  # is short and doesn't need reasoning depth.
+  triage_specifier:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 120
+```
+
+:::tip
+Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
+:::
+
+:::info
+Context compression has its own `compression:` block for thresholds and an `auxiliary.compression:` block for model/provider settings — see [Context Compression](#context-compression) above. The fallback model uses a `fallback_model:` block — see [Fallback Model](/docs/integrations/providers#fallback-model). All three follow the same provider/model/base_url pattern.
+:::
+
+### Session Search Tuning
+
+If you use a reasoning-heavy model for `auxiliary.session_search`, Hermes now gives you two built-in controls:
+
+- `auxiliary.session_search.max_concurrency`: limits how many matched sessions Hermes summarizes at once
+- `auxiliary.session_search.extra_body`: forwards provider-specific OpenAI-compatible request fields on the summarization calls
+
+Example:
+
+```yaml
+auxiliary:
+  session_search:
+    provider: "main"
+    model: "glm-4.5-air"
+    timeout: 60
+    max_concurrency: 2
+    extra_body:
+      enable_thinking: false
+```
+
+Use `max_concurrency` when your provider rate-limits request bursts and you want `session_search` to trade some parallelism for stability.
+
+Use `extra_body` only when your provider documents OpenAI-compatible request-body fields you want Hermes to pass through for that task. Hermes forwards the object as-is.
+
+:::warning
+`extra_body` is only effective when your provider actually supports the field you send. If the provider does not expose a native OpenAI-compatible reasoning-off flag, Hermes cannot synthesize one on its behalf.
+:::
+
+### OpenRouter routing & Pareto Code for auxiliary tasks
+
+When an auxiliary task resolves to OpenRouter (either explicitly or via `provider: "main"` while your main agent is on OpenRouter), the main agent's `provider_routing` and `openrouter.min_coding_score` settings **do not propagate** — by design, each auxiliary task is independent. To set OpenRouter provider preferences or use the [Pareto Code router](/docs/integrations/providers#openrouter-pareto-code-router) for a specific aux task, set them per-task via `extra_body`:
+
+```yaml
+auxiliary:
+  compression:
+    provider: openrouter
+    model: openrouter/pareto-code         # use the Pareto Code router for this task
+    extra_body:
+      provider:                            # OpenRouter provider routing prefs
+        order: [anthropic, google]         # try these providers in order
+        sort: throughput                   # or "price" | "latency"
+        # only: [anthropic]                # restrict to a specific provider
+        # ignore: [deepinfra]              # exclude specific providers
+      plugins:                             # OpenRouter Pareto Code router knob
+        - id: pareto-router
+          min_coding_score: 0.5            # 0.0–1.0; higher = stronger coders
+```
+
+The shape mirrors what OpenRouter accepts in the chat completions request body. Hermes forwards the entire `extra_body` verbatim, so any other OpenRouter request-body field documented at [openrouter.ai/docs](https://openrouter.ai/docs) works the same way.
+
+### Changing the Vision Model
+
+To use GPT-4o instead of Gemini Flash for image analysis:
+
+```yaml
+auxiliary:
+  vision:
+    model: "openai/gpt-4o"
+```
+
+Or via environment variable (in `~/.hermes/.env`):
+
+```bash
+AUXILIARY_VISION_MODEL=openai/gpt-4o
+```
+
+### Provider Options
+
+These options apply to **auxiliary task configs** (`auxiliary:`, `compression:`, `fallback_model:`), not to your main `model.provider` setting.
+
+| Provider | Description | Requirements |
+|----------|-------------|-------------|
+| `"auto"` | Best available (default). Vision tries OpenRouter → Nous → Codex. | — |
+| `"openrouter"` | Force OpenRouter — routes to any model (Gemini, GPT-4o, Claude, etc.) | `OPENROUTER_API_KEY` |
+| `"nous"` | Force Nous Portal | `hermes auth` |
+| `"codex"` | Force Codex OAuth (ChatGPT account). Supports vision (gpt-5.3-codex). | `hermes model` → Codex |
+| `"minimax-oauth"` | Force MiniMax OAuth (browser login, no API key). Uses MiniMax-M2.7-highspeed for auxiliary tasks. | `hermes model` → MiniMax (OAuth) |
+| `"main"` | Use your active custom/main endpoint. This can come from `OPENAI_BASE_URL` + `OPENAI_API_KEY` or from a custom endpoint saved via `hermes model` / `config.yaml`. Works with OpenAI, local models, or any OpenAI-compatible API. **Auxiliary tasks only — not valid for `model.provider`.** | Custom endpoint credentials + base URL |
+
+Direct API-key providers from the main provider catalog also work here when you want side tasks to bypass your default router. `gmi` is valid once `GMI_API_KEY` is configured:
+
+```yaml
+auxiliary:
+  compression:
+    provider: "gmi"
+    model: "anthropic/claude-opus-4.6"
+```
+
+For GMI auxiliary routing, use the exact model ID returned by GMI's `/v1/models` endpoint.
+
+### Common Setups
+
+**Using a direct custom endpoint** (clearer than `provider: "main"` for local/self-hosted APIs):
+```yaml
+auxiliary:
+  vision:
+    base_url: "http://localhost:1234/v1"
+    api_key: "local-key"
+    model: "qwen2.5-vl"
+```
+
+`base_url` takes precedence over `provider`, so this is the most explicit way to route an auxiliary task to a specific endpoint. For direct endpoint overrides, Hermes uses the configured `api_key` or falls back to `OPENAI_API_KEY`; it does not reuse `OPENROUTER_API_KEY` for that custom endpoint.
+
+**Using OpenAI API key for vision:**
+```yaml
+# In ~/.hermes/.env:
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_API_KEY=sk-...
+
+auxiliary:
+  vision:
+    provider: "main"
+    model: "gpt-4o"       # or "gpt-4o-mini" for cheaper
+```
+
+**Using OpenRouter for vision** (route to any model):
+```yaml
+auxiliary:
+  vision:
+    provider: "openrouter"
+    model: "openai/gpt-4o"      # or "google/gemini-2.5-flash", etc.
+```
+
+**Using Codex OAuth** (ChatGPT Pro/Plus account — no API key needed):
+```yaml
+auxiliary:
+  vision:
+    provider: "codex"     # uses your ChatGPT OAuth token
+    # model defaults to gpt-5.3-codex (supports vision)
+```
+
+**Using MiniMax OAuth** (browser login, no API key needed):
+```yaml
+model:
+  default: MiniMax-M2.7
+  provider: minimax-oauth
+  base_url: https://api.minimax.io/anthropic
+```
+Run `hermes model` and select **MiniMax (OAuth)** to log in and set this automatically. For the China region, the base URL will be `https://api.minimaxi.com/anthropic`. See the [MiniMax OAuth guide](../guides/minimax-oauth.md) for the full walkthrough.
+
+**Using a local/self-hosted model:**
+```yaml
+auxiliary:
+  vision:
+    provider: "main"      # uses your active custom endpoint
+    model: "my-local-model"
+```
+
+`provider: "main"` uses whatever provider Hermes uses for normal chat — whether that's a named custom provider (e.g. `beans`), a built-in provider like `openrouter`, or a legacy `OPENAI_BASE_URL` endpoint.
+
+:::tip
+If you use Codex OAuth as your main model provider, vision works automatically — no extra configuration needed. Codex is included in the auto-detection chain for vision.
+:::
+
+:::warning
+**Vision requires a multimodal model.** If you set `provider: "main"`, make sure your endpoint supports multimodal/vision — otherwise image analysis will fail.
+:::
+
+### Environment Variables (legacy)
+
+Auxiliary models can also be configured via environment variables. However, `config.yaml` is the preferred method — it's easier to manage and supports all options including `base_url` and `api_key`.
+
+| Setting | Environment Variable |
+|---------|---------------------|
+| Vision provider | `AUXILIARY_VISION_PROVIDER` |
+| Vision model | `AUXILIARY_VISION_MODEL` |
+| Vision endpoint | `AUXILIARY_VISION_BASE_URL` |
+| Vision API key | `AUXILIARY_VISION_API_KEY` |
+| Web extract provider | `AUXILIARY_WEB_EXTRACT_PROVIDER` |
+| Web extract model | `AUXILIARY_WEB_EXTRACT_MODEL` |
+| Web extract endpoint | `AUXILIARY_WEB_EXTRACT_BASE_URL` |
+| Web extract API key | `AUXILIARY_WEB_EXTRACT_API_KEY` |
+
+Compression and fallback model settings are config.yaml-only.
+
+:::tip
+Run `hermes config` to see your current auxiliary model settings. Overrides only show up when they differ from the defaults.
+:::
+
+## Reasoning Effort
+
+Control how much "thinking" the model does before responding:
+
+```yaml
+agent:
+  reasoning_effort: ""   # empty = medium (default). Options: none, minimal, low, medium, high, xhigh (max)
+```
+
+When unset (default), reasoning effort defaults to "medium" — a balanced level that works well for most tasks. Setting a value overrides it — higher reasoning effort gives better results on complex tasks at the cost of more tokens and latency.
+
+You can also change the reasoning effort at runtime with the `/reasoning` command:
+
+```
+/reasoning           # Show current effort level and display state
+/reasoning high      # Set reasoning effort to high
+/reasoning none      # Disable reasoning
+/reasoning show      # Show model thinking above each response
+/reasoning hide      # Hide model thinking
+```
+
+## Tool-Use Enforcement
+
+Some models occasionally describe intended actions as text instead of making tool calls ("I would run the tests..." instead of actually calling the terminal). Tool-use enforcement injects system prompt guidance that steers the model back to actually calling tools.
+
+```yaml
+agent:
+  tool_use_enforcement: "auto"   # "auto" | true | false | ["model-substring", ...]
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `gemini`, `gemma`, `grok`. Disabled for all others (Claude, DeepSeek, Qwen, etc.). |
+| `true` | Always enabled, regardless of model. Useful if you notice your current model describing actions instead of performing them. |
+| `false` | Always disabled, regardless of model. |
+| `["gpt", "codex", "qwen", "llama"]` | Enabled only when the model name contains one of the listed substrings (case-insensitive). |
+
+### What it injects
+
+When enabled, three layers of guidance may be added to the system prompt:
+
+1. **General tool-use enforcement** (all matched models) — instructs the model to make tool calls immediately instead of describing intentions, keep working until the task is complete, and never end a turn with a promise of future action.
+
+2. **OpenAI execution discipline** (GPT and Codex models only) — additional guidance addressing GPT-specific failure modes: abandoning work on partial results, skipping prerequisite lookups, hallucinating instead of using tools, and declaring "done" without verification.
+
+3. **Google operational guidance** (Gemini and Gemma models only) — conciseness, absolute paths, parallel tool calls, and verify-before-edit patterns.
+
+These are transparent to the user and only affect the system prompt. Models that already use tools reliably (like Claude) don't need this guidance, which is why `"auto"` excludes them.
+
+### When to turn it on
+
+If you're using a model not in the default auto list and notice it frequently describes what it *would* do instead of doing it, set `tool_use_enforcement: true` or add the model substring to the list:
+
+```yaml
+agent:
+  tool_use_enforcement: ["gpt", "codex", "gemini", "grok", "my-custom-model"]
+```
+
+## TTS Configuration
+
+```yaml
+tts:
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts"
+  speed: 1.0                    # Global speed multiplier (fallback for all providers)
+  edge:
+    voice: "en-US-AriaNeural"   # 322 voices, 74 languages
+    speed: 1.0                  # Speed multiplier (converted to rate percentage, e.g. 1.5 → +50%)
+  elevenlabs:
+    voice_id: "pNInz6obpgDQGcFmaJgB"
+    model_id: "eleven_multilingual_v2"
+  openai:
+    model: "gpt-4o-mini-tts"
+    voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
+    speed: 1.0                  # Speed multiplier (clamped to 0.25–4.0 by the API)
+    base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
+  minimax:
+    speed: 1.0                  # Speech speed multiplier
+    # base_url: ""              # Optional: override for OpenAI-compatible TTS endpoints
+  mistral:
+    model: "voxtral-mini-tts-2603"
+    voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral (default)
+  gemini:
+    model: "gemini-2.5-flash-preview-tts"   # or gemini-2.5-pro-preview-tts
+    voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, etc.
+  xai:
+    voice_id: "eve"             # xAI TTS voice
+    language: "en"              # ISO 639-1
+    sample_rate: 24000
+    bit_rate: 128000            # MP3 bitrate
+    # base_url: "https://api.x.ai/v1"
+  neutts:
+    ref_audio: ''
+    ref_text: ''
+    model: neuphonic/neutts-air-q4-gguf
+    device: cpu
+```
+
+This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
+
+**Speed fallback hierarchy:** provider-specific speed (e.g. `tts.edge.speed`) → global `tts.speed` → `1.0` default. Set the global `tts.speed` to apply a uniform speed across all providers, or override per-provider for fine-grained control.
+
+## Display Settings
+
+```yaml
+display:
+  tool_progress: all      # off | new | all | verbose
+  tool_progress_command: false  # Enable /verbose slash command in messaging gateway
+  platforms: {}           # Per-platform display overrides (see below)
+  tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
+  interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
+  personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
+  compact: false          # Compact output mode (less whitespace)
+  resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
+  bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
+  show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
+  streaming: false        # Stream tokens to terminal as they arrive (real-time output)
+  show_cost: false        # Show estimated $ cost in the CLI status bar
+  tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+  runtime_footer:         # Gateway: append a runtime-context footer to final replies
+    enabled: false
+    fields: ["model", "context_pct", "cwd"]
+  file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
+```
+
+### File-mutation verifier
+
+When `display.file_mutation_verifier` is `true` (default), Hermes appends a one-line advisory to the assistant's final response whenever a `write_file` or `patch` call failed during the turn and was never superseded by a successful write to the same path. This catches the "batch of parallel patches, half silently fail, model summarises success" class of over-claim without requiring you to manually run `git status` after every edit.
+
+Example footer:
+
+```
+⚠️ File-mutation verifier: 3 file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.
+  • concepts/automatic-organization.md — [patch] Could not find match for old_string
+  • concepts/lora.md — [patch] Could not find match for old_string
+  • concepts/rag-pipeline.md — [patch] Could not find match for old_string
+```
+
+Set `file_mutation_verifier: false` (or `HERMES_FILE_MUTATION_VERIFIER=0`) to suppress the footer. The verifier only fires when real failures are outstanding at turn end — a model that retries a failed patch and succeeds within the same turn will not trigger it for that file.
+
+### UI language for static messages
+
+The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
+
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
+
+You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
+
+```yaml
+display:
+  language: zh   # CLI approval prompts appear in Chinese
+```
+
+| Mode | What you see |
+|------|-------------|
+| `off` | Silent — just the final response |
+| `new` | Tool indicator only when the tool changes |
+| `all` | Every tool call with a short preview (default) |
+| `verbose` | Full args, results, and debug logs |
+
+In the CLI, cycle through these modes with `/verbose`. To use `/verbose` in messaging platforms (Telegram, Discord, Slack, etc.), set `tool_progress_command: true` in the `display` section above. The command will then cycle the mode and save to config.
+
+### Runtime-metadata footer (gateway only)
+
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn — same info the CLI shows in its status bar (model, context %, cwd, session duration, tokens, cost). Off by default; opt in per-gateway if your team wants every reply to include the provenance.
+
+```yaml
+display:
+  runtime_footer:
+    enabled: true
+    fields: ["model", "context_pct", "cwd"]   # any of: model, context_pct, cwd, duration, tokens, cost
+```
+
+The `/footer` slash command toggles this at runtime in any session.
+
+Example footer appended to a Telegram/Discord/Slack reply:
+
+```
+— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+```
+
+Only the **final** message of a turn gets the footer; interim updates stay clean.
+
+### Per-platform progress overrides
+
+Different platforms have different verbosity needs. For example, Signal can't edit messages, so each progress update becomes a separate message — noisy. Use `display.platforms` to set per-platform modes:
+
+```yaml
+display:
+  tool_progress: all          # global default
+  platforms:
+    signal:
+      tool_progress: 'off'    # silence progress on Signal
+    telegram:
+      tool_progress: verbose  # detailed progress on Telegram
+    slack:
+      tool_progress: 'off'    # quiet in shared Slack workspace
+```
+
+Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
+
+`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+## Privacy
+
+```yaml
+privacy:
+  redact_pii: false  # Strip PII from LLM context (gateway only)
+```
+
+When `redact_pii` is `true`, the gateway redacts personally identifiable information from the system prompt before sending it to the LLM on supported platforms:
+
+| Field | Treatment |
+|-------|-----------|
+| Phone numbers (user ID on WhatsApp/Signal) | Hashed to `user_<12-char-sha256>` |
+| User IDs | Hashed to `user_<12-char-sha256>` |
+| Chat IDs | Numeric portion hashed, platform prefix preserved (`telegram:<hash>`) |
+| Home channel IDs | Numeric portion hashed |
+| User names / usernames | **Not affected** (user-chosen, publicly visible) |
+
+**Platform support:** Redaction applies to WhatsApp, Signal, and Telegram. Discord and Slack are excluded because their mention systems (`<@user_id>`) require the real ID in the LLM context.
+
+Hashes are deterministic — the same user always maps to the same hash, so the model can still distinguish between users in group chats. Routing and delivery use the original values internally.
+
+## Speech-to-Text (STT)
+
+```yaml
+stt:
+  provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  local:
+    model: "base"              # tiny, base, small, medium, large-v3
+  openai:
+    model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  # model: "whisper-1"         # Legacy fallback key still respected
+```
+
+Provider behavior:
+
+- `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`.
+- `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`.
+- `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+
+If the requested provider is unavailable, Hermes falls back automatically in this order: `local` → `groq` → `openai`.
+
+Groq and OpenAI model overrides are environment-driven:
+
+```bash
+STT_GROQ_MODEL=whisper-large-v3-turbo
+STT_OPENAI_MODEL=whisper-1
+GROQ_BASE_URL=https://api.groq.com/openai/v1
+STT_OPENAI_BASE_URL=https://api.openai.com/v1
+```
+
+## Voice Mode (CLI)
+
+```yaml
+voice:
+  record_key: "ctrl+b"         # Push-to-talk key inside the CLI
+  max_recording_seconds: 120    # Hard stop for long recordings
+  auto_tts: false               # Enable spoken replies automatically when /voice on
+  beep_enabled: true            # Play record start/stop beeps in CLI voice mode
+  silence_threshold: 200        # RMS threshold for speech detection
+  silence_duration: 3.0         # Seconds of silence before auto-stop
+```
+
+Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/docs/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+
+## Streaming
+
+Stream tokens to the terminal or messaging platforms as they arrive, instead of waiting for the full response.
+
+### CLI Streaming
+
+```yaml
+display:
+  streaming: true         # Stream tokens to terminal in real-time
+  show_reasoning: true    # Also stream reasoning/thinking tokens (optional)
+```
+
+When enabled, responses appear token-by-token inside a streaming box. Tool calls are still captured silently. If the provider doesn't support streaming, it falls back to the normal display automatically.
+
+### Gateway Streaming (Telegram, Discord, Slack)
+
+```yaml
+streaming:
+  enabled: true           # Enable progressive message editing
+  transport: edit         # "edit" (progressive message editing) or "off"
+  edit_interval: 0.3      # Seconds between message edits
+  buffer_threshold: 40    # Characters before forcing an edit flush
+  cursor: " ▉"            # Cursor shown during streaming
+  fresh_final_after_seconds: 60   # Send fresh final (Telegram) when preview is this old; 0 = always edit in place
+```
+
+When enabled, the bot sends a message on the first token, then progressively edits it as more tokens arrive. Platforms that don't support message editing (Signal, Email, Home Assistant) are auto-detected on the first attempt — streaming is gracefully disabled for that session with no flood of messages.
+
+For separate natural mid-turn assistant updates without progressive token editing, set `display.interim_assistant_messages: true`.
+
+**Overflow handling:** If the streamed text exceeds the platform's message length limit (~4096 chars), the current message is finalized and a new one starts automatically.
+
+**Fresh final (Telegram):** Telegram's `editMessageText` preserves the original message timestamp, so a long-running streamed reply would keep the first-token timestamp even after completion. When `fresh_final_after_seconds > 0` (default `60`), the completed reply is delivered as a brand-new message (with the stale preview best-effort deleted) so Telegram's visible timestamp reflects completion time. Short previews still finalize in place. Set to `0` to always edit in place.
+
+:::note
+Streaming is disabled by default. Enable it in `~/.hermes/config.yaml` to try the streaming UX.
+:::
+
+## Group Chat Session Isolation
+
+Control whether shared chats keep one conversation per room or one conversation per participant:
+
+```yaml
+group_sessions_per_user: true  # true = per-user isolation in groups/channels, false = one shared session per chat
+```
+
+- `true` is the default and recommended setting. In Discord channels, Telegram groups, Slack channels, and similar shared contexts, each sender gets their own session when the platform provides a user ID.
+- `false` reverts to the old shared-room behavior. That can be useful if you explicitly want Hermes to treat a channel like one collaborative conversation, but it also means users share context, token costs, and interrupt state.
+- Direct messages are unaffected. Hermes still keys DMs by chat/DM ID as usual.
+- Threads stay isolated from their parent channel either way; with `true`, each participant also gets their own session inside the thread.
+
+For the behavior details and examples, see [Sessions](/docs/user-guide/sessions) and the [Discord guide](/docs/user-guide/messaging/discord).
+
+## Unauthorized DM Behavior
+
+Control what Hermes does when an unknown user sends a direct message:
+
+```yaml
+unauthorized_dm_behavior: pair
+
+whatsapp:
+  unauthorized_dm_behavior: ignore
+```
+
+- `pair` is the default. Hermes denies access, but replies with a one-time pairing code in DMs.
+- `ignore` silently drops unauthorized DMs.
+- Platform sections override the global default, so you can keep pairing enabled broadly while making one platform quieter.
+
+## Quick Commands
+
+Define custom commands that either run shell commands without invoking the LLM, or alias one slash command to another. Exec quick commands are zero-token and useful from messaging platforms (Telegram, Discord, etc.) for quick server checks or utility scripts.
+
+```yaml
+quick_commands:
+  status:
+    type: exec
+    command: systemctl status hermes-agent
+  disk:
+    type: exec
+    command: df -h /
+  update:
+    type: exec
+    command: cd ~/.hermes/hermes-agent && git pull && pip install -e .
+  gpu:
+    type: exec
+    command: nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
+```
+
+Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or any messaging platform. `exec` commands run locally on the host and return the output directly — no LLM call, no tokens consumed. `alias` commands rewrite to the configured slash command target.
+
+- **30-second timeout** — long-running commands are killed with an error message
+- **Priority** — quick commands are checked before skill commands, so you can override skill names
+- **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables
+- **Type** — supported types are `exec` and `alias`; other types show an error
+- **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
+
+String-only prompt shortcuts are not valid quick commands. For reusable prompt workflows, create a skill or alias to an existing slash command.
+
+## Human Delay
+
+Simulate human-like response pacing in messaging platforms:
+
+```yaml
+human_delay:
+  mode: "off"                  # off | natural | custom
+  min_ms: 800                  # Minimum delay (custom mode)
+  max_ms: 2500                 # Maximum delay (custom mode)
+```
+
+## Code Execution
+
+Configure the `execute_code` tool:
+
+```yaml
+code_execution:
+  mode: project                # project (default) | strict
+  timeout: 300                 # Max execution time in seconds
+  max_tool_calls: 50           # Max tool calls within code execution
+```
+
+**`mode`** controls the working directory and Python interpreter for scripts:
+
+- **`project`** (default) — scripts run in the session's working directory with the active virtualenv/conda env's python. Project deps (`pandas`, `torch`, project packages) and relative paths (`.env`, `./data.csv`) resolve naturally, matching what `terminal()` sees.
+- **`strict`** — scripts run in a temp staging directory with `sys.executable` (Hermes's own python). Maximum reproducibility, but project deps and relative paths won't resolve.
+
+Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIAL`, `*_PASSWD`, `*_AUTH`) and the tool whitelist apply identically in both modes — switching mode does not change the security posture.
+
+## Web Search Backends
+
+The `web_search`, `web_extract`, and `web_crawl` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+
+```yaml
+web:
+  backend: firecrawl    # firecrawl | searxng | parallel | tavily | exa
+
+  # Or use per-capability keys to mix providers (e.g. free search + paid extract):
+  search_backend: "searxng"
+  extract_backend: "firecrawl"
+```
+
+| Backend | Env Var | Search | Extract | Crawl |
+|---------|---------|--------|---------|-------|
+| **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
+| **SearXNG** | `SEARXNG_URL` | ✔ | — | — |
+| **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
+| **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
+| **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
+
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+
+**SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` and `web_crawl` require a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/docs/user-guide/features/web-search) for Docker setup instructions.
+
+**Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=*** on the server to disable auth).
+
+**Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).
+
+**Exa:** Set `EXA_API_KEY` in `~/.hermes/.env`. Supports `category` filtering (`company`, `research paper`, `news`, `people`, `personal site`, `pdf`) and domain/date filters.
+
+## Browser
+
+Configure browser automation behavior:
+
+```yaml
+browser:
+  inactivity_timeout: 120        # Seconds before auto-closing idle sessions
+  command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
+  record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
+  # Optional CDP override — when set, Hermes attaches directly to your own
+  # Chrome (via /browser connect) rather than starting a headless browser.
+  cdp_url: ""
+  # Dialog supervisor — controls how native JS dialogs (alert / confirm / prompt)
+  # are handled when a CDP backend is attached (Browserbase, local Chrome via
+  # /browser connect). Ignored on Camofox and default local agent-browser mode.
+  dialog_policy: must_respond    # must_respond | auto_dismiss | auto_accept
+  dialog_timeout_s: 300          # Safety auto-dismiss under must_respond (seconds)
+  camofox:
+    managed_persistence: false   # When true, Camofox sessions persist cookies/logins across restarts
+    user_id: ""                  # Optional externally managed Camofox userId
+    session_key: ""              # Optional session key sent when Hermes creates a tab
+    adopt_existing_tab: false    # Reuse an existing tab for this identity before creating one
+```
+
+**Dialog policies:**
+
+- `must_respond` (default) — capture the dialog, surface it in `browser_snapshot.pending_dialogs`, and wait for the agent to call `browser_dialog(action=...)`. After `dialog_timeout_s` seconds with no response, the dialog is auto-dismissed to prevent the page's JS thread from stalling forever.
+- `auto_dismiss` — capture, dismiss immediately. The agent still sees the dialog record in `browser_snapshot.recent_dialogs` with `closed_by="auto_policy"` after the fact.
+- `auto_accept` — capture, accept immediately. Useful for pages with aggressive `beforeunload` prompts.
+
+See the [browser feature page](./features/browser.md#browser_dialog) for the full dialog workflow.
+
+The browser toolset supports multiple providers. See the [Browser feature page](/docs/user-guide/features/browser) for details on Browserbase, Browser Use, and local Chrome CDP setup.
+
+## Timezone
+
+Override the server-local timezone with an IANA timezone string. Affects timestamps in logs, cron scheduling, and system prompt time injection.
+
+```yaml
+timezone: "America/New_York"   # IANA timezone (default: "" = server-local time)
+```
+
+Supported values: any IANA timezone identifier (e.g. `America/New_York`, `Europe/London`, `Asia/Kolkata`, `UTC`). Leave empty or omit for server-local time.
+
+## Discord
+
+Configure Discord-specific behavior for the messaging gateway:
+
+```yaml
+discord:
+  require_mention: true          # Require @mention to respond in server channels
+  free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
+  auto_thread: true              # Auto-create threads on @mention in channels
+```
+
+- `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
+- `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
+- `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
+
+## Security
+
+Pre-execution security scanning and secret redaction:
+
+```yaml
+security:
+  redact_secrets: false          # Redact API key patterns in tool output and logs (off by default)
+  tirith_enabled: true           # Enable Tirith security scanning for terminal commands
+  tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
+  tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
+  tirith_fail_open: true         # Allow command execution if tirith is unavailable
+  website_blocklist:             # See Website Blocklist section below
+    enabled: false
+    domains: []
+    shared_files: []
+```
+
+- `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **Off by default** — enable if you commonly work with real credentials in tool output and want a safety net. Set to `true` explicitly to turn on.
+- `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/sheeki03/tirith) before execution to detect potentially dangerous operations.
+- `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
+- `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.
+- `tirith_fail_open` — when `true` (default), commands are allowed to execute if tirith is unavailable or fails. Set to `false` to block commands when tirith cannot verify them.
+
+## Website Blocklist
+
+Block specific domains from being accessed by the agent's web and browser tools:
+
+```yaml
+security:
+  website_blocklist:
+    enabled: false               # Enable URL blocking (default: false)
+    domains:                     # List of blocked domain patterns
+      - "*.internal.company.com"
+      - "admin.example.com"
+      - "*.local"
+    shared_files:                # Load additional rules from external files
+      - "/etc/hermes/blocked-sites.txt"
+```
+
+When enabled, any URL matching a blocked domain pattern is rejected before the web or browser tool executes. This applies to `web_search`, `web_extract`, `browser_navigate`, and any tool that accesses URLs.
+
+Domain rules support:
+- Exact domains: `admin.example.com`
+- Wildcard subdomains: `*.internal.company.com` (blocks all subdomains)
+- TLD wildcards: `*.local`
+
+Shared files contain one domain rule per line (blank lines and `#` comments are ignored). Missing or unreadable files log a warning but don't disable other web tools.
+
+The policy is cached for 30 seconds, so config changes take effect quickly without restart.
+
+## Smart Approvals
+
+Control how Hermes handles potentially dangerous commands:
+
+```yaml
+approvals:
+  mode: manual   # manual | smart | off
+```
+
+| Mode | Behavior |
+|------|----------|
+| `manual` (default) | Prompt the user before executing any flagged command. In the CLI, shows an interactive approval dialog. In messaging, queues a pending approval request. |
+| `smart` | Use an auxiliary LLM to assess whether a flagged command is actually dangerous. Low-risk commands are auto-approved with session-level persistence. Genuinely risky commands are escalated to the user. |
+| `off` | Skip all approval checks. Equivalent to `HERMES_YOLO_MODE=true`. **Use with caution.** |
+
+Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
+
+:::warning
+Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.
+:::
+
+## Checkpoints
+
+Automatic filesystem snapshots before destructive file operations. See the [Checkpoints & Rollback](/docs/user-guide/checkpoints-and-rollback) for details.
+
+```yaml
+checkpoints:
+  enabled: false                 # Enable automatic checkpoints (also: hermes chat --checkpoints). Default: false (opt-in).
+  max_snapshots: 20              # Max checkpoints to keep per directory (default: 20)
+```
+
+
+## Delegation
+
+Configure subagent behavior for the delegate tool:
+
+```yaml
+delegation:
+  # model: "google/gemini-3-flash-preview"  # Override model (empty = inherit parent)
+  # provider: "openrouter"                  # Override provider (empty = inherit parent)
+  # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
+  # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
+  max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
+  max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
+  orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
+```
+
+**Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
+
+The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
+
+**Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+
+**Width and depth:** `max_concurrent_children` caps how many subagents run in parallel per batch (default `3`, floor of 1, no ceiling). Can also be set via the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var. When the model submits a `tasks` array longer than the cap, `delegate_task` returns a tool error explaining the limit rather than silently truncating. `max_spawn_depth` controls the delegation tree depth (clamped to 1-3). At the default `1`, delegation is flat: children cannot spawn grandchildren, and passing `role="orchestrator"` silently degrades to `leaf`. Raise to `2` so orchestrator children can spawn leaf grandchildren; `3` for three-level trees. The agent opts into orchestration per call via `role="orchestrator"`; `orchestrator_enabled: false` forces every child back to leaf regardless. Cost scales multiplicatively — at `max_spawn_depth: 3` with `max_concurrent_children: 3`, the tree can reach 3×3×3 = 27 concurrent leaf agents. See [Subagent Delegation → Depth Limit and Nested Orchestration](features/delegation.md#depth-limit-and-nested-orchestration) for usage patterns.
+
+## Clarify
+
+Configure the clarification prompt behavior:
+
+```yaml
+clarify:
+  timeout: 120                 # Seconds to wait for user clarification response
+```
+
+## Context Files (SOUL.md, AGENTS.md)
+
+Hermes uses two different context scopes:
+
+| File | Purpose | Scope |
+|------|---------|-------|
+| `SOUL.md` | **Primary agent identity** — defines who the agent is (slot #1 in the system prompt) | `~/.hermes/SOUL.md` or `$HERMES_HOME/SOUL.md` |
+| `.hermes.md` / `HERMES.md` | Project-specific instructions (highest priority) | Walks to git root |
+| `AGENTS.md` | Project-specific instructions, coding conventions | Recursive directory walk |
+| `CLAUDE.md` | Claude Code context files (also detected) | Working directory only |
+| `.cursorrules` | Cursor IDE rules (also detected) | Working directory only |
+| `.cursor/rules/*.mdc` | Cursor rule files (also detected) | Working directory only |
+
+- **SOUL.md** is the agent's primary identity. It occupies slot #1 in the system prompt, completely replacing the built-in default identity. Edit it to fully customize who the agent is.
+- If SOUL.md is missing, empty, or cannot be loaded, Hermes falls back to a built-in default identity.
+- **Project context files use a priority system** — only ONE type is loaded (first match wins): `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules`. SOUL.md is always loaded independently.
+- **AGENTS.md** is hierarchical: if subdirectories also have AGENTS.md, all are combined.
+- Hermes automatically seeds a default `SOUL.md` if one does not already exist.
+- All loaded context files are capped at 20,000 characters with smart truncation.
+
+See also:
+- [Personality & SOUL.md](/docs/user-guide/features/personality)
+- [Context Files](/docs/user-guide/features/context-files)
+
+## Working Directory
+
+| Context | Default |
+|---------|---------|
+| **CLI (`hermes`)** | Current directory where you run the command |
+| **Messaging gateway** | Home directory `~` (override with `MESSAGING_CWD`) |
+| **Docker / Singularity / Modal / SSH** | User's home directory inside the container or remote machine |
+
+Override the working directory:
+```bash
+# In ~/.hermes/.env or ~/.hermes/config.yaml:
+MESSAGING_CWD=/home/myuser/projects    # Gateway sessions
+TERMINAL_CWD=/workspace                # All terminal sessions
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/cron.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/cron.md
@@ -1,0 +1,544 @@
+---
+sidebar_position: 5
+title: "定时任务 (Cron)"
+description: "使用自然语言调度自动化任务，通过一个 cron 工具管理，且可附加一个或多个技能"
+---
+
+# 定时任务 (Cron)
+
+使用自然语言或 cron 表达式调度任务自动执行。Hermes 通过单一的 `cronjob` 工具提供 cron 管理，以操作式（action）方式代替独立的 schedule/list/remove 工具。
+
+## 现在 cron 能做什么
+
+Cron 任务可以：
+
+- 调度一次性或周期性任务
+- 暂停、恢复、编辑、触发和删除任务
+- 为任务附加零个、一个或多个技能
+- 将结果返回至原始聊天、本地文件或配置好的平台目标
+- 在全新的代理会话中运行，并使用常规静态工具列表
+- 在 **无代理模式** 下运行 —— 脚本按计划执行，其 stdout 原样返回，不涉及 LLM（参见下方的 [无代理模式（仅脚本任务）](#no-agent-mode-script-only-jobs)）
+
+所有这些都通过 Hermes 自身的 `cronjob` 工具实现，你可以通过自然语言创建、暂停、编辑、删除任务，无需 CLI。
+
+:::warning
+Cron 运行的会话无法递归创建更多 cron 任务。Hermes 在 cron 执行中会禁用 cron 管理工具，以防止调度循环失控。
+:::
+
+## 创建定时任务
+
+### 在聊天中使用 `/cron`
+
+```bash
+/cron add 30m "提醒我检查构建"
+/cron add "every 2h" "检查服务器状态"
+/cron add "every 1h" "总结新 feed 条目" --skill blogwatcher
+/cron add "every 1h" "使用多个技能并合并结果" --skill blogwatcher --skill maps
+```
+
+### 使用独立 CLI
+
+```bash
+hermes cron create "every 2h" "检查服务器状态"
+hermes cron create "every 1h" "总结新 feed 条目" --skill blogwatcher
+hermes cron create "every 1h" "使用多个技能并合并结果" \
+  --skill blogwatcher \
+  --skill maps \
+  --name "技能组合"
+```
+
+### 通过自然对话
+
+直接向 Hermes 发起请求，例如：
+
+```text
+每天早上 9 点，检查 Hacker News 上的 AI 新闻并在 Telegram 上发送摘要。
+```
+
+Hermes 会内部使用统一的 `cronjob` 工具完成此操作。
+
+## 具备技能的 cron 任务
+
+cron 任务可以在运行提示前加载一个或多个技能。
+
+### 单一技能
+
+```python
+cronjob(
+    action="create",
+    skill="blogwatcher",
+    prompt="检查已配置的 feed 并总结任何新内容。",
+    schedule="0 9 * * *",
+    name="早间 Feed",
+)
+```
+
+### 多个技能
+
+技能会按顺序加载。提示成为在这些技能之上叠加的任务指令。
+
+```python
+cronjob(
+    action="create",
+    skills=["blogwatcher", "maps"],
+    prompt="寻找本地新活动和有趣地点，并合并为简短简报。",
+    schedule="every 6h",
+    name="本地简报",
+)
+```
+
+这在你希望定时代理继承可复用工作流，而不必把完整技能文本塞进 cron 提示时非常有用。
+
+## 在项目目录中运行任务
+
+默认情况下 cron 任务在脱离任何仓库的环境中运行——不会加载 `AGENTS.md`、`CLAUDE.md` 或 `.cursorrules`，终端/文件/代码执行工具的工作目录为网关启动时的目录。使用 `--workdir`（CLI）或 `workdir=`（工具调用）来改变此行为：
+
+```bash
+# 独立 CLI（schedule 与 prompt 为位置参数）
+hermes cron create "every 1d at 09:00" \
+  "审计打开的 PR，汇总 CI 健康并发布到 #eng" \
+  --workdir /home/me/projects/acme
+```
+
+```python
+# 从聊天中，通过 cronjob 工具调用
+cronjob(
+    action="create",
+    schedule="every 1d at 09:00",
+    workdir="/home/me/projects/acme",
+    prompt="审计打开的 PR，汇总 CI 健康并发布到 #eng",
+)
+```
+
+设置 `workdir` 后：
+
+- `AGENTS.md`、`CLAUDE.md`、`.cursorrules` 会注入系统提示（同交互式 CLI 的发现顺序）
+- `terminal`、`read_file`、`write_file`、`patch`、`search_files`、`execute_code` 等工具的工作目录均为该目录（通过 `TERMINAL_CWD`）
+- 必须提供绝对且已存在的目录——相对路径或不存在的目录会在创建/更新时被拒绝
+- 使用 `--workdir ""`（或 `workdir=""`）可在编辑时清除并恢复默认行为
+
+:::note Serialization
+带有 `workdir` 的作业会在调度器 tick 时顺序执行，而非并行池中。这是刻意的——`TERMINAL_CWD` 为进程全局变量，同时运行的工作目录作业会相互冲突。没有 `workdir` 的作业仍然并行运行。
+:::
+
+## 编辑任务
+
+无需删除后重新创建即可修改任务。
+
+### 聊天中
+
+```bash
+/cron edit <job_id> --schedule "every 4h"
+/cron edit <job_id> --prompt "使用修订后的任务"
+/cron edit <job_id> --skill blogwatcher --skill maps
+/cron edit <job_id> --remove-skill blogwatcher
+/cron edit <job_id> --clear-skills
+```
+
+### 独立 CLI
+
+```bash
+hermes cron edit <job_id> --schedule "every 4h"
+hermes cron edit <job_id> --prompt "使用修订后的任务"
+hermes cron edit <job_id> --skill blogwatcher --skill maps
+hermes cron edit <job_id> --add-skill maps
+hermes cron edit <job_id> --remove-skill blogwatcher
+hermes cron edit <job_id> --clear-skills
+```
+
+注意：
+
+- 重复 `--skill` 会替换作业的技能列表
+- `--add-skill` 会在现有列表后追加
+- `--remove-skill` 删除指定技能
+- `--clear-skills` 删除所有技能
+
+## 生命周期操作
+
+cron 任务现在拥有更完整的生命周期，而不仅仅是创建/删除。
+
+### 聊天中
+
+```bash
+/cron list
+/cron pause <job_id>
+/cron resume <job_id>
+/cron run <job_id>
+/cron remove <job_id>
+```
+
+### 独立 CLI
+
+```bash
+hermes cron list
+hermes cron pause <job_id>
+hermes cron resume <job_id>
+hermes cron run <job_id>
+hermes cron remove <job_id>
+hermes cron status
+hermes cron tick
+```
+
+作用说明：
+
+- `pause` — 保留任务但停止调度
+- `resume` — 重新启用任务并计算下次运行时间
+- `run` — 在下一个调度 tick 时触发任务
+- `remove` — 完全删除任务
+
+## 工作原理
+
+**Cron 执行由网关守护进程处理。** 网关每 60 秒 tick 一次调度器，运行到期任务于隔离的代理会话中。
+
+```bash
+hermes gateway install     # 安装为用户服务
+sudo hermes gateway install --system   # Linux 系统服务（服务器）
+hermes gateway             # 前台运行
+
+hermes cron list
+hermes cron status
+```
+
+### 网关调度器行为
+
+每一次 tick Hermes 会：
+
+1. 从 `~/.hermes/cron/jobs.json` 加载任务
+2. 将 `next_run_at` 与当前时间比较
+3. 为每个到期任务启动全新的 `AIAgent` 会话
+4. 如有附加技能则注入
+5. 运行提示直至完成
+6. 交付最终响应
+7. 更新运行元数据并计算下次调度时间
+
+文件锁 `~/.hermes/cron/.tick.lock` 防止多实例重复运行同一批任务。
+
+## 交付选项
+
+调度任务时，你可以指定结果的发送目标：
+
+| 选项 | 描述 | 示例 |
+|------|------|------|
+| `"origin"` | 发送回创建任务的地方 | 默认在消息平台 |
+| `"local"` | 仅保存到本地文件 (`~/.hermes/cron/output/`) | 默认在 CLI |
+| `"telegram"` | Telegram 主频道 | 使用 `TELEGRAM_HOME_CHANNEL` |
+| `"telegram:123456"` | 指定 Telegram 会话 ID | 直接发送 |
+| `"telegram:-100123:17585"` | 指定 Telegram 主题 | `chat_id:thread_id` 格式 |
+| `"discord"` | Discord 主频道 | 使用 `DISCORD_HOME_CHANNEL` |
+| `"discord:#engineering"` | 指定 Discord 频道 | 按频道名 |
+| `"slack"` | Slack 主频道 |
+| `"whatsapp"` | WhatsApp 主渠道 |
+| `"signal"` | Signal |
+| `"matrix"` | Matrix 主房间 |
+| `"mattermost"` | Mattermost 主频道 |
+| `"email"` | 邮件 |
+| `"sms"` | 通过 Twilio 发送 SMS |
+| `"homeassistant"` | Home Assistant |
+| `"dingtalk"` | DingTalk |
+| `"feishu"` | 飞书/Lark |
+| `"wecom"` | 企业微信 |
+| `"weixin"` | 微信 |
+| `"bluebubbles"` | BlueBubbles (iMessage) |
+| `"qqbot"` | QQ Bot |
+| `"all"` | 向所有已连接的渠道广播 |
+| `"telegram,discord"` | 向特定集合广播 |
+| `"origin,all"` | 同时发送到原始和所有渠道 |
+
+代理的最终响应会自动交付，你无需在 cron 提示中调用 `send_message`。仅在需要额外或不同目标时才使用 `send_message`。
+
+### 路由意图 (`all`)
+
+`all` 让你将单个 cron 任务发送到所有已配置的消息渠道，无需逐个列出名称。它在触发时解析——如果在创建任务后才配置了 Telegram，下一次 tick 时该任务会自动包括 Telegram。
+
+语义：`all` 展开为所有已配置了主页渠道的平台。若没有配置任何渠道，任务仅记录交付失败。
+
+`all` 可与显式目标组合，例如 `origin,all`，会把原始聊天与所有其他已连接渠道一起发送，并按 `(platform, chat_id, thread_id)` 去重。
+
+### 响应包装
+
+默认情况下，交付的 cron 输出会加上头尾，以便接收方知道这是来自计划任务的消息：
+
+```
+Cronjob Response: Morning feeds
+-------------
+
+<agent output here>
+
+Note: The agent cannot see this message, and therefore cannot respond to it.
+```
+
+若想直接返回原始代理输出，可在 `~/.hermes/config.yaml` 中设置 `cron.wrap_response: false`：
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  wrap_response: false
+```
+
+### 静默抑制
+
+如果代理的最终响应以 `[SILENT]` 开头，则会完全抑制交付。输出仍会保存在本地 (`~/.hermes/cron/output/`) 供审计，但不会发送到任何目标。
+
+这对仅在出现异常时报告的监控任务很有用：
+
+```text
+检查 nginx 是否运行。若一切正常，仅回复 [SILENT]。
+否则，报告问题。
+```
+
+失败的任务始终会交付——只有成功运行且标记为 `[SILENT]` 时才会被静默。
+
+## 脚本超时
+
+预运行脚本（通过 `script` 参数）默认超时 120 秒。如需更长时间（例如加入随机延迟以规避机器行为），可在配置中增加：
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  script_timeout_seconds: 300   # 5 分钟
+```
+
+或设置环境变量 `HERMES_CRON_SCRIPT_TIMEOUT`。解析顺序为：环境变量 → config.yaml → 默认 120s。
+
+## 无代理模式（仅脚本任务）
+
+对于不需要 LLM 推理的循环任务——经典的看门狗、磁盘/内存告警、心跳、CI ping——在创建时传入 `no_agent=True`。调度器仅运行脚本并把 stdout 直接交付，完全跳过代理：
+
+```bash
+hermes cron create "every 5m" \
+  --no-agent \
+  --script memory-watchdog.sh \
+  --deliver telegram \
+  --name "memory-watchdog"
+```
+
+语义：
+
+- 脚本 stdout（去除前后空白） → 原样交付为消息
+- 空 stdout → 静默 tick，不交付
+- 非零退出或超时 → 发送错误警报，防止看门狗失效而沉默
+- 最后一行 `{"wakeAgent": false}` → 静默 tick（同 LLM 任务的门控）
+- 完全不使用模型、提供商回退——任务永不触及推理层
+
+`.sh` / `.bash` 文件在 `/bin/bash` 下运行，其他文件使用当前 Python 解释器 (`sys.executable`)。脚本必须放在 `~/.hermes/scripts/`（同预运行脚本的沙箱规则）。
+
+### 代理为你设置的内容
+
+`cronjob` 工具的 schema 暴露 `no_agent` 给 Hermes，因此你可以在聊天中描述看门狗，代理会自动创建脚本并调用：
+
+```text
+如果 RAM 超过 85%，每 5 分钟在 Telegram 上提醒我。
+```
+
+Hermes 会将检查脚本写入 `~/.hermes/scripts/`（通过 `write_file`），随后调用：
+
+```python
+cronjob(action="create", schedule="every 5m",
+        script="memory-watchdog.sh", no_agent=True,
+        deliver="telegram", name="memory-watchdog")
+```
+
+当消息内容完全由脚本决定时，`no_agent=True` 会被自动添加。
+
+参见 [脚本仅 cron 任务指南](/docs/guides/cron-script-only) 获取完整示例。
+
+## 使用 `context_from` 链接作业
+
+cron 作业在隔离会话中运行，默认不记忆前一次运行的输出。但有时需要将一个作业的输出作为下一个作业的输入。`context_from` 参数可以自动完成此连接——作业 B 的提示会在运行时自动把作业 A 最近的输出当作上下文前置。
+
+```python
+# 作业 1：收集原始数据
+cronjob(
+    action="create",
+    prompt="获取 Hacker News 上前 10 条 AI/ML 新闻，保存到 ~/.hermes/data/briefs/raw.md，格式为 markdown，包含标题、URL、分数。",
+    schedule="0 7 * * *",
+    name="AI News Collector",
+)
+
+# 作业 2：筛选 —— 接收作业 1 的输出作为上下文
+# 获取作业 1 的 ID：cronjob(action="list")
+cronjob(
+    action="create",
+    prompt="读取 ~/.hermes/data/briefs/raw.md。为每条新闻打 1-10 分的参与度和新颖度分数。输出前 5 条到 ~/.hermes/data/briefs/ranked.md。",
+    schedule="30 7 * * *",
+    context_from="<job1_id>",
+    name="AI News Triage",
+)
+
+# 作业 3：发送 —— 接收作业 2 的输出作为上下文
+cronjob(
+    action="create",
+    prompt="读取 ~/.hermes/data/briefs/ranked.md。生成 3 条 tweet 草稿（标题 + 正文 + 标签）。发送至 telegram:7976161601。",
+    schedule="0 8 * * *",
+    context_from="<job2_id>",
+    name="AI News Brief",
+)
+```
+
+**工作原理：**
+
+- 作业 2 触发时，Hermes 会读取作业 1 最近的输出文件 `~/.hermes/cron/output/{job1_id}/*.md`
+- 该内容会预置到作业 2 的提示前部，无需显式 `read_file`
+- 作业 3 同理，链式处理可任意长度
+
+### `context_from` 支持的格式
+
+| 格式 | 示例 |
+|------|------|
+| 单个作业 ID（字符串） | `context_from="a1b2c3d4"` |
+| 多个作业 ID（列表） | `context_from=["job_a", "job_b"]` |
+
+输出会按列出顺序拼接。
+
+## 提供商恢复
+
+cron 作业会继承全局配置的回退提供商和凭证池轮换策略。如果主 API 密钥被限流或返回错误，cron 代理可以：
+
+- **回退到备用提供商**（若在 `config.yaml` 中配置 `fallback_providers` 或旧的 `fallback_model`）
+- **轮转同提供商的下一个凭证**（使用 [credential pool](/docs/user-guide/configuration#credential-pool-strategies)）
+
+这确保高频或高峰期运行的 cron 作业更具弹性——单个限流键不会导致整个任务失败。
+
+## 调度格式
+
+### 相对延迟（一次性）
+
+```
+30m     → 30 分钟后运行一次
+2h      → 2 小时后运行一次
+1d      → 1 天后运行一次
+```
+
+### 间隔（循环）
+
+```
+every 30m    → 每 30 分钟一次
+every 2h     → 每 2 小时一次
+every 1d     → 每天一次
+```
+
+### Cron 表达式
+
+```
+0 9 * * *       → 每天 9:00 AM
+0 9 * * 1-5     → 工作日 9:00 AM
+0 */6 * * *     → 每 6 小时一次
+30 8 1 * *      → 每月 1 日 8:30 AM
+0 0 * * 0       → 每周日午夜
+```
+
+### ISO 时间戳
+
+```
+2026-03-15T09:00:00    → 2026 年 3 月 15 日 9:00 的一次性任务
+```
+
+## 重复行为
+
+| 调度类型 | 默认重复次数 | 行为 |
+|----------|--------------|------|
+| 一次性 (`30m`, 时间戳) | 1 | 只运行一次 |
+| 间隔 (`every 2h`) | 永久 | 直至手动删除 |
+| Cron 表达式 | 永久 | 直至手动删除 |
+
+你可以通过 `repeat` 参数覆盖此行为：
+
+```python
+cronjob(
+    action="create",
+    prompt="...",
+    schedule="every 2h",
+    repeat=5,
+)
+```
+
+## 编程方式管理作业
+
+代理侧的统一 API 为：
+
+```python
+cronjob(action="create", ...)
+cronjob(action="list")
+cronjob(action="update", job_id="...")
+cronjob(action="pause", job_id="...")
+cronjob(action="resume", job_id="...")
+cronjob(action="run", job_id="...")
+cronjob(action="remove", job_id="...")
+```
+
+对 `update`，传入 `skills=[]` 可移除全部已附加技能。
+
+## cron 作业可用的工具集
+
+cron 在每个作业中启动全新的代理会话，且没有任何聊天平台绑定。默认情况下，cron 代理获得 **你在 `hermes tools` 中为 `cron` 平台配置的工具集**——而不是 CLI 默认的全部工具。
+
+```bash
+hermes tools
+# → 在 curses UI 中选择 "cron" 平台
+# → 像配置 Telegram/Discord 那样开关工具集
+```
+
+对单个作业的更细粒度控制可通过 `enabled_toolsets` 字段实现（在 `cronjob.create` 或 `cronjob.update` 中）：
+
+```text
+cronjob(action="create", name="weekly-news-summary",
+        schedule="every sunday 9am",
+        enabled_toolsets=["web", "file"],      # 只启用 web + file，其他如 terminal/browser 等关闭
+        prompt="总结本周 AI 新闻： ...")
+```
+
+若作业设置了 `enabled_toolsets`，它将覆盖全局 `hermes tools` 的 cron 配置；若未设置，则使用全局配置；若全局也未配置，则使用内置默认。这对成本控制非常关键：把 `moa`、`browser`、`delegation` 等工具带入每一个“小型抓取”任务会显著增加工具-schema 提示长度和费用。
+
+### 完全跳过代理：`wakeAgent`
+
+如果你的 cron 作业附带前置检查脚本（通过 `script=`），脚本可以在运行时决定是否真的需要唤起代理。若脚本在最后一行输出 JSON `{"wakeAgent": false}`，则本次 tick 将直接跳过代理运行，仅记录日志。
+
+```text
+{"wakeAgent": false}
+```
+
+这在高频轮询（每 1‑5 分钟）且仅在状态变更时才需要 LLM 推理的场景下可省去大量费用。
+
+```python
+# 前置检查脚本示例
+import json, sys
+latest = fetch_latest_issue_count()
+prev = read_state("issue_count")
+if latest == prev:
+    print(json.dumps({"wakeAgent": False}))   # 本次 tick 静默
+    sys.exit(0)
+write_state("issue_count", latest)
+print(json.dumps({"wakeAgent": True, "context": {"new_issues": latest - prev}}))
+```
+
+如果省略 `wakeAgent`，默认视为 `true`（正常唤起代理）。
+
+#### 示例：零成本前置门控
+
+1. **文件变更门** — 仅当监视文件自上一次成功运行后有更新时才执行。
+2. **外部标记门** — 其他进程创建标记文件或设置状态后才运行。
+3. **SQL 行数门** — 仅当数据库在最近时间窗口内有新记录时才运行。
+
+上述模式均通过脚本返回 `{"wakeAgent": true/false}`，并可通过 `context` 将计数等信息传递给后续代理任务。
+
+## 作业存储
+
+作业记录保存在 `~/.hermes/cron/jobs.json`。运行输出保存至 `~/.hermes/cron/output/{job_id}/{timestamp}.md`。
+
+作业字段 `model`、`provider` 如未设置会在运行时从全局配置解析。仅在作业级别覆盖时才会出现于记录中。
+
+存储采用原子写入，防止中断导致文件损坏。
+
+## 自包含提示仍然重要
+
+:::warning 重要
+cron 作业在全新的代理会话中运行。提示必须包含除已附加技能之外的所有必要信息。
+:::
+
+**错误示例**：`"检查服务器问题"`
+
+**正确示例**：`"以用户 'deploy' SSH 登录 192.168.1.100，使用 'systemctl status nginx' 检查 nginx 是否运行，并验证 https://example.com 返回 HTTP 200。"
+
+## 安全性
+
+创建和更新 cron 提示时会进行提示注入和凭证泄露检测。包含不可见 Unicode、SSH 后门或明显的秘密泄露负载的提示会被阻止。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/delegation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/delegation.md
@@ -1,0 +1,281 @@
+---
+sidebar_position: 7
+title: "子代理委派"
+description: "使用 delegate_task 生成隔离的子代理，以并行工作流"
+---
+
+# 子代理委派
+
+`delegate_task` 工具会生成拥有独立上下文、受限工具集以及独立终端会话的子 AIAgent 实例。每个子代理拥有全新的对话并独立工作 —— 只有它们的最终摘要会进入父代理的上下文。
+
+## 单任务
+
+```python
+delegate_task(
+    goal="调试测试失败的原因",
+    context="错误：test_foo.py 第 42 行的断言",
+    toolsets=["terminal", "file"]
+)
+```
+
+## 并行批处理
+
+默认最多可同时运行 3 个子代理（可配置，无硬性上限）：
+
+```python
+delegate_task(tasks=[
+    {"goal": "研究主题 A", "toolsets": ["web"]},
+    {"goal": "研究主题 B", "toolsets": ["web"]},
+    {"goal": "修复构建", "toolsets": ["terminal", "file"]}
+])
+```
+
+## 子代理上下文如何工作
+
+:::warning Critical: Subagents Know Nothing
+子代理 **从全新对话开始**。它们对父代理的对话历史、先前的工具调用或任何之前讨论的内容一无所知。子代理唯一的上下文来源于父代理在调用 `delegate_task` 时传入的 `goal` 与 `context` 字段。
+:::
+
+这意味着父代理必须在调用中 **提供子代理所需的全部信息**：
+
+```python
+# ❌ 错误示例——子代理不知道“错误”是什么
+delegate_task(goal="修复错误")
+
+# ✅ 正确示例——子代理拥有所有必要上下文
+delegate_task(
+    goal="修复 api/handlers.py 中的 TypeError",
+    context="""文件 api/handlers.py 第 47 行出现 TypeError：
+'NoneType' 对象没有属性 'get'。
+函数 process_request() 从 parse_body() 获取 dict，
+但当 Content-Type 缺失时，parse_body() 返回 None。
+项目位于 /home/user/myproject，使用 Python 3.11。"""
+)
+```
+
+子代理会收到一个由你的目标和上下文构建的系统提示，指示它完成任务并提供结构化摘要，包括执行了什么、发现了什么、修改了哪些文件以及遇到的任何问题。
+
+## 实用示例
+
+### 并行研究
+
+同时研究多个主题并收集摘要：
+
+```python
+delegate_task(tasks=[
+    {
+        "goal": "研究 2025 年 WebAssembly 的现状",
+        "context": "关注点：浏览器支持、非浏览器运行时、语言支持",
+        "toolsets": ["web"]
+    },
+    {
+        "goal": "研究 2025 年 RISC‑V 的采用情况",
+        "context": "关注点：服务器芯片、嵌入式系统、软件生态",
+        "toolsets": ["web"]
+    },
+    {
+        "goal": "研究 2025 年量子计算的进展",
+        "context": "关注点：错误纠正突破、实际应用、关键企业",
+        "toolsets": ["web"]
+    }
+])
+```
+
+### 代码审查 + 修复
+
+将审查‑修复工作流交给全新上下文的子代理：
+
+```python
+delegate_task(
+    goal="审查认证模块的安全问题并修复所有发现的缺陷",
+    context="""项目位于 /home/user/webapp。
+认证模块文件：src/auth/login.py、src/auth/jwt.py、src/auth/middleware.py。
+项目使用 Flask、PyJWT 和 bcrypt。
+关注点：SQL 注入、JWT 验证、密码处理、会话管理。
+修复所有发现的问题并运行测试套件 (pytest tests/auth/)。""",
+    toolsets=["terminal", "file"]
+)
+```
+
+### 多文件重构
+
+当一次性重构大量文件会把父代理的上下文塞满时，可以交给子代理完成：
+
+```python
+delegate_task(
+    goal="将 src/ 下所有 Python 文件的 print() 替换为合适的日志调用",
+    context="""项目位于 /home/user/myproject。
+使用 `logging` 模块，获取 logger = logging.getLogger(__name__)。
+将 print() 调用映射为对应的日志级别：
+- print(f"Error: ...") -> logger.error(...)
+- print(f"Warning: ...") -> logger.warning(...)
+- print(f"Debug: ...") -> logger.debug(...)
+- 其他 print -> logger.info(...)
+不要修改测试文件或 CLI 输出中的 print()。
+完成后运行 pytest 验证功能未受影响。""",
+    toolsets=["terminal", "file"]
+)
+```
+
+## 批处理模式细节
+
+当提供 `tasks` 数组时，子代理会使用 **线程池** 并行运行：
+
+- **最大并发数**：默认 3（可通过 `delegation.max_concurrent_children` 或环境变量 `DELEGATION_MAX_CONCURRENT_CHILDREN` 调整；下限 1，无硬性上限）。超过限制的批次会返回工具错误，而不是悄悄截断。
+- **线程池实现**：使用 `ThreadPoolExecutor`，并发数即为最大工作线程数。
+- **进度展示**：在 CLI 模式下，以树形视图实时显示每个子代理的工具调用；在网关模式下，进度会被批量收集并通过父代理的进度回调返回。
+- **结果顺序**：无论子代理完成顺序如何，返回的结果都会按任务在输入数组中的顺序排序。
+- **中断传播**：中断父代理（例如用户发送新消息）会同时中断所有活跃子代理。
+
+单任务委派直接执行，不经过线程池开销。
+
+## 模型覆盖
+
+可以通过 `config.yaml` 为子代理配置不同的模型，以便将简单任务交给更廉价/更快的模型：
+
+```yaml
+# 位于 ~/.hermes/config.yaml
+delegation:
+  model: "google/gemini-flash-2.0"    # 子代理使用的更便宜模型
+  provider: "openrouter"              # 可选：为子代理指定不同的提供商
+```
+
+若未设置，子代理默认使用与父代理相同的模型。
+
+## 工具集选择建议
+
+`toolsets` 参数决定子代理可以使用哪些工具。请根据任务需求选择：
+
+| 工具集模式 | 使用场景 |
+|------------|----------|
+| `["terminal", "file"]` | 代码工作、调试、文件编辑、构建 |
+| `["web"]` | 研究、事实核查、文档检索 |
+| `["terminal", "file", "web"]` | 全栈任务（默认） |
+| `["file"]` | 只读分析、代码审查（不执行） |
+| `["terminal"]` | 系统管理、进程管理 |
+
+子代理始终会屏蔽以下工具集（即使你显式声明）：
+- `delegation` —— 叶子子代理默认不可再委派（除非 `role="orchestrator"` 并且提升 `max_spawn_depth`）。
+- `clarify` —— 子代理不能与用户交互。
+- `memory` —— 不能写入共享持久内存。
+- `code_execution` —— 子代理应通过逐步推理完成任务。
+- `send_message` —— 禁止跨平台副作用（如发送 Telegram 消息）。
+
+## 最大迭代次数
+
+每个子代理都有迭代上限（默认 50），控制它可以进行多少次工具调用：
+
+```python
+delegate_task(
+    goal="快速文件检查",
+    context="检查 /etc/nginx/nginx.conf 是否存在并打印前 10 行",
+    max_iterations=10  # 简单任务不需要太多轮次
+)
+```
+
+## 子代理超时
+
+若子代理在 `delegation.child_timeout_seconds` 秒内没有任何输出，则被视为卡死并被强制终止。默认 **600 秒**（10 分钟），比之前的 300 秒更宽松，以防止大型推理任务在中途被杀。可以根据模型速度自行调节：
+
+```yaml
+delegation:
+  child_timeout_seconds: 600   # 默认值
+```
+
+计时器会在子代理每次进行 API 调用或工具调用时重置，只有真正空闲时才会触发。
+
+:::tip Diagnostic dump on zero-call timeout
+如果子代理在没有进行任何 API 调用的情况下超时（常见于提供商不可达、凭证错误或工具模式被拒），`delegate_task` 会在 `~/.hermes/logs/` 下生成结构化诊断日志 `subagent-timeout-<session>-<timestamp>.log`，其中包含子代理的配置快照、凭证解析轨迹以及早期错误信息。相比过去的沉默超时，这大大便于排查。
+:::
+
+## 监控运行中的子代理（`/agents`）
+
+TUI 自带 `/agents`（别名 `/tasks`）覆盖层，将递归 `delegate_task` 的 fan‑out 以第一类审计视图呈现：
+
+- 实时树形展示运行中和最近结束的子代理，按父子关系分组
+- 每个分支的费用、token 消耗、触及文件的汇总
+- 终止与暂停控制 —— 可单独取消某个子代理而不影响其兄弟
+- 事后回顾：即使子代理已返回父代理，也可以逐步查看其每轮历史记录
+
+经典 CLI 仅输出文本摘要；TUI 则提供可交互的覆盖层。详见 [TUI — Slash commands](/docs/user-guide/tui#slash-commands)。
+
+## 深度限制与嵌套编排
+
+默认情况下，委派是 **扁平的**：父代理（深度 0）生成子代理（深度 1），而这些子代理不能再进一步委派，以防止无限递归。
+
+若需要多阶段工作流（例如先研究再综合），父代理可以生成 **编排子代理**，它们能够再次委派自己的工作者：
+
+```python
+delegate_task(
+    goal="评估三种代码审查方法并给出推荐",
+    role="orchestrator",  # 允许该子代理自行生成子代理
+    context="...",
+)
+```
+
+- `role="leaf"`（默认）：子代理不可再委派 —— 与扁平委派行为相同。
+- `role="orchestrator"`：子代理保留 `delegation` 工具集。受全局 `delegation.max_spawn_depth` 控制（默认 **1**，即平面；提升到 2 允许编排子代理再生成叶子级子代理；3 则支持三层）。
+- `delegation.orchestrator_enabled: false`：全局关闭，所有子代理强制为 `leaf`。
+
+**费用警示**：若 `max_spawn_depth: 3` 且 `max_concurrent_children: 3`，树形结构最高可达 3×3×3 = 27 个并发叶子代理。每多一级都会乘以费用——请有意识地提升深度。
+
+## 生命周期与持久性
+
+:::warning delegate_task is synchronous — not durable
+`delegate_task` **在父代理的当前回合内同步执行**。它会阻塞父代理直到所有子代理完成（或被取消），并 **不** 作为后台任务队列持久化运行：
+
+- 若父代理被中断（用户发送新消息、`/stop`、`/new`），所有活跃子代理都会被取消，返回 `status="interrupted"`，其进行中的工作将被丢弃。
+- 子代理 **不会** 在父回合结束后继续运行。
+- 被取消的子代理会返回结构化结果（`status="interrupted"`, `exit_reason="interrupted"`），但由于父回合已被中断，这些结果往往无法展示给用户。
+
+如需 **持久化长时间运行的任务**，请使用以下机制：
+
+- `cronjob`（action=`create`）——调度独立的代理运行，免受父回合中断影响。
+- `terminal(background=True, notify_on_complete=True)` —— 在后台运行的 shell 命令，代理仍可继续处理其他事务。
+:::
+
+## 关键属性
+
+- 每个子代理拥有 **独立的终端会话**（与父代理分离）
+- **嵌套委派为可选** —— 仅 `role="orchestrator"` 子代理可在提升 `max_spawn_depth` 后再委派；全局可通过 `orchestrator_enabled: false` 禁用。
+- 叶子子代理 **不能** 调用: `delegate_task`, `clarify`, `memory`, `send_message`, `code_execution`。编排子代理保留 `delegate_task`，但仍受前四项限制。
+- **中断传播**：中断父代理会连带中断所有活跃子代理（包括编排子代理的子代理）。
+- 仅最终摘要进入父上下文，令 token 使用保持高效。
+- 子代理继承父代理的 **API key、提供商配置和凭证池**（便于在速率限制时进行密钥轮换）。
+
+## Delegation 与 execute_code 对比
+
+| 对比维度 | delegate_task | execute_code |
+|----------|---------------|--------------|
+| **推理** | 完整 LLM 推理循环 | 仅执行 Python 代码 |
+| **上下文** | 新的独立对话 | 无对话，仅脚本执行 |
+| **工具访问** | 所有非阻塞工具 | 通过 RPC 提供的 7 种工具，无推理 |
+| **并行性** | 默认 3 个并发子代理（可配置） | 单脚本执行 |
+| **适用场景** | 需要判断、复杂多步骤的任务 | 机械化的多步骤流水线 |
+| **Token 成本** | 更高（完整 LLM 循环） | 更低（仅返回 stdout） |
+| **用户交互** | 无（子代理不能澄清） | 无 |
+
+**经验法则**：当子任务需要推理、判断或多步骤问题求解时使用 `delegate_task`；当需要机械数据处理或脚本化工作流时使用 `execute_code`。
+
+## 配置示例
+
+```yaml
+# 位于 ~/.hermes/config.yaml
+delegation:
+  max_iterations: 50                        # 每个子代理的最大回合（默认 50）
+  # max_concurrent_children: 3              # 每批并行子代理数（默认 3）
+  # max_spawn_depth: 1                      # 树深度 1‑3，默认 1 为扁平。提升到 2 允许编排子代理生成叶子子代理；3 为三层。
+  # orchestrator_enabled: true              # 关闭则所有子代理强制为 leaf 角色。
+  model: "google/gemini-3-flash-preview"   # 可选的模型覆盖
+  provider: "openrouter"                    # 可选的内置提供商
+
+# 或使用自建端点覆盖提供商配置：
+delegation:
+  model: "qwen2.5-coder"
+  base_url: "http://localhost:1234/v1"
+  api_key: "local-key"
+```
+
+:::tip
+代理会根据任务复杂度自动决定是否进行委派。用户无需显式请求委派，代理在必要时会自行启动子代理。
+:::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
@@ -1,0 +1,218 @@
+---
+sidebar_position: 3
+title: "持久记忆"
+description: "Hermes Agent 如何在会话之间记忆 — MEMORY.md、USER.md 与会话搜索"
+---
+
+# 持久记忆
+
+Hermes Agent 拥有有界且精心策划的记忆，可在会话之间持久保存。这让它能够记住你的偏好、项目、环境以及它所学到的东西。
+
+## 工作原理
+
+记忆由两个文件组成：
+
+| 文件 | 用途 | 字符限制 |
+|------|------|----------|
+| **MEMORY.md** | 代理的个人笔记——环境事实、约定、学习到的内容 | 2,200 字符（≈800 tokens） |
+| **USER.md** | 用户画像——你的偏好、沟通风格、期望 | 1,375 字符（≈500 tokens） |
+
+这两个文件存放在 `~/.hermes/memories/`，在会话启动时以冻结快照的形式注入系统提示。代理通过 `memory` 工具自行管理记忆——可以添加、替换或删除条目。
+
+:::info
+字符限制可以让记忆保持聚焦。当记忆已满时，代理会合并或替换条目，为新信息腾出空间。
+:::
+
+## 记忆在系统提示中的呈现方式
+
+每次会话开始时，记忆条目会从磁盘加载并渲染到系统提示中，形成一个冻结块：
+
+```
+══════════════════════════════════════════════
+MEMORY (your personal notes) [67% — 1,474/2,200 chars]
+══════════════════════════════════════════════
+User's project is a Rust web service at ~/code/myapi using Axum + SQLx
+§
+This machine runs Ubuntu 22.04, has Docker and Podman installed
+§
+User prefers concise responses, dislikes verbose explanations
+```
+
+格式包括：
+- 显示存储源（MEMORY 或 USER PROFILE）的标题
+- 使用率和字符数，帮助代理了解容量
+- 条目之间使用 `§`（章节符）分隔
+- 条目可以是多行的
+
+**冻结快照模式**：系统提示的注入只在会话开始时进行一次，期间不会改变。这是有意为之，以保持 LLM 前缀缓存的性能。当代理在会话中添加/删除记忆条目时，改动会立即写入磁盘，但不会在本次会话的系统提示中出现。工具的响应始终展示实时状态。
+
+## 记忆工具操作
+
+代理使用 `memory` 工具并提供以下动作：
+
+- **add** — 添加新记忆条目
+- **replace** — 用更新的内容替换已有条目（通过 `old_text` 子串匹配）
+- **remove** — 删除不再相关的条目（通过 `old_text` 子串匹配）
+
+没有 `read` 动作——记忆内容会在会话开始时自动注入系统提示。代理将记忆视为对话上下文的一部分。
+
+### 子串匹配
+
+`replace` 与 `remove` 动作使用短唯一子串匹配——不需要完整的条目文本。`old_text` 参数只需提供能够唯一标识单个条目的子串：
+
+```python
+# 若记忆中包含 "User prefers dark mode in all editors"
+memory(action="replace", target="memory",
+       old_text="dark mode",
+       content="User prefers light mode in VS Code, dark mode in terminal")
+```
+
+如果子串匹配到多个条目，系统会返回错误并要求提供更具体的匹配。
+
+## 两种目标的解释
+
+### `memory` — 代理的个人笔记
+用于记住与环境、工作流以及学习经验相关的信息：
+
+- 环境事实（操作系统、工具、项目结构）
+- 项目约定与配置
+- 工具的怪癖与解决办法
+- 已完成任务的日志条目
+- 有效的技能与技巧
+
+### `user` — 用户画像
+用于记住用户的身份、偏好以及沟通风格：
+
+- 姓名、角色、时区
+- 沟通偏好（简洁 vs 详细、格式偏好）
+- 讨厌的事物与需要避免的行为
+- 工作习惯
+- 技术熟练度
+
+## 保存与略过的内容
+
+### 主动保存
+代理会自动保存——无需额外指令。它会在学习到以下信息时保存：
+
+- **用户偏好**："我更喜欢 TypeScript 而不是 JavaScript" → 保存到 `user`
+- **环境事实**："这台服务器运行 Debian 12，PostgreSQL 16" → 保存到 `memory`
+- **纠正**："不要使用 `sudo` 来运行 Docker 命令，用户已在 docker 组中" → 保存到 `memory`
+- **约定**："项目使用 Tab、行宽 120、Google 风格文档字符串" → 保存到 `memory`
+- **已完成工作**："2026-01-15 将数据库从 MySQL 迁移到 PostgreSQL" → 保存到 `memory`
+- **明确请求**："记住我的 API 密钥轮换是每月一次" → 保存到 `memory`
+
+### 略过保存
+
+- **琐碎/显而易见的信息**："用户询问了 Python" — 信息过于宽泛
+- **易于重新发现的事实**："Python 3.12 支持 f-string 嵌套" — 可直接网络搜索
+- **原始数据转储**：大段代码、日志文件、数据表格 — 超出记忆容量
+- **会话特定的临时信息**：一次性调试路径、一次性文件
+- **已在上下文文件中出现的内容**：SOUL.md 与 AGENTS.md 的内容
+
+## 容量管理
+
+记忆采用严格的字符限制，以保持系统提示的规模可控：
+
+| 存储 | 限制 | 常见条目数量 |
+|------|------|--------------|
+| memory | 2,200 字符 | 8-15 条 |
+| user | 1,375 字符 | 5-10 条 |
+
+### 当记忆已满会怎样
+
+当尝试添加会导致超出上限的条目时，工具会返回错误：
+
+```json
+{
+  "success": false,
+  "error": "Memory at 2,100/2,200 chars. Adding this entry (250 chars) would exceed the limit. Replace or remove existing entries first.",
+  "current_entries": ["..."],
+  "usage": "2,100/2,200"
+}
+```
+
+随后代理应当：
+1. 读取错误响应中给出的当前条目列表
+2. 确定可以删除或合并的条目
+3. 使用 `replace` 将相关条目合并为更短的版本
+4. 再 `add` 新条目
+
+**最佳实践**：当系统提示头部显示记忆使用率超过 80% 时，先合并条目再添加新内容。例如，将三个独立的 “项目使用 X” 条目合并为一个综合的项目描述。
+
+### 优秀记忆条目示例
+
+**简洁、信息密集的条目效果最佳：**
+
+```
+# 好的：打包多个相关事实
+User runs macOS 14 Sonoma, uses Homebrew, has Docker Desktop and Podman. Shell: zsh with oh-my-zsh. Editor: VS Code with Vim keybindings.
+
+# 好的：具体可操作的约定
+Project ~/code/api uses Go 1.22, sqlc for DB queries, chi router. Run tests with 'make test'. CI via GitHub Actions.
+
+# 好的：带上下文的经验教训
+The staging server (10.0.1.50) needs SSH port 2222, not 22. Key is at ~/.ssh/staging_ed25519.
+
+# 糟糕：太模糊
+User has a project.
+
+# 糟糕：冗长
+On January 5th, 2026, the user asked me to look at their project which is
+located at ~/code/api. I discovered it uses Go version 1.22 and...
+```
+
+## 去重防止
+
+记忆系统会自动拒绝完全重复的条目。如果尝试添加已经存在的内容，会返回成功但附带 “no duplicate added” 信息。
+
+## 安全扫描
+
+记忆条目在接受之前会进行注入与泄露模式的安全扫描，因为它们会被注入系统提示。匹配威胁模式（提示注入、凭证泄露、SSH 后门）或包含不可见 Unicode 字符的内容将被阻止。
+
+## 会话搜索
+
+除了 MEMORY.md 与 USER.md，代理还可以使用 `session_search` 工具搜索过去的对话记录：
+
+- 所有 CLI 与消息会话均存储在 SQLite (`~/.hermes/state.db`) 中，使用 FTS5 全文检索
+- 搜索结果返回相关的历史对话，并通过 Gemini Flash 进行摘要
+- 代理可以查找数周前的讨论，即便这些内容不在当前活跃记忆中
+
+```bash
+hermes sessions list    # 浏览过去的会话
+```
+
+### session_search 与 memory 的对比
+
+| 功能 | 持久记忆 | 会话搜索 |
+|------|----------|----------|
+| **容量** | ~1,300 tokens 总计 | 无限（所有会话） |
+| **速度** | 即时（已在系统提示中） | 需要搜索+LLM 摘要 |
+| **使用场景** | 关键事实始终可用 | 查找特定的过去对话 |
+| **管理方式** | 代理手动策划 | 自动——所有会话均被保存 |
+| **令牌成本** | 每会话固定约 1,300 tokens | 按需求搜索时产生成本 |
+
+**Memory** 适用于必须始终在上下文中的关键事实。**Session search** 适用于 “我们上周讨论过 X 吗？” 之类需要回溯历史的查询。
+
+## 配置
+
+```yaml
+# 在 ~/.hermes/config.yaml 中
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200   # ~800 tokens
+  user_char_limit: 1375     # ~500 tokens
+```
+
+## 外部记忆提供者
+
+若需要超越 MEMORY.md 与 USER.md 的更深层持久记忆，Hermes 内置了 8 种外部记忆提供者插件——包括 Honcho、OpenViking、Mem0、Hindsight、Holographic、RetainDB、ByteRover 与 Supermemory。
+
+外部提供者 **并行** 于内置记忆运行（永不取代），并提供知识图、语义搜索、自动事实抽取、跨会话用户建模等功能。
+
+```bash
+hermes memory setup      # 选择并配置提供者
+hermes memory status     # 查看当前激活的提供者
+```
+
+请参阅 [Memory Providers](./memory-providers.md) 指南，获取每个提供者的完整细节、设置步骤以及对比表。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/overview.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/overview.md
@@ -1,0 +1,51 @@
+---
+title: "功能概览"
+sidebar_label: "概览"
+sidebar_position: 1
+---
+
+# 功能概览
+
+Hermes Agent 包含一套丰富的能力，远超基础聊天。从持久记忆（Persistent Memory）和文件感知上下文（File‑Aware Context）到浏览器自动化和语音对话，这些特性协同工作，使 Hermes 成为强大的自主助理。
+
+## 核心
+
+- **[工具与工具集（Tools & Toolsets）](tools.md)** — 工具是扩展代理功能的函数。它们被组织为逻辑工具集，可在每个平台上按需启用或禁用，涵盖网页搜索、终端执行、文件编辑、记忆、委派等。
+- **[技能系统（Skills System）](skills.md)** — 按需加载的知识文档，代理在需要时使用。技能遵循渐进披露模式以最小化 token 使用，并兼容 [agentskills.io](https://agentskills.io/specification) 开放标准。
+- **[持久记忆（Persistent Memory）](memory.md)** — 有界的、精心策划的记忆，跨会话持久化。Hermes 通过 `MEMORY.md` 与 `USER.md` 记住你的偏好、项目、环境以及学习过的内容。
+- **[上下文文件（Context Files）](context-files.md)** — Hermes 会自动发现并加载项目上下文文件（`.hermes.md`、`AGENTS.md`、`CLAUDE.md`、`SOUL.md`、`.cursorrules`），这些文件决定它在项目中的行为方式。
+- **[上下文引用（Context References）](context-references.md)** — 输入 `@` 加引用即可将文件、文件夹、git diff 与 URL 直接注入消息。Hermes 会展开引用并自动在后续追加内容。
+- **[检查点（Checkpoints）](../checkpoints-and-rollback.md)** — 在对工作目录进行文件更改前，Hermes 会自动创建快照，为出现问题时使用 `/rollback` 提供安全回滚。
+
+## 自动化
+
+- **[计划任务（Cron）](cron.md)** — 使用自然语言或 cron 表达式自动调度任务。作业可附加技能、将结果发送至任意平台，并支持暂停/恢复/编辑操作。
+- **[子代理委派（Subagent Delegation）](delegation.md)** — `delegate_task` 工具会生成具有隔离上下文、受限工具集和独立终端会话的子代理实例。默认可并行运行 3 个子代理（可配置），用于并行工作流。
+- **[代码执行（Code Execution）](code-execution.md)** — `execute_code` 工具让代理编写 Python 脚本，程序化调用 Hermes 工具，通过沙箱 RPC 将多步骤工作流压缩为单次 LLM 调用。
+- **[事件钩子（Event Hooks）](hooks.md)** — 在关键生命周期节点运行自定义代码。网关钩子处理日志、告警和 webhook；插件钩子处理工具拦截、指标与安全护栏。
+- **[批量处理（Batch Processing）](batch-processing.md)** — 在数百甚至上千个提示上并行运行 Hermes 代理，生成结构化的 ShareGPT‑format 轨迹数据，用于训练数据生成或评估。
+
+## 媒体与网络
+
+- **[语音模式（Voice Mode）](voice-mode.md)** — 在 CLI 与消息平台上实现完整语音交互。使用麦克风与代理对话，聆听语音回复，并支持在 Discord 语音频道进行实时语音会话。
+- **[浏览器自动化（Browser Automation）](browser.md)** — 多后端完整浏览器自动化：Browserbase 云、Browser Use 云、本地 Chrome（CDP）或本地 Chromium。可浏览网站、填写表单、提取信息。
+- **[视觉与图像粘贴（Vision & Image Paste）](vision.md)** — 多模态视觉支持。可将剪贴板中的图像粘贴到 CLI，并让代理使用任何具备视觉能力的模型进行分析、描述或处理。
+- **[图像生成（Image Generation）](image-generation.md)** — 使用 FAL.ai 根据文本提示生成图像。支持九种模型（FLUX 2 Klein/Pro、GPT‑Image 1.5/2、Nano Banana Pro、Ideogram V3、Recraft V4 Pro、Qwen、Z‑Image Turbo），可通过 `hermes tools` 选择。
+- **[语音与文本转语音（Voice & TTS）](tts.md)** — 在所有消息平台上提供文本转语音输出与语音消息转录，内置十种提供商：Edge TTS（免费）、ElevenLabs、OpenAI TTS、MiniMax、Mistral Voxtral、Google Gemini、xAI、NeuTTS、KittenTTS、Piper，以及支持自定义本地 TTS CLI 的命令提供商。
+
+## 集成
+
+- **[MCP 集成（MCP Integration）](mcp.md)** — 通过 stdio 或 HTTP 传输连接任意 MCP 服务器。无需编写本地 Hermes 工具，即可访问 GitHub、数据库、文件系统和内部 API 等外部工具。支持每服务器工具过滤与抽样。
+- **[提供商路由（Provider Routing）](provider-routing.md)** — 精细控制哪个 AI 提供商处理请求。通过排序、白名单、黑名单和优先级顺序，在成本、速度或质量之间优化。
+- **[后备提供商（Fallback Providers）](fallback-providers.md)** — 当主模型出现错误时自动切换至备用 LLM 提供商，辅助任务（如视觉、压缩）也可独立使用后备提供商。
+- **[凭证池（Credential Pools）](credential-pools.md)** — 为同一提供商的多个 API key 分配调用。遇到速率限制或失败时自动轮换。
+- **[记忆提供商（Memory Providers）](memory-providers.md)** — 接入外部记忆后端（Honcho、OpenViking、Mem0、Hindsight、Holographic、RetainDB、ByteRover、Supermemory），实现跨会话用户建模与个性化，超越内置记忆系统。
+- **[API 服务器（API Server）](api-server.md)** — 将 Hermes 暴露为兼容 OpenAI 的 HTTP 端点。任何支持 OpenAI 格式的前端均可对接——Open WebUI、LobeChat、LibreChat 等。
+- **[IDE 集成（ACP）](acp.md)** — 在 ACP 兼容编辑器（VS Code、Zed、JetBrains）中使用 Hermes。聊天、工具活动、文件差异与终端命令均渲染在编辑器内。
+- **[强化学习训练（RL Training）](rl-training.md)** — 从代理会话生成轨迹数据，用于强化学习与模型微调。
+
+## 定制化
+
+- **[个性与 SOUL.md（Personality & SOUL.md）](personality.md)** — 完全可自定义的代理个性。`SOUL.md` 是系统提示的首要身份文件，可在会话间切换内置或自定义的 `/personality` 预设。
+- **[皮肤与主题（Skins & Themes）](skins.md)** — 自定义 CLI 的视觉呈现：横幅颜色、加载动画、动词、响应框标签、品牌文字以及工具活动前缀。
+- **[插件（Plugins）](plugins.md)** — 在不修改核心代码的前提下添加自定义工具、钩子和集成。三类插件：通用插件（工具/钩子）、记忆提供商（跨会话知识）和上下文引擎（替代上下文管理）。通过统一的 `hermes plugins` 交互式 UI 管理。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/skills.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/skills.md
@@ -1,0 +1,566 @@
+---
+sidebar_position: 2
+title: "Skills System"
+description: "On-demand knowledge documents — progressive disclosure, agent-managed skills, and the Skills Hub"
+---
+
+# 技能系统
+
+技能是按需加载的知识文档，代理在需要时加载。它们遵循 **渐进式披露**（progressive disclosure）模式，以最小化 token 使用，并兼容 [agentskills.io](https://agentskills.io/specification) 开放标准。
+
+所有技能都位于 **`~/.hermes/skills/`** —— 这是唯一且权威的目录。全新安装时，捆绑技能会从仓库复制出来。通过 Hub 安装的以及代理创建的技能也会放在此处。代理可以修改或删除任意技能。
+
+你也可以让 Hermes 指向 **外部技能目录**——额外的文件夹会与本地目录一起被扫描。参见下文的 [外部技能目录](#external-skill-directories)。
+
+另请参阅：
+
+- [捆绑技能目录](/docs/reference/skills-catalog)
+- [官方可选技能目录](/docs/reference/optional-skills-catalog)
+
+## 使用技能
+
+每个已安装的技能会自动提供一个斜杠命令：
+
+```bash
+# 在 CLI 或任意消息平台上：
+/gif-search funny cats
+/axolotl help me fine-tune Llama 3 on my dataset
+/github-pr-workflow create a PR for the auth refactor
+/plan design a rollout for migrating our auth provider
+
+# 仅输入技能名即可加载，并让代理询问你的需求：
+/excalidraw
+```
+
+捆绑的 `plan` 技能是一个典型示例。运行 `/plan [request]` 会加载该技能的说明，指示 Hermes 在必要时检查上下文，写一份 Markdown 实现计划而不是直接执行任务，并将结果保存在工作区/后端工作目录下的 `.hermes/plans/` 中。
+
+你也可以在自然对话中与技能交互：
+
+```bash
+hermes chat --toolsets skills -q "What skills do you have?"
+hermes chat --toolsets skills -q "Show me the axolotl skill"
+```
+
+## 渐进式披露
+
+技能使用一种令牌高效的加载模式：
+
+```
+Level 0: skills_list()           → [{name, description, category}, ...]   (~3k tokens)
+Level 1: skill_view(name)        → 完整内容 + 元数据       (大小可变)
+Level 2: skill_view(name, path)  → 特定引用文件       (大小可变)
+```
+
+只有在真正需要时，代理才会加载完整的技能内容。
+
+## SKILL.md 格式
+
+```markdown
+---
+name: my-skill
+description: Brief description of what this skill does
+version: 1.0.0
+platforms: [macos, linux]     # 可选 — 限制特定操作系统平台
+metadata:
+  hermes:
+    tags: [python, automation]
+    category: devops
+    fallback_for_toolsets: [web]    # 可选 — 条件激活（见下文）
+    requires_toolsets: [terminal]   # 可选 — 条件激活（见下文）
+    config:                          # 可选 — config.yaml 设置
+      - key: my.setting
+        description: "What this controls"
+        default: "value"
+        prompt: "Prompt for setup"
+---
+
+# Skill Title
+
+## When to Use
+触发此技能的使用条件。
+
+## Procedure
+1. 步骤一
+2. 步骤二
+
+## Pitfalls
+- 已知的失败模式及解决办法
+
+## Verification
+如何确认其成功运行。
+```
+
+### 平台特定技能
+
+技能可以通过 `platforms` 字段限制只能在特定操作系统上使用：
+
+| Value | Matches |
+|-------|---------|
+| `macos` | macOS (Darwin) |
+| `linux` | Linux |
+| `windows` | Windows |
+
+```yaml
+platforms: [macos]            # 仅 macOS（例如 iMessage、Apple Reminders、FindMy）
+platforms: [macos, linux]     # macOS 与 Linux 均可
+```
+
+设置后，技能会在不兼容的平台上被隐藏，不会出现在系统提示、`skills_list()` 或斜杠命令中。若不设置，则在所有平台均可加载。
+
+### 条件激活（后备技能）
+
+技能可以根据当前会话中可用的工具集自动显示或隐藏。这在 **后备技能**（免费或本地的替代方案）最有用，当高级付费工具不可用时才出现。
+
+```yaml
+metadata:
+  hermes:
+    fallback_for_toolsets: [web]      # 仅在这些 toolsets 不可用时显示
+    requires_toolsets: [terminal]     # 仅在这些 toolsets 可用时显示
+    fallback_for_tools: [web_search]  # 仅在这些具体工具不可用时显示
+    requires_tools: [terminal]        # 仅在这些具体工具可用时显示
+```
+
+| Field | Behavior |
+|-------|----------|
+| `fallback_for_toolsets` | 当列出的 toolsets **可用** 时技能 **隐藏**；缺失时显示 |
+| `fallback_for_tools` | 同上，但检查单个工具 |
+| `requires_toolsets` | 当列出的 toolsets **不可用** 时技能 **隐藏**；可用时显示 |
+| `requires_tools` | 同上，检查单个工具 |
+
+**示例**：内置 `duckduckgo-search` 技能使用 `fallback_for_toolsets: [web]`。当你设置了 `FIRECRAWL_API_KEY`，`web` toolset 可用，代理会使用 `web_search`，此时 DuckDuckGo 技能保持隐藏。若缺少该 API key，`web` toolset 不可用，DuckDuckGo 技能则作为后备自动出现。
+
+未声明任何条件字段的技能行为保持不变——始终可见。
+
+## 加载时的安全设置
+
+技能可以声明所需的环境变量，但不会因此从发现列表中消失：
+
+```yaml
+required_environment_variables:
+  - name: TENOR_API_KEY
+    prompt: Tenor API key
+    help: Get a key from https://developers.google.com/tenor
+    required_for: full functionality
+```
+
+当加载该技能时若缺少值，Hermes 会在本地 CLI 中安全地询问用户。你可以跳过设置并继续使用技能。消息平台永远不会在聊天中请求机密信息——它们会提示你使用 `hermes setup` 或在本地的 `~/.hermes/.env` 中配置。
+
+一旦设置，声明的环境变量会 **自动传递** 给 `execute_code` 与 `terminal` 沙箱，脚本可以直接使用 `$TENOR_API_KEY`。对于非技能的环境变量，请使用 `terminal.env_passthrough` 配置项。详情请参见 [环境变量透传](/docs/user-guide/security#environment-variable-passthrough)。
+
+### 技能配置设置
+
+技能还能声明非机密的配置项（路径、偏好），存放于 `config.yaml`：
+
+```yaml
+metadata:
+  hermes:
+    config:
+      - key: myplugin.path
+        description: Path to the plugin data directory
+        default: "~/myplugin-data"
+        prompt: Plugin data directory path
+```
+
+这些设置会保存在用户的 `config.yaml` 的 `skills.config` 部分。`hermes config migrate` 会提示未配置的项，`hermes config show` 则会展示当前值。技能加载时，其解析后的配置值会注入上下文，代理因此能自动获知已配置的值。
+
+请参阅 [技能设置](/docs/user-guide/configuration#skill-settings) 与 [创建技能 — 配置设置](/docs/developer-guide/creating-skills#config-settings-configyaml)。
+
+## 技能目录结构
+
+```text
+~/.hermes/skills/                  # 单一事实来源
+├── mlops/                         # 类别目录
+│   ├── axolotl/
+│   │   ├── SKILL.md               # 必须的主说明文件
+│   │   ├── references/            # 附加文档
+│   │   ├── templates/             # 输出模板
+│   │   ├── scripts/               # 脚本库
+│   │   └── assets/                # 资源文件
+│   └── vllm/
+│       └── SKILL.md
+├── devops/
+│   └── deploy-k8s/                # 代理创建的技能
+│       ├── SKILL.md
+│       └── references/
+├── .hub/                          # Skills Hub 状态
+│   ├── lock.json
+│   ├── quarantine/
+│   └── audit.log
+└── .bundled_manifest              # 记录已种子化的捆绑技能
+```
+
+## 外部技能目录
+
+如果你在 Hermes 之外维护技能，例如共享的 `~/.agents/skills/` 目录，可让 Hermes 也扫描这些目录。
+
+在 `~/.hermes/config.yaml` 的 `skills` 部分添加 `external_dirs`：
+
+```yaml
+skills:
+  external_dirs:
+    - ~/.agents/skills
+    - /home/shared/team-skills
+    - ${SKILLS_REPO}/skills
+```
+
+路径支持 `~` 展开以及 `${VAR}` 环境变量替换。
+
+### 工作原理
+
+- **只读**：外部目录仅用于技能发现。代理创建或编辑技能时始终写入 `~/.hermes/skills/`。
+- **本地优先**：若同名技能同时存在于本地和外部目录，本地版本会覆盖。
+- **完整集成**：外部技能会出现在系统提示索引、`skills_list`、`skill_view` 以及 `/skill-name` 斜杠命令中，表现与本地技能无异。
+- **不存在的路径会被静默跳过**：如果配置的目录不存在，Hermes 会忽略且不报错，适用于可选的共享目录。
+
+### 示例
+
+```text
+~/.hermes/skills/               # 本地（主、可写）
+├── devops/deploy-k8s/
+│   └── SKILL.md
+└── mlops/axolotl/
+    └── SKILL.md
+
+~/.agents/skills/               # 外部（只读、共享）
+├── my-custom-workflow/
+│   └── SKILL.md
+└── team-conventions/
+    └── SKILL.md
+```
+
+四个技能都会出现在技能索引中。如果你在本地创建同名的 `my-custom-workflow`，它会遮蔽外部版本。
+
+## 代理管理的技能（skill_manage 工具）
+
+代理可以通过 `skill_manage` 工具创建、更新、删除自己的技能。这是代理的 **过程记忆**——当它在一次会话中找出非平凡的工作流后，会将该方法保存为技能以供日后复用。
+
+### 代理创建技能的时机
+
+- 完成一个复杂任务（5+ 工具调用）且成功
+- 在出现错误或死胡同时找到可行路径
+- 用户纠正了它的做法
+- 发现了非平凡的工作流
+
+### 操作表
+
+| Action | 用途 | 关键参数 |
+|--------|------|----------|
+| `create` | 从零创建新技能 | `name`, `content`（完整 SKILL.md），可选 `category` |
+| `patch` | 有针对性的修补（首选） | `name`, `old_string`, `new_string` |
+| `edit` | 大幅结构性改写 | `name`, `content`（完整 SKILL.md 替换） |
+| `delete` | 完全移除技能 | `name` |
+| `write_file` | 添加/更新辅助文件 | `name`, `file_path`, `file_content` |
+| `remove_file` | 删除辅助文件 | `name`, `file_path` |
+
+:::tip
+`patch` 操作因只传递变更文本而更省 token，推荐用于更新。
+:::
+
+## 技能 Hub
+
+浏览、搜索、安装、管理来自在线注册表、`skills.sh`、知名技能端点以及官方可选技能的技能。
+
+### 常用命令
+
+```bash
+hermes skills browse                              # 浏览所有 Hub 技能（官方优先）
+hermes skills browse --source official            # 只浏览官方可选技能
+hermes skills search kubernetes                   # 搜索所有源
+hermes skills search react --source skills-sh     # 在 skills.sh 目录中搜索
+hermes skills search https://mintlify.com/docs --source well-known
+hermes skills inspect openai/skills/k8s           # 安装前预览
+hermes skills install openai/skills/k8s           # 带安全扫描的安装
+hermes skills install official/security/1password
+hermes skills install skills-sh/vercel-labs/json-render/json-render-react --force
+hermes skills install well-known:https://mintlify.com/docs/.well-known/skills/mintlify
+hermes skills install https://sharethis.chat/SKILL.md              # 直接 URL（单文件 SKILL.md）
+hermes skills install https://example.com/SKILL.md --name my-skill # 当 frontmatter 无 name 时覆盖名称
+hermes skills list --source hub                   # 列出 Hub 安装的技能
+hermes skills check                               # 检查已安装 Hub 技能是否有上游更新
+hermes skills update                              # 需要时重新安装有更新的 Hub 技能
+hermes skills audit                               # 全部 Hub 技能安全重新扫描
+hermes skills uninstall k8s                       # 删除某个 Hub 技能
+hermes skills reset google-workspace              # 解除捆绑技能的 “用户已修改” 标记（见下文）
+hermes skills reset google-workspace --restore    # 同时恢复为捆绑版本，删除本地编辑
+hermes skills publish skills/my-skill --to github --repo owner/repo
+hermes skills snapshot export setup.json          # 导出技能配置
+hermes skills tap add myorg/skills-repo           # 添加自定义 GitHub 来源
+```
+
+### 支持的 Hub 来源
+
+| Source | 示例 | 说明 |
+|--------|------|------|
+| `official` | `official/security/1password` | 随 Hermes 分发的可选技能 |
+| `skills-sh` | `skills-sh/vercel-labs/agent-skills/vercel-react-best-practices` | 通过 `hermes skills search <query> --source skills-sh` 搜索。Hermes 会在 slug 与实际仓库路径不一致时进行解析。 |
+| `well-known` | `well-known:https://mintlify.com/docs/.well-known/skills/mintlify` | 直接从网站的 `/.well-known/skills/index.json` 发现的技能。 |
+| `url` | `https://sharethis.chat/SKILL.md` | 单文件 `SKILL.md` 的直接 HTTP(S) URL。 |
+| `github` | `openai/skills/k8s` | 直接从 GitHub 仓库/路径安装，也可以自定义 tap。 |
+| `clawhub`, `lobehub`, `claude-marketplace` | 各社区或市场来源 | 社区或市场集成。 |
+
+### 集成的 Hub 与注册表
+
+#### 1. 官方可选技能 (`official`)
+这些技能维护在 Hermes 仓库本身，安装时默认信任。
+- 目录：`optional-skills/`
+- 示例：
+```bash
+hermes skills browse --source official
+hermes skills install official/security/1password
+```
+
+#### 2. skills.sh (`skills-sh`)
+Vercel 公开的技能目录。Hermes 可以直接搜索、检查详情页并从底层仓库安装。
+- 站点: https://skills.sh/
+- CLI/工具仓库: https://github.com/vercel-labs/skills
+- 官方 Vercel 技能仓库: https://github.com/vercel-labs/agent-skills
+- 示例：
+```bash
+hermes skills search react --source skills-sh
+hermes skills inspect skills-sh/vercel-labs/json-render/json-render-react
+hermes skills install skills-sh/vercel-labs/json-render/json-render-react --force
+```
+
+#### 3. Well‑known 技能端点 (`well-known`)
+基于 URL 的发现，适用于在站点上发布 `/.well-known/skills/index.json` 的情况。
+- 示例端点: https://mintlify.com/docs/.well-known/skills/index.json
+- 示例：
+```bash
+hermes skills search https://mintlify.com/docs --source well-known
+hermes skills inspect well-known:https://mintlify.com/docs/.well-known/skills/mintlify
+hermes skills install well-known:https://mintlify.com/docs/.well-known/skills/mintlify
+```
+
+#### 4. 直接 GitHub 技能 (`github`)
+Hermes 可以直接从 GitHub 仓库安装技能，亦可添加自定义 tap。
+- 常用的默认 tap：
+  - openai/skills
+  - anthropics/skills
+  - huggingface/skills
+  - VoltAgent/awesome-agent-skills
+  - garrytan/gstack
+- 示例：
+```bash
+hermes skills install openai/skills/k8s
+hermes skills tap add myorg/skills-repo
+```
+
+#### 5. ClawHub (`clawhub`)
+第三方技能市场的社区来源。
+- 站点: https://clawhub.ai/
+- Hermes source id: `clawhub`
+
+#### 6. Claude Marketplace (`claude-marketplace`)
+支持发布 Claude 兼容插件/市场清单的仓库。
+- 已集成来源包括：
+  - anthropics/skills
+  - aiskillstore/marketplace
+- Hermes source id: `claude-marketplace`
+
+#### 7. LobeHub (`lobehub`)
+Hermes 可搜索 LobeHub 公共目录并转换为可安装的 Hermes 技能。
+- 站点: https://lobehub.com/
+- 公共 agents 索引: https://chat-agents.lobehub.com/
+- 后端仓库: https://github.com/lobehub/lobe-chat-agents
+- Hermes source id: `lobehub`
+
+#### 8. 直接 URL (`url`)
+安装单文件 `SKILL.md`，适用于作者自行托管技能的情况。
+- 仅限单文件 `SKILL.md`；多文件技能需使用其他来源。
+```bash
+hermes skills install https://sharethis.chat/SKILL.md
+hermes skills install https://example.com/my-skill/SKILL.md --category productivity
+```
+
+**名称解析顺序**：
+1. `name:` frontmatter（推荐）
+2. URL 路径父目录名（若满足 `^[a-z][a-z0-9_-]*$`）
+3. 交互式提示（终端）
+4. 非交互式表面错误并要求 `--name` 参数
+
+```bash
+# 前置条件没有 name 且 URL slug 不好用时：
+hermes skills install https://example.com/SKILL.md --name sharethis-chat
+# 在聊天中使用：
+/skills install https://example.com/SKILL.md --name sharethis-chat
+```
+
+信任级别始终为 `community`——与其他来源相同的安全扫描。URL 会被记录为安装标识符，`hermes skills update` 会自动从同一 URL 重新获取。
+
+## 安全扫描与 `--force`
+所有 Hub 安装的技能都会经过 **安全扫描**，检查数据外泄、提示注入、破坏性命令、供应链信号等威胁。
+
+`hermes skills inspect …` 还会展示上游元数据：
+- 仓库 URL
+- skills.sh 详情页 URL
+- 安装指令
+- 周安装次数
+- 上游安全审计状态
+- well-known 索引/端点 URL
+
+当你审查完第三方技能并决定覆盖非致命的策略阻断时，可使用 `--force`：
+```bash
+hermes skills install skills-sh/anthropics/skills/pdf --force
+```
+
+重要行为：
+- `--force` 能覆盖 **警告**（warn）类型的策略阻断。
+- `--force` **不能**覆盖 **危险**（dangerous） verdict。
+- 官方可选技能 (`official/...`) 被视为内置信任，不会出现第三方警告面板。
+
+## 信任等级
+
+| Level | Source | Policy |
+|-------|--------|--------|
+| `builtin` | 随 Hermes 分发 | 始终信任 |
+| `official` | 仓库中的 `optional-skills/` | 内置信任，无第三方警告 |
+| `trusted` | 受信任的注册表/仓库（如 openai/skills 等） | 比社区来源更宽松的策略 |
+| `community` | 其它所有来源（skills.sh、well‑known、GitHub 自定义等） | 非危险发现可用 `--force` 覆盖；危险发现仍被阻止 |
+
+## 更新生命周期
+Hub 会记录足够的来源信息以便重新检查已安装技能的上游副本：
+```bash
+hermes skills check          # 报告哪些已安装的 Hub 技能在上游有变更
+hermes skills update         # 只重新安装有更新的技能
+hermes skills update react   # 单独更新指定的已安装 Hub 技能
+```
+这通过存储的来源标识符以及当前上游内容哈希来检测漂移。
+
+:::tip GitHub 速率限制
+Hub 操作使用 GitHub API，未认证用户每小时 60 次请求。若遇到速率限制错误，可在 `.env` 中设置 `GITHUB_TOKEN` 以提升至 5,000 次/小时。错误信息会提供相应提示。
+:::
+
+## 发布自定义技能 Tap
+如果你想分享一组经过策划的技能（团队、组织或公开），可以将它们作为 **tap** 发布：一个 GitHub 仓库，其他 Hermes 用户使用 `hermes skills tap add <owner/repo>` 添加。
+无需服务器、注册表或发布流水线，只要在仓库中提供 `SKILL.md` 文件即可。
+
+### 仓库布局
+```
+owner/repo
+├── skills/                       # 默认路径，可在 tap 中自定义
+│   ├── my-workflow/
+│   │   ├── SKILL.md              # 必须
+│   │   ├── references/           # 可选支持文件
+│   │   ├── templates/
+│   │   └── scripts/
+│   ├── another-skill/
+│   │   └── SKILL.md
+│   └── third-skill/
+│       └── SKILL.md
+└── README.md                     # 可选但有帮助
+```
+**规则**：
+- 每个技能必须在 Tap 根路径（默认 `skills/`）下拥有独立目录。
+- 目录名即为技能的安装 slug。
+- 必须包含 `SKILL.md`，其中包含标准 frontmatter（`name`、`description`，以及可选的 `metadata.hermes.tags`、`version`、`author`、`platforms`、`metadata.hermes.config` 等）。
+- `references/`、`templates/`、`scripts/`、`assets/` 等子目录会在安装时一起下载。
+- 以 `.` 或 `_` 开头的目录会被忽略。
+
+Hermes 通过遍历 Tap 路径的每个子目录并检查 `SKILL.md` 来发现技能。
+
+### 最小 Tap 示例
+```
+my-org/hermes-skills
+└── skills/
+    └── deploy-runbook/
+        └── SKILL.md
+```
+`skills/deploy-runbook/SKILL.md`:
+```markdown
+---
+name: deploy-runbook
+description: 我们的部署运行手册 — 服务、回滚、Slack 频道
+version: 1.0.0
+author: My Org Platform Team
+metadata:
+  hermes:
+    tags: [deployment, runbook, internal]
+---
+# Deploy Runbook
+
+Step 1: ...
+```
+推送到 GitHub 后，任何 Hermes 用户均可订阅并安装：
+```bash
+hermes skills tap add my-org/hermes-skills
+hermes skills search deploy
+hermes skills install my-org/hermes-skills/deploy-runbook
+```
+
+### 非默认路径
+若技能不在 `skills/` 目录下（例如在已有项目中添加 `skills/` 子树），请编辑 `~/.hermes/.hub/taps.json`：
+```json
+{
+  "taps": [
+    {"repo": "my-org/platform-docs", "path": "internal/skills/"}
+  ]
+}
+```
+`hermes skills tap add` 默认使用 `path: "skills/"`，如需不同路径请手动编辑。`hermes skills tap list` 会显示每个 Tap 的实际路径。
+
+### 直接安装单个技能（无需添加 Tap）
+用户也可以直接从任意公开 GitHub 仓库安装单个技能：
+```bash
+hermes skills install owner/repo/skills/my-workflow
+```
+适用于只想分享单个技能而不要求用户订阅整个仓库的场景。
+
+### Tap 的信任等级
+新添加的 Tap 默认为 `community` 信任。其下的技能会走标准安全扫描并在首次安装时显示第三方警告面板。若你的组织或广受信任的来源需要更高信任，可在 `tools/skills_hub.py` 的 `TRUSTED_REPOS` 中加入对应仓库（需要 Hermes 核心 PR）。
+
+### Tap 管理
+```bash
+hermes skills tap list                                # 显示所有已配置的 tap
+hermes skills tap add myorg/skills-repo               # 添加（默认路径: skills/）
+hermes skills tap remove myorg/skills-repo            # 移除
+```
+在运行中的会话里：
+```
+/skills tap list
+/skills tap add myorg/skills-repo
+/skills tap remove myorg/skills-repo
+```
+Tap 会保存在 `~/.hermes/.hub/taps.json`（首次使用时创建）。
+
+## 捆绑技能更新 (`hermes skills reset`)
+Hermes 随仓库自带一套捆绑技能，安装及每次 `hermes update` 时会同步这些技能到 `~/.hermes/skills/`，并在 `~/.hermes/skills/.bundled_manifest` 中记录每个技能的内容哈希（**origin hash**）。
+
+同步时，Hermes 重新计算本地副本的哈希并与 origin hash 对比：
+- **未改变** → 安全拉取上游更改，复制新版本并记录新哈希。
+- **已修改** → 被视为 **用户已修改**，永久跳过，以防止本地编辑被覆盖。
+
+如果你编辑了捆绑技能，随后想放弃修改并恢复捆绑版本，仅复制 `~/.hermes/hermes-agent/skills/` 的内容是不够的，因为 manifest 仍保留旧的 origin hash。此时需要使用 `hermes skills reset`：
+```bash
+# 只清除 manifest 条目，保留当前副本；下次同步会以此为基准
+hermes skills reset google-workspace
+
+# 完全恢复：删除本地副本并重新复制当前捆绑版本
+hermes skills reset google-workspace --restore
+
+# 非交互式（脚本或 TUI）——跳过 --restore 确认
+hermes skills reset google-workspace --restore --yes
+```
+同样的命令可通过聊天斜杠使用：
+```text
+/skills reset google-workspace
+/skills reset google-workspace --restore
+```
+
+:::note Profiles
+每个配置文件拥有独立的 `.bundled_manifest`，因此 `hermes -p coder skills reset <name>` 只会影响该配置对应的 profile。
+:::
+
+## 斜杠命令（在聊天中）
+所有相同的命令均可通过 `/skills` 使用：
+```text
+/skills browse
+/skills search react --source skills-sh
+/skills search https://mintlify.com/docs --source well-known
+/skills inspect skills-sh/vercel-labs/json-render/json-render-react
+/skills install openai/skills/skill-creator --force
+/skills check
+/skills update
+/skills reset google-workspace
+/skills list
+```
+官方可选技能仍使用 `official/security/1password`、`official/migration/openclaw-migration` 等标识符。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tools.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tools.md
@@ -1,0 +1,207 @@
+---
+sidebar_position: 1
+title: "工具 & 工具集"
+description: "Hermes Agent 的工具概览 — 可用工具、工具集工作方式以及终端后端"
+---
+
+# 工具 & 工具集
+
+工具是扩展代理能力的函数。它们被组织为逻辑上的 **工具集**，可在不同平台上启用或禁用。
+
+## 可用工具
+
+Hermes 自带了丰富的内置工具注册表，涵盖网页搜索、浏览器自动化、终端执行、文件编辑、记忆、任务委派、强化学习训练、消息投递、Home Assistant 等。
+
+:::note
+**Honcho 跨会话记忆** 作为记忆提供者插件（`plugins/memory/honcho/`）提供，而非内置工具集。请参阅 [插件](./plugins.md) 了解安装方法。
+:::
+
+高级分类如下：
+
+| 类别 | 示例 | 描述 |
+|------|------|------|
+| **Web** | `web_search`, `web_extract` | 在网页上搜索并提取页面内容。 |
+| **终端 & 文件** | `terminal`, `process`, `read_file`, `patch` | 执行命令并操作文件。 |
+| **浏览器** | `browser_navigate`, `browser_snapshot`, `browser_vision` | 交互式浏览器自动化，支持文本和视觉。 |
+| **多媒体** | `vision_analyze`, `image_generate`, `text_to_speech` | 多模态分析与生成。 |
+| **代理编排** | `todo`, `clarify`, `execute_code`, `delegate_task` | 规划、澄清、代码执行以及子代理委派。 |
+| **记忆 & 检索** | `memory`, `session_search` | 持久记忆与会话搜索。 |
+| **自动化 & 投递** | `cronjob`, `send_message` | 支持创建/列出/更新/暂停/恢复/运行/删除的定时任务，以及外发消息投递。 |
+| **集成** | `ha_*`, MCP 服务器工具, `rl_*` | Home Assistant、MCP、强化学习训练及其他集成。 |
+
+欲获取权威的代码派生注册表，请参阅 [内置工具参考](/docs/reference/tools-reference) 与 [工具集参考](/docs/reference/toolsets-reference)。
+
+:::tip Nous Tool Gateway
+付费的 [Nous Portal](https://portal.nousresearch.com) 订阅用户可以通过 **[工具网关](tool-gateway.md)** 使用网页搜索、图像生成、文本转语音和浏览器自动化——无需单独的 API Key。运行 `hermes model` 启用，或使用 `hermes tools` 配置单独工具。
+:::
+
+## 使用工具集
+
+```bash
+# 使用特定工具集
+hermes chat --toolsets "web,terminal"
+
+# 查看所有可用工具
+hermes tools
+
+# 交互式配置平台工具（交互式）
+hermes tools
+```
+
+常用工具集包括 `web`, `search`, `terminal`, `file`, `browser`, `vision`, `image_gen`, `moa`, `skills`, `tts`, `todo`, `memory`, `session_search`, `cronjob`, `code_execution`, `delegation`, `clarify`, `homeassistant`, `messaging`, `spotify`, `discord`, `discord_admin`, `debugging`, `safe`, `rl` 等。
+
+完整列表请参见 [工具集参考](/docs/reference/toolsets-reference)，其中包括平台预设如 `hermes-cli`, `hermes-telegram`，以及动态 MCP 工具集 `mcp-<server>`。
+
+## 终端后端
+
+终端工具可以在不同环境中执行命令：
+
+| 后端 | 描述 | 适用场景 |
+|------|------|----------|
+| `local` | 在本机运行（默认） | 开发、可信任务 |
+| `docker` | 隔离容器 | 安全、可复现 |
+| `ssh` | 远程服务器 | 沙箱化、避免代理直接修改自身代码 |
+| `singularity` | HPC 容器 | 集群计算、无特权 |
+| `modal` | 云端执行 | 无服务器、弹性伸缩 |
+| `daytona` | 云端沙箱工作区 | 持久远程开发环境 |
+| `vercel_sandbox` | Vercel Sandbox 云微VM | 带快照文件系统持久化的云执行 |
+
+### 配置
+
+```yaml
+# 位于 ~/.hermes/config.yaml
+terminal:
+  backend: local    # 或: docker, ssh, singularity, modal, daytona, vercel_sandbox
+  cwd: "."          # 工作目录
+  timeout: 180      # 命令超时时间（秒）
+```
+
+### Docker 后端
+
+```yaml
+terminal:
+  backend: docker
+  docker_image: python:3.11-slim
+```
+
+**单一持久容器，整个进程共享**。Hermes 在首次使用时启动一个长期运行的容器（`docker run -d … sleep 2h`），随后所有终端、文件、`execute_code` 调用都通过 `docker exec` 进入同一容器。工作目录切换、已安装的包、写入 `/workspace` 的文件都会在后续调用中保留，跨 `/new`, `/reset` 与 `delegate_task` 子代理均保持。进程关闭时容器会被停止并删除。
+
+这意味着 Docker 后端的行为类似持久化的沙箱 VM，而不是每条指令都重新创建容器。若 `pip install foo` 一次，后续就可以直接使用；若 `cd /workspace/project`，随后的 `ls` 能看到该目录。完整生命周期请参考 [配置 → Docker 后端](../configuration.md#docker-backend) 与控制容器持久性的 `container_persistent` 标志。
+
+### SSH 后端
+
+建议用于安全——代理无法修改自身代码：
+
+```yaml
+terminal:
+  backend: ssh
+```
+
+```bash
+# 在 ~/.hermes/.env 中设置凭证
+TERMINAL_SSH_HOST=my-server.example.com
+TERMINAL_SSH_USER=myuser
+TERMINAL_SSH_KEY=~/.ssh/id_rsa
+```
+
+### Singularity/Apptainer
+
+```bash
+# 为并行工作者预构建 SIF
+apptainer build ~/python.sif docker://python:3.11-slim
+
+# 配置
+hermes config set terminal.backend singularity
+hermes config set terminal.singularity_image ~/python.sif
+```
+
+### Modal（无服务器云）
+
+```bash
+uv pip install modal
+modal setup
+hermes config set terminal.backend modal
+```
+
+### Vercel Sandbox
+
+```bash
+pip install 'hermes-agent[vercel]'
+hermes config set terminal.backend vercel_sandbox
+hermes config set terminal.vercel_runtime node24
+```
+
+需要同时设置 `VERCEL_TOKEN`、`VERCEL_PROJECT_ID` 与 `VERCEL_TEAM_ID`。此方式是 Render、Railway、Docker 等托管环境中部署及长时间运行 Hermes 进程的官方支持路径。支持的运行时包括 `node24`, `node22`, `python3.13`；Hermes 默认将远程工作空间根目录设为 `/vercel/sandbox`。
+
+在本地快速开发时，Hermes 也接受短期的 Vercel OIDC 令牌：
+
+```bash
+VERCEL_OIDC_TOKEN="$(vc project token <project-name>)" hermes chat
+```
+
+在已关联的 Vercel 项目目录下：
+
+```bash
+VERCEL_OIDC_TOKEN="$(vc project token)" hermes chat
+```
+
+开启 `container_persistent: true` 时，Vercel 快照会在同一任务的沙箱重建之间保留文件系统状态，可包括 Hermes 同步的凭证、技能与缓存文件。快照不保留活跃进程、PID 空间或相同的沙箱身份。
+
+后台终端命令仍遵循通用的非本地进程流程：生成、轮询、等待、记录、终止，使用普通 `process` 工具，但 Vercel 并未提供沙箱外的分离进程恢复能力。
+
+请保持 `container_disk` 为默认 `51200`；自定义磁盘大小在 Vercel Sandbox 上不受支持，若设置会导致诊断/后端创建失败。
+
+### 容器资源
+
+为所有容器后端统一配置 CPU、内存、磁盘与持久化选项：
+
+```yaml
+terminal:
+  backend: docker  # 或 singularity, modal, daytona, vercel_sandbox
+  container_cpu: 1              # CPU 核数（默认 1）
+  container_memory: 5120        # 内存（MB，默认 5GB）
+  container_disk: 51200         # 磁盘（MB，默认 50GB）
+  container_persistent: true    # 跨会话持久文件系统（默认 true）
+```
+
+启用 `container_persistent: true` 后，已安装的依赖、生成的文件与配置将在会话之间保存。
+
+### 容器安全
+
+所有容器后端均进行安全加固：
+
+- 只读根文件系统（Docker）
+- 丢弃所有 Linux 能力
+- 禁止提权
+- 限制 PID 数量（256 个进程）
+- 完全的命名空间隔离
+- 通过挂载卷实现持久工作区，而非可写根层
+
+Docker 可通过 `terminal.docker_forward_env` 明确转发环境变量列表，但转发的变量对容器内的所有命令可见，请视为已暴露。
+
+## 后台进程管理
+
+启动后台进程并进行管理：
+
+```python
+terminal(command="pytest -v tests/", background=true)
+# 返回: {"session_id": "proc_abc123", "pid": 12345}
+
+# 使用 process 工具进行管理：
+process(action="list")       # 列出所有运行中的进程
+process(action="poll", session_id="proc_abc123")   # 检查状态
+process(action="wait", session_id="proc_abc123")   # 阻塞直至完成
+process(action="log", session_id="proc_abc123")    # 获取完整输出
+process(action="kill", session_id="proc_abc123")   # 终止进程
+process(action="write", session_id="proc_abc123", data="y")  # 发送输入
+```
+
+设置 `pty=true` 可启用交互式 CLI 工具，如 Codex 与 Claude Code。
+
+## Sudo 支持
+
+若命令需要 sudo，系统会提示输入密码（会在会话期间缓存）。也可以在 `~/.hermes/.env` 中预先设置 `SUDO_PASSWORD`。
+
+:::warning
+在消息平台上，若 sudo 失败，输出中会包含添加 `SUDO_PASSWORD` 到 `~/.hermes/.env` 的提示。
+:::

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/security.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/security.md
@@ -1,0 +1,589 @@
+---
+sidebar_position: 8
+title: "安全"
+description: "安全模型、危险命令批准、用户授权、容器隔离以及生产部署最佳实践"
+---
+
+# 安全
+
+Hermes Agent 采用深度防御（defense-in-depth）安全模型进行设计。本页覆盖所有安全边界——从命令批准到容器隔离再到消息平台上的用户授权。
+
+## 概览
+
+安全模型共有七层：
+
+1. **用户授权** —— 谁可以与代理对话（白名单、私聊配对）
+2. **危险命令批准** —— 对破坏性操作进行人工审查
+3. **容器隔离** —— 使用 Docker/Singularity/Modal 沙箱并使用强化设置
+4. **MCP 凭证过滤** —— 为 MCP 子进程提供环境变量隔离
+5. **上下文文件扫描** —— 检测项目文件中的提示注入
+6. **跨会话隔离** —— 会话之间无法访问对方的数据或状态；cron 作业的存储路径针对路径遍历攻击进行硬化
+7. **输入消毒** —— 在终端工具后端对工作目录参数进行白名单校验，以防止 Shell 注入
+
+## 危险命令批准
+
+在执行任何命令之前，Hermes 会将其与精心挑选的危险模式列表进行匹配。如果匹配成功，则必须由用户显式批准。
+
+### 批准模式
+
+批准系统支持三种模式，可在 `~/.hermes/config.yaml` 的 `approvals.mode` 中配置：
+
+```yaml
+approvals:
+  mode: manual    # manual | smart | off
+  timeout: 60     # 等待用户响应的秒数（默认 60）
+```
+
+| 模式 | 行为 |
+|------|------|
+| **manual**（默认） | 对所有危险命令始终弹出提示让用户批准 |
+| **smart** | 使用辅助 LLM 评估风险。低风险命令（例如 `python -c "print('hello')"`）自动批准。真正危险的命令自动拒绝。无法确定的情况升级为手动提示 |
+| **off** | 关闭所有批准检查 —— 等同于使用 `--yolo` 运行。所有命令均不提示 |
+
+:::warning
+将 `approvals.mode: off` 关闭所有安全提示。仅在受信任的环境（CI/CD、容器等）中使用。
+:::
+
+### YOLO 模式
+
+YOLO 模式会为当前会话绕过 **所有** 危险命令批准提示。可通过三种方式激活：
+
+1. **CLI 标志**：使用 `hermes --yolo` 或 `hermes chat --yolo` 启动会话
+2. **斜杠命令**：在会话中输入 `/yolo` 切换开关
+3. **环境变量**：设置 `HERMES_YOLO_MODE=1`
+
+`/yolo` 命令是 **切换**——每次使用都会翻转状态：
+
+```
+> /yolo
+  ⚡ YOLO mode ON — all commands auto‑approved. Use with caution.
+
+> /yolo
+  ⚠ YOLO mode OFF — dangerous commands will require approval.
+```
+
+YOLO 模式在 CLI 与网关会话中均可使用。内部实现上，它会设置 `HERMES_YOLO_MODE` 环境变量，并在每次命令执行前进行检查。
+
+:::danger
+YOLO 模式会禁用 **所有** 危险命令安全检查 **除了** 硬性阻断列表（见下文）。仅在您完全信任生成的命令时使用（例如在一次性环境中的经过充分测试的自动化脚本）。
+:::
+
+### 硬性阻断列表（始终开启的底线）
+
+以下命令极具破坏性——不可恢复的文件系统擦除、fork 炸弹、直接写块设备——即使开启 `--yolo`、`approvals.mode: off`、cron 作业的 `approve` 模式或用户手动点击 “always allow”，Hermes 仍会拒绝执行。这些模式在 **审批层之前** 即被拦截，且没有覆盖标志。
+
+当前阻断的模式（非穷尽，随 `tools/approval.py::UNRECOVERABLE_BLOCKLIST` 同步更新）：
+
+| 模式 | 原因 |
+|---|---|
+| `rm -rf /` 及明显变体 | 删除根文件系统 |
+| `rm -rf --no-preserve-root /` | 明确表示要删除根目录 |
+| `:(){ :|:& };:`（bash fork 炸弹） | 使主机卡死直至重启 |
+| `mkfs.*` 在已挂载的根设备上 | 格式化运行系统 |
+| `dd if=/dev/zero of=/dev/sd*` | 将物理磁盘清零 |
+| 在根文件系统顶部将不可信 URL 管道至 `sh` | 过宽的远程代码执行向量 |
+
+若触发阻断列表，工具调用会返回解释性错误，且不会实际运行。如果您确实需要执行此类命令（例如在擦除‑重新安装流水线中），请在代理外部手动运行。
+
+### 批准超时
+
+当出现危险命令提示时，用户有可配置的响应时间。若在超时内未作出响应，默认 **拒绝**（fail‑closed）。
+
+在 `~/.hermes/config.yaml` 中配置超时：
+
+```yaml
+approvals:
+  timeout: 60  # 秒（默认 60）
+```
+
+### 触发批准的模式
+
+以下模式会触发批准提示（定义于 `tools/approval.py`）：
+
+| 模式 | 描述 |
+|------|------|
+| `rm -r` / `rm --recursive` | 递归删除 |
+| `rm ... /` | 在根路径下删除 |
+| `chmod 777/666` / `o+w` / `a+w` | 设为全局可写权限 |
+| `chmod --recursive` 与不安全权限组合 |
+| `chown -R root` / `chown --recursive root` | 递归 chown 为 root |
+| `mkfs` | 格式化文件系统 |
+| `dd if=` | 磁盘拷贝 |
+| `> /dev/sd` | 写块设备 |
+| `DROP TABLE/DATABASE` | SQL DROP |
+| `DELETE FROM`（无 WHERE） | SQL DELETE 无条件 |
+| `TRUNCATE TABLE` | SQL TRUNCATE |
+| `> /etc/` | 覆写系统配置文件 |
+| `systemctl stop/restart/disable/mask` | 停止/重启/禁用系统服务 |
+| `kill -9 -1` | 杀死所有进程 |
+| `pkill -9` | 强制杀进程 |
+| fork 炸弹模式 |
+| `bash -c` / `sh -c` / `zsh -c` / `ksh -c` | 通过 `-c` 执行脚本 |
+| `python -e` / `perl -e` / `ruby -e` / `node -c` | 通过 `-e`/`-c` 执行单行脚本 |
+| `curl ... \| sh` / `wget ... \| sh` | 将远程内容管道至 shell |
+| `bash <(curl ...)` / `sh <(wget ...)` | 通过进程替换执行远程脚本 |
+| `tee` 到 `/etc/`、`~/.ssh/`、`~/.hermes/.env` | 通过 tee 覆写敏感文件 |
+| `>` / `>>` 到 `/etc/`、`~/.ssh/`、`~/.hermes/.env` | 通过重定向覆盖敏感文件 |
+| `xargs rm` | xargs 与 rm 组合 |
+| `find -exec rm` / `find -delete` | find 与破坏性动作结合 |
+| `cp`/`mv`/`install` 到 `/etc/` | 将文件复制/移动到系统配置目录 |
+| `sed -i` / `sed --in-place` 在 `/etc/` 上 | 原地编辑系统配置 |
+| `pkill`/`killall` hermes/gateway | 防止自我终止 |
+| `gateway run` 与 `&`/`disown`/`nohup`/`setsid` 组合 | 防止在服务管理器之外启动网关 |
+
+:::info
+**容器绕过**：在 `docker`、`singularity`、`modal`、`daytona` 或 `vercel_sandbox` 后端运行时，危险命令检查会 **跳过**，因为容器本身已经是安全边界。容器内的破坏性命令不会危及宿主机。
+:::
+
+### 审批流程（CLI）
+
+在交互式 CLI 中，危险命令会显示内联批准提示：
+
+```
+  ⚠️  DANGEROUS COMMAND: recursive delete
+      rm -rf /tmp/old-project
+
+      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny
+
+      Choice [o/s/a/D]:
+```
+
+四个选项含义：
+
+- **once** —— 仅本次执行允许
+- **session** —— 本会话期间均允许此模式
+- **always** —— 写入永久白名单（保存至 `config.yaml`）
+- **deny**（默认） —— 阻止命令执行
+
+### 审批流程（网关/消息平台）
+
+在消息平台中，代理会将危险命令细节发送至聊天，并等待用户回复：
+
+- 回复 **yes**、**y**、**approve**、**ok**、**go** 进行批准
+- 回复 **no**、**n**、**deny**、**cancel** 拒绝
+
+`HERMES_EXEC_ASK=1` 环境变量会在网关运行时自动设置。
+
+### 永久白名单
+
+使用 “always” 批准的命令会写入 `~/.hermes/config.yaml`：
+
+```yaml
+# 永久允许的危险命令模式
+command_allowlist:
+  - rm
+  - systemctl
+```
+
+这些模式在启动时加载，并在所有后续会话中静默批准。
+
+:::tip
+使用 `hermes config edit` 查看或删除永久白名单中的模式。
+:::
+
+## 用户授权（网关）
+
+在运行消息网关时，Hermes 通过分层授权系统控制谁可以与机器人交互。
+
+### 授权检查顺序
+
+`_is_user_authorized()` 方法按以下顺序检查：
+
+1. **平台特定的全局允许标志**（如 `DISCORD_ALLOW_ALL_USERS=true`）
+2. **已配对的私聊代码列表**（通过配对码批准的用户）
+3. **平台特定白名单**（例如 `TELEGRAM_ALLOWED_USERS=12345,67890`）
+4. **全局白名单**（`GATEWAY_ALLOWED_USERS=12345,67890`）
+5. **全局全开放**（`GATEWAY_ALLOW_ALL_USERS=true`）
+6. **默认：拒绝**
+
+### 平台白名单
+
+在 `~/.hermes/.env` 中以逗号分隔方式设置允许的用户 ID：
+
+```bash
+# 平台特定白名单
+TELEGRAM_ALLOWED_USERS=123456789,987654321
+DISCORD_ALLOWED_USERS=111222333444555666
+WHATSAPP_ALLOWED_USERS=15551234567
+SLACK_ALLOWED_USERS=U01ABC123
+
+# 跨平台白名单（所有平台统一检查）
+GATEWAY_ALLOWED_USERS=123456789
+
+# 平台全开放（谨慎使用）
+DISCORD_ALLOW_ALL_USERS=true
+
+# 全局全开放（极度谨慎）
+GATEWAY_ALLOW_ALL_USERS=true
+```
+
+:::warning
+如果 **未配置任何白名单** 且 `GATEWAY_ALLOW_ALL_USERS` 未设置，**所有用户均被拒绝**。网关启动时会记录警告：
+
+```
+No user allowlists configured. All unauthorized users will be denied.
+Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access,
+or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id).
+```
+:::
+
+### 私聊配对系统
+
+为提供更灵活的授权，Hermes 包含基于一次性配对码的系统。未知用户会收到配对码，机器人所有者在 CLI 上批准后即可永久授权该用户。
+
+**工作流程**：
+
+1. 未知用户给机器人发送私聊
+2. 机器人回复 8 位配对码
+3. 机器人所有者运行 `hermes pairing approve <platform> <code>`
+4. 该用户在该平台上永久获准
+
+在 `~/.hermes/config.yaml` 中配置未授权私聊的处理方式：
+
+```yaml
+unauthorized_dm_behavior: pair
+
+whatsapp:
+  unauthorized_dm_behavior: ignore
+```
+
+- `pair` 为默认：未授权私聊会收到配对码回复
+- `ignore` 静默丢弃未授权私聊
+- 平台段可以覆盖全局默认，以实现如 Telegram 采用配对而 WhatsApp 直接忽略的需求
+
+**安全特性**（基于 OWASP + NIST SP 800‑63‑4 指南）：
+
+| 特性 | 说明 |
+|------|------|
+| 代码格式 | 8 位，使用 32 位无歧义字符（不含 0/O/1/I） |
+| 随机性 | 加密 (`secrets.choice()`) |
+| 代码有效期 | 1 小时 |
+| 限流 | 每用户每 10 分钟最多 1 次请求 |
+| 待处理上限 | 每平台最多 3 个待处理代码 |
+| 锁定 | 5 次失败批准 → 1 小时锁定 |
+| 文件安全 | 对所有配对数据文件 `chmod 0600` |
+| 日志 | 代码从不记录到 stdout |
+
+**配对 CLI 命令**：
+
+```bash
+# 列出待处理和已批准的用户
+hermes pairing list
+
+# 批准配对码
+hermes pairing approve telegram ABC12DEF
+
+# 撤销用户访问
+hermes pairing revoke telegram 123456789
+
+# 清除所有待处理代码
+hermes pairing clear-pending
+```
+
+**存储**：配对数据保存在 `~/.hermes/pairing/`，每个平台对应 JSON 文件：
+- `{platform}-pending.json` — 待处理配对请求
+- `{platform}-approved.json` — 已批准用户
+- `_rate_limits.json` — 限流与锁定追踪
+
+## 容器隔离
+
+使用 `docker` 终端后端时，Hermes 对每个容器施加严格的安全加固。
+
+### Docker 安全标记
+
+每个容器都使用以下标记（定义于 `tools/environments/docker.py`）：
+
+```python
+_SECURITY_ARGS = [
+    "--cap-drop", "ALL",                          # 丢弃所有 Linux 能力
+    "--cap-add", "DAC_OVERRIDE",                  # 让 root 能写入挂载目录
+    "--cap-add", "CHOWN",                         # 包管理器需要文件所有权
+    "--cap-add", "FOWNER",                        # 同上
+    "--security-opt", "no-new-privileges",         # 阻止特权升级
+    "--pids-limit", "256",                         # 限制进程数
+    "--tmpfs", "/tmp:rw,nosuid,size=512m",         # 限制大小的 /tmp
+    "--tmpfs", "/var/tmp:rw,noexec,nosuid,size=256m",  # /var/tmp 禁止 exec
+    "--tmpfs", "/run:rw,noexec,nosuid,size=64m",   # /run 禁止 exec
+]
+```
+
+### 资源限制
+
+容器资源可在 `~/.hermes/config.yaml` 中配置：
+
+```yaml
+terminal:
+  backend: docker
+  docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
+  docker_forward_env: []  # 仅显式白名单；空列表保持凭证不进入容器
+  container_cpu: 1        # CPU 核心数
+  container_memory: 5120  # MB（默认 5GB）
+  container_disk: 51200   # MB（默认 50GB，需要 XFS 上的 overlay2）
+  container_persistent: true  # 跨会话持久化文件系统
+```
+
+### 文件系统持久化
+
+- **持久模式** (`container_persistent: true`)：将 `~/.hermes/sandboxes/docker/<task_id>/` 中的 `/workspace` 与 `/root` 绑定挂载
+- **临时模式** (`container_persistent: false`)：使用 tmpfs，所有工作区在清理时即被删除
+
+:::tip
+在生产网关部署时，请使用 `docker`、`modal`、`daytona` 或 `vercel_sandbox` 后端，以将代理命令与宿主系统隔离。这可以完全省去危险命令批准机制。
+:::
+
+:::warning
+如果在 `terminal.docker_forward_env` 中添加变量名，这些变量会被显式注入容器供终端命令使用。适用于任务特定凭证（如 `GITHUB_TOKEN`），但也意味着容器内代码能够读取并外泄这些凭证。
+:::
+
+## 终端后端安全对比
+
+| 后端 | 隔离程度 | 危险命令检查 | 适用场景 |
+|------|----------|---------------|----------|
+| **local** | 无 —— 直接在宿主机运行 | ✅ 有 | 开发、可信用户 |
+| **ssh** | 远程机器 | ✅ 有 | 在独立服务器上运行 |
+| **docker** | 容器 | ❌ 跳过（容器即边界） | 生产网关 |
+| **singularity** | 容器 | ❌ 跳过 | HPC 环境 |
+| **modal** | 云沙箱 | ❌ 跳过 | 可扩展云隔离 |
+| **daytona** | 云沙箱 | ❌ 跳过 | 持久化云工作区 |
+| **vercel_sandbox** | 云微虚拟机 | ❌ 跳过 | 云执行并支持快照持久化 |
+
+## 环境变量透传 {#environment-variable-passthrough}
+
+`execute_code` 与 `terminal` 会从子进程中剥离敏感环境变量，以防止 LLM 生成的代码泄露凭证。但声明了 `required_environment_variables` 的技能会自动获得所需变量的透传权限。
+
+### 工作原理
+
+有两种机制可让特定变量通过沙箱过滤：
+
+1. **技能级透传（自动）**
+   当加载带有 `required_environment_variables` 声明的技能时，凡在宿主环境中已设置的变量会自动注册为透传。缺失的变量不会注册。
+
+   ```yaml
+   # 在技能的 SKILL.md frontmatter 中
+   required_environment_variables:
+     - name: TENOR_API_KEY
+       prompt: Tenor API key
+       help: Get a key from https://developers.google.com/tenor
+   ```
+
+   加载该技能后，`TENOR_API_KEY` 会在 `execute_code`、`terminal`（本地）以及远程后端（Docker、Modal）中自动可用，无需手动配置。
+
+   :::info Docker & Modal
+   在 v0.5.1 之前，Docker 的 `forward_env` 与技能透传是两套系统。现已合并——技能声明的环境变量会自动转发至 Docker 容器和 Modal 沙箱，无需手动添加至 `docker_forward_env`。
+   :::
+
+2. **配置式透传（手动）**
+   对于未被任何技能声明的变量，可在 `config.yaml` 中手动添加至 `terminal.env_passthrough`：
+
+   ```yaml
+   terminal:
+     env_passthrough:
+       - MY_CUSTOM_KEY
+       - ANOTHER_TOKEN
+   ```
+
+### 凭证文件透传（OAuth 令牌等） {#credential-file-passthrough}
+
+部分技能需要 **文件**（而非仅环境变量）在沙箱中可用，例如 Google Workspace 将 OAuth 令牌存放为 `google_token.json`。技能在 frontmatter 中声明：
+
+```yaml
+required_credential_files:
+  - path: google_token.json
+    description: Google OAuth2 token (created by setup script)
+  - path: google_client_secret.json
+    description: Google OAuth2 client credentials
+```
+
+加载后，Hermes 会检查这些文件是否存在于活动配置文件夹的 `HERMES_HOME`，并在不同后端中进行挂载：
+- **Docker**：只读绑定挂载 (`-v host:container:ro`)
+- **Modal**：在沙箱创建时挂载，并在每次命令前同步（支持中途 OAuth 设置）
+- **本地**：无需操作，文件本身已可访问
+
+也可以在 `config.yaml` 中手动列出凭证文件：
+
+```yaml
+terminal:
+  credential_files:
+    - google_token.json
+    - my_custom_oauth_token.json
+```
+
+路径相对于 `~/.hermes/`，在容器内部会挂载至 `/root/.hermes/`。
+
+### 各沙箱过滤规则概览
+
+| 沙箱 | 默认过滤 | 透传覆盖 |
+|------|----------|----------|
+| **execute_code** | 阻止包含 `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSWD`, `AUTH` 的变量；仅允许安全前缀变量 | ✅ 透传变量可绕过两层检查 |
+| **terminal**（本地） | 阻止 Hermes 基础设施变量（provider keys、gateway token、tool API keys） | ✅ 透传变量可绕过阻断列表 |
+| **terminal**（Docker） | 默认不转发宿主环境变量 | ✅ 透传变量 + `docker_forward_env` 通过 `-e` 注入 |
+| **terminal**（Modal） | 默认不转发宿主环境变量/文件 | ✅ 凭证文件挂载；环境变量通过同步透传 |
+| **MCP** | 仅保留系统变量 + 明确配置的 `env` 项 | ❌ 不受透传影响（需在 MCP `env` 中配置） |
+
+### 安全考量
+
+- 透传仅限于您或技能明确声明的变量，默认安全姿态不受影响
+- 凭证文件在 Docker 中为 **只读** 挂载
+- 技能 Guard 在安装前会扫描技能内容，检测可疑的环境变量访问模式
+- 未设置或不存在的变量永远不会被注册（不存在的东西不可能泄露）
+- Hermes 基础设施的密钥（provider API key、gateway token）绝不应加入 `env_passthrough`，它们有专用的机制进行管理
+
+## MCP 凭证处理
+
+MCP（Model Context Protocol）服务器子进程会获取 **过滤后的环境变量**，以防止意外泄露凭证。
+
+### 安全环境变量
+
+仅以下变量会从宿主传递至 MCP 子进程：
+
+```
+PATH, HOME, USER, LANG, LC_ALL, TERM, SHELL, TMPDIR
+```
+以及任何 `XDG_*` 变量。其它所有环境变量（API 密钥、令牌、秘密）均会被 **剥离**。
+
+可以在 MCP 服务器的 `env` 配置中显式声明要透传的变量：
+
+```yaml
+mcp_servers:
+  github:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."  # 仅此变量会被传递
+```
+
+### 凭证脱敏
+
+MCP 工具返回的错误信息在返回给 LLM 前会被清理，以下模式会被替换为 `[REDACTED]`：
+
+- GitHub PAT (`ghp_…`)
+- OpenAI‑style keys (`sk‑…`)
+- Bearer tokens
+- `token=`, `key=`, `API_KEY=`, `password=`, `secret=` 参数
+
+## 网站访问策略
+
+您可以通过配置限制代理能够访问的站点，以防止访问内部服务、管理面板或其他敏感 URL。
+
+```yaml
+# 位于 ~/.hermes/config.yaml
+security:
+  website_blocklist:
+    enabled: true
+    domains:
+      - "*.internal.company.com"
+      - "admin.example.com"
+    shared_files:
+      - "/etc/hermes/blocked-sites.txt"
+```
+
+当请求被阻止的 URL 时，工具会返回错误说明该域名被策略阻止。该阻名单在 `web_search`、`web_extract`、`browser_navigate` 以及所有具备 URL 能力的工具中统一生效。详细信息请参考配置指南中的 [Website Blocklist](/docs/user-guide/configuration#website-blocklist)。
+
+## SSRF 保护
+
+所有具备 URL 能力的工具（网页搜索、网页提取、视觉、浏览器）在获取前都会验证 URL，以防止服务器端请求伪造（SSRF）攻击。被阻断的地址包括：
+
+- **私有网络**（RFC 1918）：`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- **回环**：`127.0.0.0/8`, `::1`
+- **链路本地**：`169.254.0.0/16`（包括云元数据 `169.254.169.254`）
+- **CGNAT / 共享地址空间**（RFC 6598）：`100.64.0.0/10`（Tailscale、WireGuard VPN 等）
+- **云元数据主机名**：`metadata.google.internal`, `metadata.goog`
+- **保留、组播和未指定地址**
+
+SSRF 保护在面向互联网的使用场景下始终开启，DNS 解析失败视作被阻断（fail‑closed）。重定向链会在每一次跳转时重新校验，以防止通过重定向绕过。
+
+### 有意允许私有 URL
+
+某些部署确实需要访问私有/内部 URL——例如在本地网络中解析 `home.arpa` 指向 RFC 1918 地址、LAN‑only 的 Ollama/llama.cpp 端点、内部 wiki、云元数据调试等。对此类需求提供全局关闭选项：
+
+```yaml
+security:
+  allow_private_urls: true   # 默认: false
+```
+
+开启后，网页工具、浏览器、视觉 URL 获取以及网关媒体下载将不再拒绝 RFC 1918 / 回环 / 链路本地 / CGNAT / 云元数据目标。**这是一条明确的信任边界**——仅在您能够接受代理对本地网络进行任意 URL 请求的机器上启用。面向公共的网关应保持关闭。
+
+即使开启该选项，域名同形异体（Unicode 伪造）防护仍然保持开启。
+
+## Tirith 预执行安全扫描
+
+Hermes 集成了 [tirith](https://github.com/sheeki03/tirith) 进行内容层面的命令扫描。Tirith 能检测模式匹配无法捕获的威胁：
+
+- 同形异体 URL 欺骗（国际化域名攻击）
+- 管道至解释器模式（`curl | bash`, `wget | sh`）
+- 终端注入攻击
+
+Tirith 会在首次使用时自动从 GitHub Release 下载，并进行 SHA‑256 校验（若系统中有 cosign 则进行可供性验证）。
+
+```yaml
+# 位于 ~/.hermes/config.yaml
+security:
+  tirith_enabled: true       # 启用/禁用 tirith 扫描（默认 true）
+  tirith_path: "tirith"      # tirith 二进制路径（默认在 PATH 中查找）
+  tirith_timeout: 5          # 子进程超时秒数
+  tirith_fail_open: true     # tirith 不可用或超时时仍允许执行（默认 true）
+```
+
+当 `tirith_fail_open` 为 `true`（默认），若 tirith 未安装或超时，命令仍会继续执行。若在高安全环境中希望在 tirith 不可用时阻止命令，请将其设为 `false`。
+
+Tirith 的判定会整合到批准流程中：安全命令直接通过，疑似或被阻断的命令会向用户展示 tirith 检测结果（严重程度、标题、描述、可行的更安全替代方案），用户可批准或拒绝——默认选择为拒绝，以保障无人值守场景的安全。
+
+## 上下文文件注入防护
+
+上下文文件（AGENTS.md、.cursorrules、SOUL.md）在被加入系统提示前会进行提示注入扫描。扫描检测以下风险：
+
+- 指示忽略先前指令的指令
+- 含有可疑关键字的隐藏 HTML 注释
+- 读取敏感文件（`.env`、`credentials`、`.netrc`）的尝试
+- 通过 `curl` 的凭证外泄
+- 隐形 Unicode 字符（零宽空格、双向覆盖符）
+
+被阻断的文件会显示警告：
+
+```
+[BLOCKED: AGENTS.md contained potential prompt injection (prompt_injection). Content not loaded.]
+```
+
+## 生产部署最佳实践
+
+### 网关部署检查清单
+
+1. **设置明确的白名单** —— 生产环境切勿使用 `GATEWAY_ALLOW_ALL_USERS=true`
+2. **使用容器后端** —— 在 `config.yaml` 中设 `terminal.backend: docker`
+3. **限制资源配额** —— 合理设置 CPU、内存、磁盘限制
+4. **安全存储密钥** —— 将 API 密钥放入 `~/.hermes/.env`，并确保文件权限得当
+5. **启用 DM 配对** —— 如可能，使用配对码代替硬编码用户 ID
+6. **审计命令白名单** —— 定期检查 `command_allowlist` 中的条目
+7. **设置 `MESSAGING_CWD`** —— 不让代理在敏感目录下运行
+8. **以非 root 身份运行** —— 永不以 root 身份运行网关
+9. **监控日志** —— 检查 `~/.hermes/logs/` 中的未授权访问尝试
+10. **保持更新** —— 定期运行 `hermes update` 以获取安全补丁
+
+### 保护 API 密钥
+
+```bash
+# 为 .env 文件设置合适的权限
+chmod 600 ~/.hermes/.env
+
+# 为不同服务使用独立密钥
+# 永不将 .env 提交至版本控制
+```
+
+### 网络隔离
+
+若要获得最高安全性，请在独立机器或虚拟机上运行网关。将 `terminal.backend: ssh` 写入 `config.yaml`，并在 `~/.hermes/.env` 中提供主机信息：
+
+```yaml
+# ~/.hermes/config.yaml
+terminal:
+  backend: ssh
+```
+
+```bash
+# ~/.hermes/.env
+TERMINAL_SSH_HOST=agent-worker.local
+TERMINAL_SSH_USER=hermes
+TERMINAL_SSH_KEY=~/.ssh/hermes_agent_key
+```
+
+SSH 连接细节存放在 `.env`（而非 `config.yaml`），以避免在导出或共享配置时泄露。这样即可将网关的消息连接与代理的命令执行彻底分离。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
@@ -1,0 +1,415 @@
+---
+sidebar_position: 7
+title: "会话"
+description: "会话持久化、恢复、搜索、管理以及跨平台会话追踪"
+---
+
+# 会话
+
+Hermes Agent 会自动将每一次对话保存为会话。会话支持对话恢复、跨会话搜索以及完整的对话历史管理。
+
+## 会话工作原理
+
+无论是来自 CLI、Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Teams，还是其他任何消息平台的对话，都会以会话的形式存储完整的消息历史。会话在两个互补系统中进行追踪：
+
+1. **SQLite 数据库** (`~/.hermes/state.db`) — 结构化的会话元数据，支持 FTS5 全文搜索
+2. **JSONL 转录文件** (`~/.hermes/sessions/`) — 包含工具调用（gateway）的原始对话转录
+
+SQLite 数据库存储：
+- 会话 ID、来源平台、用户 ID
+- **会话标题**（唯一、可读的名称）
+- 模型名称和配置
+- 系统提示快照
+- 完整的消息历史（角色、内容、工具调用、工具结果）
+- Token 计数（输入/输出）
+- 时间戳（started_at、ended_at）
+- 父会话 ID（用于压缩触发的会话拆分）
+
+### 什么计入上下文
+
+Hermes 会存储会话历史以便恢复对话，但不会重新发送它曾经处理过的每一个字节。每一次轮次，模型只会看到：
+- 选中的系统提示
+- 当前对话窗口
+- Hermes 为该轮次显式注入的任何内容
+
+媒体附件作为轮次范围的输入处理：
+
+- 图像可以直接附加到下一个模型调用，或者在模型不支持原生视觉时被预先分析成文字描述。
+- 音频在配置了语音转文字时会被转录为文本。
+- 文本文档可以提取文本后包含；其他文档类型通常以本地路径和简短说明的形式表示。
+- 附件路径以及提取/派生的文本可以出现在转录中，但原始图片、音频或二进制文件的字节不会反复复制到后续提示中。
+
+例如，用户发送一张图片并要求 Hermes 制作表情包，Hermes 可能会使用视觉一次检查图像并运行图像处理脚本。之后的轮次不会自动携带原始 JPEG，而只会携带用户的请求、简短的图像描述、缓存路径或最终助手的回复。
+
+导致上下文增长的最常见原因不是媒体文件本身，而是冗长的文字：粘贴的转录、完整日志、庞大的工具输出、长 diff、重复的状态报告以及详细的证明输出。建议使用摘要、文件路径、聚焦的片段以及基于工具的检索，而不是把大型资产复制进聊天。
+
+:::tip
+使用 `/compress` 当会话过长，使用 `/new` 开启新线程，使用 `hermes sessions prune` 仅在想要从存储中删除已结束的旧会话时使用。压缩会减少活动上下文；它并不等同于隐私删除。
+:::
+
+### 会话来源
+
+每个会话都带有来源平台标签：
+
+| 来源 | 描述 |
+|------|------|
+| `cli` | 交互式 CLI（`hermes` 或 `hermes chat`） |
+| `telegram` | Telegram 消息 |
+| `discord` | Discord 服务器/私信 |
+| `slack` | Slack 工作区 |
+| `whatsapp` | WhatsApp 消息 |
+| `signal` | Signal 消息 |
+| `matrix` | Matrix 房间和私信 |
+| `mattermost` | Mattermost 频道 |
+| `email` | Email（IMAP/SMTP） |
+| `sms` | 通过 Twilio 的 SMS |
+| `dingtalk` | 钉钉 |
+| `feishu` | 飞书/Lark |
+| `wecom` | 企业微信 |
+| `weixin` | 个人微信 |
+| `bluebubbles` | macOS 上的 Apple iMessage (BlueBubbles) |
+| `qqbot` | 腾讯 QQ Bot（官方 API v2） |
+| `homeassistant` | Home Assistant 对话 |
+| `webhook` | 入站 webhook |
+| `api-server` | API 服务器请求 |
+| `acp` | ACP 编辑器集成 |
+| `cron` | 定时任务 |
+| `batch` | 批处理运行 |
+
+## CLI 会话恢复
+
+使用 `--continue` 或 `--resume` 从 CLI 恢复先前的对话：
+
+### 恢复最近的会话
+
+```bash
+# 恢复最近的 CLI 会话
+hermes --continue
+hermes -c
+
+# 或使用 chat 子命令
+hermes chat --continue
+hermes chat -c
+```
+这会从 SQLite 数据库中查找最近的 `cli` 会话并加载完整的对话历史。
+
+### 按名称恢复
+
+如果为会话设置了标题（参见下面的 **会话命名**），可以按名称恢复：
+
+```bash
+# 恢复已命名的会话
+hermes -c "my project"
+
+# 当存在系列变体（my project、my project #2、my project #3）时，自动恢复最近的那个
+hermes -c "my project"   # → 恢复 "my project #3"
+```
+
+### 按会话 ID 恢复
+
+```bash
+# 通过会话 ID 恢复
+hermes --resume 20250305_091523_a1b2c3d4
+hermes -r 20250305_091523_a1b2c3d4
+
+# 按标题恢复
+hermes --resume "refactoring auth"
+
+# 使用 chat 子命令
+hermes chat --resume 20250305_091523_a1b2c3d4
+```
+会话 ID 会在退出 CLI 会话时显示，也可以通过 `hermes sessions list` 查看。
+
+### 恢复时的对话概览
+
+恢复会话时，Hermes 会在输入提示前以样式化面板展示上一段对话的简要概览：
+
+![恢复概览示例](/img/docs/session-recap.svg)
+<p class="docs-figure-caption">恢复模式会在活跃提示前显示最近用户和助手的交互摘要。</p>
+
+概览特点：
+- 显示 **用户消息**（金色 `●`）和 **助手回复**（绿色 `◆`）
+- 对长消息进行截断（用户 300 字，助手 200 字/3 行）
+- 将工具调用折叠为计数并列出工具名称，例如 `[3 tool calls: terminal, web_search]`
+- 隐藏系统消息、工具结果和内部推理
+- 最多保留最近 10 轮，对更早的消息用 "... N earlier messages ..." 标记
+- 使用 **暗淡** 样式区分于活跃对话
+
+如果想禁用完整概览并保持单行行为，可在 `~/.hermes/config.yaml` 中设置：
+
+```yaml
+display:
+  resume_display: minimal   # 默认 full
+```
+
+:::tip
+会话 ID 采用 `YYYYMMDD_HHMMSS_<hex>` 格式——CLI/TUI 会话使用 6 位十六进制后缀（如 `20250305_091523_a1b2c3`），网关会话使用 8 位后缀（如 `20250305_091523_a1b2c3d4`）。可以使用完整 ID、唯一前缀或标题进行恢复，均适用于 `-c` 与 `-r`。
+:::
+
+## 跨平台移交
+
+在 CLI 会话中使用 `/handoff <platform>` 将实时对话转移到消息平台的主频道。代理会从同一个会话 ID、完整角色转录以及所有工具调用继续。
+
+```bash
+# 在 CLI 会话内部
+/handoff telegram
+```
+
+移交过程：
+1. CLI 验证 `<platform>` 已启用并设置了主频道（在目标聊天中运行 `/sethome` 配置）。
+2. CLI 将会话标记为 pending 并 **阻塞轮询** 网关。若代理正处于回复中，会拒绝并提示等待。
+3. 网关监视器获取移交并向目标适配器请求新线程：
+   - **Telegram**：打开新论坛主题（若 Bot API 9.4+ 开启 Topics）或 DM 主题。
+   - **Discord**：在主文字频道下创建 1440 分钟自动归档线程。
+   ...（同前文）
+4. 网关重新绑定目标键到现有 CLI 会话 ID，并伪造用户回合让代理确认并概括。回复落在新线程中。
+5. 网关确认成功后，CLI 打印 `/resume` 提示并优雅退出。
+6. 之后对话在平台上继续，任意有权限的成员共享同一会话。线程会话不携带 `user_id`，因此同一线程内的所有用户共享上下文。
+
+**返回 CLI**：运行 `/resume <title>`（或 `hermes -r "<title>"`）即可重新接管会话。
+
+**错误情况**：
+- 未配置主频道 → CLI 提示 `/sethome`。
+- 平台未启用或网关未运行 → CLI 在 60 秒超时后给出明确信息，会话保持完整。
+- 线程创建失败（权限、未开启 topics） → 回退到主频道，仍完成移交。
+- `adapter.send` 失败（限流、临时 API 错误） → 标记失败并给出原因，可重试。
+
+## 会话命名
+
+为会话赋予可读标题，便于查找和恢复。
+
+### 自动生成标题
+
+Hermes 会在首次交互后自动为每个会话生成 3–7 个词的简短描述标题。此过程在后台线程使用辅助模型完成，不会增加延迟。当使用 `hermes sessions list` 或 `hermes sessions browse` 浏览会话时会看到自动标题。每个会话仅生成一次，手动设置标题后自动标题会被跳过。
+
+### 手动设置标题
+
+在任意聊天会话（CLI 或网关）中使用 `/title` 命令：
+
+```
+/title my research project
+```
+标题会即时生效。如果会话尚未在数据库创建（例如在首次发送消息前使用 `/title`），则会在会话启动后应用。
+
+也可以在命令行重命名已有会话：
+
+```bash
+hermes sessions rename 20250305_091523_a1b2c3d4 "refactoring auth module"
+```
+
+### 标题规则
+- **唯一**——不同会话不能使用相同标题
+- **最长 100 字符**——保持列表输出整洁
+- **自动清理**——控制字符、零宽字符和 RTL 覆盖符会被剥除
+- **支持普通 Unicode**——emoji、中文、带音调字符均可
+
+### 自动衍生（压缩）
+
+当会话上下文被压缩（手动 `/compress` 或自动）时，Hermes 会创建一个继承会话。若原会话已有标题，新会话会自动得到带序号的标题：
+
+```
+"my project" → "my project #2" → "my project #3"
+```
+使用名称恢复（`hermes -c "my project"`）时会自动选取最新的会话。
+
+### `/title` 在消息平台中的使用
+
+所有网关平台均支持 `/title` 命令：
+- `/title My Research` — 设置会话标题
+- `/title` — 显示当前标题
+
+## 会话管理命令
+
+Hermes 提供完整的会话管理子命令 `hermes sessions`：
+
+### 列出会话
+
+```bash
+# 列出最近的会话（默认 20 条）
+hermes sessions list
+
+# 按平台过滤
+hermes sessions list --source telegram
+
+# 显示更多
+hermes sessions list --limit 50
+```
+带标题的会话会显示标题、预览和相对时间戳。
+
+### 导出会话
+
+```bash
+# 导出全部会话为 JSONL
+hermes sessions export backup.jsonl
+
+# 导出特定平台的会话
+hermes sessions export telegram-history.jsonl --source telegram
+
+# 导出单个会话
+hermes sessions export session.jsonl --session-id 20250305_091523_a1b2c3d4
+```
+导出的文件每行一个 JSON 对象，包含完整的会话元数据和所有消息。
+
+### 删除会话
+
+```bash
+# 删除指定会话（需要确认）
+hermes sessions delete 20250305_091523_a1b2c3d4
+
+# 直接删除不确认
+hermes sessions delete 20250305_091523_a1b2c3d4 --yes
+```
+
+### 重命名会话
+
+```bash
+# 设置或更改会话标题
+hermes sessions rename 20250305_091523_a1b2c3d4 "debugging auth flow"
+```
+如果标题已被其他会话使用，则会报错。
+
+### 清理旧会话
+
+```bash
+# 删除 90 天前结束的会话（默认）
+hermes sessions prune
+
+# 自定义保留天数
+hermes sessions prune --older-than 30
+
+# 仅对特定平台执行
+hermes sessions prune --source telegram --older-than 60
+
+# 跳过确认
+hermes sessions prune --older-than 30 --yes
+```
+:::info
+仅会删除 **已结束** 的会话（显式结束或自动重置的会话）。活跃会话永远不会被清理。
+:::
+
+### 会话统计
+
+```bash
+hermes sessions stats
+```
+示例输出：
+```
+Total sessions: 142
+Total messages: 3847
+  cli: 89 sessions
+  telegram: 38 sessions
+  discord: 15 sessions
+Database size: 12.4 MB
+```
+如需更深度分析（Token 使用、费用估算、工具分布、活跃模式）请使用 [`hermes insights`](/docs/reference/cli-commands#hermes-insights)。
+
+## 会话搜索工具
+
+内置的 `session_search` 工具使用 SQLite 的 FTS5 引擎对所有历史对话执行全文搜索。
+
+### 工作原理
+1. FTS5 搜索匹配的消息并按相关度排序
+2. 按会话分组，取前 N（默认 3）唯一会话
+3. 加载每个会话的对话并截取约 100K 字符的上下文
+4. 交给快速摘要模型生成精简摘要
+5. 返回每个会话的摘要、元数据和上下文片段
+
+### FTS5 查询语法
+- 简单关键词：`docker deployment`
+- 短语：`"exact phrase"`
+- 布尔：`docker OR kubernetes`、`python NOT java`
+- 前缀：`deploy*`
+
+### 使用时机
+当用户提及过去的对话或你怀疑有相关历史上下文时，模型会自动提示使用 `session_search` 在提问前检索。
+
+## 跨平台会话追踪
+
+### 网关会话
+在消息平台上，会话键由以下决定性格式组成：
+
+| 聊天类型 | 默认键格式 | 行为 |
+|----------|------------|------|
+| Telegram DM | `agent:main:telegram:dm:<chat_id>` | 每个私聊对应一个会话 |
+| Discord DM | `agent:main:discord:dm:<chat_id>` | 每个私聊对应一个会话 |
+| WhatsApp DM | `agent:main:whatsapp:dm:<canonical_identifier>` | 每个用户对应一个会话（别名合并） |
+| 群组聊天 | `agent:main:<platform>:group:<chat_id>:<user_id>` | 在平台提供用户 ID 时每用户独立会话 |
+| 群组线程/话题 | `agent:main:<platform>:group:<chat_id>:<thread_id>` | 所有线程参与者共享会话（默认）。`thread_sessions_per_user: true` 时每用户独立 |
+| 频道 | `agent:main:<platform>:channel:<chat_id>:<user_id>` | 在平台提供用户 ID 时每用户独立 |
+
+如果无法获取参与者标识，Hermes 会退回到房间级共享会话。
+
+### 共享 vs 独立群组会话
+默认 `group_sessions_per_user: true`（在 `config.yaml` 中），这意味着：
+- Alice 与 Bob 在同一 Discord 频道内对 Hermes 提问时各自拥有独立会话，互不干扰
+- 某用户的长工具任务不会污染他人的上下文窗口
+- 中断处理也保持按用户分离，因为运行的代理键匹配独立会话键
+
+如想实现共享 “房间大脑”，将其设为 `false`：
+
+```yaml
+group_sessions_per_user: false
+```
+这会把群组/频道恢复为单一共享会话，便于共享上下文但也会共享 token 成本与中断状态。
+
+### 会话重置策略
+网关会话会依据以下可配置策略自动重置：
+- **idle** — 在 N 分钟无交互后重置
+- **daily** — 每天特定时刻重置
+- **both** — 以先到者为准（idle 或 daily）
+- **none** — 永不自动重置
+
+在自动重置前，代理会获得一次轮次以保存重要记忆或技能。拥有活跃后台进程的会话永不自动重置，无论策略如何。
+
+## 存储位置
+
+| 项目 | 路径 | 描述 |
+|------|------|------|
+| SQLite 数据库 | `~/.hermes/state.db` | 所有会话元数据 + 消息，带 FTS5 |
+| 网关转录 | `~/.hermes/sessions/` | 每会话 JSONL 转录 + `sessions.json` 索引 |
+| 网关索引 | `~/.hermes/sessions/sessions.json` | 映射会话键到活动会话 ID |
+
+SQLite 使用 WAL 模式以支持并发读取，单写者模式，非常适合多平台网关架构。
+
+### 数据库模式
+- **sessions** — 会话元数据（id、source、user_id、model、title、时间戳、token 计数）。标题拥有唯一索引（NULL 允许，仅非 NULL 必须唯一）。
+- **messages** — 完整消息历史（role、content、tool_calls、tool_name、token_count）
+- **messages_fts** — FTS5 虚表，用于全文搜索
+
+## 会话过期与清理
+
+### 自动清理
+- 网关会话依据配置的重置策略自动重置
+- 重置前，代理会保存记忆与技能
+- 可选自动剪枝：`sessions.auto_prune` 为 `true` 时，结束的会话在 `sessions.retention_days`（默认 90 天）之前会被剪枝，在 CLI/网关启动时执行
+- 剪枝后若实际删除行，则对 `state.db` 执行 `VACUUM` 以回收磁盘空间（SQLite DELETE 不会收缩文件）
+- 剪枝最多每 `sessions.min_interval_hours`（默认 24）运行一次；上次运行时间记录在 `state.db` 中，所有 Hermes 进程共享该信息
+
+默认 **关闭** — 会话历史对 `session_search` 检索非常有价值，自动删除可能令用户意外。若在高负载网关/定时任务环境下 `state.db` 体积影响性能（例如 384 MB、约 1000 会话导致 FTS5 插入缓慢），可在 `~/.hermes/config.yaml` 中开启：
+
+```yaml
+sessions:
+  auto_prune: true          # 选项——默认 false
+  retention_days: 90        # 保留已结束会话的天数
+  vacuum_after_prune: true  # 剪枝后回收磁盘空间
+  min_interval_hours: 24    # 两次剪枝之间的最小间隔
+```
+活跃会话永不被自动剪枝。
+
+### 手动清理
+
+```bash
+# 剪枝超过 90 天的会话
+hermes sessions prune
+
+# 删除特定会话
+hermes sessions delete <session_id>
+
+# 在剪枝前导出备份
+hermes sessions export backup.jsonl
+hermes sessions prune --older-than 30 --yes
+```
+
+:::tip
+数据库增长缓慢（数百会话通常 10‑15 MB），会话历史为 `session_search` 提供跨会话检索能力。若出现大文件（如 384 MB）导致性能下降，可使用上面的自动或手动剪枝。
+:::


### PR DESCRIPTION
## Summary

Add Simplified Chinese (zh-Hans) translation for Hermes Agent core documentation. The i18n infrastructure (Docusaurus) was already configured for zh-Hans but only 3 out of 316 docs had been translated before this PR.

## What's translated (first batch — 15 new files)

### Getting Started
- Landing page (index.md)
- Quickstart (quickstart.md)
- Installation guide (installation.md)
- Learning path (learning-path.md)
- Updating guide (updating.md)

### User Guide
- CLI guide (cli.md)
- Configuration (configuration.md)
- Sessions (sessions.md)
- Security guide (security.md)

### Features
- Features overview (overview.md)
- Memory system (memory.md)
- Tools system (tools.md)
- Skills system (skills.md)
- Cron jobs (cron.md)
- Delegation / Sub-agents (delegation.md)

## Translation conventions
- YAML frontmatter translated; code blocks, CLI commands, file paths, URLs, and env var names kept in English
- Technical terms annotated in Chinese on first occurrence, used in English afterward
- Natural, non-machine-translated Chinese prose
- All Markdown structure preserved

## Status
Work in progress — more docs will follow in subsequent PRs.