### PR TITLE
feat(cli): show active skills in status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2848,6 +2848,7 @@ class HermesCLI:
         self._attached_images: list[Path] = []
         self._image_counter = 0
         self.preloaded_skills: list[str] = []
+        self.loaded_skill_names: list[str] = []
         self._startup_skills_line_shown = False
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
@@ -5388,6 +5389,17 @@ class HermesCLI:
             f"{toolsets_info}{provider_info}"
         )
 
+    def _active_skills_label(self) -> str:
+        """Return a display label for skills active in the current session."""
+        names: list[str] = []
+        for skill_name in (
+            list(getattr(self, "preloaded_skills", []) or [])
+            + list(getattr(self, "loaded_skill_names", []) or [])
+        ):
+            if skill_name and skill_name not in names:
+                names.append(skill_name)
+        return ", ".join(names) if names else "None"
+
     def _show_session_status(self):
         """Show gateway-style status for the current CLI session."""
         session_meta = {}
@@ -5438,6 +5450,7 @@ class HermesCLI:
             f"Last Activity: {updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"Tokens: {total_tokens:,}",
             f"Agent Running: {'Yes' if is_running else 'No'}",
+            f"Active Skills: {self._active_skills_label()}",
         ])
         self._console_print("\n".join(lines), highlight=False, markup=False)
     
@@ -8035,6 +8048,8 @@ class HermesCLI:
                 )
                 if msg:
                     skill_name = _skill_commands[base_cmd]["name"]
+                    if skill_name not in self.loaded_skill_names:
+                        self.loaded_skill_names.append(skill_name)
                     print(f"\n⚡ Loading skill: {skill_name}")
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -20,6 +20,8 @@ def _make_cli():
     cli_obj.model = "openai/gpt-5.4"
     cli_obj.provider = "openai"
     cli_obj.session_start = datetime(2026, 4, 9, 19, 24)
+    cli_obj.preloaded_skills = []
+    cli_obj.loaded_skill_names = []
     cli_obj._agent_running = False
     cli_obj._session_db = MagicMock()
     cli_obj._session_db.get_session.return_value = None
@@ -81,9 +83,22 @@ def test_show_session_status_prints_gateway_style_summary():
     assert "Model: openai/gpt-5.4 (openai)" in printed
     assert "Tokens: 321" in printed
     assert "Agent Running: No" in printed
+    assert "Active Skills: None" in printed
     _, kwargs = cli_obj.console.print.call_args
     assert kwargs.get("highlight") is False
     assert kwargs.get("markup") is False
+
+
+def test_show_session_status_prints_active_skills():
+    cli_obj = _make_cli()
+    cli_obj.preloaded_skills = ["hermes-agent", "github-pr-workflow"]
+    cli_obj.loaded_skill_names = ["github-pr-workflow", "obsidian"]
+
+    with patch("cli.display_hermes_home", return_value="~/.hermes"):
+        cli_obj._show_session_status()
+
+    printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+    assert "Active Skills: hermes-agent, github-pr-workflow, obsidian" in printed
 
 
 def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Track skill slash-command loads alongside startup preloaded skills.
- Include the current active skill list in `/status`, with duplicate names collapsed in load order.

## Test Plan
- [x] `python -m pytest tests/cli/test_cli_status_command.py -q -o 'addopts='`

Closes #24817