### PR TITLE
fix(cron): use ensure_ascii=False for CJK text in cronjob output

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -433,7 +433,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -385,12 +385,12 @@ def cronjob(
                     "job": _format_job(job),
                     "message": f"Cron job '{job['name']}' created.",
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
-            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2, ensure_ascii=False)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
@@ -412,12 +412,12 @@ def cronjob(
                         for m in exc.matches
                     ],
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
         if not job:
             return json.dumps(
                 {"success": False, "error": f"Job with ID or name '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
@@ -436,20 +436,20 @@ def cronjob(
                         "schedule": job.get("schedule_display"),
                     },
                 },
-                indent=2,
+                indent=2, ensure_ascii=False,
             )
 
         if normalized == "pause":
             updated = pause_job(job_id, reason=reason)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized == "resume":
             updated = resume_job(job_id)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized in {"run", "run_now", "trigger"}:
             updated = trigger_job(job_id)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         if normalized == "update":
             updates: Dict[str, Any] = {}
@@ -533,7 +533,7 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2, ensure_ascii=False)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 


### PR DESCRIPTION
## Summary

Fixes #26128

**Root cause:** `json.dump[s]()` defaults to `ensure_ascii=True`, which escapes all non-ASCII characters (Chinese, Japanese, Korean, etc.) as `\uXXXX` sequences. This affects both the persisted `jobs.json` file and the tool output returned to the agent.

**Fix:** Add `ensure_ascii=False` to all JSON serialization calls:
- `cron/jobs.py` `save_jobs()`: jobs.json now stores CJK text natively
- `tools/cronjob_tools.py`: all `json.dumps()` calls (list, create, update, pause, resume, remove, etc.) now output readable CJK text

**Changes:** 2 files, 10 insertions, 10 deletions (all `indent=2` changed to `indent=2, ensure_ascii=False`)

## Test plan
- `python -m py_compile cron/jobs.py tools/cronjob_tools.py`
- `python -m pytest tests/tools/test_cronjob_tools.py tests/cron/ -x -o 'addopts='`
- Manual: create a cron job with Chinese prompt, verify output is readable
