### PR TITLE
feat(mcp): allow configurable keepalive interval

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1704,6 +1704,103 @@ class TestReconnection:
 # Configurable timeouts
 # ---------------------------------------------------------------------------
 
+class TestConfigurableKeepalive:
+    """Tests for configurable per-server MCP keepalive probes."""
+
+    def test_default_keepalive_interval(self):
+        """Server with no keepalive config keeps the historical 180s default."""
+        from tools.mcp_tool import MCPServerTask, _DEFAULT_KEEPALIVE_INTERVAL
+
+        server = MCPServerTask("test_srv")
+        assert server.keepalive_interval == _DEFAULT_KEEPALIVE_INTERVAL
+        assert server.keepalive_interval == 180
+
+    def test_custom_keepalive_interval_from_config(self):
+        """Server config keepalive_interval overrides the default."""
+        from tools.mcp_tool import MCPServerTask
+
+        target_server = None
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio):
+                task = asyncio.ensure_future(
+                    server.run({"command": "test", "keepalive_interval": "600"})
+                )
+                await server._ready.wait()
+                assert server.keepalive_interval == 600
+                server._shutdown_event.set()
+                await task
+
+        asyncio.run(_test())
+
+    def test_keepalive_interval_zero_disables_probe(self):
+        """keepalive_interval=0 waits for lifecycle events without probing."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("test_srv")
+            server.keepalive_interval = 0
+            server.session = MagicMock()
+            server.session.list_tools = AsyncMock()
+
+            wait_task = asyncio.create_task(server._wait_for_lifecycle_event())
+            await asyncio.sleep(0.02)
+            server.session.list_tools.assert_not_awaited()
+
+            server._reconnect_event.set()
+            reason = await asyncio.wait_for(wait_task, timeout=1.0)
+            assert reason == "reconnect"
+            assert not server._reconnect_event.is_set()
+
+        asyncio.run(_test())
+
+    def test_keepalive_interval_triggers_probe(self):
+        """A positive interval sends list_tools when no lifecycle event fires."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("test_srv")
+            server.keepalive_interval = 0.01
+            server.session = MagicMock()
+
+            async def list_tools():
+                server._shutdown_event.set()
+                return SimpleNamespace(tools=[])
+
+            server.session.list_tools = AsyncMock(side_effect=list_tools)
+
+            reason = await asyncio.wait_for(
+                server._wait_for_lifecycle_event(), timeout=1.0
+            )
+            assert reason == "shutdown"
+            server.session.list_tools.assert_awaited_once()
+
+        asyncio.run(_test())
+
+    def test_invalid_keepalive_interval_uses_default(self, caplog):
+        """Invalid values fall back instead of breaking server startup."""
+        from tools.mcp_tool import (
+            _DEFAULT_KEEPALIVE_INTERVAL,
+            _coerce_keepalive_interval,
+        )
+
+        assert _coerce_keepalive_interval(-1, "test_srv") == _DEFAULT_KEEPALIVE_INTERVAL
+        assert "invalid keepalive_interval" in caplog.text
+
+
 class TestConfigurableTimeouts:
     """Tests for configurable per-server timeouts."""
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -255,6 +255,7 @@ if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
 
 _DEFAULT_TOOL_TIMEOUT = 120      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
+_DEFAULT_KEEPALIVE_INTERVAL = 180.0  # seconds between idle connection probes
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
@@ -283,6 +284,31 @@ _CREDENTIAL_PATTERN = re.compile(
 # Supports any non-} characters in the variable name (hyphens, dots, etc.)
 # so providers like MY-VAR or my.var work correctly.
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _coerce_keepalive_interval(value, server_name: str) -> float:
+    """Return a valid per-server MCP keepalive interval in seconds."""
+    if value is None:
+        return _DEFAULT_KEEPALIVE_INTERVAL
+    try:
+        interval = float(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "MCP server '%s': invalid keepalive_interval=%r; using default %.0fs",
+            server_name,
+            value,
+            _DEFAULT_KEEPALIVE_INTERVAL,
+        )
+        return _DEFAULT_KEEPALIVE_INTERVAL
+    if interval < 0:
+        logger.warning(
+            "MCP server '%s': invalid keepalive_interval=%r; using default %.0fs",
+            server_name,
+            value,
+            _DEFAULT_KEEPALIVE_INTERVAL,
+        )
+        return _DEFAULT_KEEPALIVE_INTERVAL
+    return interval
 
 
 # ---------------------------------------------------------------------------
@@ -951,6 +977,7 @@ class MCPServerTask:
 
     __slots__ = (
         "name", "session", "tool_timeout",
+        "keepalive_interval",
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
@@ -962,6 +989,7 @@ class MCPServerTask:
         self.name = name
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
+        self.keepalive_interval: float = _DEFAULT_KEEPALIVE_INTERVAL
         self._task: Optional[asyncio.Task] = None
         self._ready = asyncio.Event()
         self._shutdown_event = asyncio.Event()
@@ -1136,17 +1164,21 @@ class MCPServerTask:
         prevent TCP connections from going stale during long idle
         periods (#17003).  If the keepalive fails, triggers a reconnect.
         """
-        # Keepalive interval in seconds.  Must be shorter than typical
-        # LB / NAT idle-timeout (commonly 300-600s).
-        _KEEPALIVE_INTERVAL = 180  # 3 minutes
-
         shutdown_task = asyncio.create_task(self._shutdown_event.wait())
         reconnect_task = asyncio.create_task(self._reconnect_event.wait())
+        keepalive_interval = self.keepalive_interval
         try:
             while True:
+                if keepalive_interval <= 0:
+                    done, _pending = await asyncio.wait(
+                        {shutdown_task, reconnect_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    break
+
                 done, _pending = await asyncio.wait(
                     {shutdown_task, reconnect_task},
-                    timeout=_KEEPALIVE_INTERVAL,
+                    timeout=keepalive_interval,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if done:
@@ -1438,6 +1470,9 @@ class MCPServerTask:
         """
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        self.keepalive_interval = _coerce_keepalive_interval(
+            config.get("keepalive_interval"), self.name
+        )
         self._auth_type = (config.get("auth") or "").lower().strip()
 
         # Set up sampling handler if enabled and SDK types are available
@@ -2139,7 +2174,8 @@ def _load_mcp_config() -> Dict[str, dict]:
     Returns a dict of ``{server_name: server_config}`` or empty dict.
     Server config can contain either ``command``/``args``/``env`` for stdio
     transport or ``url``/``headers`` for HTTP transport, plus optional
-    ``timeout``, ``connect_timeout``, and ``auth`` overrides.
+    ``timeout``, ``connect_timeout``, ``keepalive_interval``, and ``auth``
+    overrides.
 
     ``${ENV_VAR}`` placeholders in string values are resolved from
     ``os.environ`` (which includes ``~/.hermes/.env`` loaded at startup).


### PR DESCRIPTION
## Summary
- add per-server mcp_servers.<name>.keepalive_interval config with 180s default
- allow keepalive_interval: 0 to disable idle list_tools probes
- fall back to default for invalid negative/non-numeric values

Fixes #26461

## Tests
- python -m pytest -o addopts='' tests/tools/test_mcp_tool.py::TestConfigurableKeepalive -q
- python -m pytest -o addopts='' tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_tool.py::TestConfigurableKeepalive -q
- python -m pytest -o addopts='' tests/tools/test_mcp_tool.py -q
- python -m pytest -o addopts='' tests/e2e/test_discord_adapter.py -q
- python -m pytest -o addopts='' tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q
- python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
- python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool.py tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
- git diff --check