### PR TITLE
fix(simplex): make websocket handling reliable

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -425,15 +425,19 @@ class SimplexAdapter(BasePlatformAdapter):
                 chat_items = [chat_items]
             for item in chat_items:
                 try:
-                    await self._handle_chat_item(item)
+                    await self._handle_chat_item(self._normalize_chat_item_wrapper(item))
                 except Exception:
                     logger.exception("SimpleX: error processing chat item")
             return
 
-        # Singular variant — some daemon versions emit this
+        # Singular variant — some daemon versions emit this. The AChatItem is
+        # usually nested one level down ({"type": "newChatItem", "chatItem":
+        # {"chatInfo": ..., "chatItem": ...}}); _handle_chat_item reads
+        # chatInfo/chatItem at the top level, so unwrap before dispatching or
+        # the message is silently dropped.
         if resp_type == "newChatItem":
             try:
-                await self._handle_chat_item(resp)
+                await self._handle_chat_item(self._normalize_chat_item_wrapper(resp))
             except Exception:
                 logger.exception("SimpleX: error processing chat item")
             return
@@ -469,8 +473,51 @@ class SimplexAdapter(BasePlatformAdapter):
         if resp_type:
             logger.debug("SimpleX: unhandled event type: %s", resp_type)
 
+    @staticmethod
+    def _normalize_chat_item_wrapper(payload: dict) -> dict:
+        """Normalize SimpleX AChatItem payload variants to {chatInfo, chatItem}.
+
+        Depending on daemon version and event type, the chat item wrapper
+        arrives in one of several shapes:
+
+        * ``{"chatInfo": ..., "chatItem": ...}`` — already normalized
+          (the usual ``newChatItems`` array element).
+        * ``{"type": "newChatItem", "chatItem": {"chatInfo": ...,
+          "chatItem": ...}}`` — the singular event nests the AChatItem one
+          level down.
+        * ``{"chatInfo": ..., "item": ...}`` — some responses name the item
+          field ``item`` instead of ``chatItem``.
+
+        ``_handle_chat_item`` only reads ``chatInfo``/``chatItem`` at the top
+        level, so anything not normalized here would be silently dropped.
+        """
+        if not isinstance(payload, dict):
+            return {}
+
+        nested = payload.get("chatItem")
+        if isinstance(nested, dict):
+            # Nested AChatItem: {type: newChatItem, chatItem: {chatInfo, chatItem}}
+            if isinstance(nested.get("chatInfo"), dict) and isinstance(
+                nested.get("chatItem"), dict
+            ):
+                return nested
+            # Already normalized: {chatInfo: ..., chatItem: {content/meta/...}}
+            if isinstance(payload.get("chatInfo"), dict):
+                return payload
+
+        if isinstance(payload.get("chatInfo"), dict) and isinstance(
+            payload.get("item"), dict
+        ):
+            return {"chatInfo": payload["chatInfo"], "chatItem": payload["item"]}
+
+        return payload
+
     async def _handle_chat_item(self, chat_item: dict) -> None:
         """Process a single chat item from a newChatItems event."""
+        # Normalizing here as well keeps every caller (singular event, batch
+        # array, deferred rcvFileComplete replay) safe — the helper is
+        # idempotent on already-normalized wrappers.
+        chat_item = self._normalize_chat_item_wrapper(chat_item)
         chat_info = chat_item.get("chatInfo", {}) or {}
         chat_item_data = chat_item.get("chatItem", {}) or {}
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -467,3 +467,108 @@ async def test_image_file_still_sets_photo_type():
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
+
+
+# ---------------------------------------------------------------------------
+# Nested AChatItem normalization (singular newChatItem events)
+# ---------------------------------------------------------------------------
+
+def _make_direct_text_wrapper(text: str = "hello") -> dict:
+    """Minimal normalized AChatItem wrapper for a received direct text."""
+    return {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 42, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": text},
+            },
+        },
+    }
+
+
+def test_normalize_unwraps_nested_achatitem():
+    """{type: newChatItem, chatItem: {chatInfo, chatItem}} → inner wrapper."""
+    inner = _make_direct_text_wrapper()
+    payload = {"type": "newChatItem", "chatItem": inner}
+    assert SimplexAdapter._normalize_chat_item_wrapper(payload) is inner
+
+
+def test_normalize_passes_through_normalized_wrapper():
+    """An already-normalized {chatInfo, chatItem} wrapper is returned as-is."""
+    wrapper = _make_direct_text_wrapper()
+    assert SimplexAdapter._normalize_chat_item_wrapper(wrapper) is wrapper
+
+
+def test_normalize_maps_item_key_variant():
+    """{chatInfo, item} responses normalize to {chatInfo, chatItem}."""
+    wrapper = _make_direct_text_wrapper()
+    payload = {"chatInfo": wrapper["chatInfo"], "item": wrapper["chatItem"]}
+    normalized = SimplexAdapter._normalize_chat_item_wrapper(payload)
+    assert normalized["chatInfo"] is wrapper["chatInfo"]
+    assert normalized["chatItem"] is wrapper["chatItem"]
+
+
+def test_normalize_tolerates_non_dict():
+    assert SimplexAdapter._normalize_chat_item_wrapper(None) == {}
+    assert SimplexAdapter._normalize_chat_item_wrapper("junk") == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_event_singular_new_chat_item_nested():
+    """A wrapped singular newChatItem event with the AChatItem nested one
+    level down must reach message handling instead of being silently
+    dropped because chatInfo isn't at the top level."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    event = {
+        "corrId": "",
+        "resp": {"type": "newChatItem", "chatItem": _make_direct_text_wrapper("hi there")},
+    }
+    await adapter._handle_event(event)
+
+    # Text messages are buffered by the batching layer before dispatch —
+    # the pending batch proves the item survived normalization.
+    batches = list(adapter._pending_text_batches.values())
+    assert batches, "nested newChatItem was dropped before dispatch"
+    assert batches[0].text == "hi there"
+    assert batches[0].source.chat_id == "42"
+    # Cancel the flush timer so no task leaks out of the test.
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_new_chat_items_nested_elements():
+    """newChatItems arrays whose elements nest the AChatItem one level down
+    are normalized element-by-element."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    event = {
+        "corrId": "",
+        "resp": {
+            "type": "newChatItems",
+            "chatItems": [
+                {"chatItem": _make_direct_text_wrapper("first")},
+                _make_direct_text_wrapper("second"),  # already-normalized mix
+            ],
+        },
+    }
+    await adapter._handle_event(event)
+
+    batches = list(adapter._pending_text_batches.values())
+    assert batches, "nested newChatItems elements were dropped"
+    # Same chat → batched into one pending event, in arrival order.
+    assert batches[0].text == "first\nsecond"
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()


### PR DESCRIPTION
## Summary
- normalize wrapped and nested SimpleX WebSocket event payloads before processing inbound messages
- keep the persistent WebSocket as the primary stream, with one catch-up pass after reconnect instead of continuous polling
- de-duplicate live stream items against catch-up tail responses and make outbound send failures report failure instead of fake success
- quote SimpleX command targets, prefer local display names for delivery, and allow direct SimpleX send targets
- update SimpleX docs and regression tests for the real WebSocket/send behavior

## Test plan
- python -m py_compile plugins/platforms/simplex/adapter.py
- python -m pytest tests/gateway/test_simplex_plugin.py tests/tools/test_send_message_tool.py -q -o 'addopts='
- git diff --check

## Local validation
- Restarted the local Hermes gateway
- Verified SimpleX gateway connects to the configured local WebSocket after restart