### PR TITLE
fix(local): ignore stale shell artifact temp dirs

### DIFF
--- a/tests/tools/test_local_tempdir.py
+++ b/tests/tools/test_local_tempdir.py
@@ -4,19 +4,23 @@ from tools.environments.local import LocalEnvironment
 
 
 class TestLocalTempDir:
-    def test_uses_os_tmpdir_for_session_artifacts(self, monkeypatch):
-        monkeypatch.setenv("TMPDIR", "/data/data/com.termux/files/usr/tmp")
+    def test_uses_os_tmpdir_for_session_artifacts(self, monkeypatch, tmp_path):
+        tmpdir = tmp_path / "termux-tmp"
+        tmpdir.mkdir()
+        monkeypatch.setenv("TMPDIR", str(tmpdir))
         monkeypatch.delenv("TMP", raising=False)
         monkeypatch.delenv("TEMP", raising=False)
 
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=".", timeout=10)
 
-        assert env.get_temp_dir() == "/data/data/com.termux/files/usr/tmp"
-        assert env._snapshot_path == f"/data/data/com.termux/files/usr/tmp/hermes-snap-{env._session_id}.sh"
-        assert env._cwd_file == f"/data/data/com.termux/files/usr/tmp/hermes-cwd-{env._session_id}.txt"
+        assert env.get_temp_dir() == str(tmpdir)
+        assert env._snapshot_path == f"{tmpdir}/hermes-snap-{env._session_id}.sh"
+        assert env._cwd_file == f"{tmpdir}/hermes-cwd-{env._session_id}.txt"
 
-    def test_prefers_backend_env_tmpdir_override(self, monkeypatch):
+    def test_prefers_backend_env_tmpdir_override(self, monkeypatch, tmp_path):
+        tmpdir = tmp_path / "backend-tmp"
+        tmpdir.mkdir()
         monkeypatch.delenv("TMPDIR", raising=False)
         monkeypatch.delenv("TMP", raising=False)
         monkeypatch.delenv("TEMP", raising=False)
@@ -25,16 +29,29 @@ class TestLocalTempDir:
             env = LocalEnvironment(
                 cwd=".",
                 timeout=10,
-                env={"TMPDIR": "/data/data/com.termux/files/home/.cache/hermes-tmp/"},
+                env={"TMPDIR": f"{tmpdir}/"},
             )
 
-        assert env.get_temp_dir() == "/data/data/com.termux/files/home/.cache/hermes-tmp"
-        assert env._snapshot_path == (
-            f"/data/data/com.termux/files/home/.cache/hermes-tmp/hermes-snap-{env._session_id}.sh"
-        )
-        assert env._cwd_file == (
-            f"/data/data/com.termux/files/home/.cache/hermes-tmp/hermes-cwd-{env._session_id}.txt"
-        )
+        assert env.get_temp_dir() == str(tmpdir)
+        assert env._snapshot_path == f"{tmpdir}/hermes-snap-{env._session_id}.sh"
+        assert env._cwd_file == f"{tmpdir}/hermes-cwd-{env._session_id}.txt"
+
+    def test_ignores_stale_env_temp_dir_for_session_artifacts(self, monkeypatch, tmp_path):
+        stale_tmpdir = tmp_path / "deleted-tmp"
+        usable_tmpdir = tmp_path / "usable-tmp"
+        usable_tmpdir.mkdir()
+        monkeypatch.setenv("TMPDIR", str(stale_tmpdir))
+        monkeypatch.delenv("TMP", raising=False)
+        monkeypatch.delenv("TEMP", raising=False)
+
+        with patch("tools.environments.local.os.path.isdir", side_effect=lambda p: str(p) == str(usable_tmpdir)), \
+             patch("tools.environments.local.os.access", side_effect=lambda p, mode: str(p) == str(usable_tmpdir)), \
+             patch("tools.environments.local.tempfile.gettempdir", return_value=str(usable_tmpdir)), \
+             patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=".", timeout=10)
+            assert env.get_temp_dir() == str(usable_tmpdir)
+            assert env._snapshot_path == f"{usable_tmpdir}/hermes-snap-{env._session_id}.sh"
+            assert env._cwd_file == f"{usable_tmpdir}/hermes-cwd-{env._session_id}.txt"
 
     def test_falls_back_to_tempfile_when_tmp_missing(self, monkeypatch):
         monkeypatch.delenv("TMPDIR", raising=False)
