### PR TITLE
fix: restore Hindsight profile env after daemon start

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1273,6 +1273,11 @@ class HindsightMemoryProvider(MemoryProvider):
                             client._manager.stop(profile)
 
                     client._ensure_started()
+                    # Hindsight's embedded profile registration can rewrite the
+                    # profile env with only HINDSIGHT_API_* keys. Restore the
+                    # Hermes-managed daemon keys afterward so the next provider
+                    # init does not see a false config drift and restart.
+                    _materialize_embedded_profile_env(self._config)
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,7 +10,7 @@ import os
 import re
 import stat
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -322,6 +322,77 @@ class TestConfig:
 
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
+
+    def test_local_embedded_initialize_restores_profile_env_after_ensure_started_rewrites_it(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes-seed",
+            "llm_provider": "openai_compatible",
+            "llm_api_key": "test-key",
+            "llm_base_url": "http://127.0.0.1:8080/v1",
+            "llm_model": "gpt-test",
+            "idle_timeout": 0,
+            "bank_id": "hermes",
+        }
+        config_path = hermes_home / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        class ImmediateThread:
+            def __init__(self, target, **kwargs):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        class FakeManager:
+            def is_running(self, profile):
+                return False
+
+            def stop(self, profile):  # pragma: no cover - should not be called
+                raise AssertionError("should not try to stop an already-compatible daemon")
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                self._manager = FakeManager()
+
+            def _ensure_started(self):
+                profile_env = user_home / ".hindsight" / "profiles" / "hermes-seed.env"
+                profile_env.parent.mkdir(parents=True, exist_ok=True)
+                profile_env.write_text(
+                    "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+                    "HINDSIGHT_API_LLM_API_KEY=test-key\n"
+                    "HINDSIGHT_API_LLM_MODEL=gpt-test\n"
+                    "HINDSIGHT_API_LOG_LEVEL=info\n"
+                    "HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1\n"
+                )
+
+        fake_dem = ModuleType("hindsight_embed.daemon_embed_manager")
+        fake_parent = ModuleType("hindsight_embed")
+        monkeypatch.setitem(sys.modules, "hindsight_embed", fake_parent)
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", fake_dem)
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("plugins.memory.hindsight.threading.Thread", ImmediateThread)
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="test-session", hermes_home=str(hermes_home), platform="cli")
+
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes-seed.env"
+        assert profile_env.read_text() == (
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+            "HINDSIGHT_API_LLM_API_KEY=test-key\n"
+            "HINDSIGHT_API_LLM_MODEL=gpt-test\n"
+            "HINDSIGHT_API_LOG_LEVEL=info\n"
+            "HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1\n"
+            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=0\n"
+        )
 
 
 class TestPostSetup:


### PR DESCRIPTION
## Summary

This fixes one more Hindsight embedded profile-env edge case.

PR #14011 already writes the expected profile env before starting the embedded daemon. In practice, Hindsight's embedded startup path can rewrite that profile env during `_ensure_started()` with only the `HINDSIGHT_API_*` keys. That drops Hermes-managed daemon keys such as `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT`, so the next provider init sees a config delta that is not real and may try to restart the daemon again.

This restores the Hermes-managed profile env after `_ensure_started()` returns.

## Test plan

- `python -m pytest -q tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_local_embedded_initialize_restores_profile_env_after_ensure_started_rewrites_it tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_get_client_passes_idle_timeout_to_hindsight_embedded tests/plugins/memory/test_hindsight_provider.py::TestPostSetup::test_local_embedded_setup_materializes_profile_env -o 'addopts='`
- `python -m pytest -q tests/plugins/memory/test_hindsight_provider.py -o 'addopts='`
