### PR TITLE
feat(cron): support structured script payloads

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -835,6 +835,24 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _replace_script_template_vars(prompt: str, template_vars: dict) -> str:
+    for key, value in template_vars.items():
+        prompt = prompt.replace(f"{{{{ {key} }}}}", str(value))
+        prompt = prompt.replace(f"{{{{{key}}}}}", str(value))
+    return prompt
+
+
+def _cleanup_script_paths(job: dict) -> None:
+    cleanup_paths = job.pop("_script_cleanup_paths", None) or []
+    for raw in cleanup_paths:
+        try:
+            path = Path(raw)
+            if path.exists() and path.is_file():
+                path.unlink()
+        except Exception as exc:
+            logger.warning("Failed to clean up cron script artifact '%s': %s", raw, exc)
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -857,7 +875,40 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         else:
             success, script_output = _run_job_script(script_path)
         if success:
+            script_payload = None
             if script_output:
+                try:
+                    candidate = json.loads(script_output)
+                    if isinstance(candidate, dict):
+                        script_payload = candidate
+                except Exception:
+                    script_payload = None
+
+            if script_payload is not None:
+                template_vars = script_payload.get("template_vars") or {}
+                if isinstance(template_vars, dict):
+                    prompt = _replace_script_template_vars(prompt, template_vars)
+                cleanup_paths = script_payload.get("cleanup_paths") or []
+                if isinstance(cleanup_paths, list):
+                    job["_script_cleanup_paths"] = [str(path) for path in cleanup_paths if path]
+                prepend_context = str(script_payload.get("prepend_context") or "").strip()
+                if prepend_context:
+                    prompt = (
+                        "## Script Output\n"
+                        "The following data was collected by a pre-run script. "
+                        "Use it as context for your analysis.\n\n"
+                        f"{prepend_context}\n\n"
+                        f"{prompt}"
+                    )
+                elif script_output:
+                    prompt = (
+                        "## Script Output\n"
+                        "The following data was collected by a pre-run script. "
+                        "Use it as context for your analysis.\n\n"
+                        f"```json\n{script_output}\n```\n\n"
+                        f"{prompt}"
+                    )
+            elif script_output:
                 prompt = (
                     "## Script Output\n"
                     "The following data was collected by a pre-run script. "
@@ -1614,6 +1665,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
+        _cleanup_script_paths(job)
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
         # only ever mutate it when the job has a workdir; see the setup block
         # at the top of run_job for the serialization guarantee.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -922,6 +922,38 @@ class TestRunJobSessionPersistence:
         assert success is True
         cleanup_mock.assert_called_once()
 
+    def test_run_job_cleans_script_payload_artifacts(self, tmp_path):
+        artifact = tmp_path / "script-output.json"
+        artifact.write_text("temporary", encoding="utf-8")
+        job = {
+            "id": "script-payload-job",
+            "name": "script payload",
+            "prompt": "Summarize {{ subject }}",
+            "script": "collect.py",
+        }
+        payload = json.dumps({
+            "template_vars": {"subject": "Inbox"},
+            "prepend_context": "3 unread messages",
+            "cleanup_paths": [str(artifact)],
+        })
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("cron.scheduler._run_job_script", return_value=(True, payload)), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, _final_response, _error = run_job(job)
+
+        assert success is True
+        assert not artifact.exists()
+        assert "_script_cleanup_paths" not in job
+        prompt = mock_agent.run_conversation.call_args.args[0]
+        assert "Summarize Inbox" in prompt
+        assert "3 unread messages" in prompt
+
     def _make_run_job_patches(self, tmp_path):
         """Common patches for run_job tests."""
         fake_db = MagicMock()
@@ -1772,6 +1804,25 @@ class TestSilentDelivery:
             tick(verbose=False)
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
+
+
+class TestBuildJobPromptScriptPayload:
+    def test_json_script_payload_replaces_template_vars_and_prepends_context(self):
+        job = {
+            "prompt": "Summary for {{ subject }}",
+            "script": "collect.py",
+        }
+        payload = json.dumps({
+            "template_vars": {"subject": "Inbox"},
+            "prepend_context": "3 unread messages",
+        })
+
+        with patch("cron.scheduler._run_job_script", return_value=(True, payload)):
+            result = _build_job_prompt(job)
+
+        assert "Summary for Inbox" in result
+        assert "3 unread messages" in result
+        assert "{{ subject }}" not in result
 
 
 class TestBuildJobPromptSilentHint:


### PR DESCRIPTION
## Summary

- Teach cron pre-run scripts to return a structured JSON object that can replace `{{ var }}` prompt placeholders via `template_vars`.
- Allow structured payloads to prepend explicit context with `prepend_context`, while preserving the existing raw stdout context behavior for non-JSON output.
- Track `cleanup_paths` from structured payloads and remove those temporary script artifacts after the cron job finishes.

## Test Plan

- `python -m pytest tests/cron/test_scheduler.py -q`
- `python -m py_compile cron/scheduler.py`

## Platforms Tested

- macOS / Darwin arm64, Python 3.13.13

## Related / competing PRs

Searches run for `cron structured payload`, `script payload`, `scheduled job script`, `cron script`, and `deliver` found no PR that fully supersedes this structured payload contract.

Adjacent cron script/delivery PRs:
- [PR #19709](https://github.com/NousResearch/hermes-agent/pull/19709) merged `no_agent` script-only cron jobs; this PR keeps the LLM-backed pre-run script path and only shapes script output before prompt execution.
- [PR #20354](https://github.com/NousResearch/hermes-agent/pull/20354), [PR #19810](https://github.com/NousResearch/hermes-agent/pull/19810), [PR #20323](https://github.com/NousResearch/hermes-agent/pull/20323), and [PR #21397](https://github.com/NousResearch/hermes-agent/pull/21397) touch cron script invocation details such as arguments, environment, failure status, and workdir. They are complementary to this PR's stdout payload contract.
- [PR #21438](https://github.com/NousResearch/hermes-agent/pull/21438) and [PR #21441](https://github.com/NousResearch/hermes-agent/pull/21441) adjust Discord/Slack threading and delivery mirroring. This PR intentionally avoids delivery routing, Discord thread semantics, media attachments, and mirror history.

## Notes/Risks

- Cross-platform impact: this touches cron script output handling and cleanup of files named by script payloads. Cleanup uses `pathlib.Path` and only unlinks paths that currently exist as files.
- Structured payload parsing only applies when the script stdout is a JSON object. Non-JSON stdout continues to be prepended as the existing script-output context block.
