### PR TITLE
feat(agent): add configurable budget guard

### DIFF
--- a/agent/budget_guard.py
+++ b/agent/budget_guard.py
@@ -1,0 +1,92 @@
+"""Opt-in budget guard for unattended Hermes runs.
+
+The guard is intentionally small and dependency-free: when config.yaml has no
+``budget`` section it is a no-op; when caps are configured, callers can check the
+currently known spend estimate before starting another model call.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class BudgetCaps:
+    daily_usd_cap: Optional[float] = None
+    monthly_usd_cap: Optional[float] = None
+
+    @property
+    def enabled(self) -> bool:
+        return (self.daily_usd_cap or 0) > 0 or (self.monthly_usd_cap or 0) > 0
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when a configured budget cap has already been reached."""
+
+
+def _parse_positive_float(value: Any) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def load_budget_caps(config: Optional[Mapping[str, Any]] = None) -> BudgetCaps:
+    """Load daily/monthly budget caps from Hermes config.
+
+    Supported config shape::
+
+        budget:
+          daily_usd_cap: 50.0
+          monthly_usd_cap: 500.0
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            config = {}
+    budget = config.get("budget") if isinstance(config, Mapping) else None
+    if not isinstance(budget, Mapping):
+        return BudgetCaps()
+    return BudgetCaps(
+        daily_usd_cap=_parse_positive_float(budget.get("daily_usd_cap")),
+        monthly_usd_cap=_parse_positive_float(budget.get("monthly_usd_cap")),
+    )
+
+
+def check_budget_caps(
+    *,
+    current_spend_usd: float,
+    caps: Optional[BudgetCaps] = None,
+    config: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Raise BudgetExceededError if known spend is already at a configured cap."""
+    caps = caps or load_budget_caps(config)
+    if not caps.enabled:
+        return
+    spend = max(0.0, float(current_spend_usd or 0.0))
+    violations: list[str] = []
+    if caps.daily_usd_cap and spend >= caps.daily_usd_cap:
+        violations.append(f"daily cap ${caps.daily_usd_cap:.2f}")
+    if caps.monthly_usd_cap and spend >= caps.monthly_usd_cap:
+        violations.append(f"monthly cap ${caps.monthly_usd_cap:.2f}")
+    if violations:
+        joined = " and ".join(violations)
+        raise BudgetExceededError(
+            f"Budget cap reached: current estimated spend is ${spend:.2f}, "
+            f"which meets or exceeds the configured {joined}. Refusing to start "
+            "another model call. Raise or remove budget.*_usd_cap in config.yaml "
+            "to continue."
+        )
+
+
+def enforce_configured_budget(current_spend_usd: float) -> None:
+    """Convenience wrapper for model-call preflight sites."""
+    check_budget_caps(current_spend_usd=current_spend_usd)

--- a/run_agent.py
+++ b/run_agent.py
@@ -162,6 +162,7 @@ from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.budget_guard import enforce_configured_budget
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
     _deterministic_call_id as _codex_deterministic_call_id,
@@ -7544,6 +7545,7 @@ class AIAgent:
         the main retry loop can try again with backoff / credential rotation /
         provider fallback.
         """
+        enforce_configured_budget(getattr(self, "session_estimated_cost_usd", 0.0))
         result = {"response": None, "error": None}
         request_client_holder = {"client": None}
 
@@ -8003,6 +8005,7 @@ class AIAgent:
                     pool=30.0,
                 ),
             }
+            enforce_configured_budget(getattr(self, "session_estimated_cost_usd", 0.0))
             request_client_holder["client"] = self._create_request_openai_client(
                 reason="chat_completion_stream_request",
                 api_kwargs=stream_kwargs,

--- a/tests/agent/test_budget_guard.py
+++ b/tests/agent/test_budget_guard.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agent.budget_guard import (
+    BudgetCaps,
+    BudgetExceededError,
+    check_budget_caps,
+    load_budget_caps,
+)
+
+
+def test_load_budget_caps_noop_without_config():
+    caps = load_budget_caps({})
+    assert caps.enabled is False
+    check_budget_caps(current_spend_usd=999.0, caps=caps)
+
+
+def test_load_budget_caps_ignores_invalid_or_nonpositive_values():
+    caps = load_budget_caps({"budget": {"daily_usd_cap": "nope", "monthly_usd_cap": 0}})
+    assert caps.enabled is False
+
+
+def test_daily_cap_blocks_when_estimated_spend_reaches_cap():
+    with pytest.raises(BudgetExceededError, match="daily cap"):
+        check_budget_caps(current_spend_usd=5.0, caps=BudgetCaps(daily_usd_cap=5.0))
+
+
+def test_monthly_cap_blocks_when_estimated_spend_reaches_cap():
+    with pytest.raises(BudgetExceededError, match="monthly cap"):
+        check_budget_caps(current_spend_usd=50.25, caps=BudgetCaps(monthly_usd_cap=50.0))
+
+
+def test_spend_below_cap_allows_next_call():
+    check_budget_caps(current_spend_usd=4.99, caps=BudgetCaps(daily_usd_cap=5.0, monthly_usd_cap=50.0))


### PR DESCRIPTION
## Summary
- add `agent.budget_guard` for opt-in `budget.daily_usd_cap` / `budget.monthly_usd_cap` checks
- wire model-call preflight paths to refuse additional calls once estimated session spend reaches a configured cap
- keep the guard disabled by default when no budget config is present

Closes #26382

## Test Plan
```bash
python -m pytest tests/agent/test_budget_guard.py -q -o 'addopts='
```