### PR TITLE
fix(api): preserve multimodal runs input

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2699,8 +2699,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _run_agent(
         self,
-        user_message: str,
-        conversation_history: List[Dict[str, str]],
+        user_message: Any,
+        conversation_history: List[Dict[str, Any]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -2849,11 +2849,30 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
         raw_input = body.get("input")
-        if not raw_input:
+        if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
+        input_messages: List[Dict[str, Any]] = []
+        if isinstance(raw_input, str):
+            input_messages.append({"role": "user", "content": raw_input})
+        elif isinstance(raw_input, list):
+            for idx, item in enumerate(raw_input):
+                if isinstance(item, str):
+                    input_messages.append({"role": "user", "content": item})
+                    continue
+                if not isinstance(item, dict):
+                    return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+                role = item.get("role", "user")
+                try:
+                    content = _normalize_multimodal_content(item.get("content", ""))
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                input_messages.append({"role": str(role), "content": content})
+        else:
+            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+
+        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
         instructions = body.get("instructions")
@@ -2861,7 +2880,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -2875,7 +2894,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                try:
+                    entry_content = _normalize_multimodal_content(entry["content"])
+                except ValueError as exc:
+                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
+                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -2891,17 +2914,8 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        if not conversation_history and len(input_messages) > 1:
+            conversation_history.extend(input_messages[:-1])
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -54,6 +54,16 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     return app
 
 
+async def _wait_for_thread_event(event: threading.Event, timeout: float = 2.0) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if event.is_set():
+            return True
+        await asyncio.sleep(0.01)
+    return event.is_set()
+
+
 def _make_slow_agent(**kwargs):
     """Create a mock agent that blocks in run_conversation until interrupted.
 
@@ -190,6 +200,155 @@ class TestStartRun:
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_start_preserves_multimodal_input(self, adapter):
+        app = _create_runs_app(adapter)
+        called = threading.Event()
+        captured = {}
+
+        def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+            captured["user_message"] = user_message
+            captured["conversation_history"] = conversation_history
+            called.set()
+            return {"final_response": "ok"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_text", "text": "describe"},
+                                    {
+                                        "type": "input_image",
+                                        "image_url": "data:image/png;base64,abc",
+                                    },
+                                ],
+                            }
+                        ]
+                    },
+                )
+
+                assert resp.status == 202
+                assert await _wait_for_thread_event(called)
+
+        assert captured["conversation_history"] == []
+        assert captured["user_message"] == [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_start_preserves_multimodal_history(self, adapter):
+        app = _create_runs_app(adapter)
+        called = threading.Event()
+        captured = {}
+
+        def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+            captured["user_message"] = user_message
+            captured["conversation_history"] = conversation_history
+            called.set()
+            return {"final_response": "ok"}
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "look"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "https://example.com/a.png",
+                                            "detail": "low",
+                                        },
+                                    },
+                                ],
+                            },
+                            {"role": "assistant", "content": "seen"},
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "now this"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": "https://example.com/b.png"},
+                                    },
+                                ],
+                            },
+                        ]
+                    },
+                )
+
+                assert resp.status == 202
+                assert await _wait_for_thread_event(called)
+
+        assert captured["conversation_history"] == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://example.com/a.png",
+                            "detail": "low",
+                        },
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "seen"},
+        ]
+        assert captured["user_message"] == [
+            {"type": "text", "text": "now this"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/b.png"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_invalid_multimodal_input(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image_url", "image_url": {"url": "ftp://example.com/a.png"}},
+                            ],
+                        }
+                    ]
+                },
+            )
+            data = await resp.json()
+
+        assert resp.status == 400
+        assert data["error"]["param"] == "input[0].content"
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -14,11 +14,13 @@ def get_env_value(name: str, default=None):
     """
     try:
         from hermes_cli.config import get_env_value as _hermes_get_env_value
-    except Exception:
-        return os.environ.get(name, default)
 
-    value = _hermes_get_env_value(name)
-    return default if value is None else value
+        value = _hermes_get_env_value(name)
+        if value is not None:
+            return value
+    except Exception:
+        pass
+    return os.environ.get(name, default)
 
 
 def hermes_xai_user_agent() -> str:

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 import os
 from typing import Dict
 
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
-
-
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
@@ -18,11 +12,13 @@ def get_env_value(name: str, default=None):
     ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
     xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
-        value = _hermes_get_env_value(name)
-        if value is not None:
-            return value
-    return os.environ.get(name, default)
+    try:
+        from hermes_cli.config import get_env_value as _hermes_get_env_value
+    except Exception:
+        return os.environ.get(name, default)
+
+    value = _hermes_get_env_value(name)
+    return default if value is None else value
 
 
 def hermes_xai_user_agent() -> str:


### PR DESCRIPTION
## Summary
- normalize `/v1/runs` input with the same multimodal helper used by chat completions and responses
- preserve image content parts for the active user message and inferred conversation history
- validate unsupported image/file content before allocating a run

Fixes #26504

## Tests
- python -m pytest -o addopts='' tests/gateway/test_api_server_runs.py::TestStartRun -q
- python -m pytest -o addopts='' tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_multimodal.py -q
- python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py
- python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py
- git diff --check