### PR TITLE
fix(aux): support Gemini CLI auxiliary provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -300,9 +300,15 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
 # describe as having no image_in capability. Vision lives on the separate
 # Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
+#
+# google-gemini-cli: the Cloud Code Assist / Gemini CLI adapter currently
+# accepts OpenAI-shaped chat messages but intentionally drops image_url parts
+# before calling the Gemini CLI.  Do not auto-route vision there; fall through
+# to known multimodal backends instead.
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+    "google-gemini-cli",
 })
 
 # OpenRouter app attribution headers (base — always sent).
@@ -2259,6 +2265,7 @@ def _is_payment_error(exc: Exception) -> bool:
             "payment required",
             # Daily / monthly quota exhaustion keywords
             "quota exceeded", "quota_exceeded",
+            "quota exhausted", "capacity exhausted",
             "too many tokens per day", "daily limit",
             "tokens per day", "daily quota",
             "resource exhausted",  # Vertex AI / gRPC quota errors
@@ -2339,12 +2346,17 @@ def _is_connection_error(exc: Exception) -> bool:
 
 
 def _is_auth_error(exc: Exception) -> bool:
-    """Detect auth failures that should trigger provider-specific refresh."""
+    """Detect auth failures that should trigger provider-specific refresh/fallback."""
     status = getattr(exc, "status_code", None)
     if status == 401:
         return True
     err_lower = str(exc).lower()
-    return "error code: 401" in err_lower or "authenticationerror" in type(exc).__name__.lower()
+    err_type = type(exc).__name__.lower()
+    return (
+        "error code: 401" in err_lower
+        or "authenticationerror" in err_type
+        or "googleoautherror" in err_type
+    )
 
 
 def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
@@ -2401,13 +2413,7 @@ def _evict_cached_clients(provider: str) -> None:
         for key in stale_keys:
             client = _client_cache.get(key, (None, None, None))[0]
             if client is not None:
-                _force_close_async_httpx(client)
-                try:
-                    close_fn = getattr(client, "close", None)
-                    if callable(close_fn):
-                        close_fn()
-                except Exception:
-                    pass
+                _close_cached_client(client)
             _client_cache.pop(key, None)
 
 
@@ -2441,6 +2447,7 @@ def _evict_cached_client_instance(target: Any) -> bool:
                 continue
             real = getattr(cached, "_real_client", None)
             if cached is target or real is target:
+                _close_cached_client(cached)
                 del _client_cache[key]
                 evicted = True
     return evicted
@@ -2988,6 +2995,48 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
 # below — never look up auth env vars ad-hoc.
 
 
