### PR TITLE
fix(skills): gate background review writes behind approval

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -537,6 +537,9 @@ skills:
   # Every N tool-calling iterations, remind the model to consider saving a skill.
   # Set to 0 to disable.
   creation_nudge_interval: 15
+  # Require explicit approval before the background self-improvement review
+  # writes skills. Foreground user-directed skill_manage calls are unchanged.
+  creation_requires_approval: false
 
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1228,6 +1228,10 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # When true, the background self-improvement review returns a
+        # structured approval request instead of writing skills directly.
+        # Foreground user-directed skill_manage calls are unchanged.
+        "creation_requires_approval": False,
     },
 
     # Curator — background skill maintenance.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def _is_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/run_agent.py
+++ b/run_agent.py
@@ -4220,7 +4220,13 @@ class AIAgent:
                 data = json.loads(msg.get("content", "{}"))
             except (json.JSONDecodeError, TypeError):
                 continue
-            if not isinstance(data, dict) or not data.get("success"):
+            if not isinstance(data, dict):
+                continue
+            if not data.get("success"):
+                if data.get("status") == "approval_required" and data.get("requires_approval"):
+                    action = data.get("action") or "write"
+                    name = data.get("name") or "unknown"
+                    actions.append(f"Skill '{name}' {action} requires approval")
                 continue
             message = data.get("message", "")
             target = data.get("target", "")

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -193,3 +193,30 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
     )
