### PR TITLE
fix(agent): forward fallback_providers[].extra_body during fallback activation (#26460)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1095,6 +1095,25 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _deep_merge_extra_body(base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge ``overlay`` on top of ``base`` one level deep.
+
+    OpenRouter-style nested keys like ``extra_body["provider"]`` need a nested
+    merge so a fallback chain entry setting ``provider.order`` /
+    ``allow_fallbacks`` does not clobber an existing
+    ``provider.require_parameters`` baked into ``request_overrides`` by the
+    primary configuration. Non-dict values follow shallow merge (overlay wins).
+    """
+    merged = dict(base)
+    for key, overlay_value in overlay.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(overlay_value, dict):
+            merged[key] = {**existing, **overlay_value}
+        else:
+            merged[key] = overlay_value
+    return merged
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1107,6 +1126,17 @@ class AIAgent:
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"
     )
+
+    @staticmethod
+    def _snapshot_request_overrides(value: Any) -> Dict[str, Any]:
+        """Shallow-copy ``value`` for use as a ``request_overrides`` snapshot.
+
+        Non-dict values normalize to ``{}`` so the snapshot is always safe to
+        restore back into ``self.request_overrides`` without TypeError. Used
+        in ``__init__``, ``switch_model``, and ``_try_activate_fallback`` to
+        keep the three snapshot sites in lockstep.
+        """
+        return dict(value) if isinstance(value, dict) else {}
 
     @property
     def base_url(self) -> str:
@@ -2485,10 +2515,8 @@ class AIAgent:
             # Snapshot request_overrides so fallback-entry-specific
             # extra_body forwarded by _try_activate_fallback() is cleared
             # when the primary route is restored next turn (#26460).
-            "request_overrides": (
-                dict(getattr(self, "request_overrides", None) or {})
-                if isinstance(getattr(self, "request_overrides", None), dict)
-                else {}
+            "request_overrides": self._snapshot_request_overrides(
+                getattr(self, "request_overrides", None)
             ),
             # Context engine state that _try_activate_fallback() overwrites.
             # Use getattr for model/base_url/api_key/provider since plugin
@@ -2773,10 +2801,8 @@ class AIAgent:
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
-            "request_overrides": (
-                dict(getattr(self, "request_overrides", None) or {})
-                if isinstance(getattr(self, "request_overrides", None), dict)
-                else {}
+            "request_overrides": self._snapshot_request_overrides(
+                getattr(self, "request_overrides", None)
             ),
             "compressor_model": getattr(_cc, "model", self.model) if _cc else self.model,
             "compressor_base_url": getattr(_cc, "base_url", self.base_url) if _cc else self.base_url,
@@ -8857,15 +8883,17 @@ class AIAgent:
             # when the primary route comes back. See #26460.
             fb_extra_body = fb.get("extra_body")
             if isinstance(fb_extra_body, dict) and fb_extra_body:
-                _existing_overrides = getattr(self, "request_overrides", None)
-                base_overrides = (
-                    dict(_existing_overrides)
-                    if isinstance(_existing_overrides, dict)
-                    else {}
+                base_overrides = self._snapshot_request_overrides(
+                    getattr(self, "request_overrides", None)
                 )
                 existing_eb = base_overrides.get("extra_body")
+                # Deep-merge one level so a fallback entry's nested keys
+                # (e.g. ``provider.order``) don't clobber unrelated nested
+                # keys baked into the primary override (e.g.
+                # ``provider.require_parameters``). Fallback wins on leaf
+                # collision, primary wins on absent leaves.
                 merged_eb = (
-                    {**existing_eb, **fb_extra_body}
+                    _deep_merge_extra_body(existing_eb, fb_extra_body)
                     if isinstance(existing_eb, dict)
                     else dict(fb_extra_body)
                 )
@@ -8998,9 +9026,14 @@ class AIAgent:
             self._use_prompt_caching = rt["use_prompt_caching"]
             # Drop any fallback-entry-specific request_overrides that
             # _try_activate_fallback() merged in (e.g. OpenRouter
-            # extra_body.provider routing). Snapshot may be absent on
-            # older sessions saved before #26460.
-            self.request_overrides = dict(rt.get("request_overrides", {}))
+            # extra_body.provider routing). Older sessions saved before
+            # #26460 won't have the snapshot key — leave the current
+            # request_overrides untouched in that case so any overrides
+            # set after snapshot capture are preserved.
+            if "request_overrides" in rt:
+                self.request_overrides = self._snapshot_request_overrides(
+                    rt["request_overrides"]
+                )
             # Default to native layout when the restored snapshot predates the
             # native-vs-proxy split (older sessions saved before this PR).
             self._use_native_cache_layout = rt.get(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2482,6 +2482,14 @@ class AIAgent:
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
+            # Snapshot request_overrides so fallback-entry-specific
+            # extra_body forwarded by _try_activate_fallback() is cleared
+            # when the primary route is restored next turn (#26460).
+            "request_overrides": (
+                dict(getattr(self, "request_overrides", None) or {})
+                if isinstance(getattr(self, "request_overrides", None), dict)
+                else {}
+            ),
             # Context engine state that _try_activate_fallback() overwrites.
             # Use getattr for model/base_url/api_key/provider since plugin
             # engines may not have these (they're ContextCompressor-specific).
@@ -2765,6 +2773,11 @@ class AIAgent:
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
+            "request_overrides": (
+                dict(getattr(self, "request_overrides", None) or {})
+                if isinstance(getattr(self, "request_overrides", None), dict)
+                else {}
+            ),
             "compressor_model": getattr(_cc, "model", self.model) if _cc else self.model,
             "compressor_base_url": getattr(_cc, "base_url", self.base_url) if _cc else self.base_url,
             "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
@@ -8832,6 +8845,33 @@ class AIAgent:
                 self._transport_cache.clear()
             self._fallback_activated = True
 
+            # Forward fallback-entry-specific request metadata (e.g.
+            # OpenRouter ``extra_body.provider`` routing) into
+            # request_overrides so it scopes to the active fallback route
+            # only. The chat_completions transport already merges
+            # ``request_overrides["extra_body"]`` into the outbound
+            # extra_body (see agent/transports/chat_completions.py); this
+            # makes per-fallback routing config-honored without leaking
+            # into unrelated requests. _restore_primary_runtime() resets
+            # request_overrides from the snapshot so the override clears
+            # when the primary route comes back. See #26460.
+            fb_extra_body = fb.get("extra_body")
+            if isinstance(fb_extra_body, dict) and fb_extra_body:
+                _existing_overrides = getattr(self, "request_overrides", None)
+                base_overrides = (
+                    dict(_existing_overrides)
+                    if isinstance(_existing_overrides, dict)
+                    else {}
+                )
+                existing_eb = base_overrides.get("extra_body")
+                merged_eb = (
+                    {**existing_eb, **fb_extra_body}
+                    if isinstance(existing_eb, dict)
+                    else dict(fb_extra_body)
+                )
+                base_overrides["extra_body"] = merged_eb
+                self.request_overrides = base_overrides
+
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
             # SDK default.
@@ -8956,6 +8996,11 @@ class AIAgent:
             self.api_key = rt["api_key"]
             self._client_kwargs = dict(rt["client_kwargs"])
             self._use_prompt_caching = rt["use_prompt_caching"]
+            # Drop any fallback-entry-specific request_overrides that
+            # _try_activate_fallback() merged in (e.g. OpenRouter
+            # extra_body.provider routing). Snapshot may be absent on
+            # older sessions saved before #26460.
+            self.request_overrides = dict(rt.get("request_overrides", {}))
             # Default to native layout when the restored snapshot predates the
             # native-vs-proxy split (older sessions saved before this PR).
             self._use_native_cache_layout = rt.get(

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -305,3 +305,148 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+# ── Fallback-entry extra_body forwarding (#26460) ─────────────────────────
+
+
+class TestFallbackEntryExtraBodyForwarded:
+    """When a fallback entry carries ``extra_body`` (e.g. OpenRouter
+    ``provider.order`` for request-scoped routing), activating that entry
+    must merge it into ``request_overrides`` so the chat_completions
+    transport forwards it on the very next request — without mutating the
+    agent's global ``provider_routing`` knobs (``providers_allowed`` etc.)
+    and without persisting past the next ``_restore_primary_runtime``.
+    See issue #26460."""
+
+    def _activate(self, agent):
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), agent._fallback_chain[0]["model"]),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+        ):
+            return agent._try_activate_fallback()
+
+    def test_fallback_extra_body_forwarded_to_request_overrides(self):
+        fb_extra = {
+            "provider": {
+                "order": ["baidu/fp8", "gmicloud/fp8", "deepinfra/fp4"],
+                "allow_fallbacks": False,
+            }
+        }
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "key_env": "OPENROUTER_API_KEY",
+            "extra_body": fb_extra,
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        assert "extra_body" not in (agent.request_overrides or {})
+
+        assert self._activate(agent) is True
+        eb = agent.request_overrides.get("extra_body")
+        assert isinstance(eb, dict)
+        assert eb["provider"] == fb_extra["provider"]
+
+    def test_global_provider_routing_unchanged(self):
+        """Activating a fallback entry's request-scoped extra_body must not
+        touch the agent-level provider_routing knobs — those still apply to
+        unrelated OpenRouter requests."""
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": {"provider": {"order": ["baidu/fp8"], "allow_fallbacks": False}},
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        # Snapshot the global routing knobs before activation.
+        before = (
+            list(agent.providers_allowed or []),
+            list(agent.providers_ignored or []),
+            list(agent.providers_order or []),
+            agent.provider_sort,
+        )
+
+        assert self._activate(agent) is True
+
+        after = (
+            list(agent.providers_allowed or []),
+            list(agent.providers_ignored or []),
+            list(agent.providers_order or []),
+            agent.provider_sort,
+        )
+        assert before == after
+
+    def test_fallback_without_extra_body_does_not_inject_key(self):
+        fbs = [{"provider": "openrouter", "model": "z-ai/glm-5.1"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {}
+
+        assert self._activate(agent) is True
+        assert "extra_body" not in agent.request_overrides
+
+    def test_fallback_extra_body_merges_with_existing_extra_body(self):
+        """If primary config already populated request_overrides['extra_body'],
+        the fallback's extra_body should merge on top (fallback wins on
+        key collision) rather than replace the whole dict."""
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": {"provider": {"order": ["baidu/fp8"], "allow_fallbacks": False}},
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {"extra_body": {"some_user_field": 42}}
+
+        assert self._activate(agent) is True
+        eb = agent.request_overrides["extra_body"]
+        # Pre-existing user extra_body field preserved.
+        assert eb["some_user_field"] == 42
+        # Fallback-entry extra_body merged in.
+        assert eb["provider"]["order"] == ["baidu/fp8"]
+
+    def test_invalid_extra_body_type_is_ignored(self):
+        """Defensive: a non-dict extra_body in the chain entry must not
+        crash activation or mutate request_overrides."""
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": "not-a-dict",  # invalid shape
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {}
+
+        assert self._activate(agent) is True
+        assert "extra_body" not in agent.request_overrides
+
+    def test_restore_primary_runtime_clears_fallback_extra_body(self):
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": {"provider": {"order": ["baidu/fp8"], "allow_fallbacks": False}},
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        # Snapshot baseline overrides at init (typically empty).
+        baseline_overrides = dict(agent.request_overrides or {})
+
+        assert self._activate(agent) is True
+        assert "extra_body" in agent.request_overrides
+
+        # Simulate the start of the next turn — restore from snapshot.
+        with patch.object(
+            agent, "_create_openai_client", return_value=MagicMock(),
+        ):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.request_overrides == baseline_overrides
+
+    def test_primary_runtime_snapshot_includes_request_overrides(self):
+        """Fix #26460 requires the snapshot to capture request_overrides at
+        init so restoration after fallback activation doesn't leak the
+        fallback-entry override into the primary route."""
+        agent = _make_agent(fallback_model=None)
+        assert "request_overrides" in agent._primary_runtime
+        assert isinstance(agent._primary_runtime["request_overrides"], dict)

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -422,6 +422,46 @@ class TestFallbackEntryExtraBodyForwarded:
         assert self._activate(agent) is True
         assert "extra_body" not in agent.request_overrides
 
+    def test_empty_extra_body_dict_does_not_inject_key(self):
+        """An explicit ``"extra_body": {}`` on a chain entry must behave the
+        same as an absent key — no override injected. Guards against a
+        regression if the ``and fb_extra_body`` truthiness check is later
+        removed."""
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": {},  # explicit empty
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {}
+
+        assert self._activate(agent) is True
+        assert "extra_body" not in agent.request_overrides
+
+    def test_fallback_extra_body_deep_merges_nested_provider_dict(self):
+        """When primary request_overrides already carry ``extra_body.provider``
+        (e.g. OpenRouter ``require_parameters: true`` baked in by config),
+        the fallback's ``provider.order`` / ``allow_fallbacks`` must merge
+        into that nested dict instead of replacing it wholesale."""
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5.1",
+            "extra_body": {"provider": {"order": ["baidu/fp8"], "allow_fallbacks": False}},
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {
+            "extra_body": {"provider": {"require_parameters": True, "data_collection": "deny"}}
+        }
+
+        assert self._activate(agent) is True
+        eb = agent.request_overrides["extra_body"]
+        # Pre-existing nested keys preserved.
+        assert eb["provider"]["require_parameters"] is True
+        assert eb["provider"]["data_collection"] == "deny"
+        # Fallback-entry nested keys merged in (fallback wins on collisions).
+        assert eb["provider"]["order"] == ["baidu/fp8"]
+        assert eb["provider"]["allow_fallbacks"] is False
+
     def test_restore_primary_runtime_clears_fallback_extra_body(self):
         fbs = [{
             "provider": "openrouter",
@@ -450,3 +490,26 @@ class TestFallbackEntryExtraBodyForwarded:
         agent = _make_agent(fallback_model=None)
         assert "request_overrides" in agent._primary_runtime
         assert isinstance(agent._primary_runtime["request_overrides"], dict)
+
+    def test_restore_from_older_snapshot_preserves_current_overrides(self):
+        """Older sessions persisted ``_primary_runtime`` without the
+        ``request_overrides`` field. On restore, code paths that need to
+        operate on those sessions must NOT overwrite the current
+        ``self.request_overrides`` with ``{}`` — that would silently drop
+        user-set overrides applied after the snapshot was taken."""
+        fbs = [{"provider": "openrouter", "model": "z-ai/glm-5.1"}]
+        agent = _make_agent(fallback_model=fbs)
+        assert self._activate(agent) is True
+        # Simulate an older session whose snapshot predates #26460 by
+        # dropping the request_overrides key after activation.
+        agent._primary_runtime.pop("request_overrides", None)
+        # User set an override AFTER the (older) snapshot was taken.
+        agent.request_overrides = {"extra_body": {"user_field": "preserved"}}
+
+        with patch.object(
+            agent, "_create_openai_client", return_value=MagicMock(),
+        ):
+            assert agent._restore_primary_runtime() is True
+
+        # Override survives the restore — older snapshot didn't carry the key.
+        assert agent.request_overrides == {"extra_body": {"user_field": "preserved"}}


### PR DESCRIPTION
## Summary

- `fallback_providers` entries can carry `extra_body` (e.g. OpenRouter `provider.{order, allow_fallbacks}` for per-route provider pinning) but the activation path silently dropped it. Forward it into `request_overrides` so the existing chat_completions transport merge picks it up on the very next request.
- Snapshot `request_overrides` in `_primary_runtime` (init + `switch_model`) and restore it in `_restore_primary_runtime()` so the override is strictly scoped to the active fallback route — no leak into unrelated requests, no leak past the next turn.

Fixes #26460.

## The bug

`_try_activate_fallback()` in `run_agent.py` reads `provider`, `model`, `base_url`, `api_key`, and `key_env`/`api_key_env` off the chosen fallback entry. Anything else on that entry — including a request-scoped `extra_body` block — is dropped on the floor. The reporter's case (validated against live OpenRouter):

```yaml
fallback_providers:
- provider: openrouter
  model: z-ai/glm-5.1
  key_env: OPENROUTER_API_KEY
  extra_body:
    provider:
      order: [baidu/fp8, gmicloud/fp8, deepinfra/fp4]
      allow_fallbacks: false
```

The fallback activates and Hermes routes through OpenRouter, but the `provider.order` / `allow_fallbacks` body block never lands in the request — so OpenRouter free-routes to whatever upstream is cheapest. The only existing way to pin providers (the agent-level `provider_routing` config) is too broad: it injects the same `provider` block into **every** OpenRouter request in the session, distorting routing for unrelated models picked up later via `/model`.

The fallback-suffix workaround (`z-ai/glm-5.1:baidu/fp8`) is accepted by OpenRouter but the issue's live testing shows it does not actually pin the serving provider.

## The fix

`agent/transports/chat_completions.py` already merges `request_overrides["extra_body"]` into the outbound `extra_body` (lines 387-389 / 496-505). The fix is to wire the fallback entry's `extra_body` into `request_overrides` at activation time:

1. **Activate** (`_try_activate_fallback`): after the fallback swap succeeds, merge `fb.get("extra_body")` into `self.request_overrides["extra_body"]`. Pre-existing user `extra_body` keys are preserved; the fallback wins on key collision. Non-dict `extra_body` is ignored.
2. **Snapshot** (`_primary_runtime` at init + `switch_model`): capture `request_overrides` so a later restoration knows the baseline.
3. **Restore** (`_restore_primary_runtime`): reset `request_overrides` from the snapshot so the fallback override is dropped the moment the primary route comes back.

The agent-level `provider_routing` knobs (`providers_allowed`, `providers_ignored`, `providers_order`, `provider_sort`) are intentionally **not** touched — they remain global, the fallback override is request-scoped.

## Test plan

- [x] Focused regression suite (7 new tests in `tests/run_agent/test_provider_fallback.py::TestFallbackEntryExtraBodyForwarded`):
  - `test_fallback_extra_body_forwarded_to_request_overrides` — happy path: provider order + allow_fallbacks lands in `request_overrides["extra_body"]`.
  - `test_global_provider_routing_unchanged` — invariant: agent-level `provider_routing` knobs identical before/after activation.
  - `test_fallback_without_extra_body_does_not_inject_key` — entry without `extra_body` does not add the key.
  - `test_fallback_extra_body_merges_with_existing_extra_body` — pre-existing user `extra_body` preserved; fallback wins on collision.
  - `test_invalid_extra_body_type_is_ignored` — defensive: non-dict `extra_body` does not crash activation.
  - `test_restore_primary_runtime_clears_fallback_extra_body` — invariant: after restore, override is gone.
  - `test_primary_runtime_snapshot_includes_request_overrides` — invariant: snapshot has the restoration anchor.
- [x] Adjacent suite — all green: `tests/run_agent/test_provider_fallback.py` (29), `test_primary_runtime_restore.py`, `test_fallback_model.py`, `test_compressor_fallback_update.py`, `test_switch_model_fallback_prune.py`, `test_anthropic_third_party_oauth_guard.py` — 104 passed.
- [x] Regression guard: removing the new merge block in `_try_activate_fallback` makes `test_fallback_extra_body_forwarded_to_request_overrides` fail (`request_overrides` has no `extra_body` key after activation); reapplying it passes.

## Contract protected

| Invariant | Known-bad input | Negative case |
| --- | --- | --- |
| Fallback `extra_body` is forwarded on activation. | Entry with `extra_body.provider.order` produced no `provider` block in outbound request. | Entry without `extra_body` does not inject the key (test). |
| Activating a fallback never mutates global `provider_routing` knobs. | Old behavior left the knobs untouched, but only because the entire `extra_body` was dropped — the new behavior must continue to leave them alone. | Snapshot 4-tuple compared before/after activation (test). |
| Pre-existing user `extra_body` survives the merge. | Caller config sets `request_overrides["extra_body"]["some_field"]` — must not be clobbered by fallback merge. | `test_fallback_extra_body_merges_with_existing_extra_body`. |
| `_restore_primary_runtime()` clears the fallback's `extra_body`. | Without a `request_overrides` snapshot, the fallback's override would persist into the primary turn. | `test_restore_primary_runtime_clears_fallback_extra_body`. |
| Non-dict `extra_body` does not crash activation. | Misconfigured user yaml: `extra_body: not-a-dict`. | `test_invalid_extra_body_type_is_ignored`. |

> Sibling code paths that may need the same fix: `fb.get("request_overrides")` (the issue lists this as an optional second forwarding target — same merge mechanism would carry it). Intentionally left out of this PR's scope to keep the diff focused on `extra_body`, which is the only field the reporter validated end-to-end. Happy to widen if preferred.

## Related

- Fixes #26460
- Touches the same `_try_activate_fallback` / `_restore_primary_runtime` / `_primary_runtime` machinery as #22387 (config_context_length clear), #22548 (skip-self dedup), #11314 (pool-rotation gating). All adjacent tests still green.