### PR TITLE
fix(gateway): keep thread sessions sticky by default

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -545,7 +545,9 @@ class GatewayConfig:
         """
         Get the appropriate reset policy for a session.
         
-        Priority: platform override > type override > default
+        Priority: platform override > type override > built-in thread default > default.
+        Threaded conversations are expected to stay attached to their active
+        Hermes session unless the operator explicitly opts into thread resets.
         """
         # Platform-specific override takes precedence
         if platform and platform in self.reset_by_platform:
@@ -554,6 +556,9 @@ class GatewayConfig:
         # Type-specific override (dm, group, thread)
         if session_type and session_type in self.reset_by_type:
             return self.reset_by_type[session_type]
+
+        if session_type == "thread":
+            return SessionResetPolicy(mode="none")
         
         return self.default_reset_policy
     

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,10 +1,17 @@
 """Tests for gateway session management."""
 
 import json
+from datetime import timedelta
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
+from gateway.config import (
+    Platform,
+    HomeChannel,
+    GatewayConfig,
+    PlatformConfig,
+    SessionResetPolicy,
+)
 from gateway.platforms.base import MessageEvent
 from gateway.session import (
     SessionSource,
@@ -1090,6 +1097,58 @@ class TestWhatsAppIdentifierPublicHelpers:
     def test_canonical_empty_input(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert canonical_whatsapp_identifier("") == ""
+
+
+class TestThreadSessionResetPolicy:
+    """Thread sessions should stay attached unless explicitly overridden."""
+
+    def test_discord_threads_do_not_auto_reset_under_default_policy(self, tmp_path):
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="both", at_hour=4, idle_minutes=60)
+        )
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="thread",
+            thread_id="thread-456",
+        )
+        entry = store.get_or_create_session(source)
+
+        after_daily_and_idle_deadlines = entry.updated_at + timedelta(hours=8)
+        with patch("gateway.session._now", return_value=after_daily_and_idle_deadlines):
+            resumed = store.get_or_create_session(source)
+
+        assert resumed.session_id == entry.session_id
+        assert resumed.was_auto_reset is False
+
+    def test_explicit_thread_reset_override_still_resets(self, tmp_path):
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="none"),
+            reset_by_type={"thread": SessionResetPolicy(mode="idle", idle_minutes=30)},
+        )
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-123",
+            chat_type="thread",
+            thread_id="thread-456",
+        )
+        entry = store.get_or_create_session(source)
+
+        after_idle_deadline = entry.updated_at + timedelta(minutes=31)
+        with patch("gateway.session._now", return_value=after_idle_deadline):
+            reset = store.get_or_create_session(source)
+
+        assert reset.session_id != entry.session_id
+        assert reset.was_auto_reset is True
+        assert reset.auto_reset_reason == "idle"
 
 
 class TestSessionStoreEntriesAttribute:


### PR DESCRIPTION
## Summary
- Keep gateway thread sessions attached to their existing Hermes session by default, even when the global reset policy would reset idle or daily sessions.
- Fix the failure mode where long-lived Discord threads could silently receive a new backend Hermes session after an idle/daily reset, making the agent appear to forget the ongoing thread discussion.
- Treat `chat_type="thread"` as persistent-topic state at the gateway layer, so the behavior applies to any platform adapter that marks conversations as threads, not just Discord.
- Preserve explicit operator control: existing `GatewayConfig.reset_by_platform` and `GatewayConfig.reset_by_type["thread"]` policies still take precedence over the built-in sticky thread default.
- Keep context growth managed by compression instead of time-based resets: sticky thread sessions can still be compacted, but they should not be replaced merely because the idle/daily reset window elapsed.
- Add focused gateway session-policy regression tests for the default sticky behavior and the explicit thread reset override.

## Test Plan
- `python -m pytest tests/gateway/test_session.py::TestThreadSessionResetPolicy -q`
- `python -m pytest tests/gateway/test_session.py -q`
- `python -m py_compile gateway/config.py gateway/session.py`

## Platforms Tested
- macOS 26.4.1 arm64

## Related / competing PRs
- Related: [PR #21192](https://github.com/NousResearch/hermes-agent/pull/21192) (`feat(gateway): auto-resume interrupted sessions after restart`) handles startup auto-resume for interrupted sessions after restart/shutdown/crash. That is adjacent, but it does not cover ordinary idle/daily session reset for active thread conversations that keep the same session key but would otherwise receive a new backend `session_id` after the reset window.
- Searched GitHub PRs/issues for `thread session reset gateway sticky`, `gateway session reset thread`, and `discord thread session`; found no open or merged PR that supersedes this focused policy fix.

## Notes/Risks
- This changes gateway session policy only; no Discord adapter behavior is changed.
- Thread persistence is a built-in default, not an unconditional rule: platform/type-specific gateway reset policies still win.
- Compression remains the mechanism for controlling long thread context. Compression may summarize/rotate the underlying model transcript, but it is deliberate context management rather than the surprising “forgot because the reset clock fired” behavior fixed here.
- Cross-platform impact is low: no file I/O, process management, shell command, terminal handling, or platform-specific path behavior is touched.
