### PR TITLE
docs: document profile --no-skills option

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -190,7 +190,7 @@ hermes webhook test NAME    Send a test POST
 
 ```
 hermes profile list         List all profiles
-hermes profile create NAME  Create (--clone, --clone-all, --clone-from)
+hermes profile create NAME  Create (--clone, --clone-all, --clone-from, --no-skills)
 hermes profile use NAME     Set sticky default
 hermes profile delete NAME  Delete a profile
 hermes profile show NAME    Show details

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -32,6 +32,16 @@ hermes profile create mybot
 
 Creates a fresh profile with bundled skills seeded. Run `mybot setup` to configure API keys, model, and gateway tokens.
 
+### Blank profile without bundled skills (`--no-skills`)
+
+```bash
+hermes profile create minimal --no-skills
+```
+
+Creates a fresh profile without copying or seeding the bundled skills that normally ship with Hermes. Use this for minimal test profiles, agent sandboxes, or profiles where you want to install only a curated set of skills later with `hermes skills install`.
+
+Hermes records this choice with a `.no-bundled-skills` marker in the profile home so future skill seeding keeps respecting the opt-out.
+
 ### Clone config only (`--clone`)
 
 ```bash


### PR DESCRIPTION
## Summary
- Document `hermes profile create --no-skills` in the profiles guide
- Add the option to the bundled Hermes Agent skill command reference
- Explain that `.no-bundled-skills` records the opt-out

Closes #26446

## Test Plan
- `grep -R "no-skills\|no_skills" -n --include='*.md' website skills/autonomous-ai-agents/hermes-agent/SKILL.md`