### PR TITLE
feat(memory): prefer user plugin overrides

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -6,8 +6,8 @@ Scans two directories for memory provider plugins:
 2. User-installed providers: ``$HERMES_HOME/plugins/<name>/``
 
 Each subdirectory must contain ``__init__.py`` with a class implementing
-the MemoryProvider ABC.  On name collisions, bundled providers take
-precedence.
+the MemoryProvider ABC.  On name collisions, user-installed providers take
+precedence so a same-name user plugin can override a bundled provider.
 
 Only ONE provider can be active at a time, selected via
 ``memory.provider`` in config.yaml.
@@ -67,32 +67,34 @@ def _is_memory_provider_dir(path: Path) -> bool:
 def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     """Yield ``(name, path)`` for all discovered provider directories.
 
-    Scans bundled first, then user-installed.  Bundled takes precedence
-    on name collisions (first-seen wins via ``seen`` set).
+    Scans user-installed plugins first, then bundled plugins. User plugins take
+    precedence on name collisions (first-seen wins via ``seen`` set).
     """
     seen: set = set()
     dirs: List[Tuple[str, Path]] = []
 
-    # 1. Bundled providers (plugins/memory/<name>/)
+    user_dir = _get_user_plugins_dir()
+
+    # 1. User-installed providers ($HERMES_HOME/plugins/<name>/)
+    if user_dir:
+        for child in sorted(user_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if not _is_memory_provider_dir(child):
+                continue
+            seen.add(child.name)
+            dirs.append((child.name, child))
+
+    # 2. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
         for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             if not (child / "__init__.py").exists():
                 continue
-            seen.add(child.name)
-            dirs.append((child.name, child))
-
-    # 2. User-installed providers ($HERMES_HOME/plugins/<name>/)
-    user_dir = _get_user_plugins_dir()
-    if user_dir:
-        for child in sorted(user_dir.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
-                continue
             if child.name in seen:
-                continue  # bundled takes precedence
-            if not _is_memory_provider_dir(child):
-                continue  # skip non-memory plugins
+                continue
+            seen.add(child.name)
             dirs.append((child.name, child))
 
     return dirs
@@ -101,18 +103,17 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
 def find_provider_dir(name: str) -> Optional[Path]:
     """Resolve a provider name to its directory.
 
-    Checks bundled first, then user-installed.
+    Checks user-installed providers first, then bundled providers.
     """
-    # Bundled
-    bundled = _MEMORY_PLUGINS_DIR / name
-    if bundled.is_dir() and (bundled / "__init__.py").exists():
-        return bundled
-    # User-installed
     user_dir = _get_user_plugins_dir()
     if user_dir:
         user = user_dir / name
         if user.is_dir() and _is_memory_provider_dir(user):
             return user
+
+    bundled = _MEMORY_PLUGINS_DIR / name
+    if bundled.is_dir() and (bundled / "__init__.py").exists():
+        return bundled
     return None
 
 
@@ -124,7 +125,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     """Scan bundled and user-installed directories for available providers.
 
     Returns list of (name, description, is_available) tuples.
-    Bundled providers take precedence on name collisions.
+    User providers take precedence on name collisions.
     """
     results = []
 
@@ -160,9 +161,9 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
 def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     """Load and return a MemoryProvider instance by name.
 
-    Checks both bundled (``plugins/memory/<name>/``) and user-installed
-    (``$HERMES_HOME/plugins/<name>/``) directories.  Bundled takes
-    precedence on name collisions.
+    Checks user-installed (``$HERMES_HOME/plugins/<name>/``) and bundled
+    (``plugins/memory/<name>/``) directories. User providers take precedence on
+    name collisions.
 
     Returns None if the provider is not found or fails to load.
     """

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -411,15 +411,16 @@ class TestUserInstalledProviderDiscovery:
     directory, ignoring user-installed plugins.
     """
 
-    def _make_user_memory_plugin(self, tmp_path, name="myprovider"):
+    def _make_user_memory_plugin(self, tmp_path, name="myprovider", *, provider_name=None):
         """Create a minimal user memory provider plugin."""
         plugin_dir = tmp_path / "plugins" / name
         plugin_dir.mkdir(parents=True)
+        registered_name = provider_name or name
         (plugin_dir / "__init__.py").write_text(
             "from agent.memory_provider import MemoryProvider\n"
             "class MyProvider(MemoryProvider):\n"
             f"    @property\n"
-            f"    def name(self): return {name!r}\n"
+            f"    def name(self): return {registered_name!r}\n"
             "    def is_available(self): return True\n"
             "    def initialize(self, **kw): pass\n"
             "    def sync_turn(self, *a, **kw): pass\n"
@@ -457,33 +458,20 @@ class TestUserInstalledProviderDiscovery:
         assert p.name == "myexternal"
         assert p.is_available()
 
-    def test_bundled_takes_precedence(self, tmp_path, monkeypatch):
-        """Bundled provider wins when user plugin has the same name."""
-        from plugins.memory import load_memory_provider, discover_memory_providers
-        # Create user plugin named "holographic" (same as bundled)
-        plugin_dir = tmp_path / "plugins" / "holographic"
-        plugin_dir.mkdir(parents=True)
-        (plugin_dir / "__init__.py").write_text(
-            "from agent.memory_provider import MemoryProvider\n"
-            "class Fake(MemoryProvider):\n"
-            "    @property\n"
-            "    def name(self): return 'holographic-FAKE'\n"
-            "    def is_available(self): return True\n"
-            "    def initialize(self, **kw): pass\n"
-            "    def sync_turn(self, *a, **kw): pass\n"
-            "    def get_tool_schemas(self): return []\n"
-            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
-        )
+    def test_user_plugin_overrides_bundled_same_name(self, tmp_path, monkeypatch):
+        """A same-name user memory provider overrides the bundled provider."""
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        self._make_user_memory_plugin(tmp_path, "holographic", provider_name="holographic-USER")
         monkeypatch.setattr(
             "plugins.memory._get_user_plugins_dir",
             lambda: tmp_path / "plugins",
         )
-        # Load should return bundled (name "holographic"), not user (name "holographic-FAKE")
+
         p = load_memory_provider("holographic")
         assert p is not None
-        assert p.name == "holographic"  # bundled wins
+        assert p.name == "holographic-USER"
 
-        # discover should not duplicate
         providers = discover_memory_providers()
         holo_count = sum(1 for n, _, _ in providers if n == "holographic")
         assert holo_count == 1


### PR DESCRIPTION
## Summary

- Prefer user-installed memory provider plugins over bundled providers when the provider name collides.
- Let operators customize or fork memory providers locally without editing the source tree or upstreaming site-specific provider changes.
- Preserve the existing user-provider install path: `$HERMES_HOME/plugins/<name>/`.
- Update memory provider tests to cover override precedence and duplicate suppression without changing the plugin directory layout.

## Test Plan

- `python -m pytest tests/agent/test_memory_provider.py -q`
- `python -m py_compile plugins/memory/__init__.py`
- `git diff --check`

## Platforms Tested

- macOS, Python 3.13.13.

## Related / competing PRs

- Related: [PR #10529](https://github.com/NousResearch/hermes-agent/pull/10529) discovered user-installed memory providers from `$HERMES_HOME/plugins/`, but kept bundled providers first on same-name collisions.
- Related issues from that discovery work: [issue #4956](https://github.com/NousResearch/hermes-agent/issues/4956) and [issue #9099](https://github.com/NousResearch/hermes-agent/issues/9099).
- Search performed for overlapping work: GitHub/web keyword searches for memory plugin override/provider precedence and adjacent memory-provider discovery PRs. No open or merged PR was found that fully supersedes this override-precedence change.

## Notes/Risks

- This intentionally changes same-name precedence so user-installed memory providers can override bundled providers while preserving the public provider name and configuration contract.
- This does not introduce a new provider namespace or move user providers under `$HERMES_HOME/plugins/memory/`; directory layout remains unchanged.
- Operators can also choose a distinct provider name and point `memory.provider` at it, but same-name overrides are useful when a local implementation is meant to satisfy the same provider contract as a bundled provider.
- Cross-platform impact: this touches plugin directory resolution and file I/O via `pathlib`; no shell/process behavior is changed.
