### PR TITLE
Fix TUI session lifecycle reaping

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -732,6 +732,51 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def mark_stale_open_sessions(
+        self,
+        *,
+        now: float | None = None,
+        stale_after_s: float = 43200,
+        exclude_ids: set[str] | list[str] | tuple[str, ...] | None = None,
+        end_reason: str = "dashboard_stale_reap",
+        sources: tuple[str, ...] = ("tui", "dashboard"),
+    ) -> int:
+        """Conservatively mark stale open dashboard/TUI sessions ended.
+
+        This never deletes sessions/messages/transcripts and never overwrites
+        an existing ``end_reason`` because it only updates rows with
+        ``ended_at IS NULL``. ``exclude_ids`` protects sessions currently owned
+        by a live TUI/dashboard runtime process.
+        """
+        now = time.time() if now is None else float(now)
+        cutoff = now - max(300.0, float(stale_after_s))
+        excluded = {str(sid) for sid in (exclude_ids or []) if sid}
+        source_values = tuple(str(src) for src in sources if src)
+        if not source_values:
+            source_values = ("tui",)
+
+        def _do(conn):
+            clauses = [
+                "ended_at IS NULL",
+                "COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id), started_at) < ?",
+            ]
+            params: list[Any] = [cutoff]
+            placeholders = ",".join("?" for _ in source_values)
+            clauses.append(f"source IN ({placeholders})")
+            params.extend(source_values)
+            if excluded:
+                placeholders = ",".join("?" for _ in excluded)
+                clauses.append(f"id NOT IN ({placeholders})")
+                params.extend(sorted(excluded))
+            params = [now, end_reason] + params
+            cur = conn.execute(
+                f"UPDATE sessions SET ended_at = ?, end_reason = ? WHERE {' AND '.join(clauses)}",
+                params,
+            )
+            return cur.rowcount or 0
+
+        return int(self._execute_write(_do) or 0)
+
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -422,6 +422,62 @@ class TestGatewaySurfacesNullResponse:
 # Prune: finalize_orphaned_compression_sessions
 # ===========================================================================
 
+class TestStaleOpenSessionReap:
+    def test_marks_only_stale_open_rows_and_preserves_counts(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        now = time.time()
+        db.create_session(session_id="stale", source="tui", model="test")
+        db.append_message("stale", role="user", content="hello")
+        db.create_session(session_id="recent", source="tui", model="test")
+        db.append_message("recent", role="user", content="active")
+        db.create_session(session_id="ended", source="tui", model="test")
+        db.append_message("ended", role="user", content="done")
+        db.end_session("ended", "user_exit")
+        db._execute_write(
+            lambda conn: conn.executemany(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                [(now - 90000, "stale"), (now - 90000, "ended"), (now, "recent")],
+            )
+        )
+        db._execute_write(
+            lambda conn: conn.executemany(
+                "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+                [(now - 90000, "stale"), (now - 90000, "ended")],
+            )
+        )
+
+        before_sessions = db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        before_messages = db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        marked = db.mark_stale_open_sessions(now=now, stale_after_s=43200, exclude_ids={"recent"})
+        after_sessions = db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        after_messages = db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+
+        assert marked == 1
+        assert db.get_session("stale")["end_reason"] == "dashboard_stale_reap"
+        assert db.get_session("recent")["ended_at"] is None
+        assert db.get_session("ended")["end_reason"] == "user_exit"
+        assert before_sessions == after_sessions
+        assert before_messages == after_messages
+
+    def test_stale_ended_session_can_reopen(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        now = time.time()
+        db.create_session(session_id="stale", source="tui", model="test")
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (now - 90000, "stale"),
+            )
+        )
+        assert db.mark_stale_open_sessions(now=now, stale_after_s=43200) == 1
+
+        db.reopen_session("stale")
+
+        reopened = db.get_session("stale")
+        assert reopened["ended_at"] is None
+        assert reopened["end_reason"] is None
+
+
 class TestFinalizeOrphanedCompressionSessions:
     """The prune migration marks ghost compression continuations as ended."""
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,5 +1,7 @@
 import json
 import os
