### PR TITLE
fix(honcho): preserve memory when backend rejects conclusions

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -29,6 +29,59 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+def _content_to_text(content: Any) -> str:
+    """Normalize provider message content to text before Honcho ingest.
+
+    Hermes messages can carry multimodal/OpenAI-style content lists, e.g.
+    ``[{"type": "text", "text": "..."}, {"type": "image_url", ...}]``.
+    Honcho's sync path and ``sanitize_context`` operate on strings; passing a
+    list used to raise ``expected string or bytes-like object, got 'list'`` and
+    drop the entire turn. Preserve text parts and represent non-text parts as
+    compact placeholders so memory records the event without storing large
+    binary/media payloads.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                if part:
+                    parts.append(part)
+                continue
+            if isinstance(part, dict):
+                ptype = str(part.get("type") or "").strip()
+                if ptype in {"text", "input_text", "output_text"}:
+                    text = part.get("text") or part.get("content") or ""
+                    if text:
+                        parts.append(str(text))
+                    continue
+                if ptype in {"image_url", "input_image"}:
+                    parts.append("[image attachment]")
+                    continue
+                if ptype in {"audio", "input_audio"}:
+                    parts.append("[audio attachment]")
+                    continue
+                if ptype:
+                    parts.append(f"[{ptype} attachment]")
+                    continue
+            try:
+                parts.append(json.dumps(part, ensure_ascii=False, sort_keys=True))
+            except TypeError:
+                parts.append(str(part))
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "")
+        try:
+            return json.dumps(content, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            return str(content)
+    return str(content)
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1129,8 +1182,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
-        clean_user_content = sanitize_context(user_content or "").strip()
-        clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        clean_user_content = sanitize_context(_content_to_text(user_content)).strip()
+        clean_assistant_content = sanitize_context(_content_to_text(assistant_content)).strip()
 
         def _sync():
             try:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1098,12 +1098,15 @@ class HonchoSessionManager:
                 return False
 
             if target_peer_id == session.assistant_peer_id:
+                observer_peer_id = session.assistant_peer_id
                 assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
                 conclusions_scope = assistant_peer.conclusions_of(session.assistant_peer_id)
             elif self._ai_observe_others:
+                observer_peer_id = session.assistant_peer_id
                 assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
                 conclusions_scope = assistant_peer.conclusions_of(target_peer_id)
             else:
+                observer_peer_id = target_peer_id
                 target_peer = self._get_or_create_peer(target_peer_id)
                 conclusions_scope = target_peer.conclusions_of(target_peer_id)
 
@@ -1115,7 +1118,29 @@ class HonchoSessionManager:
             return True
         except Exception as e:
             logger.error("Failed to create conclusion: %s", e)
-            return False
+            # Self-hosted Honcho deployments may store/search raw messages but
+            # reject conclusion writes when the backend LLM/OpenAI key is not
+            # configured. In that case, preserve the user's explicit durable
+            # fact by appending it to the peer card as a non-LLM fallback. This
+            # keeps honcho_conclude useful without requiring backend credentials.
+            try:
+                existing_card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+                normalized = [str(item).strip() for item in existing_card if str(item).strip()]
+                fact = content.strip()
+                if fact not in normalized:
+                    normalized.append(fact)
+                observer_peer = self._get_or_create_peer(observer_peer_id)
+                observer_peer.set_card(normalized, target=target_peer_id)
+                logger.warning(
+                    "Stored conclusion for %s as %s peer-card fallback after conclusion API failure: %s",
+                    target_peer_id,
+                    observer_peer_id,
+                    e,
+                )
+                return True
+            except Exception as fallback_error:
+                logger.error("Failed to store conclusion via peer-card fallback: %s", fallback_error)
+                return False
 
     def delete_conclusion(self, session_key: str, conclusion_id: str, peer: str = "user") -> bool:
         """Delete a conclusion by ID. Use only for PII removal.

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -364,6 +364,28 @@ class TestPeerLookupHelpers:
             "session_id": session.honcho_session_id,
         }])
 
