### PR TITLE
fix(skills): skip hidden directories during discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -26,6 +26,11 @@ PLATFORM_MAP = {
 
 EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 
+
+def is_excluded_skill_dir(name: str) -> bool:
+    """Return True when a directory should be skipped during skill indexing."""
+    return name in EXCLUDED_SKILL_DIRS or name.startswith(".")
+
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
 _yaml_load_fn = None
@@ -478,11 +483,12 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Excludes hidden workspace/metadata directories such as ``.git``,
+    ``.github``, ``.hub``, ``.archive``, ``.cursor``, and ``.opencode``.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        dirs[:] = [d for d in dirs if not is_excluded_skill_dir(d)]
         if filename in files:
             matches.append(Path(root) / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import tools.skills_tool as skills_tool_module
+from agent.skill_utils import iter_skill_index_files
 from tools.skills_tool import (
     _get_required_environment_variables,
     _parse_frontmatter,
@@ -266,6 +267,28 @@ class TestFindAllSkills:
             skills = _find_all_skills()
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
+
+    def test_skips_hidden_workspace_directories(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "real-skill")
+            hidden_dir = tmp_path / ".cursor" / "skills" / "fake-skill"
+            hidden_dir.mkdir(parents=True)
+            (hidden_dir / "SKILL.md").write_text(
+                "---\nname: fake\ndescription: x\n---\n\nBody.\n"
+            )
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "real-skill"
+
+    def test_iter_skill_index_files_skips_hidden_directories(self, tmp_path):
+        real_skill = _make_skill(tmp_path, "real-skill") / "SKILL.md"
+        hidden_dir = tmp_path / ".opencode" / "skills" / "fake-skill"
+        hidden_dir.mkdir(parents=True)
+        (hidden_dir / "SKILL.md").write_text(
+            "---\nname: fake\ndescription: x\n---\n\nBody.\n"
+        )
+
+        assert list(iter_skill_index_files(tmp_path, "SKILL.md")) == [real_skill]
 
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -101,6 +101,12 @@ _PLATFORM_MAP = {
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
+
+
+def _is_excluded_skill_dir(name: str) -> bool:
+    """Return True for skill-tree directories that should not be indexed."""
+    return name in _EXCLUDED_SKILL_DIRS or name.startswith(".")
+
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
@@ -573,7 +579,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            if any(_is_excluded_skill_dir(part) for part in skill_md.relative_to(scan_dir).parts):
                 continue
 
             skill_dir = skill_md.parent


### PR DESCRIPTION
## Summary
- Skip hidden directories while indexing skill files
- Filter hidden path components in skill listing as a defensive guard
- Add regression tests for `.cursor` and `.opencode` skill-tree copies

Closes #26451

## Test Plan
- `python -m pytest tests/tools/test_skills_tool.py::TestFindAllSkills -q`