### PR TITLE
fix(gateway): update chunked progress messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -663,6 +663,95 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _progress_message_chunks(adapter: Any, content: str) -> List[str]:
+    """Split a tool-progress payload into edit-safe platform chunks.
+
+    Tool-progress bubbles are edited repeatedly. If we hand an oversized
+    payload to a platform adapter, Telegram's edit overflow fallback has to
+    create continuation messages on every update because the caller only knows
+    about one message id. Pre-splitting here lets the gateway track and edit
+    each visible progress chunk in place.
+    """
+    len_fn = adapter.message_len_fn if isinstance(adapter, BasePlatformAdapter) else len
+    raw_limit = getattr(adapter, "MAX_MESSAGE_LENGTH", 4096)
+    # Leave room for platform formatting/escaping and chunk indicators so the
+    # adapter's own send/edit path does not need to split a chunk again.
+    safe_limit = max(500, int(raw_limit) - 100)
+    return adapter.truncate_message(content, safe_limit, len_fn=len_fn)
+
+
+async def _send_or_update_progress_chunks(
+    *,
+    adapter: Any,
+    chat_id: str,
+    content: str,
+    message_ids: List[str],
+    reply_to: Optional[str],
+    metadata: Optional[Dict[str, Any]],
+    cleanup_msg_ids: Optional[List[str]] = None,
+    platform: Any = None,
+) -> bool:
+    """Send/edit all chunks for a growing tool-progress bubble.
+
+    ``message_ids`` is mutated in-place and contains the visible progress
+    messages in display order. Existing chunks are edited; new chunks are sent
+    only when the rendered status grows past another platform limit.
+    """
+    chunks = _progress_message_chunks(adapter, content)
+    if not chunks:
+        return True
+
+    platform_value = getattr(platform, "value", platform)
+    for idx, chunk in enumerate(chunks):
+        if idx < len(message_ids):
+            result = await adapter.edit_message(
+                chat_id=chat_id,
+                message_id=message_ids[idx],
+                content=chunk,
+            )
+            if not result.success:
+                return False
+            continue
+
+        if idx > 0 and platform_value == "telegram" and message_ids:
+            chunk_reply_to = message_ids[-1]
+        else:
+            chunk_reply_to = reply_to
+        result = await adapter.send(
+            chat_id=chat_id,
+            content=chunk,
+            reply_to=chunk_reply_to,
+            metadata=metadata,
+        )
+        if not result.success or not result.message_id:
+            return False
+        message_ids.append(str(result.message_id))
+        if cleanup_msg_ids is not None:
+            cleanup_msg_ids.append(str(result.message_id))
+        for continuation_id in getattr(result, "continuation_message_ids", ()) or ():
+            cid = str(continuation_id)
+            if cid and cid not in message_ids:
+                message_ids.append(cid)
+                if cleanup_msg_ids is not None:
+                    cleanup_msg_ids.append(cid)
+
+    # Progress only grows in normal operation, but dedup/reset edge cases can
+    # make the rendered chunk count shrink. Best-effort delete stale trailing
+    # chunks so they don't keep showing old content.
+    if len(message_ids) > len(chunks):
+        stale_ids = message_ids[len(chunks):]
+        del message_ids[len(chunks):]
+        delete_fn = getattr(adapter, "delete_message", None)
+        if delete_fn is not None:
+            for stale_id in stale_ids:
+                try:
+                    await delete_fn(chat_id=chat_id, message_id=stale_id)
+                except Exception:
+                    logger.debug("Progress stale chunk delete failed", exc_info=True)
+
+    return True
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -14614,7 +14703,7 @@ class GatewayRunner:
                 return
 
             progress_lines = []      # Accumulated tool lines
-            progress_msg_id = None   # ID of the progress message to edit
+            progress_msg_ids = []    # IDs of progress chunk messages to edit, in order
             can_edit = True          # False once an edit fails (platform doesn't support it)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
@@ -14662,7 +14751,7 @@ class GatewayRunner:
                         # order. Mirrors GatewayStreamConsumer.on_segment_break
                         # on the content side. (Issue: tool + content
                         # linearization regression after PR #7885.)
-                        progress_msg_id = None
+                        progress_msg_ids = []
                         progress_lines = []
                         last_progress_msg[0] = None
                         repeat_count[0] = 0
@@ -14687,16 +14776,21 @@ class GatewayRunner:
                     if not _run_still_current():
                         return
 
-                    if can_edit and progress_msg_id is not None:
+                    if can_edit and progress_msg_ids:
                         # Try to edit the existing progress message
                         full_text = "\n".join(progress_lines)
