### PR TITLE
fix(tui): apply custom TUI branding to banner surfaces

### DIFF
--- a/ui-tui/src/__tests__/branding.test.tsx
+++ b/ui-tui/src/__tests__/branding.test.tsx
@@ -1,0 +1,115 @@
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { PassThrough } from 'stream'
+import { describe, expect, it } from 'vitest'
+
+import { Banner, SessionPanel } from '../components/branding.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME, fromSkin, type Theme } from '../theme.js'
+import type { SessionInfo } from '../types.js'
+
+function renderNode(node: React.ReactElement, columns = 80) {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+function renderBanner(t = DEFAULT_THEME, columns = 80) {
+  return renderNode(React.createElement(Banner, { t }), columns)
+}
+
+function renderSessionPanel(t = DEFAULT_THEME, columns = 120) {
+  const info: SessionInfo = {
+    cwd: '/tmp/project',
+    model: 'openai/gpt-5.4',
+    skills: {},
+    tools: {},
+    version: '0.0.1'
+  }
+
+  return renderNode(React.createElement(SessionPanel, { info, sid: 'sess-1', t }), columns)
+}
+
+function customBrandTheme(name = 'HELIX', overrides: Partial<Theme> = {}) {
+  const t = fromSkin({}, { agent_name: name })
+
+  return {
+    ...t,
+    ...overrides,
+    brand: {
+      ...t.brand,
+      ...(overrides.brand ?? {})
+    }
+  }
+}
+
+describe('Banner branding', () => {
+  it('keeps default branding in narrow mode', () => {
+    const rendered = renderBanner(DEFAULT_THEME, 60)
+
+    expect(rendered).toContain('NOUS HERMES')
+    expect(rendered).toContain('Nous Research · Messenger of the Digital Gods')
+  })
+
+  it('uses display.skin.branding.agent_name in narrow mode instead of hardcoded Nous strings', () => {
+    const rendered = renderBanner(customBrandTheme(), 60)
+
+    expect(rendered).toContain('HELIX')
+    expect(rendered).toContain('HELIX · AI Agent')
+    expect(rendered).not.toContain('NOUS HERMES')
+    expect(rendered).not.toContain('Nous Research · Messenger of the Digital Gods')
+  })
+
+  it('falls back to text branding for custom brands in wide mode', () => {
+    const rendered = renderBanner(customBrandTheme(), 200)
+
+    expect(rendered).toContain('HELIX')
+    expect(rendered).toContain('HELIX · AI Agent')
+    expect(rendered).not.toContain('NOUS HERMES')
+  })
+
+  it('still renders explicit custom banner logo art for custom brands', () => {
+    const rendered = renderBanner(customBrandTheme('HELIX', {
+      bannerLogo: '[#ffffff]CUSTOM HELIX ART[/]'
+    }), 200)
+
+    expect(rendered).toContain('CUSTOM HELIX ART')
+    expect(rendered).not.toContain('NOUS HERMES')
+  })
+})
+
+describe('SessionPanel branding', () => {
+  it('replaces the hardcoded Nous Research label for custom brands in wide mode', () => {
+    const rendered = renderSessionPanel(customBrandTheme(), 140)
+
+    expect(rendered).toContain('gpt-5.4 · HELIX')
+    expect(rendered).not.toContain('Nous Research')
+  })
+
+  it('falls back to text branding instead of default hero art for custom brands without bannerHero', () => {
+    const rendered = renderSessionPanel(customBrandTheme(), 140)
+
+    expect(rendered).toContain('⚕ HELIX')
+    expect(rendered).not.toContain('⢀⣀⡀')
+  })
+})

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -4,10 +4,25 @@ import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
 import { flat } from '../lib/text.js'
-import type { Theme } from '../theme.js'
+import { type Theme } from '../theme.js'
 import type { PanelSection, SessionInfo } from '../types.js'
 
 const LOADER_TICK_MS = 120
+const DEFAULT_BANNER_TITLE = 'NOUS HERMES'
+const DEFAULT_SESSION_LABEL = 'Nous Research'
+const DEFAULT_TAGLINE = 'Nous Research · Messenger of the Digital Gods'
+
+function bannerTitle(t: Theme) {
+  return t.brand.builtinBranding ? DEFAULT_BANNER_TITLE : t.brand.name
+}
+
+function bannerSubtitle(t: Theme) {
+  return t.brand.builtinBranding ? DEFAULT_TAGLINE : `${t.brand.name} · AI Agent`
+}
+
+function sessionBrandLabel(t: Theme) {
+  return t.brand.builtinBranding ? DEFAULT_SESSION_LABEL : t.brand.name
+}
 
 function InlineLoader({ label, t }: { label: string; t: Theme }) {
   const [tick, setTick] = useState(0)
@@ -42,18 +57,21 @@ export function ArtLines({ lines }: { lines: [string, string][] }) {
 export function Banner({ t }: { t: Theme }) {
   const cols = useStdout().stdout?.columns ?? 80
   const logoLines = logo(t.color, t.bannerLogo || undefined)
+  const canShowArt = Boolean(t.bannerLogo) || t.brand.builtinBranding
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      {cols >= (t.bannerLogo ? artWidth(logoLines) : LOGO_WIDTH) ? (
+      {canShowArt && cols >= (t.bannerLogo ? artWidth(logoLines) : LOGO_WIDTH) ? (
         <ArtLines lines={logoLines} />
       ) : (
         <Text bold color={t.color.primary}>
-          {t.brand.icon} NOUS HERMES
+          {t.brand.icon} {bannerTitle(t)}
         </Text>
       )}
 
-      <Text color={t.color.muted}>{t.brand.icon} Nous Research · Messenger of the Digital Gods</Text>
+      <Text color={t.color.muted}>
+        {t.brand.icon} {bannerSubtitle(t)}
+      </Text>
     </Box>
   )
 }
@@ -99,6 +117,7 @@ const TOOLSETS_MAX = 8
 export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   const cols = useStdout().stdout?.columns ?? 100
   const heroLines = caduceus(t.color, t.bannerHero || undefined)
+  const canShowHeroArt = Boolean(t.bannerHero) || t.brand.builtinBranding
   const leftW = Math.min((artWidth(heroLines) || CADUCEUS_WIDTH) + 4, Math.floor(cols * 0.4))
   const wide = cols >= 90 && leftW + 40 < cols
   const w = Math.max(20, wide ? cols - leftW - 14 : cols - 12)
@@ -219,12 +238,18 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
     <Box borderColor={t.color.border} borderStyle="round" marginBottom={1} paddingX={2} paddingY={1}>
       {wide && (
         <Box flexDirection="column" marginRight={2} width={leftW}>
-          <ArtLines lines={heroLines} />
+          {canShowHeroArt ? (
+            <ArtLines lines={heroLines} />
+          ) : (
+            <Text bold color={t.color.primary}>
+              {t.brand.icon} {t.brand.name}
+            </Text>
+          )}
           <Text />
 
           <Text color={t.color.accent}>
             {info.model.split('/').pop()}
-            <Text color={t.color.muted}> · Nous Research</Text>
+            <Text color={t.color.muted}> · {sessionBrandLabel(t)}</Text>
           </Text>
 
           <Text color={t.color.muted} wrap="truncate-end">

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -42,6 +42,7 @@ export interface ThemeBrand {
   goodbye: string
   tool: string
   helpHeader: string
+  builtinBranding: boolean
 }
 
 export interface Theme {
@@ -236,14 +237,17 @@ function normalizeAnsiForeground(color: string): string {
 
 // ── Defaults ─────────────────────────────────────────────────────────
 
+export const DEFAULT_BRAND_NAME = 'Hermes Agent'
+
 const BRAND: ThemeBrand = {
-  name: 'Hermes Agent',
+  name: DEFAULT_BRAND_NAME,
   icon: '⚕',
   prompt: '❯',
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
   tool: '┊',
-  helpHeader: '(^_^)? Commands'
+  helpHeader: '(^_^)? Commands',
+  builtinBranding: true
 }
 
 const cleanPromptSymbol = (s: string | undefined, fallback: string) => {
@@ -580,7 +584,8 @@ export function fromSkin(
       welcome: branding.welcome ?? d.brand.welcome,
       goodbye: branding.goodbye ?? d.brand.goodbye,
       tool: toolPrefix || d.brand.tool,
-      helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader)
+      helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader),
+      builtinBranding: !branding.agent_name || branding.agent_name === d.brand.name
     },
 
     bannerLogo,


### PR DESCRIPTION
## Summary
- apply `display.skin.branding.agent_name` to TUI banner text surfaces
- replace hardcoded Nous branding in custom-brand banner and session panel paths
- preserve explicit banner art overrides and add render-level regression coverage

## Test Plan
- `cd ui-tui && npm run build --prefix packages/hermes-ink`
- `cd ui-tui && npm test -- src/__tests__/branding.test.tsx`
- `cd ui-tui && npm test -- src/__tests__/theme.test.ts src/__tests__/branding.test.tsx`
- `cd ui-tui && npm run type-check`

Closes #25704