### PR TITLE
Plane integration V1.1

### DIFF
--- a/docs/plans/2026-05-14-plane-v1-integration.md
+++ b/docs/plans/2026-05-14-plane-v1-integration.md
@@ -1,0 +1,398 @@
+# Plane ↔ Hermes V1 Integration Plan
+
+> Reprise rapide: objectif = donner à Hermes un petit toolset Plane robuste, sans créer de nouvelle UI, sans dupliquer Plane, et sans agir sur Plane autrement qu’à la demande d’Emeric.
+
+Date de cadrage: 2026-05-14 22:56 CEST
+Dernière mise à jour d’exécution: 2026-05-15 16:45 CEST
+
+## État d’avancement réel
+
+Implémenté dans le repo:
+- `tools/plane_client.py`
+- `tools/plane_tool.py`
+- `toolsets.py`
+- `tests/tools/test_plane_client.py`
+- `tests/tools/test_plane_tool.py`
+
+Documenté:
+- `docs/plans/2026-05-14-plane-v1-integration.md`
+- `website/docs/user-guide/features/plane.md`
+
+Validations faites:
+- compilation Python OK
+- tests ciblés OK: `27 passed` sur `tests/tools/test_plane_client.py` et `tests/tools/test_plane_tool.py`
+- lecture live du projet Plane OK via `plane_board_snapshot` et `plane_list_work_items`
+- `plane_ping` validé en live
+- `plane_add_comment` validé en live
+- `plane_sync_progress` validé en live
+- `plane_import_to_kanban` validé en live avec création du workdir local
+
+Points déjà confirmés en live sur le projet `AI_Factory`:
+- identifier projet: `AIFACTORY`
+- états lus correctement: `Backlog`, `Todo`, `In Progress`, `Waiting`, `Done`, `Cancelled`
+- 11 work items actuellement lus par l’outil au moment de la dernière validation
+- les URLs Plane générées pointent bien vers le projet configuré
+
+Validation live dédiée V1 / phase 2:
+- carte Plane de test créée: `AIFACTORY-13`
+- `work_item_id`: `2af7e7d3-145b-4d21-b383-3f4833067cea`
+- carte Hermes importée: `t_87e21cd3`
+- workdir créé: `/home/emeric/AI Factory/AIFACTORY-13_validation-live-v1-hermes-plane-updated`
+- commentaire Plane créé par `plane_add_comment`: `8a4afebe-0896-4f0f-a2f5-45cbd40bcf0f`
+- commentaire Plane créé par `plane_sync_progress`: `6a0c130b-e5a1-4189-92bb-64ac80fc3af3`
+
+Point important observé en live:
+- le retry de `plane_create_work_item` avec le même couple `external_source` + `external_id` est bien bloqué côté Plane par une unicité serveur, mais le handler Hermes remonte encore actuellement un `409 Conflict` au lieu de retourner proprement `already_existed=true`
+- donc la protection anti-doublon est effective, mais l’expérience d’idempotence n’est pas encore complètement lissée côté outil
+
+## Objectif
+
+Construire une V1 minimale utile pour intégrer Plane dans Hermes comme couche opératoire:
+- lecture efficace du board Plane
+- création / mise à jour ciblée de work items
+- import explicite de tâches Plane dans le kanban Hermes
+- préparation d’un dossier local `AI Factory` pour les livrables
+
+## Contraintes validées
+
+- Plane reste la source de vérité visuelle et projet.
+- Aucun dashboard Hermes dédié à Plane.
+- Aucun portail parallèle.
+- Pas de sync automatique en V1.
+- Les écritures Plane ne doivent se faire qu’à la demande de l’utilisateur.
+- Le client Plane doit toujours envoyer un vrai `User-Agent` de navigateur pour éviter les 403 Cloudflare `browser_signature_banned`.
+
+## Pré-requis déjà vérifiés localement
+
+- `~/.hermes/.env` existe.
+- `PLANE_API_KEY` présent.
+- `PLANE_WORKSPACE=ai_factory` présent.
+- `PLANE_PROJECT_ID=8695a8d1-e6fc-44e1-8bd2-9f37158b5124` présent.
+- Aucun dossier local canonique `AI Factory` n’a encore été trouvé. Il faudra en créer un explicitement.
+
+## État du repo avant modification
+
+Commande observée:
+
+```bash
+git -C /home/emeric/.hermes/hermes-agent status --short --branch
+```
+
+Résultat au moment du cadrage:
+
+```text
+## main...origin/main [behind 630]
+ M agent/context_compressor.py
+ M agent/title_generator.py
+ M plugins/memory/holographic/__init__.py
+ M tools/approval.py
+ M tools/browser_camofox.py
+```
+
+Implication:
+- le repo est déjà sale avant ce chantier
+- éviter de mélanger les changements non liés
+- si besoin, créer ensuite une branche dédiée avant d’aller plus loin
+
+## Décisions d’architecture V1
+
+### 1. Un client Plane partagé
+
+Créer un module interne unique qui gère:
+- lecture de `PLANE_API_KEY`, `PLANE_WORKSPACE`, `PLANE_PROJECT_ID`
+- `BASE_URL = https://api.plane.so`
+- header `X-API-Key`
+- header `User-Agent` navigateur obligatoire
+- pagination
+- sérialisation / gestion d’erreurs HTTP
+- helpers de résolution d’état par nom et de work item par id lisible
+
+### 2. Un petit toolset Hermes `plane`
+
+V1 cible:
+- `plane_ping`
+- `plane_board_snapshot`
+- `plane_list_work_items`
+- `plane_get_work_item`
+- `plane_create_work_item`
+- `plane_update_work_item`
+- `plane_add_comment`
+- `plane_sync_progress`
+- `plane_import_to_kanban`
+- `plane_prepare_workdir`
+
+### 3. Plane = pilotage, Hermes = exécution
+
+Convention:
+- Plane garde la vérité métier / planning / suivi humain
+- Hermes kanban ne sert qu’à l’exécution, la décomposition, la délégation, la revue
+- pas de mirroring exhaustif des sous-tâches Hermes dans Plane
+
+### 4. Dossier local canonique des livrables
+
+Créer une racine unique:
+
+```text
+/home/emeric/AI Factory/
+```
+
+Puis par tâche importée:
+
+```text
+/home/emeric/AI Factory/AIFACTORY-12_<slug>/
+```
+
+Structure V1 du dossier tâche:
+
+```text
+README.md
+work/
+deliverables/
+```
+
+## Mapping Plane ↔ Hermes
+
+Quand une tâche Plane est importée dans le kanban Hermes, conserver au minimum:
+- `plane_workspace_slug`
+- `plane_project_id`
+- `plane_work_item_id`
+- `plane_sequence_id`
+- `plane_url`
+- `plane_state_id` optionnel
+
+Convention de titre Hermes:
+
+```text
+[Plane AIFACTORY-12] <titre>
+```
+
+Convention recommandée pour la body / commentaire initial Hermes:
+- résumé opératoire de la tâche
+- URL Plane
+- état au moment de l’import
+- instruction d’origine si utile
+
+## Fichiers à créer ou modifier
+
+### Code
+
+Créer:
+- `tools/plane_client.py`
+- `tools/plane_tool.py`
+
+Modifier:
+- `toolsets.py`
+
+### Tests
+
+Créer:
+- `tests/tools/test_plane_client.py`
+- `tests/tools/test_plane_tool.py`
+- éventuellement compléter `tests/test_toolsets.py`
+
+### Documentation
+
+Créer ou compléter:
+- `docs/plans/2026-05-14-plane-v1-integration.md` (ce fichier)
+- `website/docs/user-guide/features/plane.md` si le chantier va assez loin
+- éventuellement une référence courte dans le skill local `plane` si des pièges d’implémentation apparaissent
+
+## Détail des outils V1
+
+### `plane_board_snapshot`
+
+But:
+- vue synthétique du projet
+- états disponibles
+- comptes par état
+- quelques cartes notables
+
+Entrées V1:
+- `project_id` optionnel
+- `include_items_per_state` bool optionnel
+- `per_state_limit` optionnel
+
+### `plane_list_work_items`
+
+But:
+- lister les cartes
+- filtrer par état, label, assignee, priorité, texte
+
+Entrées V1:
+- `state`
+- `label`
+- `assignee`
+- `priority`
+- `query`
+- `limit`
+
+### `plane_get_work_item`
+
+But:
+- lire une carte précise
+
+Entrées V1:
+- `work_item_id` ou `sequence_id`
+
+### `plane_create_work_item`
+
+But:
+- créer une carte Plane
+
+Entrées V1:
+- `name`
+- `description_html` ou `description_markdown` converti en HTML simple
+- `priority`
+- `state`
+- `labels`
+- `assignees`
+- `start_date`
+- `target_date`
+- `external_source` défaut `nova-hermes`
+- `external_id` optionnel
+
+### `plane_update_work_item`
+
+But:
+- mettre à jour une carte existante
+
+Entrées V1:
+- `work_item_id`
+- mêmes champs modifiables que create
+
+### `plane_add_comment`
+
+But:
+- poster un commentaire sur une carte Plane sans changer son état
+
+Entrées V1:
+- `work_item_id` ou `sequence_id`
+- `body_markdown`, converti en HTML simple
+- `prefix` bool optionnel, défaut `true`, ajoute `[Nova]`
+
+Effet attendu:
+- `POST /issues/{work_item_id}/comments/` avec `comment_html`
+- retourne le commentaire créé, le résumé de la carte, et le HTML envoyé
+
+### `plane_import_to_kanban`
+
+But:
+- transformer une ou plusieurs cartes Plane en cartes Hermes
+
+Entrées V1:
+- `work_item_ids` ou `sequence_ids`
+- `assignee`
+- `workspace` défaut `scratch`
+- `priority` optionnel
+- `create_workdir` bool
+
+Effet attendu:
+- crée les cartes Hermes liées à Plane
+- ajoute la trace Plane dans le titre + body
+- peut enchaîner sur `plane_prepare_workdir`
+
+### `plane_prepare_workdir`
+
+But:
+- créer la base locale de travail liée à une carte Plane
+
+Entrées V1:
+- `sequence_id`
+- `title`
+- `base_dir` optionnel, défaut `/home/emeric/AI Factory`
+
+Effet attendu:
+- crée le dossier tâche
+- crée `README.md`, `work/`, `deliverables/`
+- retourne le chemin absolu
+
+## Phasage recommandé
+
+### Phase 1: lecture fiable
+- client Plane partagé
+- `plane_board_snapshot`
+- `plane_list_work_items`
+- `plane_get_work_item`
+- tests unitaires sur headers, auth, pagination, filtres
+
+### Phase 2: écriture maîtrisée
+- `plane_create_work_item`
+- `plane_update_work_item`
+- `plane_add_comment`
+- tests unitaires sur payloads, commentaires et erreurs HTTP
+- pas de delete
+
+### Phase 3: pont d’exécution Hermes
+- `plane_import_to_kanban`
+- `plane_prepare_workdir`
+- tests sur mapping et conventions locales
+
+## Détails techniques à respecter
+
+### Headers
+
+Toujours envoyer au minimum:
+
+```text
+X-API-Key: <PLANE_API_KEY>
+Accept: application/json
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36
+```
+
+### Endpoints à couvrir en premier
+
+- `GET /api/v1/workspaces/{workspace}/projects/{project_id}/`
+- `GET /api/v1/workspaces/{workspace}/projects/{project_id}/states/?per_page=100`
+- `GET /api/v1/workspaces/{workspace}/projects/{project_id}/work-items/?per_page=100&expand=state,assignees,labels`
+- `POST /api/v1/workspaces/{workspace}/projects/{project_id}/work-items/`
+- `PATCH /api/v1/workspaces/{workspace}/projects/{project_id}/work-items/{work_item_id}/`
+- `POST /api/v1/workspaces/{workspace}/projects/{project_id}/issues/{work_item_id}/comments/`
+
+Endpoints utiles mais non bloquants V1:
+- `GET /api/v1/users/me/`
+- `GET /api/v1/workspaces/{workspace}/work-items/{PROJECTKEY}-{NUMBER}/`
+- commentaires, labels, modules, cycles
+
+## Convention de reprise si le chantier s’interrompt
+
+Ordre de reprise conseillé:
+1. relire ce fichier
+2. relire `tools/plane_client.py` et `tools/plane_tool.py`
+3. exécuter les tests Plane ciblés
+4. vérifier `toolsets.py`
+5. vérifier le kanban Hermes si une carte d’implémentation a été créée
+
+## Checklist de progression
+
+- [x] créer `tools/plane_client.py`
+- [x] créer `tools/plane_tool.py`
+- [x] enregistrer le toolset `plane` dans `toolsets.py`
+- [x] exposer les outils read-only V1
+- [x] écrire tests client
+- [x] écrire tests outils
+- [x] ajouter create/update
+- [x] ajouter import kanban
+- [x] ajouter préparation workdir
+- [x] documenter l’usage utilisateur
+
+## État final V1 après validation live
+
+- [x] p5. Valider en live les écritures Plane de V1 sur une carte de test dédiée
+- [x] p6. Valider le pont Plane → Hermes kanban + création du workdir AI Factory sur un import réel
+
+Conclusion courte:
+- la V1 est utilisable en réel pour lire Plane, créer et mettre à jour une carte, commenter, refléter un progrès depuis Hermes, importer une carte dans le kanban Hermes et créer le workdir local associé
+- il reste un point de finition fonctionnelle sur `plane_create_work_item`: convertir le conflit serveur 409 en réponse idempotente propre quand la carte existe déjà
+
+## Notes CODex / bonnes idées à garder
+
+Les suggestions reçues et jugées utiles:
+- commencer par REST, pas par MCP Plane
+- ne pas activer DELETE au début
+- prioriser lecture d’états, lecture work items, create, update, move, comment
+- prévoir `plane_ping` et éventuellement `plane_search_work_items` plus tard
+
+Décision actuelle:
+- `plane_ping` est intégré au toolset pour diagnostiquer auth, `User-Agent`, réseau et accès projet
+- `plane_move_work_item` peut rester un alias ergonomique ultérieur de `plane_update_work_item` avec seul champ `state`
+- `plane_add_comment` est inclus pour refléter le progrès Hermes dans Plane sans changer les champs métier

--- a/docs/plans/2026-05-15-plane-v1-phase-2-action-plan.md
+++ b/docs/plans/2026-05-15-plane-v1-phase-2-action-plan.md
@@ -1,0 +1,483 @@
+# Plane V1 - Plan d'action phase 2
+
+> Suite au document `2026-05-15-plane-v1-review-notes.md`.
+> Objectif: transformer les notes de review en plan d'exécution réaliste, en séparant ce qui est déjà partiellement résolu de ce qui manque vraiment.
+
+Date: 2026-05-15 11:36 CEST
+Dernière validation terrain: 2026-05-15 16:45 CEST
+
+## Résumé exécutif
+
+Le chantier Plane V1 est déjà dans un état correct pour la lecture et le pont de base vers le kanban Hermes.
+La phase 2 prioritaire a bien été implémentée et les cartes kanban associées sont maintenant clôturées.
+
+Validation réelle effectuée:
+- `plane_ping` OK
+- `plane_add_comment` OK
+- `plane_sync_progress` OK
+- `plane_import_to_kanban` OK avec réutilisation idempotente de la même carte Hermes `t_87e21cd3`
+- création du workdir local OK: `/home/emeric/AI Factory/AIFACTORY-13_validation-live-v1-hermes-plane-updated`
+
+Caveat important découvert en live:
+- la stratégie d'idempotence de `plane_create_work_item` n'est pas encore totalement lissée côté retour outil
+- en pratique, un retry avec le même couple `external_source` + `external_id` est bien bloqué par Plane, mais remonte encore un `409 Conflict` au lieu d'un retour Hermes propre `already_existed=true`
+- autrement dit: la sécurité anti-doublon est là, l'ergonomie de l'idempotence reste à finir
+
+---
+
+## Audit rapide du code actuel vs review notes
+
+### Déjà partiellement ou totalement couvert
+
+#### Point 1 - Idempotence de `plane_import_to_kanban`
+Partiellement couvert.
+
+Constat:
+- `plane_import_to_kanban` passe déjà un `idempotency_key` à `kb.create_task(...)`
+- clé actuelle: `plane:{workspace_slug}:{project_id}:{work_item_id}`
+- `kanban_db.create_task()` sait déjà retourner une tâche existante si cette clé existe
+
+Limite:
+- le retour n'indique pas explicitement `already_imported=True`
+- il n'y a pas de lookup orienté metadata utilisateur, seulement l'idempotency côté création
+- la sémantique n'est pas documentée comme garantie produit
+
+Verdict:
+- protection technique déjà présente
+- contrat outil encore incomplet
+
+#### Point 2 - Sortie compacte par défaut
+Plutôt couvert, mais pas proprement spécifié.
+
+Constat:
+- `plane_list_work_items` renvoie déjà un résumé compact via `_summarize_item(...)`
+- `plane_board_snapshot` renvoie encore trop de données brutes pour `project` et `states`
+- `plane_get_work_item` renvoie un item enrichi proche du brut
+
+Verdict:
+- l'intention compacte existe déjà
+- il faut rendre le contrat cohérent et documenté, avec `verbose=True`
+
+#### Point 3 - PATCH partiel strict pour `plane_update_work_item`
+Globalement couvert.
+
+Constat:
+- `_build_work_item_payload()` n'ajoute que les champs explicitement passés
+- `_handle_update_work_item()` refuse un patch vide
+- donc on évite déjà le gros risque d'écrasement total involontaire
+
+Limite:
+- la distinction "champ absent" vs "champ volontairement remis à null" n'est pas formalisée
+- le code filtre encore `None`, donc il ne permet pas aujourd'hui un reset explicite de certains champs
+
+Verdict:
+- risque principal déjà bien réduit
+- reste à formaliser et tester le comportement sur `None`
+
+#### Point 9 - `plane_state_id` à l'import
+Déjà couvert dans la body Hermes.
+
+Constat:
+- `plane_import_to_kanban` écrit déjà `plane_state_id: ...` dans la body de la tâche importée
+
+Limite:
+- ce n'est pas stocké dans un vrai champ metadata structuré de la tâche kanban
+- c'est donc exploitable, mais moins propre pour les évolutions futures
+
+Verdict:
+- acceptable pour V1
+- améliorable plus tard
+
+#### Point 11 - le préfixe titre ne doit pas servir de clé
+Déjà OK dans l'esprit.
+
+Constat:
+- l'idempotence d'import repose sur `work_item_id`, pas sur le titre
+- le titre préfixé est un confort de lecture
+
+Verdict:
+- simple vérification/rappel doc
+
+---
+
+### Manques réels à traiter
+
+#### Point 1 - Idempotence de `plane_create_work_item`
+Non couvert.
+
+Constat:
+- `plane_create_work_item` POSTe directement
+- `external_source` existe dans le payload
+- `external_id` est supporté dans le schéma
+- mais aucun lookup préalable n'est fait avant création
+
+Impact:
+- retry agent ou réseau = doublons Plane possibles
+
+#### Point 4 - `plane_add_comment`
+Absent.
+
+Impact:
+- impossible d'utiliser Plane comme tableau de bord vivant pendant qu'Hermes bosse
+
+#### Point 5 - `plane_sync_progress`
+Absent.
+
+Impact:
+- pas de boucle de retour propre Hermes -> Plane
+- usage quotidien vite pénible
+
+#### Point 6 - pipeline markdown -> HTML
+Très insuffisant actuellement.
+
+Constat:
+- `_markdown_to_html()` fait juste `escape + <br>` dans un `<p>`
+- pas de listes, pas de gras, pas de liens, pas de code blocks, pas de nettoyage structuré
+
+Impact:
+- rendu Plane pauvre et peu prévisible
+
+#### Point 7 - traçabilité visuelle des writes Nova
+Absente.
+
+Impact:
+- faible confiance humaine sur l'origine des changements
+
+#### Point 8 - détection de drift Plane -> Hermes
+Absente.
+
+Impact:
+- risque réel de continuer à travailler dans Hermes sur une carte annulée ou déplacée dans Plane
+
+#### Point 10 - `plane_ping`
+Absent.
+
+Impact:
+- faible coût, bon gain en diagnostic
+
+#### Point 12 - exemple end-to-end dans la doc
+Absent.
+
+Impact:
+- pas bloquant techniquement, mais utile pour usage réel et futurs sous-agents
+
+---
+
+## Priorisation recommandée
+
+### P0 réel pour stabiliser la V1
+
+1. `plane_add_comment`
+2. `plane_sync_progress`
+3. idempotence explicite de `plane_create_work_item`
+4. formalisation du contrat compact/verbose des outils de lecture
+5. test/clarification du patch partiel strict sur `plane_update_work_item`
+
+### P1 utile juste après
+
+6. traçabilité automatique des writes via commentaire Plane
+7. `plane_ping`
+8. détection de drift `plane_check_kanban_links`
+9. pipeline markdown -> HTML plus propre
+
+### P2 ensuite
+
+10. stockage plus structuré des métadonnées Plane dans le kanban Hermes
+11. exemple end-to-end dans la doc
+12. polish divers
+
+---
+
+## Ordre d'implémentation conseillé
+
+## Lot A - Fermer la boucle de pilotage humain
+
+### A1. Ajouter `plane_add_comment`
+Statut: implémenté en phase 2.
+
+But:
+- poster un commentaire simple et fiable sur une carte Plane
+
+À faire:
+- `tools/plane_client.py`
+  - ajouter méthode cliente pour POST comments
+- `tools/plane_tool.py`
+  - ajouter outil `plane_add_comment`
+  - accepter `work_item_id` ou `sequence_id`
+  - `body_markdown` + conversion HTML
+  - option `prefix=True` par défaut pour ajouter `[Nova]`
+- tests
+  - client
+  - outil
+- doc
+  - plan principal
+  - `website/docs/user-guide/features/plane.md`
+
+Critère de fin:
+- Nova peut poster un commentaire lisible sur une carte Plane sans modifier l'état
+
+### A2. Ajouter `plane_sync_progress`
+Statut: implémenté en phase 2.
+
+But:
+- faire un seul appel pour refléter dans Plane un jalon Hermes
+
+Contrat retenu:
+- outil `plane_sync_progress(hermes_card_id=None, summary, status=None, prefix=True)`
+- `hermes_card_id` peut être omis par un worker kanban, fallback sur `HERMES_KANBAN_TASK`
+- lookup du lien Plane depuis le body de la tâche Hermes importée, via les champs `plane_work_item_id`, `plane_sequence_id`, `plane_url`
+- commentaire Plane posté avec `summary` et préfixe `[Nova]` par défaut
+- si `status` est fourni, résolution nom/id d'état puis PATCH de l'état Plane avant le commentaire
+- erreur claire si la tâche Hermes n'existe pas ou ne contient pas de lien Plane
+
+À faire:
+- `tools/plane_tool.py`
+  - nouvel outil `plane_sync_progress`
+  - entrées minimales: `hermes_task_id` ou équivalent, `summary`, `status=None`, `prefix=True`
+  - récupérer le lien Plane depuis la tâche Hermes importée
+  - poster le commentaire
+  - si `status` fourni, appeler aussi update state
+- selon besoin, helper dans `kanban_db.py` ou lecture directe de la tâche Hermes existante
+- tests
+  - task liée -> commentaire
+  - task liée + status -> commentaire + update state
+  - erreur claire si pas de lien Plane
+- doc
+  - convention d'usage explicite
+
+Critère de fin:
+- un worker Hermes peut annoncer son progrès dans Plane sans bricolage multi-appels
+
+Pourquoi ce lot en premier:
+- c'est la partie qui change le plus l'expérience réelle
+- ça rend Plane utile comme dashboard vivant, sans UI parallèle
+
+---
+
+## Lot B - Sécuriser contre les doublons et comportements flous
+
+### B1. Rendre `plane_create_work_item` idempotent
+But:
+- éviter les doublons Plane en cas de retry ou concurrence agentique
+
+Statut: implémenté le 2026-05-15.
+
+Contrat retenu:
+- priorité à l'`external_id` fourni par l'appelant
+- `external_source` vaut `nova-hermes` par défaut
+- si `external_id` est absent, Hermes génère `plane-create:<sha256-prefix>` depuis une base stable explicite: workspace Plane, project Plane, external source, nom normalisé
+- les champs mutables (`description`, labels, state, dates, assignees) sont exclus du hash pour qu'un retry avec petites différences de payload ne crée pas de doublon
+- avant POST, l'outil cherche un item Plane avec le même couple `external_source` + `external_id`
+- si trouvé, l'outil retourne l'item existant avec `already_existed=True`, `created=None`, et ne POSTe pas
+
+À faire:
+- `tools/plane_client.py`
+  - lookup direct par `external_source` + `external_id` tenté via query params
+  - fallback via list/search filtré côté client
+- `tools/plane_tool.py`
+  - lookup avant POST
+  - retour enrichi avec `already_existed`, `external_id_generated`, `external_source`, `external_id`
+- tests
+  - création première fois
+  - deuxième appel même external_id
+  - génération stable du fallback
+
+Critère de fin:
+- un même create rejoué ne duplique plus la carte
+
+### B2. Rendre l'import idempotent visible côté API outil
+But:
+- formaliser ce qui est déjà en partie vrai
+
+À faire:
+- conserver l'`idempotency_key` actuelle
+- enrichir la réponse avec `already_imported=True` si la tâche existait déjà
+- idéalement retourner aussi `task_id` existant explicitement comme tel
+- documenter la garantie
+
+Critère de fin:
+- un import répété renvoie clairement la même tâche Hermes
+
+### B3. Verrouiller le comportement patch partiel de `plane_update_work_item`
+But:
+- rendre le contrat clair et testé
+
+À faire:
+- tests ciblés sur:
+  - champ absent => non envoyé
+  - champ présent avec valeur => envoyé
+  - champ présent à `None` => décision explicite à documenter
+- si on garde V1 simple:
+  - documenter que `None` n'est pas encore un reset explicite supporté
+
+Critère de fin:
+- plus d'ambiguïté sur le comportement du PATCH
+
+---
+
+## Lot C - Rendre les lectures plus propres et moins coûteuses
+
+### C1. Définir un vrai mode compact par défaut
+Statut: implémenté le 2026-05-15 dans `tools/plane_tool.py`.
+
+Contrat retenu:
+- `plane_board_snapshot` compact par défaut: `project` réduit à `{id,name,identifier}`, `states` à `{id,name,group,count}`, items compacts.
+- `plane_list_work_items` compact par défaut: items `{id, sequence_id, readable_id, name, state_name, state_id, priority, labels, assignees_names, url}`.
+- `plane_get_work_item` compact par défaut avec le même schéma item.
+- `verbose=True` ajoute les payloads bruts: `project_payload` / `states_payload` / `items_payload` pour le snapshot, `items_payload` pour la liste, `payload` + `enriched_item` pour le get.
+
+But:
+- réduire le bruit contexte pour Nova
+
+À faire:
+- `plane_board_snapshot`
+  - compacter `project`
+  - compacter `states`
+  - garder uniquement les champs utiles par défaut
+- `plane_list_work_items`
+  - déjà proche de l'objectif, juste harmoniser
+- `plane_get_work_item`
+  - décider un compact riche par défaut
+- ajouter `verbose=True` aux outils de lecture
+- documenter les schémas de sortie
+
+Critère de fin:
+- les outils de lecture ont un contrat stable, compact par défaut, verbeux sur demande
+
+### C2. Option docstring/schema plus précise
+But:
+- permettre à Nova et aux sous-agents de mieux anticiper les sorties
+
+À faire:
+- descriptions de schéma plus précises dans `plane_tool.py`
+- doc utilisateur synchronisée
+
+---
+
+## Lot D - Fiabilité d'usage quotidien
+
+### D1. Ajouter `plane_ping`
+Statut: implémenté le 2026-05-15.
+
+But:
+- health check simple auth + UA + réseau
+
+À faire:
+- endpoint `GET /api/v1/users/me/`
+- éventuellement enchaîner un `get_project()` léger pour confirmer la config projet
+- retourner: `ok`, `latency_ms`, `user`, `workspace`, `project`
+
+Critère de fin:
+- diagnostic immédiat de l'intégration
+
+### D2. Ajouter `plane_check_kanban_links`
+But:
+- détecter le drift Plane -> Hermes avant de bosser pour rien
+
+À faire:
+- lister tâches Hermes liées à Plane
+- relire leur état Plane
+- comparer avec l'état mémorisé à l'import ou avec les attentes Hermes
+- retourner la liste des divergences
+
+Critère de fin:
+- Nova peut détecter qu'une carte a changé côté Plane avant de continuer le travail
+
+### D3. Traçabilité automatique des writes
+But:
+- rendre visible dans Plane ce que Nova a modifié
+
+À faire:
+- sur create/update, option `trace_comment=True` par défaut
+- commentaire style:
+  `[Nova] updated: priority=high, target_date=2026-05-20`
+- dépend de `plane_add_comment`
+
+Critère de fin:
+- un humain voit dans Plane qu'une action vient de Nova
+
+---
+
+## Lot E - Amélioration du rendu markdown -> HTML
+
+But:
+- rendre les descriptions/commentaires plus fiables dans Plane
+
+À faire:
+- remplacer `_markdown_to_html()` minimaliste par un pipeline défini
+- choisir une lib légère et prévisible
+- whitelist de tags supportés
+- tests sur listes, code, liens, blockquotes, titres simples
+
+Note:
+- utile, mais pas le tout premier bloc à faire si l'objectif est de rendre Plane vivant rapidement
+
+---
+
+## Proposition de découpage en exécution
+
+### Sprint 1
+- A1 `plane_add_comment`
+- A2 `plane_sync_progress`
+- B2 réponse explicite `already_imported`
+- D1 `plane_ping`
+
+### Sprint 2
+- B1 idempotence `plane_create_work_item`
+- B3 verrouillage patch partiel
+- C1 compact/verbose
+
+### Sprint 3
+- D3 traçabilité automatique
+- D2 drift detection
+- E markdown -> HTML plus propre
+- doc end-to-end
+
+---
+
+## Décisions à prendre avant implémentation
+
+1. `plane_sync_progress` prend-il `hermes_task_id` uniquement, ou aussi `plane_work_item_id` pour usage direct hors kanban ?
+2. Pour l'idempotence create, veut-on imposer `external_id` à l'appelant ou générer un fallback automatique ?
+3. Pour les commentaires automatiques de traçabilité, veut-on `trace_comment=True` par défaut partout, ou seulement sur demande ?
+4. Pour `None` dans update, veut-on supporter le reset explicite en phase 2 ou le repousser ?
+
+Recommandation simple:
+- `plane_sync_progress`: accepter `hermes_task_id` d'abord, plus propre pour la boucle Hermes -> Plane
+- `external_id`: fallback auto si absent
+- `trace_comment`: défaut on, désactivable
+- reset `None`: pas nécessaire dans le tout prochain lot si ça complique trop
+
+---
+
+## Recommandation finale
+
+Si on veut maximiser la valeur rapidement sans sur-ingénierie:
+
+1. `plane_add_comment`
+2. `plane_sync_progress`
+3. rendre l'import explicitement idempotent dans sa réponse
+4. ajouter `plane_ping`
+5. seulement ensuite traiter l'idempotence de création et le compact/verbose
+
+C'est le meilleur ratio valeur / effort / stabilité.
+
+---
+
+## Fichiers probablement touchés en phase 2
+
+Code:
+- `tools/plane_client.py`
+- `tools/plane_tool.py`
+- éventuellement `hermes_cli/kanban_db.py` si helper de lookup utile
+- `toolsets.py` si nouveaux outils
+
+Tests:
+- `tests/tools/test_plane_client.py`
+- `tests/tools/test_plane_tool.py`
+- éventuellement tests kanban ciblés si on ajoute un vrai helper côté kanban
+
+Doc:
+- `docs/plans/2026-05-14-plane-v1-integration.md`
+- `docs/plans/2026-05-15-plane-v1-review-notes.md`
+- `website/docs/user-guide/features/plane.md`

