### PR TITLE
docs(security): document YOLO mode visual indicators added in #26238

### DIFF
--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -64,6 +64,11 @@ The `/yolo` command is a **toggle** — each use flips the mode on or off:
 
 YOLO mode is available in both CLI and gateway sessions. Internally, it sets the `HERMES_YOLO_MODE` environment variable which is checked before every command execution.
 
+When YOLO is active, Hermes shows two persistent visual reminders so it's hard to forget that approval prompts are bypassed:
+
+- A red banner line at session start when YOLO is already active: `⚠ YOLO mode — all approval prompts bypassed`. Hidden when YOLO is off so the default banner stays uncluttered.
+- A `⚠ YOLO` fragment in the status bar across all width tiers, updated live as you toggle YOLO on or off (rich-text renderer and plain-text fallback).
+
 :::danger
 YOLO mode disables **all** dangerous command safety checks for the session — **except** the hardline blocklist (see below). Use only when you fully trust the commands being generated (e.g., well-tested automation scripts in disposable environments).
 :::


### PR DESCRIPTION
Catches the docs for the YOLO visual indicators added in #26238 (teknium1, 2026-05-15) — the security guide's "YOLO Mode" section currently only documents the `/yolo` toggle output, not the new banner line or `⚠ YOLO` status-bar fragment.

## Diff

`website/docs/user-guide/security.md` — adds two bullets after the toggle example documenting:
- the red banner line at session start (`⚠ YOLO mode — all approval prompts bypassed`)
- the `⚠ YOLO` status-bar fragment in all width tiers, rich-text + plain-text fallback

5 additions, 0 deletions. Pure docs, no behavior change.

## Verification

Strings match #26238 implementation:
- Banner: `hermes_cli/banner.py` → `[bold red]⚠ YOLO mode[/] — all approval prompts bypassed`
- Status bar: `cli.py` `_get_status_bar_fragments` + `_build_status_bar_text` → `⚠ YOLO` in <52 / <76 / ≥76 tiers

---

If this has already landed via separate patch (or is being consolidated with another docs sweep), please feel free to close and mark accordingly.
