### PR TITLE
feat(config): support custom provider headers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2984,6 +2984,21 @@ def resolve_provider_client(
                         extra["default_headers"] = dict(_ph_custom.default_headers)
                 except Exception:
                     pass
+            custom_headers = {}
+            if isinstance(main_runtime, dict):
+                raw_headers = main_runtime.get("default_headers") or main_runtime.get("headers")
+                if isinstance(raw_headers, dict):
+                    custom_headers.update({str(k): str(v) for k, v in raw_headers.items()})
+            if not custom_headers:
+                try:
+                    from hermes_cli.config import get_custom_provider_headers
+                    custom_headers = get_custom_provider_headers(custom_base)
+                except Exception:
+                    custom_headers = {}
+            if custom_headers:
+                merged_headers = dict(extra.get("default_headers") or {})
+                merged_headers.update(custom_headers)
+                extra["default_headers"] = merged_headers
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -3049,6 +3064,11 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                _custom_headers2 = custom_entry.get("headers")
+                if isinstance(_custom_headers2, dict) and _custom_headers2:
+                    _extra2["default_headers"] = {
+                        str(k): str(v) for k, v in _custom_headers2.items()
+                    }
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -3071,6 +3091,8 @@ def resolve_provider_client(
                         _fallback_base = _to_openai_base_url(custom_base)
                         _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
                         _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        if "default_headers" in _extra2:
+                            _fb_extra["default_headers"] = dict(_extra2["default_headers"])
                         client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2862,6 +2862,8 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "defaultHeaders": "headers",
+        "customHeaders": "headers",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -2871,7 +2873,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "headers",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2963,6 +2965,26 @@ def _normalize_custom_provider_entry(
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
 
+    headers = _normalize_custom_provider_headers(entry.get("headers"))
+    if headers:
+        normalized["headers"] = headers
+
+    return normalized
+
+
+def _normalize_custom_provider_headers(headers: Any) -> Dict[str, str]:
+    """Return a string-only HTTP header map from a custom provider config."""
+    if not isinstance(headers, dict):
+        return {}
+
+    normalized: Dict[str, str] = {}
+    for key, value in headers.items():
+        header_name = str(key or "").strip()
+        if not header_name:
+            continue
+        if value is None:
+            continue
+        normalized[header_name] = str(value)
     return normalized
 
 
@@ -3095,6 +3117,40 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_headers(
+    base_url: str,
+    *,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Return configured default HTTP headers for a custom endpoint."""
+    if not base_url:
+        return {}
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return {}
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return {}
+
+    target_url = str(base_url or "").rstrip("/")
+    if not target_url:
+        return {}
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = str(entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        return _normalize_custom_provider_headers(entry.get("headers"))
+    return {}
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
@@ -3123,7 +3179,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "headers",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
@@ -3476,6 +3532,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     new_entry["default_model"] = entry["model"]
                 if entry.get("api_mode"):
                     new_entry["transport"] = entry["api_mode"]
+                headers = _normalize_custom_provider_headers(entry.get("headers"))
+                if headers:
+                    new_entry["headers"] = headers
 
                 providers_dict[key] = new_entry
                 migrated_count += 1

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -29,7 +29,11 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import (
+    get_compatible_custom_providers,
+    get_custom_provider_headers,
+    load_config,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname
 
@@ -459,6 +463,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    headers = get_custom_provider_headers(
+                        base_url,
+                        custom_providers=get_compatible_custom_providers(config),
+                    )
+                    if headers:
+                        result["headers"] = headers
                     # The v11→v12 migration writes the API mode under the new
                     # ``transport`` field, but hand-edited configs may still
                     # use the legacy ``api_mode`` spelling.  Accept both —
@@ -484,6 +494,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        headers = get_custom_provider_headers(
+                            base_url,
+                            custom_providers=get_compatible_custom_providers(config),
+                        )
+                        if headers:
+                            result["headers"] = headers
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
@@ -527,6 +543,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             result["key_env"] = key_env
         if provider_key:
             result["provider_key"] = provider_key
+        headers = get_custom_provider_headers(
+            base_url,
+            custom_providers=custom_providers,
+        )
+        if headers:
+            result["headers"] = headers
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
@@ -566,7 +588,7 @@ def _resolve_named_custom_runtime(
             (c for c in api_key_candidates if has_usable_secret(c)),
             "",
         ) or "no-key-required"
-        return {
+        result = {
             "provider": "custom",
             "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
             "base_url": base_url,
@@ -574,6 +596,10 @@ def _resolve_named_custom_runtime(
             "source": "direct-alias",
             "requested_provider": requested_provider,
         }
+        headers = get_custom_provider_headers(base_url)
+        if headers:
+            result["default_headers"] = headers
+        return result
 
     custom_provider = _get_named_custom_provider(requested_provider)
     if not custom_provider:
@@ -594,6 +620,9 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        headers = custom_provider.get("headers")
+        if isinstance(headers, dict) and headers:
+            pool_result["default_headers"] = dict(headers)
         return pool_result
 
     api_key_candidates = [
@@ -618,6 +647,9 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    headers = custom_provider.get("headers")
+    if isinstance(headers, dict) and headers:
+        result["default_headers"] = dict(headers)
     return result
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1095,6 +1095,26 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _custom_provider_headers_for_base_url(base_url: str, provider: str) -> dict:
+    provider = str(provider or "").strip().lower()
+    if not provider.startswith("custom"):
+        return {}
+    try:
+        from hermes_cli.config import get_custom_provider_headers
+
+        return get_custom_provider_headers(base_url)
+    except Exception:
+        return {}
+
+
+def _merge_default_headers(client_kwargs: dict, headers: dict) -> None:
+    if not headers:
+        return
+    merged = dict(client_kwargs.get("default_headers") or {})
+    merged.update({str(k): str(v) for k, v in headers.items()})
+    client_kwargs["default_headers"] = merged
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1693,6 +1713,10 @@ class AIAgent:
                             client_kwargs["default_headers"] = dict(_ph.default_headers)
                     except Exception:
                         pass
+                _merge_default_headers(
+                    client_kwargs,
+                    _custom_provider_headers_for_base_url(effective_base, self.provider),
+                )
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -2714,6 +2738,7 @@ class AIAgent:
             _sm_timeout = get_provider_request_timeout(self.provider, self.model)
             if _sm_timeout is not None:
                 self._client_kwargs["timeout"] = _sm_timeout
+            self._apply_client_headers_for_base_url(str(effective_base or ""))
             self.client = self._create_openai_client(
                 dict(self._client_kwargs),
                 reason="switch_model",
@@ -7387,6 +7412,10 @@ class AIAgent:
                 self._client_kwargs["default_headers"] = _ph_headers
             else:
                 self._client_kwargs.pop("default_headers", None)
+        _merge_default_headers(
+            self._client_kwargs,
+            _custom_provider_headers_for_base_url(base_url, self.provider),
+        )
 
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -137,6 +137,31 @@ class TestResolveProviderClientNamedCustom:
         assert model == "my-model"
         assert "beans.local" in str(client.base_url)
 
+    def test_named_custom_provider_default_headers(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {
+                    "name": "bifrost",
+                    "base_url": "http://bifrost.local/v1",
+                    "api_key": "k",
+                    "headers": {"x-bf-mcp-include-tools": "__none__"},
+                },
+            ],
+        })
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("bifrost", "my-model")
+
+        assert client is not None
+        assert model == "my-model"
+        assert mock_openai.call_args.kwargs["default_headers"] == {
+            "x-bf-mcp-include-tools": "__none__"
+        }
+
     def test_named_custom_provider_default_model(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "main-model"},

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -11,6 +11,7 @@ from hermes_cli.config import (
     get_hermes_home,
     ensure_hermes_home,
     get_compatible_custom_providers,
+    get_custom_provider_headers,
     load_config,
     load_env,
     migrate_config,
@@ -593,6 +594,59 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["base_url"] == "https://api.openai.com/v1"
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
+
+    def test_custom_provider_headers_survive_migration(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 11,
+                    "custom_providers": [
+                        {
+                            "name": "Cloudflare Proxy",
+                            "base_url": "https://api.example.com/v1",
+                            "api_key": "test-key",
+                            "headers": {
+                                "User-Agent": "HermesTest/1.0",
+                                "x-bf-mcp-include-tools": "__none__",
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            compatible = get_compatible_custom_providers()
+
+        migrated = raw["providers"]["cloudflare-proxy"]
+        assert migrated["headers"]["User-Agent"] == "HermesTest/1.0"
+        assert compatible[0]["headers"]["x-bf-mcp-include-tools"] == "__none__"
+
+    def test_get_custom_provider_headers_matches_providers_dict(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "bifrost": {
+                            "api": "https://bifrost.example.com/v1",
+                            "headers": {"x-bf-mcp-include-tools": "__none__"},
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            headers = get_custom_provider_headers("https://bifrost.example.com/v1/")
+
+        assert headers == {"x-bf-mcp-include-tools": "__none__"}
 
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
         """URL field precedence is base_url > url > api (PR #9332)."""

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1581,6 +1581,23 @@ def test_get_named_custom_provider_includes_model(monkeypatch):
     assert result["model"] == "qwen3.6-plus"
 
 
+def test_get_named_custom_provider_includes_headers(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: {
+        "providers": {
+            "bifrost": {
+                "name": "Bifrost",
+                "api": "https://bifrost.example.com/v1",
+                "api_key": "test-key",
+                "headers": {"x-bf-mcp-include-tools": "__none__"},
+            },
+        },
+    })
+
+    result = rp._get_named_custom_provider("bifrost")
+    assert result is not None
+    assert result["headers"] == {"x-bf-mcp-include-tools": "__none__"}
+
+
 def test_get_named_custom_provider_excludes_empty_model(monkeypatch):
     """Empty or whitespace-only model field should not appear in result."""
     for model_val in ["", "   ", None]:
@@ -1621,6 +1638,24 @@ def test_named_custom_runtime_propagates_model_direct_path(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert resolved["model"] == "qwen3.6-plus"
     assert resolved["provider"] == "custom"
+
+
+def test_named_custom_runtime_propagates_default_headers(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
+    monkeypatch.setattr(
+        rp,
+        "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-server",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "test-key",
+            "headers": {"User-Agent": "HermesTest/1.0"},
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="my-server")
+    assert resolved["default_headers"] == {"User-Agent": "HermesTest/1.0"}
 
 
 def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -177,6 +177,104 @@ def test_unknown_base_url_clears_default_headers(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_custom_provider_base_url_applies_configured_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    cfg = {
+        "custom_providers": [
+            {
+                "name": "Cloudflare Proxy",
+                "base_url": "https://api.example.com/v1",
+                "headers": {
+                    "User-Agent": "HermesTest/1.0",
+                    "x-bf-mcp-include-tools": "__none__",
+                },
+            }
+        ]
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            provider="custom",
+            model="test-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"] == "HermesTest/1.0"
+    assert headers["x-bf-mcp-include-tools"] == "__none__"
+
+
+@patch("run_agent.OpenAI")
+def test_custom_provider_headers_replace_stale_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    cfg = {
+        "providers": {
+            "proxy": {
+                "api": "https://api.example.com/v1",
+                "headers": {"User-Agent": "HermesTest/1.0"},
+            }
+        }
+    }
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        provider="custom",
+        model="test-model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._client_kwargs["default_headers"] = {"X-Stale": "yes"}
+
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        agent._apply_client_headers_for_base_url("https://api.example.com/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers == {"User-Agent": "HermesTest/1.0"}
+
+
+@patch("run_agent.OpenAI")
+def test_switch_model_applies_custom_provider_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    cfg = {
+        "custom_providers": [
+            {
+                "name": "Bifrost",
+                "base_url": "https://bifrost.example.com/v1",
+                "headers": {"x-bf-mcp-include-tools": "__none__"},
+            }
+        ]
+    }
+    with patch("hermes_cli.config.load_config", return_value=cfg), patch(
+        "agent.model_metadata.get_model_context_length",
+        return_value=128000,
+    ):
+        agent = AIAgent(
+            api_key="old-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="old/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.switch_model(
+            new_model="new-model",
+            new_provider="custom",
+            api_key="new-key",
+            base_url="https://bifrost.example.com/v1",
+            api_mode="chat_completions",
+        )
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers == {"x-bf-mcp-include-tools": "__none__"}
+
+
+@patch("run_agent.OpenAI")
 def test_openrouter_headers_include_response_cache_when_enabled(mock_openai):
     """When openrouter.response_cache is True, the cache header is injected."""
     mock_openai.return_value = MagicMock()

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1204,11 +1204,17 @@ custom_providers:
     base_url: https://gpu-server.internal.corp/v1
     key_env: CORP_API_KEY
     api_mode: chat_completions   # optional, auto-detected from URL
+    headers:                     # optional default HTTP headers
+      User-Agent: HermesAgent/1.0
+      x-bf-mcp-include-tools: "__none__"
   - name: anthropic-proxy
     base_url: https://proxy.example.com/anthropic
     key_env: ANTHROPIC_PROXY_KEY
     api_mode: anthropic_messages  # for Anthropic-compatible proxies
 ```
+
+Use `headers` for OpenAI-compatible proxies that require a custom `User-Agent`
+or gateway controls such as Bifrost's `x-bf-mcp-include-tools`.
 
 Switch between them mid-session with the triple syntax:
 


### PR DESCRIPTION
## Summary
- preserve `headers` in custom provider config and v11->v12 provider migration
- apply configured custom provider headers to main agent, runtime switches, and auxiliary clients
- document custom provider headers and add regression coverage

Fixes #9721

## Tests
- python -m pytest -o addopts='' tests/agent/test_auxiliary_named_custom_providers.py -q
- python -m pytest -o addopts='' tests/hermes_cli/test_runtime_provider_resolution.py -q
- python -m pytest -o addopts='' tests/hermes_cli/test_config.py::TestCustomProviderCompatibility tests/hermes_cli/test_config_env_refs.py -q
- python -m pytest -o addopts='' tests/run_agent/test_provider_attribution_headers.py -q
- python -m pytest -o addopts='' tests/e2e/test_discord_adapter.py -q
- python -m pytest -o addopts='' tests/run_agent/test_provider_parity.py::TestDeveloperRoleSwap::test_developer_role_via_nous_portal tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_includes_nous_product_tags tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal::test_uses_chat_completions_format -q
- python -m py_compile hermes_cli/config.py hermes_cli/runtime_provider.py agent/auxiliary_client.py run_agent.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_attribution_headers.py tests/agent/test_auxiliary_named_custom_providers.py tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
- python -m ruff check hermes_cli/config.py hermes_cli/runtime_provider.py agent/auxiliary_client.py run_agent.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_attribution_headers.py tests/agent/test_auxiliary_named_custom_providers.py tests/e2e/conftest.py tests/run_agent/test_provider_parity.py
- git diff --check