### PR TITLE
Fix GPT-5 custom provider token accounting

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Mapping, Optional
 
 from agent.model_metadata import fetch_endpoint_model_metadata, fetch_model_metadata
 from utils import base_url_host_matches
@@ -689,49 +689,63 @@ def normalize_usage(
     if not response_usage:
         return CanonicalUsage()
 
+    def _usage_value(obj: Any, name: str, default: Any = None) -> Any:
+        if isinstance(obj, Mapping):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+
     provider_name = (provider or "").strip().lower()
     mode = (api_mode or "").strip().lower()
 
+    has_chat_usage = (
+        _usage_value(response_usage, "prompt_tokens") is not None
+        or _usage_value(response_usage, "completion_tokens") is not None
+    )
+    has_responses_usage = (
+        _usage_value(response_usage, "input_tokens") is not None
+        or _usage_value(response_usage, "output_tokens") is not None
+    )
+
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
-    elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_tokens = _to_int(_usage_value(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_value(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_value(response_usage, "cache_creation_input_tokens", 0))
+    elif mode == "codex_responses" and has_responses_usage and not has_chat_usage:
+        input_total = _to_int(_usage_value(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "output_tokens", 0))
+        details = _usage_value(response_usage, "input_tokens_details")
+        cache_read_tokens = _to_int(_usage_value(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_value(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_value(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "completion_tokens", 0))
+        details = _usage_value(response_usage, "prompt_tokens_details")
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel
         # AI Gateway, Cline) expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_value(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_value(response_usage, "cache_read_input_tokens", 0))
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_value(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_value(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
     reasoning_tokens = 0
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_value(response_usage, "output_tokens_details")
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_value(output_details, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3047,6 +3047,8 @@ def get_custom_provider_context_length(
         if not isinstance(models, dict):
             continue
         model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict) and "/" in model:
+            model_cfg = models.get(model.rsplit("/", 1)[-1])
         if not isinstance(model_cfg, dict):
             continue
         raw_ctx = model_cfg.get("context_length")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -86,6 +86,13 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _model_prefers_responses_api(model: str) -> bool:
+    m = (model or "").strip().lower()
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    return m.startswith("gpt-5")
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -373,6 +380,7 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
+    model_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
@@ -390,7 +398,12 @@ def _try_resolve_from_custom_pool(
             return None
         return {
             "provider": provider_label,
-            "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": (
+                api_mode_override
+                or _detect_api_mode_for_url(base_url)
+                or ("codex_responses" if _model_prefers_responses_api(model_name or "") else None)
+                or "chat_completions"
+            ),
             "base_url": base_url,
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
@@ -538,6 +551,7 @@ def _resolve_named_custom_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
@@ -582,7 +596,14 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    model_name = str(custom_provider.get("model") or target_model or "").strip()
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+        model_name=model_name,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -600,11 +621,16 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or ("codex_responses" if _model_prefers_responses_api(model_name) else None)
+        or "chat_completions"
+    )
+
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -1011,6 +1037,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -331,6 +331,8 @@ def _resolve_runtime_from_pool_entry(
             detected = _detect_api_mode_for_url(base_url)
             if detected:
                 api_mode = detected
+            elif _model_prefers_responses_api(str(effective_model or "")):
+                api_mode = "codex_responses"
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
@@ -562,7 +564,12 @@ def _resolve_named_custom_runtime(
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        pool_result = _try_resolve_from_custom_pool(
+            base_url,
+            "custom",
+            None,
+            model_name=target_model,
+        )
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
@@ -577,7 +584,11 @@ def _resolve_named_custom_runtime(
         ) or "no-key-required"
         return {
             "provider": "custom",
-            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": (
+                _detect_api_mode_for_url(base_url)
+                or ("codex_responses" if _model_prefers_responses_api(target_model or "") else None)
+                or "chat_completions"
+            ),
             "base_url": base_url,
             "api_key": api_key,
             "source": "direct-alias",
@@ -647,6 +658,7 @@ def _resolve_openrouter_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
@@ -732,6 +744,7 @@ def _resolve_openrouter_runtime(
         pool_result = _try_resolve_from_custom_pool(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
             provider_name=requested_provider if requested_norm != "custom" else None,
+            model_name=target_model or model_cfg.get("default") or "",
         )
         if pool_result:
             return pool_result
@@ -743,6 +756,7 @@ def _resolve_openrouter_runtime(
         "provider": effective_provider,
         "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
         or _detect_api_mode_for_url(base_url)
+        or ("codex_responses" if _model_prefers_responses_api(target_model or model_cfg.get("default") or "") else None)
         or "chat_completions",
         "base_url": base_url,
         "api_key": api_key,
@@ -839,6 +853,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -966,6 +981,10 @@ def _resolve_explicit_runtime(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
+                else:
+                    model_name = str(target_model or model_cfg.get("default") or "").strip()
+                    if _model_prefers_responses_api(model_name):
+                        api_mode = "codex_responses"
 
         return {
             "provider": provider,
@@ -997,6 +1016,8 @@ def resolve_runtime_provider(
     behavior (api_mode derived from config).
     """
     requested_provider = resolve_requested_provider(requested)
+    model_cfg = _get_model_config()
+    effective_target_model = target_model or str(model_cfg.get("default") or "").strip() or None
 
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
@@ -1026,10 +1047,10 @@ def resolve_runtime_provider(
     if requested_provider == "azure-foundry":
         azure_runtime = _resolve_azure_foundry_runtime(
             requested_provider=requested_provider,
-            model_cfg=_get_model_config(),
+            model_cfg=model_cfg,
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
-            target_model=target_model,
+            target_model=effective_target_model,
         )
         return azure_runtime
 
@@ -1037,7 +1058,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
-        target_model=target_model,
+        target_model=effective_target_model,
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
@@ -1048,13 +1069,13 @@ def resolve_runtime_provider(
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
-    model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,
         requested_provider=requested_provider,
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=effective_target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1113,7 +1134,7 @@ def resolve_runtime_provider(
                 requested_provider=requested_provider,
                 model_cfg=model_cfg,
                 pool=pool,
-                target_model=target_model,
+                target_model=effective_target_model,
             )
 
     if provider == "nous":
@@ -1420,6 +1441,7 @@ def resolve_runtime_provider(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=effective_target_model,
     )
     runtime["requested_provider"] = requested_provider
     return runtime

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -106,6 +106,39 @@ def test_normalize_usage_openai_prefers_prompt_tokens_details_over_top_level():
     assert normalized.cache_write_tokens == 150
 
 
+def test_normalize_usage_codex_responses_mode_accepts_chat_usage_shape():
+    """OpenAI-compatible gateways may route GPT/Codex-named models through
+    Chat Completions while Hermes has api_mode=codex_responses from model
+    heuristics or config. Token accounting should follow the response shape,
+    not blindly trust the configured request mode.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=123,
+        completion_tokens=45,
+        total_tokens=168,
+    )
+
+    normalized = normalize_usage(usage, provider="custom", api_mode="codex_responses")
+
+    assert normalized.input_tokens == 123
+    assert normalized.output_tokens == 45
+    assert normalized.total_tokens == 168
+
+
+def test_normalize_usage_codex_responses_mode_accepts_dict_chat_usage_shape():
+    usage = {
+        "prompt_tokens": 123,
+        "completion_tokens": 45,
+        "total_tokens": 168,
+    }
+
+    normalized = normalize_usage(usage, provider="custom", api_mode="codex_responses")
+
+    assert normalized.input_tokens == 123
+    assert normalized.output_tokens == 45
+    assert normalized.total_tokens == 168
+
+
 def test_openrouter_models_api_pricing_is_converted_from_per_token_to_per_million(monkeypatch):
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_model_metadata",

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -83,6 +83,20 @@ class TestGetCustomProviderContextLength:
             is None
         )
 
+    def test_matches_slash_prefixed_model_alias(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "models": {"gpt-5.5": {"context_length": 272_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "azure/gpt-5.5", "https://example.invalid/v1", custom
+            )
+            == 272_000
+        )
+
     def test_returns_none_for_string_value(self):
         """'256K' string is not a valid int — skip silently.
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1464,6 +1464,55 @@ def test_custom_provider_no_key_gets_placeholder(monkeypatch):
     assert resolved["base_url"] == "http://localhost:8080/v1"
 
 
+def test_named_custom_gpt5_provider_infers_responses_api(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "bifrost",
+                    "base_url": "https://bifrost.example.test/v1",
+                    "api_key": "sk-test",
+                    "model": "gpt-5.5",
+                }
+            ],
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:bifrost")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["model"] == "gpt-5.5"
+
+
+def test_named_custom_explicit_api_mode_wins_over_gpt5_inference(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "azure-openai-proxy",
+                    "base_url": "https://proxy.example.test/v1",
+                    "api_key": "sk-test",
+                    "model": "gpt-5.5",
+                    "api_mode": "chat_completions",
+                }
+            ],
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:azure-openai-proxy")
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_auto_detected_nous_auth_failure_falls_through_to_openrouter(monkeypatch):
     """When auto-detect picks Nous but credentials are revoked, fall through to OpenRouter."""
     from hermes_cli.auth import AuthError

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1513,6 +1513,51 @@ def test_named_custom_explicit_api_mode_wins_over_gpt5_inference(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_top_level_custom_gpt5_provider_infers_responses_api(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://bifrost.example.test/v1",
+                "api_key": "sk-test",
+                "default": "azure/gpt-5.5",
+            },
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://bifrost.example.test/v1"
+
+
+def test_top_level_custom_explicit_api_mode_wins_over_gpt5_inference(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://bifrost.example.test/v1",
+                "api_key": "sk-test",
+                "default": "azure/gpt-5.5",
+                "api_mode": "chat_completions",
+            },
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_auto_detected_nous_auth_failure_falls_through_to_openrouter(monkeypatch):
     """When auto-detect picks Nous but credentials are revoked, fall through to OpenRouter."""
     from hermes_cli.auth import AuthError


### PR DESCRIPTION
## Summary
- normalize usage parsing for chat-shaped usage objects returned while running the Responses/Codex path
- infer `codex_responses` for GPT-5 custom providers across named providers, top-level `model.provider: custom`, direct aliases, and credential-pool resolution
- keep explicit custom-provider `api_mode` values authoritative for non-compatible gateways
- allow custom-provider context-length overrides to match slash-prefixed routed model ids like `azure/gpt-5.5` against `gpt-5.5`

## Root cause
Hermes had multiple custom-provider resolution paths. The named `custom:<name>` path was one path, but gateway sessions using top-level `model.provider: custom` plus `model.base_url` went through the OpenRouter/custom fallback and credential-pool branches. Those branches still defaulted GPT-5 custom endpoints to `chat_completions`, so live Bifrost sessions used `chat_completion_stream_request` and logged zero token usage.

A related compaction/config issue was that `custom_providers[].models.gpt-5.5.context_length` did not apply when the active routed model id was `azure/gpt-5.5`, causing Hermes to fall back to probe/default context metadata instead of the configured model window.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_custom_provider_context_length.py tests/agent/test_usage_pricing.py`

## Live verification
Against a Bifrost-backed custom endpoint configured as `model.default: azure/gpt-5.5`, a fresh run resolved `api_mode=codex_responses`, used `codex_stream_request`, loaded context length `272000`, and logged nonzero usage: `in=223 out=5 total=228`.

