### PR TITLE
fix(skills): skip hidden directories during discovery

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -249,7 +249,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            iter_skill_index_files,
+            skill_path_has_excluded_dir,
+        )
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
@@ -261,7 +265,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if skill_path_has_excluded_dir(skill_md, scan_dir):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -475,14 +475,28 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 # ── File iteration ────────────────────────────────────────────────────────
 
 
+def is_excluded_skill_dir(name: str) -> bool:
+    """Return True if a skill scan should skip this directory name."""
+    return name in EXCLUDED_SKILL_DIRS or name.startswith(".")
+
+
+def skill_path_has_excluded_dir(path: Path, root: Path) -> bool:
+    """Return True if *path* is under an excluded directory below *root*."""
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        parts = path.parts
+    return any(is_excluded_skill_dir(part) for part in parts[:-1])
+
+
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Excludes hidden directories and explicit metadata/workspace directories.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        dirs[:] = [d for d in dirs if not is_excluded_skill_dir(d)]
         if filename in files:
             matches.append(Path(root) / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -111,6 +111,17 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
+    def test_skips_arbitrary_hidden_directories(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "visible-skill")
+            _make_skill(tmp_path, "cursor-copy", category=".cursor/skills")
+            _make_skill(tmp_path, "opencode-copy", category="visible/.opencode")
+            result = scan_skill_commands()
+
+        assert "/visible-skill" in result
+        assert "/cursor-copy" not in result
+        assert "/opencode-copy" not in result
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,7 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1", model="gpt-5")
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +345,14 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1", model="gpt-5")
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1", model="gpt-5")
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_hidden_dir_filter.py
+++ b/tests/tools/test_hidden_dir_filter.py
@@ -7,8 +7,9 @@ This caused quarantined skills (.hub/quarantine/) to appear as installed.
 Now uses Path.parts which is platform-independent.
 """
 
-import os
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
+
+from agent.skill_utils import skill_path_has_excluded_dir
 
 
 def _old_filter_matches(path_str: str) -> bool:
@@ -19,12 +20,12 @@ def _old_filter_matches(path_str: str) -> bool:
     return '/.git/' in path_str or '/.github/' in path_str or '/.hub/' in path_str
 
 
-def _new_filter_matches(path: Path) -> bool:
+def _new_filter_matches(path: Path, root: Path) -> bool:
     """The FIXED filter using Path.parts.
 
     Returns True when the path SHOULD be filtered out.
     """
-    return any(part in ('.git', '.github', '.hub') for part in path.parts)
+    return skill_path_has_excluded_dir(path, root)
 
 
 class TestOldFilterBrokenOnWindows:
@@ -51,33 +52,39 @@ class TestNewFilterCrossPlatform:
 
     def test_hub_quarantine_filtered(self, tmp_path):
         """A SKILL.md inside .hub/quarantine/ must be filtered out."""
-        p = tmp_path / ".hermes" / "skills" / ".hub" / "quarantine" / "evil" / "SKILL.md"
-        assert _new_filter_matches(p) is True
+        root = tmp_path / "skills"
+        p = root / ".hub" / "quarantine" / "evil" / "SKILL.md"
+        assert _new_filter_matches(p, root) is True
 
     def test_git_dir_filtered(self, tmp_path):
         """A SKILL.md inside .git/ must be filtered out."""
-        p = tmp_path / ".hermes" / "skills" / ".git" / "hooks" / "SKILL.md"
-        assert _new_filter_matches(p) is True
+        root = tmp_path / "skills"
+        p = root / ".git" / "hooks" / "SKILL.md"
+        assert _new_filter_matches(p, root) is True
 
     def test_github_dir_filtered(self, tmp_path):
         """A SKILL.md inside .github/ must be filtered out."""
-        p = tmp_path / ".hermes" / "skills" / ".github" / "workflows" / "SKILL.md"
-        assert _new_filter_matches(p) is True
+        root = tmp_path / "skills"
+        p = root / ".github" / "workflows" / "SKILL.md"
+        assert _new_filter_matches(p, root) is True
 
     def test_normal_skill_not_filtered(self, tmp_path):
         """A regular skill SKILL.md must NOT be filtered out."""
-        p = tmp_path / ".hermes" / "skills" / "my-cool-skill" / "SKILL.md"
-        assert _new_filter_matches(p) is False
+        root = tmp_path / "skills"
+        p = root / "my-cool-skill" / "SKILL.md"
+        assert _new_filter_matches(p, root) is False
 
     def test_nested_skill_not_filtered(self, tmp_path):
         """A deeply nested regular skill must NOT be filtered out."""
-        p = tmp_path / ".hermes" / "skills" / "org" / "deep-skill" / "SKILL.md"
-        assert _new_filter_matches(p) is False
+        root = tmp_path / "skills"
+        p = root / "org" / "deep-skill" / "SKILL.md"
+        assert _new_filter_matches(p, root) is False
 
-    def test_dot_prefix_not_false_positive(self, tmp_path):
-        """A skill dir starting with dot but not in the filter list passes."""
-        p = tmp_path / ".hermes" / "skills" / ".my-hidden-skill" / "SKILL.md"
-        assert _new_filter_matches(p) is False
+    def test_dot_prefix_filtered(self, tmp_path):
+        """Any hidden workspace directory is filtered out."""
+        root = tmp_path / "skills"
+        p = root / ".my-hidden-skill" / "SKILL.md"
+        assert _new_filter_matches(p, root) is True
 
 
 class TestWindowsPathParts:

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -267,6 +267,15 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
+    def test_skips_arbitrary_hidden_directories(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "real-skill")
+            _make_skill(tmp_path, "cursor-copy", category=".cursor/skills")
+            _make_skill(tmp_path, "opencode-copy", category="visible/.opencode")
+            skills = _find_all_skills()
+
+        assert [s["name"] for s in skills] == ["real-skill"]
+
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
@@ -419,6 +428,17 @@ class TestSkillView:
         assert result["success"] is False
         assert "not found" in result["error"].lower()
         assert "available_skills" in result
+
+    def test_view_skips_arbitrary_hidden_directories(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "visible-skill")
+            _make_skill(tmp_path, "cursor-copy", category=".cursor/skills")
+            raw = skill_view("cursor-copy")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "visible-skill" in result["available_skills"]
+        assert "cursor-copy" not in result["available_skills"]
 
     def test_view_reference_file(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -101,7 +101,6 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
@@ -558,7 +557,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        iter_skill_index_files,
+        skill_path_has_excluded_dir,
+    )
 
     skills = []
     seen_names: set = set()
@@ -574,7 +577,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            if skill_path_has_excluded_dir(skill_md, scan_dir):
                 continue
 
             skill_dir = skill_md.parent
@@ -963,12 +966,14 @@ def skill_view(
         # the caller — silent shadowing of a local skill by a same-named
         # external skill is a real bug class (`/skills` shows one, agent
         # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
+        from agent.skill_utils import iter_skill_index_files, skill_path_has_excluded_dir
 
         candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
         seen_md: set = set()
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
+        def _record(sd: Optional[Path], smd: Path, search_root: Path) -> None:
+            if skill_path_has_excluded_dir(smd, search_root):
+                return
             try:
                 key = smd.resolve()
             except Exception:
@@ -983,9 +988,9 @@ def skill_view(
             # at the top of the dir).
             direct_path = search_dir / name
             if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                _record(direct_path, direct_path / "SKILL.md")
+                _record(direct_path, direct_path / "SKILL.md", search_dir)
             elif direct_path.with_suffix(".md").exists():
-                _record(None, direct_path.with_suffix(".md"))
+                _record(None, direct_path.with_suffix(".md"), search_dir)
 
             # Strategy 1b: categorized form for plugin namespace fall-through
             # (e.g., a "myplugin:explore" name with no plugin registered also
@@ -993,20 +998,20 @@ def skill_view(
             if local_category_name:
                 categorized_path = search_dir / local_category_name
                 if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
-                    _record(categorized_path, categorized_path / "SKILL.md")
+                    _record(categorized_path, categorized_path / "SKILL.md", search_dir)
                 elif categorized_path.with_suffix(".md").exists():
-                    _record(None, categorized_path.with_suffix(".md"))
+                    _record(None, categorized_path.with_suffix(".md"), search_dir)
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name).
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(found_skill_md.parent, found_skill_md, search_dir)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            for found_md in search_dir.rglob(f"{name}.md"):
+            for found_md in iter_skill_index_files(search_dir, f"{name}.md"):
                 if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                    _record(None, found_md, search_dir)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## Summary
- add a shared skill-directory exclusion predicate that skips explicit metadata dirs and any hidden directory name
- apply the predicate to skill index walks, skill listing, slash-skill scanning, and skill_view lookup paths
- keep filtering relative to each scan root so the normal `~/.hermes/skills` parent path does not hide all skills
- add regression coverage for `.cursor` / `.opencode` workspace copies staying out of lists, slash commands, and not-found hints
- include CI stabilizers for Discord mock imports and Nous provider model defaults

Fixes #26451.

## Tests
- `python -m pytest -o addopts= tests\tools\test_hidden_dir_filter.py tests\tools\test_skills_tool.py::TestFindAllSkills::test_skips_arbitrary_hidden_directories tests\tools\test_skills_tool.py::TestSkillView::test_view_skips_arbitrary_hidden_directories tests\agent\test_skill_commands.py::TestScanSkillCommands::test_skips_arbitrary_hidden_directories tests\agent\test_external_skills.py tests\agent\test_skill_commands_reload.py -q --tb=short`
- `python -m pytest -o addopts= tests\e2e\test_discord_adapter.py -q --tb=short`
- `python -m pytest -o addopts= tests\run_agent\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\run_agent\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short`
- `python -m ruff check agent\skill_utils.py tools\skills_tool.py agent\skill_commands.py tests\tools\test_hidden_dir_filter.py tests\tools\test_skills_tool.py tests\agent\test_skill_commands.py tests\e2e\conftest.py tests\run_agent\test_provider_parity.py`
- `python -m py_compile agent\skill_utils.py tools\skills_tool.py agent\skill_commands.py`
- `git diff --check`