+    def test_create_conclusion_falls_back_to_peer_card_when_backend_rejects(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        user_peer = MagicMock()
+        scope = MagicMock()
+        scope.create.side_effect = RuntimeError("OpenAI API key is required")
+        assistant_peer.conclusions_of.return_value = scope
+        user_peer.get_card.return_value = ["Existing fact"]
+        mgr._get_or_create_peer = MagicMock(side_effect=[assistant_peer, user_peer, user_peer])
+
+        ok = mgr.create_conclusion(session.key, "User prefers Korean casual tone")
+
+        assert ok is True
+        user_peer.get_card.assert_called_once_with(target=session.user_peer_id)
+        user_peer.set_card.assert_called_once_with(
+            [
+                "Existing fact",
+                "User prefers Korean casual tone",
+            ],
+            target=session.user_peer_id,
+        )
+
 
 class TestConcludeToolDispatch:
     def test_conclude_schema_has_no_anyof(self):
@@ -557,6 +579,37 @@ class TestConcludeToolDispatch:
 
         assert session.add_message.call_args_list[0].args == ("user", "hello")
         assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
+
+    def test_sync_turn_normalizes_multimodal_list_content(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = SimpleNamespace(message_max_chars=25000)
+
+        session = MagicMock()
+        provider._manager.get_or_create.return_value = session
+
+        provider.sync_turn(
+            [
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+            [
+                {"type": "output_text", "text": "I inspected it."},
+                {"type": "input_audio"},
+            ],
+        )
+        provider._sync_thread.join(timeout=1.0)
+
+        assert session.add_message.call_args_list[0].args == (
+            "user",
+            "look at this\n[image attachment]",
+        )
+        assert session.add_message.call_args_list[1].args == (
+            "assistant",
+            "I inspected it.\n[audio attachment]",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes two Honcho memory reliability failures seen in normal Hermes sessions:

1. `sync_turn` now normalizes structured/multimodal message content before calling `sanitize_context`, so image/audio/list-style provider payloads do not raise `TypeError: expected string or bytes-like object, got 'list'` and drop the whole turn.
2. `honcho_conclude` now preserves explicit durable facts in the target peer card when a self-hosted Honcho backend can store/search raw messages but rejects conclusion creation because backend LLM credentials are missing.

The fallback keeps the same observer/target relationship used by the normal conclusion path and deduplicates the fact before appending it to the peer card.

## Related Issue

No linked GitHub issue.

Related open PRs found while checking for duplicates:
- #22768 covers the multimodal `sync_turn` crash only.
- #23022 covers peer-card observer/target writes.
- #24270 is broader and includes Honcho hardening among unrelated dashboard/TUI changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/__init__.py`
  - Add `_content_to_text()` to coerce strings, dicts, and OpenAI-style content lists into safe text before Honcho ingest.
  - Preserve text parts and replace media parts with compact placeholders such as `[image attachment]` and `[audio attachment]`.
- `plugins/memory/honcho/session.py`
  - Track the observer peer used for conclusion creation.
  - If the conclusion API rejects the write, append the fact to the observer's target peer card as a fallback.
- `tests/honcho_plugin/test_session.py`
  - Add regression coverage for multimodal `sync_turn` normalization.
  - Add regression coverage for conclusion-to-peer-card fallback behavior.

## How to Test

1. `python -m pytest tests/honcho_plugin/test_session.py -q -o 'addopts='`
2. `git diff --check`
3. `python -m compileall -q plugins/memory/honcho tests/honcho_plugin`
4. `python -m ruff check plugins/memory/honcho/__init__.py plugins/memory/honcho/session.py tests/honcho_plugin/test_session.py`

Full-suite note: I also attempted `scripts/run_tests.sh` for CI parity. It reached 93% before the 600s local command timeout and had unrelated failures outside this Honcho change area, so this PR reports the focused checks above rather than claiming a full-suite pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8.0-39-generic / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/honcho_plugin/test_session.py -q -o 'addopts='
117 passed in 3.66s

$ git diff --check && python -m compileall -q plugins/memory/honcho tests/honcho_plugin
# no output

$ python -m ruff check plugins/memory/honcho/__init__.py plugins/memory/honcho/session.py tests/honcho_plugin/test_session.py
All checks passed!
```
