### PR TITLE
fix(i18n): localize CLI startup tips

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -1,8 +1,8 @@
 """Lightweight internationalization (i18n) for Hermes static user-facing messages.
 
 Scope (thin slice, by design): only the highest-impact static strings shown
-to the user by Hermes itself -- approval prompts, a handful of gateway slash
-command replies, restart-drain notices.  Agent-generated output, log lines,
+to the user by Hermes itself -- approval prompts, CLI startup tips, a handful
+of gateway slash command replies, restart-drain notices.  Agent-generated output, log lines,
 error tracebacks, tool outputs, and slash-command descriptions all stay in
 English.
 
@@ -80,6 +80,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "hungarian": "hu", "magyar": "hu", "hu-hu": "hu",
 }
 
+_raw_catalog_cache: dict[str, dict[str, Any]] = {}
 _catalog_cache: dict[str, dict[str, str]] = {}
 _catalog_lock = threading.Lock()
 
@@ -118,8 +119,37 @@ def _normalize_lang(value: Any) -> str:
     return DEFAULT_LANGUAGE
 
 
+def _load_raw_catalog(lang: str) -> dict[str, Any]:
+    """Load one locale YAML file into a nested dict.
+
+    Raw catalogs are used for structured values such as ``cli.tips`` lists.
+    """
+    with _catalog_lock:
+        cached = _raw_catalog_cache.get(lang)
+        if cached is not None:
+            return cached
+
+    path = _locales_dir() / f"{lang}.yaml"
+    if not path.is_file():
+        logger.debug("i18n catalog missing for %s at %s", lang, path)
+        raw: dict[str, Any] = {}
+    else:
+        try:
+            import yaml  # PyYAML is already a hermes dependency
+            with path.open("r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            raw = loaded if isinstance(loaded, dict) else {}
+        except Exception as exc:
+            logger.warning("Failed to load i18n catalog %s: %s", path, exc)
+            raw = {}
+
+    with _catalog_lock:
+        _raw_catalog_cache[lang] = raw
+    return raw
+
+
 def _load_catalog(lang: str) -> dict[str, str]:
-    """Load and flatten one locale YAML file into a dotted-key dict.
+    """Flatten one locale YAML file into a dotted-key string dict.
 
     YAML files can be nested for human readability; this produces the flat
     key space :func:`t` expects.  Cached per-language for the process.
@@ -129,23 +159,7 @@ def _load_catalog(lang: str) -> dict[str, str]:
         if cached is not None:
             return cached
 
-    path = _locales_dir() / f"{lang}.yaml"
-    if not path.is_file():
-        logger.debug("i18n catalog missing for %s at %s", lang, path)
-        with _catalog_lock:
-            _catalog_cache[lang] = {}
-        return {}
-
-    try:
-        import yaml  # PyYAML is already a hermes dependency
-        with path.open("r", encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
-    except Exception as exc:
-        logger.warning("Failed to load i18n catalog %s: %s", path, exc)
-        with _catalog_lock:
-            _catalog_cache[lang] = {}
-        return {}
-
+    raw = _load_raw_catalog(lang)
     flat: dict[str, str] = {}
     _flatten_into(raw, "", flat)
     with _catalog_lock:
@@ -161,6 +175,25 @@ def _flatten_into(node: Any, prefix: str, out: dict[str, str]) -> None:
     elif isinstance(node, str):
         out[prefix] = node
     # Non-string, non-dict leaves are ignored -- catalogs are text-only.
+
+
+def _lookup_raw(node: Any, key: str) -> Any:
+    """Return a raw nested catalog value for a dotted key."""
+    cur = node
+    for part in key.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _coerce_string_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    items = [item for item in value if isinstance(item, str) and item.strip()]
+    if len(items) != len(value):
+        return None
+    return items
 
 
 @lru_cache(maxsize=1)
@@ -191,6 +224,7 @@ def reset_language_cache() -> None:
     """
     _config_language_cached.cache_clear()
     with _catalog_lock:
+        _raw_catalog_cache.clear()
         _catalog_cache.clear()
 
 
@@ -249,10 +283,27 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     return value
 
 
+def t_list(key: str, lang: str | None = None) -> list[str] | None:
+    """Translate a dotted key to a list of strings.
+
+    This is intentionally separate from :func:`t` so existing string callers
+    keep their simple fallback behavior. Missing or invalid lists fall back to
+    English; if English is also missing, ``None`` is returned.
+    """
+    target = _normalize_lang(lang) if lang else get_language()
+    value = _coerce_string_list(_lookup_raw(_load_raw_catalog(target), key))
+
+    if value is None and target != DEFAULT_LANGUAGE:
+        value = _coerce_string_list(_lookup_raw(_load_raw_catalog(DEFAULT_LANGUAGE), key))
+
+    return value
+
+
 __all__ = [
     "SUPPORTED_LANGUAGES",
     "DEFAULT_LANGUAGE",
     "t",
+    "t_list",
     "get_language",
     "reset_language_cache",
 ]

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -475,13 +475,24 @@ TIPS = [
 ]
 
 
-def get_random_tip(exclude_recent: int = 0) -> str:
+def get_tips(lang: str | None = None) -> list[str]:
+    """Return the active tip corpus, localized when a catalog provides one."""
+    try:
+        from agent.i18n import t_list
+        localized = t_list("cli.tips", lang=lang)
+    except Exception:
+        localized = None
+    return localized if localized else TIPS
+
+
+def get_random_tip(exclude_recent: int = 0, lang: str | None = None) -> str:
     """Return a random tip string.
 
     Args:
         exclude_recent: not used currently; reserved for future
             deduplication across sessions.
+        lang: optional language override for tests and explicit callers.
     """
