### PR TITLE
fix(kanban): severity filter should be >= not exact-match as documented

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1402,8 +1402,9 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         # Severity filter.
         sev = getattr(args, "severity", None)
         if sev:
+            threshold = kd.SEVERITY_ORDER.index(sev)
             for tid in list(diags_by_task.keys()):
-                kept = [d for d in diags_by_task[tid] if d.severity == sev]
+                kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= threshold]
                 if kept:
                     diags_by_task[tid] = kept
                 else:


### PR DESCRIPTION
Fixes #26379

## Problem

`hermes kanban diagnostics --severity` uses exact-match (`==`) instead of the documented "at or above this severity" semantics. This silently drops higher-severity diagnostics when filtering.

## Fix

In `hermes_cli/kanban.py:1406`, changed:
```python
kept = [d for d in diags_by_task[tid] if d.severity == sev]
```
to:
```python
threshold = kd.SEVERITY_ORDER.index(sev)
kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= threshold]
```

Where `SEVERITY_ORDER = ("warning", "error", "critical")`.

Now `--severity warning` returns `warning` + `error` + `critical`, `--severity error` returns `error` + `critical`, and `--severity critical` returns only `critical` — matching the documented behavior.