### PR TITLE
Fix Honcho key scoping and Codex watchdog default

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -331,17 +331,16 @@ class CodexAppServerSession:
         *,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
-        post_tool_quiet_timeout: float = 90.0,
+        post_tool_quiet_timeout: Optional[float] = 0.0,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
         into Hermes' messages shape.
 
-        post_tool_quiet_timeout: if codex emits a tool completion and then
-        goes quiet for this many seconds without emitting another item or
-        `turn/completed`, fast-fail and mark the session for retirement.
-        Mirrors openclaw beta.8's post-tool completion watchdog (#81697)
-        so a wedged codex doesn't burn the full turn deadline.
+        post_tool_quiet_timeout: optional watchdog for "tool result, then
+        silence" wedges. Non-positive values disable it, which is the
+        default because codex can legitimately spend longer than 90 seconds
+        thinking after a tool result in unattended cron/gateway turns.
         """
         # Pre-create the result so startup failures (codex subprocess can't
         # spawn, initialize handshake rejects, thread/start blows up) surface
@@ -439,7 +438,9 @@ class CodexAppServerSession:
             # signal and codex has been silent past the quiet timeout, give
             # up on this turn instead of waiting for the outer deadline.
             if (
-                last_tool_completion_at is not None
+                post_tool_quiet_timeout is not None
+                and post_tool_quiet_timeout > 0
+                and last_tool_completion_at is not None
                 and (time.time() - last_tool_completion_at)
                     > post_tool_quiet_timeout
             ):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -887,6 +887,8 @@ delegation:
 # Requires: pip install honcho-ai
 # Config: ~/.honcho/config.json (shared with Claude Code, Cursor, etc.)
 # API key: HONCHO_API_KEY in ~/.hermes/.env or ~/.honcho/config.json
+# Self-hosted Honcho model/embedding key: LLM_OPENAI_API_KEY in ~/.hermes/.env
+#   This is intentionally separate from Hermes' general OPENAI_API_KEY.
 #
 # Hermes-specific overrides (optional — most config comes from ~/.honcho/config.json):
 # honcho: {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2220,6 +2220,15 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
     },
+    "LLM_OPENAI_API_KEY": {
+        "description": "OpenAI key used only by self-hosted Honcho for text generation and embeddings",
+        "prompt": "Honcho OpenAI key (text generation + embeddings)",
+        "url": "https://platform.openai.com/api-keys",
+        "tools": ["honcho_context"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
 
     # ── Langfuse observability ──
     "HERMES_LANGFUSE_PUBLIC_KEY": {

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -268,6 +268,10 @@ Presets:
 | `HONCHO_ENVIRONMENT` | `environment` |
 | `HERMES_HONCHO_HOST` | Host key override |
 
+For self-hosted Honcho v3, use `LLM_OPENAI_API_KEY` for Honcho's own
+text-generation and embedding providers. Do not use Hermes' general
+`OPENAI_API_KEY` for this unless you also want Hermes model selection to see it.
+
 ## CLI Commands
 
 | Command | Description |

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -14,6 +14,8 @@ from hermes_constants import get_hermes_home
 from plugins.memory.honcho.client import resolve_active_host, resolve_config_path, HOST
 from hermes_cli.config import cfg_get
 
+HONCHO_LLM_OPENAI_ENV_VAR = "LLM_OPENAI_API_KEY"
+
 
 def clone_honcho_for_profile(profile_name: str) -> bool:
     """Auto-clone Honcho config for a new profile from the default host block.
@@ -324,6 +326,12 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
     return val or (default or "")
 
 
+def _mask_secret(value: str) -> str:
+    if not value:
+        return "not set"
+    return f"...{value[-8:]}" if len(value) > 8 else "set"
+
+
 def _ensure_sdk_installed() -> bool:
     """Check honcho-ai is importable; offer to install if not. Returns True if ready."""
     try:
@@ -403,13 +411,24 @@ def cmd_setup(args) -> None:
             print("  Local connections will skip auth automatically.")
         else:
             print("\n  No API key set. Local no-auth ready.")
+
+        current_llm_key = os.environ.get(HONCHO_LLM_OPENAI_ENV_VAR, "")
+        print("\n  Honcho LLM key for self-hosted text generation + embeddings:")
+        print(f"    {HONCHO_LLM_OPENAI_ENV_VAR}: {_mask_secret(current_llm_key)}")
+        print("    This key is scoped to Honcho and is not Hermes' general OPENAI_API_KEY.")
+        new_llm_key = _prompt(
+            "OpenAI API key for Honcho text generation + embeddings (leave blank to keep current)",
+            secret=True,
+        )
+        if new_llm_key:
+            from hermes_cli.config import save_env_value
+            save_env_value(HONCHO_LLM_OPENAI_ENV_VAR, new_llm_key)
     else:
         # --- Cloud: set default base URL, require API key ---
         cfg.pop("baseUrl", None)  # cloud uses SDK default
 
         current_key = cfg.get("apiKey", "")
