### PR TITLE
feat(cron): create Discord threads for cron job delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -29,6 +29,7 @@ except ImportError:
         msvcrt = None
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import parse_qs
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -256,6 +257,47 @@ def _iter_home_target_platforms():
         pass
 
 
+def _parse_delivery_options(target_ref: str) -> tuple[str, dict]:
+    """Split a platform target ref into its raw target and query-string options."""
+    raw_target, _, query = (target_ref or "").partition("?")
+    if not query:
+        return raw_target, {}
+
+    parsed = parse_qs(query, keep_blank_values=True)
+    options: dict = {}
+
+    def _first(name: str) -> Optional[str]:
+        values = parsed.get(name) or []
+        for value in values:
+            text = str(value or "").strip()
+            if text:
+                return text
+        return None
+
+    def _truthy(name: str) -> Optional[bool]:
+        value = _first(name)
+        if value is None:
+            return None
+        return value.lower() in {"1", "true", "yes", "on"}
+
+    thread_name = _first("thread_name") or _first("title")
+    if thread_name:
+        options["thread_name"] = _hermes_now().strftime(thread_name)
+
+    into_history = _truthy("into_history")
+    if into_history is not None:
+        options["into_history"] = into_history
+
+    auto_archive_duration = _first("auto_archive_duration")
+    if auto_archive_duration:
+        try:
+            options["auto_archive_duration"] = int(auto_archive_duration)
+        except Exception:
+            logger.warning("Invalid auto_archive_duration query value %r", auto_archive_duration)
+
+    return raw_target, options
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -291,6 +333,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     if ":" in deliver_value:
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
+        rest, delivery_options = _parse_delivery_options(rest)
 
         from tools.send_message_tool import _parse_target_ref
 
@@ -319,6 +362,7 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
+            **delivery_options,
         }
 
     platform_name = deliver_value
@@ -413,7 +457,14 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     for part in parts:
         target = _resolve_single_delivery_target(job, part)
         if target:
-            key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))
+            key = (
+                target["platform"].lower(),
+                str(target["chat_id"]),
+                target.get("thread_id"),
+                target.get("thread_name"),
+                target.get("into_history"),
+                target.get("auto_archive_duration"),
+            )
             if key not in seen:
                 seen.add(key)
                 targets.append(target)
