### PR TITLE
fix(title): use lineage fallback for generated titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -118,16 +118,27 @@ def auto_title_session(
     if not title:
         return
 
+    final_title = title
     try:
-        session_db.set_session_title(session_id, title)
-        logger.debug("Auto-generated session title: %s", title)
-        if title_callback is not None:
-            try:
-                title_callback(title)
-            except Exception:
-                logger.debug("Auto-title callback failed", exc_info=True)
+        session_db.set_session_title(session_id, final_title)
+    except ValueError as e:
+        logger.debug("Auto-generated title conflict for '%s': %s", final_title, e)
+        try:
+            final_title = session_db.get_next_title_in_lineage(final_title)
+            session_db.set_session_title(session_id, final_title)
+        except Exception as lineage_error:
+            logger.debug("Failed to set lineage auto-generated title: %s", lineage_error)
+            return
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
+        return
+
+    logger.debug("Auto-generated session title: %s", final_title)
+    if title_callback is not None:
+        try:
+            title_callback(final_title)
+        except Exception:
+            logger.debug("Auto-title callback failed", exc_info=True)
 
 
 def maybe_auto_title(

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -151,6 +151,47 @@ class TestAutoTitleSession:
         db.set_session_title.assert_called_once_with("sess-1", "Readable Session")
         assert seen == ["Readable Session"]
 
+    def test_uses_next_lineage_title_on_uniqueness_conflict(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.set_session_title.side_effect = [ValueError("Title conflict"), True]
+        db.get_next_title_in_lineage.return_value = "New Title #2"
+        seen = []
+
+        with patch("agent.title_generator.generate_title", return_value="New Title"):
+            auto_title_session(
+                db,
+                "sess-1",
+                "hi",
+                "hello",
+                title_callback=seen.append,
+            )
+
+        assert db.set_session_title.call_args_list == [
+            (("sess-1", "New Title"),),
+            (("sess-1", "New Title #2"),),
+        ]
+        db.get_next_title_in_lineage.assert_called_once_with("New Title")
+        assert seen == ["New Title #2"]
+
+    def test_skips_callback_if_lineage_fallback_fails(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.set_session_title.side_effect = ValueError("Title conflict")
+        db.get_next_title_in_lineage.side_effect = RuntimeError("boom")
+        seen = []
+
+        with patch("agent.title_generator.generate_title", return_value="New Title"):
+            auto_title_session(
+                db,
+                "sess-1",
+                "hi",
+                "hello",
+                title_callback=seen.append,
+            )
+
+        assert seen == []
+
     def test_skips_if_generation_fails(self):
         db = MagicMock()
         db.get_session_title.return_value = None


### PR DESCRIPTION
## Summary
- Use `SessionDB.get_next_title_in_lineage()` when an auto-generated session title collides with an existing title.
- Apply the fallback title before firing `title_callback`, so listeners receive the persisted title rather than the rejected duplicate.
- Add focused regression coverage for the successful fallback path and the failure path where no callback should fire.

## Test Plan
- `python -m pytest tests/agent/test_title_generator.py -q`
- `python -m py_compile agent/title_generator.py`

## Platforms Tested
- macOS 26.4.1, arm64

## Related / competing PRs
- Searched GitHub issues/PRs for `get_next_title_in_lineage`, `lineage fallback`, `generated titles`, and title-generator uniqueness/conflict terms.
- No open or merged PR found that supersedes this collision fallback.
- Adjacent non-duplicate title-generator work found: [PR #17797](https://github.com/NousResearch/hermes-agent/pull/17797), [PR #11280](https://github.com/NousResearch/hermes-agent/pull/11280), [PR #18839](https://github.com/NousResearch/hermes-agent/pull/18839), [PR #4946](https://github.com/NousResearch/hermes-agent/pull/4946), [PR #19137](https://github.com/NousResearch/hermes-agent/pull/19137), [PR #20338](https://github.com/NousResearch/hermes-agent/pull/20338), [PR #13211](https://github.com/NousResearch/hermes-agent/pull/13211). These cover other auto-title paths such as reasoning output, timing, stale model reloads, or clean input selection.

## Notes/Risks
- This is limited to auto-generated titles. Manual `/title` conflicts still surface through the existing `set_session_title()` behavior.
- Cross-platform impact: none expected. The change is pure Python session-title control flow and does not touch file I/O, process management, shell commands, gateway runtime, or terminal handling.
