### PR TITLE
feat(skills): add optional Prismtek/Buddy lipsync workflow

### DIFF
--- a/optional-skills/media/prismtek-youtube-buddy-lipsync/SKILL.md
+++ b/optional-skills/media/prismtek-youtube-buddy-lipsync/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: prismtek-youtube-buddy-lipsync
+description: Use when producing Prismtek/Buddy YouTube videos that need a clean pixel-art Buddy host overlay with audio-reactive mouth movement.
+version: 1.0.0
+author: Prismtek / Hermes Agent
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [youtube, video, ffmpeg, imagemagick, pixel-art, vtuber, prismtek]
+    related_skills: [youtube-content]
+---
+# Prismtek YouTube Buddy Lip-Sync
+
+## Overview
+
+Use this skill to turn a static clean Buddy host PNG into a lightweight audio-reactive VTuber-style overlay for narrated Prismtek YouTube videos.
+
+The workflow is intentionally simple and robust on low-memory machines:
+- no ML lip-sync dependency;
+- no Pillow/PIL dependency;
+- ImageMagick for tiny pixel-art viseme generation;
+- FFmpeg/ffprobe for audio RMS analysis and video compositing;
+- small v12-style mouth assets that match Buddy's reference sheet.
+
+## When to Use
+
+- A Prismtek YouTube video has narration and Buddy should look like he is speaking.
+- The static Buddy overlay feels too lifeless.
+- You need a reproducible way to generate mouth states from a clean Buddy base PNG.
+- You need to avoid previous bad mouth regressions: giant oval mouth, darker mint mouth patch, or two-mouth artifact.
+
+## Required Tools
+
+```bash
+command -v magick
+command -v ffmpeg
+command -v ffprobe
+python3 --version
+```
+
+Do **not** use PIL/Pillow; some target environments intentionally do not have it installed.
+
+## Canonical Local Asset Pattern
+
+A known-good Prismtek production base on Cody's Mac is:
+
+```text
+~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v5-full-arm-clean.png
+```
+
+This base is already cropped/cleaned so it preserves Buddy's full viewer-right arm and avoids source-sheet borders/sparkles.
+
+Generate v12 visemes from that clean base:
+
+```bash
+python3 optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/generate_buddy_v12_visemes.py \
+  ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v5-full-arm-clean.png \
+  --out-dir ~/.hermes/assets/prismtek-youtube/avatar
+```
+
+Then render a proof clip:
+
+```bash
+python3 optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/prismtek_youtube_avatar_lipsync.py \
+  /path/to/base-video.mp4 \
+  --closed ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v12-mouth-closed.png \
+  --open ~/.hermes/assets/prismtek-youtube/avatar/buddy-host-main-v12-mouth-small-open.png \
+  --output /tmp/buddy-lipsync-proof.mp4 \
+  --limit-seconds 20
+```
+
+For full render, omit `--limit-seconds`.
+
+## v12 Mouth Style Rules
+
+v12 is the current accepted style:
+- slightly bigger than the first good tiny-mouth attempt;
+- still a small/cute pixel-art mouth, not a large oval;
+- no darker mint rectangle around the mouth;
+- no original-smile leftovers that create a second mouth;
+- full Buddy crop/arm remains intact.
+
+Rejected styles:
+- oversized v5 open-mouth/Pac-Man mouth;
+- v8 darker mint erase patch;
+- v10 two-mouth artifact from leftover original-smile pixels.
+
+## Verification Checklist
+
+Before upload, render at least a 20s proof and extract frames around speech/silence:
+
+```bash
+ffmpeg -y -v error -ss 00:00:05 -i /tmp/buddy-lipsync-proof.mp4 -frames:v 1 /tmp/buddy-open.png
+ffmpeg -y -v error -ss 00:00:10 -i /tmp/buddy-lipsync-proof.mp4 -frames:v 1 /tmp/buddy-closed.png
+ffprobe -v error -show_entries format=duration -show_entries stream=codec_type,codec_name,width,height -of compact=p=0:nk=1 /tmp/buddy-lipsync-proof.mp4
+```
+
+Visual QA:
+- one mouth only;
+- no lower/side second mouth dashes;
+- no darker mint patch around mouth;
+- mouth opens/closes with narration energy;
+- Buddy's full viewer-right arm remains visible;
+- no source-sheet cyan border/sparkles;
+- output duration/audio streams are preserved.
+
+## Scripts
+
+- `scripts/generate_buddy_v12_visemes.py` — creates no-mouth base and v12 mouth states from a clean Buddy PNG using ImageMagick.
+- `scripts/prismtek_youtube_avatar_lipsync.py` — overlays closed/open mouth states based on audio RMS.
+
+## Notes
+
+This package does not include private production videos, credentials, OAuth tokens, or YouTube receipts. It stores the reusable process only.