-    return random.choice(TIPS)
+    return random.choice(get_tips(lang=lang))
 
 

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -348,3 +348,21 @@ gateway:
     session_db_unavailable_prefix: "会话数据库不可用"
     session_not_found:           "数据库中未找到该会话。"
     warn_passthrough:            "⚠️ {error}"
+
+cli:
+  tips:
+    - "/background <提示> 会在单独会话中运行任务，当前会话仍可继续使用。"
+    - "/branch 会复制当前会话，方便探索另一种方案而不丢失进度。"
+    - "/compress 可在上下文变长时手动压缩对话。"
+    - "/model 可在会话中切换模型，例如 /model sonnet 或 /model gpt-5。"
+    - "/reload-skills 会重新扫描 ~/.hermes/skills/，无需重启即可加载新技能。"
+    - "输入 @ 会触发文件路径补全，可交互式选择要注入的文件。"
+    - "Alt+Enter 插入换行；在 Windows Terminal 中请使用 Ctrl+Enter。"
+    - "hermes doctor --fix 会诊断并自动修复可修复的配置和依赖问题。"
+    - "设置 display.streaming: true 可实时看到模型生成的 token。"
+    - "skills.external_dirs 可从自定义目录加载技能。"
+    - "危险命令审批有 4 个级别：一次、本会话、永久允许、拒绝。"
+    - "SSRF 防护会阻止私有网络、loopback、link-local 和云元数据地址。"
+    - "上下文达到阈值时会自动压缩，并刷新记忆、总结历史。"
+    - "MCP 服务器在 config.yaml 中配置，stdio 和 HTTP 传输都受支持。"
+    - "每个 profile 都有自己的配置、API key、记忆、会话、技能和 cron 任务。"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -24,7 +24,7 @@ def _flatten(d, prefix="") -> dict:
         key = f"{prefix}.{k}" if prefix else k
         if isinstance(v, dict):
             flat.update(_flatten(v, key))
-        else:
+        elif isinstance(v, str):
             flat[key] = v
     return flat
 
@@ -145,6 +145,32 @@ def test_t_missing_key_returns_key():
     """A missing key returns its own path -- ugly but never crashes."""
     result = i18n.t("nonexistent.key.path", lang="en")
     assert result == "nonexistent.key.path"
+
+
+def test_t_list_explicit_lang():
+    tips = i18n.t_list("cli.tips", lang="zh")
+    assert tips is not None
+    assert any("危险命令" in tip for tip in tips)
+
+
+def test_t_list_missing_key_returns_none():
+    assert i18n.t_list("nonexistent.list.path", lang="en") is None
+
+
+def test_t_list_missing_in_non_english_falls_back_to_english(tmp_path, monkeypatch):
+    fake_locales = tmp_path / "locales"
+    fake_locales.mkdir()
+    (fake_locales / "en.yaml").write_text(
+        "cli:\n  tips:\n    - English Tip\n",
+        encoding="utf-8",
+    )
+    (fake_locales / "zh.yaml").write_text("# intentionally empty\n", encoding="utf-8")
+    monkeypatch.setattr(i18n, "_locales_dir", lambda: fake_locales)
+    i18n.reset_language_cache()
+    try:
+        assert i18n.t_list("cli.tips", lang="zh") == ["English Tip"]
+    finally:
+        i18n.reset_language_cache()
 
 
 def test_t_missing_key_in_non_english_falls_back_to_english(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_tips.py
+++ b/tests/hermes_cli/test_tips.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli/tips.py — random tip display at session start."""
 
 import pytest
-from hermes_cli.tips import TIPS, get_random_tip
+from hermes_cli.tips import TIPS, get_random_tip, get_tips
 
 
 class TestTipsCorpus:
@@ -44,6 +44,24 @@ class TestGetRandomTip:
     def test_returns_tip_from_corpus(self):
         tip = get_random_tip()
         assert tip in TIPS
+
+    def test_default_tips_use_english_corpus(self):
+        assert get_tips(lang="en") == TIPS
+
+    def test_unknown_language_uses_english_corpus(self):
+        assert get_tips(lang="klingon") == TIPS
+
+    def test_zh_tips_use_localized_catalog(self):
+        tips = get_tips(lang="zh")
+        assert tips != TIPS
+        assert all(isinstance(tip, str) and tip.strip() for tip in tips)
+        assert any("危险命令" in tip for tip in tips)
+
+    def test_random_tip_uses_localized_corpus(self, monkeypatch):
+        import hermes_cli.tips as tips_mod
+
+        monkeypatch.setattr(tips_mod.random, "choice", lambda seq: seq[0])
+        assert get_random_tip(lang="zh") == get_tips(lang="zh")[0]
 
     def test_randomness(self):
         """Multiple calls should eventually return different tips."""

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs


### PR DESCRIPTION
## Summary
- add structured list lookup support to the i18n catalog for localized tip corpora
- keep the existing English TIPS corpus as the default and fallback behavior
- add Simplified Chinese startup tips for display.language: zh
- stabilize the Discord e2e mock by making discord.Forbidden catchable

Fixes #26518

## Tests
- python -m pytest -o addopts='' tests\\hermes_cli\\test_tips.py tests\\agent\\test_i18n.py -q --tb=short
- python -m pytest -o addopts='' tests\\e2e\\test_discord_adapter.py -q --tb=short
- python -m py_compile agent\\i18n.py hermes_cli\\tips.py tests\\agent\\test_i18n.py tests\\hermes_cli\\test_tips.py tests\\e2e\\conftest.py
- python -m ruff check agent\\i18n.py hermes_cli\\tips.py tests\\agent\\test_i18n.py tests\\hermes_cli\\test_tips.py tests\\e2e\\conftest.py
- git diff --check