+import signal
+import subprocess
 import sys
 import threading
 import time
@@ -753,6 +755,136 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_session_close_teardown_is_idempotent_and_single_path(monkeypatch):
+    events: list[str] = []
+
+    class _Agent:
+        session_id = "agent-session"
+
+        def close(self):
+            events.append("agent.close")
+
+    class _Worker:
+        def close(self):
+            events.append("worker.close")
+
+    monkeypatch.setattr(server, "_get_db", lambda: types.SimpleNamespace(end_session=lambda sid, reason: events.append(f"end:{sid}:{reason}")))
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda event, sid: events.append(f"hook:{event}:{sid}"))
+    monkeypatch.setitem(sys.modules, "tools.approval", types.SimpleNamespace(unregister_gateway_notify=lambda key: events.append(f"unregister:{key}")))
+    server._sessions["sid"] = _session(agent=_Agent(), slash_worker=_Worker())
+
+    try:
+        first = server.handle_request({"id": "1", "method": "session.close", "params": {"session_id": "sid"}})
+        second = server.handle_request({"id": "2", "method": "session.close", "params": {"session_id": "sid"}})
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert first["result"]["closed"] is True
+    assert second["result"]["closed"] is False
+    assert events == [
+        "hook:on_session_finalize:agent-session",
+        "end:agent-session:tui_close",
+        "unregister:session-key",
+        "agent.close",
+        "worker.close",
+    ]
+
+
+def test_shutdown_sessions_uses_canonical_teardown_once(monkeypatch):
+    closed: list[tuple[str, str]] = []
+    monkeypatch.setattr(server, "_close_session", lambda sid, reason="tui_close": closed.append((sid, reason)) or server._sessions.pop(sid, None) is not None)
+    server._sessions["sid"] = _session()
+    try:
+        server._shutdown_sessions()
+        server._shutdown_sessions()
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert closed == [("sid", "tui_shutdown")]
+
+
+def test_shutdown_signal_runs_session_closeout_before_exit(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(server, "_shutdown_sessions", lambda: calls.append("shutdown"))
+
+    try:
+        server._handle_shutdown_signal(signal.SIGTERM, None)
+        raise AssertionError("shutdown signal handler did not exit")
+    except SystemExit as exc:
+        assert exc.code == 128 + signal.SIGTERM
+
+    assert calls == ["shutdown"]
+
+
+def test_shutdown_signals_are_registered():
+    for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        assert signal.getsignal(signum) is server._handle_shutdown_signal
+
+
+def test_reap_idle_sessions_closes_only_eligible(monkeypatch):
+    now = 1000.0
+    closed: list[tuple[str, str]] = []
+    monkeypatch.setattr(server, "_close_session", lambda sid, reason="tui_close": closed.append((sid, reason)) or server._sessions.pop(sid, None) is not None)
+    server._sessions.update(
+        {
+            "idle": _session(last_seen_at=now - 7200, running=False),
+            "active": _session(last_seen_at=now - 7200, running=True),
+            "recent": _session(last_seen_at=now - 10, running=False),
+        }
+    )
+    try:
+        result = server._reap_idle_sessions(now=now, max_idle_s=3600)
+    finally:
+        for sid in ("idle", "active", "recent"):
+            server._sessions.pop(sid, None)
+
+    assert result == {"sessions_finalized": 1}
+    assert closed == [("idle", "tui_idle_reap")]
+
+
+def test_slash_worker_close_kills_and_waits_after_timeout(monkeypatch):
+    events: list[str] = []
+
+    class _Stdin:
+        def close(self):
+            events.append("stdin.close")
+
+    class _Proc:
+        stdin = _Stdin()
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def __init__(self):
+            self.waits = 0
+            self.alive = True
+
+        def poll(self):
+            return None if self.alive else 0
+
+        def terminate(self):
+            events.append("terminate")
+
+        def kill(self):
+            events.append("kill")
+            self.alive = False
+
+        def wait(self, timeout=None):
+            self.waits += 1
+            events.append(f"wait:{timeout}")
+            if self.waits < 2:
+                raise subprocess.TimeoutExpired("slash", timeout)
+            self.alive = False
+            return 0
+
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: _Proc())
+
+    worker = server._SlashWorker("session-key", "model")
+    worker.close()
+    worker.close()
+
+    assert events == ["stdin.close", "terminate", "wait:1.0", "kill", "wait:1.0"]
 
 
 def test_init_session_fires_reset_hook(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import queue
+import signal
 import subprocess
 import sys
 import threading
@@ -253,15 +254,48 @@ class _SlashWorker:
             )
 
     def close(self):
