### PR TITLE
feat(agent): expose fallback model awareness to the agent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6977,6 +6977,15 @@ class HermesCLI:
                 _cprint("  /model --provider <slug>             switch provider")
                 return
 
+            # Show fallback status if active (issue #25852)
+            if getattr(self, "_fallback_activated", False):
+                _primary = ((self._primary_runtime or {}).get("model") or "unknown")
+                _cprint(
+                    f"  [dim]⚡ Fallback active: {_primary} → {model_display} "
+                    f"({provider_display})[/]"
+                )
+                _cprint("")
+
             self._open_model_picker(
                 providers,
                 model_display,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8877,6 +8877,21 @@ class AIAgent:
                 self._transport_cache.clear()
             self._fallback_activated = True
 
+            # Inject fallback awareness into the system prompt so the agent
+            # knows its runtime model differs from the configured primary.
+            # Uses ephemeral_system_prompt (per-call, not cached) so the note
+            # appears on the current turn's API call without breaking prefix
+            # cache stability.  See issue #25852.
+            _fallback_note = (
+                f"Note: the primary model ({old_model}) failed and this request "
+                f"is being handled by fallback model {fb_model} via {fb_provider}. "
+                f"Adjust response accordingly (e.g., model code prefixes)."
+            )
+            if getattr(self, "ephemeral_system_prompt", None):
+                self.ephemeral_system_prompt += f"\n\n{_fallback_note}"
+            else:
+                self.ephemeral_system_prompt = _fallback_note
+
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
             # SDK default.
@@ -9038,6 +9053,17 @@ class AIAgent:
 
             # ── Reset fallback chain for the new turn ──
             self._fallback_activated = False
+
+            # Clear fallback awareness note from ephemeral system prompt.
+            # The note was injected by _try_activate_fallback; on primary
+            # restoration it must be removed so subsequent turns don't carry
+            # stale fallback messages.  See issue #25852.
+            if getattr(self, "ephemeral_system_prompt", None):
+                _marker = "Note: the primary model"
+                if _marker in self.ephemeral_system_prompt:
+                    # Remove everything from the marker to the end
+                    idx = self.ephemeral_system_prompt.index(_marker)
+                    self.ephemeral_system_prompt = self.ephemeral_system_prompt[:idx].strip() or None
             self._fallback_index = 0
 
             logging.info(


### PR DESCRIPTION
## Summary

When Hermes Agent's fallback mechanism activates (primary model fails, backup kicks in), the agent (LLM) now receives a notification in its system prompt indicating the active runtime model. This enables model-aware response behaviors like correct model code prefixes.

Closes #25852

## Problem

The fallback mechanism was completely transparent to the agent. When a fallback kicked in, the system prompt still showed the configured primary model. Users who prefix responses with model codes (e.g., G31P-T for gemini-3.1-pro) would get wrong prefixes after fallback.

## Solution

Three targeted changes:

1. **run_agent.py - ephemeral_system_prompt injection**: When _try_activate_fallback() succeeds, a note is appended to ephemeral_system_prompt (per-call, not cached) telling the agent which fallback model/provider is active. Using ephemeral_system_prompt avoids breaking prefix cache stability.

2. **run_agent.py - cleanup on primary restoration**: When _restore_primary_runtime() runs at turn start, the fallback note is stripped from ephemeral_system_prompt so subsequent turns don't carry stale messages.

3. **cli.py - /model status display**: When /model is invoked with no args during an active fallback, a status line shows the primary to fallback transition.

## Files Changed

| File | Change |
|------|--------|
| run_agent.py | +26 lines: fallback note injection + cleanup on restore |
| cli.py | +9 lines: fallback status in model picker |

## Test Results

tests/run_agent/test_fallback_model.py - 31 passed (162.92s)

All existing fallback tests pass without modification.

## Design Decisions

- **ephemeral_system_prompt over _cached_system_prompt**: The cached system prompt is never rebuilt mid-session (prefix cache stability). ephemeral_system_prompt is injected per-API-call, making it the right place for transient runtime state.
- **Append-only note**: The fallback note is appended to any existing ephemeral_system_prompt content, preserving user/config-set ephemeral prompts.
- **String marker cleanup**: On primary restoration, the note is removed by finding the unique marker string, avoiding fragile regex or line-count assumptions.