### PR TITLE
feat(gateway): emit session:new hook after /new or /reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8242,6 +8242,14 @@ class GatewayRunner:
             new_entry = self.session_store.get_or_create_session(source, force_new=True)
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_new")
 
+        # Emit session:new hook (session is starting)
+        await self.hooks.emit("session:new", {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "session_key": session_key,
+            "new_session_id": new_entry.session_id if new_entry else None,
+        })
+
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""


### PR DESCRIPTION
## Summary

- Adds a dedicated `session:new` hook emitted inside `_handle_reset_command()` whenever `/new` or `/reset` is executed
- Hook fires **after** both `new_entry` assignment paths converge (L8238–L8243), so `new_session_id` is always a valid value
- Payload mirrors the existing `session:end` / `session:reset` hooks and adds `new_session_id` for the freshly-created session

## Hook payload

```python
await self.hooks.emit("session:new", {
    "platform": source.platform.value if source.platform else "",
    "user_id": source.user_id,
    "session_key": session_key,
    "new_session_id": new_entry.session_id if new_entry else None,
})
```

## Related hooks (for reference)

| Hook | Location | Purpose |
|---|---|---|
| `session:end` | L8219 | Old session is ending |
| `session:reset` | L8226 | Reset command received |
| `session:new` | L8245 (new) | New session is starting |

## Test plan

- [ ] Trigger `/new` on any gateway platform; confirm `session:new` fires with correct `platform`, `user_id`, `session_key`, and `new_session_id`
- [ ] Trigger `/reset`; same verification
- [ ] Confirm `session:end` → `session:reset` → `session:new` order is preserved
- [ ] Register a test hook handler in `gateway/builtin_hooks/` and validate printed payload fields