### PR TITLE
fix: strip reasoning_content for Cerebras (HTTP 400 on replay)

### DIFF
--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,76 @@
+"""Cerebras provider profile.
+
+Cerebras runs wafer-scale inference for open-weight models (e.g. Llama,
+DeepSeek-R1-Distill, GPT-OSS) via an OpenAI-compatible endpoint.  Their
+API accepts the standard Chat Completions schema but explicitly rejects
+the ``reasoning_content`` field in replayed assistant messages, returning:
+
+    HTTP 400: messages.N.assistant.reasoning_content:
+    property '...' is unsupported
+
+This profile strips ``reasoning_content`` from every assistant message
+before the request goes out, which is the correct fix for sessions that
+were initially started with a reasoning-capable provider (DeepSeek, Kimi,
+MiMo, …) and later switched to Cerebras, or for sessions where the SDK
+returned reasoning tokens that Cerebras does not accept on replay.
+
+Configure in ``~/.hermes/config.yaml``::
+
+    model: llama-4-scout-17b-16e-instruct   # or any Cerebras model
+    provider: cerebras
+
+Or point a custom endpoint at the Cerebras base URL and the URL-based
+detection in ``AIAgent._strips_reasoning_content_from_api_messages``
+handles the sanitization automatically for ``provider: custom`` users.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CerebrasProfile(ProviderProfile):
+    """Cerebras wafer-scale inference — strips reasoning_content on replay."""
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Remove ``reasoning_content`` from assistant messages.
+
+        Cerebras rejects the field with HTTP 400 when it appears in replayed
+        history.  This belt-and-suspenders cleanup runs in the transport layer
+        for sessions going through the profile path (``provider: cerebras``).
+        The primary guard lives in
+        ``AIAgent._strips_reasoning_content_from_api_messages`` / ``_copy_reasoning_content_for_api``
+        which covers the ``provider: custom`` + Cerebras URL case as well.
+        """
+        sanitized = []
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "assistant" and "reasoning_content" in msg:
+                msg = copy.copy(msg)
+                del msg["reasoning_content"]
+            sanitized.append(msg)
+        return sanitized
+
+
+cerebras = CerebrasProfile(
+    name="cerebras",
+    display_name="Cerebras",
+    description="Cerebras wafer-scale chip inference (OpenAI-compatible)",
+    signup_url="https://cerebras.ai",
+    env_vars=("CEREBRAS_API_KEY",),
+    base_url="https://api.cerebras.ai/v1",
+    hostname="api.cerebras.ai",
+    fallback_models=(
+        "llama-4-scout-17b-16e-instruct",
+        "llama-3.3-70b",
+        "llama3.1-8b",
+        "llama3.1-70b",
+        "deepseek-r1-distill-llama-70b",
+        "qwen-3-32b",
+    ),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/cerebras/plugin.yaml
+++ b/plugins/model-providers/cerebras/plugin.yaml
@@ -1,0 +1,4 @@
+name: cerebras
+kind: model-provider
+version: "1.0.0"
+description: "Cerebras wafer-scale chip inference (OpenAI-compatible)"

--- a/run_agent.py
+++ b/run_agent.py
@@ -10211,9 +10211,31 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
+    def _strips_reasoning_content_from_api_messages(self) -> bool:
+        """Return True when the active provider rejects ``reasoning_content``
+        in replayed assistant messages and returns HTTP 400 when it is present.
+
+        Unlike providers that *require* reasoning echo-back (DeepSeek, Kimi,
+        MiMo), these providers explicitly forbid the field and must receive
+        clean assistant messages without it.
+
+        Current providers:
+          - Cerebras (``api.cerebras.ai``) — their OpenAI-compatible endpoint
+            rejects ``reasoning_content`` with: "property
+            'messages.N.assistant.reasoning_content' is unsupported"
+        """
+        return base_url_host_matches(self.base_url, "api.cerebras.ai")
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Copy provider-facing reasoning fields onto an API replay message."""
         if source_msg.get("role") != "assistant":
+            return
+
+        # 0. Providers that actively reject reasoning_content in message
+        # history: strip any stored value (from msg.copy()) and return early
+        # so no branch below re-adds the field.
+        if self._strips_reasoning_content_from_api_messages():
+            api_msg.pop("reasoning_content", None)
             return
 
         # 1. Explicit reasoning_content already set — preserve it verbatim

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,19 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan", "cerebras",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/run_agent/test_cerebras_reasoning_strip.py
+++ b/tests/run_agent/test_cerebras_reasoning_strip.py
@@ -1,0 +1,228 @@
+"""Regression test: Cerebras rejects reasoning_content in assistant messages.
+
+Cerebras serves models via an OpenAI-compatible endpoint but does NOT accept
+the ``reasoning_content`` field in replayed assistant messages, returning::
+
+    HTTP 400: messages.N.assistant.reasoning_content:
+    property '...' is unsupported
+
+Two complementary guards prevent this:
+
+1. ``AIAgent._strips_reasoning_content_from_api_messages`` — detects Cerebras
+   by URL so the agent-level ``_copy_reasoning_content_for_api`` never adds
+   the field (covers ``provider: custom`` + Cerebras URL, and ``provider:
+   cerebras`` via the registered profile's hostname).
+
+2. ``CerebrasProfile.prepare_messages`` — transport-layer strip as a belt-
+   and-suspenders guard for the profile path (``provider: cerebras``).
+
+Refs: HTTP 400 "property 'messages.2.assistant.reasoning_content' is
+unsupported" when using gpt-oss-120b / llama-4-scout on api.cerebras.ai.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    """Create a minimal AIAgent instance without a real session."""
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# _strips_reasoning_content_from_api_messages — URL detection
+# ---------------------------------------------------------------------------
+
+
+class TestStripsReasoningContentDetection:
+    """_strips_reasoning_content_from_api_messages detects Cerebras by URL."""
+
+    def test_cerebras_base_url_detected(self):
+        agent = _make_agent(base_url="https://api.cerebras.ai/v1")
+        assert agent._strips_reasoning_content_from_api_messages() is True
+
+    def test_cerebras_base_url_no_path(self):
+        agent = _make_agent(base_url="https://api.cerebras.ai")
+        assert agent._strips_reasoning_content_from_api_messages() is True
+
+    def test_cerebras_custom_provider_still_detected(self):
+        """provider=custom + Cerebras URL should be detected."""
+        agent = _make_agent(provider="custom", base_url="https://api.cerebras.ai/v1")
+        assert agent._strips_reasoning_content_from_api_messages() is True
+
+    def test_non_cerebras_url_not_detected(self):
+        agent = _make_agent(base_url="https://api.openai.com/v1")
+        assert agent._strips_reasoning_content_from_api_messages() is False
+
+    def test_deepseek_not_detected(self):
+        agent = _make_agent(
+            provider="deepseek", base_url="https://api.deepseek.com/v1"
+        )
+        assert agent._strips_reasoning_content_from_api_messages() is False
+
+    def test_empty_base_url_not_detected(self):
+        agent = _make_agent(base_url="")
+        assert agent._strips_reasoning_content_from_api_messages() is False
+
+    def test_subdomain_spoof_not_detected(self):
+        """evil.com/api.cerebras.ai should not match."""
+        agent = _make_agent(base_url="https://evil.com/api.cerebras.ai/v1")
+        assert agent._strips_reasoning_content_from_api_messages() is False
+
+    def test_similar_domain_not_detected(self):
+        """api.cerebras.ai.evil.com should not match."""
+        agent = _make_agent(base_url="https://api.cerebras.ai.evil.com/v1")
+        assert agent._strips_reasoning_content_from_api_messages() is False
+
+
+# ---------------------------------------------------------------------------
+# _copy_reasoning_content_for_api — Cerebras strips reasoning_content
+# ---------------------------------------------------------------------------
+
+
+class TestCopyReasoningContentForApiCerebras:
+    """_copy_reasoning_content_for_api strips reasoning_content for Cerebras."""
+
+    def _cerebras_agent(self) -> AIAgent:
+        return _make_agent(
+            provider="custom", base_url="https://api.cerebras.ai/v1"
+        )
+
+    def test_strips_reasoning_content_from_api_msg(self):
+        """reasoning_content copied via msg.copy() must be removed."""
+        agent = self._cerebras_agent()
+        source = {
+            "role": "assistant",
+            "content": "Hello",
+            "reasoning_content": "some reasoning text",
+        }
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_strips_reasoning_content_with_tool_calls(self):
+        """Tool-call assistant messages also have reasoning_content stripped."""
+        agent = self._cerebras_agent()
+        source = {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "planning step",
+            "tool_calls": [{"id": "tc1", "function": {"name": "foo", "arguments": "{}"}}],
+        }
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+        # tool_calls must not be touched by this method
+        assert api_msg.get("tool_calls") is source["tool_calls"]
+
+    def test_handles_missing_reasoning_content_gracefully(self):
+        """No reasoning_content in source — api_msg should not gain one."""
+        agent = self._cerebras_agent()
+        source = {"role": "assistant", "content": "Hello", "reasoning": "think"}
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_non_assistant_roles_untouched(self):
+        """Non-assistant messages are always left untouched."""
+        agent = self._cerebras_agent()
+        for role in ("user", "system", "tool"):
+            source = {"role": role, "content": "x", "reasoning_content": "leak"}
+            api_msg = source.copy()
+            agent._copy_reasoning_content_for_api(source, api_msg)
+            # _copy_reasoning_content_for_api returns immediately for non-assistant
+            # roles without modifying reasoning_content; the field stays as copied.
+            # The important invariant: no Cerebras-path strip runs on non-assistant.
+            # (The api_msg.copy() retains whatever was there — the transport layer
+            # does not send reasoning_content for non-assistant roles because the
+            # field only appears in assistant messages in practice.)
+            assert api_msg["role"] == role
+
+    def test_non_cerebras_provider_preserves_reasoning_content(self):
+        """DeepSeek agent must NOT strip reasoning_content."""
+        agent = _make_agent(
+            provider="deepseek", base_url="https://api.deepseek.com/v1"
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "chain of thought",
+        }
+        api_msg = source.copy()
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == "chain of thought"
+
+
+# ---------------------------------------------------------------------------
+# CerebrasProfile.prepare_messages — transport-layer strip
+# ---------------------------------------------------------------------------
+
+
+class TestCerebrasProfilePrepareMessages:
+    """CerebrasProfile.prepare_messages strips reasoning_content for all
+    assistant messages and leaves other roles untouched."""
+
+    @pytest.fixture
+    def profile(self):
+        from providers import get_provider_profile
+
+        return get_provider_profile("cerebras")
+
+    def test_strips_reasoning_content(self, profile):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "Hi there!",
+                "reasoning_content": "I should greet the user.",
+            },
+            {"role": "user", "content": "Bye"},
+        ]
+        result = profile.prepare_messages(messages)
+        for msg in result:
+            assert "reasoning_content" not in msg
+
+    def test_system_and_user_messages_preserved(self, profile):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "usr"},
+        ]
+        result = profile.prepare_messages(messages)
+        assert result[0]["content"] == "sys"
+        assert result[1]["content"] == "usr"
+
+    def test_does_not_mutate_original_messages(self, profile):
+        original = {
+            "role": "assistant",
+            "content": "hi",
+            "reasoning_content": "think",
+        }
+        messages = [original]
+        profile.prepare_messages(messages)
+        # Original dict must be unchanged
+        assert "reasoning_content" in original
+
+    def test_passthrough_when_no_reasoning_content(self, profile):
+        messages = [
+            {"role": "assistant", "content": "answer"},
+        ]
+        result = profile.prepare_messages(messages)
+        assert result[0]["content"] == "answer"
+        assert "reasoning_content" not in result[0]


### PR DESCRIPTION
## Problem

When using Cerebras (`api.cerebras.ai`) as a provider — including via `provider: custom` — the agent fails with HTTP 400 on the second turn:

```
messages.N.assistant.reasoning_content: property '...' is unsupported
```

This happens because `_copy_reasoning_content_for_api` copies any stored `reasoning_content` (produced by reasoning-capable models like DeepSeek, Kimi, MiMo, or surfaced by the Cerebras SDK) into every replayed assistant message. Cerebras explicitly rejects this field.

## Changes

### `run_agent.py`
- Add `_strips_reasoning_content_from_api_messages()` — detects Cerebras by hostname (`api.cerebras.ai`) using the existing `base_url_host_matches` helper. Covers both `provider: custom` + Cerebras URL and the new first-class `provider: cerebras`.
- Add **block 0** in `_copy_reasoning_content_for_api`: when the method returns `True`, pop `reasoning_content` from the API message copy and return early so no downstream branch can re-add it. Follows the same guard pattern used for DeepSeek, Kimi, and MiMo (`_needs_deepseek_tool_reasoning`, `_needs_kimi_tool_reasoning`, `_needs_mimo_tool_reasoning`) but with opposite polarity.

### `plugins/model-providers/cerebras/` (new)
- First-class `CerebrasProfile` that overrides `prepare_messages` to strip `reasoning_content` from assistant messages as a belt-and-suspenders transport-layer guard for `provider: cerebras` sessions.
- `fallback_models` list with current Cerebras agentic models.
- `plugin.yaml` manifest.

### `tests/run_agent/test_cerebras_reasoning_strip.py` (new)
- 17 tests: URL detection, `_copy_reasoning_content_for_api` stripping, DeepSeek isolation (no regression), and `CerebrasProfile.prepare_messages`.

### `tests/providers/test_plugin_discovery.py`
- Bump expected profile count 34 → 35; add `cerebras` to spot-check.

## Testing

```
scripts/run_tests.sh tests/run_agent/test_cerebras_reasoning_strip.py tests/run_agent/test_deepseek_reasoning_content_echo.py tests/providers/ -v
# → 145 passed
```
