### PR TITLE
fix(codex): refresh pool entries from auth store

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -689,6 +689,9 @@ class CredentialPool:
                     except Exception as wexc:
                         logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
             elif self.provider == "openai-codex":
+                synced = self._sync_codex_entry_from_auth_store(entry)
+                if synced is not entry:
+                    entry = synced
                 refreshed = auth_mod.refresh_codex_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,
@@ -797,6 +800,39 @@ class CredentialPool:
                     self._persist()
                     self._sync_device_code_entry_to_auth_store(updated)
                     return updated
+            # For openai-codex: another process may have consumed the
+            # single-use refresh token between our proactive sync and the HTTP
+            # call. Re-sync from auth.json and retry once with the fresher pair.
+            if self.provider == "openai-codex":
+                synced = self._sync_codex_entry_from_auth_store(entry)
+                if synced.refresh_token != entry.refresh_token or synced.access_token != entry.access_token:
+                    logger.debug("Codex refresh failed but auth.json has newer tokens — retrying")
+                    try:
+                        refreshed = auth_mod.refresh_codex_oauth_pure(
+                            synced.access_token,
+                            synced.refresh_token,
+                        )
+                        updated = replace(
+                            synced,
+                            access_token=refreshed["access_token"],
+                            refresh_token=refreshed["refresh_token"],
+                            last_refresh=refreshed.get("last_refresh"),
+                            last_status=STATUS_OK,
+                            last_status_at=None,
+                            last_error_code=None,
+                            last_error_reason=None,
+                            last_error_message=None,
+                            last_error_reset_at=None,
+                        )
+                        self._replace_entry(synced, updated)
+                        self._persist()
+                        self._sync_device_code_entry_to_auth_store(updated)
+                        return updated
+                    except Exception as retry_exc:
+                        logger.debug("Codex retry refresh also failed: %s", retry_exc)
+                elif not self._entry_needs_refresh(synced):
+                    logger.debug("Codex auth.json has valid token, using without refresh")
+                    return synced
             self._mark_exhausted(entry, None)
             return None
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1563,6 +1563,84 @@ def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
     assert synced is entry
 
 
+def test_codex_refresh_uses_newer_auth_store_tokens_before_network_retry(tmp_path, monkeypatch):
+    """Codex refresh tokens are single-use; re-sync before refreshing stale pool entries."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    assert entry.refresh_token == "refresh-OLD"
+
+    # Another process refreshed the singleton auth store first, consuming the
+    # pool entry's refresh token while this in-memory pool still holds it.
+    _write_auth_store(tmp_path, _codex_auth_store("access-FRESH", "refresh-FRESH"))
+
+    def fake_refresh(access_token, refresh_token):
+        assert access_token == "access-FRESH"
+        assert refresh_token == "refresh-FRESH"
+        return {
+            "access_token": "access-NEW",
+            "refresh_token": "refresh-NEW",
+            "last_refresh": "2026-04-28T00:05:00Z",
+        }
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        fake_refresh,
+    )
+
+    refreshed = pool._refresh_entry(entry, force=False)
+
+    assert refreshed is not None
+    assert refreshed.access_token == "access-NEW"
+    assert refreshed.refresh_token == "refresh-NEW"
+    assert refreshed.last_status == "ok"
+
+
+def test_codex_refresh_retries_after_auth_store_changes_during_failure(tmp_path, monkeypatch):
+    """If another process consumes a Codex refresh token mid-call, re-sync and retry once."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+
+    calls = []
+
+    def fake_refresh(access_token, refresh_token):
+        calls.append((access_token, refresh_token))
+        if refresh_token == "refresh-OLD":
+            _write_auth_store(tmp_path, _codex_auth_store("access-FRESH", "refresh-FRESH"))
+            raise RuntimeError("invalid_grant")
+        assert access_token == "access-FRESH"
+        assert refresh_token == "refresh-FRESH"
+        return {
+            "access_token": "access-NEW",
+            "refresh_token": "refresh-NEW",
+            "last_refresh": "2026-04-28T00:10:00Z",
+        }
+
+    monkeypatch.setattr(
+        "agent.credential_pool.auth_mod.refresh_codex_oauth_pure",
+        fake_refresh,
+    )
+
+    refreshed = pool._refresh_entry(entry, force=False)
+
+    assert calls == [("access-OLD", "refresh-OLD"), ("access-FRESH", "refresh-FRESH")]
+    assert refreshed is not None
+    assert refreshed.access_token == "access-NEW"
+    assert refreshed.refresh_token == "refresh-NEW"
+    assert refreshed.last_status == "ok"
+
+
 def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch):
     """An exhausted Codex entry should recover when auth.json has newer tokens.
 


### PR DESCRIPTION
## Summary
- Re-sync `openai-codex` pool entries from `auth.json` immediately before refreshing OAuth tokens.
- Retry once with a fresher auth-store token pair if a Codex refresh fails because another process consumed the pool entry's single-use refresh token.
- Keep refreshed pool tokens mirrored back to `auth.json` so future pool loads do not resurrect stale token pairs.

## Test Plan
- `python -m pytest tests/agent/test_credential_pool.py -q`
- `python -m py_compile agent/credential_pool.py`
- `git diff --check`

## Platforms Tested
- macOS arm64, Python 3.13.13.

## Related / competing PRs
- [PR #17001](https://github.com/NousResearch/hermes-agent/pull/17001) fixed the exhausted-after-reauth path by syncing Codex pool entries from `auth.json` before availability checks. This PR covers the remaining in-memory refresh race: a non-exhausted pool entry can still hold a stale single-use refresh token while `providers.openai-codex.tokens` already has a newer pair.
- [PR #19612](https://github.com/NousResearch/hermes-agent/pull/19612) mirrors Codex tokens from `hermes_cli/auth.py` into the credential pool after CLI/runtime refresh. This PR is complementary on the agent pool side: it adopts newer `auth.json` tokens before pool refresh and retries after a mid-call race.
- [PR #22906](https://github.com/NousResearch/hermes-agent/pull/22906) addresses profile/global pool shadowing in `hermes_cli/auth.py`; it does not change `CredentialPool._refresh_entry` behavior.
- [PR #22415](https://github.com/NousResearch/hermes-agent/pull/22415) rotates auxiliary Codex credentials on quota/rate-limit failures in `agent/auxiliary_client.py`; this PR is lower-level OAuth freshness handling in `agent/credential_pool.py`.
- [PR #21488](https://github.com/NousResearch/hermes-agent/pull/21488) is Codex auxiliary Responses request sanitization and does not overlap with credential-pool OAuth refresh.

## Notes/Risks
- The change is scoped to device-code `openai-codex` OAuth entries because `_sync_codex_entry_from_auth_store()` only adopts from `auth.json` for that source.
- The retry path only activates when `auth.json` has a different access or refresh token after the first refresh failure, avoiding extra retries against unchanged stale credentials.
