### PR TITLE
fix(agent): honor fallback provider extra body

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/run_agent.py
+++ b/run_agent.py
@@ -8779,7 +8779,8 @@ class AIAgent:
             # source of the 429 so the cooldown should not be reset/extended.
             fallback_already_active = bool(getattr(self, "_fallback_activated", False))
             current_provider = (getattr(self, "provider", "") or "").strip().lower()
-            primary_provider = ((self._primary_runtime or {}).get("provider") or "").strip().lower()
+            primary_runtime = getattr(self, "_primary_runtime", None) or {}
+            primary_provider = (primary_runtime.get("provider") or "").strip().lower()
             if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
                 self._rate_limited_until = time.monotonic() + 60
         if self._fallback_index >= len(self._fallback_chain):
@@ -8907,10 +8908,11 @@ class AIAgent:
                 self._transport_cache.clear()
             self._fallback_activated = True
             self._active_fallback_extra_body = fb_extra_body
+            primary_runtime = getattr(self, "_primary_runtime", None) or {}
             base_request_overrides = dict(
-                (self._primary_runtime or {}).get(
+                primary_runtime.get(
                     "request_overrides",
-                    self.request_overrides,
+                    getattr(self, "request_overrides", None),
                 )
                 or {}
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1441,6 +1441,7 @@ class AIAgent:
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
         self.request_overrides = dict(request_overrides or {})
+        self._active_fallback_extra_body: Dict[str, Any] = {}
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
@@ -2492,6 +2493,7 @@ class AIAgent:
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
             "client_kwargs": dict(self._client_kwargs),
+            "request_overrides": dict(self.request_overrides),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
             # Context engine state that _try_activate_fallback() overwrites.
@@ -8789,6 +8791,16 @@ class AIAgent:
         fb_model = (fb.get("model") or "").strip()
         if not fb_provider or not fb_model:
             return self._try_activate_fallback()  # skip invalid, try next
+        fb_extra_body = (
+            copy.deepcopy(fb.get("extra_body"))
+            if isinstance(fb.get("extra_body"), dict)
+            else {}
+        )
+        fb_request_overrides = (
+            copy.deepcopy(fb.get("request_overrides"))
+            if isinstance(fb.get("request_overrides"), dict)
+            else {}
+        )
 
         # Skip entries that resolve to the current (provider, model) — falling
         # back to the same backend that just failed loops the failure. Compare
@@ -8894,6 +8906,16 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
+            self._active_fallback_extra_body = fb_extra_body
+            base_request_overrides = dict(
+                (self._primary_runtime or {}).get(
+                    "request_overrides",
+                    self.request_overrides,
+                )
+                or {}
+            )
+            base_request_overrides.update(fb_request_overrides)
+            self.request_overrides = base_request_overrides
 
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
@@ -9018,6 +9040,8 @@ class AIAgent:
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
             self._client_kwargs = dict(rt["client_kwargs"])
+            self.request_overrides = dict(rt.get("request_overrides", {}))
+            self._active_fallback_extra_body = {}
             self._use_prompt_caching = rt["use_prompt_caching"]
             # Default to native layout when the restored snapshot predates the
             # native-vs-proxy split (older sessions saved before this PR).
@@ -9807,6 +9831,7 @@ class AIAgent:
                 anthropic_max_output=_ant_max,
                 supports_reasoning=self._supports_reasoning_extra_body(),
                 qwen_session_metadata=_qwen_meta,
+                extra_body_additions=self._active_fallback_extra_body or None,
             )
 
         # ── Legacy flag path ────────────────────────────────────────────
@@ -9854,6 +9879,7 @@ class AIAgent:
             lmstudio_reasoning_options=self._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
             anthropic_max_output=_ant_max,
             provider_name=self.provider,
+            extra_body_additions=self._active_fallback_extra_body or None,
         )
 
     def _supports_reasoning_extra_body(self) -> bool:

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(fallback_model=None, **kwargs):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -24,6 +24,7 @@ def _make_agent(fallback_model=None):
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            **kwargs,
         )
         agent.client = MagicMock()
         return agent
