### PR TITLE
fix(honcho): use safe profile host keys

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1189,8 +1189,9 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 
 def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) -> None:
     """Rename Honcho host blocks for a renamed profile without changing peers."""
-    old_host = f"hermes.{old_name}"
-    new_host = f"hermes.{new_name}"
+    old_host = f"hermes_{old_name}"
+    legacy_old_host = f"hermes.{old_name}"
+    new_host = f"hermes_{new_name}"
 
     candidates = [
         new_dir / "honcho.json",
@@ -1214,18 +1215,24 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
             continue
 
         hosts = raw.get("hosts")
-        if not isinstance(hosts, dict) or old_host not in hosts:
+        if not isinstance(hosts, dict):
+            continue
+        source_host = old_host if old_host in hosts else legacy_old_host
+        if source_host not in hosts:
             continue
 
         if new_host in hosts:
             print(f"⚠ Honcho host block not migrated: {new_host} already exists in {path}")
             continue
 
-        block = hosts[old_host]
+        block = hosts[source_host]
         if isinstance(block, dict) and "aiPeer" not in block:
-            bare = old_host.split(".", 1)[1] if "." in old_host else old_host
+            if source_host.startswith("hermes_"):
+                bare = source_host.split("_", 1)[1]
+            else:
+                bare = source_host.split(".", 1)[1] if "." in source_host else source_host
             block["aiPeer"] = bare
-        hosts[new_host] = hosts.pop(old_host)
+        hosts[new_host] = hosts.pop(source_host)
         tmp = path.with_suffix(path.suffix + ".tmp")
         try:
             tmp.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
@@ -1237,7 +1244,7 @@ def _migrate_honcho_profile_host(old_name: str, new_name: str, new_dir: Path) ->
                 pass
             continue
 
-        print(f"✓ Honcho host updated: {old_host} → {new_host}")
+        print(f"✓ Honcho host updated: {source_host} → {new_host}")
 
 
 def rename_profile(old_name: str, new_name: str) -> Path:

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -109,7 +109,7 @@ Config is read from the first file that exists:
 | 2 | `~/.hermes/honcho.json` | Default profile (shared host blocks) |
 | 3 | `~/.honcho/config.json` | Global (cross-app interop) |
 
-Host key is derived from the active Hermes profile: `hermes` (default) or `hermes.<profile>`.
+Host key is derived from the active Hermes profile: `hermes` (default) or `hermes_<profile>`.
 
 For every key, resolution order is: **host block > root > env var > default**.
 
@@ -190,7 +190,7 @@ Multiple Hermes profiles can share one workspace while maintaining separate AI i
       "recallMode": "hybrid",
       "sessionStrategy": "per-directory"
     },
