### PR TITLE
feat(gateway): optional per-message ISO-8601 timestamp prefix

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -476,6 +476,14 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Per-message timestamps: when True, prepend each inbound user message
+    # with an ISO-8601 timestamp (rendered in the gateway host's local tz)
+    # before it enters the agent loop. Helps the model reason about message
+    # gaps in long-running sessions where the system prompt's "session
+    # start" timestamp is the only clock signal. Off by default — opt-in
+    # to avoid surprising downstream consumers that grep transcript text.
+    timestamp_messages: bool = False
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -576,6 +584,7 @@ class GatewayConfig:
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
+            "timestamp_messages": self.timestamp_messages,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -621,6 +630,7 @@ class GatewayConfig:
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
+        timestamp_messages = data.get("timestamp_messages")
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -644,6 +654,7 @@ class GatewayConfig:
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
+            timestamp_messages=_coerce_bool(timestamp_messages, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
@@ -733,6 +744,9 @@ def load_gateway_config() -> GatewayConfig:
 
             if "thread_sessions_per_user" in yaml_cfg:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
+
+            if "timestamp_messages" in yaml_cfg:
+                gw_data["timestamp_messages"] = yaml_cfg["timestamp_messages"]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if not isinstance(streaming_cfg, dict):

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -484,6 +484,18 @@ class GatewayConfig:
     # to avoid surprising downstream consumers that grep transcript text.
     timestamp_messages: bool = False
 
+    # Gap-since-last-message threshold (seconds) that gates the per-message
+    # timestamp prefix above. Only applies when timestamp_messages is True.
+    # 0 = always prepend (legacy behaviour). Positive values skip the prefix
+    # for messages arriving within ``threshold`` seconds of the previous
+    # inbound message in the same session — avoids token waste in active
+    # back-and-forth where the model already has temporal context. The
+    # default (600s / 10min) re-anchors on the first message after any
+    # meaningful pause without spamming prefixes mid-conversation. The first
+    # message after gateway restart always gets a prefix (no prior timestamp
+    # in memory), which is the desired behaviour: re-anchor after a gap.
+    message_timestamp_threshold_seconds: int = 600
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -585,6 +597,7 @@ class GatewayConfig:
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "timestamp_messages": self.timestamp_messages,
+            "message_timestamp_threshold_seconds": self.message_timestamp_threshold_seconds,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -631,6 +644,11 @@ class GatewayConfig:
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         timestamp_messages = data.get("timestamp_messages")
+        message_timestamp_threshold_seconds = _coerce_int(
+            data.get("message_timestamp_threshold_seconds"), 600,
+        )
+        if message_timestamp_threshold_seconds < 0:
+            message_timestamp_threshold_seconds = 0
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -655,6 +673,7 @@ class GatewayConfig:
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             timestamp_messages=_coerce_bool(timestamp_messages, False),
+            message_timestamp_threshold_seconds=message_timestamp_threshold_seconds,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
@@ -747,6 +766,9 @@ def load_gateway_config() -> GatewayConfig:
 
             if "timestamp_messages" in yaml_cfg:
                 gw_data["timestamp_messages"] = yaml_cfg["timestamp_messages"]
+
+            if "message_timestamp_threshold_seconds" in yaml_cfg:
+                gw_data["message_timestamp_threshold_seconds"] = yaml_cfg["message_timestamp_threshold_seconds"]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if not isinstance(streaming_cfg, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6809,6 +6809,26 @@ class GatewayRunner:
         if _is_shared_multi_user and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
+        # Optional per-message timestamp prefix. Off by default. Renders the
+        # platform-supplied event timestamp as ISO-8601 with a numeric offset
+        # in the gateway host's local timezone. Applied before any context
+        # backfill or media enrichment so the timestamp brackets the trigger
+        # message only.
+        if getattr(self.config, "timestamp_messages", False):
+            _ts = getattr(event, "timestamp", None)
+            if _ts is not None:
+                try:
+                    # `astimezone()` with no argument converts to local time;
+                    # for naive datetimes it assumes the value is local already,
+                    # which matches our datetime.now() fallback in MessageEvent.
+                    _ts_local = _ts.astimezone()
+                    # ISO 8601, second precision, with numeric offset.
+                    _stamp = _ts_local.replace(microsecond=0).isoformat()
+                    message_text = f"[{_stamp}] {message_text}"
+                except Exception:
+                    # Bad timestamps must never block message delivery.
+                    logger.debug("timestamp_messages: failed to format event.timestamp", exc_info=True)
+
         # Prepend channel context from history backfill (if any).  This
         # happens after sender-prefix so the prefix only applies to the
         # trigger message, not the backfill block.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1251,6 +1251,12 @@ class GatewayRunner:
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
+        # Tracks the timestamp of the most recent inbound message per session,
+        # used by the per-message timestamp prefix feature to suppress prefixes
+        # during active back-and-forth. Lives only in-memory: a gateway restart
+        # naturally re-anchors via a fresh prefix on the first message, which
+        # is the desired behaviour for a long-gap recovery.
+        self._last_inbound_message_ts: Dict[str, datetime] = {}
         self._session_run_generation: Dict[str, int] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
         # fallback routing paths (shutdown notifications, synthetic
@@ -6814,6 +6820,14 @@ class GatewayRunner:
         # in the gateway host's local timezone. Applied before any context
         # backfill or media enrichment so the timestamp brackets the trigger
         # message only.
+        #
+        # When ``message_timestamp_threshold_seconds`` is positive (default
+        # 600s / 10 min), the prefix is suppressed for messages arriving
+        # within that window of the previous inbound message in the same
+        # session — avoids token waste during active back-and-forth.  The
+        # first message after gateway restart always gets a prefix (no prior
+        # timestamp in memory), which is the desired re-anchor behaviour.
+        # Set the threshold to 0 to prefix every message (legacy behaviour).
         if getattr(self.config, "timestamp_messages", False):
             _ts = getattr(event, "timestamp", None)
             if _ts is not None:
@@ -6822,9 +6836,30 @@ class GatewayRunner:
                     # for naive datetimes it assumes the value is local already,
                     # which matches our datetime.now() fallback in MessageEvent.
                     _ts_local = _ts.astimezone()
-                    # ISO 8601, second precision, with numeric offset.
-                    _stamp = _ts_local.replace(microsecond=0).isoformat()
-                    message_text = f"[{_stamp}] {message_text}"
+                    _threshold = max(
+                        int(getattr(self.config, "message_timestamp_threshold_seconds", 600) or 0),
+                        0,
+                    )
+                    _prev = self._last_inbound_message_ts.get(session_key)
+                    _should_prefix = True
+                    if _threshold > 0 and _prev is not None:
+                        try:
+                            _gap = (_ts_local - _prev).total_seconds()
+                        except Exception:
+                            _gap = None
+                        # Negative gaps (out-of-order delivery) are treated as
+                        # "fresh enough" — don't re-anchor on a late-arriving
+                        # message that pre-dates the last one we saw.
+                        if _gap is not None and _gap <= _threshold:
+                            _should_prefix = False
+                    if _should_prefix:
+                        # ISO 8601, second precision, with numeric offset.
+                        _stamp = _ts_local.replace(microsecond=0).isoformat()
+                        message_text = f"[{_stamp}] {message_text}"
+                    # Always update the last-seen timestamp, even when we skip
+                    # the prefix — the threshold is a rolling gap, not anchored
+                    # to the last *prefixed* message.
+                    self._last_inbound_message_ts[session_key] = _ts_local
                 except Exception:
                     # Bad timestamps must never block message delivery.
                     logger.debug("timestamp_messages: failed to format event.timestamp", exc_info=True)

--- a/tests/gateway/test_timestamp_messages.py
+++ b/tests/gateway/test_timestamp_messages.py
@@ -1,0 +1,184 @@
+"""Tests for the per-message timestamp prefix feature.
+
+When ``GatewayConfig.timestamp_messages`` is True, the gateway prepends each
+inbound user message with an ISO-8601 timestamp (rendered in the host's
+local timezone) before it enters the agent loop. This gives the model a
+clock signal on every turn in long-running sessions where the system
+prompt's "session start" timestamp is the only built-in clock.
+"""
+
+import re
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+_ISO_PREFIX_RE = re.compile(
+    r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2}|Z)\] "
+)
+
+
+def _make_runner(config: GatewayConfig) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="504464026",
+        chat_name="Simon",
+        chat_type="private",
+        user_name="Simon",
+    )
+
+
+@pytest.mark.asyncio
+async def test_timestamp_prefix_added_when_enabled():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+        )
+    )
+    # Fixed UTC time so we can assert the rendered offset is well-formed.
+    fixed_ts = datetime(2026, 5, 15, 18, 25, 0, tzinfo=timezone.utc)
+    source = _make_source()
+    event = MessageEvent(text="hello", source=source, timestamp=fixed_ts)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert _ISO_PREFIX_RE.match(result), f"missing/malformed iso prefix: {result!r}"
+    assert result.endswith(" hello")
+
+
+@pytest.mark.asyncio
+async def test_timestamp_prefix_skipped_when_disabled_by_default():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            # timestamp_messages defaults to False
+        )
+    )
+    source = _make_source()
+    event = MessageEvent(
+        text="hello",
+        source=source,
+        timestamp=datetime(2026, 5, 15, 18, 25, 0, tzinfo=timezone.utc),
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_timestamp_prefix_preserves_numeric_offset():
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+        )
+    )
+    # Build a tz-aware datetime in a non-UTC zone (BST-equivalent +01:00) and
+    # confirm the rendered prefix carries a numeric offset (could be either
+    # the original or the host-local one — astimezone() converts to local).
+    bst = timezone(timedelta(hours=1))
+    event_ts = datetime(2026, 5, 15, 19, 25, 0, tzinfo=bst)
+    source = _make_source()
+    event = MessageEvent(text="hi", source=source, timestamp=event_ts)
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    # Must contain a numeric offset (+HH:MM or -HH:MM); never a bare time.
+    assert re.search(r"[+-]\d{2}:\d{2}\]", result), f"no numeric offset: {result!r}"
+    assert result.endswith(" hi")
+
+
+@pytest.mark.asyncio
+async def test_timestamp_prefix_applies_before_sender_prefix_in_shared_group():
+    """When both shared-group sender prefix and timestamp_messages are on,
+    the timestamp wraps the already-prefixed message (one prefix per line)."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            group_sessions_per_user=False,
+            timestamp_messages=True,
+        )
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_name="Test Group",
+        chat_type="group",
+        user_name="Alice",
+    )
+    event = MessageEvent(
+        text="hello",
+        source=source,
+        timestamp=datetime(2026, 5, 15, 18, 25, 0, tzinfo=timezone.utc),
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert _ISO_PREFIX_RE.match(result), f"missing iso prefix: {result!r}"
+    # The sender prefix should still be present, after the timestamp.
+    assert "[Alice] hello" in result
+
+
+@pytest.mark.asyncio
+async def test_timestamp_prefix_survives_malformed_timestamp():
+    """A bad timestamp must never block delivery — it should silently no-op."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+        )
+    )
+    source = _make_source()
+    # Provide an object that masquerades as a datetime but raises on astimezone.
+    class _BadTs:
+        tzinfo = None
+
+        def astimezone(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    event = MessageEvent(text="hello", source=source)
+    event.timestamp = _BadTs()  # type: ignore[assignment]
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    # Original message comes through unchanged.
+    assert result == "hello"

--- a/tests/gateway/test_timestamp_messages.py
+++ b/tests/gateway/test_timestamp_messages.py
@@ -29,6 +29,7 @@ def _make_runner(config: GatewayConfig) -> GatewayRunner:
     runner.adapters = {}
     runner._model = "openai/gpt-4.1-mini"
     runner._base_url = None
+    runner._last_inbound_message_ts = {}
     return runner
 
 
@@ -182,3 +183,238 @@ async def test_timestamp_prefix_survives_malformed_timestamp():
 
     # Original message comes through unchanged.
     assert result == "hello"
+
+
+# -----------------------------------------------------------------------------
+# message_timestamp_threshold_seconds — gap-gated prefix
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_message_always_gets_prefix_regardless_of_threshold():
+    """No prior inbound timestamp = re-anchor scenario; prefix must apply."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,  # default-ish
+        )
+    )
+    source = _make_source()
+    event = MessageEvent(
+        text="hello",
+        source=source,
+        timestamp=datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc),
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert _ISO_PREFIX_RE.match(result), f"first message missing prefix: {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_threshold_suppresses_prefix_within_window():
+    """Rapid back-and-forth: second message within threshold gets no prefix."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,  # 10 min
+        )
+    )
+    source = _make_source()
+    t0 = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(seconds=30)  # well inside 10 min window
+
+    # First message anchors the gap tracker and emits a prefix.
+    first = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hello", source=source, timestamp=t0),
+        source=source,
+        history=[],
+    )
+    assert first is not None and _ISO_PREFIX_RE.match(first)
+
+    # Second message arrives 30s later — well inside the 10 min window.
+    second = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="follow up", source=source, timestamp=t1),
+        source=source,
+        history=[],
+    )
+    assert second == "follow up", f"expected no prefix, got {second!r}"
+
+
+@pytest.mark.asyncio
+async def test_threshold_restores_prefix_after_gap():
+    """Re-anchor after a longer-than-threshold gap."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,  # 10 min
+        )
+    )
+    source = _make_source()
+    t0 = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(seconds=900)  # 15 min later — past the 10 min window
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hello", source=source, timestamp=t0),
+        source=source,
+        history=[],
+    )
+
+    second = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="back", source=source, timestamp=t1),
+        source=source,
+        history=[],
+    )
+    assert second is not None
+    assert _ISO_PREFIX_RE.match(second), f"expected re-anchor prefix, got {second!r}"
+
+
+@pytest.mark.asyncio
+async def test_threshold_zero_always_prefixes():
+    """Threshold=0 preserves the original always-on behaviour."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=0,
+        )
+    )
+    source = _make_source()
+    t0 = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)
+
+    # Three back-to-back messages, all 1s apart — every one should be prefixed.
+    for i in range(3):
+        msg = await runner._prepare_inbound_message_text(
+            event=MessageEvent(
+                text=f"msg{i}",
+                source=source,
+                timestamp=t0 + timedelta(seconds=i),
+            ),
+            source=source,
+            history=[],
+        )
+        assert msg is not None
+        assert _ISO_PREFIX_RE.match(msg), f"msg{i} missing prefix at threshold=0: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_threshold_tracks_per_session_independently():
+    """Two sessions in the same runner must not share the gap tracker."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,
+        )
+    )
+    source_a = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="111",
+        chat_name="Alice",
+        chat_type="private",
+        user_name="Alice",
+    )
+    source_b = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="222",
+        chat_name="Bob",
+        chat_type="private",
+        user_name="Bob",
+    )
+    t0 = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)
+
+    # Session A: anchor.
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="hi", source=source_a, timestamp=t0),
+        source=source_a,
+        history=[],
+    )
+
+    # Session B's first message: must still get a prefix (independent gap
+    # tracker), even though session A just received one moments ago.
+    msg_b = await runner._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="hello",
+            source=source_b,
+            timestamp=t0 + timedelta(seconds=5),
+        ),
+        source=source_b,
+        history=[],
+    )
+    assert msg_b is not None
+    assert _ISO_PREFIX_RE.match(msg_b), f"session B should re-anchor: {msg_b!r}"
+
+
+@pytest.mark.asyncio
+async def test_threshold_updates_last_ts_even_when_prefix_suppressed():
+    """Suppressed messages still bump the anchor: gap is rolling, not anchored
+    to last *prefixed* message."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,  # 10 min
+        )
+    )
+    source = _make_source()
+    t0 = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)
+
+    # Three messages 5 min apart. Without rolling updates the third (10 min
+    # after t0) would re-anchor; with rolling updates it stays inside the
+    # window from the previous (suppressed) message.
+    first = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="m1", source=source, timestamp=t0),
+        source=source,
+        history=[],
+    )
+    second = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="m2", source=source, timestamp=t0 + timedelta(seconds=300)),
+        source=source,
+        history=[],
+    )
+    third = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="m3", source=source, timestamp=t0 + timedelta(seconds=600)),
+        source=source,
+        history=[],
+    )
+
+    assert first is not None and _ISO_PREFIX_RE.match(first)
+    assert second == "m2"  # within 5min of m1 (≤600s)
+    assert third == "m3"  # within 5min of m2 (≤600s), rolling
+
+
+@pytest.mark.asyncio
+async def test_threshold_handles_out_of_order_delivery_gracefully():
+    """A message with a timestamp earlier than the previous one is treated as
+    'within window' (negative gap) — never re-anchors retroactively."""
+    runner = _make_runner(
+        GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+            timestamp_messages=True,
+            message_timestamp_threshold_seconds=600,
+        )
+    )
+    source = _make_source()
+    t_late = datetime(2026, 5, 18, 9, 5, 0, tzinfo=timezone.utc)
+    t_early = datetime(2026, 5, 18, 9, 0, 0, tzinfo=timezone.utc)  # arrives second but timestamped earlier
+
+    await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="later", source=source, timestamp=t_late),
+        source=source,
+        history=[],
+    )
+    out_of_order = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text="earlier", source=source, timestamp=t_early),
+        source=source,
+        history=[],
+    )
+    # Late-arriving older message must not trigger a misleading re-anchor.
+    assert out_of_order == "earlier"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1403,6 +1403,21 @@ group_sessions_per_user: true  # true = per-user isolation in groups/channels, f
 
 For the behavior details and examples, see [Sessions](/docs/user-guide/sessions) and the [Discord guide](/docs/user-guide/messaging/discord).
 
