### PR TITLE
fix(profiles): replace hardcoded ~/.hermes paths with get_hermes_home()

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -9,11 +9,8 @@ from typing import Optional
 
 def _hermes_home_path() -> Path:
     """Resolve the active HERMES_HOME (profile-aware) without circular imports."""
-    try:
-        from hermes_constants import get_hermes_home  # local import to avoid cycles
-        return get_hermes_home()
-    except Exception:
-        return Path(os.path.expanduser("~/.hermes"))
+    from hermes_constants import get_hermes_home  # local import to avoid cycles
+    return get_hermes_home()
 
 
 def _hermes_root_path() -> Path:

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -122,10 +122,8 @@ def _is_windows() -> bool:
 
 def hermes_lsp_bin_dir() -> Path:
     """Return the Hermes-owned bin staging dir for LSP servers."""
-    home = os.environ.get("HERMES_HOME")
-    if home is None:
-        home = os.path.join(os.path.expanduser("~"), ".hermes")
-    p = Path(home) / "lsp" / "bin"
+    from hermes_constants import get_hermes_home
+    p = get_hermes_home() / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -28,11 +28,8 @@ _STATE_FILENAME = "nous.json"
 
 def _state_path() -> str:
     """Return the path to the Nous rate limit state file."""
-    try:
-        from hermes_constants import get_hermes_home
-        base = get_hermes_home()
-    except ImportError:
-        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    from hermes_constants import get_hermes_home
+    base = get_hermes_home()
     return os.path.join(base, _STATE_SUBDIR, _STATE_FILENAME)
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -232,7 +232,8 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    from hermes_constants import get_hermes_home
+    home_path = Path(hermes_home) if hermes_home else get_hermes_home()
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1630,7 +1630,8 @@ def _ensure_tui_node() -> None:
     if not helper.is_file():
         return
 
-    hermes_home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    from hermes_constants import get_hermes_home
+    hermes_home = str(get_hermes_home())
     try:
         # Helper writes logs to stderr; we ask bash to print `command -v node`
         # on stdout once ensure_node succeeds. Subshell PATH edits don't leak

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -195,12 +195,8 @@ def slack_manifest_command(args) -> int:
     if write_target is not None:
         if isinstance(write_target, bool) and write_target:
             # --write with no value → default location
-            try:
-                from hermes_constants import get_hermes_home
-
-                target = Path(get_hermes_home()) / "slack-manifest.json"
-            except Exception:
-                target = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")) / "slack-manifest.json"
+            from hermes_constants import get_hermes_home
+            target = get_hermes_home() / "slack-manifest.json"
         else:
             target = Path(write_target).expanduser()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -28,14 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-try:
-    from hermes_constants import get_hermes_home
-except Exception:  # pragma: no cover — plugin may load before constants resolves
-    import os
-
-    def get_hermes_home() -> Path:  # type: ignore[no-redef]
-        val = (os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val).resolve() if val else (Path.home() / ".hermes").resolve()
+from hermes_constants import get_hermes_home
 
 
 logger = logging.getLogger(__name__)

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -12,13 +12,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-try:
-    from hermes_constants import get_hermes_home
-except ImportError:
-    import os as _os
-    def get_hermes_home() -> Path:  # type: ignore[misc]
-        val = (_os.environ.get("HERMES_HOME") or "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
+from hermes_constants import get_hermes_home
 
 try:
     from fastapi import APIRouter

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -718,11 +718,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # active side-threads survive gateway restarts (the bug that
         # made the in-memory version of this heuristic flaky for
         # multi-restart sessions).
-        try:
-            from hermes_constants import get_hermes_home as _get_hermes_home
-            _hermes_home = _get_hermes_home()
-        except (ModuleNotFoundError, ImportError):
-            _hermes_home = _Path.home() / ".hermes"
+        from hermes_constants import get_hermes_home as _get_hermes_home
+        _hermes_home = _get_hermes_home()
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )
@@ -916,7 +913,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
+        from hermes_constants import get_hermes_home as _get_hermes_home
+        base = str(_get_hermes_home())
         return _Path(base) / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -74,22 +74,7 @@ logger = logging.getLogger("gateway.platforms.google_chat_user_oauth")
 
 # Use the project's HERMES_HOME helper so the token follows the user's
 # profile (e.g. tests can override via HERMES_HOME=/tmp/...).