-        masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
-        print(f"\n  Current API key: {masked}")
+        print(f"\n  Current API key: {_mask_secret(current_key)}")
         new_key = _prompt("Honcho API key (leave blank to keep current)", secret=True)
         if new_key:
             cfg["apiKey"] = new_key

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -666,6 +666,30 @@ class TestSessionRetirement:
         # Confirm we issued turn/interrupt to free codex compute
         assert any(method == "turn/interrupt" for (method, _) in client.requests)
 
+    def test_post_tool_quiet_watchdog_can_be_disabled(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution", "id": "ex1",
+                "command": "echo hi", "cwd": "/tmp",
+                "status": "completed", "aggregatedOutput": "hi",
+                "exitCode": 0, "commandActions": [],
+            },
+            threadId="t", turnId="tu1",
+        )
+        s = make_session(client)
+        r = s.run_turn(
+            "tool then model thinks for a long time",
+            turn_timeout=0.05,
+            notification_poll_timeout=0.01,
+            post_tool_quiet_timeout=0,
+        )
+        assert r.interrupted is True
+        assert r.should_retire is True
+        assert r.error and "timed out" in r.error
+        assert "silent" not in r.error
+
     def test_post_tool_watchdog_resets_on_further_activity(self):
         """A tool completion followed by an agent message should NOT trip
         the watchdog — further activity = codex still alive."""

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for plugins/memory/honcho/cli.py."""
 
+import os
 from types import SimpleNamespace
 
 
@@ -154,3 +155,73 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "FAILED (Invalid API key)" in out
         assert "Connection... OK" not in out
+
+
+class TestCmdSetup:
+    def test_local_setup_scopes_openai_key_to_honcho_llm(self, monkeypatch, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        saved_env = {}
+        prompts = iter([
+            "local",
+            "http://localhost:8000",
+            "sk-honcho-openai",
+            "alice",
+            "hermes",
+            "hermes",
+            "directional",
+            "async",
+            "hybrid",
+            "uncapped",
+            "2",
+            "low",
+            "per-session",
+        ])
+
+        class FakeConfig:
+            workspace_id = "hermes"
+            peer_name = "alice"
+            ai_peer = "hermes"
+            observation_mode = "directional"
+            write_frequency = "async"
+            recall_mode = "hybrid"
+            session_strategy = "per-session"
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {})
+        monkeypatch.setattr(
+            honcho_cli,
+            "_write_config",
+            lambda cfg, path=None: cfg_path.write_text("{}"),
+        )
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr(honcho_cli, "_prompt", lambda *args, **kwargs: next(prompts))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-general-openai")
+        monkeypatch.delenv("LLM_OPENAI_API_KEY", raising=False)
+
+        def fake_save_env_value(key, value):
+            saved_env[key] = value
+            os.environ[key] = value
+
+        monkeypatch.setattr("hermes_cli.config.save_env_value", fake_save_env_value)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda config: None)
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: FakeConfig(),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: object(),
+        )
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+        assert saved_env == {"LLM_OPENAI_API_KEY": "sk-honcho-openai"}
+        assert os.environ["OPENAI_API_KEY"] == "sk-general-openai"

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -106,6 +106,8 @@ The auto-injected dialectic scales `dialecticReasoningLevel` by query length: +1
 
 Honcho is configured in `~/.honcho/config.json` (global) or `$HERMES_HOME/honcho.json` (profile-local). The setup wizard handles this for you.
 
+For self-hosted Honcho v3, put the OpenAI key used by Honcho's own text-generation and embedding providers in `LLM_OPENAI_API_KEY`. That keeps it scoped to Honcho instead of exposing it as Hermes' general `OPENAI_API_KEY`.
+
 ### Full Config Reference
 
 | Key | Default | Description |


### PR DESCRIPTION
## Summary
- disable the Codex post-tool quiet watchdog by default
- add a Honcho-scoped LLM_OPENAI_API_KEY setup path
- document and test the scoped Honcho key behavior

## Verification
- PYTEST_PLUGINS= scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/honcho_plugin/test_cli.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_drift.py tests/tools/test_local_env_blocklist.py
- Result: 160 passed, 8 warnings from tools/environments/base.py fileno handling in local env blocklist tests