### PR TITLE
feat(discord): sync thread names from session titles

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1618,6 +1618,24 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def rename_thread(self, thread_id: str, name: str) -> SendResult:
+        """Rename a Discord thread by ID."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            channel = self._client.get_channel(int(thread_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(thread_id))
+            if not channel:
+                return SendResult(success=False, error=f"Thread {thread_id} not found")
+
+            await channel.edit(name=(name or "").strip())
+            return SendResult(success=True, message_id=str(thread_id))
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[%s] Failed to rename Discord thread %s: %s", self.name, thread_id, e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     async def _send_file_attachment(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11497,6 +11497,65 @@ class GatewayRunner:
             response += f"\n\nLast Hermes message:\n{last_assistant}"
         return response
 
+    async def _rename_discord_thread_for_title(self, source: SessionSource, title: str) -> None:
+        """Best-effort Discord thread rename when a session title changes."""
+        if source.platform != Platform.DISCORD:
+            return
+        thread_id = str(source.thread_id or "").strip()
+        if not thread_id:
+            return
+        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is None or not hasattr(adapter, "rename_thread"):
+            return
+        try:
+            await adapter.rename_thread(thread_id, title)
+        except Exception:
+            logger.debug("Failed to sync Discord thread title for %s", thread_id, exc_info=True)
+
+    def _schedule_auto_title_thread_rename(
+        self,
+        source: SessionSource,
+        title: str,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Schedule a Discord thread rename from the auto-title background thread."""
+        if loop.is_closed():
+            logger.debug("Skipping auto-title Discord thread sync; gateway loop is closed")
+            return
+
+        coro = self._rename_discord_thread_for_title(source, title)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError:
+            coro.close()
+            logger.debug("Failed to schedule auto-title Discord thread sync", exc_info=True)
+            return
+
+        def _log_failure(done_future) -> None:
+            try:
+                done_future.result()
+            except Exception:
+                logger.debug("Auto-title Discord thread sync failed", exc_info=True)
+
+        future.add_done_callback(_log_failure)
+
+    def _discord_auto_title_callback(self, source: SessionSource):
+        """Return a thread-title callback for Discord auto-title generation."""
+        if source.platform != Platform.DISCORD or not source.thread_id:
+            return None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_gateway_loop", None)
+        if loop is None:
+            logger.debug("Skipping auto-title Discord thread sync; no gateway loop available")
+            return None
+        return lambda title, _loop=loop: self._schedule_auto_title_thread_rename(
+            source,
+            title,
+            _loop,
+        )
+
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""
         source = event.source
@@ -11533,6 +11592,7 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    await self._rename_discord_thread_for_title(source, sanitized)
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")
@@ -15648,7 +15708,10 @@ class GatewayRunner:
                             "api_mode": getattr(agent, "api_mode", None),
                         } if agent else None,
                     }
-                    if self._is_telegram_topic_lane(source):
+                    title_callback = self._discord_auto_title_callback(source)
+                    if title_callback is not None:
+                        maybe_auto_title_kwargs["title_callback"] = title_callback
+                    elif self._is_telegram_topic_lane(source):
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
                             source,
                             effective_session_id,

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -4,6 +4,7 @@ Tests the _handle_title_command handler (set/show session titles)
 across all gateway messenger platforms.
 """
 
+import asyncio
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,13 +17,14 @@ from gateway.session import SessionSource
 
 
 def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", thread_id=None):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
         user_name="testuser",
+        thread_id=thread_id,
     )
     return MessageEvent(text=text, source=source)
 
@@ -70,6 +72,49 @@ class TestHandleTitleCommand:
         # Verify in DB
         assert db.get_session_title("test_session_123") == "My Research Project"
         db.close()
+
+    @pytest.mark.asyncio
+    async def test_discord_thread_title_renamed_when_setting_title(self, tmp_path):
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        adapter = SimpleNamespace(rename_thread=AsyncMock())
+        runner = _make_runner(session_db=db)
+        runner.adapters = {Platform.DISCORD: adapter}
+        event = _make_event(
+            text="/title Project Thread",
+            platform=Platform.DISCORD,
+            chat_id="111",
+            thread_id="222",
+        )
+
+        result = await runner._handle_title_command(event)
+
+        assert "Project Thread" in result
+        adapter.rename_thread.assert_awaited_once_with("222", "Project Thread")
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_discord_auto_title_callback_uses_running_loop_without_legacy_loop_attr(self):
+        runner = _make_runner()
+        calls = []
+
+        def schedule(source, title, loop):
+            calls.append((source, title, loop))
+
+        runner._schedule_auto_title_thread_rename = schedule
+        event = _make_event(
+            platform=Platform.DISCORD,
+            chat_id="111",
+            thread_id="222",
+        )
+
+        callback = runner._discord_auto_title_callback(event.source)
+        assert callback is not None
+        callback("Generated Title")
+
+        assert calls == [(event.source, "Generated Title", asyncio.get_running_loop())]
 
     @pytest.mark.asyncio
     async def test_show_title_when_set(self, tmp_path):


### PR DESCRIPTION
## Summary
- Add a Discord thread rename helper so gateway session titles can update the corresponding thread name.
- Sync manual `/title ...` changes immediately when the command is run from a Discord thread.
- Wire auto-generated session titles through a callback that schedules the Discord rename on the gateway event loop, avoiding polling the session DB or using a stale/nonexistent loop from the auto-title background thread.

## Test Plan
- `python -m pytest tests/gateway/test_title_command.py -q`
- `python -m py_compile gateway/platforms/discord.py gateway/run.py`
- Live Discord behavior was smoke-tested via manual title updates and has been exercised in production use; automated coverage uses gateway tests/mocks.

## Platforms Tested
- macOS arm64.

## Related / competing PRs
- [PR #15757](https://github.com/NousResearch/hermes-agent/pull/15757), `feat(gateway/discord): sync thread names with session titles`, targets the same user-visible Discord thread/session title sync behavior. This PR supersedes it by avoiding the DB polling loop, scheduling auto-title renames directly from the title callback onto the gateway event loop, keeping the scope focused, and adding regression tests.
- [PR #24311](https://github.com/NousResearch/hermes-agent/pull/24311) is an even closer duplicate of the callback-based approach, but it was closed as duplicate and did not cover immediate manual `/title` renames in the same tested path. This PR is a consolidated successor rather than another duplicate.
- [PR #3009](https://github.com/NousResearch/hermes-agent/pull/3009) and [PR #17378](https://github.com/NousResearch/hermes-agent/pull/17378) are adjacent Discord auto-thread-title work, but they focus on generated auto-thread names rather than syncing established session titles to existing Discord thread names.
- [PR #18429](https://github.com/NousResearch/hermes-agent/pull/18429) and [PR #16059](https://github.com/NousResearch/hermes-agent/pull/16059) are closed related attempts to rename Discord-owned threads after title generation.
- [PR #9921](https://github.com/NousResearch/hermes-agent/pull/9921), [PR #16408](https://github.com/NousResearch/hermes-agent/pull/16408), [PR #20681](https://github.com/NousResearch/hermes-agent/pull/20681), [PR #21111](https://github.com/NousResearch/hermes-agent/pull/21111) are Telegram topic-title sync analogues, not Discord thread sync.

## Notes/Risks
- Cross-platform impact is limited to the Discord gateway path. The implementation uses asyncio scheduling and discord.py channel editing; it does not add file I/O, shell commands, terminal handling, or process management.
- Thread renames are best-effort. If the Discord adapter is unavailable, the source is not a Discord thread, or Discord rejects the edit, the title command/session flow still succeeds.
