### PR TITLE
fix(agent): classify root-level skills under general

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -910,9 +910,9 @@ def _build_snapshot_entry(
     """Build a serialisable metadata dict for one skill."""
     rel_path = skill_file.relative_to(skills_dir)
     parts = rel_path.parts
-    if len(parts) >= 2:
+    if len(parts) > 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2])
     else:
         category = "general"
         skill_name = skill_file.parent.name

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -266,6 +266,30 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    @pytest.mark.parametrize(
+        ("skill_name", "description"),
+        [
+            ("handoff-doc", "Handoff notes"),
+            ("hermes-dev-workflow", "Hermes development workflow"),
+            ("dogfood", "Exploratory QA"),
+        ],
+    )
+    def test_root_level_skills_use_general_category(
+        self, monkeypatch, tmp_path, skill_name, description
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / skill_name
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_name}\ndescription: {description}\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "  general:" in result
+        assert f"    - {skill_name}: {description}" in result
+        assert f"  {skill_name}:" not in result
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"


### PR DESCRIPTION
### Bug Description

Under normal usage in the CLI client, I noticed some known skills failing to load with errors. Some examples:

- Recovery example — bogus self-qualified lookup fails, then the correct bare skill loads:

  ```text
  ┊ 📚 skill     hermes-dev-workflow:hermes-dev-workflow  0.0s [error]
  ┊ 📚 skill     hermes-dev-workflow  0.0s
  ```

- Give-up example — after the bogus self-qualified lookup failed, the intended skill was not loaded by bare name before the agent continued with other work:

  ```text
  ┊ 📚 skill     dogfood:dogfood  0.0s [error]
  ┊ 📚 skill     systematic-debugging  0.0s
  ```

These failures match the root cause fixed here: the prompt index was presenting root-level local skills in a self-qualified `skill:skill` shape, but `skill_view()` treats colon syntax as plugin/category-qualified resolution rather than ordinary bare local skill lookup. When recovery did not happen, Hermes lost task-specific instructions that should have been loaded, producing lower-quality outcomes.


## What does this PR do?

Fixes root-level local skills being rendered as if their directory name were also a category in the `<available_skills>` prompt block.

For a root-level skill stored at `handoff-doc/SKILL.md`, the current prompt-builder logic treats the relative path `("handoff-doc", "SKILL.md")` as categorized and renders:

```text
handoff-doc:
  - handoff-doc: ...
```

That shape is misleading because colon-qualified names are reserved for plugin skills in `skill_view()`. It nudges the model toward invalid lookups like `skill_view("handoff-doc:handoff-doc")` even though ordinary local skills should be loaded by bare name.

This PR changes `_build_snapshot_entry()` so only nested paths like `software-development/plan/SKILL.md` get a category. Root-level skills now fall back to `general` and render as bare skills:

```text
general:
  - handoff-doc: ...
```

Nested categorized skills keep their existing category behavior.

## Related Issue

Related to the same skill category / namespace confusion area as #10713, #10753, #10830, #13630, and #18223, but fixes an earlier prompt-builder source of confusion: root-level local skills were being presented in a pseudo-namespaced shape before `skill_view()` was even called.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Fixed root-level skill prompt classification in `agent/prompt_builder.py`.
- Added regression coverage in `tests/agent/test_prompt_builder.py`.

## How to Test

Reproduction on current `origin/main`:

1. Create a root-level local skill at `HERMES_HOME/skills/handoff-doc/SKILL.md`.
2. Call `build_skills_system_prompt()`.
3. Observe that current `origin/main` renders the skill under a `handoff-doc:` category:

   ```text
   handoff-doc:
     - handoff-doc: Handoff notes
   ```

Fixed behavior on this branch:

1. Run:

   ```bash
   scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/test_plugin_skills.py -q
   ```
2. Confirm root-level skills render under `general` as bare skill names.
3. Confirm plugin-qualified skill behavior remains covered by the plugin skill tests.

Local validation:

```bash
python -m pytest tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt::test_root_level_skills_use_general_category -q -o addopts=''
# 3 passed

scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/test_plugin_skills.py -q
# 152 passed, 1 skipped

python -m ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py
# All checks passed
```

Full-suite note:

```bash
scripts/run_tests.sh tests/ -q
# 61 failed, 22906 passed, 80 skipped, 252 warnings in 834.22s (0:13:54)
```

The full-suite rerun completed locally after expanding the root-level skill regression examples and failed in broad areas outside this prompt-builder change: compression feasibility, subagent stop-hook payloads, gateway service/systemd/WSL behavior, file-tool read/staleness/state guards, Anthropic/OAuth credential handling, auxiliary/provider priority, update/setup helpers, live-system guard passthroughs, plugin discovery, delegate heartbeat, process-registry cleanup, provider parity, and TUI gateway browser-launch hints. The focused prompt-builder/plugin coverage for this fix passed.


Security review:

* Prompt-index metadata only; no new filesystem writes, subprocesses, network calls, credentials, or privilege-bearing paths.
* Does not change `skill_view()` resolver semantics or plugin-qualified skill trust boundaries.
* Reduces prompt/loader drift by no longer presenting ordinary local root-level skills in a plugin-like namespaced shape.
* Verdict: no security blockers.

## Checklist

### Code

- [X] I've read the [Contributing Guide](<https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md>)
- [X] My commit messages follow [Conventional Commits](<https://www.conventionalcommits.org/>) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](<https://github.com/NousResearch/hermes-agent/pulls>) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: macOS / darwin-arm64 local worktree

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](<https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility>) — no OS-specific behavior changed
- [X] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

N/A — no UI screenshots or log excerpts are needed for this prompt-index metadata fix.