+## Per-Message Timestamps
+
+Prepend an ISO-8601 timestamp to each inbound user message before it enters the agent loop:
+
+```yaml
+timestamp_messages: false  # default
+```
+
+When `true`, every incoming user message is rewritten from `hello` to `[2026-05-15T19:25:00+01:00] hello` before the agent sees it. This is useful for long-running sessions (e.g. an always-on Telegram chat that spans many hours or days) where the only built-in clock signal is the "session start" line in the system prompt — without timestamps the model has no way to tell whether your last message arrived 30 seconds ago or three hours ago.
+
+- Timestamps come from the platform's own message timestamp (e.g. Telegram's `date` field), not the gateway's wall clock when the message is processed.
+- Rendered in the gateway host's local timezone. Override with the standard `TZ` environment variable when running the gateway.
+- Off by default to avoid surprising downstream consumers that grep the transcript text.
+- Currently wired up for Telegram. Other platforms still pass `event.timestamp` through, so this flag will work everywhere `MessageEvent.timestamp` is populated.
+
 ## Unauthorized DM Behavior
 
 Control what Hermes does when an unknown user sends a direct message:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1408,11 +1408,23 @@ For the behavior details and examples, see [Sessions](/docs/user-guide/sessions)
 Prepend an ISO-8601 timestamp to each inbound user message before it enters the agent loop:
 
 ```yaml
-timestamp_messages: false  # default
+timestamp_messages: false                # default (off)
+message_timestamp_threshold_seconds: 600 # default — only prefix after 10min+ gap
 ```
 