--- a/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
+++ b/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
@@ -82,19 +82,31 @@ Bonus optionnel (non bloquant) : passer `?expand=...` dans le premier `list_work
 
 Ces 6 points sont déjà documentés dans `2026-05-15-plane-v1-review-notes.md` mais n'ont pas été inclus dans le rapport de clôture. Aucun n'est bloquant individuellement, mais leur cumul rend le terme "V1 complète" inexact.
 
-### L1. Rendu Markdown vers HTML insuffisant [REPORTÉ V1.2, hors scope Claude 2026-05-15]
+### L1. Rendu Markdown vers HTML insuffisant [REPORTÉ V1.2, décision Nova 2026-05-15]
 Pipeline actuel : `escape + <br>`. Listes, gras, italique, code, liens ne fonctionnent pas dans les commentaires Plane envoyés depuis Hermes.
 Action : décider si on traite en V1.1 (introduire `markdown` ou `mistune`, lib stable, sans dépendances lourdes) ou si on le reporte explicitement avec une mention claire dans `plane.md`.
 
-**Statut 2026-05-15 (Claude) :** non implémenté côté code. La limite est désormais documentée explicitement dans `plane.md` (section `plane_add_comment` et troubleshooting). Intégration d'une lib Markdown réservée à Nova qui peut valider live contre l'API Plane.
+**Décision 2026-05-15 (Nova) :** report V1.2.
 
-### L2. Drift detection absente (`plane_check_kanban_links`) [HORS SCOPE Claude, à faire par Nova]
+**Justification :** `markdown` est déjà installé mais non sûr tel quel pour du contenu utilisateur, car il laisse passer HTML brut et liens `javascript:`. `mistune` serait un meilleur candidat pur Python pour une V1.2 sandboxée, avec périmètre minimal recommandé : gras, italique, listes, code inline/blocs, liens http/https uniquement. Pour V1.1, la bonne décision produit est de garder le pipeline minimal déjà documenté plutôt que d'introduire un rendu riche insuffisamment assaini.
+
+**Statut 2026-05-15 (Claude + Nova) :** limite déjà documentée dans `plane.md`. Pas de changement code en V1.1.
+
+### L2. Drift detection absente (`plane_check_kanban_links`) [TRAITÉ 2026-05-15 Nova]
 Risque réel : si une carte Plane est annulée / supprimée pendant qu'Hermes bosse dessus, le travail continue dans le vide.
 Action V1.1 minimale : un outil `plane_check_kanban_links` qui prend la liste des tâches Hermes liées à des cartes Plane et retourne celles dont l'état Plane est `Cancelled` ou la carte introuvable. Pas d'auto-action, juste du reporting.
 
-### L3. Traçabilité automatique des writes absente [HORS SCOPE Claude, à faire par Nova]
+**Décision 2026-05-15 (Nova) :** in V1.1.
+
+**Statut 2026-05-15 (Nova) :** implémenté dans `tools/plane_tool.py`. Contrat retenu : entrée `hermes_card_ids: string[]`, sortie `{"items": [...]}` contenant uniquement les anomalies `cancelled` ou `missing`, sans auto-action. Validation live sur carte dédiée `AIFACTORY-15` importée dans le kanban Hermes, puis basculée en `Cancelled` et détectée correctement par l'outil.
+
+### L3. Traçabilité automatique des writes absente [REPORTÉ V1.2, décision Nova 2026-05-15]
 Quand Hermes modifie une carte Plane, rien ne distingue visuellement la modification d'une modification humaine.
 Action V1.1 : ajouter systématiquement un commentaire `[hermes] <action>` après chaque write (`update_work_item`, `add_comment`, changement d'état). Comportement désactivable via flag d'outil pour les cas où c'est explicitement non voulu.
+
+**Décision 2026-05-15 (Nova) :** report V1.2.
+
+**Justification :** le risque de spam est réel, surtout sur `add_comment` et `plane_sync_progress` qui signent déjà l'origine côté contenu. Le bon comportement produit est plus fin qu'un `always on`: probablement actif par défaut sur `plane_update_work_item` et changements d'état, inactif sur `plane_add_comment`, avec un flag d'override explicite. Ça demande un contrat transversal supplémentaire sur tous les outils d'écriture, donc mieux traité proprement en V1.2.
 
 ### L4. `already_imported=True` non exposé sur `plane_import_to_kanban` [TRAITÉ 2026-05-15 Claude]
 Le handler ne retourne pas de signal clair quand la carte Plane est déjà importée dans le kanban Hermes. Symétrique au B1.
@@ -108,9 +120,13 @@ Action V1.1 : décider (recommandation : `None` = ignoré, seuls les champs expl
 
 **Statut 2026-05-15 (Claude) :** sémantique retenue : `None` (ou absent) = ignoré, non envoyé en PATCH. Liste vide `[]` sur `labels` / `assignees` = signal explicite de clear, transmis tel quel. Comportement déjà conforme dans `_build_work_item_payload` ; commentaire de contrat explicite ajouté. Tests `test_plane_update_work_item_ignores_none_fields_in_patch_payload` et `test_plane_update_work_item_empty_list_clears_labels_and_assignees` ajoutés. Documenté dans `plane.md` section `plane_update_work_item`.
 
-### L6. Repo 630 commits behind `origin/main` + 5 fichiers modifiés non liés [HORS SCOPE Claude, à faire par Nova]
+### L6. Repo 630 commits behind `origin/main` + 5 fichiers modifiés non liés [TRAITÉ 2026-05-15 Nova]
 Au démarrage du chantier, l'arbre Git était significativement dérivé. Pas de mention dans le rapport.
 Action immédiate : `git fetch && git status` partagés, décision explicite (rebase, merge, ou ignorer), nettoyage des fichiers modifiés non liés.
+
+**Décision 2026-05-15 (Nova) :** ne pas rebase ni merge pendant cette passe. Isoler d'abord le lot Plane V1.1 sur branche dédiée, préserver les changements hors scope à part, puis laisser la remise à niveau avec `origin/main` pour une étape Git séparée une fois le lot stabilisé.
+
+**Statut 2026-05-15 (Nova) :** clarifié avec Emeric. Branche de travail `plane-v1.1-nova`, branche de préservation `wip/plane-v1-preserve-20260515`, fichiers hors scope sortis du lot courant dans `stash@{0}`. Aucun changement Claude perdu.
 
 ## 4. P2 : code smells secondaires
 
@@ -128,9 +144,13 @@ Fix : prendre le `project_key` réel depuis le project Plane récupéré, pas la
 
 **Statut 2026-05-15 (Claude) :** signature de `prepare_workdir` enrichie d'un kwarg optionnel `project_key`. `_handle_import_to_kanban` passe le `key` calculé via `_project_key(client, project)`. `_handle_prepare_workdir` essaie de résoudre via `get_plane_client().get_project_identifier()` si l'env Plane est configurée, sinon fallback `AIFACTORY`. Le schéma `PLANE_PREPARE_WORKDIR_SCHEMA` expose désormais `project_key` (optionnel). Tests `test_plane_prepare_workdir_honours_custom_project_key` et `test_plane_import_to_kanban_workdir_uses_real_project_key` ajoutés.
 
-### C3. Double scan complet du board à chaque create [HORS SCOPE Claude, à faire par Nova]
+### C3. Double scan complet du board à chaque create [TRAITÉ 2026-05-15 Nova]
 `tools/plane_client.py:280-285`. Coûteux dès que le board grossit, et appelé systématiquement à chaque `plane_create_work_item`.
 Fix : si le premier appel filtré côté serveur retourne 0, ne pas faire le fallback non filtré. Documenter que le lookup externe est best effort.
+
+**Décision 2026-05-15 (Nova) :** in V1.1, mais sous forme de correctif de robustesse plutôt que d'optimisation pure.
+
+**Statut 2026-05-15 (Nova) :** mesuré en live sur le board AI_Factory actuel, charge négligeable. En revanche, le vrai problème observé est plus grave : l'API Plane retourne parfois `404` sur le lookup filtré `external_source` + `external_id`. Le fallback full scan reste donc nécessaire pour la correction fonctionnelle. Implémentation retenue : le filtre serveur reste le premier essai, et les codes `400/404/422` basculent silencieusement vers un scan best effort du board complet. Validation live réussie via création idempotente d'une carte dédiée `AIFACTORY-15`.
 
 ### C4. Usage abusif de `Any` contre les guidelines [TRAITÉ 2026-05-15 Claude]
 Plusieurs helpers internes prennent `client: Any` alors que `PlaneClient` est connu.
@@ -138,8 +158,12 @@ Fix : typer correctement les helpers internes.
 
 **Statut 2026-05-15 (Claude) :** 12 helpers privés re-typés `client: PlaneClient` : `_client_workspace`, `_client_project_id`, `_project_key`, `_summarize_project`, `_plane_url`, `_summarize_item`, `_enrich_item`, `_resolve_item`, `_resolve_state_id`, `_fallback_external_id`, `_prepare_create_idempotency`, `_find_existing_by_external_id`, `_build_work_item_payload`, `_selected_items`. Le `Any` est conservé uniquement pour les dicts JSON Plane (typage runtime via duck-typing tolère le stub client des tests). Tests verts.
 
-### C5. Payload `state_id` + `state` dupliqués [HORS SCOPE Claude, à faire par Nova]
+### C5. Payload `state_id` + `state` dupliqués [TRAITÉ 2026-05-15 Nova]
 `tools/plane_tool.py:401-403` et `:616`. Si c'est un contournement d'un bug Plane connu, le commenter. Sinon, retirer le doublon.
+
+**Décision 2026-05-15 (Nova) :** in V1.1 comme workaround documenté.
+
+**Statut 2026-05-15 (Nova) :** vérifié en live. Le board AI_Factory accepte correctement les transitions quand Hermes envoie à la fois `state_id` et `state`, et ce doublon correspond bien au comportement attendu par l'API dans notre contexte. Le code garde donc les deux champs avec commentaire explicite, et un test de régression vérifie que le PATCH transmis contient bien `state_id` et `state`.
 
 ## 5. Trous de tests à combler
 
@@ -162,8 +186,12 @@ Action : un test par méthode minimum, avec mock HTTP `_FakeResponse`.
 
 **Statut 2026-05-15 (Claude) :** 4 tests ajoutés dans `tests/tools/test_plane_client.py` : `test_create_work_item_posts_payload_to_work_items_endpoint`, `test_create_work_item_rejects_empty_payload`, `test_update_work_item_sends_patch_with_payload`, `test_update_work_item_requires_id_and_payload`. Tous utilisent `_FakeResponse` + `urllib.request.urlopen` mocké.
 
-### T4. Cas d'erreur réseau non couverts [HORS SCOPE Claude, à faire par Nova]
+### T4. Cas d'erreur réseau non couverts [REPORTÉ V1.2, décision Nova 2026-05-15]
 Aucun test pour timeout, 5xx, retry behavior. Pas critique en V1 mais à ajouter avant d'aller en prod intensive.
+
+**Décision 2026-05-15 (Nova) :** report V1.2.
+
+**Justification :** le besoin est réel, mais non bloquant pour fermer V1.1. Les chemins critiques de V1.1 ont désormais un filet de sécurité fonctionnel côté create idempotent, et un vrai traitement retry/timeout mérite d'être conçu proprement au niveau client, pas ajouté à moitié dans cette passe.
 
 ### T5. `plane_update_work_item` chemin nominal [TRAITÉ 2026-05-15 Claude]
 Le seul test actuel valide juste le message d'erreur de validation. Le path qui marche n'est pas couvert.
@@ -197,8 +225,10 @@ V1.1 considérée comme finie si et seulement si :
 5. L6 (état Git) clarifié et nettoyé.
 6. Doc `plane.md` mise à jour sur les 4 points listés en section 6.
 7. C1 (silencieux) et C2 (`AIFACTORY` hardcodé) fixés.
+8. Décisions actées pour le lot restant : L1 report V1.2, L2 in V1.1, L3 report V1.2, C3 in V1.1, C5 in V1.1, T4 report V1.2.
+9. Les items retenus in V1.1 par Nova sont implémentés, testés en mock et validés en live.
 
-L1 (Markdown), L2 (drift), L3 (traçabilité auto), C3 / C4 / C5 : décision explicite "in V1.1" ou "report V1.2", documentée.
+**Etat 2026-05-15 (Nova) :** conditions 1 à 9 satisfaites sur le lot Plane V1.1. Baseline actuelle : `pytest tests/tools/test_plane_client.py tests/tools/test_plane_tool.py tests/test_toolsets.py -q` => `67 passed`.
 
 ## 8. Hors scope V1.1 (à acter)
 
@@ -242,16 +272,16 @@ Fichiers touchés :
 
 ## 11. Reste pour Nova (runtime live requis)
 
-Tout ce qui suit demande un accès à l'API Plane live ou des décisions produits que Claude n'a pas vocation à trancher :
+Tout ce qui suit demandait un accès à l'API Plane live ou des décisions produits que Claude n'avait pas vocation à trancher :
 
-| Item | Pourquoi Nova |
-| --- | --- |
-| **L1 — Markdown riche** | Choix de lib + validation live du rendu côté Plane (escape, sécurité). |
-| **L2 — `plane_check_kanban_links`** | Nouvel outil, doit être validé en live contre cartes annulées / supprimées. |
-| **L3 — Traçabilité auto `[hermes]`** | Décision produit + risque de spam de commentaires, à valider sur board réel. |
-| **L6 — État Git** | `git fetch`, decision rebase / merge, nettoyage des fichiers modifiés non liés. |
-| **T4 — Cas erreur réseau** | Timeouts, 5xx, retry. Utile mais nécessite scénario live ou framework d'injection de pannes. |
-| **C3 — Double scan board** | Optimisation, validation perfs sur board réel + risque de manquer une carte si fallback supprimé. |
-| **C5 — `state_id` + `state` dupliqués** | Vérifier si c'est un workaround Plane connu (Nova a l'historique live). |
+| Item | Statut au 2026-05-15 | Note |
+| --- | --- | --- |
+| **L1 — Markdown riche** | **REPORTÉ V1.2** | `markdown` jugé trop permissif sans sanitization. Candidat recommandé pour V1.2 : `mistune` avec allowlist minimale. |
+| **L2 — `plane_check_kanban_links`** | **TRAITÉ 2026-05-15** | Outil implémenté, contrat figé, tests mockés ajoutés, validation live sur `AIFACTORY-15`. |
+| **L3 — Traçabilité auto `[hermes]`** | **REPORTÉ V1.2** | Décision produit à affiner pour éviter le spam et définir les overrides par outil. |
+| **L6 — État Git** | **TRAITÉ 2026-05-15** | Lot isolé sur `plane-v1.1-nova`, préservation sur `wip/plane-v1-preserve-20260515`, hors scope en `stash@{0}`. |
+| **T4 — Cas erreur réseau** | **REPORTÉ V1.2** | Retry/timeout utiles mais non critiques pour fermer V1.1. |
+| **C3 — Double scan board** | **TRAITÉ 2026-05-15** | Coût live négligeable, mais fallback full scan conservé pour contourner un `404` réel du filtre Plane. |
+| **C5 — `state_id` + `state` dupliqués** | **TRAITÉ 2026-05-15** | Workaround confirmé en live, commenté et couvert par test. |
 
-Conditions d'acceptation V1.1 (section 7) restantes pour Nova : **L6** (état Git), et décision explicite "in V1.1 / report V1.2" sur **L1, L2, L3, C3, C5, T4** documentée dans ce même doc.
+Synthèse Nova : V1.1 retient **L2 + C3 + C5**. **L1 + L3 + T4** sont explicitement reportés en V1.2.

--- a/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
+++ b/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
@@ -243,6 +243,8 @@ Ne pas glisser dans la V1.1, à reporter explicitement :
 - Garder Plane comme interface visuelle, pas de dérive.
 - À chaque fois qu'on découvre une nouvelle limite non triviale, la consigner ici, pas dans un rapport oral.
 - Les fichiers `2026-05-14-plane-v1-integration.md` et `2026-05-15-plane-v1-phase-2-action-plan.md` restent valides comme historique mais ne reflètent plus le vrai statut. Ce doc fait foi.
+- **Finding 2026-05-15 (Nova) : assignees Plane attendent des UUID utilisateur, pas un display name.** Aujourd'hui le payload `assignees` n'est pas résolu côté Hermes, ce qui rend l'usage par display name silencieusement non fonctionnel. Embarqué dans le backlog V1.2 (voir section 12).
+- **Branche de préservation `wip/plane-v1-preserve-20260515` et `stash@{0}`** : conserver jusqu'à merge V1.1 sur la branche de référence et début effectif de V1.2. À nettoyer ensuite via decision explicite.
 
 ## 10. Lot statique livré (Claude, 2026-05-15)
 
@@ -285,3 +287,19 @@ Tout ce qui suit demandait un accès à l'API Plane live ou des décisions produ
 | **C5 — `state_id` + `state` dupliqués** | **TRAITÉ 2026-05-15** | Workaround confirmé en live, commenté et couvert par test. |
 
 Synthèse Nova : V1.1 retient **L2 + C3 + C5**. **L1 + L3 + T4** sont explicitement reportés en V1.2.
+
+## 12. Backlog V1.2
+
+Quatre items reportés. Ordre d'attaque recommandé, à valider avant démarrage effectif.
+
+| Ordre | Item | Raison de l'ordre |
+| --- | --- | --- |
+| 1 | **L1 — Markdown riche** (`mistune` + allowlist minimale) | Brique fondamentale réutilisée par L3 et par tout futur outil qui écrit du contenu sur Plane. À sécuriser en premier. |
+| 2 | **Assignees UUID** (résolution display name → UUID) | Bug fonctionnel silencieux remonté par Nova en fin de V1.1. Petit chantier isolé, bénéfice immédiat sur `plane_create_work_item` et `plane_update_work_item`. |
+| 3 | **L3 — Traçabilité auto `[hermes]`** | Dépend de L1 (le commentaire de traçabilité doit pouvoir être stylé proprement). Demande une décision produit sur le périmètre par défaut (par outil) et le mécanisme d'override. |
+| 4 | **T4 — Erreurs réseau** (timeout, 5xx, retry) | Hygiène prod, indépendant des autres items. Peut être traité en parallèle ou en dernier. À concevoir au niveau client `PlaneClient`, pas au niveau handler. |
+
+Critères d'entrée V1.2 :
+- V1.1 mergée sur la branche de référence.
+- Branche `wip/plane-v1-preserve-20260515` et `stash@{0}` arbitrés (conservés ou supprimés).
+- Nouveau doc `docs/plans/AAAA-MM-JJ-plane-v1.2-action-plan.md` créé pour piloter V1.2 (ce doc-ci reste l'historique V1 / V1.1).

--- a/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
+++ b/docs/plans/2026-05-15-plane-v1-post-review-action-plan.md
@@ -1,0 +1,257 @@
+---
+date: 2026-05-15
+audience: emeric, nova
+status: plan d'action V1.1, lot statique livré par Claude le 2026-05-15, reste runtime live pour Nova
+supersedes_status_in:
+  - 2026-05-14-plane-v1-integration.md
+  - 2026-05-15-plane-v1-phase-2-action-plan.md
+sources:
+  - 2026-05-15-plane-v1-review-notes.md
+  - rapport Nova du 2026-05-15
+  - audit code/docs/tests Claude du 2026-05-15
+---
+
+# Plane V1.1 : plan d'action post-review
+
+## 0. Pourquoi ce doc
+
+Nova a livré la V1 + la phase 2 prioritaire de l'intégration Plane le 2026-05-15. Une review croisée (code, docs, tests) a confirmé que la direction est la bonne, mais a aussi identifié plusieurs limites non remontées dans le rapport initial. Ce doc remplace le suivi en cours et devient la référence pour finir la V1.1 proprement avant d'élargir le scope.
+
+Principe directeur inchangé : Plane reste la source de vérité visuelle, Hermes ne fournit que des outils, pas d'UI parallèle.
+
+## 1. Etat actuel honnête
+
+### Ce qui marche réellement
+- Architecture client / tool propre (`plane_client.py` transport, `plane_tool.py` orchestration).
+- 4 capacités attendues couvertes par des outils dédiés : lire (`plane_board_snapshot`, `plane_list_work_items`, `plane_get_work_item`), modifier (`plane_create_work_item`, `plane_update_work_item`, `plane_add_comment`), importer vers kanban (`plane_import_to_kanban`), livrables (`plane_prepare_workdir` + workdir auto à l'import).
+- 27 tests passent (`pytest tests/tools/test_plane_client.py tests/tools/test_plane_tool.py -q`, 0.88s).
+- User-Agent navigateur injecté partout, contournement Cloudflare validé.
+- Clé API jamais loggée, jamais exposée dans les retours d'outils.
+- Workdir live `AIFACTORY-13_validation-live-v1-hermes-plane-updated` créé avec `README.md`, `work/`, `deliverables/validation-live-v1.md`. Cohérent.
+- Pont Hermes vers Plane validé en live (commentaire, sync avancement, changement d'état).
+
+### Ce qui est partiel ou cassé
+- Bug bloquant `plane_create_work_item` au retry (voir P0/B1).
+- Plusieurs limites P1 documentées dans le `review-notes` mais omises du rapport (voir P1).
+- Couverture de tests inégale, notamment sur les chemins exécutés en live (voir Tests).
+- Doc utilisateur `plane.md` honnête sur le bug 409 mais incomplète sur le reste.
+
+## 2. P0 : bug bloquant à corriger en priorité
+
+### B1. Idempotence 409 sur `plane_create_work_item` [TRAITÉ 2026-05-15 Claude]
+
+Symptôme : un retry avec mêmes `external_source` + `external_id` renvoie `tool_error` (409 Conflict) au lieu d'un `already_existed=true` propre.
+
+Localisation : `tools/plane_tool.py:531` (handler `_handle_create_work_item`). Aucun `except` autour de `client.create_work_item(payload)`. Le `PlaneAPIError(409)` remonte au `except Exception` ligne 542 et devient un `tool_error`.
+
+Cause racine : le lookup préalable `_find_existing_by_external_id` (`plane_client.py:267-285`) fait deux passes mais Plane Cloud ne renvoie pas systématiquement `external_source` / `external_id` dans la liste sans `expand`. Quand le lookup rate alors que la carte existe vraiment côté Plane, le POST déclenche le 409 non rattrapé.
+
+Fix proposé (minimal, dans `_handle_create_work_item`) :
+
+```python
+from tools.plane_client import PlaneClient, PlaneAPIError
+
+try:
+    item = client.create_work_item(payload)
+except PlaneAPIError as exc:
+    if exc.status_code == 409:
+        existing = _find_existing_by_external_id(client, external_source, external_id)
+        if existing:
+            enriched = _enrich_item(client, existing, project)
+            return _ok(
+                item=enriched,
+                created=None,
+                already_existed=True,
+                external_source=external_source,
+                external_id=external_id,
+                external_id_generated=not external_id_provided,
+            )
+    raise
+```
+
+Test de régression OBLIGATOIRE (sans test, on accepte pas le fix) :
+- `test_plane_create_work_item_recovers_from_409_when_lookup_misses`
+- Mock `StubClient` qui : retourne `[]` sur `find_work_item_by_external_id`, lève `PlaneAPIError(status_code=409)` sur `create_work_item`, puis retourne la carte existante sur le second `find_work_item_by_external_id`.
+- Assert : `already_existed=True`, `created=None`, item enrichi présent.
+
+Bonus optionnel (non bloquant) : passer `?expand=...` dans le premier `list_work_items` pour réduire la fréquence du fallback double-scan.
+
+**Statut 2026-05-15 (Claude) :** fix appliqué dans `tools/plane_tool.py` `_handle_create_work_item` via `try/except PlaneAPIError` + double lookup en cas de 409. Test de régression `test_plane_create_work_item_recovers_from_409_when_lookup_misses` ajouté dans `tests/tools/test_plane_tool.py`. Tous les tests passent.
+
+## 3. P1 : limites non remontées dans le rapport, à clarifier avant de prétendre V1 complète
+
+Ces 6 points sont déjà documentés dans `2026-05-15-plane-v1-review-notes.md` mais n'ont pas été inclus dans le rapport de clôture. Aucun n'est bloquant individuellement, mais leur cumul rend le terme "V1 complète" inexact.
+
+### L1. Rendu Markdown vers HTML insuffisant [REPORTÉ V1.2, hors scope Claude 2026-05-15]
+Pipeline actuel : `escape + <br>`. Listes, gras, italique, code, liens ne fonctionnent pas dans les commentaires Plane envoyés depuis Hermes.
+Action : décider si on traite en V1.1 (introduire `markdown` ou `mistune`, lib stable, sans dépendances lourdes) ou si on le reporte explicitement avec une mention claire dans `plane.md`.
+
+**Statut 2026-05-15 (Claude) :** non implémenté côté code. La limite est désormais documentée explicitement dans `plane.md` (section `plane_add_comment` et troubleshooting). Intégration d'une lib Markdown réservée à Nova qui peut valider live contre l'API Plane.
+
+### L2. Drift detection absente (`plane_check_kanban_links`) [HORS SCOPE Claude, à faire par Nova]
+Risque réel : si une carte Plane est annulée / supprimée pendant qu'Hermes bosse dessus, le travail continue dans le vide.
+Action V1.1 minimale : un outil `plane_check_kanban_links` qui prend la liste des tâches Hermes liées à des cartes Plane et retourne celles dont l'état Plane est `Cancelled` ou la carte introuvable. Pas d'auto-action, juste du reporting.
+
+### L3. Traçabilité automatique des writes absente [HORS SCOPE Claude, à faire par Nova]
+Quand Hermes modifie une carte Plane, rien ne distingue visuellement la modification d'une modification humaine.
+Action V1.1 : ajouter systématiquement un commentaire `[hermes] <action>` après chaque write (`update_work_item`, `add_comment`, changement d'état). Comportement désactivable via flag d'outil pour les cas où c'est explicitement non voulu.
+
+### L4. `already_imported=True` non exposé sur `plane_import_to_kanban` [TRAITÉ 2026-05-15 Claude]
+Le handler ne retourne pas de signal clair quand la carte Plane est déjà importée dans le kanban Hermes. Symétrique au B1.
+Action V1.1 : ajouter `already_imported: bool` au retour, basé sur la présence d'un linkage existant.
+
+**Statut 2026-05-15 (Claude) :** implémenté via pré-check SQL sur `idempotency_key` (`plane:<workspace>:<project>:<work_item_id>`) avant l'appel à `kb.create_task`. Aucune modification de `kanban_db.py` requise. Test `test_plane_import_to_kanban_flags_already_imported_when_idempotency_hits` ajouté. Champ `already_imported: bool` ajouté dans chaque entrée `created_tasks`. Doc utilisateur `plane.md` mise à jour.
+
+### L5. PATCH partiel `plane_update_work_item` : comportement sur `None` non formalisé [TRAITÉ 2026-05-15 Claude]
+Aujourd'hui, passer `None` à un champ : est-ce ignoré, est-ce que ça écrase ? Pas testé, pas documenté.
+Action V1.1 : décider (recommandation : `None` = ignoré, seuls les champs explicitement passés sont envoyés en PATCH), ajouter un test, documenter dans `plane.md`.
+
+**Statut 2026-05-15 (Claude) :** sémantique retenue : `None` (ou absent) = ignoré, non envoyé en PATCH. Liste vide `[]` sur `labels` / `assignees` = signal explicite de clear, transmis tel quel. Comportement déjà conforme dans `_build_work_item_payload` ; commentaire de contrat explicite ajouté. Tests `test_plane_update_work_item_ignores_none_fields_in_patch_payload` et `test_plane_update_work_item_empty_list_clears_labels_and_assignees` ajoutés. Documenté dans `plane.md` section `plane_update_work_item`.
+
+### L6. Repo 630 commits behind `origin/main` + 5 fichiers modifiés non liés [HORS SCOPE Claude, à faire par Nova]
+Au démarrage du chantier, l'arbre Git était significativement dérivé. Pas de mention dans le rapport.
+Action immédiate : `git fetch && git status` partagés, décision explicite (rebase, merge, ou ignorer), nettoyage des fichiers modifiés non liés.
+
+## 4. P2 : code smells secondaires
+
+Pas urgents, mais à traiter quand on touche les fichiers concernés.
+
+### C1. `except Exception: pass` silencieux dans `_check_plane_requirements` [TRAITÉ 2026-05-15 Claude]
+`tools/plane_tool.py:33-35`. Si `load_hermes_dotenv` plante autrement que par variable manquante, l'erreur disparaît.
+Fix : narrow l'except à la classe d'erreur attendue, logger le reste.
+
+**Statut 2026-05-15 (Claude) :** narrow à `except OSError` (couvre `FileNotFoundError`, `PermissionError`). Commentaire explicite ajouté pour signaler que toute autre exception remontera désormais.
+
+### C2. `prepare_workdir` hardcode `AIFACTORY` [TRAITÉ 2026-05-15 Claude]
+`tools/plane_tool.py:424`. Si le projet Plane change un jour, le nom de dossier diverge du `readable_id` réel.
+Fix : prendre le `project_key` réel depuis le project Plane récupéré, pas la constante de fallback.
+
+**Statut 2026-05-15 (Claude) :** signature de `prepare_workdir` enrichie d'un kwarg optionnel `project_key`. `_handle_import_to_kanban` passe le `key` calculé via `_project_key(client, project)`. `_handle_prepare_workdir` essaie de résoudre via `get_plane_client().get_project_identifier()` si l'env Plane est configurée, sinon fallback `AIFACTORY`. Le schéma `PLANE_PREPARE_WORKDIR_SCHEMA` expose désormais `project_key` (optionnel). Tests `test_plane_prepare_workdir_honours_custom_project_key` et `test_plane_import_to_kanban_workdir_uses_real_project_key` ajoutés.
+
+### C3. Double scan complet du board à chaque create [HORS SCOPE Claude, à faire par Nova]
+`tools/plane_client.py:280-285`. Coûteux dès que le board grossit, et appelé systématiquement à chaque `plane_create_work_item`.
+Fix : si le premier appel filtré côté serveur retourne 0, ne pas faire le fallback non filtré. Documenter que le lookup externe est best effort.
+
+### C4. Usage abusif de `Any` contre les guidelines [TRAITÉ 2026-05-15 Claude]
+Plusieurs helpers internes prennent `client: Any` alors que `PlaneClient` est connu.
+Fix : typer correctement les helpers internes.
+
+**Statut 2026-05-15 (Claude) :** 12 helpers privés re-typés `client: PlaneClient` : `_client_workspace`, `_client_project_id`, `_project_key`, `_summarize_project`, `_plane_url`, `_summarize_item`, `_enrich_item`, `_resolve_item`, `_resolve_state_id`, `_fallback_external_id`, `_prepare_create_idempotency`, `_find_existing_by_external_id`, `_build_work_item_payload`, `_selected_items`. Le `Any` est conservé uniquement pour les dicts JSON Plane (typage runtime via duck-typing tolère le stub client des tests). Tests verts.
+
+### C5. Payload `state_id` + `state` dupliqués [HORS SCOPE Claude, à faire par Nova]
+`tools/plane_tool.py:401-403` et `:616`. Si c'est un contournement d'un bug Plane connu, le commenter. Sinon, retirer le doublon.
+
+## 5. Trous de tests à combler
+
+Liste minimale pour passer V1.1 :
+
+### T1. Régression 409 (couvre B1) [TRAITÉ 2026-05-15 Claude]
+Voir P0/B1.
+
+**Statut 2026-05-15 (Claude) :** `test_plane_create_work_item_recovers_from_409_when_lookup_misses` ajouté dans `tests/tools/test_plane_tool.py`.
+
+### T2. Handler `plane_import_to_kanban` non testé directement [TRAITÉ 2026-05-15 Claude]
+Aujourd'hui seul `test_parse_plane_linkage_from_imported_kanban_body` teste un utilitaire. Le handler complet (lookup carte Plane, création tâche kanban, écriture linkage, création workdir) n'a aucun test.
+Action : ajouter au minimum 2 tests (chemin nominal + carte déjà importée, lié à L4).
+
+**Statut 2026-05-15 (Claude) :** 3 tests ajoutés dans `tests/tools/test_plane_tool.py` : `test_plane_import_to_kanban_creates_kanban_task_with_plane_linkage` (chemin nominal, body avec linkages + workdir + idempotency_key vérifiés), `test_plane_import_to_kanban_flags_already_imported_when_idempotency_hits` (couvre L4), `test_plane_import_to_kanban_workdir_uses_real_project_key` (couvre C2). `kanban_db` est intégralement mocké, aucun appel réel à SQLite.
+
+### T3. `PlaneClient.create_work_item` et `update_work_item` non testés [TRAITÉ 2026-05-15 Claude]
+Pas un seul test direct sur ces deux méthodes du client.
+Action : un test par méthode minimum, avec mock HTTP `_FakeResponse`.
+
+**Statut 2026-05-15 (Claude) :** 4 tests ajoutés dans `tests/tools/test_plane_client.py` : `test_create_work_item_posts_payload_to_work_items_endpoint`, `test_create_work_item_rejects_empty_payload`, `test_update_work_item_sends_patch_with_payload`, `test_update_work_item_requires_id_and_payload`. Tous utilisent `_FakeResponse` + `urllib.request.urlopen` mocké.
+
+### T4. Cas d'erreur réseau non couverts [HORS SCOPE Claude, à faire par Nova]
+Aucun test pour timeout, 5xx, retry behavior. Pas critique en V1 mais à ajouter avant d'aller en prod intensive.
+
+### T5. `plane_update_work_item` chemin nominal [TRAITÉ 2026-05-15 Claude]
+Le seul test actuel valide juste le message d'erreur de validation. Le path qui marche n'est pas couvert.
+
+**Statut 2026-05-15 (Claude) :** `test_plane_update_work_item_nominal_path` ajouté dans `tests/tools/test_plane_tool.py`. Couvre payload construit (name, state_id, labels résolus, priority), `last_update` du StubClient vérifié.
+
+## 6. Doc utilisateur `plane.md` à compléter [TRAITÉ 2026-05-15 Claude]
+
+Manques identifiés :
+- Liste exhaustive des champs supportés par `plane_update_work_item` (aujourd'hui : "selected fields" sans énumération).
+- Mention explicite de la limite Markdown actuelle (lié à L1).
+- Contrat de retour `already_imported` sur `plane_import_to_kanban` (lié à L4).
+- Section troubleshooting au-delà du Cloudflare 403 (erreurs idempotence, lookup raté, drift, etc.).
+- Un exemple end-to-end du workflow type : import carte Plane vers Hermes, sync progress, fermeture.
+
+**Statut 2026-05-15 (Claude) :** `website/docs/user-guide/features/plane.md` mise à jour sur tous les points :
+- Énumération complète des champs supportés par `plane_update_work_item` + section dédiée sur la sémantique PATCH partial (None=ignoré, []=clear explicite).
+- Mention explicite de la limite Markdown V1.1 sous `plane_add_comment` et dans la section troubleshooting.
+- Contrat `already_imported` documenté sous `plane_import_to_kanban` (return shape complet + comportement idempotent).
+- Section troubleshooting enrichie : Cloudflare 403, 409 idempotence, lookup misses, kanban non lié, workdir / project_key.
+- Nouvelle section "End-to-end example" avec un workflow JSON complet (import → first sync → comment → close).
+- Documentation du nouveau paramètre `project_key` sur `plane_prepare_workdir`.
+
+## 7. Conditions d'acceptation V1.1
+
+V1.1 considérée comme finie si et seulement si :
+1. B1 fixé + test de régression T1 vert.
+2. T2 et T3 ajoutés et verts.
+3. L4 (`already_imported`) exposé dans le retour.
+4. L5 (comportement PATCH sur `None`) décidé, testé, documenté.
+5. L6 (état Git) clarifié et nettoyé.
+6. Doc `plane.md` mise à jour sur les 4 points listés en section 6.
+7. C1 (silencieux) et C2 (`AIFACTORY` hardcodé) fixés.
+
+L1 (Markdown), L2 (drift), L3 (traçabilité auto), C3 / C4 / C5 : décision explicite "in V1.1" ou "report V1.2", documentée.
+
+## 8. Hors scope V1.1 (à acter)
+
+Ne pas glisser dans la V1.1, à reporter explicitement :
+- Pipeline Markdown HTML "riche" (au-delà de ce qui est décidé pour L1).
+- Traçabilité visuelle avancée (badges, couleurs, etc.).
+- Sub-agents / délégation profils Hermes basée sur les tâches Plane.
+- UI Hermes dédiée Plane (toujours interdit par le brief initial).
+
+## 9. Notes ouvertes
+
+- Garder Plane comme interface visuelle, pas de dérive.
+- À chaque fois qu'on découvre une nouvelle limite non triviale, la consigner ici, pas dans un rapport oral.
+- Les fichiers `2026-05-14-plane-v1-integration.md` et `2026-05-15-plane-v1-phase-2-action-plan.md` restent valides comme historique mais ne reflètent plus le vrai statut. Ce doc fait foi.
+
+## 10. Lot statique livré (Claude, 2026-05-15)
+
+Couvert dans la passe Claude (zéro accès live à Plane, tout mocké) :
+
+| Item | Statut | Tests |
+| --- | --- | --- |
+| B1 (fix 409 idempotence) | ✅ | +T1 |
+| L4 (`already_imported`) | ✅ | +T2 (2 tests) |
+| L5 (PATCH `None` = ignoré) | ✅ | +2 tests dédiés |
+| C1 (narrow except dotenv) | ✅ | couvert par existants |
+| C2 (`project_key` réel) | ✅ | +2 tests (handler + import) |
+| C4 (`client: PlaneClient`) | ✅ | tests verts |
+| T1 (régression 409) | ✅ | ajouté |
+| T2 (handler import_to_kanban) | ✅ | 3 tests ajoutés |
+| T3 (client create + update) | ✅ | 4 tests ajoutés |
+| T5 (update path nominal) | ✅ | ajouté |
+| Doc utilisateur `plane.md` | ✅ | section 6 traitée |
+
+Baseline 27 tests → final **39 tests verts** (`pytest tests/tools/test_plane_client.py tests/tools/test_plane_tool.py -q`).
+
+Fichiers touchés :
+- `tools/plane_tool.py` : fix B1, comment PATCH partial, `prepare_workdir(project_key=…)`, narrow except C1, typage `PlaneClient`, schema `plane_prepare_workdir` enrichi, `already_imported` ajouté au retour de `_handle_import_to_kanban`.
+- `tests/tools/test_plane_tool.py` : +8 tests.
+- `tests/tools/test_plane_client.py` : +4 tests.
+- `website/docs/user-guide/features/plane.md` : sections idempotence, PATCH partial, `already_imported`, Markdown limit, end-to-end example, troubleshooting enrichi.
+
+## 11. Reste pour Nova (runtime live requis)
+
+Tout ce qui suit demande un accès à l'API Plane live ou des décisions produits que Claude n'a pas vocation à trancher :
+
+| Item | Pourquoi Nova |
+| --- | --- |
+| **L1 — Markdown riche** | Choix de lib + validation live du rendu côté Plane (escape, sécurité). |
+| **L2 — `plane_check_kanban_links`** | Nouvel outil, doit être validé en live contre cartes annulées / supprimées. |
+| **L3 — Traçabilité auto `[hermes]`** | Décision produit + risque de spam de commentaires, à valider sur board réel. |
+| **L6 — État Git** | `git fetch`, decision rebase / merge, nettoyage des fichiers modifiés non liés. |
+| **T4 — Cas erreur réseau** | Timeouts, 5xx, retry. Utile mais nécessite scénario live ou framework d'injection de pannes. |
+| **C3 — Double scan board** | Optimisation, validation perfs sur board réel + risque de manquer une carte si fallback supprimé. |
+| **C5 — `state_id` + `state` dupliqués** | Vérifier si c'est un workaround Plane connu (Nova a l'historique live). |
+
+Conditions d'acceptation V1.1 (section 7) restantes pour Nova : **L6** (état Git), et décision explicite "in V1.1 / report V1.2" sur **L1, L2, L3, C3, C5, T4** documentée dans ce même doc.

--- a/docs/plans/2026-05-15-plane-v1-review-notes.md
+++ b/docs/plans/2026-05-15-plane-v1-review-notes.md
@@ -1,0 +1,248 @@
+# Plane V1 - Notes de review et points à traiter
+
+> Addendum au plan `2026-05-14-plane-v1-integration.md`.
+> Objectif: lister les points pertinents identifiés lors d'une review externe, pour traitement avec Nova.
+> Contexte: les outils Plane sont appelés par Nova (agent Hermes) et par ses sous-agents/profils, pas seulement par un humain.
+
+Date de rédaction: 2026-05-15
+
+## Comment utiliser ce document
+
+Les points sont classés par priorité (P0/P1/P2). Pour chaque point:
+- **Problème**: ce qui ne va pas ou ce qui manque
+- **Proposition**: action concrète
+- **Effort estimé**: petit / moyen / gros
+
+À traiter dans l'ordre. Cocher au fur et à mesure. Ne pas tout faire d'un coup si certains points ouvrent un débat.
+
+---
+
+## P0 - À traiter avant de considérer la V1 stable
+
+### [ ] 1. Idempotence stricte de `plane_create_work_item` et `plane_import_to_kanban`
+
+**Problème**
+Un retry réseau, un agent qui réessaie, ou deux sous-agents Hermes qui reçoivent la même instruction en parallèle peuvent créer:
+- des doublons de cartes Plane (`plane_create_work_item`)
+- des doublons de cartes Hermes liées à la même carte Plane (`plane_import_to_kanban`)
+
+Aucun mécanisme de dédup n'est actuellement spécifié.
+
+**Proposition**
+- `plane_create_work_item`: utiliser `external_source='nova-hermes'` + `external_id` (fourni par l'appelant ou hash stable du `name`). Avant POST, faire un lookup Plane par `external_id`. Si trouvé, retourner la carte existante avec un flag `already_existed=True` au lieu de re-créer.
+- `plane_import_to_kanban`: avant de créer la carte Hermes, chercher dans le kanban Hermes une carte avec metadata `plane_work_item_id` == cible. Si trouvée, retourner cette carte avec `already_imported=True`.
+
+**Statut 2026-05-15**
+- `plane_create_work_item` est traité: lookup `external_source` + `external_id`, fallback stable basé sur workspace/project/source/name normalisé, retour `already_existed=True` sur doublon.
+- `plane_import_to_kanban` reste à rendre explicitement visible côté retour (`already_imported=True`).
+
+**Effort**: petit/moyen
+
+---
+
+### [ ] 2. Format de sortie compact par défaut pour les outils de lecture
+
+**Problème**
+Le plan détaille les entrées de chaque outil mais pas les sorties. Si `plane_list_work_items` ou `plane_board_snapshot` retournent le JSON Plane brut (50+ champs par item), chaque appel pollue le contexte de Nova pour rien. À l'échelle d'une session avec plusieurs appels, ça coûte cher en tokens et dégrade la qualité de raisonnement de l'agent.
+
+**Proposition**
+Pour chaque outil de lecture, définir explicitement deux modes:
+- Mode par défaut: projection compacte. Pour un work item: `{sequence_id, name, state_name, priority, assignees_names, url}`. Pour un état: `{name, group, count}`.
+- Mode `verbose=True`: payload Plane complet.
+
+Documenter le schéma de sortie dans `plane_tool.py` (docstring de l'outil) pour que Nova sache à quoi s'attendre.
+
+**Effort**: moyen
+
+---
+
+### [ ] 3. `plane_update_work_item` doit être un patch partiel strict
+
+**Problème**
+Si l'outil renvoie systématiquement tous les champs (même ceux que l'agent n'a pas explicitement passés), il peut écraser silencieusement des modifications faites côté UI Plane entre un read et un write effectués par Nova. C'est typiquement le scénario où je touche moi-même une carte dans Plane et où Nova revient quelques minutes après.
+
+**Proposition**
+Le PATCH HTTP envoyé à Plane doit contenir uniquement les champs explicitement passés par l'appelant. Distinguer "champ non passé" de "champ passé à None" (None peut être une valeur de reset volontaire). Tester ça explicitement.
+
+**Effort**: petit (mais à vérifier dans le code actuel, c'est peut-être déjà OK)
+
+---
+
+### [ ] 4. `plane_add_comment` à remonter en V1, pas V1.5
+
+**Problème**
+Le plan met `plane_add_comment` en V1.5. Mais c'est l'outil qui ferme la boucle de pilotage humain:
+- je garde Plane ouvert sous les yeux (exigence explicite du prompt initial)
+- Nova bosse dans Hermes pendant 30 minutes ou 2h
+- sans `plane_add_comment`, je dois rouvrir Hermes pour voir où elle en est
+
+Avec, Nova poste sur la carte Plane "[Nova] X fait, Y en cours" et le board Plane reste vivant comme tableau de bord.
+
+**Proposition**
+Ajouter en V1:
+- `plane_add_comment(work_item_id_or_sequence_id, body_markdown)`
+- conversion markdown -> HTML simple comme pour `description` (point #6)
+- préfixe automatique `[Nova]` configurable par flag `prefix` (défaut on)
+
+**Effort**: petit
+
+---
+
+## P1 - Important pour l'usage agent quotidien
+
+### [ ] 5. Boucle de retour Hermes -> Plane explicite
+
+**Problème**
+Quand Nova finit une sous-tâche dans son kanban interne, par quel mécanisme l'état Plane bouge? Le plan ne décrit pas cette boucle. Sans elle, soit Nova le fait à la main à chaque palier (verbeux, oubliable), soit le board Plane se désynchronise progressivement de la réalité du travail.
+
+**Proposition**
+Créer un outil agrégateur:
+```
+plane_sync_progress(hermes_card_id, status, summary)
+```
+qui:
+- récupère le `plane_work_item_id` lié à la carte Hermes
+- poste un commentaire Plane avec le `summary`
+- si `status` fourni, change l'état Plane (`In Progress`, `Waiting`, `Done`, etc.)
+- retourne l'URL Plane mise à jour
+
+Convention d'usage à documenter: Nova appelle ça à chaque transition d'état significative côté Hermes.
+
+**Effort**: petit/moyen
+
+---
+
+### [ ] 6. Spécifier le pipeline markdown -> HTML
+
+**Problème**
+Le plan parle de `description_markdown` converti en HTML simple, sans préciser:
+- quel parser
+- quels éléments supportés
+- quel comportement sur les éléments non supportés
+
+Risque: le rendu Plane diverge de ce que Nova croit avoir envoyé.
+
+**Proposition**
+Choisir une lib (`markdown` Python avec extensions minimales, ou `markdown-it-py`). Documenter la liste blanche supportée: `p`, `strong`, `em`, `ul/ol/li`, `code`, `pre`, `a`, `h2/h3`, `blockquote`. Tout le reste est strippé. Tester quelques cas de bord.
+
+**Effort**: petit
+
+---
+
+### [ ] 7. Traçabilité visuelle des actions de Nova côté Plane
+
+**Problème**
+`external_source='nova-hermes'` à la création, c'est bien. Mais sur un UPDATE, rien n'indique visuellement dans Plane que c'est Nova qui a touché. Je risque de me demander "c'est moi ou c'est elle qui a changé ce truc?" et de perdre confiance dans le board.
+
+**Proposition**
+Après chaque write réussi (`plane_create_work_item`, `plane_update_work_item`), poster automatiquement un mini-commentaire généré:
+```
+[Nova] updated: priority=high, target_date=2026-05-20
+```
+Configurable par flag `trace_comment` (défaut on, désactivable au cas par cas).
+Dépend du point #4 (`plane_add_comment` doit exister).
+
+**Effort**: petit, dépend de #4
+
+---
+
+### [ ] 8. Détection de drift Plane -> Hermes
+
+**Problème**
+Pas de sync auto est une bonne décision. Mais ça veut dire que si je passe AIFACTORY-12 manuellement de `In Progress` à `Cancelled` côté Plane, Nova continue à bosser dessus dans son kanban Hermes pendant des heures. Travail jeté à la poubelle.
+
+**Proposition**
+Créer un outil:
+```
+plane_check_kanban_links(hermes_card_ids=None)
+```
+qui:
+- prend la liste des cartes Hermes liées à Plane (ou un sous-ensemble)
+- batch-read leur état actuel côté Plane
+- retourne les divergences: `[(hermes_card, plane_state_before, plane_state_now), ...]`
+
+Convention d'usage: Nova l'appelle au démarrage d'une session de travail sur une carte importée, ou au début d'un cycle d'agent.
+
+**Effort**: petit/moyen
+
+---
+
+## P2 - Nice to have, à creuser
+
+### [ ] 9. `plane_state_id` obligatoire à l'import, pas optionnel
+
+**Problème**
+Le mapping kanban décrit `plane_state_id` comme optionnel. Si on l'a au moment de l'import, autant le stocker. Sinon, chaque update nécessite un lookup states avant d'envoyer.
+
+**Proposition**
+Rendre `plane_state_id` obligatoire dans les metadata stockées par `plane_import_to_kanban`. Si l'API ne le renvoie pas en expand, faire le lookup à l'import (une fois) plutôt qu'à chaque update.
+
+**Effort**: petit
+
+---
+
+### [x] 10. Garder `plane_ping`
+
+**Problème**
+Le plan a écarté `plane_ping` du V1. Décision défendable, mais vu le piège Cloudflare déjà rencontré (`browser_signature_banned`), un health-check qui exerce auth + UA + un endpoint simple (`GET /api/v1/users/me/`) coûte 10 lignes et fait gagner du temps au debug futur.
+
+**Proposition**
+Ajouter `plane_ping()` qui retourne `{ok: bool, latency_ms: int, user_email: str, project_name: str}`. Outil que Nova peut appeler au début d'une session pour vérifier que l'intégration est saine.
+
+**Effort**: trivial
+
+---
+
+### [ ] 11. Préfixe titre `[Plane AIFACTORY-12]`
+
+**Problème** (mineur)
+Le préfixe dans le titre Hermes est fragile si quelqu'un renomme la carte d'un côté ou de l'autre. La metadata reste l'ancre sérieuse.
+
+**Proposition**
+Confort de lecture, à garder, mais ne JAMAIS s'en servir comme clé de rapprochement dans le code. Tout matching doit passer par la metadata `plane_work_item_id`. Vérifier que c'est bien le cas dans `plane_import_to_kanban` et autres outils.
+
+**Effort**: vérification, pas de code à écrire si c'est déjà OK
+
+---
+
+### [ ] 12. Documentation utilisateur: ajouter un exemple end-to-end
+
+**Problème**
+`website/docs/user-guide/features/plane.md` décrit bien chaque outil mais ne montre pas un flow concret. Un utilisateur (ou un futur sous-agent qui découvre le toolset) ne voit pas comment chaîner les outils.
+
+**Proposition**
+Ajouter une section `## Example session` avec un dialogue type:
+```
+User: Snapshot du board.
+Nova: [appelle plane_board_snapshot] -> 5 cartes, dont 2 en Todo.
+User: Importe AIFACTORY-3 dans le kanban.
+Nova: [appelle plane_get_work_item puis plane_import_to_kanban et plane_prepare_workdir] -> carte Hermes créée, workdir /home/emeric/AI Factory/AIFACTORY-3_<slug>/ prêt.
+User: Avance dessus.
+[Nova bosse, puis:]
+Nova: [appelle plane_sync_progress] -> commentaire posté sur Plane.
+```
+
+Documenter aussi le `workspace='scratch'` par défaut de `plane_import_to_kanban` (un utilisateur qui ne connaît pas Hermes ne pige pas ce que ça veut dire).
+
+**Effort**: petit, pure doc
+
+---
+
+## Points écartés après relecture
+
+Pour traçabilité, j'avais initialement levé deux remarques que je retire:
+
+- **Espace dans le chemin `/home/emeric/AI Factory/`**: c'est une exigence nominative explicite du prompt initial ("dossier spécifique nommé AI Factory"). À garder tel quel, le code doit juste gérer les chemins avec espaces (quoting bash, `pathlib`). Non négociable.
+- **Repo 630 commits behind origin/main**: vrai signal mais hors scope de ce chantier Plane. À traiter ailleurs.
+
+---
+
+## Suggestion d'ordre de traitement avec Nova demain
+
+1. Audit du code actuel par rapport aux points P0 (1, 2, 3): est-ce que certains sont déjà résolus dans l'implémentation actuelle? Lire `tools/plane_client.py` et `tools/plane_tool.py` avec ces points en tête.
+2. Implémenter `plane_add_comment` (point 4) + `plane_sync_progress` (point 5). Ces deux outils ensemble débloquent le workflow "Plane comme dashboard vivant".
+3. Traiter les autres P0 dans l'ordre.
+4. P1 ensuite.
+5. P2 quand le reste est stable.
+
+Pour chaque point traité: mettre à jour le plan principal (`2026-05-14-plane-v1-integration.md`) et la doc utilisateur (`website/docs/user-guide/features/plane.md`) en conséquence.

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -32,6 +32,24 @@ class TestGetToolset:
         assert ts is not None
         assert "web_search" in ts["tools"]
 
