### PR TITLE
fix(cli): preserve spaces in path completion tokens

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1178,11 +1178,23 @@ class SlashCommandCompleter(Completer):
         """
         if not text:
             return None
-        # Walk backwards to find the start of the current "word".
-        # Words are delimited by spaces, but paths can contain almost anything.
+        # Walk backwards to find the start of the current "word".  Spaces
+        # normally delimit words, but they can also be part of path tokens such
+        # as ``./My Documents/file.txt``.  Keep walking across spaces inside a
+        # path, but stop at the argument boundary before explicit path prefixes
+        # like ``./`` and ``~/`` so command text is not included.
         i = len(text) - 1
-        while i >= 0 and text[i] != " ":
-            i -= 1
+        while i >= 0:
+            if text[i] != " ":
+                i -= 1
+                continue
+            rest = text[i + 1:]
+            if rest.startswith(("./", "../", "~/", "/")):
+                break
+            if "/" in rest:
+                i -= 1
+                continue
+            break
         word = text[i + 1:]
         if not word:
             return None

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1148,6 +1148,27 @@ class TestTelegramMenuCommands:
 
 
 # ---------------------------------------------------------------------------
+# Path completion helpers
+# ---------------------------------------------------------------------------
+
+class TestPathCompletionHelpers:
+    def test_extract_path_word_preserves_spaces_in_prefixed_paths(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("open ./My Documents/file.txt")
+            == "./My Documents/file.txt"
+        )
+
+    def test_extract_path_word_preserves_completed_directory_with_space(self):
+        assert (
+            SlashCommandCompleter._extract_path_word("./My Documents/")
+            == "./My Documents/"
+        )
+
+    def test_extract_path_word_still_ignores_plain_words(self):
+        assert SlashCommandCompleter._extract_path_word("hello world") is None
+
+
+# ---------------------------------------------------------------------------
 # Backward-compat aliases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Preserve spaces inside path-like completion tokens
- Stop at command/argument boundaries before explicit path prefixes
- Add regression coverage for directories like `./My Documents/`

Closes #26223

## Test Plan
- `python -m pytest tests/hermes_cli/test_commands.py::TestPathCompletionHelpers -q`