+        with self._lock:
+            if getattr(self, "_closed", False):
+                return
+            self._closed = True
+            proc = self.proc
+
+        pid = getattr(proc, "pid", None)
         try:
-            if self.proc.poll() is None:
-                self.proc.terminate()
-                self.proc.wait(timeout=1)
-        except Exception:
+            if getattr(proc, "stdin", None):
+                try:
+                    proc.stdin.close()
+                except Exception as exc:
+                    logger.debug("slash worker stdin close failed pid=%s: %s", pid, exc)
+
+            if proc.poll() is not None:
+                try:
+                    proc.wait(timeout=0)
+                except Exception:
+                    pass
+                return
+
             try:
-                self.proc.kill()
-            except Exception:
-                pass
+                proc.terminate()
+                proc.wait(timeout=1.0)
+                logger.info("slash worker closed pid=%s", pid)
+                return
+            except subprocess.TimeoutExpired:
+                logger.warning("slash worker terminate timed out; killing pid=%s", pid)
+            except Exception as exc:
+                logger.warning("slash worker terminate/wait failed pid=%s: %s", pid, exc)
+
+            try:
+                proc.kill()
+            except Exception as exc:
+                logger.warning("slash worker kill failed pid=%s: %s", pid, exc)
+            try:
+                proc.wait(timeout=1.0)
+                logger.warning("slash worker killed and reaped pid=%s", pid)
+            except Exception as exc:
+                logger.warning("slash worker kill wait failed pid=%s: %s", pid, exc)
+        except Exception as exc:
+            logger.warning("slash worker close failed pid=%s: %s", pid, exc)
 
 
 def _load_busy_input_mode() -> str:
@@ -321,18 +355,124 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             pass
 
 
+def _close_session(sid: str, end_reason: str = "tui_close") -> bool:
+    """Canonical best-effort teardown for one TUI/dashboard runtime session."""
+    session = _sessions.pop(sid, None)
+    if not session:
+        return False
+    session["closed_at"] = time.time()
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        unregister_gateway_notify(session["session_key"])
+    except Exception as exc:
+        logger.debug("approval notify unregister failed sid=%s: %s", sid, exc)
+    try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception as exc:
+        logger.debug("agent close failed sid=%s: %s", sid, exc)
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+            session["slash_worker"] = None
+    except Exception as exc:
+        logger.warning("slash worker close failed sid=%s: %s", sid, exc)
+    logger.info("TUI session finalized sid=%s reason=%s", sid, end_reason)
+    return True
+
+
 def _shutdown_sessions() -> None:
-    for session in list(_sessions.values()):
-        _finalize_session(session, end_reason="tui_shutdown")
+    finalized = 0
+    for sid in list(_sessions.keys()):
+        if _close_session(sid, "tui_shutdown"):
+            finalized += 1
+    if finalized:
+        logger.info("TUI shutdown finalized sessions=%s", finalized)
+
+
+def _reap_idle_sessions(*, now: float | None = None, max_idle_s: float | None = None) -> dict:
+    now = time.time() if now is None else float(now)
+    if max_idle_s is None:
         try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+            max_idle_s = float(os.environ.get("HERMES_TUI_IDLE_REAP_S") or "43200")