+    def test_plane_toolset_declared(self):
+        ts = get_toolset("plane")
+        assert ts is not None
+        assert ts["description"]
+        assert set(ts["tools"]) == {
+            "plane_ping",
+            "plane_board_snapshot",
+            "plane_list_work_items",
+            "plane_get_work_item",
+            "plane_create_work_item",
+            "plane_update_work_item",
+            "plane_add_comment",
+            "plane_sync_progress",
+            "plane_check_kanban_links",
+            "plane_import_to_kanban",
+            "plane_prepare_workdir",
+        }
+
     def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
         reg = ToolRegistry()
         reg.register(
@@ -246,11 +264,3 @@ class TestPluginToolsets:
         all_toolsets = get_all_toolsets()
         assert "plugin_bundle" in all_toolsets
         assert all_toolsets["plugin_bundle"]["tools"] == ["plugin_tool"]
-
-
-class TestDefaultPlatformWebSearchCoverage:
-    def test_hermes_whatsapp_toolset_includes_web_search(self):
-        assert "web_search" in resolve_toolset("hermes-whatsapp")
-
-    def test_hermes_api_server_toolset_includes_web_search(self):
-        assert "web_search" in resolve_toolset("hermes-api-server")

--- a/tests/tools/test_plane_client.py
+++ b/tests/tools/test_plane_client.py
@@ -136,6 +136,33 @@ def test_find_work_item_by_external_id_filters_client_side_after_api_lookup(plan
     assert len(calls) == 2
 
 
+def test_find_work_item_by_external_id_falls_back_when_server_rejects_external_filters(plane_env):
+    client = PlaneClient.from_env()
+    calls = []
+
+    def fake_list_work_items(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("external_id") == "ext-1":
+            raise PlaneAPIError(404, '{"error":"The requested resource does not exist."}', "https://api.plane.so/test")
+        return [
+            {"id": "match", "external_source": "nova-hermes", "external_id": "ext-1"},
+            {"id": "other", "external_source": "nova-hermes", "external_id": "ext-2"},
+        ]
+
+    client.list_work_items = fake_list_work_items
+
+    item = client.find_work_item_by_external_id(
+        external_source="nova-hermes",
+        external_id="ext-1",
+    )
+
+    assert item["id"] == "match"
+    assert calls[0]["external_source"] == "nova-hermes"
+    assert calls[0]["external_id"] == "ext-1"
+    assert "external_source" not in calls[1]
+    assert "external_id" not in calls[1]
+
+
 def test_resolve_state_id_by_name_and_id(plane_env):
     client = PlaneClient.from_env()
     client._states_cache = [

--- a/tests/tools/test_plane_client.py
+++ b/tests/tools/test_plane_client.py
@@ -1,0 +1,250 @@
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+import tools.plane_client as plane_client
+from tools.plane_client import (
+    BROWSER_USER_AGENT,
+    PlaneAPIError,
+    PlaneClient,
+    PlaneConfigurationError,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def read(self):
+        if self.payload is None:
+            return b""
+        return json.dumps(self.payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def plane_env(monkeypatch):
+    monkeypatch.setenv("PLANE_API_KEY", "plane-token")
+    monkeypatch.setenv("PLANE_WORKSPACE", "ai_factory")
+    monkeypatch.setenv("PLANE_PROJECT_ID", "project-123")
+
+
+def test_from_env_requires_all_values(monkeypatch):
+    monkeypatch.setattr(plane_client, "load_hermes_dotenv", lambda hermes_home=None: None)
+    monkeypatch.delenv("PLANE_API_KEY", raising=False)
+    monkeypatch.delenv("PLANE_WORKSPACE", raising=False)
+    monkeypatch.delenv("PLANE_PROJECT_ID", raising=False)
+    with pytest.raises(PlaneConfigurationError, match="PLANE_API_KEY"):
+        PlaneClient.from_env()
+
+
+def test_headers_include_browser_user_agent_and_api_key(plane_env):
+    client = PlaneClient.from_env()
+    headers = client.headers()
+    assert headers["X-API-Key"] == "plane-token"
+    assert headers["User-Agent"] == BROWSER_USER_AGENT
+    assert headers["Accept"] == "application/json"
+
+
+def test_request_raises_plane_api_error_with_response_body(plane_env):
+    client = PlaneClient.from_env()
+    err = urllib.error.HTTPError(
+        url="https://api.plane.so/test",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=None,
+    )
+    err.read = lambda: b'{"detail":"browser_signature_banned"}'
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(PlaneAPIError, match="403") as exc:
+            client._request("GET", "/test")
+    assert "browser_signature_banned" in exc.value.body
+
+
+def test_get_current_user_calls_users_me_endpoint(plane_env):
+    client = PlaneClient.from_env()
+    calls = []
+
+    def fake_urlopen(req, timeout=30):
+        calls.append(req)
+        return _FakeResponse({"id": "u1", "email": "emeric@example.com"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        user = client.get_current_user()
+
+    assert user["email"] == "emeric@example.com"
+    assert calls[0].full_url == "https://api.plane.so/api/v1/users/me/"
+    assert calls[0].headers["User-agent"] == BROWSER_USER_AGENT
+
+
+def test_list_work_items_follows_next_cursor_pagination(plane_env):
+    client = PlaneClient.from_env()
+    calls = []
+
+    def fake_urlopen(req, timeout=30):
+        calls.append(req.full_url)
+        if len(calls) == 1:
+            return _FakeResponse({
+                "results": [{"id": "1"}],
+                "next_page_results": True,
+                "next_cursor": "cursor-2",
+            })
+        return _FakeResponse({
+            "results": [{"id": "2"}],
+            "next_page_results": False,
+        })
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        items = client.list_work_items()
+
+    assert [item["id"] for item in items] == ["1", "2"]
+    assert "cursor=cursor-2" in calls[1]
+
+
+def test_find_work_item_by_external_id_filters_client_side_after_api_lookup(plane_env):
+    client = PlaneClient.from_env()
+    calls = []
+
+    def fake_paginate(path, *, params=None):
+        calls.append(dict(params or {}))
+        if params and params.get("external_id") == "ext-1":
+            return [{"id": "wrong", "external_source": "other", "external_id": "ext-1"}]
+        return [
+            {"id": "match", "external_source": "nova-hermes", "external_id": "ext-1"},
+            {"id": "other", "external_source": "nova-hermes", "external_id": "ext-2"},
+        ]
+
+    client.paginate = fake_paginate
+
+    item = client.find_work_item_by_external_id(
+        external_source="nova-hermes",
+        external_id="ext-1",
+    )
+
+    assert item["id"] == "match"
+    assert calls[0]["external_source"] == "nova-hermes"
+    assert calls[0]["external_id"] == "ext-1"
+    assert len(calls) == 2
+
+
+def test_resolve_state_id_by_name_and_id(plane_env):
+    client = PlaneClient.from_env()
+    client._states_cache = [
+        {"id": "s1", "name": "Todo"},
+        {"id": "s2", "name": "Done"},
+    ]
+    assert client.resolve_state_id("Todo") == "s1"
+    assert client.resolve_state_id("s2") == "s2"
+    with pytest.raises(ValueError, match="Unknown Plane state"):
+        client.resolve_state_id("Missing")
+
+
+def test_resolve_label_ids_by_name_and_id(plane_env):
+    client = PlaneClient.from_env()
+    client._labels_cache = [
+        {"id": "l1", "name": "backend"},
+        {"id": "l2", "name": "research"},
+    ]
+    assert client.resolve_label_ids(["backend", "l2", "backend"]) == ["l1", "l2"]
+    with pytest.raises(ValueError, match="Unknown Plane label"):
+        client.resolve_label_ids(["missing"])
+
+
+def test_create_work_item_posts_payload_to_work_items_endpoint(plane_env):
+    client = PlaneClient.from_env()
+    seen = {}
+
+    def fake_urlopen(req, timeout=30):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        seen["content_type"] = req.headers["Content-type"]
+        return _FakeResponse({
+            "id": "w-new",
+            "sequence_id": 7,
+            "name": "Nouvelle tâche",
+            "external_source": "nova-hermes",
+            "external_id": "ext-7",
+        })
+
+    payload = {
+        "name": "Nouvelle tâche",
+        "description_html": "<p>Body</p>",
+        "external_source": "nova-hermes",
+        "external_id": "ext-7",
+    }
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        created = client.create_work_item(payload)
+
+    assert created["id"] == "w-new"
+    assert seen["method"] == "POST"
+    assert seen["url"].endswith(
+        "/api/v1/workspaces/ai_factory/projects/project-123/work-items/"
+    )
+    assert seen["body"] == payload
+    assert seen["content_type"] == "application/json"
+
+
+def test_create_work_item_rejects_empty_payload(plane_env):
+    client = PlaneClient.from_env()
+    with pytest.raises(ValueError, match="payload is required"):
+        client.create_work_item({})
+
+
+def test_update_work_item_sends_patch_with_payload(plane_env):
+    client = PlaneClient.from_env()
+    seen = {}
+
+    def fake_urlopen(req, timeout=30):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse({"id": "w1", "name": "Updated"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        updated = client.update_work_item("w1", {"name": "Updated", "priority": "high"})
+
+    assert updated["id"] == "w1"
+    assert seen["method"] == "PATCH"
+    assert seen["url"].endswith(
+        "/api/v1/workspaces/ai_factory/projects/project-123/work-items/w1/"
+    )
+    assert seen["body"] == {"name": "Updated", "priority": "high"}
+
+
+def test_update_work_item_requires_id_and_payload(plane_env):
+    client = PlaneClient.from_env()
+    with pytest.raises(ValueError, match="work_item_id is required"):
+        client.update_work_item("", {"name": "x"})
+    with pytest.raises(ValueError, match="payload is required"):
+        client.update_work_item("w1", {})
+
+
+def test_add_comment_posts_comment_html_to_issue_comments_endpoint(plane_env):
+    client = PlaneClient.from_env()
+    seen = {}
+
+    def fake_urlopen(req, timeout=30):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode("utf-8"))
+        seen["content_type"] = req.headers["Content-type"]
+        return _FakeResponse({"id": "c1", "comment_html": "<p>[Nova] done</p>"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        comment = client.add_comment("w1", "<p>[Nova] done</p>")
+
+    assert comment["id"] == "c1"
+    assert seen["method"] == "POST"
+    assert seen["url"].endswith("/api/v1/workspaces/ai_factory/projects/project-123/issues/w1/comments/")
+    assert seen["body"] == {"comment_html": "<p>[Nova] done</p>"}
+    assert seen["content_type"] == "application/json"

--- a/tests/tools/test_plane_tool.py
+++ b/tests/tools/test_plane_tool.py
@@ -121,6 +121,7 @@ def test_plane_toolset_registered():
     assert "plane_board_snapshot" in resolved
     assert "plane_add_comment" in resolved
     assert "plane_sync_progress" in resolved
+    assert "plane_check_kanban_links" in resolved
     assert "plane_import_to_kanban" in resolved
 
 
@@ -338,6 +339,7 @@ def test_plane_update_work_item_nominal_path(stub_client):
     assert stub_client.last_update["work_item_id"] == "w1"
     assert payload["name"] == "Renamed via Hermes"
     assert payload["state_id"] == "s2"
+    assert payload["state"] == "s2"
     assert payload["labels"] == ["l1"]
     assert payload["priority"] == "high"
 
@@ -447,6 +449,87 @@ def test_plane_sync_progress_requires_linked_hermes_card(monkeypatch, stub_clien
     }))
 
     assert "not linked to a Plane work item" in data["error"]
+
+
+def test_plane_check_kanban_links_reports_cancelled_and_missing(monkeypatch, stub_client):
+    linkages = {
+        "task-cancelled": {
+            "hermes_card_id": "task-cancelled",
+            "plane_work_item_id": "w-cancelled",
+            "plane_sequence_id": 7,
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-7",
+            "plane_state_id": "s-cancelled",
+        },
+        "task-missing": {
+            "hermes_card_id": "task-missing",
+            "plane_work_item_id": "w-missing",
+            "plane_sequence_id": 8,
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-8",
+        },
+        "task-healthy": {
+            "hermes_card_id": "task-healthy",
+            "plane_work_item_id": "w-healthy",
+            "plane_sequence_id": 9,
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-9",
+        },
+    }
+
+    monkeypatch.setattr(
+        stub_client,
+        "list_states",
+        lambda: [
+            {"id": "s1", "name": "Todo", "group": "unstarted"},
+            {"id": "s-cancelled", "name": "Cancelled", "group": "cancelled"},
+        ],
+    )
+
+    def fake_lookup(card_id):
+        return dict(linkages[card_id])
+
+    def fake_resolve_item(client, *, work_item_id=None, sequence_id=None):
+        if work_item_id == "w-missing":
+            raise plane_tool.PlaneAPIError(404, '{"error":"not found"}', "https://api.plane.so/test")
+        if work_item_id == "w-cancelled":
+            return {
+                "id": "w-cancelled",
+                "sequence_id": sequence_id,
+                "name": "Cancelled item",
+                "state": "s-cancelled",
+            }
+        return {
+            "id": "w-healthy",
+            "sequence_id": sequence_id,
+            "name": "Healthy item",
+            "state": "s1",
+        }
+
+    monkeypatch.setattr(plane_tool, "_lookup_plane_link_from_kanban_task", fake_lookup)
+    monkeypatch.setattr(plane_tool, "_resolve_item", fake_resolve_item)
+
+    data = json.loads(plane_tool._handle_check_kanban_links({
+        "hermes_card_ids": ["task-cancelled", "task-missing", "task-healthy"],
+    }))
+
+    assert data["success"] is True
+    assert data["count"] == 2
+    assert data["items"] == [
+        {
+            "hermes_card_id": "task-cancelled",
+            "status": "cancelled",
+            "plane_work_item_id": "w-cancelled",
+            "plane_sequence_id": 7,
+            "plane_state_id": "s-cancelled",
+            "plane_state_name": "Cancelled",
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-7",
+        },
+        {
+            "hermes_card_id": "task-missing",
+            "status": "missing",
+            "plane_work_item_id": "w-missing",
+            "plane_sequence_id": 8,
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-8",
+        },
+    ]
 
 
 def test_plane_prepare_workdir_creates_expected_structure(tmp_path):

--- a/tests/tools/test_plane_tool.py
+++ b/tests/tools/test_plane_tool.py
@@ -1,0 +1,621 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import tools.plane_tool as plane_tool
+from toolsets import TOOLSETS, resolve_toolset
+
+
+@pytest.fixture
+def stub_client(monkeypatch):
+    class StubClient:
+        workspace_slug = "ai_factory"
+        project_id = "project-123"
+
+        class config:
+            workspace_slug = "ai_factory"
+            project_id = "project-123"
+
+        def get_project_identifier(self):
+            return "AIFACTORY"
+
+        def get_current_user(self):
+            return {"id": "user-1", "email": "emeric@example.com", "display_name": "Emeric"}
+
+        def get_project(self):
+            return {"id": "project-123", "name": "AI_Factory", "identifier": "AIFACTORY"}
+
+        def list_states(self):
+            return [
+                {"id": "s1", "name": "Todo"},
+                {"id": "s2", "name": "Done"},
+            ]
+
+        def list_labels(self):
+            return [
+                {"id": "l1", "name": "backend"},
+                {"id": "l2", "name": "research"},
+            ]
+
+        def list_work_items(self, **kwargs):
+            return [
+                {
+                    "id": "w1",
+                    "sequence_id": 1,
+                    "name": "Test modifié par Hermes",
+                    "priority": "medium",
+                    "state": {"id": "s1", "name": "Todo"},
+                    "labels": [{"id": "l1", "name": "backend"}],
+                    "assignees": [{"id": "u1", "display_name": "Emeric"}],
+                    "description_html": "<p>First task</p>",
+                },
+                {
+                    "id": "w2",
+                    "sequence_id": 2,
+                    "name": "Deuxième carte créée par Hermes",
+                    "priority": "high",
+                    "state": {"id": "s2", "name": "Done"},
+                    "labels": [{"id": "l2", "name": "research"}],
+                    "assignees": [{"id": "u2", "display_name": "Nova"}],
+                    "description_html": "<p>Second task</p>",
+                },
+            ]
+
+        def get_work_item(self, **kwargs):
+            for item in self.list_work_items():
+                if kwargs.get("work_item_id") == item["id"]:
+                    return item
+                if kwargs.get("sequence_id") == item["sequence_id"]:
+                    return item
+                rid = f"AIFACTORY-{item['sequence_id']}"
+                if kwargs.get("readable_id") == rid:
+                    return item
+            raise ValueError("not found")
+
+        def resolve_state_id(self, value):
+            return {"Todo": "s1", "Done": "s2", "s1": "s1", "s2": "s2"}[value]
+
+        def resolve_label_ids(self, values):
+            mapping = {"backend": "l1", "research": "l2", "l1": "l1", "l2": "l2"}
+            return [mapping[v] for v in values]
+
+        def create_work_item(self, payload):
+            return {
+                "id": "w3",
+                "sequence_id": 3,
+                "name": payload["name"],
+                "priority": payload.get("priority"),
+                "state": {"id": payload.get("state"), "name": "Todo"},
+                "labels": [{"id": lid, "name": lid} for lid in payload.get("labels", [])],
+                "assignees": [{"id": aid, "display_name": aid} for aid in payload.get("assignees", [])],
+                "description_html": payload.get("description_html"),
+            }
+
+        def update_work_item(self, work_item_id, payload):
+            self.last_update = {"work_item_id": work_item_id, "payload": payload}
+            return {
+                "id": work_item_id,
+                "sequence_id": 1,
+                "name": payload.get("name", "Updated"),
+                "priority": payload.get("priority"),
+                "state": {"id": payload.get("state"), "name": "Done"},
+                "labels": [{"id": lid, "name": lid} for lid in payload.get("labels", [])],
+                "assignees": [{"id": aid, "display_name": aid} for aid in payload.get("assignees", [])],
+                "description_html": payload.get("description_html"),
+            }
+
+        def add_comment(self, work_item_id, comment_html):
+            self.last_comment = {"work_item_id": work_item_id, "comment_html": comment_html}
+            return {"id": "c1", "issue": work_item_id, "comment_html": comment_html}
+
+    client = StubClient()
+    monkeypatch.setattr(plane_tool, "get_plane_client", lambda: client)
+    return client
+
+
+def test_plane_toolset_registered():
+    assert "plane" in TOOLSETS
+    resolved = resolve_toolset("plane")
+    assert "plane_ping" in resolved
+    assert "plane_board_snapshot" in resolved
+    assert "plane_add_comment" in resolved
+    assert "plane_sync_progress" in resolved
+    assert "plane_import_to_kanban" in resolved
+
+
+def test_plane_ping_reports_user_project_and_latency(stub_client):
+    data = json.loads(plane_tool._handle_ping({}))
+    assert data["ok"] is True
+    assert data["latency_ms"] >= 0
+    assert data["user_email"] == "emeric@example.com"
+    assert data["user"]["display_name"] == "Emeric"
+    assert data["workspace"] == "ai_factory"
+    assert data["project_name"] == "AI_Factory"
+    assert data["project"]["identifier"] == "AIFACTORY"
+
+
+def test_plane_board_snapshot_summarizes_counts(stub_client):
+    data = json.loads(plane_tool._handle_board_snapshot({"include_items_per_state": True, "per_state_limit": 1}))
+    assert data["project"] == {"id": "project-123", "name": "AI_Factory", "identifier": "AIFACTORY"}
+    assert data["total_items"] == 2
+    assert data["counts_by_state"]["Todo"] == 1
+    assert data["states"][0] == {"id": "s1", "name": "Todo", "group": None, "count": 1}
+    assert data["items_by_state"]["Todo"][0]["readable_id"] == "AIFACTORY-1"
+    assert "description_html" not in data["items"][0]
+    assert "project_payload" not in data
+
+
+def test_plane_board_snapshot_verbose_includes_raw_payloads(stub_client):
+    data = json.loads(plane_tool._handle_board_snapshot({"verbose": True}))
+    assert data["project_payload"]["identifier"] == "AIFACTORY"
+    assert data["states_payload"][0]["id"] == "s1"
+    assert data["items_payload"][0]["description_html"] == "<p>First task</p>"
+
+
+def test_plane_list_work_items_filters_by_state_and_query(stub_client):
+    data = json.loads(plane_tool._handle_list_work_items({"state": "Done", "query": "Deuxième"}))
+    assert data["count"] == 1
+    assert data["items"][0]["readable_id"] == "AIFACTORY-2"
+    assert data["items"][0]["state_name"] == "Done"
+    assert data["items"][0]["assignees_names"] == ["Nova"]
+    assert data["items"][0]["url"].endswith("/issues/AIFACTORY-2")
+    assert "description_html" not in data["items"][0]
+
+
+def test_plane_list_work_items_verbose_includes_raw_payloads(stub_client):
+    data = json.loads(plane_tool._handle_list_work_items({"state": "Done", "verbose": True}))
+    assert data["items_payload"][0]["description_html"] == "<p>Second task</p>"
+
+
+def test_plane_get_work_item_supports_sequence_id(stub_client):
+    data = json.loads(plane_tool._handle_get_work_item({"sequence_id": 1}))
+    assert data["item"]["readable_id"] == "AIFACTORY-1"
+    assert data["item"]["state_name"] == "Todo"
+    assert "description_html" not in data["item"]
+
+
+def test_plane_get_work_item_verbose_includes_raw_and_enriched_payload(stub_client):
+    data = json.loads(plane_tool._handle_get_work_item({"sequence_id": 1, "verbose": True}))
+    assert data["item"]["readable_id"] == "AIFACTORY-1"
+    assert data["payload"]["description_html"] == "<p>First task</p>"
+    assert data["enriched_item"]["state_name"] == "Todo"
+
+
+def test_plane_create_work_item_normalizes_state_labels_and_markdown(stub_client):
+    data = json.loads(plane_tool._handle_create_work_item({
+        "name": "Nouvelle tâche",
+        "description_markdown": "Bonjour\n\nMonde",
+        "state": "Todo",
+        "labels": ["backend"],
+        "assignees": ["u1"],
+    }))
+    assert data["item"]["name"] == "Nouvelle tâche"
+    assert data["item"]["state"]["id"] == "s1"
+    assert data["already_existed"] is False
+    assert data["external_source"] == "nova-hermes"
+    assert data["external_id"].startswith("plane-create:")
+    assert data["external_id_generated"] is True
+    assert "Bonjour" in data["item"]["description_html"]
+
+
+def test_plane_create_work_item_returns_existing_for_same_external_id(monkeypatch):
+    class IdempotentClient:
+        workspace_slug = "ai_factory"
+        project_id = "project-123"
+
+        class config:
+            workspace_slug = "ai_factory"
+            project_id = "project-123"
+
+        def __init__(self):
+            self.created_payloads = []
+
+        def get_project(self):
+            return {"id": "project-123", "name": "AI_Factory", "identifier": "AIFACTORY"}
+
+        def find_work_item_by_external_id(self, *, external_source, external_id):
+            assert external_source == "nova-hermes"
+            assert external_id == "retry-key-1"
+            return {
+                "id": "w-existing",
+                "sequence_id": 7,
+                "name": "Already there",
+                "external_source": external_source,
+                "external_id": external_id,
+                "state": {"id": "s1", "name": "Todo"},
+            }
+
+        def create_work_item(self, payload):
+            self.created_payloads.append(payload)
+            raise AssertionError("create_work_item should not be called")
+
+        def resolve_state_id(self, value):
+            return None
+
+    client = IdempotentClient()
+    monkeypatch.setattr(plane_tool, "get_plane_client", lambda: client)
+
+    data = json.loads(plane_tool._handle_create_work_item({
+        "name": "Already there",
+        "external_id": "retry-key-1",
+    }))
+
+    assert data["already_existed"] is True
+    assert data["created"] is None
+    assert data["item"]["id"] == "w-existing"
+    assert data["external_id_generated"] is False
+    assert client.created_payloads == []
+
+
+def test_plane_create_work_item_generates_same_external_id_from_normalized_name(stub_client):
+    first = json.loads(plane_tool._handle_create_work_item({"name": "  Same   Name  "}))
+    second = json.loads(plane_tool._handle_create_work_item({"name": "same name"}))
+
+    assert first["external_id"] == second["external_id"]
+    assert first["external_id_generated"] is True
+
+
+def test_plane_create_work_item_recovers_from_409_when_lookup_misses(monkeypatch):
+    from tools.plane_client import PlaneAPIError
+
+    class FlakyLookupClient:
+        workspace_slug = "ai_factory"
+        project_id = "project-123"
+
+        class config:
+            workspace_slug = "ai_factory"
+            project_id = "project-123"
+
+        def __init__(self):
+            self.find_calls = 0
+            self.create_calls = 0
+
+        def get_project(self):
+            return {"id": "project-123", "name": "AI_Factory", "identifier": "AIFACTORY"}
+
+        def get_project_identifier(self):
+            return "AIFACTORY"
+
+        def find_work_item_by_external_id(self, *, external_source, external_id):
+            self.find_calls += 1
+            if self.find_calls == 1:
+                return None
+            return {
+                "id": "w-existing",
+                "sequence_id": 42,
+                "name": "Already there",
+                "external_source": external_source,
+                "external_id": external_id,
+                "state": {"id": "s1", "name": "Todo"},
+            }
+
+        def create_work_item(self, payload):
+            self.create_calls += 1
+            raise PlaneAPIError(
+                409,
+                '{"error":"duplicate external id"}',
+                "https://api.plane.so/work-items/",
+            )
+
+        def resolve_state_id(self, value):
+            return None
+
+    client = FlakyLookupClient()
+    monkeypatch.setattr(plane_tool, "get_plane_client", lambda: client)
+
+    data = json.loads(plane_tool._handle_create_work_item({
+        "name": "Already there",
+        "external_id": "retry-key-409",
+    }))
+
+    assert data["success"] is True
+    assert data["already_existed"] is True
+    assert data["created"] is None
+    assert data["item"]["id"] == "w-existing"
+    assert data["external_id"] == "retry-key-409"
+    assert data["external_id_generated"] is False
+    assert client.find_calls == 2
+    assert client.create_calls == 1
+
+
+def test_plane_update_work_item_requires_changes(stub_client):
+    raw = plane_tool._handle_update_work_item({"work_item_id": "w1"})
+    assert "at least one updatable field is required" in raw
+
+
+def test_plane_update_work_item_nominal_path(stub_client):
+    data = json.loads(plane_tool._handle_update_work_item({
+        "work_item_id": "w1",
+        "name": "Renamed via Hermes",
+        "state": "Done",
+        "labels": ["backend"],
+        "priority": "high",
+    }))
+    assert data["success"] is True
+    assert data["item"]["id"] == "w1"
+    payload = stub_client.last_update["payload"]
+    assert stub_client.last_update["work_item_id"] == "w1"
+    assert payload["name"] == "Renamed via Hermes"
+    assert payload["state_id"] == "s2"
+    assert payload["labels"] == ["l1"]
+    assert payload["priority"] == "high"
+
+
+def test_plane_update_work_item_ignores_none_fields_in_patch_payload(stub_client):
+    data = json.loads(plane_tool._handle_update_work_item({
+        "work_item_id": "w1",
+        "name": "New name only",
+        "priority": None,
+        "state": None,
+        "labels": None,
+        "assignees": None,
+        "target_date": None,
+        "description_markdown": None,
+    }))
+    assert data["success"] is True
+    payload = stub_client.last_update["payload"]
+    assert payload == {"name": "New name only"}
+
+
+def test_plane_update_work_item_empty_list_clears_labels_and_assignees(stub_client):
+    json.loads(plane_tool._handle_update_work_item({
+        "work_item_id": "w1",
+        "labels": [],
+        "assignees": [],
+    }))
+    payload = stub_client.last_update["payload"]
+    assert payload.get("labels") == []
+    assert payload.get("assignees") == []
+
+
+def test_plane_add_comment_supports_sequence_id_and_default_nova_prefix(stub_client):
+    data = json.loads(plane_tool._handle_add_comment({
+        "sequence_id": 1,
+        "body_markdown": "Terminé\nProchaine étape: revue",
+    }))
+    assert data["success"] is True
+    assert data["comment"]["issue"] == "w1"
+    assert data["item"]["readable_id"] == "AIFACTORY-1"
+    assert "[Nova] Terminé" in data["comment_html"]
+    assert "<br>" in data["comment_html"]
+
+
+def test_plane_add_comment_can_disable_prefix(stub_client):
+    data = json.loads(plane_tool._handle_add_comment({
+        "work_item_id": "w1",
+        "body_markdown": "Message brut",
+        "prefix": False,
+    }))
+    assert "[Nova]" not in data["comment_html"]
+    assert "Message brut" in data["comment_html"]
+
+
+def test_parse_plane_linkage_from_imported_kanban_body():
+    body = """Imported from Plane AIFACTORY-12
+
+plane_workspace_slug: ai_factory
+plane_project_id: project-123
+plane_work_item_id: w1
+plane_sequence_id: 12
+plane_url: https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-12
+plane_state_id: s1
+"""
+    linkage = plane_tool._parse_plane_linkage_from_body(body)
+    assert linkage["plane_work_item_id"] == "w1"
+    assert linkage["plane_sequence_id"] == 12
+    assert linkage["plane_url"].endswith("AIFACTORY-12")
+
+
+def test_plane_sync_progress_comments_and_updates_status(monkeypatch, stub_client):
+    monkeypatch.setattr(
+        plane_tool,
+        "_lookup_plane_link_from_kanban_task",
+        lambda hermes_card_id: {
+            "hermes_card_id": hermes_card_id,
+            "plane_work_item_id": "w1",
+            "plane_sequence_id": 1,
+            "plane_url": "https://app.plane.so/ai_factory/projects/project-123/issues/AIFACTORY-1",
+        },
+    )
+
+    data = json.loads(plane_tool._handle_sync_progress({
+        "hermes_card_id": "t_imported",
+        "summary": "Implémentation terminée",
+        "status": "Done",
+    }))
+
+    assert data["success"] is True
+    assert data["hermes_card_id"] == "t_imported"
+    assert data["item"]["readable_id"] == "AIFACTORY-1"
+    assert data["status"] == "Done"
+    assert data["status_updated"] is True
+    assert stub_client.last_update == {"work_item_id": "w1", "payload": {"state_id": "s2", "state": "s2"}}
+    assert stub_client.last_comment["work_item_id"] == "w1"
+    assert "[Nova] Implémentation terminée" in stub_client.last_comment["comment_html"]
+
+
+def test_plane_sync_progress_requires_linked_hermes_card(monkeypatch, stub_client):
+    def missing_link(card_id):
+        raise ValueError(f"Hermes kanban task {card_id} is not linked to a Plane work item")
+
+    monkeypatch.setattr(plane_tool, "_lookup_plane_link_from_kanban_task", missing_link)
+
+    data = json.loads(plane_tool._handle_sync_progress({
+        "hermes_card_id": "t_plain",
+        "summary": "Avancement",
+    }))
+
+    assert "not linked to a Plane work item" in data["error"]
+
+
+def test_plane_prepare_workdir_creates_expected_structure(tmp_path):
+    data = json.loads(plane_tool._handle_prepare_workdir({
+        "sequence_id": 12,
+        "title": "RAG benchmark",
+        "base_dir": str(tmp_path),
+        "project_key": "AIFACTORY",
+    }))
+    task_dir = Path(data["workdir"])
+    assert task_dir.name.startswith("AIFACTORY-12_")
+    assert task_dir.exists()
+    assert (task_dir / "work").is_dir()
+    assert (task_dir / "deliverables").is_dir()
+    assert (task_dir / "README.md").exists()
+    readme = (task_dir / "README.md").read_text(encoding="utf-8")
+    assert "AIFACTORY-12" in readme
+
+
+def test_plane_prepare_workdir_honours_custom_project_key(tmp_path):
+    data = json.loads(plane_tool._handle_prepare_workdir({
+        "sequence_id": 7,
+        "title": "Test",
+        "base_dir": str(tmp_path),
+        "project_key": "novax",
+    }))
+    task_dir = Path(data["workdir"])
+    assert task_dir.name.startswith("NOVAX-7_")
+    readme = (task_dir / "README.md").read_text(encoding="utf-8")
+    assert "NOVAX-7" in readme
+
+
+def test_plane_import_to_kanban_workdir_uses_real_project_key(
+    monkeypatch, tmp_path
+):
+    class CustomKeyClient:
+        workspace_slug = "ai_factory"
+        project_id = "project-123"
+
+        class config:
+            workspace_slug = "ai_factory"
+            project_id = "project-123"
+
+        def get_project_identifier(self):
+            return "NOVAX"
+
+        def get_project(self):
+            return {"id": "project-123", "name": "Nova X", "identifier": "NOVAX"}
+
+        def list_work_items(self, **kwargs):
+            return [{
+                "id": "w42",
+                "sequence_id": 42,
+                "name": "Carte custom",
+                "state": {"id": "s1", "name": "Todo"},
+            }]
+
+        def get_work_item(self, **kwargs):
+            return self.list_work_items()[0]
+
+    client = CustomKeyClient()
+    monkeypatch.setattr(plane_tool, "get_plane_client", lambda: client)
+
+    class FakeConn:
+        def execute(self, sql, params=()):
+            class _Cur:
+                def fetchone(self):
+                    return None
+
+            return _Cur()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_cli.kanban_db.init_db", lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.create_task",
+        lambda conn, **kwargs: "task-1",
+    )
+
+    data = json.loads(plane_tool._handle_import_to_kanban({
+        "sequence_ids": [42],
+        "assignee": "emeric",
+        "create_workdir": True,
+        "workdir_base_dir": str(tmp_path),
+    }))
+    workdir = Path(data["created_tasks"][0]["workdir"])
+    assert workdir.name.startswith("NOVAX-42_")
+
+
+def test_plane_import_to_kanban_creates_kanban_task_with_plane_linkage(
+    monkeypatch, stub_client, tmp_path
+):
+    class FakeConn:
+        def execute(self, sql, params=()):
+            class _Cur:
+                def fetchone(self):
+                    return None
+
+            return _Cur()
+
+        def close(self):
+            pass
+
+    captured: dict[str, list] = {"calls": []}
+
+    def fake_create_task(conn, **kwargs):
+        captured["calls"].append(kwargs)
+        return "task-newly-imported"
+
+    monkeypatch.setattr("hermes_cli.kanban_db.init_db", lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: FakeConn())
+    monkeypatch.setattr("hermes_cli.kanban_db.create_task", fake_create_task)
+
+    data = json.loads(plane_tool._handle_import_to_kanban({
+        "sequence_ids": [1],
+        "assignee": "emeric",
+        "create_workdir": True,
+        "workdir_base_dir": str(tmp_path),
+    }))
+
+    assert data["success"] is True
+    assert len(data["created_tasks"]) == 1
+    created_task = data["created_tasks"][0]
+    assert created_task["task_id"] == "task-newly-imported"
+    assert created_task["plane_work_item_id"] == "w1"
+    assert created_task["plane_sequence_id"] == 1
+    assert created_task["already_imported"] is False
+    assert Path(created_task["workdir"]).exists()
+
+    assert len(captured["calls"]) == 1
+    create_kwargs = captured["calls"][0]
+    assert create_kwargs["title"] == "[Plane AIFACTORY-1] Test modifié par Hermes"
+    assert create_kwargs["assignee"] == "emeric"
+    assert create_kwargs["idempotency_key"] == "plane:ai_factory:project-123:w1"
+    assert "plane_work_item_id: w1" in create_kwargs["body"]
+    assert "plane_sequence_id: 1" in create_kwargs["body"]
+    assert "plane_url:" in create_kwargs["body"]
+
+
+def test_plane_import_to_kanban_flags_already_imported_when_idempotency_hits(
+    monkeypatch, stub_client
+):
+    class FakeConn:
+        def execute(self, sql, params=()):
+            class _Cur:
+                def fetchone(self):
+                    return {"id": "task-existing-row"}
+
+            return _Cur()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_cli.kanban_db.init_db", lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: FakeConn())
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.create_task",
+        lambda conn, **kwargs: "task-existing-row",
+    )
+
+    data = json.loads(plane_tool._handle_import_to_kanban({
+        "sequence_ids": [1],
+        "assignee": "emeric",
+    }))
+
+    assert data["success"] is True
+    created_task = data["created_tasks"][0]
+    assert created_task["task_id"] == "task-existing-row"
+    assert created_task["already_imported"] is True
+    assert created_task["workdir"] is None

--- a/tools/plane_client.py
+++ b/tools/plane_client.py
@@ -1,0 +1,394 @@
+"""Shared Plane REST client for Hermes tools.
+
+Read-first client for Plane Cloud with a browser-like User-Agent to avoid
+Cloudflare `browser_signature_banned` false negatives on otherwise valid API
+requests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_cli.env_loader import load_hermes_dotenv
+
+BASE_URL = "https://api.plane.so"
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+)
+
+
+class PlaneConfigurationError(ValueError):
+    """Raised when Plane environment configuration is incomplete."""
+
+
+class PlaneAPIError(RuntimeError):
+    """Raised when a Plane API request fails."""
+
+    def __init__(self, status_code: int, body: str, url: str):
+        self.status_code = int(status_code)
+        self.status = self.status_code  # backward-compatible alias
+        self.body = body
+        self.url = url
+        hint = ""
+        if "browser_signature_banned" in body:
+            hint = " Retry with a browser-like User-Agent."
+        super().__init__(f"Plane API error {status_code} for {url}: {body}{hint}")
+
+
+@dataclass
+class PlaneConfig:
+    api_key: str
+    workspace_slug: str
+    project_id: str
+    base_url: str = BASE_URL
+    user_agent: str = BROWSER_USER_AGENT
+
+    @classmethod
+    def from_env(cls) -> "PlaneConfig":
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+        api_key = (os.getenv("PLANE_API_KEY") or "").strip()
+        workspace_slug = (os.getenv("PLANE_WORKSPACE") or "").strip()
+        project_id = (os.getenv("PLANE_PROJECT_ID") or "").strip()
+        base_url = (os.getenv("PLANE_BASE_URL") or BASE_URL).strip().rstrip("/")
+        missing = [
+            name
+            for name, value in (
+                ("PLANE_API_KEY", api_key),
+                ("PLANE_WORKSPACE", workspace_slug),
+                ("PLANE_PROJECT_ID", project_id),
+            )
+            if not value
+        ]
+        if missing:
+            raise PlaneConfigurationError(
+                f"Missing required Plane env vars: {', '.join(missing)}"
+            )
+        return cls(
+            api_key=api_key,
+            workspace_slug=workspace_slug,
+            project_id=project_id,
+            base_url=base_url,
+        )
+
+
+class PlaneClient:
+    def __init__(self, config: PlaneConfig):
+        self.config = config
+        self._project_cache: Optional[dict[str, Any]] = None
+        self._states_cache: Optional[list[dict[str, Any]]] = None
+        self._labels_cache: Optional[list[dict[str, Any]]] = None
+
+    @classmethod
+    def from_env(cls) -> "PlaneClient":
+        return cls(PlaneConfig.from_env())
+
+    @property
+    def workspace_slug(self) -> str:
+        return self.config.workspace_slug
+
+    @property
+    def project_id(self) -> str:
+        return self.config.project_id
+
+    @property
+    def base_url(self) -> str:
+        return self.config.base_url.rstrip("/")
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "X-API-Key": self.config.api_key,
+            "Accept": "application/json",
+            "User-Agent": self.config.user_agent,
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
+        timeout: int = 30,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        if clean_params:
+            url += "?" + urllib.parse.urlencode(clean_params, doseq=True)
+
+        data = None
+        headers = self.headers()
+        if json_body is not None:
+            data = json.dumps(json_body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method.upper(),
+            headers=headers,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                raw = resp.read().decode("utf-8")
+                if not raw:
+                    return None
+                return json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            error_body = ""
+            try:
+                error_body = exc.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+            raise PlaneAPIError(exc.code, error_body, url) from exc
+
+    # Backward-compatible private aliases used by earlier local drafts.
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        body: Optional[dict[str, Any]] = None,
+        timeout: int = 30,
+    ) -> Any:
+        return self.request(method, path, params=params, json_body=body, timeout=timeout)
+
+    def _project_path(self) -> str:
+        return f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/"
+
+    def _work_items_path(self) -> str:
+        return self._project_path() + "work-items/"
+
+    def get_current_user(self) -> dict[str, Any]:
+        """Return the authenticated Plane user.
+
+        This intentionally exercises the same auth headers and browser-like
+        User-Agent as every other Plane request, making it suitable for a cheap
+        integration health check.
+        """
+        data = self.request("GET", "/api/v1/users/me/")
+        if isinstance(data, dict):
+            return dict(data)
+        return {}
+
+    def paginate(self, path: str, *, params: Optional[dict[str, Any]] = None) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        next_params = dict(params or {})
+        while True:
+            data = self.request("GET", path, params=next_params)
+            if isinstance(data, list):
+                out.extend(data)
+                break
+            if not isinstance(data, dict):
+                break
+            out.extend(list(data.get("results") or []))
+            if not data.get("next_page_results"):
+                break
+            cursor = data.get("next_cursor") or data.get("cursor")
+            if not cursor:
+                break
+            next_params = dict(next_params)
+            next_params["cursor"] = cursor
+        return out
+
+    def get_project(self, force: bool = False) -> dict[str, Any]:
+        if self._project_cache is None or force:
+            self._project_cache = self.request("GET", self._project_path())
+        return dict(self._project_cache or {})
+
+    def get_project_identifier(self) -> str:
+        project = self.get_project()
+        identifier = (
+            project.get("identifier")
+            or project.get("project_identifier")
+            or project.get("key")
+            or ""
+        )
+        return str(identifier).strip()
+
+    def list_states(self, force: bool = False) -> list[dict[str, Any]]:
+        if self._states_cache is None or force:
+            self._states_cache = self.paginate(
+                self._project_path() + "states/", params={"per_page": 100}
+            )
+        return [dict(x) for x in (self._states_cache or [])]
+
+    def list_labels(self, force: bool = False) -> list[dict[str, Any]]:
+        if self._labels_cache is None or force:
+            self._labels_cache = self.paginate(
+                self._project_path() + "labels/", params={"per_page": 100}
+            )
+        return [dict(x) for x in (self._labels_cache or [])]
+
+    def list_work_items(
+        self,
+        *,
+        per_page: int = 100,
+        limit: Optional[int] = None,
+        expand: Optional[Iterable[str]] = ("state", "assignees", "labels"),
+        fields: Optional[Iterable[str]] = None,
+        **filters: Any,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"per_page": min(max(int(per_page), 1), 100)}
+        if expand:
+            params["expand"] = ",".join(str(x) for x in expand if x)
+        if fields:
+            params["fields"] = ",".join(str(x) for x in fields if x)
+        for key, value in filters.items():
+            if value is not None:
+                params[key] = value
+        items = self.paginate(self._work_items_path(), params=params)
+        if limit is not None:
+            return items[: int(limit)]
+        return items
+
+    def find_work_item_by_external_id(
+        self,
+        *,
+        external_source: str,
+        external_id: str,
+    ) -> Optional[dict[str, Any]]:
+        source = str(external_source or "").strip()
+        identifier = str(external_id or "").strip()
+        if not source or not identifier:
+            return None
+
+        # Plane Cloud may support these filters directly. Keep the exact same
+        # client-side filter below as a compatibility fallback because the API
+        # has not been stable across deployments for external fields.
+        candidates = self.list_work_items(
+            external_source=source,
+            external_id=identifier,
+        )
+        for item in candidates:
+            if (
+                str(item.get("external_source") or "").strip() == source
+                and str(item.get("external_id") or "").strip() == identifier
+            ):
+                return item
+
+        # If the API ignored unknown query params or omitted external fields in
+        # filtered results, fetch a normal expanded page set and filter locally.
+        for item in self.list_work_items():
+            if (
+                str(item.get("external_source") or "").strip() == source
+                and str(item.get("external_id") or "").strip() == identifier
+            ):
+                return item
+        return None
+
+    def get_work_item_by_id(self, work_item_id: str) -> dict[str, Any]:
+        wid = str(work_item_id).strip()
+        if not wid:
+            raise ValueError("work_item_id is required")
+        return self.request("GET", self._work_items_path() + f"{wid}/")
+
+    def get_work_item_by_readable_id(self, readable_id: str) -> dict[str, Any]:
+        rid = str(readable_id).strip()
+        if not rid:
+            raise ValueError("readable_id is required")
+        return self.request("GET", f"/api/v1/workspaces/{self.workspace_slug}/work-items/{rid}/")
+
+    def get_work_item(
+        self,
+        work_item_id: Optional[str] = None,
+        *,
+        readable_id: Optional[str] = None,
+        sequence_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        if work_item_id:
+            return self.get_work_item_by_id(work_item_id)
+        if readable_id:
+            return self.get_work_item_by_readable_id(readable_id)
+        if sequence_id is not None:
+            project_identifier = self.get_project_identifier()
+            if not project_identifier:
+                raise ValueError("project identifier unavailable, cannot resolve sequence_id")
+            return self.get_work_item_by_readable_id(f"{project_identifier}-{int(sequence_id)}")
+        raise ValueError("one of work_item_id, readable_id, or sequence_id is required")
+
+    def create_work_item(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if not payload:
+            raise ValueError("payload is required")
+        return self.request("POST", self._work_items_path(), json_body=payload)
+
+    def update_work_item(self, work_item_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        wid = str(work_item_id).strip()
+        if not wid:
+            raise ValueError("work_item_id is required")
+        if not payload:
+            raise ValueError("payload is required")
+        return self.request("PATCH", self._work_items_path() + f"{wid}/", json_body=payload)
+
+    def add_comment(self, work_item_id: str, comment_html: str) -> dict[str, Any]:
+        wid = str(work_item_id).strip()
+        if not wid:
+            raise ValueError("work_item_id is required")
+        body = str(comment_html or "").strip()
+        if not body:
+            raise ValueError("comment_html is required")
+        return self.request(
+            "POST",
+            self._project_path() + f"issues/{wid}/comments/",
+            json_body={"comment_html": body},
+        )
+
+    def resolve_state_id(self, state_value: Optional[str]) -> Optional[str]:
+        if state_value is None:
+            return None
+        raw = str(state_value).strip()
+        if not raw:
+            return None
+        states = self.list_states()
+        lowered = raw.casefold()
+        for state in states:
+            sid = str(state.get("id") or "").strip()
+            if sid == raw:
+                return sid
+        for state in states:
+            if str(state.get("name") or "").strip().casefold() == lowered:
+                return str(state.get("id") or "").strip() or None
+        raise ValueError(f"Unknown Plane state: {state_value}")
+
+    def resolve_label_ids(self, labels: Optional[Iterable[str]]) -> Optional[list[str]]:
+        if labels is None:
+            return None
+        raw_labels = [str(x).strip() for x in labels if str(x).strip()]
+        if not raw_labels:
+            return []
+        known = self.list_labels()
+        by_id = {
+            str(item.get("id") or "").strip(): str(item.get("id") or "").strip()
+            for item in known
+            if str(item.get("id") or "").strip()
+        }
+        by_name = {
+            str(item.get("name") or "").strip().casefold(): str(item.get("id") or "").strip()
+            for item in known
+            if str(item.get("name") or "").strip()
+        }
+        resolved: list[str] = []
+        for value in raw_labels:
+            if value in by_id:
+                resolved.append(by_id[value])
+                continue
+            match = by_name.get(value.casefold())
+            if match:
+                resolved.append(match)
+                continue
+            raise ValueError(f"Unknown Plane label: {value}")
+        out: list[str] = []
+        seen: set[str] = set()
+        for item in resolved:
+            if item not in seen:
+                out.append(item)
+                seen.add(item)
+        return out

--- a/tools/plane_client.py
+++ b/tools/plane_client.py
@@ -23,6 +23,7 @@ BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
 )
+UNSUPPORTED_EXTERNAL_FILTER_STATUS_CODES = {400, 404, 422}
 
 
 class PlaneConfigurationError(ValueError):
@@ -264,10 +265,19 @@ class PlaneClient:
         # Plane Cloud may support these filters directly. Keep the exact same
         # client-side filter below as a compatibility fallback because the API
         # has not been stable across deployments for external fields.
-        candidates = self.list_work_items(
-            external_source=source,
-            external_id=identifier,
-        )
+        try:
+            candidates = self.list_work_items(
+                external_source=source,
+                external_id=identifier,
+            )
+        except PlaneAPIError as exc:
+            # Plane Cloud may reject these query params on some deployments.
+            # Treat the filtered lookup as best effort, then fall back to a
+            # normal expanded board scan below.
+            if exc.status_code in UNSUPPORTED_EXTERNAL_FILTER_STATUS_CODES:
+                candidates = []
+            else:
+                raise
         for item in candidates:
             if (
                 str(item.get("external_source") or "").strip() == source

--- a/tools/plane_tool.py
+++ b/tools/plane_tool.py
@@ -1,0 +1,1121 @@
+"""Plane tools — Hermes action layer for Plane work items.
+
+Plane remains the source of truth. These tools provide explicit read/create/update
+operations and an opt-in bridge to Hermes kanban execution tasks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_cli.env_loader import load_hermes_dotenv
+from tools.plane_client import PlaneAPIError, PlaneClient
+from tools.registry import registry, tool_error
+
+PROJECT_KEY_FALLBACK = "AIFACTORY"
+DEFAULT_WORKDIR_BASE = "/home/emeric/AI Factory"
+
+
+def _ok(**fields: Any) -> str:
+    return json.dumps({"success": True, **fields}, ensure_ascii=False)
+
+
+def _check_plane_requirements() -> bool:
+    try:
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except OSError:
+        # Missing or unreadable .env is non-fatal: env vars may be exported
+        # in the shell. Any other failure (parse error, programmer bug) must
+        # surface and is not swallowed here.
+        pass
+    return all(
+        (os.getenv(name) or "").strip()
+        for name in ("PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID")
+    )
+
+
+def get_plane_client() -> PlaneClient:
+    return _client()
+
+
+# Compatibility alias for earlier local tests and drafts.
+def _client() -> PlaneClient:
+    return PlaneClient.from_env()
+
+
+def _client_workspace(client: PlaneClient) -> str:
+    config = getattr(client, "config", None)
+    return str(getattr(config, "workspace_slug", None) or getattr(client, "workspace_slug", ""))
+
+
+def _client_project_id(client: PlaneClient) -> str:
+    config = getattr(client, "config", None)
+    return str(getattr(config, "project_id", None) or getattr(client, "project_id", ""))
+
+
+def _project_key(client: PlaneClient, project: Optional[dict[str, Any]] = None) -> str:
+    project = project or {}
+    key = (
+        project.get("identifier")
+        or project.get("project_identifier")
+        or project.get("key")
+        or ""
+    )
+    if not key and hasattr(client, "get_project_identifier"):
+        try:
+            key = client.get_project_identifier()
+        except Exception:
+            key = ""
+    return str(key or PROJECT_KEY_FALLBACK).strip().upper()
+
+
+def _sequence_id(item: dict[str, Any]) -> Optional[int]:
+    value = item.get("sequence_id") or item.get("sequence")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _state_name(item: dict[str, Any]) -> str:
+    state = item.get("state")
+    if isinstance(state, dict):
+        return str(state.get("name") or state.get("id") or "").strip()
+    return str(state or "").strip()
+
+
+def _state_id(item: dict[str, Any]) -> Optional[str]:
+    state = item.get("state")
+    if isinstance(state, dict):
+        return str(state.get("id") or "").strip() or None
+    return None
+
+
+def _state_group(state: dict[str, Any]) -> Optional[str]:
+    group = state.get("group") or state.get("state_group")
+    return str(group).strip() if group is not None and str(group).strip() else None
+
+
+def _labels(item: dict[str, Any]) -> list[str]:
+    raw = item.get("labels") or []
+    if not isinstance(raw, list):
+        return []
+    return [str(x.get("name") if isinstance(x, dict) else x).strip() for x in raw if str(x).strip()]
+
+
+def _assignees(item: dict[str, Any]) -> list[str]:
+    raw = item.get("assignees") or []
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for assignee in raw:
+        if isinstance(assignee, dict):
+            name = assignee.get("display_name") or assignee.get("name") or assignee.get("email") or assignee.get("id")
+        else:
+            name = assignee
+        if str(name or "").strip():
+            out.append(str(name).strip())
+    return out
+
+
+def _summarize_user(user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": user.get("id"),
+        "email": user.get("email"),
+        "display_name": user.get("display_name") or user.get("name") or user.get("first_name"),
+    }
+
+
+def _summarize_project(project: dict[str, Any], client: PlaneClient) -> dict[str, Any]:
+    return {
+        "id": project.get("id") or _client_project_id(client),
+        "name": project.get("name"),
+        "identifier": _project_key(client, project),
+    }
+
+
+def _plane_url(client: PlaneClient, item: dict[str, Any], project: Optional[dict[str, Any]] = None) -> str:
+    seq = _sequence_id(item)
+    key = _project_key(client, project)
+    workspace = _client_workspace(client)
+    project_id = _client_project_id(client)
+    if seq is not None:
+        return f"https://app.plane.so/{workspace}/projects/{project_id}/issues/{key}-{seq}"
+    wid = item.get("id") or ""
+    return f"https://app.plane.so/{workspace}/projects/{project_id}/issues/{wid}"
+
+
+def _strip_html(value: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", str(value or ""))
+    return " ".join(html.unescape(text).split())
+
+
+def _compact_project(project: dict[str, Any]) -> dict[str, Any]:
+    """Compact project projection returned by read tools by default."""
+    return {
+        "id": project.get("id"),
+        "name": project.get("name"),
+        "identifier": project.get("identifier") or project.get("project_identifier") or project.get("key"),
+    }
+
+
+def _compact_state(state: dict[str, Any], count: int = 0) -> dict[str, Any]:
+    """Compact state projection returned by read tools by default."""
+    return {
+        "id": state.get("id"),
+        "name": state.get("name") or state.get("id"),
+        "group": _state_group(state),
+        "count": count,
+    }
+
+
+def _summarize_item(client: PlaneClient, item: dict[str, Any], project: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Compact work-item projection returned by read tools by default.
+
+    Contract: {id, sequence_id, readable_id, name, state_name, state_id,
+    priority, labels, assignees_names, url}. Full Plane payloads are only
+    returned by read tools when verbose=True.
+    """
+    seq = _sequence_id(item)
+    key = _project_key(client, project)
+    readable_id = f"{key}-{seq}" if seq is not None else None
+    return {
+        "id": item.get("id"),
+        "sequence_id": seq,
+        "readable_id": readable_id,
+        "name": item.get("name") or item.get("title"),
+        "priority": item.get("priority"),
+        "state_name": _state_name(item),
+        "state_id": _state_id(item),
+        "labels": _labels(item),
+        "assignees_names": _assignees(item),
+        "url": _plane_url(client, item, project),
+    }
+
+
+def _enrich_item(client: PlaneClient, item: dict[str, Any], project: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    enriched = dict(item)
+    enriched.update(_summarize_item(client, item, project))
+    return enriched
+
+
+def _matches_filter(value: Optional[str], candidates: Iterable[str]) -> bool:
+    if value is None or str(value).strip() == "":
+        return True
+    needle = str(value).strip().casefold()
+    return any(needle in str(candidate).casefold() for candidate in candidates)
+
+
+def _filter_items(items: list[dict[str, Any]], args: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not _matches_filter(args.get("state"), [_state_name(item), _state_id(item) or ""]):
+            continue
+        if not _matches_filter(args.get("label"), _labels(item)):
+            continue
+        if not _matches_filter(args.get("assignee"), _assignees(item)):
+            continue
+        if args.get("priority") and str(item.get("priority") or "").casefold() != str(args["priority"]).casefold():
+            continue
+        query = args.get("query")
+        if query:
+            text = " ".join(
+                str(item.get(field) or "")
+                for field in ("name", "title", "description_html", "description_stripped")
+            )
+            if str(query).casefold() not in text.casefold():
+                continue
+        out.append(item)
+    return out
+
+
+def _resolve_item(client: PlaneClient, *, work_item_id: Optional[str] = None, sequence_id: Optional[Any] = None) -> dict[str, Any]:
+    if work_item_id:
+        try:
+            return client.get_work_item(str(work_item_id))
+        except TypeError:
+            return client.get_work_item(work_item_id=str(work_item_id))
+    if sequence_id is not None:
+        seq = int(sequence_id)
+        for item in client.list_work_items():
+            if _sequence_id(item) == seq:
+                return item
+        try:
+            return client.get_work_item(sequence_id=seq)
+        except TypeError:
+            pass
+    raise ValueError("work_item_id or sequence_id is required")
+
+
+def _markdown_to_html(markdown: str) -> str:
+    escaped = html.escape(str(markdown)).replace("\n", "<br>")
+    return f"<p>{escaped}</p>"
+
+
+def _comment_markdown(body_markdown: str, *, prefix: bool = True) -> str:
+    body = str(body_markdown or "").strip()
+    if not body:
+        raise ValueError("body_markdown is required")
+    if prefix and not body.startswith("[Nova]"):
+        return f"[Nova] {body}"
+    return body
+
+
+def _parse_plane_linkage_from_body(body: Optional[str]) -> dict[str, Any]:
+    """Extract Plane linkage fields from a Hermes kanban task body.
+
+    ``plane_import_to_kanban`` stores the foreign keys as simple
+    ``plane_*: value`` lines in the task body. Keep this parser deliberately
+    small and tolerant so imported cards created by older drafts remain usable.
+    """
+    fields: dict[str, Any] = {}
+    for line in str(body or "").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key.startswith("plane_"):
+            continue
+        fields[key] = value.strip()
+    if "plane_sequence_id" in fields:
+        try:
+            fields["plane_sequence_id"] = int(fields["plane_sequence_id"])
+        except (TypeError, ValueError):
+            fields.pop("plane_sequence_id", None)
+    return fields
+
+
+def _lookup_plane_link_from_kanban_task(hermes_card_id: str) -> dict[str, Any]:
+    card_id = str(hermes_card_id or "").strip()
+    if not card_id:
+        raise ValueError("hermes_card_id is required")
+
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, card_id)
+    finally:
+        conn.close()
+    if task is None:
+        raise ValueError(f"Hermes kanban task not found: {card_id}")
+
+    linkage = _parse_plane_linkage_from_body(task.body)
+    work_item_id = str(linkage.get("plane_work_item_id") or "").strip()
+    sequence_id = linkage.get("plane_sequence_id")
+    if not work_item_id and sequence_id is None:
+        raise ValueError(f"Hermes kanban task {card_id} is not linked to a Plane work item")
+    linkage["hermes_card_id"] = card_id
+    return linkage
+
+
+def _resolve_state_id(client: PlaneClient, value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    if hasattr(client, "resolve_state_id"):
+        return client.resolve_state_id(value)
+    raw = str(value).strip()
+    for state in client.list_states():
+        if raw == str(state.get("id") or ""):
+            return raw
+        if raw.casefold() == str(state.get("name") or "").casefold():
+            return str(state.get("id") or "")
+    raise ValueError(f"Unknown Plane state: {value}")
+
+
+def _canonical_external_source(args: dict[str, Any]) -> str:
+    return str(args.get("external_source") or "nova-hermes").strip() or "nova-hermes"
+
+
+def _fallback_external_id(args: dict[str, Any], client: PlaneClient, external_source: str) -> str:
+    # Explicit V1 fallback contract: if the caller does not provide an
+    # external_id, derive one from the stable creation identity: workspace,
+    # project, external source, and normalized name. Optional mutable fields
+    # such as description, labels, state, and dates are deliberately excluded
+    # so retries with small payload differences still deduplicate.
+    name = " ".join(str(args.get("name") or "").split()).casefold()
+    if not name:
+        raise ValueError("name is required")
+    basis = "\0".join([
+        _client_workspace(client),
+        _client_project_id(client),
+        external_source,
+        name,
+    ])
+    digest = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
+    return f"plane-create:{digest}"
+
+
+def _prepare_create_idempotency(args: dict[str, Any], client: PlaneClient) -> tuple[str, str, bool]:
+    external_source = _canonical_external_source(args)
+    provided = args.get("external_id") is not None and str(args.get("external_id") or "").strip() != ""
+    external_id = str(args.get("external_id") or "").strip()
+    if not external_id:
+        external_id = _fallback_external_id(args, client, external_source)
+    return external_source, external_id, provided
+
+
+def _find_existing_by_external_id(client: PlaneClient, external_source: str, external_id: str) -> Optional[dict[str, Any]]:
+    if hasattr(client, "find_work_item_by_external_id"):
+        return client.find_work_item_by_external_id(
+            external_source=external_source,
+            external_id=external_id,
+        )
+    for item in client.list_work_items():
+        if (
+            str(item.get("external_source") or "").strip() == external_source
+            and str(item.get("external_id") or "").strip() == external_id
+        ):
+            return item
+    return None
+
+
+def _build_work_item_payload(args: dict[str, Any], client: PlaneClient, *, require_name: bool = False) -> dict[str, Any]:
+    # PATCH partial contract: a field passed as None (or absent) is ignored
+    # and never sent to Plane. Only explicitly-provided non-null fields are
+    # forwarded. Empty list ([]) for assignees/labels is explicit "clear".
+    payload: dict[str, Any] = {}
+    if args.get("name"):
+        payload["name"] = str(args["name"]).strip()
+    elif require_name:
+        raise ValueError("name is required")
+
+    if args.get("description_html"):
+        payload["description_html"] = str(args["description_html"])
+    elif args.get("description_markdown"):
+        payload["description_html"] = _markdown_to_html(str(args["description_markdown"]))
+
+    for key in ("priority", "start_date", "target_date", "external_id"):
+        if args.get(key) is not None:
+            payload[key] = args[key]
+
+    if "external_source" in args:
+        payload["external_source"] = args.get("external_source") or "nova-hermes"
+    elif require_name:
+        payload["external_source"] = "nova-hermes"
+
+    state_id = _resolve_state_id(client, args.get("state"))
+    if state_id:
+        payload["state_id"] = state_id
+        payload["state"] = state_id
+
+    if args.get("assignees") is not None:
+        payload["assignees"] = args.get("assignees") or []
+
+    if args.get("labels") is not None:
+        if hasattr(client, "resolve_label_ids"):
+            payload["labels"] = client.resolve_label_ids(args.get("labels"))
+        else:
+            payload["labels"] = args.get("labels") or []
+
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def _safe_slug(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug[:80] or "work-item"
+
+
+def prepare_workdir(
+    sequence_id: int,
+    title: str,
+    base_dir: str = DEFAULT_WORKDIR_BASE,
+    *,
+    project_key: Optional[str] = None,
+) -> str:
+    key = str(project_key or "").strip().upper() or PROJECT_KEY_FALLBACK
+    base = Path(base_dir).expanduser()
+    workdir = base / f"{key}-{int(sequence_id)}_{_safe_slug(title)}"
+    (workdir / "work").mkdir(parents=True, exist_ok=True)
+    (workdir / "deliverables").mkdir(parents=True, exist_ok=True)
+    readme = workdir / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            f"# {key}-{int(sequence_id)} {title}\n\n"
+            "## Objectif\n\n"
+            "À compléter.\n\n"
+            "## Livrables\n\n"
+            "Déposer les livrables dans `deliverables/`.\n",
+            encoding="utf-8",
+        )
+    return str(workdir)
+
+
+def _handle_board_snapshot(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        project = client.get_project()
+        states = client.list_states()
+        items = client.list_work_items()
+        verbose = bool(args.get("verbose"))
+        counts = {str(state.get("name") or state.get("id") or ""): 0 for state in states}
+        for item in items:
+            state = _state_name(item) or "No state"
+            counts[state] = counts.get(state, 0) + 1
+        state_rows = [_compact_state(state, counts.get(str(state.get("name") or state.get("id") or ""), 0)) for state in states]
+        result = {
+            "project": _compact_project(project),
+            "states": state_rows,
+            "counts_by_state": counts,
+            "total_items": len(items),
+            "items": [_summarize_item(client, item, project) for item in items[: int(args.get("limit") or 20)]],
+        }
+        if args.get("include_items_per_state"):
+            per_state_limit = int(args.get("per_state_limit") or 5)
+            grouped: dict[str, list[dict[str, Any]]] = {}
+            for item in items:
+                state = _state_name(item) or "No state"
+                grouped.setdefault(state, [])
+                if len(grouped[state]) < per_state_limit:
+                    grouped[state].append(_summarize_item(client, item, project))
+            result["items_by_state"] = grouped
+        if verbose:
+            result.update({
+                "project_payload": project,
+                "states_payload": states,
+                "items_payload": items,
+            })
+        return _ok(**result)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_list_work_items(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        project = client.get_project()
+        limit = int(args.get("limit") or 50)
+        verbose = bool(args.get("verbose"))
+        items = _filter_items(client.list_work_items(), args)[:limit]
+        result = {"items": [_summarize_item(client, item, project) for item in items], "count": len(items)}
+        if verbose:
+            result["items_payload"] = items
+        return _ok(**result)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_get_work_item(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        project = client.get_project()
+        item = _resolve_item(
+            client,
+            work_item_id=args.get("work_item_id"),
+            sequence_id=args.get("sequence_id"),
+        )
+        result = {"item": _summarize_item(client, item, project)}
+        if args.get("verbose"):
+            result["payload"] = item
+            result["enriched_item"] = _enrich_item(client, item, project)
+        return _ok(**result)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_create_work_item(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        project = client.get_project()
+        external_source, external_id, external_id_provided = _prepare_create_idempotency(args, client)
+        create_args = {**args, "external_source": external_source, "external_id": external_id}
+        existing = _find_existing_by_external_id(client, external_source, external_id)
+        if existing:
+            enriched = _enrich_item(client, existing, project)
+            return _ok(
+                item=enriched,
+                created=None,
+                already_existed=True,
+                external_source=external_source,
+                external_id=external_id,
+                external_id_generated=not external_id_provided,
+            )
+
+        payload = _build_work_item_payload(create_args, client, require_name=True)
+        try:
+            item = client.create_work_item(payload)
+        except PlaneAPIError as exc:
+            # Plane server-side uniqueness on external_source + external_id
+            # surfaces as 409 when the pre-create lookup missed the existing
+            # card. Re-scan and treat the conflict as a clean idempotent hit.
+            if exc.status_code == 409:
+                recovered = _find_existing_by_external_id(client, external_source, external_id)
+                if recovered:
+                    enriched = _enrich_item(client, recovered, project)
+                    return _ok(
+                        item=enriched,
+                        created=None,
+                        already_existed=True,
+                        external_source=external_source,
+                        external_id=external_id,
+                        external_id_generated=not external_id_provided,
+                    )
+            raise
+        enriched = _enrich_item(client, item, project)
+        return _ok(
+            item=enriched,
+            created=enriched,
+            already_existed=False,
+            external_source=external_source,
+            external_id=external_id,
+            external_id_generated=not external_id_provided,
+        )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_update_work_item(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        work_item_id = str(args.get("work_item_id") or "").strip()
+        if not work_item_id:
+            raise ValueError("work_item_id is required")
+        payload = _build_work_item_payload(args, client, require_name=False)
+        if not payload:
+            raise ValueError("at least one updatable field is required")
+        item = client.update_work_item(work_item_id, payload)
+        return _ok(item=item)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_add_comment(args: dict[str, Any], **kw) -> str:
+    try:
+        client = get_plane_client()
+        item = _resolve_item(
+            client,
+            work_item_id=args.get("work_item_id"),
+            sequence_id=args.get("sequence_id"),
+        )
+        work_item_id = str(item.get("id") or args.get("work_item_id") or "").strip()
+        if not work_item_id:
+            raise ValueError("resolved Plane work item has no id")
+        body_markdown = _comment_markdown(
+            str(args.get("body_markdown") or ""),
+            prefix=bool(args.get("prefix", True)),
+        )
+        comment_html = _markdown_to_html(body_markdown)
+        comment = client.add_comment(work_item_id, comment_html)
+        project = client.get_project()
+        return _ok(
+            comment=comment,
+            item=_summarize_item(client, item, project),
+            comment_html=comment_html,
+        )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_sync_progress(args: dict[str, Any], **kw) -> str:
+    try:
+        hermes_card_id = str(
+            args.get("hermes_card_id")
+            or kw.get("task_id")
+            or os.getenv("HERMES_KANBAN_TASK")
+            or ""
+        ).strip()
+        summary = str(args.get("summary") or args.get("body_markdown") or "").strip()
+        if not summary:
+            raise ValueError("summary is required")
+
+        linkage = _lookup_plane_link_from_kanban_task(hermes_card_id)
+        client = get_plane_client()
+        item = _resolve_item(
+            client,
+            work_item_id=linkage.get("plane_work_item_id"),
+            sequence_id=linkage.get("plane_sequence_id"),
+        )
+        work_item_id = str(item.get("id") or linkage.get("plane_work_item_id") or "").strip()
+        if not work_item_id:
+            raise ValueError("resolved Plane work item has no id")
+
+        status = str(args.get("status") or "").strip()
+        status_update = None
+        if status:
+            state_id = _resolve_state_id(client, status)
+            if not state_id:
+                raise ValueError(f"Unknown Plane state: {status}")
+            payload = {"state_id": state_id, "state": state_id}
+            status_update = client.update_work_item(work_item_id, payload)
+            if isinstance(status_update, dict):
+                item = status_update
+
+        body_markdown = _comment_markdown(
+            summary,
+            prefix=bool(args.get("prefix", True)),
+        )
+        comment_html = _markdown_to_html(body_markdown)
+        comment = client.add_comment(work_item_id, comment_html)
+        project = client.get_project()
+        return _ok(
+            hermes_card_id=hermes_card_id,
+            plane_linkage=linkage,
+            item=_summarize_item(client, item, project),
+            plane_url=_plane_url(client, item, project),
+            comment=comment,
+            comment_html=comment_html,
+            status=status or None,
+            status_updated=bool(status),
+            status_update=status_update,
+        )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_ping(args: dict[str, Any], **kw) -> str:
+    started = time.perf_counter()
+    try:
+        client = get_plane_client()
+        user = client.get_current_user() if hasattr(client, "get_current_user") else {}
+        project = client.get_project()
+        latency_ms = int(round((time.perf_counter() - started) * 1000))
+        return _ok(
+            ok=True,
+            latency_ms=latency_ms,
+            user=user,
+            user_email=user.get("email") or user.get("display_email") or "",
+            workspace=_client_workspace(client),
+            project=project,
+            project_name=project.get("name") or "",
+            project_identifier=_project_key(client, project),
+        )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_prepare_workdir(args: dict[str, Any], **kw) -> str:
+    try:
+        sequence_id = args.get("sequence_id")
+        title = str(args.get("title") or "").strip()
+        if sequence_id is None:
+            raise ValueError("sequence_id is required")
+        if not title:
+            raise ValueError("title is required")
+        project_key = str(args.get("project_key") or "").strip() or None
+        if not project_key and _check_plane_requirements():
+            try:
+                project_key = get_plane_client().get_project_identifier() or None
+            except Exception:
+                project_key = None
+        workdir = prepare_workdir(
+            int(sequence_id),
+            title,
+            args.get("base_dir") or DEFAULT_WORKDIR_BASE,
+            project_key=project_key,
+        )
+        return _ok(workdir=workdir)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _selected_items(client: PlaneClient, args: dict[str, Any]) -> list[dict[str, Any]]:
+    items = []
+    for wid in args.get("work_item_ids") or []:
+        items.append(_resolve_item(client, work_item_id=wid))
+    for seq in args.get("sequence_ids") or []:
+        items.append(_resolve_item(client, sequence_id=seq))
+    if not items:
+        raise ValueError("work_item_ids or sequence_ids is required")
+    return items
+
+
+def _handle_import_to_kanban(args: dict[str, Any], **kw) -> str:
+    try:
+        assignee = str(args.get("assignee") or "").strip()
+        if not assignee:
+            raise ValueError("assignee is required")
+        client = get_plane_client()
+        project = client.get_project()
+        key = _project_key(client, project)
+        create_workdir = bool(args.get("create_workdir"))
+        priority = int(args.get("priority") or 0)
+        workspace_kind = str(args.get("workspace") or "scratch").strip()
+        created = []
+
+        from hermes_cli import kanban_db as kb
+
+        kb.init_db()
+        conn = kb.connect()
+        try:
+            for item in _selected_items(client, args):
+                seq = _sequence_id(item)
+                if seq is None:
+                    raise ValueError(f"Plane item {item.get('id')} has no sequence_id")
+                title = str(item.get("name") or item.get("title") or f"Plane {key}-{seq}").strip()
+                plane_url = _plane_url(client, item, project)
+                workdir = None
+                task_workspace_kind = workspace_kind
+                task_workspace_path = None
+                if create_workdir:
+                    workdir = prepare_workdir(
+                        seq,
+                        title,
+                        args.get("workdir_base_dir") or DEFAULT_WORKDIR_BASE,
+                        project_key=key,
+                    )
+                    task_workspace_kind = "dir"
+                    task_workspace_path = workdir
+                elif workspace_kind == "dir" and args.get("workspace_path"):
+                    task_workspace_path = str(args["workspace_path"])
+
+                body = "\n".join(
+                    [
+                        f"Imported from Plane {key}-{seq}: {title}",
+                        "",
+                        f"plane_workspace_slug: {client.config.workspace_slug}",
+                        f"plane_project_id: {client.config.project_id}",
+                        f"plane_work_item_id: {item.get('id')}",
+                        f"plane_sequence_id: {seq}",
+                        f"plane_url: {plane_url}",
+                        f"plane_state_id: {_state_id(item) or ''}",
+                        "",
+                        f"State at import: {_state_name(item) or 'unknown'}",
+                        f"Priority: {item.get('priority') or ''}",
+                        "",
+                        str(item.get("description_html") or item.get("description_stripped") or ""),
+                    ]
+                )
+                idempotency_key = (
+                    f"plane:{client.config.workspace_slug}:"
+                    f"{client.config.project_id}:{item.get('id')}"
+                )
+                # Pre-check the idempotency key so we can surface
+                # already_imported=True to the caller. kb.create_task itself
+                # is already idempotent and will return the existing task id.
+                existing_row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                already_imported = existing_row is not None
+                task_id = kb.create_task(
+                    conn,
+                    title=f"[Plane {key}-{seq}] {title}",
+                    body=body,
+                    assignee=assignee,
+                    created_by=os.getenv("HERMES_PROFILE") or "plane_tool",
+                    workspace_kind=task_workspace_kind,
+                    workspace_path=task_workspace_path,
+                    priority=priority,
+                    idempotency_key=idempotency_key,
+                )
+                created.append(
+                    {
+                        "task_id": task_id,
+                        "plane_work_item_id": item.get("id"),
+                        "plane_sequence_id": seq,
+                        "workdir": workdir,
+                        "already_imported": already_imported,
+                    }
+                )
+        finally:
+            conn.close()
+        return _ok(created_tasks=created)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+# Function-style wrappers kept for tests and direct module use.
+def plane_board_snapshot_tool(include_items_per_state: bool = False, per_state_limit: int = 5, **kwargs) -> str:
+    return _handle_board_snapshot({
+        "include_items_per_state": include_items_per_state,
+        "per_state_limit": per_state_limit,
+        **kwargs,
+    })
+
+
+def plane_ping_tool(args: Optional[dict[str, Any]] = None) -> str:
+    return _handle_ping(args or {})
+
+
+def plane_list_work_items_tool(args: dict[str, Any]) -> str:
+    return _handle_list_work_items(args)
+
+
+def plane_get_work_item_tool(args: dict[str, Any]) -> str:
+    return _handle_get_work_item(args)
+
+
+def plane_create_work_item_tool(args: dict[str, Any]) -> str:
+    return _handle_create_work_item(args)
+
+
+def plane_update_work_item_tool(args: dict[str, Any]) -> str:
+    return _handle_update_work_item(args)
+
+
+def plane_add_comment_tool(args: dict[str, Any]) -> str:
+    return _handle_add_comment(args)
+
+
+def plane_sync_progress_tool(args: dict[str, Any]) -> str:
+    return _handle_sync_progress(args)
+
+
+def plane_prepare_workdir_tool(args: dict[str, Any]) -> str:
+    if args.get("sequence_id") is None and args.get("readable_id"):
+        match = re.search(r"(\d+)$", str(args.get("readable_id")))
+        if match:
+            args = {**args, "sequence_id": int(match.group(1))}
+    out = json.loads(_handle_prepare_workdir(args))
+    if "workdir" in out:
+        out["task_dir"] = out["workdir"]
+    return json.dumps(out, ensure_ascii=False)
+
+
+def plane_import_to_kanban_tool(args: dict[str, Any]) -> str:
+    return _handle_import_to_kanban(args)
+
+
+PLANE_BOARD_SNAPSHOT_SCHEMA = {
+    "name": "plane_board_snapshot",
+    "description": "Read a compact snapshot of the configured Plane project. Default output: {project:{id,name,identifier}, states:[{id,name,group,count}], counts_by_state, total_items, items:[compact work items]}. Compact work item: {id, sequence_id, readable_id, name, state_name, state_id, priority, labels, assignees_names, url}. Set verbose=True to also include raw project_payload, states_payload, and items_payload.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "include_items_per_state": {"type": "boolean", "default": False},
+            "per_state_limit": {"type": "integer", "default": 5},
+            "limit": {"type": "integer", "default": 20},
+            "verbose": {"type": "boolean", "default": False},
+        },
+    },
+}
+
+PLANE_PING_SCHEMA = {
+    "name": "plane_ping",
+    "description": "Health check the Plane integration: verifies auth, browser-like User-Agent, network, and configured project access.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
+
+PLANE_LIST_WORK_ITEMS_SCHEMA = {
+    "name": "plane_list_work_items",
+    "description": "List Plane work items with optional client-side filters. Default output: {count, items:[{id, sequence_id, readable_id, name, state_name, state_id, priority, labels, assignees_names, url}]}. Set verbose=True to also include raw items_payload.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "state": {"type": "string"},
+            "label": {"type": "string"},
+            "assignee": {"type": "string"},
+            "priority": {"type": "string"},
+            "query": {"type": "string"},
+            "limit": {"type": "integer", "default": 50},
+            "verbose": {"type": "boolean", "default": False},
+        },
+    },
+}
+
+PLANE_GET_WORK_ITEM_SCHEMA = {
+    "name": "plane_get_work_item",
+    "description": "Get a Plane work item by UUID or project sequence number. Default output: {item:{id, sequence_id, readable_id, name, state_name, state_id, priority, labels, assignees_names, url}}. Set verbose=True to also include raw payload and enriched_item.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "work_item_id": {"type": "string"},
+            "sequence_id": {"type": "integer"},
+            "verbose": {"type": "boolean", "default": False},
+        },
+    },
+}
+
+_CREATE_UPDATE_PROPERTIES = {
+    "name": {"type": "string"},
+    "description_html": {"type": "string"},
+    "description_markdown": {"type": "string"},
+    "priority": {"type": "string"},
+    "state": {"type": "string"},
+    "labels": {"type": "array", "items": {"type": "string"}},
+    "assignees": {"type": "array", "items": {"type": "string"}},
+    "start_date": {"type": "string"},
+    "target_date": {"type": "string"},
+    "external_source": {"type": "string", "default": "nova-hermes"},
+    "external_id": {"type": "string"},
+}
+
+PLANE_CREATE_WORK_ITEM_SCHEMA = {
+    "name": "plane_create_work_item",
+    "description": "Create a Plane work item explicitly requested by the user. Idempotent by external_source + external_id; if external_id is omitted, Hermes generates a stable id from workspace, project, source, and normalized name. No delete operation is exposed.",
+    "parameters": {
+        "type": "object",
+        "properties": _CREATE_UPDATE_PROPERTIES,
+        "required": ["name"],
+    },
+}
+
+PLANE_UPDATE_WORK_ITEM_SCHEMA = {
+    "name": "plane_update_work_item",
+    "description": "Update selected fields of an existing Plane work item.",
+    "parameters": {
+        "type": "object",
+        "properties": {"work_item_id": {"type": "string"}, **_CREATE_UPDATE_PROPERTIES},
+        "required": ["work_item_id"],
+    },
+}
+
+PLANE_ADD_COMMENT_SCHEMA = {
+    "name": "plane_add_comment",
+    "description": "Add a comment to a Plane work item by UUID or project sequence number. body_markdown is converted to simple HTML; prefix defaults to true and prepends [Nova].",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "work_item_id": {"type": "string"},
+            "sequence_id": {"type": "integer"},
+            "body_markdown": {"type": "string"},
+            "prefix": {"type": "boolean", "default": True},
+        },
+        "required": ["body_markdown"],
+    },
+}
+
+PLANE_SYNC_PROGRESS_SCHEMA = {
+    "name": "plane_sync_progress",
+    "description": "Reflect progress from an imported Hermes kanban task back to Plane: finds the linked Plane work item from the Hermes card body, posts a progress comment, and optionally updates the Plane state when status is provided. hermes_card_id defaults to the current kanban task when available.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "hermes_card_id": {"type": "string"},
+            "summary": {"type": "string"},
+            "status": {"type": "string"},
+            "prefix": {"type": "boolean", "default": True},
+        },
+        "required": ["summary"],
+    },
+}
+
+PLANE_IMPORT_TO_KANBAN_SCHEMA = {
+    "name": "plane_import_to_kanban",
+    "description": "Explicitly import one or more Plane work items into Hermes kanban execution tasks, preserving Plane IDs in the body.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "work_item_ids": {"type": "array", "items": {"type": "string"}},
+            "sequence_ids": {"type": "array", "items": {"type": "integer"}},
+            "assignee": {"type": "string"},
+            "workspace": {"type": "string", "default": "scratch"},
+            "workspace_path": {"type": "string"},
+            "priority": {"type": "integer"},
+            "create_workdir": {"type": "boolean", "default": False},
+            "workdir_base_dir": {"type": "string", "default": DEFAULT_WORKDIR_BASE},
+        },
+        "required": ["assignee"],
+    },
+}
+
+PLANE_PREPARE_WORKDIR_SCHEMA = {
+    "name": "plane_prepare_workdir",
+    "description": "Create the canonical local AI Factory work directory for a Plane sequence id. If project_key is omitted, Hermes will resolve it from the configured Plane project when available, falling back to AIFACTORY otherwise.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "sequence_id": {"type": "integer"},
+            "title": {"type": "string"},
+            "base_dir": {"type": "string", "default": DEFAULT_WORKDIR_BASE},
+            "project_key": {"type": "string"},
+        },
+        "required": ["sequence_id", "title"],
+    },
+}
+
+registry.register(
+    name="plane_ping",
+    toolset="plane",
+    schema=PLANE_PING_SCHEMA,
+    handler=_handle_ping,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_board_snapshot",
+    toolset="plane",
+    schema=PLANE_BOARD_SNAPSHOT_SCHEMA,
+    handler=_handle_board_snapshot,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_list_work_items",
+    toolset="plane",
+    schema=PLANE_LIST_WORK_ITEMS_SCHEMA,
+    handler=_handle_list_work_items,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_get_work_item",
+    toolset="plane",
+    schema=PLANE_GET_WORK_ITEM_SCHEMA,
+    handler=_handle_get_work_item,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_create_work_item",
+    toolset="plane",
+    schema=PLANE_CREATE_WORK_ITEM_SCHEMA,
+    handler=_handle_create_work_item,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_update_work_item",
+    toolset="plane",
+    schema=PLANE_UPDATE_WORK_ITEM_SCHEMA,
+    handler=_handle_update_work_item,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_add_comment",
+    toolset="plane",
+    schema=PLANE_ADD_COMMENT_SCHEMA,
+    handler=_handle_add_comment,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_sync_progress",
+    toolset="plane",
+    schema=PLANE_SYNC_PROGRESS_SCHEMA,
+    handler=_handle_sync_progress,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_import_to_kanban",
+    toolset="plane",
+    schema=PLANE_IMPORT_TO_KANBAN_SCHEMA,
+    handler=_handle_import_to_kanban,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_prepare_workdir",
+    toolset="plane",
+    schema=PLANE_PREPARE_WORKDIR_SCHEMA,
+    handler=_handle_prepare_workdir,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)

--- a/tools/plane_tool.py
+++ b/tools/plane_tool.py
@@ -85,23 +85,56 @@ def _sequence_id(item: dict[str, Any]) -> Optional[int]:
         return None
 
 
-def _state_name(item: dict[str, Any]) -> str:
+def _resolve_state_payload(client: Optional[PlaneClient], item: dict[str, Any]) -> Optional[dict[str, Any]]:
+    state = item.get("state")
+    if isinstance(state, dict):
+        return state
+    raw = str(state or "").strip()
+    if not raw or client is None or not hasattr(client, "list_states"):
+        return None
+    try:
+        for candidate in client.list_states():
+            candidate_id = str(candidate.get("id") or "").strip()
+            if candidate_id == raw:
+                return candidate
+    except Exception:
+        return None
+    return None
+
+
+def _state_name(item: dict[str, Any], client: Optional[PlaneClient] = None) -> str:
+    resolved = _resolve_state_payload(client, item)
+    if resolved is not None:
+        return str(resolved.get("name") or resolved.get("id") or "").strip()
     state = item.get("state")
     if isinstance(state, dict):
         return str(state.get("name") or state.get("id") or "").strip()
     return str(state or "").strip()
 
 
-def _state_id(item: dict[str, Any]) -> Optional[str]:
+def _state_id(item: dict[str, Any], client: Optional[PlaneClient] = None) -> Optional[str]:
+    resolved = _resolve_state_payload(client, item)
+    if resolved is not None:
+        return str(resolved.get("id") or "").strip() or None
     state = item.get("state")
     if isinstance(state, dict):
         return str(state.get("id") or "").strip() or None
-    return None
+    raw = str(state or "").strip()
+    return raw or None
 
 
 def _state_group(state: dict[str, Any]) -> Optional[str]:
     group = state.get("group") or state.get("state_group")
     return str(group).strip() if group is not None and str(group).strip() else None
+
+
+def _is_cancelled_state(item: dict[str, Any], client: Optional[PlaneClient] = None) -> bool:
+    group = None
+    resolved = _resolve_state_payload(client, item)
+    if isinstance(resolved, dict):
+        group = _state_group(resolved)
+    state_name = _state_name(item, client)
+    return str(group or "").strip().casefold() == "cancelled" or state_name.casefold() == "cancelled"
 
 
 def _labels(item: dict[str, Any]) -> list[str]:
@@ -193,8 +226,8 @@ def _summarize_item(client: PlaneClient, item: dict[str, Any], project: Optional
         "readable_id": readable_id,
         "name": item.get("name") or item.get("title"),
         "priority": item.get("priority"),
-        "state_name": _state_name(item),
-        "state_id": _state_id(item),
+        "state_name": _state_name(item, client),
+        "state_id": _state_id(item, client),
         "labels": _labels(item),
         "assignees_names": _assignees(item),
         "url": _plane_url(client, item, project),
@@ -214,10 +247,10 @@ def _matches_filter(value: Optional[str], candidates: Iterable[str]) -> bool:
     return any(needle in str(candidate).casefold() for candidate in candidates)
 
 
-def _filter_items(items: list[dict[str, Any]], args: dict[str, Any]) -> list[dict[str, Any]]:
+def _filter_items(client: Optional[PlaneClient], items: list[dict[str, Any]], args: dict[str, Any]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for item in items:
-        if not _matches_filter(args.get("state"), [_state_name(item), _state_id(item) or ""]):
+        if not _matches_filter(args.get("state"), [_state_name(item, client), _state_id(item, client) or ""]):
             continue
         if not _matches_filter(args.get("label"), _labels(item)):
             continue
@@ -405,6 +438,9 @@ def _build_work_item_payload(args: dict[str, Any], client: PlaneClient, *, requi
 
     state_id = _resolve_state_id(client, args.get("state"))
     if state_id:
+        # Live Plane behavior on AI_Factory requires both keys for state
+        # transitions. Sending only state_id can be ignored server-side and
+        # silently leave the item in its previous or default state.
         payload["state_id"] = state_id
         payload["state"] = state_id
 
@@ -459,7 +495,7 @@ def _handle_board_snapshot(args: dict[str, Any], **kw) -> str:
         verbose = bool(args.get("verbose"))
         counts = {str(state.get("name") or state.get("id") or ""): 0 for state in states}
         for item in items:
-            state = _state_name(item) or "No state"
+            state = _state_name(item, client) or "No state"
             counts[state] = counts.get(state, 0) + 1
         state_rows = [_compact_state(state, counts.get(str(state.get("name") or state.get("id") or ""), 0)) for state in states]
         result = {
@@ -473,7 +509,7 @@ def _handle_board_snapshot(args: dict[str, Any], **kw) -> str:
             per_state_limit = int(args.get("per_state_limit") or 5)
             grouped: dict[str, list[dict[str, Any]]] = {}
             for item in items:
-                state = _state_name(item) or "No state"
+                state = _state_name(item, client) or "No state"
                 grouped.setdefault(state, [])
                 if len(grouped[state]) < per_state_limit:
                     grouped[state].append(_summarize_item(client, item, project))
@@ -495,7 +531,7 @@ def _handle_list_work_items(args: dict[str, Any], **kw) -> str:
         project = client.get_project()
         limit = int(args.get("limit") or 50)
         verbose = bool(args.get("verbose"))
-        items = _filter_items(client.list_work_items(), args)[:limit]
+        items = _filter_items(client, client.list_work_items(), args)[:limit]
         result = {"items": [_summarize_item(client, item, project) for item in items], "count": len(items)}
         if verbose:
             result["items_payload"] = items
@@ -671,6 +707,55 @@ def _handle_sync_progress(args: dict[str, Any], **kw) -> str:
         return tool_error(str(exc))
 
 
+def _handle_check_kanban_links(args: dict[str, Any], **kw) -> str:
+    try:
+        hermes_card_ids = args.get("hermes_card_ids") or []
+        if not isinstance(hermes_card_ids, list) or not hermes_card_ids:
+            raise ValueError("hermes_card_ids is required")
+
+        client = get_plane_client()
+        project = client.get_project()
+        anomalies: list[dict[str, Any]] = []
+
+        for raw_card_id in hermes_card_ids:
+            hermes_card_id = str(raw_card_id or "").strip()
+            if not hermes_card_id:
+                continue
+            linkage = _lookup_plane_link_from_kanban_task(hermes_card_id)
+            try:
+                item = _resolve_item(
+                    client,
+                    work_item_id=linkage.get("plane_work_item_id"),
+                    sequence_id=linkage.get("plane_sequence_id"),
+                )
+            except PlaneAPIError as exc:
+                if exc.status_code != 404:
+                    raise
+                anomalies.append({
+                    "hermes_card_id": hermes_card_id,
+                    "status": "missing",
+                    "plane_work_item_id": linkage.get("plane_work_item_id"),
+                    "plane_sequence_id": linkage.get("plane_sequence_id"),
+                    "plane_url": linkage.get("plane_url"),
+                })
+                continue
+
+            if _is_cancelled_state(item, client):
+                anomalies.append({
+                    "hermes_card_id": hermes_card_id,
+                    "status": "cancelled",
+                    "plane_work_item_id": item.get("id") or linkage.get("plane_work_item_id"),
+                    "plane_sequence_id": _sequence_id(item) or linkage.get("plane_sequence_id"),
+                    "plane_state_id": _state_id(item, client) or linkage.get("plane_state_id"),
+                    "plane_state_name": _state_name(item, client),
+                    "plane_url": _plane_url(client, item, project),
+                })
+
+        return _ok(count=len(anomalies), items=anomalies)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
 def _handle_ping(args: dict[str, Any], **kw) -> str:
     started = time.perf_counter()
     try:
@@ -776,9 +861,9 @@ def _handle_import_to_kanban(args: dict[str, Any], **kw) -> str:
                         f"plane_work_item_id: {item.get('id')}",
                         f"plane_sequence_id: {seq}",
                         f"plane_url: {plane_url}",
-                        f"plane_state_id: {_state_id(item) or ''}",
+                        f"plane_state_id: {_state_id(item, client) or ''}",
                         "",
-                        f"State at import: {_state_name(item) or 'unknown'}",
+                        f"State at import: {_state_name(item, client) or 'unknown'}",
                         f"Priority: {item.get('priority') or ''}",
                         "",
                         str(item.get("description_html") or item.get("description_stripped") or ""),
@@ -860,6 +945,10 @@ def plane_add_comment_tool(args: dict[str, Any]) -> str:
 
 def plane_sync_progress_tool(args: dict[str, Any]) -> str:
     return _handle_sync_progress(args)
+
+
+def plane_check_kanban_links_tool(args: dict[str, Any]) -> str:
+    return _handle_check_kanban_links(args)
 
 
 def plane_prepare_workdir_tool(args: dict[str, Any]) -> str:
@@ -995,6 +1084,18 @@ PLANE_SYNC_PROGRESS_SCHEMA = {
     },
 }
 
+PLANE_CHECK_KANBAN_LINKS_SCHEMA = {
+    "name": "plane_check_kanban_links",
+    "description": "Check linked Hermes kanban tasks against Plane and return only anomalies: cards whose Plane item is Cancelled or missing.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "hermes_card_ids": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["hermes_card_ids"],
+    },
+}
+
 PLANE_IMPORT_TO_KANBAN_SCHEMA = {
     "name": "plane_import_to_kanban",
     "description": "Explicitly import one or more Plane work items into Hermes kanban execution tasks, preserving Plane IDs in the body.",
@@ -1097,6 +1198,15 @@ registry.register(
     toolset="plane",
     schema=PLANE_SYNC_PROGRESS_SCHEMA,
     handler=_handle_sync_progress,
+    check_fn=_check_plane_requirements,
+    requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
+    emoji="🛩️",
+)
+registry.register(
+    name="plane_check_kanban_links",
+    toolset="plane",
+    schema=PLANE_CHECK_KANBAN_LINKS_SCHEMA,
+    handler=_handle_check_kanban_links,
     check_fn=_check_plane_requirements,
     requires_env=["PLANE_API_KEY", "PLANE_WORKSPACE", "PLANE_PROJECT_ID"],
     emoji="🛩️",

--- a/toolsets.py
+++ b/toolsets.py
@@ -61,15 +61,14 @@ _HERMES_CORE_TOOLS = [
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is
-    # spawned as a kanban worker (HERMES_KANBAN_TASK env set) or the current
-    # profile explicitly enables the kanban toolset. Gated via check_fn in
-    # tools/kanban_tools.py.
-    "kanban_show", "kanban_list",
-    "kanban_complete", "kanban_block", "kanban_heartbeat",
+    # spawned as a kanban worker (HERMES_KANBAN_TASK env set), otherwise
+    # zero schema footprint. Gated via check_fn in tools/kanban_tools.py.
+    "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
-    "kanban_unblock",
-    # Computer use (macOS, gated on cua-driver being installed via check_fn)
-    "computer_use",
+    # Plane project-management action layer — gated on PLANE_* env vars.
+    "plane_ping", "plane_board_snapshot", "plane_list_work_items", "plane_get_work_item",
+    "plane_create_work_item", "plane_update_work_item", "plane_add_comment",
+    "plane_sync_progress", "plane_check_kanban_links", "plane_import_to_kanban", "plane_prepare_workdir",
 ]
 
 
@@ -86,6 +85,16 @@ TOOLSETS = {
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
+        "includes": []
+    },
+
+    "plane": {
+        "description": "Plane project-management tools: board snapshot, work-item read/write, Hermes kanban import, and local AI Factory workdir preparation",
+        "tools": [
+            "plane_ping", "plane_board_snapshot", "plane_list_work_items", "plane_get_work_item",
+            "plane_create_work_item", "plane_update_work_item", "plane_add_comment",
+            "plane_sync_progress", "plane_check_kanban_links", "plane_import_to_kanban", "plane_prepare_workdir",
+        ],
         "includes": []
     },
     
@@ -106,28 +115,7 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-
-    "video_gen": {
-        "description": (
-            "Video generation tools. Single ``video_generate`` tool covers "
-            "text-to-video (prompt only) and image-to-video (prompt + "
-            "image_url) — the active backend auto-routes. Configure via "
-            "``hermes tools`` → Video Generation."
-        ),
-        "tools": ["video_generate"],
-        "includes": []
-    },
-
-    "computer_use": {
-        "description": (
-            "Background macOS desktop control via cua-driver — screenshots, "
-            "mouse, keyboard, scroll, drag. Does NOT steal the user's cursor "
-            "or keyboard focus. Works with any tool-capable model."
-        ),
-        "tools": ["computer_use"],
-        "includes": []
-    },
-
+    
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
@@ -169,7 +157,18 @@ TOOLSETS = {
         "tools": ["send_message"],
         "includes": []
     },
-
+    
+    "rl": {
+        "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
+        "tools": [
+            "rl_list_environments", "rl_select_environment",
+            "rl_get_current_config", "rl_edit_config",
+            "rl_start_training", "rl_check_status",
+            "rl_stop_training", "rl_get_results",
+            "rl_list_runs", "rl_test_inference"
+        ],
+        "includes": []
+    },
     
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
@@ -236,13 +235,12 @@ TOOLSETS = {
             "`kanban.dispatch_in_gateway` in config.yaml. Lets workers mark "
             "tasks done with structured handoffs, block for human input, "
             "heartbeat during long ops, comment on threads, and (for "
-            "orchestrators) list, unblock, and fan out tasks."
+            "orchestrators) fan out into child tasks."
         ),
         "tools": [
-            "kanban_show", "kanban_list", "kanban_complete", "kanban_block",
+            "kanban_show", "kanban_complete", "kanban_block",
             "kanban_heartbeat", "kanban_comment",
             "kanban_create", "kanban_link",
-            "kanban_unblock",
         ],
         "includes": [],
     },
@@ -379,7 +377,7 @@ TOOLSETS = {
         # Mirrors hermes-cli so cron's "default" toolset is the same set of
         # core tools users see interactively — then `hermes tools` filters
         # them down per the platform config. _DEFAULT_OFF_TOOLSETS (moa,
-        # homeassistant) are excluded by _get_platform_tools() unless
+        # homeassistant, rl) are excluded by _get_platform_tools() unless
         # the user explicitly enables them.
         "description": "Default cron toolset - same core tools as hermes-cli; gated by `hermes tools`",
         "tools": _HERMES_CORE_TOOLS,

--- a/website/docs/user-guide/features/plane.md
+++ b/website/docs/user-guide/features/plane.md
@@ -169,6 +169,23 @@ The tool reads the Plane linkage fields stored by `plane_import_to_kanban` in th
 
 Convention: call `plane_sync_progress` on meaningful kanban transitions, for example task start, blocked state, implementation complete, or review done. Use `plane_add_comment` only for comments that should not imply state movement.
 
+`plane_check_kanban_links`
+
+Checks a list of Hermes kanban tasks already linked to Plane and returns only the anomalies. Supports:
+
+- `hermes_card_ids`, required list of Hermes task ids
+
+Return shape: `{"items": [{"hermes_card_id", "status", "plane_work_item_id", "plane_sequence_id", "plane_state_id", "plane_state_name", "plane_url"}], "count": <int>}`.
+
+Behavior:
+
+- `status: "cancelled"` when the linked Plane work item still exists but is in the `Cancelled` state
+- `status: "missing"` when the linked Plane work item can no longer be resolved from the stored linkage
+- no automatic side effects, no kanban mutation, no Plane write
+- tasks not linked to Plane fail fast with a validation error instead of being silently skipped
+
+Use it as a read-only drift detector before starting work on imported Hermes tasks, or as a periodic audit step on in-flight kanban items.
+
 `plane_import_to_kanban`
 
 Creates Hermes kanban tasks from selected Plane work items. The task body stores Plane linkage fields:
@@ -210,9 +227,10 @@ The folder prefix matches the Plane project identifier. If `project_key` is prov
 3. Use `plane_get_work_item` for the specific card.
 4. Use `plane_import_to_kanban` only when a Plane card should become executable agent work.
 5. Agents work in Hermes kanban and local workdirs.
-6. Use `plane_sync_progress` from kanban workers to reflect meaningful progress and optional state transitions back to Plane.
-7. Use `plane_add_comment` for extra notes that should not move the Plane state.
-8. Update Plane explicitly when other fields should change on the project board.
+6. Use `plane_check_kanban_links` before starting or resuming work on imported Hermes tasks when you want a quick drift check against Plane.
+7. Use `plane_sync_progress` from kanban workers to reflect meaningful progress and optional state transitions back to Plane.
+8. Use `plane_add_comment` for extra notes that should not move the Plane state.
+9. Update Plane explicitly when other fields should change on the project board.
 
 ## End-to-end example
 
@@ -254,7 +272,11 @@ A second call to `plane_import_to_kanban` with the same `sequence_ids` returns t
 
 **HTTP 409 on `plane_create_work_item`.** Means another caller (or a previous Hermes attempt) already created the work item with the same `external_source` + `external_id`. The handler converts this case into a clean `already_existed: true` response, with `created: null` and `item` populated with the existing card. If you still see a `tool_error` 409 surface, capture the payload and the resolved `external_id` so the lookup path can be tightened further.
 
-**Lookup misses but card exists.** The pre-create lookup uses the Plane filter API on `external_source` + `external_id`, then falls back to a full board scan. On large boards or when Plane Cloud omits `external_source` / `external_id` from filtered list results, the lookup can briefly miss a card that exists. The 409 fallback above is the safety net.
+**Lookup misses but card exists.** The pre-create lookup uses the Plane filter API on `external_source` + `external_id`, then falls back to a full board scan. On the current Plane Cloud board the full scan cost is negligible, and it remains necessary because the filtered lookup can return `400`, `404`, or `422` even when the card exists. The fallback is therefore intentional best effort behavior, not dead code.
+
+**State update succeeds only with duplicated `state_id` + `state`.** In the current Plane environment Hermes must send both keys for state transitions. The tool keeps this workaround intentionally. If you remove one of the two fields and live updates start failing again, put the duplication back before debugging anything else.
+
+**`plane_check_kanban_links` reports `missing` or `cancelled`.** `missing` means the stored Plane linkage no longer resolves. `cancelled` means the Plane card still exists but has reached the `Cancelled` state. The tool is read-only by design: it reports drift but does not archive, cancel, or edit the Hermes task for you.
 
 **`plane_sync_progress` says the kanban task is not linked.** The Hermes kanban task body must contain the `plane_*` linkage lines written by `plane_import_to_kanban`. Tasks created manually via `hermes kanban` are not linked unless those lines are added by hand.
 

--- a/website/docs/user-guide/features/plane.md
+++ b/website/docs/user-guide/features/plane.md
@@ -1,0 +1,261 @@
+---
+title: Plane
+sidebar_position: 37
+---
+
+# Plane
+
+Hermes can expose a small `plane` toolset for working with Plane as the human-visible project board while keeping Hermes kanban as the execution layer.
+
+V1 is intentionally explicit:
+
+- no dashboard or parallel portal
+- no automatic sync
+- no delete operation
+- writes to Plane only happen when the user asks for a create or update
+- Plane remains the project source of truth
+
+## Configuration
+
+Set these values in `~/.hermes/.env`:
+
+```bash
+PLANE_API_KEY=...
+PLANE_WORKSPACE=ai_factory
+PLANE_PROJECT_ID=8695a8d1-e6fc-44e1-8bd2-9f37158b5124
+# optional, defaults to https://api.plane.so
+PLANE_BASE_URL=https://api.plane.so
+```
+
+The Plane client always sends:
+
+- `X-API-Key`
+- `Accept: application/json`
+- a browser-like `User-Agent`
+
+The browser `User-Agent` is required because Plane Cloud can reject valid script requests with Cloudflare `browser_signature_banned` when the request does not look browser-like.
+
+## Tools
+
+`plane_ping`
+
+Runs a quick health check for the configured integration. It calls `GET /api/v1/users/me/` and the configured project endpoint using the shared client, then returns:
+
+- `ok`
+- `latency_ms`
+- `user` / `user_email`
+- `workspace`
+- `project` / `project_name`
+
+Use it first when debugging auth, network, Cloudflare `User-Agent`, or project access issues.
+
+`plane_board_snapshot`
+
+Returns a compact project snapshot by default:
+
+```json
+{
+  "project": {"id": "...", "name": "...", "identifier": "AIFACTORY"},
+  "states": [{"id": "...", "name": "Todo", "group": "backlog", "count": 3}],
+  "counts_by_state": {"Todo": 3},
+  "total_items": 12,
+  "items": [{"id": "...", "sequence_id": 12, "readable_id": "AIFACTORY-12", "name": "...", "state_name": "Todo", "state_id": "...", "priority": "medium", "labels": [], "assignees_names": [], "url": "..."}]
+}
+```
+
+Options:
+
+- `include_items_per_state`
+- `per_state_limit`
+- `limit`
+- `verbose`
+
+When `verbose=true`, the response also includes raw `project_payload`, `states_payload`, and `items_payload`.
+
+`plane_list_work_items`
+
+Lists compact work items with optional filters:
+
+- `state`
+- `label`
+- `assignee`
+- `priority`
+- `query`
+- `limit`
+- `verbose`
+
+Default item shape:
+
+```json
+{"id": "...", "sequence_id": 12, "readable_id": "AIFACTORY-12", "name": "...", "state_name": "Todo", "state_id": "...", "priority": "medium", "labels": [], "assignees_names": [], "url": "..."}
+```
+
+When `verbose=true`, the response also includes raw `items_payload`.
+
+`plane_get_work_item`
+
+Reads one work item by `work_item_id` or `sequence_id`. The default `item` uses the same compact shape as `plane_list_work_items`. When `verbose=true`, the response also includes raw `payload` and `enriched_item`.
+
+`plane_create_work_item`
+
+Creates a Plane work item idempotently. Supports:
+
+- `name`
+- `description_html` or `description_markdown`
+- `priority`
+- `state`
+- `labels`
+- `assignees`
+- `start_date`
+- `target_date`
+- `external_source`
+- `external_id`
+
+Idempotence contract:
+
+- Hermes tries to look up an existing Plane work item before creation using `external_source` + `external_id`.
+- If `external_source` is omitted, it defaults to `nova-hermes`.
+- If `external_id` is omitted, Hermes generates a stable fallback from workspace, project, external source, and normalized `name`: `plane-create:<sha256-prefix>`.
+- The fallback deliberately excludes mutable fields such as description, labels, state, dates, and assignees so a retry with minor payload differences still targets the same logical item.
+- When the pre-create lookup misses but Plane still rejects the POST with `409 Conflict` (server-side uniqueness on `external_source` + `external_id`), Hermes now performs a second lookup and returns the existing item with `already_existed: true`, `created: null`. Callers see a stable idempotent response in both cases.
+
+`plane_update_work_item`
+
+Updates selected fields of an existing work item. Requires `work_item_id` and at least one update field.
+
+Supported fields (PATCH partial):
+
+- `name`
+- `description_html` or `description_markdown`
+- `priority`
+- `state` (state name or id)
+- `labels` (list of label names or ids)
+- `assignees` (list of user ids)
+- `start_date`
+- `target_date`
+- `external_source`
+- `external_id`
+
+PATCH partial semantics:
+
+- A field passed as `None` (or absent from the call) is **ignored** and never sent to Plane.
+- A field passed with an explicit non-null value is sent to Plane and overwrites the current value.
+- For list fields (`labels`, `assignees`), an empty list `[]` is the explicit "clear" signal and is forwarded as-is. Use `None` (or omit the key) to leave the current list untouched.
+
+This means retries with the same payload are safe, and partial updates do not accidentally clear fields the caller did not mention.
+
+`plane_add_comment`
+
+Adds a comment to an existing work item without changing its state. Supports:
+
+- `work_item_id` or `sequence_id`
+- `body_markdown`
+- `prefix`, default `true`, prepends `[Nova]`
+
+`body_markdown` is converted to simple HTML and sent to Plane as `comment_html` on the work item comments endpoint.
+
+**Known limitation (V1.1):** the current Markdown pipeline is intentionally minimal. It escapes HTML and turns line breaks into `<br>` tags. Lists, bold, italic, inline code, and links are **not** rendered as Markdown by Plane. Plain text and line breaks are the only formatting that survives end-to-end. Rich Markdown support is tracked for V1.2.
+
+`plane_sync_progress`
+
+Reflects progress from an imported Hermes kanban task back to Plane in one call. Supports:
+
+- `hermes_card_id`, optional when called by a kanban worker because it defaults to `HERMES_KANBAN_TASK`
+- `summary`, posted as a Plane comment
+- `status`, optional Plane state name or id, for example `In Progress`, `Waiting`, or `Done`
+- `prefix`, default `true`, prepends `[Nova]` to the comment
+
+The tool reads the Plane linkage fields stored by `plane_import_to_kanban` in the Hermes task body (`plane_work_item_id`, `plane_sequence_id`, `plane_url`). If the Hermes card is not linked to Plane, it fails without posting a comment. If `status` is provided, it updates the Plane state before posting the progress comment and returns the compact item, Plane URL, comment payload, and update payload.
+
+Convention: call `plane_sync_progress` on meaningful kanban transitions, for example task start, blocked state, implementation complete, or review done. Use `plane_add_comment` only for comments that should not imply state movement.
+
+`plane_import_to_kanban`
+
+Creates Hermes kanban tasks from selected Plane work items. The task body stores Plane linkage fields:
+
+- `plane_workspace_slug`
+- `plane_project_id`
+- `plane_work_item_id`
+- `plane_sequence_id`
+- `plane_url`
+- `plane_state_id`
+
+Titles use:
+
+```text
+[Plane AIFACTORY-12] <title>
+```
+
+Return shape: `{"created_tasks": [{"task_id", "plane_work_item_id", "plane_sequence_id", "workdir", "already_imported"}]}`.
+
+The `already_imported` flag is `true` when a non-archived Hermes kanban task already exists for the same Plane work item (resolved via the `plane:<workspace>:<project>:<work_item_id>` idempotency key). In that case Hermes returns the existing task id instead of creating a duplicate. Callers can rely on this to make `plane_import_to_kanban` safe to call repeatedly without polluting the kanban.
+
+`plane_prepare_workdir`
+
+Creates a local work directory for deliverables:
+
+```text
+/home/emeric/AI Factory/AIFACTORY-12_<slug>/
+├── README.md
+├── work/
+└── deliverables/
+```
+
+The folder prefix matches the Plane project identifier. If `project_key` is provided in the call, it is used directly. If omitted and Plane is configured, Hermes resolves it from the Plane project (`get_project_identifier`). Otherwise it falls back to `AIFACTORY`.
+
+## Recommended workflow
+
+1. Use `plane_ping` to verify auth, browser-like `User-Agent`, network, and project access.
+2. Use `plane_board_snapshot` to inspect the current board.
+3. Use `plane_get_work_item` for the specific card.
+4. Use `plane_import_to_kanban` only when a Plane card should become executable agent work.
+5. Agents work in Hermes kanban and local workdirs.
+6. Use `plane_sync_progress` from kanban workers to reflect meaningful progress and optional state transitions back to Plane.
+7. Use `plane_add_comment` for extra notes that should not move the Plane state.
+8. Update Plane explicitly when other fields should change on the project board.
+
+## End-to-end example
+
+Typical flow for picking up Plane card `AIFACTORY-13` as an Hermes execution task:
+
+```json
+// 1) Import the card and create a local workdir.
+{"tool": "plane_import_to_kanban", "args": {
+  "sequence_ids": [13],
+  "assignee": "emeric",
+  "create_workdir": true
+}}
+// → {"created_tasks":[{"task_id":"t_abc","plane_sequence_id":13,"workdir":"/home/emeric/AI Factory/AIFACTORY-13_…","already_imported":false}]}
+
+// 2) From the kanban worker, post first progress update.
+{"tool": "plane_sync_progress", "args": {
+  "summary": "Started implementation, scaffolding in place.",
+  "status": "In Progress"
+}}
+
+// 3) Add an extra note that should not move the state.
+{"tool": "plane_add_comment", "args": {
+  "sequence_id": 13,
+  "body_markdown": "Quick design note: switching to PATCH partial semantics."
+}}
+
+// 4) Close the loop when work is done.
+{"tool": "plane_sync_progress", "args": {
+  "summary": "Implementation complete, validation pending.",
+  "status": "Done"
+}}
+```
+
+A second call to `plane_import_to_kanban` with the same `sequence_ids` returns the existing task id and `already_imported: true`, so it is safe to call from idempotent automations.
+
+## Troubleshooting
+
+**HTTP 403 with `browser_signature_banned` in the body.** Cloudflare in front of Plane Cloud is rejecting the request. Verify the call goes through the shared client from `tools/plane_client.py`. Do not replace it with ad hoc `curl` or `requests` calls without the browser-like `User-Agent`.
+
+**HTTP 409 on `plane_create_work_item`.** Means another caller (or a previous Hermes attempt) already created the work item with the same `external_source` + `external_id`. The handler converts this case into a clean `already_existed: true` response, with `created: null` and `item` populated with the existing card. If you still see a `tool_error` 409 surface, capture the payload and the resolved `external_id` so the lookup path can be tightened further.
+
+**Lookup misses but card exists.** The pre-create lookup uses the Plane filter API on `external_source` + `external_id`, then falls back to a full board scan. On large boards or when Plane Cloud omits `external_source` / `external_id` from filtered list results, the lookup can briefly miss a card that exists. The 409 fallback above is the safety net.
+
+**`plane_sync_progress` says the kanban task is not linked.** The Hermes kanban task body must contain the `plane_*` linkage lines written by `plane_import_to_kanban`. Tasks created manually via `hermes kanban` are not linked unless those lines are added by hand.
+
+**Workdir folder name does not match the Plane project key.** Before V1.1, `plane_prepare_workdir` hardcoded `AIFACTORY` regardless of the configured Plane project. From V1.1 onwards, the folder prefix follows the real Plane project identifier (or the explicit `project_key` argument), with a final fallback to `AIFACTORY` only when no project identifier can be resolved.


### PR DESCRIPTION
# Plane integration V1.1

## Context

Closes the Plane integration V1 review cycle. V1 had been validated live but a cross review (code, docs, tests) found a critical idempotency bug, six undocumented limitations, and several test gaps. This PR delivers V1.1 in two passes: a static lot (mocked, no live API) and a live runtime lot.

Source of truth: `docs/plans/2026-05-15-plane-v1-post-review-action-plan.md`.

## Scope V1.1 — what changed

### Bug fixes
- **B1 (P0)** — `plane_create_work_item` now recovers from a 409 Conflict on retry by re-running the lookup and returning `already_existed=true`. Idempotency contract is now honored end to end.

### New tool
- **`plane_check_kanban_links`** — drift detection between Hermes kanban tasks and their linked Plane cards. Returns anomalies (`cancelled`, `missing`), no auto-action.

### Behavior changes
- **`plane_import_to_kanban`** now exposes `already_imported: bool` per imported card.
- **`plane_update_work_item`** PATCH semantics formalized: `None` = field ignored, `[]` on `labels` / `assignees` = explicit clear.
- **`plane_prepare_workdir`** accepts an explicit `project_key`, falls back to live resolution via `get_project_identifier()` instead of the hardcoded `AIFACTORY` constant.
- **`plane_create_work_item`** lookup now best-effort tolerates server-side 400/404/422 on the filtered query and falls back to a full scan (workaround for an observed Plane filter regression).
- Plane state enrichment when API returns only a raw state id.

### Internal cleanup
- Narrowed silent `except Exception` in `_check_plane_requirements` to `except OSError`.
- Re-typed 12 internal helpers from `client: Any` to `client: PlaneClient`.
- Explicit comment on the `state_id` + `state` payload duplication (confirmed live workaround).

### User documentation
- `website/docs/user-guide/features/plane.md` updated: PATCH partial semantics, `already_imported` contract, Markdown limitation, `plane_check_kanban_links`, troubleshooting (Cloudflare 403, 409, lookup misses, fallback full scan, missing/cancelled), end to end JSON example.

## Tests

Baseline before V1.1: 27 passing.
Baseline after V1.1: **67 passing**.

```text
pytest tests/tools/test_plane_client.py tests/tools/test_plane_tool.py tests/test_toolsets.py -q
```

Live validation:
- `AIFACTORY-15` — imported, transitioned to Cancelled, drift detected by `plane_check_kanban_links`.
- `AIFACTORY-16` — create + idempotent retry (`already_existed=true`) + transition to In Progress + kanban import + drift check after Cancelled.

## Explicitly deferred to V1.2

Documented in section 12 of the action plan:
- **L1** — Rich Markdown rendering (`mistune` + minimal allowlist).
- **L3** — Auto traceability `[hermes]` on writes (anti-spam policy required).
- **T4** — Network error handling (timeout, 5xx, retry).
- **Assignees UUID resolution** — Plane API expects user UUIDs, display names silently no-op today.

## Files changed

- `tools/plane_client.py`
- `tools/plane_tool.py`
- `toolsets.py`
- `tests/tools/test_plane_client.py`
- `tests/tools/test_plane_tool.py`
- `tests/test_toolsets.py`
- `website/docs/user-guide/features/plane.md`
- `docs/plans/2026-05-15-plane-v1-post-review-action-plan.md`

## Branch hygiene

- Working branch: `plane-v1.1-nova` (commit `061384990`).
- Preservation branch: `wip/plane-v1-preserve-20260515` (kept until V1.2 starts, then cleanup decision).
- `stash@{0}`: unrelated WIP from main, kept until merge.

## Test plan for reviewer

- [ ] `pytest tests/tools/test_plane_client.py tests/tools/test_plane_tool.py tests/test_toolsets.py -q` returns `67 passed`.
- [ ] Read `docs/plans/2026-05-15-plane-v1-post-review-action-plan.md` sections 7, 10, 11, 12 to confirm scope match.
- [ ] Spot check `plane.md` user doc renders correctly.
- [ ] Optional: live retry of the B1 scenario against a dedicated Plane card.
