### PR TITLE
fix(delegation): honor provider overrides for subagents

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -32,6 +33,7 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _load_config,
 )
 
 
@@ -890,6 +892,42 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    def test_provider_endpoint_preserves_provider_routing(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "deepseek-v4-flash",
+            "provider": "deepseek",
+            "base_url": "https://api.deepseek.com/v1",
+            "api_key": "sk-delegation",
+        }
+
+        with patch("hermes_cli.runtime_provider._get_model_config", return_value={}):
+            creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], "deepseek-v4-flash")
+        self.assertEqual(creds["provider"], "deepseek")
+        self.assertEqual(creds["base_url"], "https://api.deepseek.com/v1")
+        self.assertEqual(creds["api_key"], "sk-delegation")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
+    def test_runtime_cli_config_expands_delegation_env_refs(self):
+        cli_module = SimpleNamespace(
+            CLI_CONFIG={
+                "delegation": {
+                    "provider": "deepseek",
+                    "api_key": "${HERMES_DELEGATION_TEST_KEY}",
+                }
+            }
+        )
+        with patch.dict(sys.modules, {"cli": cli_module}), patch.dict(
+            os.environ,
+            {"HERMES_DELEGATION_TEST_KEY": "sk-expanded"},
+            clear=False,
+        ):
+            cfg = _load_config()
+
+        self.assertEqual(cfg["api_key"], "sk-expanded")
+
     def test_direct_endpoint_returns_none_api_key_when_not_configured(self):
         # When base_url is set without api_key, api_key should be None so
         # _build_child_agent inherits the parent's key (effective_api_key = override or parent).
@@ -1032,6 +1070,47 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], "sk-or-key")
             self.assertNotEqual(kwargs["base_url"], parent.base_url)
             self.assertNotEqual(kwargs["api_key"], parent.api_key)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_child_credential_pool", return_value=None)
+    def test_provider_override_clears_parent_acp_transport(
+        self, mock_pool, mock_cfg
+    ):
+        """A direct provider override must not inherit the parent's ACP command."""
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "copilot-acp"
+        parent.base_url = "acp://copilot"
+        parent.api_key = "copilot-acp"
+        parent.api_mode = "chat_completions"
+        parent.acp_command = "copilot"
+        parent.acp_args = ["--stdio"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Use DeepSeek",
+                context=None,
+                toolsets=["terminal"],
+                model="deepseek-v4-flash",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                override_provider="deepseek",
+                override_base_url="https://api.deepseek.com/v1",
+                override_api_key="sk-delegation",
+                override_api_mode="chat_completions",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "deepseek")
+        self.assertEqual(kwargs["model"], "deepseek-v4-flash")
+        self.assertEqual(kwargs["base_url"], "https://api.deepseek.com/v1")
+        self.assertEqual(kwargs["api_key"], "sk-delegation")
+        self.assertIsNone(kwargs["acp_command"])
+        self.assertEqual(kwargs["acp_args"], [])
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2340,18 +2340,21 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
-    If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
-    omitted, ``api_key`` is returned as ``None`` so ``_build_child_agent``
-    inherits the parent agent's key (``effective_api_key = override_api_key or
-    parent_api_key``). This lets providers that store their key outside
-    ``OPENAI_API_KEY`` (e.g. ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work
-    without a duplicate config entry.
+    If ``delegation.base_url`` is configured without a concrete provider,
+    subagents use that direct OpenAI-compatible endpoint. ``delegation.api_key``
+    overrides the key; when omitted, ``api_key`` is returned as ``None`` so
+    ``_build_child_agent`` inherits the parent agent's key
+    (``effective_api_key = override_api_key or parent_api_key``). This lets
+    providers that store their key outside ``OPENAI_API_KEY`` (e.g.
+    ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work without a duplicate config
+    entry.
 
     Otherwise, if ``delegation.provider`` is configured, the full credential
     bundle (base_url, api_key, api_mode, provider) is resolved via the runtime
     provider system — the same path used by CLI/gateway startup. This lets
-    subagents run on a completely different provider:model pair.
+    subagents run on a completely different provider:model pair. Configured
+    ``delegation.base_url`` and ``delegation.api_key`` values are passed as
+    explicit overrides so provider-specific routing is preserved.
 
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
@@ -2363,7 +2366,11 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
-    if configured_base_url:
+    direct_endpoint_only = configured_base_url and (
+        not configured_provider
+        or configured_provider.lower() in {"auto", "custom", "openrouter"}
+    )
+    if direct_endpoint_only:
         # When delegation.api_key is not set, return None so _build_child_agent
         # falls back to the parent agent's API key via the credential inheritance
         # path (effective_api_key = override_api_key or parent_api_key). This
@@ -2410,7 +2417,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
+        runtime = resolve_runtime_provider(
+            requested=configured_provider,
+            explicit_api_key=configured_api_key,
+            explicit_base_url=configured_base_url,
+            target_model=configured_model,
+        )
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
@@ -2450,6 +2462,12 @@ def _load_config() -> dict:
 
         cfg = CLI_CONFIG.get("delegation") or {}
         if cfg:
+            try:
+                from hermes_cli.config import _expand_env_vars
+
+                cfg = _expand_env_vars(cfg)
+            except Exception:
+                pass
             return cfg
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- preserve concrete delegation.provider routing when delegation.base_url/api_key are set
- pass delegation endpoint/key as explicit runtime provider overrides instead of relabeling provider-specific children as custom
- expand \\ references from runtime CLI_CONFIG delegation settings
- add regression coverage for DeepSeek subagent overrides and parent ACP transport clearing

Fixes #26482

## Tests
- python -m pytest -o addopts= tests\\tools\\test_delegate.py -q --tb=short
- python -m pytest -o addopts= tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m pytest -o addopts= tests\\run_agent\\test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests\\run_agent\\test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q --tb=short
- python -m ruff check tools\\delegate_tool.py tests\\tools\\test_delegate.py tests\\e2e\\conftest.py tests\\run_agent\\test_provider_parity.py
- git diff --check