-When `true`, every incoming user message is rewritten from `hello` to `[2026-05-15T19:25:00+01:00] hello` before the agent sees it. This is useful for long-running sessions (e.g. an always-on Telegram chat that spans many hours or days) where the only built-in clock signal is the "session start" line in the system prompt — without timestamps the model has no way to tell whether your last message arrived 30 seconds ago or three hours ago.
+When `timestamp_messages: true`, incoming user messages may be rewritten from `hello` to `[2026-05-15T19:25:00+01:00] hello` before the agent sees it. This is useful for long-running sessions (e.g. an always-on Telegram chat that spans many hours or days) where the only built-in clock signal is the "session start" line in the system prompt — without timestamps the model has no way to tell whether your last message arrived 30 seconds ago or three hours ago.
 
+The `message_timestamp_threshold_seconds` knob controls when the prefix is actually added:
+
+- **`600` (default)**: prefix only when the gap since the previous inbound message in the same session exceeds 10 minutes. Avoids token waste during active back-and-forth where the model already has temporal context, while still re-anchoring after a meaningful pause.
+- **`0`**: prefix every message (legacy always-on behaviour).
+- **Higher values** (e.g. `3600`): only re-anchor after big gaps. Useful for chatty setups.
+
+Behavioural notes:
+
+- The first message in a session (or after a gateway restart) always gets a prefix — there's no prior timestamp in memory, which is treated as a "fresh re-anchor" situation.
+- The gap is tracked per session (DM, group, thread), so two users chatting in parallel sessions don't interfere with each other's anchors.
+- The gap is rolling: the anchor advances on every message, prefixed or not. Three messages 5 minutes apart will only prefix the first one when the threshold is 10 minutes.
 - Timestamps come from the platform's own message timestamp (e.g. Telegram's `date` field), not the gateway's wall clock when the message is processed.
 - Rendered in the gateway host's local timezone. Override with the standard `TZ` environment variable when running the gateway.
 - Off by default to avoid surprising downstream consumers that grep the transcript text.


