### PR TITLE
fix(vision): preserve named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -168,7 +168,11 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
             return "custom"
-        normalized = suffix
+        # Preserve named custom providers (``custom:<name>``) through routing.
+        # Dropping the prefix makes auxiliary/vision routes look for a bare
+        # provider name and can fall back to the default custom endpoint instead
+        # of the explicitly selected custom provider.
+        normalized = f"custom:{suffix}"
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -396,6 +396,36 @@ class TestResolveVisionMainFirst:
         assert provider == "nous"
         mock_strict.assert_called_once_with("nous", None)
 
+    def test_named_custom_provider_override_preserves_custom_prefix(self):
+        """Explicit custom:<name> vision overrides route to that named provider."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openrouter",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="anthropic/claude-opus-4.6",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom:morecode-openai", "vision-model", None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend"
+        ) as mock_strict:
+            mock_client = MagicMock()
+            mock_resolve.return_value = (mock_client, "vision-model")
+
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "custom:morecode-openai"
+        assert client is mock_client
+        assert model == "vision-model"
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.args[0] == "custom:morecode-openai"
+        assert mock_resolve.call_args.kwargs.get("is_vision") is True
+        mock_strict.assert_not_called()
+
 
 # ── Constant cleanup ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Preserve `custom:<name>` provider identifiers during auxiliary/vision provider normalization.
- Add a regression test that explicit named custom vision overrides route through `resolve_provider_client()` instead of the strict/default custom backend.

## Test Plan
- [x] `python -m pytest tests/agent/test_auxiliary_main_first.py::TestResolveVisionMainFirst::test_named_custom_provider_override_preserves_custom_prefix -q -o 'addopts='`

Closes #12638