### PR TITLE
fix(codex): bound prompt cache keys

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,7 +5,25 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import hashlib
 from typing import Any, Dict, List, Optional
+
+
+_MAX_PROMPT_CACHE_KEY_LENGTH = 64
+_PROMPT_CACHE_KEY_HASH_LENGTH = 16
+
+
+def _prompt_cache_key_from_session_id(session_id: Any) -> str:
+    """Return a stable Responses prompt_cache_key within provider limits."""
+    cache_key = str(session_id or "").strip()
+    if len(cache_key) <= _MAX_PROMPT_CACHE_KEY_LENGTH:
+        return cache_key
+
+    digest = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()[
+        :_PROMPT_CACHE_KEY_HASH_LENGTH
+    ]
+    prefix_length = _MAX_PROMPT_CACHE_KEY_LENGTH - _PROMPT_CACHE_KEY_HASH_LENGTH - 1
+    return f"{cache_key[:prefix_length]}-{digest}"
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
@@ -101,7 +119,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         session_id = params.get("session_id")
         if not is_github_responses and session_id:
-            kwargs["prompt_cache_key"] = session_id
+            kwargs["prompt_cache_key"] = _prompt_cache_key_from_session_id(session_id)
 
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -45,11 +45,11 @@ class TestCodexBuildKwargs:
             {"role": "user", "content": "Hello"},
         ]
         kw = transport.build_kwargs(
-            model="gpt-5.4",
+            model="test-model",
             messages=messages,
             tools=[],
         )
-        assert kw["model"] == "gpt-5.4"
+        assert kw["model"] == "test-model"
         assert kw["instructions"] == "You are helpful."
         assert "input" in kw
         assert kw["store"] is False
@@ -59,18 +59,18 @@ class TestCodexBuildKwargs:
             {"role": "system", "content": "Custom system prompt"},
             {"role": "user", "content": "Hi"},
         ]
-        kw = transport.build_kwargs(model="gpt-5.4", messages=messages, tools=[])
+        kw = transport.build_kwargs(model="test-model", messages=messages, tools=[])
         assert kw["instructions"] == "Custom system prompt"
 
     def test_no_system_uses_default(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
-        kw = transport.build_kwargs(model="gpt-5.4", messages=messages, tools=[])
+        kw = transport.build_kwargs(model="test-model", messages=messages, tools=[])
         assert kw["instructions"]  # should be non-empty default
 
     def test_reasoning_config(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             reasoning_config={"effort": "high"},
         )
         assert kw.get("reasoning", {}).get("effort") == "high"
@@ -78,7 +78,7 @@ class TestCodexBuildKwargs:
     def test_reasoning_disabled(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             reasoning_config={"enabled": False},
         )
         assert "reasoning" not in kw or kw.get("include") == []
@@ -86,15 +86,31 @@ class TestCodexBuildKwargs:
     def test_session_id_sets_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             session_id="test-session-123",
         )
         assert kw.get("prompt_cache_key") == "test-session-123"
 
+    def test_long_session_id_sets_bounded_stable_cache_key(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        session_id = "cron_mdjob_agentfile-maintenance--agents-md-review_20260508_050008"
+
+        first = transport.build_kwargs(
+            model="test-model", messages=messages, tools=[], session_id=session_id
+        )
+        second = transport.build_kwargs(
+            model="test-model", messages=messages, tools=[], session_id=session_id
+        )
+
+        assert len(session_id) == 66
+        assert first["prompt_cache_key"] == second["prompt_cache_key"]
+        assert len(first["prompt_cache_key"]) <= 64
+        assert first["prompt_cache_key"] != session_id
+
     def test_github_responses_no_cache_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             session_id="test-session",
             is_github_responses=True,
         )
@@ -103,7 +119,7 @@ class TestCodexBuildKwargs:
     def test_max_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             max_tokens=4096,
         )
         assert kw.get("max_output_tokens") == 4096
@@ -111,7 +127,7 @@ class TestCodexBuildKwargs:
     def test_codex_backend_no_max_output_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             max_tokens=4096,
             is_codex_backend=True,
         )
@@ -143,7 +159,7 @@ class TestCodexBuildKwargs:
     def test_minimal_effort_clamped(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
-            model="gpt-5.4", messages=messages, tools=[],
+            model="test-model", messages=messages, tools=[],
             reasoning_config={"effort": "minimal"},
         )
         # "minimal" should be clamped to "low"


### PR DESCRIPTION
## Summary
- Keep OpenAI Responses `prompt_cache_key` values within the provider's 64-character limit.
- Preserve existing short session IDs unchanged for prompt-cache continuity.
- Use a stable hash suffix for longer session IDs, including cron session IDs derived from long job names.

## Test Plan
- `python -m pytest tests/agent/transports/test_codex_transport.py -q`
- `python -m py_compile agent/transports/codex.py`
- `git diff --check`

## Platforms Tested
- macOS arm64, Python 3.13.13.

## Related / competing PRs
- [PR #10006](https://github.com/NousResearch/hermes-agent/pull/10006) improves Codex prompt-cache routing headers and usage accounting, but does not touch `agent/transports/codex.py` or bound the OpenAI `prompt_cache_key` body field.
- [PR #5252](https://github.com/NousResearch/hermes-agent/pull/5252) proposes broader provider-aware session-affinity routing. This PR is a smaller bug fix for the current Responses transport and can stand independently.
- [PR #6461](https://github.com/NousResearch/hermes-agent/pull/6461) was a closed SSE proxy cache-routing attempt; it does not supersede this OpenAI request validation fix.
- Searched PRs/issues for `prompt_cache_key length`, `prompt_cache_key Responses`, and `prompt_cache_key`; found no open or merged PR specifically fixing the 64-character limit failure.

## Notes/Risks
- Long cache keys remain deterministic, so repeated calls for the same Hermes session still share the same prompt-cache identity.
- Short cache keys are unchanged to avoid unnecessary cache churn.
- Cross-platform impact is low: this only changes request kwargs construction for the Responses API transport and adds no file I/O, shell commands, process management, or platform-specific behavior.
