### PR TITLE
fix: add paste collapse logging to aid debugging

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12090,6 +12090,7 @@ class HermesCLI:
                     paste_dir.mkdir(parents=True, exist_ok=True)
                     paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
                     paste_file.write_text(pasted_text, encoding="utf-8")
+                    logger.info("Collapsed paste #%d: %d lines, %d chars -> %s", _paste_counter[0], line_count + 1, len(pasted_text), paste_file)
                     placeholder = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
                     prefix = ""
                     if buf.cursor_position > 0 and buf.text[buf.cursor_position - 1] != '\n':
@@ -12257,6 +12258,7 @@ class HermesCLI:
                 paste_dir.mkdir(parents=True, exist_ok=True)
                 paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
                 paste_file.write_text(text, encoding="utf-8")
+                logger.info("Collapsed paste #%d: %d lines, %d chars -> %s (fallback)", _paste_counter[0], line_count + 1, len(text), paste_file)
                 _paste_just_collapsed[0] = True
                 buf.text = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
                 buf.cursor_position = len(buf.text)


### PR DESCRIPTION
What does this PR do?

Adds 2 lines of logger.info — one in handle_paste (bracketed paste path) and one in _on_text_changed (fallback heuristic path) — that log the paste ID, line count, character count, and file path whenever a large paste is collapsed to a file reference. This is purely a diagnostic aid: it does not fix the underlying paste-drop issue, but it gives operators a way to correlate missing-content reports with specific paste files in the log.

Changes Made:
- cli.py:12093 — Added logger.info("Collapsed paste #%d: %d lines, %d chars -> %s", ...) after bracketed-paste file write
- cli.py:12260 — Added logger.info("... (fallback)", ...) after text-change-heuristic file write

How to Test:
Paste 10+ lines of text in the CLI. Check the log for "Collapsed paste #1: 11 lines, 500 chars -> ~/.hermes/pastes/paste_1_*.txt". Delete the paste file, then send the message. The placeholder remains and a warning log fires.