+        except (TypeError, ValueError):
+            max_idle_s = 43200.0
+    max_idle_s = max(300.0, float(max_idle_s))
+    closed = 0
+    for sid, session in list(_sessions.items()):
+        last_seen = float(session.get("last_seen_at") or session.get("created_at") or now)
+        if session.get("running") or now - last_seen < max_idle_s:
+            continue
+        if _close_session(sid, "tui_idle_reap"):
+            closed += 1
+    if closed:
+        logger.info("TUI idle reaper finalized sessions=%s max_idle_s=%s", closed, max_idle_s)
+    return {"sessions_finalized": closed}
+
+
+def _mark_session_activity(sid: str | None) -> None:
+    if not sid:
+        return
+    session = _sessions.get(sid)
+    if session is not None:
+        session["last_seen_at"] = time.time()
+
+
+def _run_stale_session_maintenance() -> int:
+    db = _get_db()
+    if db is None or not hasattr(db, "mark_stale_open_sessions"):
+        return 0
+    live_ids = {
+        getattr(session.get("agent"), "session_id", None) or session.get("session_key")
+        for session in list(_sessions.values())
+    }
+    live_ids = {sid for sid in live_ids if sid}
+    try:
+        marked = db.mark_stale_open_sessions(exclude_ids=live_ids)
+    except Exception as exc:
+        logger.warning("TUI stale-session DB maintenance failed: %s", exc)
+        return 0
+    if marked:
+        logger.info("TUI stale-session DB maintenance marked rows=%s", marked)
+    return int(marked or 0)
+
+
+def _maintenance_loop() -> None:
+    try:
+        interval = float(os.environ.get("HERMES_TUI_REAPER_INTERVAL_S") or "300")
+    except (TypeError, ValueError):
+        interval = 300.0
+    interval = max(30.0, interval)
+    while True:
+        time.sleep(interval)
+        _reap_idle_sessions()
+        _run_stale_session_maintenance()
+
+
+if os.environ.get("HERMES_TUI_REAPER_DISABLED") != "1":
+    _reaper_thread = threading.Thread(
+        target=_maintenance_loop,
+        name="tui-session-reaper",
+        daemon=True,
+    )
+    _reaper_thread.start()
 
 
 atexit.register(_shutdown_sessions)
+
+
+def _handle_shutdown_signal(signum, _frame) -> None:
+    """Finalize live TUI sessions before Python exits on OS signals."""
+    _shutdown_sessions()
+    raise SystemExit(128 + int(signum))
+
+
+for _shutdown_signal in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(_shutdown_signal, _handle_shutdown_signal)
 
 
 # ── Plumbing ──────────────────────────────────────────────────────────
@@ -493,6 +633,7 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        _mark_session_activity((_params or {}).get("session_id"))
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 
@@ -1930,6 +2071,8 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         # Pin async event emissions to whichever transport created the
         # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
         "transport": current_transport() or _stdio_transport,
+        "created_at": time.time(),
+        "last_seen_at": time.time(),
     }
     try:
         _sessions[sid]["slash_worker"] = _SlashWorker(
@@ -2120,6 +2263,8 @@ def _(rid, params: dict) -> dict:
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
         "transport": current_transport() or _stdio_transport,
+        "created_at": time.time(),
+        "last_seen_at": time.time(),
     }
 
     # Return the lightweight session immediately so Ink can paint the composer
@@ -2637,29 +2782,8 @@ def _(rid, params: dict) -> dict:
 @method("session.close")
 def _(rid, params: dict) -> dict:
     sid = params.get("session_id", "")
-    session = _sessions.pop(sid, None)
-    if not session:
-        return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
-    return _ok(rid, {"closed": True})
+    closed = _close_session(sid, "tui_close")
+    return _ok(rid, {"closed": closed})
 
 
 @method("session.branch")


### PR DESCRIPTION
## Summary
- route explicit close, shutdown, signal handling, and idle reaping through a canonical idempotent TUI session teardown path
- make slash worker close idempotent with stdin EOF, terminate/wait, and kill/wait escalation
- add conservative stale open session DB maintenance that marks old TUI/dashboard rows ended without deleting sessions/messages or overwriting existing end reasons

## Tests
- `python -m pytest tests/test_tui_gateway_server.py tests/test_lazy_session_regressions.py -q -o 'addopts='` → 202 passed
- `scripts/run_tests.sh` → failed before running tests: no virtualenv found in worktree `.venv` or `venv`
