### PR TITLE
fix(codex-app-server): honor approvals.mode/yolo for gateway-context approval routing

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1950,6 +1950,19 @@ class AIAgent:
             _agent_cfg = _load_agent_config()
         except Exception:
             _agent_cfg = {}
+        _approvals_cfg = _agent_cfg.get("approvals", {})
+        if not isinstance(_approvals_cfg, dict):
+            _approvals_cfg = {}
+        try:
+            from tools.approval import _normalize_approval_mode
+            _approval_mode = _normalize_approval_mode(
+                _approvals_cfg.get("mode", "manual")
+            )
+        except Exception:
+            _approval_mode = str(
+                _approvals_cfg.get("mode", "manual")
+            ).lower()
+        self._codex_app_server_auto_approve_requests = _approval_mode == "off"
         try:
             self._tool_guardrails = ToolCallGuardrailController(
                 ToolCallGuardrailConfig.from_mapping(
@@ -15748,7 +15761,10 @@ class AIAgent:
         Called from run_conversation() when self.api_mode == "codex_app_server".
         Returns the same dict shape as the chat_completions path.
         """
-        from agent.transports.codex_app_server_session import CodexAppServerSession
+        from agent.transports.codex_app_server_session import (
+            CodexAppServerSession,
+            _ServerRequestRouting,
+        )
 
         # Lazy session: one CodexAppServerSession per AIAgent instance.
         # Spawned on first turn, reused across turns, closed at AIAgent
@@ -15763,9 +15779,36 @@ class AIAgent:
                 approval_callback = _get_approval_callback()
             except Exception:
                 approval_callback = None
+            # Gateway contexts have no UI to surface codex's approval
+            # requests through, so codex app-server exec / apply_patch
+            # requests fail closed (silently decline) by default. When the
+            # user has explicitly opted out of Hermes approvals — via
+            # `approvals.mode: off` in config, the /yolo session toggle,
+            # or HERMES_YOLO_MODE=1 — honor that and let codex's own
+            # sandbox permission profile be the policy gate instead of
+            # double-gating with a missing Hermes UI.
+            _auto_approve_requests = bool(
+                self._codex_app_server_auto_approve_requests
+            )
+            try:
+                from tools.approval import is_current_session_yolo_enabled
+                _auto_approve_requests = (
+                    _auto_approve_requests
+                    or is_current_session_yolo_enabled()
+                )
+            except Exception:
+                pass
+            _auto_approve_requests = (
+                _auto_approve_requests
+                or os.getenv("HERMES_YOLO_MODE", "").lower() in {"1", "true", "yes", "on"}
+            )
             self._codex_session = CodexAppServerSession(
                 cwd=cwd,
                 approval_callback=approval_callback,
+                request_routing=_ServerRequestRouting(
+                    auto_approve_exec=_auto_approve_requests,
+                    auto_approve_apply_patch=_auto_approve_requests,
+                ),
             )
 
         # NOTE: the user message is ALREADY appended to messages by the

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -232,6 +232,168 @@ class TestRunConversationCodexPath:
             agent.run_conversation("hi")
         assert not client_mock.chat.completions.create.called
 
+    def test_approvals_mode_off_auto_approves_codex_server_requests(self, monkeypatch):
+        """When the user disables Hermes approvals, codex app-server approval
+        requests should not fail closed just because no interactive callback
+        is wired (typical gateway path). Codex's own sandbox permission profile
+        remains the filesystem boundary.
+        """
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(final_text="ok", thread_id="th", turn_id="tu")
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th"
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "off"}},
+        ):
+            agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("write something")
+
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_yaml_boolean_false_approval_mode_also_auto_approves(self, monkeypatch):
+        """YAML parses unquoted `off` as False; match the normal approval
+        subsystem's compatibility behavior for codex app-server routing too.
+        """
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "run_turn",
+            lambda self, user_input, **kwargs: TurnResult(
+                final_text="ok", thread_id="th", turn_id="tu"
+            ),
+        )
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th"
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": False}},
+        ):
+            agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("write something")
+
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_manual_approvals_keep_codex_server_requests_fail_closed(self, monkeypatch):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(final_text="ok", thread_id="th", turn_id="tu")
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th"
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("write something")
+
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is False
+        assert routing.auto_approve_apply_patch is False
+
+    def test_hermes_yolo_env_auto_approves_codex_server_requests(self, monkeypatch):
+        """HERMES_YOLO_MODE should flow through to codex app-server routing
+        so gateway/cron contexts do not fail closed when the user explicitly
+        enabled yolo mode outside the CLI slash-command path.
+        """
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(final_text="ok", thread_id="th", turn_id="tu")
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th"
+        )
+        monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("write something")
+
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
+    def test_session_yolo_auto_approves_codex_server_requests(self, monkeypatch):
+        """The /yolo session toggle should be honored at Codex session
+        creation time, independent of the startup-time approvals config.
+        """
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(final_text="ok", thread_id="th", turn_id="tu")
+
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th"
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"approvals": {"mode": "manual"}},
+        ):
+            agent = _make_codex_agent()
+
+        with patch(
+            "tools.approval.is_current_session_yolo_enabled",
+            return_value=True,
+        ), patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("write something")
+
+        routing = captured["request_routing"]
+        assert routing.auto_approve_exec is True
+        assert routing.auto_approve_apply_patch is True
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background


### PR DESCRIPTION
Fixes #26530

## What

When Hermes runs the codex_app_server runtime on a gateway / cron / non-CLI context (Discord, Telegram, Slack, scheduled jobs, etc.), codex's exec and apply_patch approval requests now respect `approvals.mode: off`, the `/yolo` session toggle, and `HERMES_YOLO_MODE=1` instead of silently failing closed.

## Why

Symptom from the user's side: ask a codex-runtime Discord bot to write a file. Bot responds with "patch rejected by user" (or no output at all for shell exec). No approval prompt appears anywhere. From the user's POV, the bot is silently read-only with no path to grant approval.

The bug is in `run_agent.py:_dispatch_codex_app_server_turn()` — it sets `approval_callback` from `tools.terminal_tool._get_approval_callback()` which only gets installed by the interactive CLI thread. Gateway/cron paths get `None`, and the session falls back to its own `"decline"` default for safety. With no UI surface to ask through, the second gate (Hermes approval router) silently denies everything.

This is double-gating with a missing second gate: codex's own sandbox permission profile (`:read-only` / `:workspace` / `:danger-no-sandbox` in `~/.codex/config.toml`) is the user-configurable filesystem boundary; Hermes' approval router was meant to add a per-command interactive checkpoint on top of codex's sandbox. With no UI, the second gate doesn't ask — just denies.

## How

When the user has explicitly opted out of Hermes approvals through any documented mechanism, pass `request_routing=_ServerRequestRouting(auto_approve_exec=True, auto_approve_apply_patch=True)` to the session so codex's approval requests don't enter the Hermes approval flow at all. Codex's own sandbox profile remains the active policy gate.

The opt-out mechanisms honored:

- `approvals.mode: "off"` in `~/.hermes/config.yaml` (string)
- `approvals.mode: false` (YAML 1.1 parses unquoted `off` as `False`) — handled via `_normalize_approval_mode()` to match the rest of the approval subsystem
- `HERMES_YOLO_MODE=1` environment variable
- `/yolo` session toggle (`is_current_session_yolo_enabled()` checked at session-spawn time so mid-session toggles take effect on next codex turn)

Defaults are unchanged: `approvals.mode: manual` (or unset) → fail-closed preserved. Users on the interactive CLI continue to see approval prompts as before because that path goes through the wired `_approval_callback` and never reaches the auto-approve fast-path.

## Semantics note

This is a semantics extension worth flagging in release notes: **`approvals.mode: off` now also applies to codex app-server tool requests.** Users who explicitly turned off approvals for Hermes-native tools now get consistent behavior for codex-runtime tools too. This is what users probably wanted but may not have specifically considered.

## Tests

5 new integration tests in `tests/run_agent/test_codex_app_server_integration.py`:

- `test_approvals_mode_off_auto_approves_codex_server_requests` — string `"off"` → auto-approve ON
- `test_yaml_boolean_false_approval_mode_also_auto_approves` — YAML 1.1 `False` → auto-approve ON
- `test_manual_approvals_keep_codex_server_requests_fail_closed` — default → auto-approve OFF (regression coverage for the default path)
- `test_hermes_yolo_env_auto_approves_codex_server_requests` — env var path
- `test_session_yolo_auto_approves_codex_server_requests` — runtime toggle path

```
$ python -m pytest tests/run_agent/test_codex_app_server_integration.py tests/hermes_cli/test_codex_runtime_*.py -o addopts="" -q
117 passed in 7.45s
```

## Why not just wire the gateway approval callback?

Routing codex's exec/apply_patch approvals through Discord-side messages (e.g. `/approve` and `/deny` slash commands) is a real feature but a much bigger one — codex's approvals are per-tool-call and would need async correlation between the codex turn loop and the gateway's message lifecycle. Worth a separate issue + PR. The "honor approvals.mode/yolo" fix unblocks the immediate "my bot is silently read-only" case and is something users can take action on today.

## Scope

Single-commit, two-file change. Production code change is ~35 lines (initialization read of approvals config + session-spawn-time fold of the three opt-out mechanisms). Existing tests for the manual-approval default-fail-closed behavior remain green; regression coverage is added in the new tests.