--- a/optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/generate_buddy_v12_visemes.py
+++ b/optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/generate_buddy_v12_visemes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate v12 Buddy pixel-art mouth/viseme assets from a clean base PNG.
+
+Dependencies: ImageMagick `magick` only. No PIL/Pillow.
+
+This implements the accepted Prismtek/Buddy v12 mouth recipe:
+- start from a clean full-arm Buddy base PNG;
+- create a no-mouth base by cloning nearby face texture over the original smile;
+- surgically erase the remaining lower smile dashes that caused a two-mouth artifact;
+- draw small, slightly larger-than-v8 pixel-art mouth states.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def magick(*args: str | Path) -> None:
+    run(["magick", *map(str, args)])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate v12 Buddy mouth/viseme PNGs from a clean base avatar")
+    parser.add_argument("base", type=Path, help="Clean Buddy PNG, e.g. buddy-host-main-v5-full-arm-clean.png")
+    parser.add_argument("--out-dir", type=Path, help="Output directory. Defaults to base image directory")
+    parser.add_argument("--prefix", default="buddy-host-main-v12", help="Output filename prefix")
+    args = parser.parse_args()
+
+    if shutil.which("magick") is None:
+        raise SystemExit("Missing dependency: ImageMagick `magick`")
+    if not args.base.exists():
+        raise SystemExit(f"Base image not found: {args.base}")
+
+    out_dir = args.out_dir or args.base.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prefix = args.prefix
+
+    no_mouth = out_dir / f"{prefix}-no-mouth-base.png"
+
+    # Clone clean face texture from above the mouth into the original smile zone.
+    # Coordinates are for the canonical 442x440 v5 clean crop.
+    magick(
+        args.base,
+        "(", args.base, "-crop", "50x30+216+224", "+repage", ")",
+        "-geometry", "+216+246", "-compose", "over", "-composite",
+        no_mouth,
+    )
+
+    # Surgical erase of the leftover lower smile dashes identified in v10/v11 QA.
+    magick(
+        no_mouth,
+        "-fill", "#d2f5eb", "-draw", "rectangle 222,273 232,278",
+        "-fill", "#d1f4ea", "-draw", "rectangle 252,273 263,278",
+        no_mouth,
+    )
+
+    states: dict[str, list[str]] = {
+        "mouth-closed": [
+            "-fill", "#18205e", "-draw",
+            "rectangle 229,253 234,258 rectangle 234,258 244,262 rectangle 244,253 250,258",
+        ],
+        "mouth-small-open": [
+            "-fill", "#18205e", "-draw", "rectangle 231,249 249,266 rectangle 234,266 246,270",
+            "-fill", "#ff6f8f", "-draw", "rectangle 235,254 245,268",
+            "-fill", "#ffe2d2", "-draw", "rectangle 236,252 244,255",
+        ],
+        "mouth-wide-open": [
+            "-fill", "#18205e", "-draw", "rectangle 226,248 254,264 rectangle 230,264 250,270",
+            "-fill", "#ff6f8f", "-draw", "rectangle 231,254 249,268",
+            "-fill", "#ffe2d2", "-draw", "rectangle 233,252 247,255",
+        ],
+        "mouth-round-o": [
+            "-fill", "#18205e", "-draw", "rectangle 232,249 248,266 rectangle 235,266 245,270",
+            "-fill", "#ff6f8f", "-draw", "rectangle 236,253 244,265",
+        ],
+        "mouth-soft": [
+            "-fill", "#18205e", "-draw", "rectangle 229,255 250,261",
+        ],
+    }
+
+    for name, draw_args in states.items():
+        out = out_dir / f"{prefix}-{name}.png"
+        magick(no_mouth, *draw_args, out)
+        print(out)
+
+    print(no_mouth)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/prismtek_youtube_avatar_lipsync.py
+++ b/optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/prismtek_youtube_avatar_lipsync.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Audio-reactive Buddy avatar overlay for Prismtek/Buddy YouTube videos.
+
+Creates a lightweight two-state VTuber mouth animation driven by input audio RMS.
+Designed for low-memory machines: no ML lip-sync, no PIL/Pillow, only FFmpeg.
+"""
+from __future__ import annotations
+
+import argparse
+import array
+import json
+import math
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def check_output(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
+
+
+def duration_seconds(path: Path) -> float:
+    return float(check_output([
+        "ffprobe", "-v", "error", "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1", str(path),
+    ]))
+
+
+def stream_summary(path: Path) -> str:
+    try:
+        return check_output([
+            "ffprobe", "-v", "error", "-show_entries", "stream=codec_type,codec_name,width,height",
+            "-of", "compact=p=0:nk=1", str(path),
+        ])
+    except Exception as exc:  # pragma: no cover - receipt helper
+        return f"ffprobe_failed:{exc}"
+
+
+def audio_rms_by_frame(video: Path, fps: int, duration: float) -> list[float]:
+    sample_rate = 16000
+    raw = subprocess.check_output([
+        "ffmpeg", "-v", "error", "-i", str(video), "-vn", "-ac", "1", "-ar", str(sample_rate), "-f", "s16le", "-",
+    ])
+    samples = array.array("h")
+    samples.frombytes(raw)
+    frame_count = max(1, math.ceil(duration * fps))
+    samples_per_frame = max(1, round(sample_rate / fps))
+    rms: list[float] = []
+    for i in range(frame_count):
+        start = i * samples_per_frame
+        chunk = samples[start:start + samples_per_frame]
+        if not chunk:
+            rms.append(0.0)
+            continue
+        mean_sq = sum(int(x) * int(x) for x in chunk) / len(chunk)
+        rms.append(math.sqrt(mean_sq) / 32768.0)
+    return rms
+
+
+def mouth_states(rms: list[float], sensitivity: float) -> tuple[list[bool], dict[str, float]]:
+    if not rms:
+        return [], {"threshold": 0.0}
+    nonzero = [x for x in rms if x > 0.0005] or rms
+    med = statistics.median(nonzero)
+    p85 = sorted(nonzero)[int(0.85 * (len(nonzero) - 1))]
+    p95 = sorted(nonzero)[int(0.95 * (len(nonzero) - 1))]
+    threshold = max(0.006, med + (p85 - med) * (0.42 / max(0.1, sensitivity)))
+    open_threshold = threshold
+    close_threshold = threshold * 0.62
+
+    states: list[bool] = []
+    open_now = False
+    hold = 0
+    for val in rms:
+        if open_now:
+            if val < close_threshold and hold <= 0:
+                open_now = False
+            else:
+                hold -= 1
+        elif val > open_threshold:
+            open_now = True
+            hold = 1
+        states.append(open_now)
+
+    # Tiny deterministic syllable closures during long open runs prevent a stuck-open mouth.
+    run_start = None
+    for i, state in enumerate(states + [False]):
+        if state and run_start is None:
+            run_start = i
+        if (not state) and run_start is not None:
+            run_len = i - run_start
+            if run_len >= 10:
+                for j in range(run_start + 5, i, 7):
+                    if j < len(states):
+                        states[j] = False
+            run_start = None
+
+    return states, {
+        "median_rms": med,
+        "p85_rms": p85,
+        "p95_rms": p95,
+        "threshold": threshold,
+        "open_ratio": sum(states) / max(1, len(states)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Overlay audio-reactive Buddy mouth animation onto a video")
+    parser.add_argument("input_video", type=Path)
+    parser.add_argument("--closed", type=Path, required=True, help="Closed-mouth Buddy PNG")
+    parser.add_argument("--open", type=Path, required=True, help="Open-mouth Buddy PNG")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--width", type=int, default=360)
+    parser.add_argument("--margin-x", type=int, default=34)
+    parser.add_argument("--margin-y", type=int, default=42)
+    parser.add_argument("--fps", type=int, default=12)
+    parser.add_argument("--sensitivity", type=float, default=1.0)
+    parser.add_argument("--limit-seconds", type=float, help="Optional render limit for proof clips")
+    parser.add_argument("--receipt", type=Path)
+    args = parser.parse_args()
+
+    for dep in ["ffmpeg", "ffprobe"]:
+        if shutil.which(dep) is None:
+            raise SystemExit(f"Missing dependency: {dep}")
+    for p in [args.input_video, args.closed, args.open]:
+        if not p.exists():
+            raise SystemExit(f"Missing file: {p}")
+
+    source_duration = duration_seconds(args.input_video)
+    render_duration = min(source_duration, args.limit_seconds) if args.limit_seconds else source_duration
+    output = args.output or args.input_video.with_name(f"{args.input_video.stem}-buddy-lipsync.mp4")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    rms = audio_rms_by_frame(args.input_video, args.fps, render_duration)
+    states, stats = mouth_states(rms, args.sensitivity)
+    frame_count = max(1, math.ceil(render_duration * args.fps))
+    states = states[:frame_count]
+
+    with tempfile.TemporaryDirectory(prefix="buddy_lipsync_frames_") as td:
+        frames = Path(td)
+        for i in range(frame_count):
+            src = args.open if states[i] else args.closed
+            os.symlink(src, frames / f"frame_{i:06d}.png")
+        vf = f"[1:v]scale={args.width}:-1[avatar];[0:v][avatar]overlay=W-w-{args.margin_x}:H-h-{args.margin_y}:format=auto[v]"
+        cmd = [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-i", str(args.input_video),
+            "-framerate", str(args.fps), "-i", str(frames / "frame_%06d.png"),
+            "-filter_complex", vf,
+            "-map", "[v]", "-map", "0:a?",
+            "-t", f"{render_duration:.3f}",
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18", "-preset", "veryfast",
+            "-c:a", "copy", str(output),
+        ]
+        run(cmd)
+
+    receipt = {
+        "receipt_type": "buddy_lipsync_receipt",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "input_video": str(args.input_video),
+        "output_video": str(output),
+        "closed_avatar": str(args.closed),
+        "open_avatar": str(args.open),
+        "source_duration_seconds": source_duration,
+        "render_duration_seconds": render_duration,
+        "fps": args.fps,
+        "overlay": {"width": args.width, "margin_x": args.margin_x, "margin_y": args.margin_y},
+        "mouth_stats": stats,
+        "output_size_bytes": output.stat().st_size if output.exists() else None,
+        "streams": stream_summary(output) if output.exists() else None,
+    }
+    receipt_path = args.receipt or output.with_suffix(".lipsync-receipt.json")
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(receipt, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add an optional Prismtek/Buddy media skill for a lightweight talking-host overlay workflow.
- Add an ImageMagick-based Buddy mouth/viseme generator.
- Add an FFmpeg/ffprobe-based audio RMS mouth animation renderer.

## Scope
This PR is intentionally an optional Hermes-compatible skill contribution. It stores only reusable workflow/scripts and does not include private media, generated renders, or account-specific assets.

The broader Prismtek/Buddy ownership split is being handled in the Prismtek repos:

- Canonical runtime package: codysumpter-cloud/buddy-agent#18
- Operator skill reference: codysumpter-cloud/buddy-brain#315
- Omni/local-device reference: codysumpter-cloud/omni-buddy#11
- App-facing contract: codysumpter-cloud/prismtek-apps#138
- Knowledge-vault archive: codysumpter-cloud/knowledge-vault#4
- Hermes fork reference: codysumpter-cloud/hermes-agent#2

## Verification
- `python3 -m py_compile optional-skills/media/prismtek-youtube-buddy-lipsync/scripts/*.py`
- Generated v12 visemes from a local clean Buddy base asset
- Rendered a 6s proof MP4 with preserved h264 1920x1080 video + AAC audio
- Secret-pattern scan passed for committed files

## Notes
This is not a publishing/upload workflow. It is a deterministic local render workflow for an optional Buddy media skill.