### PR TITLE
fix(codex-runtime): re-running /codex-runtime codex_app_server when already enabled now triggers migration

### DIFF
--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -144,8 +144,19 @@ def apply(
             codex_version=ver if ok else None,
         )
 
-    # No change requested
-    if new_value == current:
+    # No-config-change paths. For `auto` we return immediately — disabling
+    # doesn't touch ~/.codex/. For `codex_app_server`, we fall through to
+    # the migration block below: the config value is already correct, but
+    # the world state (managed block in ~/.codex/config.toml, hermes-tools
+    # MCP callback, plugin discovery) may be stale or missing — common
+    # footgun when users pre-set `openai_runtime: codex_app_server` in
+    # config.yaml without ever running the slash command. The migration is
+    # idempotent by design (it replaces its own managed block in place), so
+    # re-running is cheap and safe.
+    reapplying_enable = (
+        new_value == current and new_value == "codex_app_server"
+    )
+    if new_value == current and not reapplying_enable:
         return CodexRuntimeStatus(
             success=True,
             new_value=current,
@@ -172,22 +183,28 @@ def apply(
                 codex_version=None,
             )
 
-    set_runtime(config, new_value)
-    if persist_callback is not None:
-        try:
-            persist_callback(config)
-        except Exception as exc:
-            logger.exception("failed to persist openai_runtime change")
-            return CodexRuntimeStatus(
-                success=False,
-                new_value=new_value,
-                old_value=current,
-                message=f"updated config in memory but persist failed: {exc}",
-            )
+    if not reapplying_enable:
+        set_runtime(config, new_value)
+        if persist_callback is not None:
+            try:
+                persist_callback(config)
+            except Exception as exc:
+                logger.exception("failed to persist openai_runtime change")
+                return CodexRuntimeStatus(
+                    success=False,
+                    new_value=new_value,
+                    old_value=current,
+                    message=f"updated config in memory but persist failed: {exc}",
+                )
 
-    msg_lines = [
-        f"openai_runtime: {current} → {new_value}",
-    ]
+    if reapplying_enable:
+        msg_lines = [
+            f"openai_runtime already set to {current} — re-applying migration",
+        ]
+    else:
+        msg_lines = [
+            f"openai_runtime: {current} → {new_value}",
+        ]
     if new_value == "codex_app_server":
         ok, ver = _check_binary_cached()
         if ok:

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -96,6 +96,56 @@ class TestApply:
         assert r.success
         assert r.message == "openai_runtime already set to auto"
 
+    def test_reapply_codex_app_server_runs_migration(self):
+        """Re-applying codex_app_server when already enabled must still
+        run the migration. Common footgun: user pre-sets
+        `openai_runtime: codex_app_server` in config.yaml, then runs
+        /codex-runtime codex_app_server expecting the migration. Without
+        this, the slash command short-circuits with "already set" and
+        ~/.codex/config.toml never gets the hermes-tools MCP callback
+        or plugin migration — silent partial setup.
+        """
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "mcp_servers": {
+                "filesystem": {"command": "npx", "args": ["-y", "fs-server"]},
+            },
+        }
+        persisted = {}
+
+        def persist(c):
+            persisted.update(c)
+
+        with patch.object(crs, "check_codex_binary_ok",
+                          return_value=(True, "0.130.0")), \
+             patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = ["filesystem", "hermes-tools"]
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.errors = []
+            mig.return_value.target_path = "/fake/.codex/config.toml"
+            r = crs.apply(cfg, "codex_app_server",
+                          persist_callback=persist)
+        assert r.success
+        assert mig.called, "migration must run on reapply, not just first enable"
+        # Re-apply should signal "already set" but still announce migration ran
+        assert "already set" in r.message
+        assert "re-applying migration" in r.message
+        # Migration output still surfaces
+        assert "Migrated 1 MCP server" in r.message
+        assert "filesystem" in r.message
+        assert "Default sandbox: :workspace" in r.message
+        # No config write needed when value is unchanged — the persist
+        # callback should NOT have fired (avoids spurious config.yaml mtimes
+        # on every re-apply).
+        assert persisted == {}, (
+            "persist_callback fired despite no config-value change"
+        )
+        # Caller still needs a fresh session for the cached agent to pick
+        # up any migration-driven changes.
+        assert r.requires_new_session is True
+
     def test_enable_blocked_when_codex_missing(self):
         cfg = {}
         with patch.object(crs, "check_codex_binary_ok",


### PR DESCRIPTION
Fixes #26529

## What

When `model.openai_runtime` is already set to `codex_app_server`, re-running `/codex-runtime codex_app_server` now triggers the migration (writes managed block to `~/.codex/config.toml`, registers hermes-tools MCP callback, discovers native plugins) instead of short-circuiting with "already set".

## Why

The current short-circuit at `hermes_cli/codex_runtime_switch.py:148` returns early when `new_value == current`, skipping the entire migration block. This conflates "the config value is correct" with "the world state is converged" — which is fine for the `auto` → no-op case (disabling has no world-state side effects) but breaks for `codex_app_server` → no-op, where the user can have the config value correct but be missing the `~/.codex/config.toml` managed block, the MCP callback, and the plugin discovery.

How users hit this: pre-set `openai_runtime: codex_app_server` in `config.yaml` (legitimate workflow — `hermes profile create --clone` does it automatically when cloning a profile that has codex runtime enabled), then run `/codex-runtime codex_app_server` to trigger migration. Silent no-op. The bot looks like it's on the app-server runtime but is actually on `codex_responses` fallback.

## How

Fall through to the migration block when re-applying `codex_app_server` while skipping config persistence (no value-level change → no need to rewrite `config.yaml`). The migration is idempotent by design (uses `_strip_existing_managed_block()` before writing), so re-running is safe and cheap. The user-visible message changes to `"openai_runtime already set to codex_app_server — re-applying migration"` so re-runs surface what happened.

The `auto` re-apply path keeps the early-return short-circuit since disabling has no world-state side effects to converge.

## Tests

New regression test `test_reapply_codex_app_server_runs_migration` asserts:
- `migrate()` was called when re-applying
- `persist_callback` was NOT called (no spurious config writes on no-op transitions)
- Migration output (MCP servers, sandbox default) surfaces in the user-visible message
- `requires_new_session` is True so callers know to `/reset`

Verified RED→GREEN locally: the test fails on origin/main with "migration must run on reapply, not just first enable" and passes with this fix.

```
$ python -m pytest tests/hermes_cli/test_codex_runtime_switch.py -o addopts="" -q
31 passed in 0.54s
```

## Scope

Single-commit, two-file change. Production code change is ~15 lines (one new code path branching on `reapplying_enable`). Existing tests for the value-changing transitions remain green and unmodified.
