### PR TITLE
fix(credentials): parse ISO reset timestamps from provider error messages

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1989,7 +1989,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     if "reset_at" not in context:
         message = context.get("message") or ""
         if isinstance(message, str):
-            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
             if delay_match:
                 value = float(delay_match.group(1))
                 seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
@@ -2002,6 +2002,26 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                 )
                 if sec_match:
                     context["reset_at"] = time.time() + float(sec_match.group(1))
+                else:
+                    # Handle providers that embed an absolute reset timestamp in
+                    # the error message, e.g. MiniMax: "resets at 2026-05-18T00:00:00Z".
+                    # Without this, the credential pool falls back to the 1-hour
+                    # default TTL and rotates the key back in well before the
+                    # provider's actual weekly/daily quota resets.
+                    iso_match = re.search(
+                        r"resets?\s+at\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?(?:[+-]\d{2}:?\d{2})?)",
+                        message,
+                        re.IGNORECASE,
+                    )
+                    if iso_match:
+                        try:
+                            from datetime import datetime
+                            raw = iso_match.group(1).replace("Z", "+00:00")
+                            reset_ts = datetime.fromisoformat(raw).timestamp()
+                            if reset_ts > time.time():
+                                context["reset_at"] = reset_ts
+                        except (ValueError, OverflowError):
+                            pass
 
     return context
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -245,6 +245,17 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
+    # Handle providers that embed an absolute reset timestamp in the error message,
+    # e.g. MiniMax: "resets at 2026-05-18T00:00:00Z"
+    reset_match = re.search(
+        r"resets?\s+at\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?(?:[+-]\d{2}:?\d{2})?)",
+        message,
+        re.IGNORECASE,
+    )
+    if reset_match:
+        reset_ts = _parse_absolute_timestamp(reset_match.group(1))
+        if reset_ts is not None:
+            return max(0.0, reset_ts - time.time())
     return None
 
 


### PR DESCRIPTION
Providers like MiniMax embed absolute reset times in 429 error bodies (e.g. 'resets at 2026-05-18T00:00:00Z') rather than returning a Retry-After header or relative delay. The existing _extract_retry_delay_seconds only matched relative patterns (quotaResetDelay, retry after N seconds), so the pool fell back to the 1-hour default TTL and retried hourly instead of waiting until the actual quota window reset.

Add a third pattern that matches 'resets? at <ISO-8601>' and converts the absolute timestamp to a delay via _parse_absolute_timestamp, which already handles Z-suffix and epoch formats. This ensures that last_error_reset_at is set correctly, so weekly (or any long-window) quotas are respected without repeated failed attempts.