+class _AsyncGeminiCloudCodeCompletions:
+    """Async facade for Gemini Cloud Code's sync completions adapter."""
+
+    def __init__(self, sync_client: Any):
+        self._sync_client = sync_client
+
+    async def create(self, **kwargs: Any) -> Any:
+        import asyncio
+
+        return await asyncio.to_thread(
+            self._sync_client.chat.completions.create,
+            **kwargs,
+        )
+
+
+class _AsyncGeminiCloudCodeChat:
+    def __init__(self, sync_client: Any):
+        self.completions = _AsyncGeminiCloudCodeCompletions(sync_client)
+
+
+class _AsyncGeminiCloudCodeClient:
+    """Async-compatible wrapper preserving Gemini CLI Cloud Code OAuth routing."""
+
+    def __init__(self, sync_client: Any):
+        self._real_client = sync_client
+        self.api_key = getattr(sync_client, "api_key", "google-oauth")
+        self.base_url = getattr(sync_client, "base_url", "cloudcode-pa://google")
+        self.chat = _AsyncGeminiCloudCodeChat(sync_client)
+
+    @property
+    def is_closed(self) -> bool:
+        return bool(getattr(self._real_client, "is_closed", False))
+
+    def close(self) -> None:
+        close_fn = getattr(self._real_client, "close", None)
+        if callable(close_fn):
+            close_fn()
+
+    async def aclose(self) -> None:
+        self.close()
+
+
 def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """Convert a sync client to its async counterpart, preserving Codex routing.
 
@@ -3007,6 +3056,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
 
         if isinstance(sync_client, GeminiNativeClient):
             return AsyncGeminiNativeClient(sync_client), model
+    except ImportError:
+        pass
+    try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+        if isinstance(sync_client, GeminiCloudCodeClient):
+            return _AsyncGeminiCloudCodeClient(sync_client), model
     except ImportError:
         pass
     try:
@@ -3665,6 +3721,20 @@ def resolve_provider_client(
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "google-gemini-cli":
+            # Gemini CLI / Cloud Code Assist uses Google OAuth, not an API key.
+            # Its adapter exposes the same .chat.completions.create() surface
+            # as OpenAI clients, so text-only auxiliary tasks (compression,
+            # title generation, etc.) can use it directly when explicitly
+            # selected via auxiliary.<task>.provider.
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+            final_model = _normalize_resolved_model(
+                model or "gemini-3-flash-preview", provider
+            )
+            client = GeminiCloudCodeClient()
+            return (_to_async_client(client, final_model, is_vision=is_vision)
+                    if async_mode else (client, final_model))
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
@@ -3769,7 +3839,12 @@ def get_available_vision_backends() -> List[str]:
     # 1. Active provider — if the user configured a provider, try it first.
     main_provider = _read_main_provider()
     if main_provider and main_provider not in {"auto", ""}:
-        if main_provider in _VISION_AUTO_PROVIDER_ORDER:
+        if main_provider in _PROVIDERS_WITHOUT_VISION:
+            logger.debug(
+                "Vision backend list: skipping main provider %s (no vision support)",
+                main_provider,
+            )
+        elif main_provider in _VISION_AUTO_PROVIDER_ORDER:
             if _strict_vision_backend_available(main_provider):
                 available.append(main_provider)
         else:
@@ -4004,13 +4079,7 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
         if old_entry is not None and old_entry[0] is not client:
-            _force_close_async_httpx(old_entry[0])
-            try:
-                close_fn = getattr(old_entry[0], "close", None)
-                if callable(close_fn):
-                    close_fn()
-            except Exception:
-                pass
+            _close_cached_client(old_entry[0])
         _client_cache[cache_key] = (client, default_model, bound_loop)
 
 
@@ -4111,30 +4180,31 @@ def _force_close_async_httpx(client: Any) -> None:
         pass
 
 
+def _close_cached_client(client: Any) -> None:
+    """Best-effort close for clients removed from the auxiliary cache."""
+    import inspect
+
+    _force_close_async_httpx(client)
+    try:
+        close_fn = getattr(client, "close", None)
+        if close_fn and not inspect.iscoroutinefunction(close_fn):
+            close_fn()
+    except (OSError, RuntimeError, TypeError, AttributeError):
+        logger.debug("Auxiliary: cached client close failed", exc_info=True)
+
+
 def shutdown_cached_clients() -> None:
     """Close all cached clients (sync and async) to prevent event-loop errors.
 
     Call this during CLI shutdown, *before* the event loop is closed, to
     avoid ``AsyncHttpxClientWrapper.__del__`` raising on a dead loop.
     """
-    import inspect
-
     with _client_cache_lock:
         for key, entry in list(_client_cache.items()):
             client = entry[0]
             if client is None:
                 continue
-            # Mark any async httpx transport as closed first (prevents __del__
-            # from scheduling aclose() on a dead event loop).
-            _force_close_async_httpx(client)
-            # Sync clients: close the httpx connection pool cleanly.
-            # Async clients: skip — we already neutered __del__ above.
-            try:
-                close_fn = getattr(client, "close", None)
-                if close_fn and not inspect.iscoroutinefunction(close_fn):
-                    close_fn()
-            except Exception:
-                pass
+            _close_cached_client(client)
         _client_cache.clear()
 
 
@@ -4151,7 +4221,7 @@ def cleanup_stale_async_clients() -> None:
         for key, entry in _client_cache.items():
             client, _default, cached_loop = entry
             if cached_loop is not None and cached_loop.is_closed():
-                _force_close_async_httpx(client)
+                _close_cached_client(client)
                 stale_keys.append(key)
         for key in stale_keys:
             del _client_cache[key]
@@ -4244,7 +4314,7 @@ def _get_cached_client(
                     effective = _compat_model(cached_client, model, cached_default)
                     return cached_client, effective
                 # Stale — evict and fall through to create a new client.
-                _force_close_async_httpx(cached_client)
+                _close_cached_client(cached_client)
                 del _client_cache[cache_key]
             else:
                 effective = _compat_model(cached_client, model, cached_default)
@@ -4270,7 +4340,7 @@ def _get_cached_client(
                 # the oldest entries (FIFO — dict preserves insertion order).
                 while len(_client_cache) >= _CLIENT_CACHE_MAX_SIZE:
                     evict_key, evict_entry = next(iter(_client_cache.items()))
-                    _force_close_async_httpx(evict_entry[0])
+                    _close_cached_client(evict_entry[0])
                     del _client_cache[evict_key]
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
@@ -4857,6 +4927,7 @@ def call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_auth_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
         # validation, etc.) but allow fallback when the provider clearly cannot
@@ -4880,6 +4951,8 @@ def call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_auth_error(first_err):
+                reason = "auth error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -4903,6 +4976,12 @@ def call_llm(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
+                if _is_connection_error(first_err):
+                    try:
+                        _evict_cached_client_instance(client)
+                    except Exception:
+                        logger.debug("Auxiliary: cache eviction before fallback failed",
+                                     exc_info=True)
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
@@ -5219,6 +5298,7 @@ async def async_call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_auth_error(first_err)
         )
         # Capacity errors (payment/quota/connection) bypass the explicit-provider
         # gate — the provider cannot serve the request regardless of user intent.
@@ -5233,6 +5313,8 @@ async def async_call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_auth_error(first_err):
+                reason = "auth error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
@@ -5255,6 +5337,12 @@ async def async_call_llm(
                         resolved_provider, task, reason=reason)
 
             if fb_client is not None:
+                if _is_connection_error(first_err):
+                    try:
+                        _evict_cached_client_instance(client)
+                    except Exception:
+                        logger.debug("Auxiliary (async): cache eviction before fallback failed",
+                                     exc_info=True)
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -712,10 +712,18 @@ class GeminiCloudCodeClient:
         headers.update(self._default_headers)
 
         if stream:
-            return self._stream_completion(model=model, wrapped=wrapped, headers=headers)
+            return self._stream_completion(
+                model=model,
+                wrapped=wrapped,
+                headers=headers,
+                timeout=timeout,
+            )
 
         url = f"{CODE_ASSIST_ENDPOINT}/v1internal:generateContent"
-        response = self._http.post(url, json=wrapped, headers=headers)
+        request_kwargs: Dict[str, Any] = {"json": wrapped, "headers": headers}
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
+        response = self._http.post(url, **request_kwargs)
         if response.status_code != 200:
             raise _gemini_http_error(response)
         try:
@@ -733,6 +741,7 @@ class GeminiCloudCodeClient:
         model: str,
         wrapped: Dict[str, Any],
         headers: Dict[str, str],
+        timeout: Any = None,
     ) -> Iterator[_GeminiStreamChunk]:
         """Generator that yields OpenAI-shaped streaming chunks."""
         url = f"{CODE_ASSIST_ENDPOINT}/v1internal:streamGenerateContent?alt=sse"
@@ -741,7 +750,10 @@ class GeminiCloudCodeClient:
 
         def _generator() -> Iterator[_GeminiStreamChunk]:
             try:
-                with self._http.stream("POST", url, json=wrapped, headers=stream_headers) as response:
+                request_kwargs: Dict[str, Any] = {"json": wrapped, "headers": stream_headers}
+                if timeout is not None:
+                    request_kwargs["timeout"] = timeout
+                with self._http.stream("POST", url, **request_kwargs) as response:
                     if response.status_code != 200:
                         # Materialize error body for better diagnostics
                         response.read()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -23,6 +23,7 @@ from agent.auxiliary_client import (
     _get_provider_chain,
     _is_payment_error,
     _is_rate_limit_error,
+    _is_auth_error,
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
@@ -82,6 +83,129 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
+
+
+class TestGeminiCliAuxiliaryProvider:
+    def test_explicit_google_gemini_cli_returns_cloudcode_client(self):
+        fake_client = MagicMock()
+        with patch(
+            "agent.gemini_cloudcode_adapter.GeminiCloudCodeClient",
+            return_value=fake_client,
+        ) as mock_client:
+            client, model = resolve_provider_client(
+                "google-gemini-cli",
+                model="gemini-3-flash-preview",
+            )
+
+        assert client is fake_client
+        assert model == "gemini-3-flash-preview"
+        mock_client.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_async_google_gemini_cli_preserves_cloudcode_adapter(self):
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient, MARKER_BASE_URL
+
+        client, model = resolve_provider_client(
+            "google-gemini-cli",
+            model="gemini-3-flash-preview",
+            async_mode=True,
+        )
+        assert client is not None
+        try:
+            assert model == "gemini-3-flash-preview"
+            assert client.base_url == MARKER_BASE_URL
+            assert isinstance(client._real_client, GeminiCloudCodeClient)
+
+            response = SimpleNamespace(choices=[])
+            client._real_client.chat.completions.create = MagicMock(return_value=response)
+            result = await client.chat.completions.create(model=model, messages=[])
+
+            assert result is response
+            client._real_client.chat.completions.create.assert_called_once_with(
+                model=model,
+                messages=[],
+            )
+        finally:
+            client.close()
+
+    def test_stale_async_cleanup_closes_wrapped_cloudcode_client(self):
+        import asyncio
+        from agent.auxiliary_client import (
+            _AsyncGeminiCloudCodeClient,
+            _client_cache,
+            _client_cache_key,
+            _client_cache_lock,
+            cleanup_stale_async_clients,
+        )
+
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        sync_client = SimpleNamespace(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            close=MagicMock(),
+        )
+        wrapper = _AsyncGeminiCloudCodeClient(sync_client)
+        cache_key = _client_cache_key("google-gemini-cli", async_mode=True)
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (wrapper, "gemini-3-flash-preview", closed_loop)
+        try:
+            cleanup_stale_async_clients()
+
+            sync_client.close.assert_called_once_with()
+            assert cache_key not in _client_cache
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
+    def test_stale_async_cache_hit_closes_wrapped_cloudcode_client(self):
+        import asyncio
+        import agent.auxiliary_client as aux
+        from agent.auxiliary_client import (
+            _AsyncGeminiCloudCodeClient,
+            _client_cache,
+            _client_cache_key,
+            _client_cache_lock,
+        )
+
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        sync_client = SimpleNamespace(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            close=MagicMock(),
+        )
+        stale_wrapper = _AsyncGeminiCloudCodeClient(sync_client)
+        fresh_wrapper = MagicMock(name="fresh_async_cloudcode_wrapper")
+        cache_key = _client_cache_key("google-gemini-cli", async_mode=True)
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (stale_wrapper, "gemini-3-flash-preview", closed_loop)
+        try:
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fresh_wrapper, "gemini-3-flash-preview"),
+            ) as mock_resolve:
+                client, model = aux._get_cached_client(
+                    "google-gemini-cli",
+                    "gemini-3-flash-preview",
+                    async_mode=True,
+                )
+
+            sync_client.close.assert_called_once_with()
+            assert client is fresh_wrapper
+            assert model == "gemini-3-flash-preview"
+            mock_resolve.assert_called_once()
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
+    def test_google_oauth_error_is_auth_error_for_fallback(self):
+        class GoogleOAuthError(Exception):
+            pass
+
+        assert _is_auth_error(GoogleOAuthError("Google OAuth credentials not found"))
 
 
 class TestReadCodexAccessToken:
@@ -931,6 +1055,13 @@ class TestIsPaymentError:
         """Cloud provider quota exhaustion (e.g. Vertex AI) is a payment error."""
         exc = Exception("RESOURCE_EXHAUSTED: quota exceeded for project")
         exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    @pytest.mark.parametrize("message", ["Gemini quota exhausted", "Gemini capacity exhausted"])
+    def test_429_gemini_cli_quota_capacity_exhausted(self, message):
+        """Gemini CLI quota/capacity exhaustion should bypass explicit-provider fallback gate."""
+        exc = Exception(message)
+        setattr(exc, "status_code", 429)
         assert _is_payment_error(exc) is True
 
     def test_429_too_many_tokens_per_day(self):
@@ -2288,6 +2419,7 @@ class TestVisionAutoSkipsKimiCoding:
         assert _PROVIDERS_WITHOUT_VISION == frozenset({
             "kimi-coding",
             "kimi-coding-cn",
+            "google-gemini-cli",
         })
 
 
@@ -2594,6 +2726,93 @@ class TestAuxiliaryClientPoisonedCacheEviction:
                         task="compression",
                         messages=[{"role": "user", "content": "x"}],
                     )
+            assert cache_key not in _client_cache
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
+    def test_call_llm_evicts_before_successful_connection_fallback(self):
+        from agent.auxiliary_client import _client_cache, _client_cache_lock
+
+        poisoned = MagicMock(name="poisoned_client")
+        poisoned.base_url = "https://cloudcode-pa.googleapis.com"
+        poisoned.chat.completions.create.side_effect = TimeoutError("timed out")
+        fallback = MagicMock(name="fallback_client")
+        fallback.base_url = "https://fallback.example/v1"
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        fallback.chat.completions.create.return_value = response
+
+        cache_key = ("google-gemini-cli", False, None, None, None)
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (poisoned, "gemini-3-flash-preview", None)
+
+        try:
+            with patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("google-gemini-cli", "gemini-3-flash-preview", None, None, None),
+            ), patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(poisoned, "gemini-3-flash-preview"),
+            ), patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fallback, "fallback-model", "fallback_chain[0](openrouter)"),
+            ), patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ):
+                assert call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                ) is response
+            assert cache_key not in _client_cache
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_evicts_before_successful_connection_fallback(self):
+        from agent.auxiliary_client import _client_cache, _client_cache_lock
+
+        poisoned = MagicMock(name="poisoned_async_client")
+        poisoned.base_url = "https://cloudcode-pa.googleapis.com"
+        poisoned.chat.completions.create = AsyncMock(side_effect=TimeoutError("timed out"))
+        fallback = MagicMock(name="fallback_client")
+        fallback.base_url = "https://fallback.example/v1"
+        async_fallback = MagicMock(name="async_fallback_client")
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        async_fallback.chat.completions.create = AsyncMock(return_value=response)
+
+        cache_key = ("google-gemini-cli", True, None, None, None)
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[cache_key] = (poisoned, "gemini-3-flash-preview", None)
+
+        try:
+            with patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("google-gemini-cli", "gemini-3-flash-preview", None, None, None),
+            ), patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(poisoned, "gemini-3-flash-preview"),
+            ), patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fallback, "fallback-model", "fallback_chain[0](openrouter)"),
+            ), patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ), patch(
+                "agent.auxiliary_client._to_async_client",
+                return_value=(async_fallback, "fallback-model"),
+            ):
+                assert await async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                ) is response
             assert cache_key not in _client_cache
         finally:
             with _client_cache_lock:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -254,6 +254,49 @@ class TestResolveVisionProviderClientModelNormalization:
         assert client is not None
         assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
 
+    def test_vision_auto_skips_gemini_cli_main_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gemini-3-flash-preview", "provider": "google-gemini-cli"},
+        })
+        fallback_client = MagicMock()
+
+        def fake_strict(provider, model=None):
+            if provider == "openrouter":
+                return fallback_client, "openrouter/vision-model"
+            return None, None
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve,
+            patch("agent.auxiliary_client._resolve_strict_vision_backend", side_effect=fake_strict),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "openrouter"
+        assert client is fallback_client
+        assert model == "openrouter/vision-model"
+        mock_resolve.assert_not_called()
+
+    def test_available_vision_backends_skips_gemini_cli_main_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gemini-3-flash-preview", "provider": "google-gemini-cli"},
+        })
+
+        def fake_strict(provider, model=None):
+            return (MagicMock(), f"{provider}-vision") if provider == "openrouter" else (None, None)
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve,
+            patch("agent.auxiliary_client._resolve_strict_vision_backend", side_effect=fake_strict),
+        ):
+            from agent.auxiliary_client import get_available_vision_backends
+
+            backends = get_available_vision_backends()
+
+        assert backends == ["openrouter"]
+        mock_resolve.assert_not_called()
+
 
 class TestVisionPathApiMode:
     """Vision path should propagate api_mode to _get_cached_client."""

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -954,6 +954,61 @@ class TestGeminiCloudCodeClient:
         finally:
             client.close()
 
+    def test_forwards_timeout_to_non_stream_request(self):
+        from agent import gemini_cloudcode_adapter as adapter
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+        from agent.google_code_assist import ProjectContext
+
+        fake_response = MagicMock(status_code=200)
+        fake_response.json.return_value = {
+            "response": {
+                "candidates": [
+                    {"content": {"parts": [{"text": "ok"}], "role": "model"}}
+                ]
+            }
+        }
+        http = MagicMock()
+        http.post.return_value = fake_response
+        client = GeminiCloudCodeClient(api_key="dummy")
+        client._http = http
+        client._project_context = ProjectContext(project_id="proj")
+        try:
+            with patch.object(adapter.google_oauth, "get_valid_access_token", return_value="tok"):
+                client.chat.completions.create(
+                    model="gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hi"}],
+                    timeout=7.5,
+                )
+        finally:
+            client.close()
+
+        assert http.post.call_args.kwargs["timeout"] == 7.5
+
+    def test_forwards_timeout_to_stream_request(self):
+        from agent import gemini_cloudcode_adapter as adapter
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+        from agent.google_code_assist import ProjectContext
+
+        http = MagicMock()
+        client = GeminiCloudCodeClient(api_key="dummy")
+        client._http = http
+        client._project_context = ProjectContext(project_id="proj")
+        try:
+            with patch.object(adapter.google_oauth, "get_valid_access_token", return_value="tok"):
+                stream = client.chat.completions.create(
+                    model="gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hi"}],
+                    stream=True,
+                    timeout=3.25,
+                )
+                # Force the lazy generator to enter the HTTP stream context.
+                with pytest.raises(Exception):
+                    next(iter(stream))
+        finally:
+            client.close()
+
+        assert http.stream.call_args.kwargs["timeout"] == 3.25
+
 
 class TestGeminiHttpErrorParsing:
     """Regression coverage for _gemini_http_error Google-envelope parsing.


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary-provider routing for explicit `google-gemini-cli` requests so Gemini CLI auxiliary calls use the Gemini Cloud Code client and provider defaults instead of falling through to the generic auxiliary client path.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route explicit `google-gemini-cli` auxiliary provider requests to `GeminiCloudCodeClient`.
- Add/use the provider default auxiliary model when no auxiliary model is specified.
- Include `GoogleOAuthError` in the auth-error/fallback path so OAuth failures trigger the intended fallback behavior.
- Add regression tests for Gemini CLI auxiliary routing and OAuth-error fallback behavior.

## How to Test

1. Run the auxiliary-provider focused test suite.
2. Verify Gemini CLI auxiliary routing uses the Gemini Cloud Code client path.
3. Verify `GoogleOAuthError` is treated as an auth failure/fallback candidate.
4. Run a read-only Codex review of the final branch delta.

Verification performed during refresh:

- `uv run --extra dev pytest ...` focused auxiliary tests: 271 passed.
- Read-only Codex review: first BLOCKED → fixes applied → fresh final review `VERDICT: CLEAN`.
- Branch was rebased onto current `main` and updated with `--force-with-lease`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Note: I ran focused/regression tests locally for the changed auxiliary-provider area and am relying on GitHub Actions for the full matrix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

N/A. Relevant verification is in local focused test output, Codex review logs, and GitHub Actions checks.
