### PR TITLE
fix: reset gateway sessions on context overflow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7740,13 +7740,16 @@ class GatewayRunner:
                     session_entry.session_id,
                 )
 
-            # When compression is exhausted, the session is permanently too
-            # large to process.  Auto-reset it so the next message starts
-            # fresh instead of replaying the same oversized context in an
-            # infinite fail loop.  (#9893)
-            if agent_result.get("compression_exhausted") and session_entry and session_key:
+            # When a session is too large to process, auto-reset it so the
+            # next message starts fresh instead of replaying the same oversized
+            # context in an infinite fail loop.  ``compression_exhausted`` is
+            # the explicit signal, but some providers fail earlier with a
+            # context-length 400 before Hermes can mark compression exhausted.
+            # Treat any classified context-overflow failure as terminal for
+            # that session.  (#9893)
+            if is_context_overflow_failure and session_entry and session_key:
                 logger.info(
-                    "Auto-resetting session %s after compression exhaustion.",
+                    "Auto-resetting session %s after context-overflow failure.",
                     session_entry.session_id,
                 )
                 self.session_store.reset_session(session_key)
@@ -7757,8 +7760,8 @@ class GatewayRunner:
                     self._pending_model_notes.pop(session_key, None)
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
-                    "maximum context size and could not be compressed further. "
-                    "Your next message will start a fresh session."
+                    "maximum context size. Your next message will start a "
+                    "fresh session."
                 )
 
             ts = datetime.now().isoformat()


### PR DESCRIPTION
## Summary
- Reset gateway sessions after any classified context-overflow failure, not only explicit compression exhaustion
- Prevents Discord/gateway sessions from getting stuck replaying an oversized transcript forever

## Test Plan
- /Users/taiblack/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_7100_transient_failure_transcript.py -q