-                        result = await adapter.edit_message(
+                        ok = await _send_or_update_progress_chunks(
+                            adapter=adapter,
                             chat_id=source.chat_id,
-                            message_id=progress_msg_id,
                             content=full_text,
+                            message_ids=progress_msg_ids,
+                            reply_to=_progress_reply_to,
+                            metadata=_progress_metadata,
+                            cleanup_msg_ids=_cleanup_msg_ids if _cleanup_progress else None,
+                            platform=source.platform,
                         )
-                        if not result.success:
-                            _err = (getattr(result, "error", "") or "").lower()
+                        if not ok:
+                            _err = ""
                             if "flood" in _err or "retry after" in _err:
                                 # Flood control hit — disable further edits,
                                 # switch to sending new messages only for
@@ -14722,12 +14816,17 @@ class GatewayRunner:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(
+                            ok = await _send_or_update_progress_chunks(
+                                adapter=adapter,
                                 chat_id=source.chat_id,
                                 content=full_text,
+                                message_ids=progress_msg_ids,
                                 reply_to=_progress_reply_to,
                                 metadata=_progress_metadata,
+                                cleanup_msg_ids=_cleanup_msg_ids if _cleanup_progress else None,
+                                platform=source.platform,
                             )
+                            result = None
                         else:
                             # Editing unsupported: send just this line
                             result = await adapter.send(
@@ -14736,10 +14835,12 @@ class GatewayRunner:
                                 reply_to=_progress_reply_to,
                                 metadata=_progress_metadata,
                             )
-                        if result.success and result.message_id:
-                            progress_msg_id = result.message_id
+                        if result is not None and result.success and result.message_id:
+                            progress_msg_ids = [str(result.message_id)]
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(str(result.message_id))
+                        elif can_edit and not ok:
+                            can_edit = False
 
                     _last_edit_ts = time.monotonic()
 
@@ -14763,17 +14864,22 @@ class GatewayRunner:
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
                                 # one for any tool lines that arrived after.
-                                if can_edit and progress_lines and progress_msg_id:
+                                if can_edit and progress_lines and progress_msg_ids:
                                     _pending_text = "\n".join(progress_lines)
                                     try:
-                                        await adapter.edit_message(
+                                        await _send_or_update_progress_chunks(
+                                            adapter=adapter,
                                             chat_id=source.chat_id,
-                                            message_id=progress_msg_id,
                                             content=_pending_text,
+                                            message_ids=progress_msg_ids,
+                                            reply_to=_progress_reply_to,
+                                            metadata=_progress_metadata,
+                                            cleanup_msg_ids=_cleanup_msg_ids if _cleanup_progress else None,
+                                            platform=source.platform,
                                         )
                                     except Exception:
                                         pass
-                                progress_msg_id = None
+                                progress_msg_ids = []
                                 progress_lines = []
                                 last_progress_msg[0] = None
                                 repeat_count[0] = 0
@@ -14782,13 +14888,18 @@ class GatewayRunner:
                         except Exception:
                             break
                     # Final edit with all remaining tools (only if editing works)
-                    if can_edit and progress_lines and progress_msg_id:
+                    if can_edit and progress_lines and progress_msg_ids:
                         full_text = "\n".join(progress_lines)
                         try:
-                            await adapter.edit_message(
+                            await _send_or_update_progress_chunks(
+                                adapter=adapter,
                                 chat_id=source.chat_id,
-                                message_id=progress_msg_id,
                                 content=full_text,
+                                message_ids=progress_msg_ids,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                                cleanup_msg_ids=_cleanup_msg_ids if _cleanup_progress else None,
+                                platform=source.platform,
                             )
                         except Exception:
                             pass

--- a/tests/gateway/test_progress_chunking.py
+++ b/tests/gateway/test_progress_chunking.py
@@ -1,0 +1,140 @@
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import _send_or_update_progress_chunks
+
+
+class FakeProgressAdapter:
+    MAX_MESSAGE_LENGTH = 650
+    truncate_message = staticmethod(BasePlatformAdapter.truncate_message)
+
+    def __init__(self):
+        self.next_id = 1
+        self.sends = []
+        self.edits = []
+        self.deletes = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        assert len(content) <= self.MAX_MESSAGE_LENGTH
+        message_id = f"m{self.next_id}"
+        self.next_id += 1
+        self.sends.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "message_id": message_id,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(self, chat_id, message_id, content, *, finalize=False):
+        assert len(content) <= self.MAX_MESSAGE_LENGTH
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def delete_message(self, chat_id, message_id):
+        self.deletes.append((chat_id, message_id))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_chunked_progress_updates_existing_chunks_instead_of_resending():
+    adapter = FakeProgressAdapter()
+    message_ids = []
+
+    first_text = "\n".join(
+        [
+            "📚 skill_view: nockchain",
+            "📋 todo: planning 4 task(s)",
+            "📖 read_file: " + "/Users/david/Desktop/stuff/nockails/README.md " * 8,
+            "🔧 patch: " + "/Users/david/Desktop/stuff/nockails/crates/app/src/lib.rs " * 7,
+        ]
+    )
+
+    ok = await _send_or_update_progress_chunks(
+        adapter=adapter,
+        chat_id="chat-1",
+        content=first_text,
+        message_ids=message_ids,
+        reply_to="root-msg",
+        metadata={"thread_id": "topic-1"},
+        platform=Platform.TELEGRAM,
+    )
+
+    assert ok is True
+    assert len(message_ids) > 1
+    assert len(adapter.sends) == len(message_ids)
+    assert adapter.sends[0]["reply_to"] == "root-msg"
+    assert adapter.sends[1]["reply_to"] == message_ids[0]
+
+    adapter.sends.clear()
+    adapter.edits.clear()
+
+    # Same rendered chunk count, but changed content. This is the case that
+    # used to append a fresh `(2/2)` continuation on every update after the
+    # first split instead of editing the existing two progress chunks.
+    second_text = first_text.replace("crates/app", "crates/bin")
+    ok = await _send_or_update_progress_chunks(
+        adapter=adapter,
+        chat_id="chat-1",
+        content=second_text,
+        message_ids=message_ids,
+        reply_to="root-msg",
+        metadata={"thread_id": "topic-1"},
+        platform=Platform.TELEGRAM,
+    )
+
+    assert ok is True
+    assert adapter.sends == []
+    assert [edit["message_id"] for edit in adapter.edits] == message_ids
+
+
+@pytest.mark.asyncio
+async def test_chunked_progress_sends_only_new_chunks_when_chunk_count_grows():
+    adapter = FakeProgressAdapter()
+    message_ids = []
+
+    base = "\n".join(f"tool_{i}: " + ("x" * 70) for i in range(8))
+    ok = await _send_or_update_progress_chunks(
+        adapter=adapter,
+        chat_id="chat-1",
+        content=base,
+        message_ids=message_ids,
+        reply_to="root-msg",
+        metadata=None,
+        platform=Platform.TELEGRAM,
+    )
+    assert ok is True
+    initial_ids = list(message_ids)
+    initial_send_count = len(adapter.sends)
+    assert initial_send_count >= 1
+
+    adapter.sends.clear()
+    adapter.edits.clear()
+
+    larger = base + "\n" + "new_tool: " + ("y" * 700)
+    ok = await _send_or_update_progress_chunks(
+        adapter=adapter,
+        chat_id="chat-1",
+        content=larger,
+        message_ids=message_ids,
+        reply_to="root-msg",
+        metadata=None,
+        platform=Platform.TELEGRAM,
+    )
+
+    assert ok is True
+    assert [edit["message_id"] for edit in adapter.edits] == initial_ids
+    assert len(adapter.sends) == len(message_ids) - len(initial_ids)
+    if adapter.sends:
+        assert adapter.sends[0]["reply_to"] == initial_ids[-1]


### PR DESCRIPTION
## What does this PR do?

Fixes a Telegram gateway progress-update bug where tool-progress text that has already split into multiple messages keeps spawning fresh continuation replies instead of updating the existing progress messages.

The progress loop now tracks every visible progress chunk message id in order. On each update it edits existing chunks in place, sends a new chunk only when the rendered progress grows past another platform limit, and best-effort deletes stale trailing chunks if the rendered chunk count shrinks.

I searched existing bug reports and PRs before opening this. This overlaps with #26207 and the open rollover PRs #26208 / #26242, but takes a different approach: instead of rolling over to a new one-line/current bubble before overflow, it makes already-chunked progress messages stable and editable.

## Related Issue

Refs #26207
Related: #26208, #26242, #25198

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Adds progress-specific chunking helpers with platform-aware message limits.
  - Tracks progress chunk message ids as an ordered list instead of a single id.
  - Edits existing progress chunks in place after split.
  - Sends only newly needed chunks when the progress grows.
  - Best-effort deletes stale trailing chunks when the rendered progress shrinks.
- `tests/gateway/test_progress_chunking.py`
  - Adds regression coverage for updating already-split progress chunks without sending duplicate continuations.
  - Adds coverage for sending only newly needed chunks when the progress grows into another chunk.

## How to Test

1. `python -m compileall -q gateway/run.py tests/gateway/test_progress_chunking.py`
2. `ruff check gateway/run.py tests/gateway/test_progress_chunking.py`
3. `git diff --check`
4. `python scripts/check-windows-footguns.py --all`
5. `python -m pytest tests/gateway/test_progress_chunking.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_topic_mode.py -q -o 'addopts='`

Local result: `163 passed` for the targeted Telegram/gateway subset.

I also tried a full local `python -m pytest tests/gateway -q -o 'addopts='` before committing, but this checkout hit an existing local pytest resource issue: `OSError: [Errno 24] Too many open files`. I am not marking the full-suite checklist complete based on that run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
python -m pytest tests/gateway/test_progress_chunking.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_topic_mode.py -q -o 'addopts='
........................................................................ [ 44%]
........................................................................ [ 88%]
...................                                                      [100%]
163 passed in 7.79s

python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (456 file(s) scanned).
```
