### PR TITLE
feat(auth): support Azure Foundry bearer tokens

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -7,7 +7,9 @@ import os
 import re
 import shlex
 import subprocess
-from typing import Any, Dict, Optional
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -760,7 +762,47 @@ def _run_azure_foundry_token_command(command: str) -> str:
     return (result.stdout or "").strip()
 
 
-def _resolve_azure_foundry_bearer_token(model_cfg: Dict[str, Any]) -> str:
+_AZURE_FOUNDRY_DEFAULT_TOKEN_COMMAND = (
+    "az account get-access-token --resource https://cognitiveservices.azure.com "
+    "--query accessToken -o tsv"
+)
+_AZURE_FOUNDRY_TOKEN_TTL_SECONDS = 50 * 60
+
+
+class _AzureFoundryTokenProvider:
+    """Callable OpenAI SDK api_key provider for short-lived Entra tokens.
+
+    Azure CLI access tokens commonly expire after one hour.  The OpenAI SDK
+    accepts ``api_key`` as a callable, so keep command-backed bearer auth
+    refreshable instead of snapshotting the token at Hermes startup.  A small
+    TTL cache avoids shelling out for every request while still refreshing well
+    before the usual 60-minute expiry.
+    """
+
+    def __init__(self, command: str, *, ttl_seconds: int = _AZURE_FOUNDRY_TOKEN_TTL_SECONDS):
+        self.command = command
+        self.ttl_seconds = ttl_seconds
+        self._token = ""
+        self._expires_at = 0.0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> str:
+        now = time.monotonic()
+        if self._token and now < self._expires_at:
+            return self._token
+        with self._lock:
+            now = time.monotonic()
+            if self._token and now < self._expires_at:
+                return self._token
+            token = _run_azure_foundry_token_command(self.command)
+            if not token:
+                raise AuthError("Azure Foundry token_command returned an empty bearer token.")
+            self._token = token
+            self._expires_at = now + max(int(self.ttl_seconds), 0)
+            return token
+
+
+def _resolve_azure_foundry_bearer_token(model_cfg: Dict[str, Any]) -> str | Callable[[], str]:
     """Resolve Microsoft Entra/Bearer token auth for Azure Foundry."""
     configured_token = str(
         model_cfg.get("bearer_token")
@@ -772,16 +814,8 @@ def _resolve_azure_foundry_bearer_token(model_cfg: Dict[str, Any]) -> str:
     env_token = os.getenv("AZURE_FOUNDRY_BEARER_TOKEN", "").strip()
     if env_token:
         return env_token
-    token_command = str(model_cfg.get("token_command") or "").strip()
-    if not token_command:
-        token_command = (
-            "az account get-access-token --resource https://cognitiveservices.azure.com "
-            "--query accessToken -o tsv"
-        )
-    token = _run_azure_foundry_token_command(token_command)
-    if not token:
-        raise AuthError("Azure Foundry token_command returned an empty bearer token.")
-    return token
+    token_command = str(model_cfg.get("token_command") or "").strip() or _AZURE_FOUNDRY_DEFAULT_TOKEN_COMMAND
+    return _AzureFoundryTokenProvider(token_command)
 
 
 def _resolve_azure_foundry_runtime(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
+import subprocess
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -729,6 +731,59 @@ def _resolve_openrouter_runtime(
     }
 
 
+def _run_azure_foundry_token_command(command: str) -> str:
+    """Run a configured Azure token command and return its stdout token."""
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        raise AuthError(f"Invalid Azure Foundry token_command: {exc}") from exc
+    if not argv:
+        return ""
+    try:
+        result = subprocess.run(
+            argv,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as exc:
+        raise AuthError(
+            f"Azure Foundry token_command executable not found: {argv[0]}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise AuthError("Azure Foundry token_command timed out after 30 seconds.") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise AuthError(f"Azure Foundry token_command failed{suffix}") from exc
+    return (result.stdout or "").strip()
+
+
+def _resolve_azure_foundry_bearer_token(model_cfg: Dict[str, Any]) -> str:
+    """Resolve Microsoft Entra/Bearer token auth for Azure Foundry."""
+    configured_token = str(
+        model_cfg.get("bearer_token")
+        or model_cfg.get("access_token")
+        or ""
+    ).strip()
+    if configured_token:
+        return configured_token
+    env_token = os.getenv("AZURE_FOUNDRY_BEARER_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    token_command = str(model_cfg.get("token_command") or "").strip()
+    if not token_command:
+        token_command = (
+            "az account get-access-token --resource https://cognitiveservices.azure.com "
+            "--query accessToken -o tsv"
+        )
+    token = _run_azure_foundry_token_command(token_command)
+    if not token:
+        raise AuthError("Azure Foundry token_command returned an empty bearer token.")
+    return token
+
+
 def _resolve_azure_foundry_runtime(
     *,
     requested_provider: str,
@@ -780,20 +835,25 @@ def _resolve_azure_foundry_runtime(
             "the AZURE_FOUNDRY_BASE_URL environment variable."
         )
 
-    api_key = explicit_api_key
-    if not api_key:
-        try:
-            from hermes_cli.config import get_env_value
-            api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
-        except Exception:
-            api_key = ""
-    if not api_key:
-        api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip()
-    if not api_key:
-        raise AuthError(
-            "Azure Foundry requires an API key. Set AZURE_FOUNDRY_API_KEY in "
-            "~/.hermes/.env or run 'hermes model' to configure."
-        )
+    auth_type = str(model_cfg.get("auth_type") or "api_key").strip().lower().replace("-", "_")
+    if auth_type in {"azure_entra", "entra", "bearer", "bearer_token"}:
+        api_key = _resolve_azure_foundry_bearer_token(model_cfg)
+    else:
+        api_key = explicit_api_key
+        if not api_key:
+            try:
+                from hermes_cli.config import get_env_value
+                api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
+            except Exception:
+                api_key = ""
+        if not api_key:
+            api_key = os.getenv("AZURE_FOUNDRY_API_KEY", "").strip()
+        if not api_key:
+            raise AuthError(
+                "Azure Foundry requires an API key. Set AZURE_FOUNDRY_API_KEY in "
+                "~/.hermes/.env or run 'hermes model' to configure. For Entra ID, "
+                "set model.auth_type to 'azure_entra' or 'bearer'."
+            )
 
     # Anthropic SDK appends /v1/messages itself, so strip any trailing /v1
     # we inherited from the configured base_url to avoid double-/v1 paths.
@@ -806,6 +866,7 @@ def _resolve_azure_foundry_runtime(
         "api_mode": cfg_api_mode,
         "base_url": base_url,
         "api_key": api_key,
+        "auth_type": auth_type,
         "source": source,
         "requested_provider": requested_provider,
     }

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1839,7 +1839,9 @@ class TestAzureFoundryResolution:
 
         resolved = rp.resolve_runtime_provider(requested="azure-foundry")
 
-        assert resolved["api_key"] == "entra-token"
+        token_provider = resolved["api_key"]
+        assert callable(token_provider)
+        assert token_provider() == "entra-token"
         assert resolved["auth_type"] == "azure_entra"
         assert "https://cognitiveservices.azure.com" in captured["command"]
 
@@ -1861,7 +1863,9 @@ class TestAzureFoundryResolution:
 
         resolved = rp.resolve_runtime_provider(requested="azure-foundry")
 
-        assert resolved["api_key"] == "configured-token"
+        token_provider = resolved["api_key"]
+        assert callable(token_provider)
+        assert token_provider() == "configured-token"
         assert resolved["auth_type"] == "bearer"
         assert captured["command"] == "az account get-access-token --query accessToken -o tsv"
 
@@ -1873,12 +1877,44 @@ class TestAzureFoundryResolution:
         cfg = self._make_cfg("https://my-resource.openai.azure.com/openai/v1")
         cfg["auth_type"] = "bearer"
         monkeypatch.setattr(rp, "_get_model_config", lambda: cfg)
-        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", lambda command: (_ for _ in ()).throw(AssertionError("should not run token command")))
+        monkeypatch.setattr(
+            rp,
+            "_run_azure_foundry_token_command",
+            lambda command: (_ for _ in ()).throw(AssertionError("should not run token command")),
+        )
 
         resolved = rp.resolve_runtime_provider(requested="azure-foundry")
 
         assert resolved["api_key"] == "env-bearer-token"
         assert resolved["auth_type"] == "bearer"
+
+    def test_azure_foundry_token_command_provider_refreshes_after_ttl(self, monkeypatch):
+        calls = []
+
+        def fake_run(command):
+            calls.append(command)
+            return f"token-{len(calls)}"
+
+        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", fake_run)
+        provider = rp._AzureFoundryTokenProvider("az token", ttl_seconds=0)
+
+        assert provider() == "token-1"
+        assert provider() == "token-2"
+        assert calls == ["az token", "az token"]
+
+    def test_azure_foundry_token_command_provider_caches_within_ttl(self, monkeypatch):
+        calls = []
+
+        def fake_run(command):
+            calls.append(command)
+            return f"token-{len(calls)}"
+
+        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", fake_run)
+        provider = rp._AzureFoundryTokenProvider("az token", ttl_seconds=3000)
+
+        assert provider() == "token-1"
+        assert provider() == "token-1"
+        assert calls == ["az token"]
 
     def test_azure_foundry_missing_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1821,6 +1821,65 @@ class TestAzureFoundryResolution:
         with pytest.raises(rp.AuthError, match="base URL"):
             rp.resolve_runtime_provider(requested="azure-foundry")
 
+    def test_azure_foundry_entra_auth_uses_default_az_token_command(self, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_FOUNDRY_BEARER_TOKEN", raising=False)
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "azure-foundry")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        captured = {}
+
+        def fake_run(command):
+            captured["command"] = command
+            return "entra-token"
+
+        cfg = self._make_cfg("https://my-resource.openai.azure.com/openai/v1")
+        cfg["auth_type"] = "azure_entra"
+        monkeypatch.setattr(rp, "_get_model_config", lambda: cfg)
+        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", fake_run)
+
+        resolved = rp.resolve_runtime_provider(requested="azure-foundry")
+
+        assert resolved["api_key"] == "entra-token"
+        assert resolved["auth_type"] == "azure_entra"
+        assert "https://cognitiveservices.azure.com" in captured["command"]
+
+    def test_azure_foundry_bearer_auth_uses_config_token_command(self, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_FOUNDRY_BEARER_TOKEN", raising=False)
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "azure-foundry")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        captured = {}
+
+        def fake_run(command):
+            captured["command"] = command
+            return "configured-token"
+
+        cfg = self._make_cfg("https://my-resource.openai.azure.com/openai/v1")
+        cfg.update({"auth_type": "bearer", "token_command": "az account get-access-token --query accessToken -o tsv"})
+        monkeypatch.setattr(rp, "_get_model_config", lambda: cfg)
+        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", fake_run)
+
+        resolved = rp.resolve_runtime_provider(requested="azure-foundry")
+
+        assert resolved["api_key"] == "configured-token"
+        assert resolved["auth_type"] == "bearer"
+        assert captured["command"] == "az account get-access-token --query accessToken -o tsv"
+
+    def test_azure_foundry_bearer_auth_prefers_env_token(self, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_FOUNDRY_BEARER_TOKEN", "env-bearer-token")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "azure-foundry")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        cfg = self._make_cfg("https://my-resource.openai.azure.com/openai/v1")
+        cfg["auth_type"] = "bearer"
+        monkeypatch.setattr(rp, "_get_model_config", lambda: cfg)
+        monkeypatch.setattr(rp, "_run_azure_foundry_token_command", lambda command: (_ for _ in ()).throw(AssertionError("should not run token command")))
+
+        resolved = rp.resolve_runtime_provider(requested="azure-foundry")
+
+        assert resolved["api_key"] == "env-bearer-token"
+        assert resolved["auth_type"] == "bearer"
+
     def test_azure_foundry_missing_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
         # `get_env_value` reads from ~/.hermes/.env — mock it to return None


### PR DESCRIPTION
## Summary
- add Azure Foundry `model.auth_type: azure_entra` / `bearer` support
- resolve bearer tokens from `AZURE_FOUNDRY_BEARER_TOKEN` or `model.token_command`
- default `azure_entra` token command to Azure CLI cognitive services access token

Closes #25162

## Test Plan
```bash
python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::TestAzureFoundryResolution -q -o 'addopts='
```