### PR TITLE
fix(plugins): read plugin.yml in shared manifest helper

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -156,17 +156,26 @@ def _repo_name_from_url(url: str) -> str:
 
 
 def _read_manifest(plugin_dir: Path) -> dict:
-    """Read plugin.yaml and return the parsed dict, or empty dict."""
+    """Read ``plugin.yaml`` / ``plugin.yml`` and return a manifest dict."""
     manifest_file = plugin_dir / "plugin.yaml"
+    if not manifest_file.exists():
+        manifest_file = plugin_dir / "plugin.yml"
     if not manifest_file.exists():
         return {}
     try:
         import yaml
 
         with open(manifest_file, encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            logger.warning(
+                "Failed to read plugin manifest %s: YAML root must be a mapping",
+                manifest_file,
+            )
+            return {}
+        return data
     except Exception as e:
-        logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
+        logger.warning("Failed to read plugin manifest %s: %s", manifest_file, e)
         return {}
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -213,12 +213,26 @@ class TestReadManifest:
         with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
             result = _read_manifest(tmp_path)
         assert result == {}
-        assert any("Failed to read plugin.yaml" in r.message for r in caplog.records)
+        assert any("Failed to read plugin manifest" in r.message for r in caplog.records)
 
     def test_empty_file_returns_empty(self, tmp_path):
         (tmp_path / "plugin.yaml").write_text("")
         result = _read_manifest(tmp_path)
         assert result == {}
+
+    def test_valid_yml_fallback(self, tmp_path):
+        manifest = {"name": "cool-plugin", "version": "1.0.1"}
+        (tmp_path / "plugin.yml").write_text(yaml.dump(manifest))
+        result = _read_manifest(tmp_path)
+        assert result["name"] == "cool-plugin"
+        assert result["version"] == "1.0.1"
+
+    def test_non_mapping_yaml_returns_empty_and_logs(self, tmp_path, caplog):
+        (tmp_path / "plugin.yml").write_text("- just\n- a\n- list\n")
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
+            result = _read_manifest(tmp_path)
+        assert result == {}
+        assert any("YAML root must be a mapping" in r.message for r in caplog.records)
 
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix shared plugin manifest loading so `plugin.yml` is treated the same as `plugin.yaml` in `hermes_cli.plugins_cmd`.

Before this change, general plugin discovery already recognized both manifest extensions, but `_read_manifest()` only loaded `plugin.yaml`. That created inconsistent behavior for valid plugins shipped with `plugin.yml`:

- install paths could miss `name`, `manifest_version`, and `requires_env`
- manifest-based plugin existence checks could fail to match the declared plugin name
- fallback metadata paths that read `provides_tools` could silently lose tool information

This change keeps the scope narrow by fixing the shared helper instead of refactoring call sites.

## What changed

- add `plugin.yml` fallback support to `_read_manifest()`
- reject non-mapping YAML roots with a warning instead of treating them like valid manifests
- add regression tests for:
  - `plugin.yml` fallback loading
  - non-mapping YAML root handling
- update the existing invalid-manifest log assertion to match the helper’s new warning text

## Why this is safe

- behavior only changes for plugin directories that already rely on manifest helper paths
- `plugin.yaml` behavior is preserved
- `plugin.yml` was already recognized in other plugin discovery/listing code paths, so this aligns existing semantics rather than introducing a new feature

## Testing

Passed:
- `uv run pytest tests/hermes_cli/test_plugins_cmd.py -q -k TestReadManifest`

Tried but environment-limited:
- `uv run pytest tests/hermes_cli/test_plugins_cmd.py -q`

The full file still has pre-existing environment-dependent failures unrelated to this change (`rich`, `_curses`, `dotenv` missing in the local Windows test environment).
