### PR TITLE
fix(discord): suppress embeds for plain text sends

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1436,6 +1436,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        suppress_embeds=True,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -1458,6 +1459,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            suppress_embeds=True,
                         )
                     else:
                         raise

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -54,7 +54,7 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     sent_msg = SimpleNamespace(id=1234)
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -92,7 +92,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -135,7 +135,7 @@ async def test_send_does_not_retry_on_unrelated_errors():
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **_kwargs):
         send_calls.append({"content": content, "reference": reference})
         raise RuntimeError(
             "403 Forbidden (error code: 50013): Missing Permissions"

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -97,9 +97,19 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    for name in (
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_IGNORE_NO_MENTION",
+    ):
+        monkeypatch.delenv(name, raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
+    adapter._allowed_user_ids = {"42"}
     adapter._client = SimpleNamespace(
         tree=FakeTree(),
         get_channel=lambda _id: None,
@@ -980,4 +990,20 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
+
+
+@pytest.mark.asyncio
+async def test_send_suppresses_embeds_for_plain_text_messages(adapter):
+    channel = SimpleNamespace(id=123)
+    channel.send = AsyncMock(return_value=SimpleNamespace(id=456))
+    adapter._client.get_channel = MagicMock(return_value=channel)
+
+    result = await adapter.send("123", "See https://example.com")
+
+    assert result.success is True
+    channel.send.assert_awaited_once_with(
+        content="See https://example.com",
+        reference=None,
+        suppress_embeds=True,
+    )
 


### PR DESCRIPTION
## Summary
- Suppress Discord embeds when the gateway sends plain text responses so URLs in agent output do not generate link preview cards.
- Use discord.py's built-in `suppress_embeds=True` on the normal send path and the retry path used when Discord rejects a reply reference.
- Add a focused regression test for plain text sends with URLs.

## Test Plan
- `python -m pytest tests/gateway/test_discord_send.py tests/gateway/test_discord_slash_commands.py -q`
- `python -m py_compile gateway/platforms/discord.py`
- Focused unit coverage for the Discord adapter; live gateway smoke coverage was exercised for plain-text Discord responses.

## Platforms Tested
- macOS arm64, Python 3.13.13.

## Related / competing PRs
- Searched GitHub PRs/issues for `Discord embeds`, `suppress embeds`, `allowed_mentions`, and `plain text sends`.
- No open or merged PR was found that suppresses Discord URL embeds for plain text sends.
- Adjacent but not competing: [PR #11479](https://github.com/NousResearch/hermes-agent/pull/11479) / [PR #11339](https://github.com/NousResearch/hermes-agent/pull/11339) cover `allowed_mentions`, and [PR #503](https://github.com/NousResearch/hermes-agent/pull/503) tracks broader rich interaction surfaces.

## Notes/Risks
- This is intentionally scoped to generated plain-text gateway responses. Suppressing previews by default avoids noisy or unintended expansion of arbitrary links while still sending the URL text itself.
- There is no user-facing override in this patch. If maintainers want configurable behavior, a narrow Discord setting such as `discord.suppress_plain_text_embeds` can be added in a follow-up.
- Cross-platform impact: Discord-only change; no file I/O, process management, shell command, gateway runtime lifecycle, or terminal behavior changes.