### PR DESCRIPTION
Closes #9628.

## Summary

Adds an opt-in `timestamp_messages` flag to `GatewayConfig`. When enabled, every inbound user message is prepended with an ISO-8601 timestamp before it enters the agent loop:

```
hello                                  # default (unchanged)
[2026-05-15T19:25:00+01:00] hello      # with timestamp_messages: true
```

## Motivation

Same problem #9628 describes: in long-running messaging-platform sessions, the only clock signal the model has is the "session start" line in the system prompt. Once a session has been alive for several hours, the model has no way to tell whether the most recent user message arrived seconds or hours ago — leading to gaffes like cheerily saying "morning!" twelve hours into a session, or losing track of "pepperami for dinner" being a 7pm thing and not a breakfast thing.

Real-world prompt for this PR: I was 12.5 hours into a Telegram session this evening and the agent kept lighting up with "morning!" because it had latched onto the original session-start timestamp and never updated its mental clock.

## Differences from #9628's sketch

The issue proposes `[MM-dd HH:mm]` in UTC, keyed under `gateway.message_timestamp_prefix`. This PR ships:

- **ISO 8601 with numeric offset** (`[2026-05-15T19:25:00+01:00]`) rather than compact UTC — full ISO is unambiguous, includes the year (matters for multi-week sessions), and shows the user's local time directly without requiring the model to do tz math
- **Top-level `timestamp_messages: true`** to match existing top-level gateway flags (`group_sessions_per_user`, `thread_sessions_per_user`, `unauthorized_dm_behavior`) rather than the nested form
- **Sourced from `MessageEvent.timestamp`** (i.e. the platform's `date` field) rather than `datetime.now()` at processing time — stays accurate even if messages queue
- Happy to flip format / config key if reviewers prefer the issue's original shape

## Design

- New config flag: `timestamp_messages: false` (default off — opt-in to avoid surprising consumers that grep transcript text)
- Rendered in the gateway host's local timezone via `datetime.astimezone()`, with the standard `TZ` env var honoured
- ISO 8601, second precision, with numeric offset
- Applied inside `_prepare_inbound_message_text` so both the normal inbound path and the queued follow-up path get the prefix consistently
- Composes cleanly with the existing shared-group sender prefix: `[2026-05-15T19:25:00+01:00] [Alice] hello`
- Failures in timestamp formatting are caught and logged; never block message delivery
- Currently exercised on Telegram (which already populates `event.timestamp` from `message.date`); other platforms with a populated `MessageEvent.timestamp` will work automatically

## Test plan

New file: `tests/gateway/test_timestamp_messages.py` — 5 cases covering:

- prefix added when enabled (with ISO regex assertion)
- prefix skipped by default
- numeric offset is preserved end-to-end
- composes with the shared-group `[sender]` prefix
- malformed timestamp falls back gracefully (message passes through unmodified)

```
$ python -m pytest tests/gateway/test_config.py \
                    tests/gateway/test_timestamp_messages.py \
                    tests/gateway/test_shared_group_sender_prefix.py \
                    tests/gateway/test_session.py \
                    tests/gateway/test_reply_to_injection.py -q
138 passed in 4.71s
```

## Docs

User-guide entry added under `configuration.md` → "Per-Message Timestamps".

## Notes

- Default is `false` so this is a pure additive change for existing installs
- I'm dogfooding this locally on a Telegram gateway and will flip it on after merge
- Apologies for not finding #9628 before opening this — happy to close in favour of an amended version if reviewers prefer the issue's exact proposal

🤖 Drafted with [Hermes Agent](https://github.com/NousResearch/hermes-agent)