@@ -46,6 +63,6 @@ class TestLocalTempDir:
              patch("tools.environments.local.tempfile.gettempdir", return_value="/cache/tmp"), \
              patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
             env = LocalEnvironment(cwd=".", timeout=10)
-            assert env.get_temp_dir() == "/cache/tmp"
-            assert env._snapshot_path == f"/cache/tmp/hermes-snap-{env._session_id}.sh"
-            assert env._cwd_file == f"/cache/tmp/hermes-cwd-{env._session_id}.txt"
+            assert env.get_temp_dir() == "/tmp"
+            assert env._snapshot_path == f"/tmp/hermes-snap-{env._session_id}.sh"
+            assert env._cwd_file == f"/tmp/hermes-cwd-{env._session_id}.txt"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -421,14 +421,24 @@ class LocalEnvironment(BaseEnvironment):
 
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
-            if candidate and candidate.startswith("/"):
+            if (
+                candidate
+                and candidate.startswith("/")
+                and os.path.isdir(candidate)
+                and os.access(candidate, os.W_OK | os.X_OK)
+            ):
                 return candidate.rstrip("/") or "/"
 
         if os.path.isdir("/tmp") and os.access("/tmp", os.W_OK | os.X_OK):
             return "/tmp"
 
         candidate = tempfile.gettempdir()
-        if candidate.startswith("/"):
+        if (
+            candidate
+            and candidate.startswith("/")
+            and os.path.isdir(candidate)
+            and os.access(candidate, os.W_OK | os.X_OK)
+        ):
             return candidate.rstrip("/") or "/"
 
         return "/tmp"


### PR DESCRIPTION
## Summary
- Validate `TMPDIR`, `TMP`, `TEMP`, and `tempfile.gettempdir()` before using them as the local backend's shell artifact directory.
- Fall through to the next candidate when a temp env var points at a deleted, inaccessible, or non-directory path.
- Keep local shell snapshot and cwd marker files on a writable/executable POSIX temp path instead of creating stale artifact paths.

## Test Plan
- `python -m py_compile tools/environments/local.py`
- `python -m pytest tests/tools/test_local_tempdir.py -q` (4 passed)

## Platforms Tested
- macOS arm64.

## Related / competing PRs
- [PR #17558](https://github.com/NousResearch/hermes-agent/pull/17558) / `9644b8ae6` fixed recovery when the persistent shell cwd has been deleted before `subprocess.Popen`. This PR covers a different failure mode: stale temp env dirs used for shell snapshot/cwd marker artifacts.
- [PR #20627](https://github.com/NousResearch/hermes-agent/pull/20627) is open and skips checkpoint creation for temp directories in `tools/checkpoint_manager.py`. It does not touch `tools/environments/local.py` or local shell artifact temp-dir selection.
- Keyword search for stale temp dirs / shell artifacts did not find a superseding PR.

## Notes/Risks
- Cross-platform impact: this only changes local backend temp-dir selection. macOS/Linux/Termux-style POSIX temp paths are still accepted when they exist and are writable/executable. Stale env temp paths are skipped. WSL2 should follow the same POSIX-path behavior through Git Bash/Linux environments; Windows-native non-POSIX temp paths are still not selected by this helper.
- The behavior intentionally prefers a known-good `/tmp` over an invalid `tempfile.gettempdir()` result. If neither is valid, the existing final fallback remains `/tmp`.
- No public docs changes; this is a narrow robustness fix for local process/file handling.