-    "hermes.coder": {
+    "hermes_coder": {
       "aiPeer": "coder",
       "recallMode": "tools",
       "sessionStrategy": "per-repo"
@@ -201,7 +201,7 @@ Multiple Hermes profiles can share one workspace while maintaining separate AI i
 
 Both profiles see the same user (`yourname`) in the same shared environment (`hermes`), but each AI peer builds its own observations, conclusions, and behavior patterns. The coder's memory stays code-oriented; the main agent's stays broad.
 
-Host key is derived from the active Hermes profile: `hermes` (default) or `hermes.<profile>` (e.g. `hermes -p coder` → host key `hermes.coder`).
+Host key is derived from the active Hermes profile: `hermes` (default) or `hermes_<profile>` (e.g. `hermes -p coder` -> host key `hermes_coder`). Older `hermes.<profile>` host blocks are still read for compatibility and are migrated when the CLI writes profile-scoped Honcho config.
 
 ### Dialectic & Reasoning
 
@@ -309,7 +309,7 @@ Presets:
       "dialecticMaxChars": 600,
       "saveMessages": true
     },
-    "hermes.coder": {
+    "hermes_coder": {
       "enabled": true,
       "aiPeer": "coder",
       "sessionStrategy": "per-repo",

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -11,7 +11,12 @@ import sys
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
-from plugins.memory.honcho.client import resolve_active_host, resolve_config_path, HOST
+from plugins.memory.honcho.client import (
+    HOST,
+    profile_host_key,
+    resolve_active_host,
+    resolve_config_path,
+)
 from hermes_cli.config import cfg_get
 
 
@@ -36,7 +41,12 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     if not default_block and not has_key:
         return False
 
-    new_host = f"{HOST}.{profile_name}"
+    new_host = profile_host_key(profile_name)
+    if _migrate_legacy_host_block(cfg, new_host):
+        _write_config(cfg)
+        _ensure_peer_exists(new_host)
+        return True
+
     if new_host in hosts:
         return False  # already exists
 
@@ -96,6 +106,7 @@ def cmd_enable(args) -> None:
     """Enable Honcho for the active profile."""
     cfg = _read_config()
     host = _host_key()
+    migrated = _migrate_legacy_host_block(cfg, host)
     label = f"[{host}] " if host != "hermes" else ""
     block = cfg.setdefault("hosts", {}).setdefault(host, {})
 
@@ -119,11 +130,13 @@ def cmd_enable(args) -> None:
         if peer_name and "peerName" not in block:
             block["peerName"] = peer_name
         # Use bare profile name as AI peer, not the host key
-        ai_peer = host.split(".", 1)[1] if "." in host else host
+        ai_peer = _profile_name_from_host(host)
         block.setdefault("aiPeer", ai_peer)
         block.setdefault("workspace", default_block.get("workspace") or cfg.get("workspace") or HOST)
 
     _write_config(cfg)
+    if migrated:
+        print(f"  {label}Migrated legacy Honcho host key.")
     print(f"  {label}Honcho enabled.")
 
     # Create peer eagerly
@@ -139,10 +152,13 @@ def cmd_disable(args) -> None:
     """Disable Honcho for the active profile."""
     cfg = _read_config()
     host = _host_key()
+    migrated = _migrate_legacy_host_block(cfg, host)
     label = f"[{host}] " if host != "hermes" else ""
-    block = cfg_get(cfg, "hosts", host, default={})
+    block = _host_block(cfg, host)
 
     if not block or block.get("enabled") is False:
+        if migrated:
+            _write_config(cfg)
         print(f"  {label}Honcho is already disabled.\n")
         return
 
@@ -184,7 +200,7 @@ def cmd_sync(args) -> None:
         if p.name == "default":
             continue
         if clone_honcho_for_profile(p.name):
-            print(f"  + {p.name} -> hermes.{p.name}")
+            print(f"  + {p.name} -> {profile_host_key(p.name)}")
             created += 1
         else:
             skipped += 1
@@ -233,10 +249,48 @@ _profile_override: str | None = None
 def _host_key() -> str:
     """Return the active Honcho host key, derived from the current Hermes profile."""
     if _profile_override:
-        if _profile_override in ("default", "custom"):
-            return HOST
-        return f"{HOST}.{_profile_override}"
+        return profile_host_key(_profile_override)
     return resolve_active_host()
+
+
+def _legacy_host_alias(host: str) -> str | None:
+    prefix = f"{HOST}_"
+    if host.startswith(prefix) and len(host) > len(prefix):
+        return f"{HOST}.{host[len(prefix):]}"
+    return None
+
+
+def _host_block(cfg: dict, host: str) -> dict:
+    hosts = cfg.get("hosts") or {}
+    if not isinstance(hosts, dict):
+        return {}
+    block = hosts.get(host)
+    if isinstance(block, dict):
+        return block
+    legacy = _legacy_host_alias(host)
+    if legacy:
+        legacy_block = hosts.get(legacy)
+        if isinstance(legacy_block, dict):
+            return legacy_block
+    return {}
+
+
+def _migrate_legacy_host_block(cfg: dict, host: str) -> bool:
+    legacy = _legacy_host_alias(host)
+    hosts = cfg.get("hosts")
+    if not legacy or not isinstance(hosts, dict):
+        return False
+    if legacy not in hosts or host in hosts:
+        return False
+    hosts[host] = hosts.pop(legacy)
+    return True
+
+
+def _profile_name_from_host(host: str) -> str:
+    for prefix in (f"{HOST}_", f"{HOST}."):
+        if host.startswith(prefix) and len(host) > len(prefix):
+            return host[len(prefix):]
+    return host
 
 
 def _config_path() -> Path:
@@ -284,7 +338,7 @@ def _resolve_api_key(cfg: dict) -> str:
     config shapes, e.g. ``localhost:8000``) still pass — the Honcho SDK
     will reject them itself with a clearer error than ours.
     """
-    host_key = ((cfg.get("hosts") or {}).get(_host_key()) or {}).get("apiKey")
+    host_key = _host_block(cfg, _host_key()).get("apiKey")
     key = host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
     if not key:
         base_url = cfg.get("baseUrl") or cfg.get("base_url") or os.environ.get("HONCHO_BASE_URL", "")
@@ -357,6 +411,8 @@ def _ensure_sdk_installed() -> bool:
 def cmd_setup(args) -> None:
     """Interactive Honcho setup wizard."""
     cfg = _read_config()
+    host = _host_key()
+    _migrate_legacy_host_block(cfg, host)
 
     write_path = _local_config_path()
     read_path = _config_path()
@@ -371,7 +427,7 @@ def cmd_setup(args) -> None:
         return
 
     hosts = cfg.setdefault("hosts", {})
-    hermes_host = hosts.setdefault(_host_key(), {})
+    hermes_host = hosts.setdefault(host, {})
 
     # --- 1. Cloud or local? ---
     print("  Deployment:")
@@ -618,8 +674,8 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     for p in profiles:
         if p.name == "default":
             continue
-        h = f"{HOST}.{p.name}"
-        results.append((p.name, h, hosts.get(h, {})))
+        h = profile_host_key(p.name)
+        results.append((p.name, h, _host_block(cfg, h)))
 
     return results
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -32,12 +32,49 @@ logger = logging.getLogger(__name__)
 HOST = "hermes"
 
 
+def profile_host_key(profile: str | None) -> str:
+    """Return the Honcho host key for a Hermes profile.
+
+    Honcho workspace and peer IDs allow letters, numbers, underscores, and
+    hyphens. Keep auto-derived profile host keys in that same safe subset so
+    fallback workspace IDs remain valid.
+    """
+    profile = (profile or "").strip()
+    if not profile or profile in ("default", "custom"):
+        return HOST
+    return f"{HOST}_{profile}"
+
+
+def _legacy_profile_host_alias(host: str) -> str | None:
+    """Return the pre-underscore host alias for a profile-scoped host."""
+    prefix = f"{HOST}_"
+    if host.startswith(prefix) and len(host) > len(prefix):
+        return f"{HOST}.{host[len(prefix):]}"
+    return None
+
+
+def _host_block(raw: dict, host: str) -> dict:
+    """Return host config, accepting legacy dot-form profile host keys."""
+    hosts = raw.get("hosts") or {}
+    if not isinstance(hosts, dict):
+        return {}
+    block = hosts.get(host)
+    if isinstance(block, dict):
+        return block
+    legacy = _legacy_profile_host_alias(host)
+    if legacy:
+        legacy_block = hosts.get(legacy)
+        if isinstance(legacy_block, dict):
+            return legacy_block
+    return {}
+
+
 def resolve_active_host() -> str:
     """Derive the Honcho host key from the active Hermes profile.
 
     Resolution order:
       1. HERMES_HONCHO_HOST env var (explicit override)
-      2. Active profile name via profiles system -> ``hermes.<profile>``
+      2. Active profile name via profiles system -> ``hermes_<profile>``
       3. Fallback: ``"hermes"`` (default profile)
     """
     explicit = os.environ.get("HERMES_HONCHO_HOST", "").strip()
@@ -47,8 +84,7 @@ def resolve_active_host() -> str:
     try:
         from hermes_cli.profiles import get_active_profile_name
         profile = get_active_profile_name()
-        if profile and profile not in ("default", "custom"):
-            return f"{HOST}.{profile}"
+        return profile_host_key(profile)
     except Exception:
         pass
     return HOST
@@ -367,7 +403,7 @@ class HonchoClientConfig:
             logger.warning("Failed to read %s: %s, falling back to env", path, e)
             return cls.from_env(host=resolved_host)
 
-        host_block = (raw.get("hosts") or {}).get(resolved_host, {})
+        host_block = _host_block(raw, resolved_host)
         # A hosts.hermes block or explicit enabled flag means the user
         # intentionally configured Honcho for this host.
         _explicitly_configured = bool(host_block) or raw.get("enabled") is True

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -647,8 +647,8 @@ class TestRenameProfile:
 
         cfg = json.loads(honcho_path.read_text())
         assert "hermes.ssi_health" not in cfg["hosts"]
-        assert cfg["hosts"]["hermes.heimdall"]["aiPeer"] == "ssi_health"
-        assert cfg["hosts"]["hermes.heimdall"]["peerName"] == "user-peer"
+        assert cfg["hosts"]["hermes_heimdall"]["aiPeer"] == "ssi_health"
+        assert cfg["hosts"]["hermes_heimdall"]["peerName"] == "user-peer"
 
     def test_pins_ai_peer_when_absent_on_honcho_host_rename(self, profile_env):
         tmp_path = profile_env
@@ -665,8 +665,8 @@ class TestRenameProfile:
 
         cfg = json.loads(honcho_path.read_text())
         assert "hermes.ssi_health" not in cfg["hosts"]
-        assert cfg["hosts"]["hermes.heimdall"]["aiPeer"] == "ssi_health"
-        assert cfg["hosts"]["hermes.heimdall"]["workspace"] == "hermes"
+        assert cfg["hosts"]["hermes_heimdall"]["aiPeer"] == "ssi_health"
+        assert cfg["hosts"]["hermes_heimdall"]["workspace"] == "hermes"
 
     def test_does_not_overwrite_existing_honcho_host_on_rename(self, profile_env):
         tmp_path = profile_env
@@ -675,7 +675,7 @@ class TestRenameProfile:
         honcho_path.write_text(json.dumps({
             "hosts": {
                 "hermes.ssi_health": {"aiPeer": "ssi_health"},
-                "hermes.heimdall": {"aiPeer": "heimdall"},
+                "hermes_heimdall": {"aiPeer": "heimdall"},
             }
         }))
 
@@ -684,7 +684,7 @@ class TestRenameProfile:
 
         cfg = json.loads(honcho_path.read_text())
         assert cfg["hosts"]["hermes.ssi_health"]["aiPeer"] == "ssi_health"
-        assert cfg["hosts"]["hermes.heimdall"]["aiPeer"] == "heimdall"
+        assert cfg["hosts"]["hermes_heimdall"]["aiPeer"] == "heimdall"
 
     def test_default_raises_value_error(self, profile_env):
         with pytest.raises(ValueError, match="default"):

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -1,6 +1,37 @@
 """Tests for plugins/memory/honcho/cli.py."""
 
+import copy
 from types import SimpleNamespace
+
+
+class TestHostKeys:
+    def test_profile_override_uses_honcho_safe_host_key(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        monkeypatch.setattr(honcho_cli, "_profile_override", "fundraising")
+
+        assert honcho_cli._host_key() == "hermes_fundraising"
+
+    def test_clone_migrates_legacy_dot_profile_host(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg = {
+            "apiKey": "root-key",
+            "hosts": {
+                "hermes": {"workspace": "hermes"},
+                "hermes.fundraising": {"aiPeer": "fundraising"},
+            },
+        }
+        writes = []
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda new_cfg: writes.append(copy.deepcopy(new_cfg)))
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host: True)
+
+        assert honcho_cli.clone_honcho_for_profile("fundraising") is True
+        assert "hermes_fundraising" in cfg["hosts"]
+        assert "hermes.fundraising" not in cfg["hosts"]
+        assert writes[-1]["hosts"]["hermes_fundraising"]["aiPeer"] == "fundraising"
 
 
 class TestResolveApiKey:
@@ -17,6 +48,13 @@ class TestResolveApiKey:
         monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
         cfg = {"hosts": {"hermes": {"apiKey": "host-key"}}, "apiKey": "root-key"}
+        assert honcho_cli._resolve_api_key(cfg) == "host-key"
+
+    def test_returns_api_key_from_legacy_profile_host_block(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes_fundraising")
+        monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+        cfg = {"hosts": {"hermes.fundraising": {"apiKey": "host-key"}}, "apiKey": "root-key"}
         assert honcho_cli._resolve_api_key(cfg) == "host-key"
 
     def test_returns_local_for_base_url_without_api_key(self, monkeypatch):

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -13,6 +13,7 @@ import pytest
 from plugins.memory.honcho.client import (
     HonchoClientConfig,
     get_honcho_client,
+    profile_host_key,
     reset_honcho_client,
     resolve_active_host,
     resolve_config_path,
@@ -431,6 +432,10 @@ class TestResolveConfigPath:
 
 
 class TestResolveActiveHost:
+    def test_profile_host_key_uses_honcho_safe_separator(self):
+        assert profile_host_key("coder") == "hermes_coder"
+        assert profile_host_key("default") == "hermes"
+
     def test_default_returns_hermes(self):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("HERMES_HONCHO_HOST", None)
@@ -445,7 +450,7 @@ class TestResolveActiveHost:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HERMES_HONCHO_HOST", None)
             with patch("hermes_cli.profiles.get_active_profile_name", return_value="coder"):
-                assert resolve_active_host() == "hermes.coder"
+                assert resolve_active_host() == "hermes_coder"
 
     def test_default_profile_returns_hermes(self):
         with patch.dict(os.environ, {}, clear=False):
@@ -478,10 +483,10 @@ class TestResolveActiveHost:
 class TestProfileScopedConfig:
     def test_from_env_uses_profile_host(self):
         with patch.dict(os.environ, {"HONCHO_API_KEY": "key"}):
-            config = HonchoClientConfig.from_env(host="hermes.coder")
-        assert config.host == "hermes.coder"
+            config = HonchoClientConfig.from_env(host="hermes_coder")
+        assert config.host == "hermes_coder"
         assert config.workspace_id == "hermes"  # shared workspace
-        assert config.ai_peer == "hermes.coder"
+        assert config.ai_peer == "hermes_coder"
 
     def test_from_env_default_workspace_preserved_for_default_host(self):
         with patch.dict(os.environ, {"HONCHO_API_KEY": "key"}):
@@ -495,19 +500,19 @@ class TestProfileScopedConfig:
             "apiKey": "shared-key",
             "hosts": {
                 "hermes": {"aiPeer": "hermes", "peerName": "alice"},
-                "hermes.coder": {
-                    "aiPeer": "hermes.coder",
+                "hermes_coder": {
+                    "aiPeer": "hermes_coder",
                     "peerName": "alice-coder",
                     "workspace": "coder-ws",
                 },
             },
         }))
         config = HonchoClientConfig.from_global_config(
-            host="hermes.coder", config_path=config_file,
+            host="hermes_coder", config_path=config_file,
         )
-        assert config.host == "hermes.coder"
+        assert config.host == "hermes_coder"
         assert config.workspace_id == "coder-ws"
-        assert config.ai_peer == "hermes.coder"
+        assert config.ai_peer == "hermes_coder"
         assert config.peer_name == "alice-coder"
 
     def test_from_global_config_auto_resolves_host(self, tmp_path):
@@ -515,13 +520,29 @@ class TestProfileScopedConfig:
         config_file.write_text(json.dumps({
             "apiKey": "key",
             "hosts": {
+                "hermes_dreamer": {"peerName": "dreamer-user"},
+            },
+        }))
+        with patch("plugins.memory.honcho.client.resolve_active_host", return_value="hermes_dreamer"):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.host == "hermes_dreamer"
+        assert config.peer_name == "dreamer-user"
+
+    def test_from_global_config_reads_legacy_dot_profile_host_block(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "key",
+            "hosts": {
                 "hermes.dreamer": {"peerName": "dreamer-user"},
             },
         }))
-        with patch("plugins.memory.honcho.client.resolve_active_host", return_value="hermes.dreamer"):
-            config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.host == "hermes.dreamer"
+        config = HonchoClientConfig.from_global_config(
+            host="hermes_dreamer",
+            config_path=config_file,
+        )
+        assert config.host == "hermes_dreamer"
         assert config.peer_name == "dreamer-user"
+        assert config.workspace_id == "hermes_dreamer"
 
 
 class TestObservationModeMigration:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- derive profile-scoped Honcho host keys with underscores so fallback workspace IDs match Honcho's ID regex
- keep reading legacy dot-form host blocks and migrate them when CLI writes profile-scoped config
- update profile rename handling, docs, and regression tests
- include CI stabilizers for Discord e2e mocks and Nous provider parity tests

Fixes #26459

## Tests
- python -m ruff check plugins\\memory\\honcho\\client.py plugins\\memory\\honcho\\cli.py hermes_cli\\profiles.py tests\\honcho_plugin\\test_client.py tests\\honcho_plugin\\test_cli.py tests\\hermes_cli\\test_profiles.py tests\\e2e\\conftest.py tests\\run_agent\\test_provider_parity.py
- python -m pytest -o addopts= tests\\honcho_plugin -q --tb=short
- python -m pytest -o addopts= tests\\hermes_cli\\test_profiles.py -q --tb=short
- python -m pytest -o addopts= tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m pytest -o addopts= tests\\run_agent\\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m py_compile plugins\\memory\\honcho\\client.py plugins\\memory\\honcho\\cli.py hermes_cli\\profiles.py
- git diff --check