### PR TITLE
fix(cli): sync _skill_commands after /reload-skills so Tab completion picks up new skills

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2412,6 +2412,7 @@ def _looks_like_slash_command(text: str) -> bool:
 
 from agent.skill_commands import (
     scan_skill_commands,
+    get_skill_commands,
     build_skill_invocation_message,
     build_preloaded_skills_prompt,
 )
@@ -9604,6 +9605,8 @@ class HermesCLI:
                 print("🔄 Reloading skills...")
 
             result = reload_skills()
+            global _skill_commands
+            _skill_commands = get_skill_commands()
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)


### PR DESCRIPTION
Fixes #26441

## Problem

After installing new skills and running `/reload-skills`, the command reports the new skills as added, but they do not appear in the Tab completion menu when typing `/` in the chat prompt. The only workaround is restarting the entire Hermes session.

## Root Cause

`cli.py` has a module-level `_skill_commands` variable assigned at startup (line 2419) that is captured by the Tab completion lambda (line 12609: `skill_commands_provider=lambda: _skill_commands`).

When `/reload-skills` runs, `reload_skills()` in `agent/skill_commands.py` calls `scan_skill_commands()` which creates a NEW dict in `agent.skill_commands._skill_commands`. But `cli.py._skill_commands` still points to the OLD dict — so the Tab completion lambda never sees the updated skills.

## Fix

Two changes in `cli.py`:

1. Add `get_skill_commands` to the existing import from `agent.skill_commands`
2. After `result = reload_skills()` in `_reload_skills()`, sync the module-level variable:
   ```python
   global _skill_commands
   _skill_commands = get_skill_commands()
   ```

## Validation

- `python3 -c "import ast; ast.parse(open('cli.py').read()); print('OK')"` → OK
- One-line semantic change, additive only, no behavioral regression