-try:
-    from hermes_constants import display_hermes_home, get_hermes_home
-except (ModuleNotFoundError, ImportError):
-    # Fallback for environments where hermes_constants isn't importable
-    # (mirrors the same fallback used by the google-workspace skill's
-    # _hermes_home.py shim).
-    def get_hermes_home() -> Path:
-        val = os.environ.get("HERMES_HOME", "").strip()
-        return Path(val) if val else Path.home() / ".hermes"
-
-    def display_hermes_home() -> str:
-        home = get_hermes_home()
-        try:
-            return "~/" + str(home.relative_to(Path.home()))
-        except ValueError:
-            return str(home)
+from hermes_constants import display_hermes_home, get_hermes_home
 
 from utils import atomic_replace
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1297,11 +1297,8 @@ class LineAdapter(BasePlatformAdapter):
         if not path.exists() or not path.is_file():
             return web.Response(status=404, text="not found")
 
-        try:
-            from hermes_constants import get_hermes_home
-            hermes_home = Path(get_hermes_home()).resolve()
-        except Exception:
-            hermes_home = Path.home().joinpath(".hermes").resolve()
+        from hermes_constants import get_hermes_home
+        hermes_home = Path(get_hermes_home()).resolve()
 
         allowed_roots = {
             Path(tempfile.gettempdir()).resolve(),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -637,11 +637,8 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         if which_hit:
             resolved_command = which_hit
         elif resolved_command in {"npx", "npm", "node"}:
-            hermes_home = os.path.expanduser(
-                os.getenv(
-                    "HERMES_HOME", os.path.join(os.path.expanduser("~"), ".hermes")
-                )
-            )
+            from hermes_constants import get_hermes_home
+            hermes_home = str(get_hermes_home())
             candidates = [
                 os.path.join(hermes_home, "node", "bin", resolved_command),
                 os.path.join(os.path.expanduser("~"), ".local", "bin", resolved_command),


### PR DESCRIPTION
## What does this PR do?

Replaces hardcoded `Path.home() / ".hermes"` fallbacks in 14 production files with `get_hermes_home()` from `hermes_constants`. Each file had a `try/except ImportError` fallback that was dead code since `hermes_constants` is always importable.

These fallbacks bypassed the profile-aware path resolution, breaking multi-profile support.

## Related Issue

Discovered during full repo audit (2026-05-14). No pre-existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mcp_serve.py`: 3 fallbacks removed in `_get_sessions_dir`, `_load_channel_directory`, cache poll
- `agent/file_safety.py`: Fallback removed in `_hermes_home_path()`
- `agent/lsp/install.py`: Replaced env var read with `get_hermes_home()` in `hermes_lsp_bin_dir()`
- `agent/nous_rate_guard.py`: Fallback removed in `_state_path()`
- `tools/mcp_oauth.py`: Fallback removed in `_get_token_dir()`
- `tools/mcp_tool.py`: Replaced env var read with `get_hermes_home()` for node binary resolution
- `hermes_cli/env_loader.py`: Replaced `Path.home() / ".hermes"` fallback
- `hermes_cli/slack_cli.py`: Fallback removed in manifest write path
- `hermes_cli/main.py`: Replaced env var read in `_ensure_node_available()`
- `plugins/disk-cleanup/disk_cleanup.py`: Removed local `get_hermes_home()` redefinition
- `plugins/hermes-achievements/dashboard/plugin_api.py`: Removed local redefinition
- `plugins/platforms/google_chat/oauth.py`: Removed fallback with `display_hermes_home` shim
- `plugins/platforms/google_chat/adapter.py`: 2 fallbacks removed
- `plugins/platforms/line/adapter.py`: Fallback removed

**Intentionally excluded:**
- `hermes_constants.py` — canonical source of truth
- `hermes_cli/auth.py:769` — test guard comparing against real default path
- `hermes_cli/gateway.py:2090` — intentional comparison for service user path remapping
- Scripts/optional-skills — standalone scripts without import access

## How to Test

1. `scripts/run_tests.sh tests/plugins/ tests/tools/test_mcp*.py tests/cli/ tests/run_agent/ -q` — all pass
2. Set `HERMES_HOME` to a custom path, verify plugins/tools resolve correctly