+
+
+def test_background_review_summary_surfaces_skill_approval_requests():
+    """Approval-gated skill writes should be visible to the user."""
+    import json
+
+    agent = _bare_agent()
+    actions = agent._summarize_background_review_actions(
+        review_messages=[
+            {
+                "role": "tool",
+                "tool_call_id": "call_approval",
+                "content": json.dumps(
+                    {
+                        "success": False,
+                        "status": "approval_required",
+                        "requires_approval": True,
+                        "action": "create",
+                        "name": "review-sediment",
+                    }
+                ),
+            }
+        ],
+        prior_snapshot=[],
+    )
+
+    assert actions == ["Skill 'review-sediment' create requires approval"]

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -254,8 +254,12 @@ class TestDeveloperRoleSwap:
         assert messages[0]["role"] == "system"
 
     def test_developer_role_via_nous_portal(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
-        agent.model = "gpt-5"
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [
             {"role": "system", "content": "You are helpful."},
             {"role": "user", "content": "hi"},
@@ -346,14 +350,24 @@ class TestBuildApiKwargsAIGateway:
 class TestBuildApiKwargsNousPortal:
     def test_includes_nous_product_tags(self, monkeypatch):
         from agent.portal_tags import nous_portal_tags
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
         assert extra.get("tags") == nous_portal_tags()
 
     def test_uses_chat_completions_format(self, monkeypatch):
-        agent = _make_agent(monkeypatch, "nous", base_url="https://inference-api.nousresearch.com/v1")
+        agent = _make_agent(
+            monkeypatch,
+            "nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model="gpt-5",
+        )
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert "messages" in kwargs

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -567,6 +567,94 @@ class TestSkillManageDispatcher:
         assert result["success"] is True
         assert usage["review-sediment"]["created_by"] == "agent"
 
+    def test_background_create_requires_approval_when_enabled(self, tmp_path):
+        """Opt-in approval blocks background-review skill creation before write."""
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _skill_dir(tmp_path), \
+                 patch(
+                     "tools.skill_manager_tool.load_config",
+                     return_value={"skills": {"creation_requires_approval": True}},
+                 ):
+                raw = skill_manage(
+                    action="create",
+                    name="review-sediment",
+                    content=VALID_SKILL_CONTENT,
+                )
+        finally:
+            reset_current_write_origin(token)
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert result["status"] == "approval_required"
+        assert result["requires_approval"] is True
+        assert result["action"] == "create"
+        assert "# Test Skill" in result["proposed_content"]
+        assert not (tmp_path / "review-sediment" / "SKILL.md").exists()
+
+    def test_foreground_create_ignores_background_approval_setting(self, tmp_path):
+        """The approval option only gates the background review fork."""
+        with _skill_dir(tmp_path), \
+             patch(
+                 "tools.skill_manager_tool.load_config",
+                 return_value={"skills": {"creation_requires_approval": True}},
+             ):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert (tmp_path / "test-skill" / "SKILL.md").exists()
+
+    def test_background_edit_requires_approval_with_diff(self, tmp_path):
+        """Existing skill updates return a diff and leave files unchanged."""
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        with _skill_dir(tmp_path):
+            skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+            )
+
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                with patch(
+                    "tools.skill_manager_tool.load_config",
+                    return_value={"skills": {"creation_requires_approval": True}},
+                ):
+                    raw = skill_manage(
+                        action="edit",
+                        name="test-skill",
+                        content=VALID_SKILL_CONTENT_2,
+                    )
+            finally:
+                reset_current_write_origin(token)
+
+            stored = (tmp_path / "test-skill" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert result["status"] == "approval_required"
+        assert "-# Test Skill" in result["diff"]
+        assert "+# Test Skill v2" in result["diff"]
+        assert "# Test Skill v2" not in stored
+
     def test_delete_via_dispatcher_threads_absorbed_into(self, tmp_path):
         # Dispatcher must plumb absorbed_into through to _delete_skill so the
         # validation + message suffix paths are exercised end-to-end.

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -58,6 +58,33 @@ class TestProviderSelectionGate:
         finally:
             importlib.reload(tt)
 
+    def test_xai_resolver_import_after_config_env_patch_uses_restored_dotenv_loader(self):
+        """xAI HTTP auth must not cache a temporarily patched env helper."""
+        import importlib
+        import hermes_cli.config as config_mod
+        from tools import xai_http
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(config_mod, "get_env_value", lambda name, default=None: "")
+            xai_http = importlib.reload(xai_http)
+
+        try:
+            with patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=RuntimeError("no oauth"),
+            ), patch(
+                "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+                return_value={},
+            ), patch(
+                "hermes_cli.config.load_env",
+                return_value={"XAI_API_KEY": "dotenv-secret"},
+            ):
+                creds = xai_http.resolve_xai_http_credentials()
+        finally:
+            importlib.reload(xai_http)
+
+        assert creds["api_key"] == "dotenv-secret"
+
     def test_explicit_groq_sees_dotenv(self):
         from tools import transcription_tools as tt
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -32,6 +32,7 @@ Directory layout for user skills:
             └── SKILL.md
 """
 
+import difflib
 import json
 import logging
 import os
@@ -43,7 +44,7 @@ from hermes_constants import get_hermes_home, display_hermes_home
 from typing import Dict, Any, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -163,12 +164,22 @@ def _pinned_guard(name: str) -> Optional[str]:
 
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
+MAX_APPROVAL_PREVIEW_CHARS = 12_000
 
 # Characters allowed in skill names (filesystem-safe, URL-friendly)
 VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+
+APPROVAL_GATED_ACTIONS = {
+    "create",
+    "edit",
+    "patch",
+    "delete",
+    "write_file",
+    "remove_file",
+}
 
 
 # =============================================================================
@@ -251,6 +262,204 @@ def _validate_frontmatter(content: str) -> Optional[str]:
         return "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
 
     return None
+
+
+def _background_skill_write_approval_enabled() -> bool:
+    """Return True when background review skill writes need user approval."""
+    try:
+        from tools.skill_provenance import is_background_review
+
+        if not is_background_review():
+            return False
+        cfg = load_config()
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "creation_requires_approval"),
+            default=False,
+        )
+    except Exception:
+        return False
+
+
+def _approval_preview(text: str) -> str:
+    if len(text) <= MAX_APPROVAL_PREVIEW_CHARS:
+        return text
+    omitted = len(text) - MAX_APPROVAL_PREVIEW_CHARS
+    return text[:MAX_APPROVAL_PREVIEW_CHARS] + f"\n... ({omitted} chars omitted)"
+
+
+def _approval_diff(
+    before: str,
+    after: str,
+    *,
+    before_label: str,
+    after_label: str,
+) -> str:
+    diff = "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=before_label,
+            tofile=after_label,
+        )
+    )
+    return _approval_preview(diff)
+
+
+def _skill_write_approval_result(
+    action: str,
+    name: str,
+    *,
+    content: str = None,
+    category: str = None,
+    file_path: str = None,
+    file_content: str = None,
+    old_string: str = None,
+    new_string: str = None,
+    replace_all: bool = False,
+    absorbed_into: str = None,
+) -> Optional[Dict[str, Any]]:
+    """Build a no-write approval payload for background-review skill writes.
+
+    Returns None when the action would fail before writing anyway, so the
+    normal action handler can return its specific validation error.
+    """
+    if action not in APPROVAL_GATED_ACTIONS:
+        return None
+    if not _background_skill_write_approval_enabled():
+        return None
+
+    result: Dict[str, Any] = {
+        "success": False,
+        "status": "approval_required",
+        "requires_approval": True,
+        "action": action,
+        "name": name,
+        "message": (
+            f"Background review wants to run skill_manage(action='{action}', "
+            f"name='{name}'), but skills.creation_requires_approval is enabled."
+        ),
+    }
+
+    existing = _find_skill(name)
+    if existing:
+        result["existing_path"] = str(existing["path"])
+
+    if action == "create":
+        target = _resolve_skill_dir(name, category) / "SKILL.md"
+        result["target_path"] = str(target)
+        if category:
+            result["category"] = category
+        if existing:
+            skill_md = existing["path"] / "SKILL.md"
+            if skill_md.exists():
+                before = skill_md.read_text(encoding="utf-8")
+                result["diff"] = _approval_diff(
+                    before,
+                    content or "",
+                    before_label=str(skill_md),
+                    after_label=f"proposed:{name}/SKILL.md",
+                )
+            else:
+                result["proposed_content"] = _approval_preview(content or "")
+        else:
+            result["proposed_content"] = _approval_preview(content or "")
+        return result
+
+    if action == "edit":
+        if not existing:
+            return None
+        skill_md = existing["path"] / "SKILL.md"
+        before = skill_md.read_text(encoding="utf-8") if skill_md.exists() else ""
+        result["target_path"] = str(skill_md)
+        result["diff"] = _approval_diff(
+            before,
+            content or "",
+            before_label=str(skill_md),
+            after_label=f"proposed:{name}/SKILL.md",
+        )
+        return result
+
+    if action == "patch":
+        if not existing:
+            return None
+        skill_dir = existing["path"]
+        if file_path:
+            err = _validate_file_path(file_path)
+            if err:
+                return None
+            target, err = _resolve_skill_target(skill_dir, file_path)
+            if err:
+                return None
+        else:
+            target = skill_dir / "SKILL.md"
+        if not target.exists():
+            return None
+        before = target.read_text(encoding="utf-8")
+        try:
+            from tools.fuzzy_match import fuzzy_find_and_replace
+
+            after, _match_count, _strategy, match_error = fuzzy_find_and_replace(
+                before,
+                old_string or "",
+                new_string or "",
+                replace_all,
+            )
+            if match_error:
+                return None
+        except Exception:
+            return None
+        result["target_path"] = str(target)
+        result["diff"] = _approval_diff(
+            before,
+            after,
+            before_label=str(target),
+            after_label=f"proposed:{target.name}",
+        )
+        return result
+
+    if action == "write_file":
+        if not existing:
+            return None
+        err = _validate_file_path(file_path or "")
+        if err:
+            return None
+        target, err = _resolve_skill_target(existing["path"], file_path)
+        if err:
+            return None
+        result["target_path"] = str(target)
+        if target.exists():
+            before = target.read_text(encoding="utf-8")
+            result["diff"] = _approval_diff(
+                before,
+                file_content or "",
+                before_label=str(target),
+                after_label=f"proposed:{file_path}",
+            )
+        else:
+            result["proposed_content"] = _approval_preview(file_content or "")
+        return result
+
+    if action == "remove_file":
+        if not existing:
+            return None
+        err = _validate_file_path(file_path or "")
+        if err:
+            return None
+        target, err = _resolve_skill_target(existing["path"], file_path)
+        if err or not target.exists():
+            return None
+        result["target_path"] = str(target)
+        return result
+
+    if action == "delete":
+        if not existing:
+            return None
+        result["target_path"] = str(existing["path"])
+        if absorbed_into is not None:
+            result["absorbed_into"] = absorbed_into
+        return result
+
+    return result
 
 
 def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[str]:
@@ -730,11 +939,44 @@ def skill_manage(
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
+        err = _validate_name(name)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        err = _validate_category(category)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        err = _validate_frontmatter(content)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        err = _validate_content_size(content)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            content=content,
+            category=category,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _create_skill(name, content, category)
 
     elif action == "edit":
         if not content:
             return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
+        err = _validate_frontmatter(content)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        err = _validate_content_size(content)
+        if err:
+            return json.dumps({"success": False, "error": err}, ensure_ascii=False)
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            content=content,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _edit_skill(name, content)
 
     elif action == "patch":
@@ -742,9 +984,26 @@ def skill_manage(
             return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
         if new_string is None:
             return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            file_path=file_path,
+            old_string=old_string,
+            new_string=new_string,
+            replace_all=replace_all,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
     elif action == "delete":
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            absorbed_into=absorbed_into,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _delete_skill(name, absorbed_into=absorbed_into)
 
     elif action == "write_file":
@@ -752,11 +1011,26 @@ def skill_manage(
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
         if file_content is None:
             return tool_error("file_content is required for 'write_file'.", success=False)
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            file_path=file_path,
+            file_content=file_content,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _write_file(name, file_path, file_content)
 
     elif action == "remove_file":
         if not file_path:
             return tool_error("file_path is required for 'remove_file'.", success=False)
+        approval = _skill_write_approval_result(
+            action,
+            name,
+            file_path=file_path,
+        )
+        if approval is not None:
+            return json.dumps(approval, ensure_ascii=False)
         result = _remove_file(name, file_path)
 
     else:

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 import os
 from typing import Dict
 
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
-
 
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
@@ -18,10 +13,14 @@ def get_env_value(name: str, default=None):
     ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
     xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
+    try:
+        from hermes_cli.config import get_env_value as _hermes_get_env_value
+
         value = _hermes_get_env_value(name)
         if value is not None:
             return value
+    except Exception:
+        pass
     return os.environ.get(name, default)
 
 


### PR DESCRIPTION
## Summary
- add `skills.creation_requires_approval` for background-review skill writes
- return structured `approval_required` payloads with proposed content or diffs before writing
- surface approval-gated skill proposals in the self-improvement review summary

## Tests
- `python -m pytest -o addopts='' tests\tools\test_skill_manager_tool.py tests\tools\test_skill_provenance.py tests\run_agent\test_background_review.py -q --tb=short`
- `python -m ruff check tools\skill_manager_tool.py tests\tools\test_skill_manager_tool.py hermes_cli\config.py run_agent.py tests\run_agent\test_background_review.py`
- `python -m py_compile tools\skill_manager_tool.py tests\tools\test_skill_manager_tool.py hermes_cli\config.py run_agent.py tests\run_agent\test_background_review.py`

Fixes #26298