@@ -511,22 +562,28 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
+    delivery_content = content
+
+    # Extract MEDIA: tags so attachments are forwarded as files, not raw text.
+    # Visible platform delivery intentionally stays body-only; when wrapping is
+    # enabled, the cron header/footer is mirrored into history for agent
+    # continuity instead of being shown to the user.
+    from gateway.platforms.base import BasePlatformAdapter
+    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    cleaned_mirror_body = cleaned_delivery_content.strip()
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
-        delivery_content = (
+        cron_session_id = job.get("cron_session_id") or job.get("session_id")
+        mirror_text = (
             f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
+            f"(job_id: {job_id}{f', cron_session_id: {cron_session_id}' if cron_session_id else ''})\n"
             f"-------------\n\n"
-            f"{content}\n\n"
+            f"{cleaned_mirror_body}\n\n"
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
         )
     else:
-        delivery_content = content
-
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
-    from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+        mirror_text = cleaned_mirror_body
 
     try:
         config = load_gateway_config()
@@ -574,13 +631,113 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
+        def _mirror_into_history() -> None:
+            if not target.get("into_history"):
+                return
+            mirror_text_for_history = str(mirror_text or "").strip()
+            if not mirror_text_for_history:
+                return
+            try:
+                from gateway.mirror import mirror_to_session
+
+                extra_fields = {
+                    "cron_job_id": job.get("id", ""),
+                    "into_history": True,
+                }
+                cron_session_id = job.get("cron_session_id") or job.get("session_id")
+                if cron_session_id:
+                    extra_fields["cron_session_id"] = cron_session_id
+                mirror_chat_id = str(thread_id) if platform_name.lower() == "discord" and thread_id else str(chat_id)
+                mirror_to_session(
+                    platform_name.lower(),
+                    mirror_chat_id,
+                    mirror_text_for_history,
+                    source_label="cron",
+                    thread_id=str(thread_id) if thread_id else None,
+                    extra_fields=extra_fields,
+                    create_session_if_missing=True,
+                    source_overrides={
+                        "chat_type": "thread" if thread_id else "channel",
+                        "chat_name": str(target.get("thread_name") or ""),
+                        "parent_chat_id": str(chat_id) if thread_id else None,
+                    },
+                )
+            except Exception as mirror_exc:
+                logger.debug(
+                    "Job '%s': failed to mirror cron delivery: %s",
+                    job.get("id", "?"), mirror_exc,
+                )
+
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
+                if (
+                    platform_name.lower() == "discord"
+                    and not thread_id
+                    and target.get("thread_name")
+                    and hasattr(runtime_adapter, "create_delivery_thread")
+                ):
+                    future = asyncio.run_coroutine_threadsafe(
+                        runtime_adapter.create_delivery_thread(
+                            chat_id=str(chat_id),
+                            name=str(target["thread_name"]),
+                            auto_archive_duration=target.get("auto_archive_duration", 1440),
+                        ),
+                        loop,
+                    )
+                    try:
+                        thread_result = future.result(timeout=60)
+                    except TimeoutError:
+                        future.cancel()
+                        raise
+                    if isinstance(thread_result, dict) and thread_result.get("success", True):
+                        created_thread_id = thread_result.get("thread_id")
+                        if created_thread_id:
+                            thread_id = str(created_thread_id)
+                            target["thread_id"] = thread_id
+                            target["chat_id"] = str(chat_id)
+                        seed_message = str(thread_result.get("seed_message") or "").strip()
+                        if target.get("into_history") and thread_id and seed_message:
+                            try:
+                                from gateway.mirror import mirror_to_session
+
+                                extra_fields = {
+                                    "cron_job_id": job.get("id", ""),
+                                    "into_history": True,
+                                    "thread_seed": True,
+                                }
+                                cron_session_id = job.get("cron_session_id") or job.get("session_id")
+                                if cron_session_id:
+                                    extra_fields["cron_session_id"] = cron_session_id
+                                mirror_to_session(
+                                    "discord",
+                                    str(thread_id),
+                                    seed_message,
+                                    source_label="cron-thread-seed",
+                                    thread_id=str(thread_id),
+                                    extra_fields=extra_fields,
+                                    create_session_if_missing=True,
+                                    source_overrides={
+                                        "chat_type": "thread",
+                                        "chat_name": str(thread_result.get("thread_name") or target.get("thread_name") or ""),
+                                    },
+                                )
+                            except Exception as mirror_exc:
+                                logger.debug(
+                                    "Job '%s': failed to mirror Discord thread seed: %s",
+                                    job.get("id", "?"), mirror_exc,
+                                )
+                    else:
+                        err = thread_result.get("error", "unknown") if isinstance(thread_result, dict) else "unknown"
+                        logger.warning(
+                            "Job '%s': failed to create Discord delivery thread for %s:%s (%s); sending to parent",
+                            job["id"], platform_name, chat_id, err,
+                        )
+
+                send_metadata = {"thread_id": thread_id} if thread_id else None
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
@@ -616,6 +773,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    _mirror_into_history()
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -650,6 +808,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            _mirror_into_history()
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from gateway.config import Platform, load_gateway_config
+from gateway.session import SessionSource, SessionStore
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -29,6 +31,9 @@ def mirror_to_session(
     source_label: str = "cli",
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    extra_fields: Optional[dict] = None,
+    create_session_if_missing: bool = False,
+    source_overrides: Optional[dict] = None,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -47,14 +52,23 @@ def mirror_to_session(
             user_id=user_id,
         )
         if not session_id:
-            logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
-                platform,
-                chat_id,
-                thread_id,
-                user_id,
-            )
-            return False
+            if create_session_if_missing:
+                session_id = _ensure_session_for_delivery(
+                    platform,
+                    str(chat_id),
+                    thread_id=thread_id,
+                    user_id=user_id,
+                    source_overrides=source_overrides,
+                )
+            if not session_id:
+                logger.debug(
+                    "Mirror: no session found for %s:%s:%s:%s",
+                    platform,
+                    chat_id,
+                    thread_id,
+                    user_id,
+                )
+                return False
 
         mirror_msg = {
             "role": "assistant",
@@ -63,6 +77,8 @@ def mirror_to_session(
             "mirror": True,
             "mirror_source": source_label,
         }
+        if extra_fields:
+            mirror_msg.update(extra_fields)
 
         _append_to_jsonl(session_id, mirror_msg)
         _append_to_sqlite(session_id, mirror_msg)
@@ -80,6 +96,36 @@ def mirror_to_session(
             e,
         )
         return False
+
+
+def _ensure_session_for_delivery(
+    platform: str,
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    source_overrides: Optional[dict] = None,
+) -> Optional[str]:
+    """Create a gateway session for a delivered message when none exists yet."""
+    try:
+        platform_enum = Platform(platform.lower())
+        overrides = source_overrides or {}
+        source = SessionSource(
+            platform=platform_enum,
+            chat_id=str(chat_id),
+            chat_name=overrides.get("chat_name"),
+            chat_type=overrides.get("chat_type") or ("thread" if thread_id else "channel"),
+            user_id=user_id,
+            thread_id=str(thread_id) if thread_id else None,
+            parent_chat_id=overrides.get("parent_chat_id"),
+            message_id=overrides.get("message_id"),
+        )
+        store = SessionStore(load_gateway_config().session)
+        entry = store.get_or_create_session(source)
+        return entry.session_id
+    except Exception as e:
+        logger.debug("Mirror: failed to create delivery session for %s:%s:%s: %s", platform, chat_id, thread_id, e)
+        return None
 
 
 def _find_session_id(
@@ -166,10 +212,16 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
     try:
         from hermes_state import SessionDB
         db = SessionDB()
+        metadata = {
+            k: v
+            for k, v in message.items()
+            if k not in {"role", "content", "timestamp"}
+        }
         db.append_message(
             session_id=session_id,
             role=message.get("role", "assistant"),
             content=message.get("content"),
+            reasoning_details=metadata or None,
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1479,6 +1479,88 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def create_thread(
+        self,
+        chat_id: str,
+        name: str,
+        auto_archive_duration: int = 1440,
+        message: str = "",
+    ) -> Dict[str, Any]:
+        """Create a Discord thread from a parent-channel seed message."""
+        if not self._client:
+            return {"success": False, "error": "Not connected"}
+
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return {"success": False, "error": f"Channel {chat_id} not found"}
+
+            seed_message_text = message.strip() if message else str(name).strip()
+            if not message:
+                mentions = [
+                    f"<@{user_id}>"
+                    for user_id in sorted(str(uid) for uid in self._allowed_user_ids)
+                    if user_id.isdigit()
+                ]
+                if mentions:
+                    seed_message_text = f"{seed_message_text} {' '.join(mentions)}"
+
+            seed_msg = await channel.send(seed_message_text, suppress_embeds=True)
+            thread = await seed_msg.create_thread(
+                name=str(name),
+                auto_archive_duration=auto_archive_duration,
+            )
+            thread_id = str(getattr(thread, "id", ""))
+            thread_name = str(getattr(thread, "name", name))
+            seed_message_id = str(getattr(seed_msg, "id", ""))
+
+            if thread_id:
+                try:
+                    self._threads.mark(thread_id)
+                except Exception as exc:
+                    logger.debug("[%s] Failed to mark Discord delivery thread %s as managed: %s", self.name, thread_id, exc)
+
+            session_store = getattr(self, "_session_store", None)
+            if session_store is not None and thread_id:
+                try:
+                    source = self.build_source(
+                        chat_id=thread_id,
+                        chat_name=thread_name,
+                        chat_type="thread",
+                        thread_id=thread_id,
+                        parent_chat_id=str(chat_id),
+                        message_id=seed_message_id or None,
+                    )
+                    session_store.get_or_create_session(source)
+                except Exception as exc:
+                    logger.debug("[%s] Failed to register Discord delivery thread session: %s", self.name, exc)
+
+            return {
+                "success": True,
+                "thread_id": thread_id,
+                "thread_name": thread_name,
+                "seed_message": seed_message_text,
+                "seed_message_id": seed_message_id,
+            }
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[%s] Failed to create Discord thread in %s: %s", self.name, chat_id, e, exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    async def create_delivery_thread(
+        self,
+        chat_id: str,
+        name: str,
+        auto_archive_duration: int = 1440,
+    ) -> Dict[str, Any]:
+        """Compatibility wrapper used by cron live delivery."""
+        return await self.create_thread(
+            chat_id=chat_id,
+            name=name,
+            auto_archive_duration=auto_archive_duration,
+        )
+
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
@@ -1624,6 +1706,7 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -1633,11 +1716,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
+        target_id = str(metadata.get("thread_id") or chat_id) if metadata else str(chat_id)
+        channel = self._client.get_channel(int(target_id))
         if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._client.fetch_channel(int(target_id))
         if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+            noun = "Thread" if metadata and metadata.get("thread_id") else "Channel"
+            return SendResult(success=False, error=f"{noun} {target_id} not found")
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -1810,11 +1895,13 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
+            target_id = str(metadata.get("thread_id") or chat_id) if metadata else str(chat_id)
+            channel = self._client.get_channel(int(target_id))
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+                channel = await self._client.fetch_channel(int(target_id))
             if not channel:
-                return SendResult(success=False, error=f"Channel {chat_id} not found")
+                noun = "Thread" if metadata and metadata.get("thread_id") else "Channel"
+                return SendResult(success=False, error=f"{noun} {target_id} not found")
 
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=f"Audio file not found: {audio_path}")
@@ -2510,7 +2597,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2675,7 +2762,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2693,7 +2780,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -151,6 +151,37 @@ class TestResolveDeliveryTarget:
             "thread_id": "topic-7",
         }
 
+    def test_discord_delivery_target_parses_thread_query_options(self):
+        job = {
+            "deliver": "discord:parent-42?thread_name=Daily+Digest+%Y&into_history=true&auto_archive_duration=10080",
+        }
+
+        target = _resolve_delivery_target(job)
+
+        assert target == {
+            "platform": "discord",
+            "chat_id": "parent-42",
+            "thread_id": None,
+            "thread_name": "Daily Digest 2026",
+            "into_history": True,
+            "auto_archive_duration": 10080,
+        }
+
+    def test_discord_delivery_target_parses_title_alias_and_false_history(self):
+        job = {
+            "deliver": "discord:4242:9999?title=Fallback+Title&into_history=false",
+        }
+
+        target = _resolve_delivery_target(job)
+
+        assert target == {
+            "platform": "discord",
+            "chat_id": "4242",
+            "thread_id": "9999",
+            "thread_name": "Fallback Title",
+            "into_history": False,
+        }
+
     def test_explicit_telegram_topic_target_with_thread_id(self):
         """deliver: 'telegram:chat_id:thread_id' parses correctly."""
         job = {
@@ -441,10 +472,10 @@ class TestRoutingIntents:
 
 
 class TestDeliverResultWrapping:
-    """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+    """Verify that cron deliveries stay clean while history keeps breadcrumbs."""
 
-    def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+    def test_delivery_sends_body_only_even_when_wrap_response_enabled(self):
+        """Visible delivery should not include cron metadata noise."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -464,11 +495,10 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
-        assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        assert sent_content == "Here is today's summary."
+        assert "Cronjob Response" not in sent_content
+        assert "job_id" not in sent_content
+        assert "To stop or manage this job" not in sent_content
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -489,7 +519,8 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Output.")
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: abc-123" in sent_content
+        assert sent_content == "Output."
+        assert "Cronjob Response" not in sent_content
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""
@@ -640,6 +671,75 @@ class TestDeliverResultWrapping:
         assert adapter.send_image_file.call_args[1]["image_path"] == "/tmp/chart.png"
         adapter.send_voice.assert_not_called()
 
+    def test_live_discord_delivery_creates_thread_and_routes_text_and_media(self):
+        """A Discord delivery target with thread_name should create a thread first,
+        then route both text and MEDIA attachments to the created thread."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.create_delivery_thread.return_value = {
+            "success": True,
+            "thread_id": "thread-999",
+            "thread_name": "Daily Digest",
+            "seed_message": "Daily Digest <@123>",
+        }
+        adapter.send.return_value = MagicMock(success=True)
+        adapter.send_image_file.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        results = [
+            adapter.create_delivery_thread.return_value,
+            MagicMock(success=True),
+            MagicMock(success=True),
+        ]
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(results.pop(0))
+            if hasattr(coro, "close"):
+                coro.close()
+            return future
+
+        job = {
+            "id": "digest-job",
+            "deliver": "discord:parent-42?thread_name=Daily+Digest&into_history=false&auto_archive_duration=10080",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            error = _deliver_result(
+                job,
+                "Digest body\nMEDIA:/tmp/digest.png",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        assert error is None
+        adapter.create_delivery_thread.assert_called_once_with(
+            chat_id="parent-42",
+            name="Daily Digest",
+            auto_archive_duration=10080,
+        )
+        adapter.send.assert_called_once_with(
+            "parent-42",
+            "Digest body",
+            metadata={"thread_id": "thread-999"},
+        )
+        adapter.send_image_file.assert_called_once_with(
+            chat_id="parent-42",
+            image_path="/tmp/digest.png",
+            metadata={"thread_id": "thread-999"},
+        )
+
     def test_live_adapter_media_only_no_text(self):
         """When content is ONLY a MEDIA tag with no text, media should still be sent."""
         from gateway.config import Platform
@@ -727,7 +827,7 @@ class TestDeliverResultWrapping:
         assert "Report" in text_sent
 
     def test_no_mirror_to_session_call(self):
-        """Cron deliveries should NOT mirror into the gateway session."""
+        """Cron deliveries should not mirror unless into_history is explicitly requested."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -746,6 +846,40 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Hello!")
 
         mirror_mock.assert_not_called()
+
+    def test_into_history_mirrors_wrapped_cron_breadcrumbs(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "history-job",
+                "name": "History Job",
+                "deliver": "telegram:123?into_history=true",
+                "cron_session_id": "cron_123",
+            }
+            _deliver_result(job, "Hello history")
+
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.args[0:2] == ("telegram", "123")
+        mirrored_text = mirror_mock.call_args.args[2]
+        assert "Cronjob Response: History Job" in mirrored_text
+        assert "(job_id: history-job, cron_session_id: cron_123)" in mirrored_text
+        assert "Hello history" in mirrored_text
+        assert mirror_mock.call_args.kwargs["source_label"] == "cron"
+        assert mirror_mock.call_args.kwargs["thread_id"] is None
+        assert mirror_mock.call_args.kwargs["extra_fields"] == {
+            "cron_job_id": "history-job",
+            "cron_session_id": "cron_123",
+            "into_history": True,
+        }
 
     def test_origin_delivery_preserves_thread_id(self):
         """Origin delivery should forward thread_id to the send helper."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -54,7 +54,7 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     sent_msg = SimpleNamespace(id=1234)
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -92,7 +92,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -135,7 +135,7 @@ async def test_send_does_not_retry_on_unrelated_errors():
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         raise RuntimeError(
             "403 Forbidden (error code: 50013): Missing Permissions"
@@ -158,6 +158,55 @@ async def test_send_does_not_retry_on_unrelated_errors():
     # Only the first attempt happens — no reference-retry replay.
     assert channel.send.await_count == 1
     assert send_calls[0]["reference"] is reference_obj
+
+
+@pytest.mark.asyncio
+async def test_send_document_uses_metadata_thread_id(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    file_path = tmp_path / "report.txt"
+    file_path.write_text("report")
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(send=AsyncMock(return_value=sent_msg))
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=channel),
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_document(
+        "111",
+        str(file_path),
+        caption="caption",
+        metadata={"thread_id": "222"},
+    )
+
+    assert result.success is True
+    adapter._client.get_channel.assert_called_once_with(222)
+    adapter._client.fetch_channel.assert_not_awaited()
+    channel.send.assert_awaited_once()
+    assert channel.send.call_args.kwargs["content"] == "caption"
+
+
+@pytest.mark.asyncio
+async def test_send_voice_uses_metadata_thread_id(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"ogg")
+    channel = SimpleNamespace(id=222, send=AsyncMock(return_value=SimpleNamespace(id=1235)))
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=channel),
+        fetch_channel=AsyncMock(),
+        http=SimpleNamespace(request=AsyncMock(return_value={"id": "9999"})),
+    )
+
+    result = await adapter.send_voice(
+        "111",
+        str(audio_path),
+        metadata={"thread_id": "222"},
+    )
+
+    assert result.success is True
+    adapter._client.get_channel.assert_called_once_with(222)
+    adapter._client.fetch_channel.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +326,64 @@ async def test_send_to_forum_create_thread_failure():
 
     assert result.success is False
     assert "rate limited" in result.error
+
+
+@pytest.mark.asyncio
+async def test_create_delivery_thread_sends_seed_with_allowed_user_mentions_and_registers_session():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._allowed_user_ids = {"123", "not-numeric"}
+
+    seed_msg = SimpleNamespace(id=321, create_thread=AsyncMock(return_value=SimpleNamespace(id=654, name="Daily Digest")))
+    parent = SimpleNamespace(send=AsyncMock(return_value=seed_msg))
+    session_store = MagicMock()
+    adapter.set_session_store(session_store)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.create_delivery_thread("999", "Daily Digest", auto_archive_duration=10080)
+
+    assert result == {
+        "success": True,
+        "thread_id": "654",
+        "thread_name": "Daily Digest",
+        "seed_message": "Daily Digest <@123>",
+        "seed_message_id": "321",
+    }
+    parent.send.assert_awaited_once_with("Daily Digest <@123>", suppress_embeds=True)
+    seed_msg.create_thread.assert_awaited_once_with(name="Daily Digest", auto_archive_duration=10080)
+    session_store.get_or_create_session.assert_called_once()
+    source = session_store.get_or_create_session.call_args.args[0]
+    assert source.chat_id == "654"
+    assert source.thread_id == "654"
+    assert source.chat_type == "thread"
+    assert source.parent_chat_id == "999"
+
+
+@pytest.mark.asyncio
+async def test_send_file_attachment_honors_thread_metadata(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    payload = tmp_path / "digest.png"
+    payload.write_bytes(b"fake image")
+
+    parent = SimpleNamespace(send=AsyncMock())
+    thread = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(id=987)))
+
+    def get_channel(channel_id):
+        return thread if int(channel_id) == 654 else parent
+
+    adapter._client = SimpleNamespace(
+        get_channel=get_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter._send_file_attachment("999", str(payload), metadata={"thread_id": "654"})
+
+    assert result.success is True
+    assert result.message_id == "987"
+    thread.send.assert_awaited_once()
+    parent.send.assert_not_called()
 
 
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -293,8 +293,30 @@ async def test_plugin_command_name_conflict_skipped(adapter):
 
 
 # ------------------------------------------------------------------
-# _handle_thread_create_slash — success, session dispatch, failure
+# create_thread / _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_thread_marks_delivery_thread_as_managed(adapter):
+    created_thread = SimpleNamespace(id=555, name="Cron Digest")
+    seed_message = SimpleNamespace(id=777, create_thread=AsyncMock(return_value=created_thread))
+    parent_channel = SimpleNamespace(send=AsyncMock(return_value=seed_message))
+    adapter._client.get_channel = lambda _id: parent_channel
+    adapter._client.fetch_channel = AsyncMock()
+    adapter._allowed_user_ids = {"42"}
+    adapter._threads = MagicMock()
+
+    result = await adapter.create_thread("123", "Cron Digest", auto_archive_duration=10080)
+
+    assert result["success"] is True
+    assert result["thread_id"] == "555"
+    adapter._threads.mark.assert_called_once_with("555")
+    parent_channel.send.assert_awaited_once_with("Cron Digest <@42>", suppress_embeds=True)
+    seed_message.create_thread.assert_awaited_once_with(
+        name="Cron Digest",
+        auto_archive_duration=10080,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -267,6 +267,41 @@ class TestMirrorToSession:
 
         assert result is False
 
+    def test_create_session_if_missing_writes_thread_transcript(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+
+        fake_entry = MagicMock(session_id="sess_thread")
+        fake_store = MagicMock()
+        fake_store.get_or_create_session.return_value = fake_entry
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite"), \
+             patch("gateway.mirror.load_gateway_config", return_value=MagicMock(session=MagicMock())), \
+             patch("gateway.mirror.SessionStore", return_value=fake_store):
+            result = mirror_to_session(
+                "discord",
+                "thread-123",
+                "Seed starter",
+                source_label="cron-thread-seed",
+                thread_id="thread-123",
+                extra_fields={"cron_job_id": "job-1", "thread_seed": True},
+                create_session_if_missing=True,
+                source_overrides={"chat_type": "thread", "chat_name": "Cron Smoke"},
+            )
+
+        assert result is True
+        source = fake_store.get_or_create_session.call_args.args[0]
+        assert source.chat_id == "thread-123"
+        assert source.thread_id == "thread-123"
+        assert source.chat_type == "thread"
+        assert source.chat_name == "Cron Smoke"
+        msg = json.loads((sessions_dir / "sess_thread.jsonl").read_text().strip())
+        assert msg["content"] == "Seed starter"
+        assert msg["mirror_source"] == "cron-thread-seed"
+        assert msg["cron_job_id"] == "job-1"
+        assert msg["thread_seed"] is True
+
     def test_error_returns_false(self, tmp_path):
         with patch("gateway.mirror._find_session_id", side_effect=Exception("boom")):
             result = mirror_to_session("telegram", "123", "msg")


### PR DESCRIPTION
## Summary

- Add query-string delivery options for scheduled job targets, including `thread_name`, `title`, `into_history`, and `auto_archive_duration`.
- Let live Discord cron delivery create a new thread before sending the job body, then route both text and extracted `MEDIA:` attachments into that thread.
- Mirror requested cron deliveries into gateway history, creating a delivery session when needed, while keeping the visible delivery body user-facing and free of cron wrapper metadata.

## Test Plan

- `python -m pytest tests/cron/test_scheduler.py tests/gateway/test_discord_send.py tests/gateway/test_mirror.py -q`
- `python -m pytest tests/gateway/test_discord_slash_commands.py::test_create_thread_marks_delivery_thread_as_managed -q`
- `python -m py_compile cron/scheduler.py gateway/platforms/discord.py gateway/mirror.py`
- Live Discord smoke coverage was exercised for the cron delivery flow.

## Platforms Tested

- macOS 26.4.1, Python 3.13.13.

## Related / competing PRs

- [PR #8480](https://github.com/NousResearch/hermes-agent/pull/8480) also targets cron-created Discord delivery threads. This PR keeps creation on the live gateway adapter path, routes extracted `MEDIA:` attachments into the created thread, and mirrors the resulting delivery into gateway history when requested.
- [PR #17299](https://github.com/NousResearch/hermes-agent/pull/17299) overlaps on Discord cron auto-threading, but also includes unrelated stock quote/toolset work and a standalone REST thread-creation helper. This PR keeps the scope to configured cron delivery behavior.
- [PR #7400](https://github.com/NousResearch/hermes-agent/pull/7400) adds opt-in cron output mirroring into gateway conversation history via `into_history`. This PR uses the same user-facing history concept as part of Discord thread delivery, and adds new-thread creation plus thread-aware media/history routing.
- [PR #21438](https://github.com/NousResearch/hermes-agent/pull/21438) enables cron jobs to call messaging tools so the agent can create threaded replies itself. This PR remains useful because it implements deterministic scheduler delivery behavior for configured `deliver:` targets instead of depending on prompt-following or model-issued `send_message` calls.
- [PR #19754](https://github.com/NousResearch/hermes-agent/pull/19754) adds a separate web delivery platform and does not supersede Discord thread delivery.
- [PR #9802](https://github.com/NousResearch/hermes-agent/pull/9802) changes cron memory-provider behavior and does not overlap with this delivery path.

## Notes/Risks

- Discord thread creation only runs when the gateway live adapter is available and the target has a `thread_name` without an existing `thread_id`; failures fall back to sending in the parent channel.
- Attachment routing is limited to existing `MEDIA:` extraction and native adapter send methods.
- Gateway/session metadata is kept generic to support delivery history and management without exposing internal cron wrapper metadata to users.
- Cross-platform impact is low: this touches cron delivery parsing, gateway session mirroring, and Discord adapter calls, with no new shell/process management or OS-specific file I/O beyond existing transcript writes.