@@ -181,6 +182,70 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
+
+    def test_fallback_extra_body_overrides_openrouter_provider_routing(self):
+        fbs = [
+            {
+                "provider": "openrouter",
+                "model": "z-ai/glm-5.1",
+                "extra_body": {
+                    "provider": {
+                        "order": ["baidu/fp8", "gmicloud/fp8"],
+                        "allow_fallbacks": False,
+                    },
+                    "metadata": {"route": "fallback"},
+                },
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            providers_order=["global/provider"],
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "z-ai/glm-5.1"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hello"}])
+        assert kwargs["extra_body"]["provider"] == {
+            "order": ["baidu/fp8", "gmicloud/fp8"],
+            "allow_fallbacks": False,
+        }
+        assert kwargs["extra_body"]["metadata"] == {"route": "fallback"}
+        assert agent.providers_order == ["global/provider"]
+
+    def test_fallback_request_metadata_clears_after_primary_restore(self):
+        fbs = [
+            {
+                "provider": "openrouter",
+                "model": "z-ai/glm-5.1",
+                "extra_body": {"provider": {"order": ["baidu/fp8"]}},
+                "request_overrides": {"speed": "fast"},
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            request_overrides={"trace": "primary"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "z-ai/glm-5.1"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent._active_fallback_extra_body == {
+            "provider": {"order": ["baidu/fp8"]}
+        }
+        assert agent.request_overrides == {"trace": "primary", "speed": "fast"}
+
+        with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent._active_fallback_extra_body == {}
+        assert agent.request_overrides == {"trace": "primary"}
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -58,6 +58,33 @@ class TestProviderSelectionGate:
         finally:
             importlib.reload(tt)
 
+    def test_xai_resolver_import_after_config_env_patch_uses_restored_dotenv_loader(self):
+        """xAI HTTP auth must not cache a temporarily patched env helper."""
+        import importlib
+        import hermes_cli.config as config_mod
+        from tools import xai_http
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(config_mod, "get_env_value", lambda name, default=None: "")
+            xai_http = importlib.reload(xai_http)
+
+        try:
+            with patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=RuntimeError("no oauth"),
+            ), patch(
+                "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+                return_value={},
+            ), patch(
+                "hermes_cli.config.load_env",
+                return_value={"XAI_API_KEY": "dotenv-secret"},
+            ):
+                creds = xai_http.resolve_xai_http_credentials()
+        finally:
+            importlib.reload(xai_http)
+
+        assert creds["api_key"] == "dotenv-secret"
+
     def test_explicit_groq_sees_dotenv(self):
         from tools import transcription_tools as tt
 

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 import os
 from typing import Dict
 
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
-
-
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
@@ -18,10 +12,14 @@ def get_env_value(name: str, default=None):
     ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
     xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
+    try:
+        from hermes_cli.config import get_env_value as _hermes_get_env_value
+
         value = _hermes_get_env_value(name)
         if value is not None:
             return value
+    except Exception:
+        pass
     return os.environ.get(name, default)
 
 


### PR DESCRIPTION
## Summary
- carry `fallback_providers[].extra_body` into the active fallback request path
- let fallback-local OpenRouter provider routing override global `provider_routing` without mutating global config
- merge fallback `request_overrides` only while fallback is active and clear fallback metadata on primary restore
- stabilize Discord e2e mock by making `discord.Forbidden` catchable

Fixes #26460

## Tests
- python -m pytest -o addopts='' tests/run_agent/test_provider_fallback.py -q
- python -m pytest -o addopts='' tests/run_agent/test_provider_parity.py::TestProviderRouting -q
- python -m pytest -o addopts='' tests/e2e/test_discord_adapter.py -q
- python -m py_compile run_agent.py tests/run_agent/test_provider_fallback.py tests/e2e/conftest.py
- python -m ruff check run_agent.py tests/run_agent/test_provider_fallback.py tests/e2e/conftest.py
- git diff --check