### PR TITLE
fix(bedrock): correct api_mode detection for bearer-token auth

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -118,6 +118,12 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     - Kimi Code's ``api.kimi.com/coding`` endpoint also speaks the
       Anthropic Messages protocol (the /coding route accepts Claude
       Code's native request shape).
+    - AWS Bedrock runtime endpoints (bedrock-runtime.<region>.amazonaws.com)
+      use the native Converse API via boto3, not the OpenAI-compat path.
+      Without this detection, ``provider: custom`` with a Bedrock URL
+      silently falls through to ``chat_completions``, which returns
+      ``UnknownOperationException`` and triggers the empty-response retry
+      loop before failing over to the fallback provider.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
     hostname = base_url_hostname(base_url)
@@ -136,6 +142,10 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return "anthropic_messages"
+    if hostname.startswith("bedrock-runtime.") and base_url_host_matches(
+        normalized, "amazonaws.com"
+    ):
+        return "bedrock_converse"
     return None
 
 
@@ -1975,9 +1985,19 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
+        #
+        # Exception: when auth is a Bedrock API bearer token
+        # (AWS_BEARER_TOKEN_BEDROCK), the AnthropicBedrock SDK cannot use it —
+        # that SDK only supports IAM credentials via the boto3 credential chain.
+        # Bearer tokens ARE picked up by boto3's default chain (botocore supports
+        # them natively), so we fall back to bedrock_converse for both Claude and
+        # non-Claude models in this case.  The Converse API supports all Claude
+        # models including Opus 4.7 / Sonnet 4.x and covers prompt caching via
+        # the performanceConfig field.
         _current_model = str(target_model or model_cfg.get("default") or "").strip()
-        if is_anthropic_bedrock_model(_current_model):
-            # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
+        _use_bearer_path = auth_source == "AWS_BEARER_TOKEN_BEDROCK"
+        if is_anthropic_bedrock_model(_current_model) and not _use_bearer_path:
+            # Claude on Bedrock + IAM creds → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",
                 "api_mode": "anthropic_messages",
@@ -1989,7 +2009,8 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
         else:
-            # Non-Claude (Nova, DeepSeek, Llama, etc.) → Converse API
+            # Non-Claude (Nova, DeepSeek, Llama, etc.) OR bearer-token auth
+            # → Converse API via boto3 (bearer token picked up automatically)
             runtime = {
                 "provider": "bedrock",
                 "api_mode": "bedrock_converse",

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -359,3 +359,82 @@ class TestBedrockOverlayRegistration:
         for alias in ("aws", "aws-bedrock", "amazon-bedrock", "amazon"):
             assert normalize_provider(alias) == "bedrock", \
                 f"alias {alias!r} should normalize to 'bedrock'"
+
+
+# ---------------------------------------------------------------------------
+# 5. Bearer-token routing in resolve_runtime_provider
+# ---------------------------------------------------------------------------
+
+class TestBedrockBearerTokenRouting:
+    """When AWS_BEARER_TOKEN_BEDROCK is the auth source, resolve_runtime_provider
+    must route to bedrock_converse (boto3), not anthropic_messages (AnthropicBedrock SDK).
+
+    The AnthropicBedrock SDK requires IAM credentials (access key + secret or
+    instance role) and raises "could not resolve credentials from session" when
+    only a bearer token is configured.  boto3's default credential chain does
+    support bearer tokens natively, so bedrock_converse is the correct path.
+    """
+
+    def _make_env(self, *, bearer_token="fake-bearer-token-abc123", access_key=None):
+        env = {}
+        if bearer_token:
+            env["AWS_BEARER_TOKEN_BEDROCK"] = bearer_token
+        if access_key:
+            env["AWS_ACCESS_KEY_ID"] = access_key
+            env["AWS_SECRET_ACCESS_KEY"] = "fake-secret"
+        return env
+
+    def test_bearer_token_routes_claude_to_bedrock_converse(self, monkeypatch):
+        """Claude model + bearer token → bedrock_converse, not anthropic_messages."""
+        import os
+        from unittest.mock import patch, MagicMock
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        env = self._make_env()
+        with patch.dict(os.environ, env, clear=False):
+            # Patch botocore credential check so has_aws_credentials() returns True
+            with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                 patch("agent.bedrock_adapter.resolve_aws_auth_env_var", return_value="AWS_BEARER_TOKEN_BEDROCK"), \
+                 patch("hermes_cli.runtime_provider.load_config", return_value={"model": {"default": "us.anthropic.claude-opus-4-7"}}):
+                result = resolve_runtime_provider(requested="bedrock")
+
+        assert result is not None
+        assert result["api_mode"] == "bedrock_converse", (
+            f"Expected bedrock_converse with bearer token, got {result['api_mode']!r}"
+        )
+        assert result.get("bedrock_anthropic") is not True
+
+    def test_iam_credentials_route_claude_to_anthropic_messages(self, monkeypatch):
+        """Claude model + IAM access key → anthropic_messages (AnthropicBedrock SDK)."""
+        import os
+        from unittest.mock import patch
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        env = self._make_env(bearer_token=None, access_key="AKIAIOSFODNN7EXAMPLE")
+        with patch.dict(os.environ, env, clear=False):
+            with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                 patch("agent.bedrock_adapter.resolve_aws_auth_env_var", return_value="AWS_ACCESS_KEY_ID"), \
+                 patch("hermes_cli.runtime_provider.load_config", return_value={"model": {"default": "us.anthropic.claude-opus-4-7"}}):
+                result = resolve_runtime_provider(requested="bedrock")
+
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages", (
+            f"Expected anthropic_messages with IAM creds, got {result['api_mode']!r}"
+        )
+        assert result.get("bedrock_anthropic") is True
+
+    def test_bearer_token_routes_non_claude_to_bedrock_converse(self, monkeypatch):
+        """Non-Claude model + bearer token → bedrock_converse (same as IAM path)."""
+        import os
+        from unittest.mock import patch
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        env = self._make_env()
+        with patch.dict(os.environ, env, clear=False):
+            with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+                 patch("agent.bedrock_adapter.resolve_aws_auth_env_var", return_value="AWS_BEARER_TOKEN_BEDROCK"), \
+                 patch("hermes_cli.runtime_provider.load_config", return_value={"model": {"default": "us.amazon.nova-pro-v1:0"}}):
+                result = resolve_runtime_provider(requested="bedrock")
+
+        assert result is not None
+        assert result["api_mode"] == "bedrock_converse"

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -116,6 +116,69 @@ class TestAnthropicMessagesDetection:
         assert _detect_api_mode_for_url("https://api.example.com/anthropic/v1/models") is None
 
 
+class TestBedrockConverseDetection:
+    """AWS Bedrock runtime endpoints should resolve to bedrock_converse.
+
+    Without this detection, ``provider: custom`` with a Bedrock base URL
+    falls through to ``chat_completions``, which hits
+    ``UnknownOperationException`` on the Bedrock endpoint and triggers
+    the empty-response retry loop.
+    """
+
+    def test_bedrock_us_east_1_returns_bedrock_converse(self):
+        assert (
+            _detect_api_mode_for_url(
+                "https://bedrock-runtime.us-east-1.amazonaws.com"
+            )
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_us_west_2_returns_bedrock_converse(self):
+        assert (
+            _detect_api_mode_for_url(
+                "https://bedrock-runtime.us-west-2.amazonaws.com"
+            )
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_eu_west_1_returns_bedrock_converse(self):
+        assert (
+            _detect_api_mode_for_url(
+                "https://bedrock-runtime.eu-west-1.amazonaws.com"
+            )
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_trailing_slash_tolerated(self):
+        assert (
+            _detect_api_mode_for_url(
+                "https://bedrock-runtime.us-east-1.amazonaws.com/"
+            )
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_uppercase_tolerated(self):
+        assert (
+            _detect_api_mode_for_url(
+                "HTTPS://BEDROCK-RUNTIME.US-EAST-1.AMAZONAWS.COM"
+            )
+            == "bedrock_converse"
+        )
+
+    def test_non_bedrock_runtime_amazonaws_does_not_match(self):
+        # Only bedrock-runtime.* hostnames should match, not arbitrary amazonaws.com hosts.
+        assert _detect_api_mode_for_url("https://s3.amazonaws.com") is None
+
+    def test_bedrock_runtime_hostname_suffix_does_not_match(self):
+        # Protects against hostname suffix spoofing.
+        assert (
+            _detect_api_mode_for_url(
+                "https://evil.bedrock-runtime.us-east-1.amazonaws.com"
+            )
+            is None
+        )
+
+
 class TestDefaultCase:
     def test_generic_url_returns_none(self):
         assert _detect_api_mode_for_url("https://api.together.xyz/v1") is None


### PR DESCRIPTION
## Summary

Fixes two related issues that caused Hermes to fail with `AWS_BEARER_TOKEN_BEDROCK` and silently fall back to the secondary provider on every request.

## Root cause

1. **`_detect_api_mode_for_url()` in `runtime_provider.py` did not recognize `bedrock-runtime.*.amazonaws.com` URLs.** With `provider='custom'` (or any non-`bedrock` label) pointing at a Bedrock endpoint, callers fell through to `chat_completions`, which returns `UnknownOperationException` and triggers the empty-response retry loop.

2. **`resolve_runtime_provider()` routed Claude-on-Bedrock to `api_mode='anthropic_messages'` (AnthropicBedrock SDK) regardless of auth type.** The `AnthropicBedrock` SDK requires IAM credentials (`AWS_ACCESS_KEY_ID` / instance role); it does not support `AWS_BEARER_TOKEN_BEDROCK` and raises `could not resolve credentials from session`. boto3's default credential chain does support bearer tokens, so the fix routes bearer-token users to `bedrock_converse` (boto3) instead. IAM users continue to use the `AnthropicBedrock` SDK for full feature parity (thinking budgets, adaptive thinking).

The fallback provider happened to work because `_try_activate_fallback()` has its own URL-based `api_mode` detection that independently resolves to `bedrock_converse` — which is why only the primary model failed.

## Files changed

- `hermes_cli/runtime_provider.py` — bedrock URL detection + bearer-token routing
- `tests/hermes_cli/test_detect_api_mode_for_url.py` — 7 new bedrock URL tests
- `tests/hermes_cli/test_bedrock_model_picker.py` — 3 new bearer-token routing tests

## Tests

All 26 tests in the affected files pass. Primary model verified working end-to-end with `AWS_BEARER_TOKEN_BEDROCK`.
