### PR TITLE
fix: strip image parts for non-vision models with provider profiles

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9724,6 +9724,11 @@ class AIAgent:
             if _ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None
 
+            # Strip image parts for non-vision models that have provider profiles
+            # (e.g. DeepSeek, Kimi). The legacy path below already does this, but
+            # registered providers with profiles were bypassing the strip.
+            api_messages = self._prepare_messages_for_non_vision_model(api_messages)
+
             return _ct.build_kwargs(
                 model=self.model,
                 messages=api_messages,


### PR DESCRIPTION
## Problem

When using non-vision models like DeepSeek v4-pro with the native provider, `image_url` content blocks from tools like `browser_vision`, `computer_use` screenshots, or `/paste` cause HTTP 400 errors:

```
unknown variant `image_url`, expected `text`
```

The image blocks persist in conversation history, making the session unusable.

## Root Cause

In `run_agent.py`'s `_build_api_kwargs()`, `_prepare_messages_for_non_vision_model()` is only called in the **legacy flag path** (line 9715), which is reached when `get_provider_profile()` returns `None` — i.e., unknown/unregistered providers.

Registered providers with profiles (DeepSeek, Kimi, MiniMax, etc.) take the **provider profile path** (line 9680-9705), which passes `api_messages` directly to `_ct.build_kwargs()` **without** stripping images.

## Fix

Add the same `_prepare_messages_for_non_vision_model()` call to the provider profile path, mirroring the legacy path behavior. Vision-capable models are unaffected (the function is a no-op for them).

## Verification

- DeepSeek v4-pro: images are stripped before API call → no more 400 errors
- Claude/GPT/Gemini: no-op, behavior unchanged
- Other non-vision providers with profiles (Kimi, MiniMax): also protected

## Related

- PR #16506 added the original `_prepare_messages_for_non_vision_model`
- PR #23602 added reactive image-stripping fallback for Codex