### PR TITLE
fix(plugins): rename per-turn hook from on_session_end to on_turn_end

### DIFF
--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -141,6 +141,7 @@ _DEFAULT_PAYLOADS = {
     },
     "on_session_start": {"session_id": "test-session"},
     "on_session_end": {"session_id": "test-session"},
+    "on_turn_end": {"session_id": "test-session", "completed": True, "interrupted": False},
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},
     "pre_api_request": {

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -140,6 +140,7 @@ VALID_HOOKS: Set[str] = {
     "post_api_request",
     "on_session_start",
     "on_session_end",
+    "on_turn_end",
     "on_session_finalize",
     "on_session_reset",
     "subagent_stop",

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -308,7 +308,7 @@ def _handle_slash(raw_args: str) -> Optional[str]:
 
 def register(ctx) -> None:
     ctx.register_hook("post_tool_call", _on_post_tool_call)
-    ctx.register_hook("on_session_end", _on_session_end)
+    ctx.register_hook("on_turn_end", _on_session_end)
     ctx.register_command(
         "disk-cleanup",
         handler=_handle_slash,

--- a/run_agent.py
+++ b/run_agent.py
@@ -15700,13 +15700,14 @@ class AIAgent:
         # handled by the CLI (atexit / /reset) and gateway (session expiry /
         # _reset_session).
 
-        # Plugin hook: on_session_end
-        # Fired at the very end of every run_conversation call.
-        # Plugins can use this for cleanup, flushing buffers, etc.
+        # Plugin hook: on_turn_end (fires every run_conversation call,
+        # i.e. once per user message — NOT at session boundaries).
+        # Use on_session_end for actual session-end cleanup (CLI exit,
+        # /reset, gateway session expiry).
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _invoke_hook(
-                "on_session_end",
+                "on_turn_end",
                 session_id=self.session_id,
                 completed=completed,
                 interrupted=interrupted,
@@ -15714,7 +15715,7 @@ class AIAgent:
                 platform=getattr(self, "platform", None) or "",
             )
         except Exception as exc:
-            logger.warning("on_session_end hook failed: %s", exc)
+            logger.warning("on_turn_end hook failed: %s", exc)
 
         return result
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -5,7 +5,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
   * ``disk_cleanup`` library: track / forget / dry_run / quick / status,
     ``is_safe_path`` and ``guess_category`` filtering.
   * Plugin ``__init__``: ``post_tool_call`` hook auto-tracks files created
-    by ``write_file`` / ``terminal``; ``on_session_end`` hook runs quick
+    by ``write_file`` / ``terminal``; ``on_turn_end`` hook runs quick
     cleanup when anything was tracked during the turn.
   * Slash command handler: status / dry-run / quick / track / forget /
     unknown subcommand behaviours.
@@ -394,7 +394,7 @@ class TestBundledDiscovery:
         loaded = mgr._plugins["disk-cleanup"]
         assert loaded.enabled
         assert "post_tool_call" in loaded.hooks_registered
-        assert "on_session_end" in loaded.hooks_registered
+        assert "on_turn_end" in loaded.hooks_registered
         assert "disk-cleanup" in loaded.commands_registered
 
     def test_disabled_beats_enabled(self, _isolate_env):


### PR DESCRIPTION
## What does this PR do?

Renames the per-turn plugin hook from `on_session_end` to `on_turn_end` in `run_agent.py`. The hook fired at the end of every `run_conversation()` call (once per user message), not at actual session boundaries — the name was misleading.

**Note:** This conflicts with PR #22095 which adds `on_turn_start`/`on_turn_end` as NEW hooks while keeping `on_session_end` firing per-turn. This PR takes the cleaner approach: rename the existing per-turn fire instead of adding redundant hooks. PR #22095 should adapt to use the `on_turn_end` hook added here.

## Related Issue

Discovered during full repo audit (2026-05-14). No pre-existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py`: Added `on_turn_end` to `VALID_HOOKS`
- `hermes_cli/hooks.py`: Added `on_turn_end` test fixture
- `run_agent.py`: Changed per-turn hook fire from `on_session_end` to `on_turn_end`
- `plugins/disk-cleanup/__init__.py`: Migrated registration from `on_session_end` to `on_turn_end`
- `tests/plugins/test_disk_cleanup_plugin.py`: Updated assertion to check `on_turn_end`

**Not changed:** `google_meet` plugin stays on `on_session_end` (fires at real session boundaries from CLI/gateway).

## How to Test

1. `scripts/run_tests.sh tests/plugins/ tests/hermes_cli/test_hooks_cli.py -q` — all pass
2. Verify disk-cleanup plugin registers `on_turn_end` hook
3. Verify google_meet plugin still registers `on_session_end` hook