### PR TITLE
feat(dashboard): add dashboard.tui_workdir config key

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -992,6 +992,7 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        "tui_workdir": "",  # Working directory for the embedded TUI chat (sets TERMINAL_CWD). Empty = inherit cwd.
     },
 
     # Privacy settings

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3213,6 +3213,14 @@ def _resolve_chat_argv(
     # the dashboard PTY path.
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
 
+    # Honour ``dashboard.tui_workdir`` — overrides TERMINAL_CWD so the
+    # embedded TUI's context-file discovery (AGENTS.md, etc.) starts from
+    # the configured directory rather than the repo checkout, preventing
+    # large dev-only context files from inflating the system prompt.
+    cfg_tui_workdir = load_config().get("dashboard", {}).get("tui_workdir", "")
+    if cfg_tui_workdir:
+        env["TERMINAL_CWD"] = os.path.expanduser(cfg_tui_workdir)
+
     if resume:
         latest_resume, _latest_path = _session_latest_descendant(resume)
         if latest_resume:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2068,6 +2068,65 @@ skip_on_windows = pytest.mark.skipif(
 )
 
 
+class TestResolveChatArgv:
+    """Unit tests for _resolve_chat_argv — specifically the tui_workdir plumbing."""
+
+    def _call(self, monkeypatch, cfg_override, resume=None, sidecar_url=None):
+        """Stub out _make_tui_argv and load_config, then call _resolve_chat_argv."""
+        import hermes_cli.web_server as ws
+        from pathlib import Path
+
+        fake_argv = ["/usr/bin/node", "/fake/entry.js"]
+        fake_cwd = Path("/fake/ui-tui")
+
+        monkeypatch.setattr(
+            ws,
+            "_resolve_chat_argv",
+            ws._resolve_chat_argv,  # ensure we're testing the real function
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server.load_config",
+            lambda: cfg_override,
+        )
+
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server._make_tui_argv" if hasattr(ws, "_make_tui_argv") else "hermes_cli.main._make_tui_argv",
+            lambda *a, **kw: (fake_argv, fake_cwd),
+        )
+        # _resolve_chat_argv imports _make_tui_argv inside the function body,
+        # so patch it on the main module directly.
+        monkeypatch.setattr(main_mod, "_make_tui_argv", lambda *a, **kw: (fake_argv, fake_cwd))
+
+        return ws._resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+
+    def test_tui_workdir_sets_terminal_cwd(self, monkeypatch, tmp_path):
+        """dashboard.tui_workdir is expanded and forwarded as TERMINAL_CWD."""
+        cfg = {"dashboard": {"tui_workdir": str(tmp_path)}}
+        _argv, _cwd, env = self._call(monkeypatch, cfg)
+        assert env.get("TERMINAL_CWD") == str(tmp_path)
+
+    def test_tui_workdir_tilde_expanded(self, monkeypatch):
+        """Tilde in dashboard.tui_workdir is expanded."""
+        cfg = {"dashboard": {"tui_workdir": "~"}}
+        _argv, _cwd, env = self._call(monkeypatch, cfg)
+        import os
+        assert env.get("TERMINAL_CWD") == os.path.expanduser("~")
+        assert "~" not in env.get("TERMINAL_CWD", "")
+
+    def test_tui_workdir_empty_leaves_terminal_cwd_unset(self, monkeypatch):
+        """Empty dashboard.tui_workdir does not inject TERMINAL_CWD."""
+        cfg = {"dashboard": {"tui_workdir": ""}}
+        _argv, _cwd, env = self._call(monkeypatch, cfg)
+        assert "TERMINAL_CWD" not in env
+
+    def test_tui_workdir_absent_leaves_terminal_cwd_unset(self, monkeypatch):
+        """Missing dashboard key does not inject TERMINAL_CWD."""
+        _argv, _cwd, env = self._call(monkeypatch, {})
+        assert "TERMINAL_CWD" not in env
+
+
 @skip_on_windows
 class TestPtyWebSocket:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Adds a `dashboard.tui_workdir` config key that sets `TERMINAL_CWD` in the PTY environment for the embedded `/chat` TUI, redirecting context-file discovery (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) away from the repo checkout directory.

## Motivation

Running `hermes dashboard` from a dev checkout causes the repo's `AGENTS.md` (~45 KB for hermes-agent itself) to be injected into every dashboard chat session via `os.getcwd()`. This inflates the system prompt with dev-only instructions that have no relevance to general use.

`TERMINAL_CWD` was already the right mechanism (`run_agent.py` uses it to avoid exactly this in gateway mode), but there was no way to set it from config for the dashboard PTY path.

## Changes

- **`hermes_cli/config.py`** — adds `dashboard.tui_workdir: ""` to `DEFAULT_CONFIG`; empty string preserves existing behaviour
- **`hermes_cli/web_server.py`** — `_resolve_chat_argv()` reads the key, expands `~`, and injects `TERMINAL_CWD` into the PTY env
- **`tests/hermes_cli/test_web_server.py`** — `TestResolveChatArgv` covers set/empty/absent/tilde cases (4 tests)

## Usage

```yaml
# ~/.hermes/config.yaml
dashboard:
  tui_workdir: "~"   # or any path; empty string = inherit cwd (default)
```

## Test Plan

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestResolveChatArgv -v
# 4 passed
```