### PR TITLE
fix: support large Telegram documents

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import tempfile
 import html as _html
 import re
@@ -73,6 +74,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_video_from_bytes,
     cache_document_from_bytes,
+    get_document_cache_dir,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -4127,15 +4129,43 @@ class TelegramAdapter(BasePlatformAdapter):
                         ext = mime_to_ext.get(doc_mime, "")
 
                 # Check file size early so image documents cannot bypass the
-                # document size limit by taking the image path.
-                MAX_DOC_BYTES = 20 * 1024 * 1024
-                if not doc.file_size or doc.file_size > MAX_DOC_BYTES:
-                    event.text = (
-                        "The document is too large or its size could not be verified. "
-                        "Maximum: 20 MB."
+                # document size limit by taking the image path. The limit is
+                # profile-configurable (platforms.telegram.extra.max_document_mb)
+                # because self-hosted/local Bot API deployments can safely handle
+                # files far above Telegram Cloud's 20 MB download limit.
+                max_document_mb_raw = self.config.extra.get("max_document_mb", 20)
+                try:
+                    max_document_mb = float(max_document_mb_raw)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "[Telegram] Invalid max_document_mb=%r; falling back to 20 MB",
+                        max_document_mb_raw,
                     )
-                    logger.info("[Telegram] Document too large: %s bytes", doc.file_size)
-                    await self.handle_message(event)
+                    max_document_mb = 20.0
+                max_doc_bytes = int(max_document_mb * 1024 * 1024)
+
+                if not doc.file_size:
+                    await self.send(
+                        event.source.chat_id,
+                        "Не смогла проверить размер документа, поэтому не скачиваю его. "
+                        "Перешлите PDF ещё раз; если повторится — пришлите файл меньшего размера.",
+                        reply_to=event.message_id,
+                    )
+                    logger.info("[Telegram] Document size could not be verified")
+                    return
+
+                if doc.file_size > max_doc_bytes:
+                    limit_label = f"{max_document_mb:g} MB"
+                    await self.send(
+                        event.source.chat_id,
+                        f"Документ слишком большой: {doc.file_size:,} bytes. Лимит этого бота: {limit_label}.",
+                        reply_to=event.message_id,
+                    )
+                    logger.info(
+                        "[Telegram] Document too large: %s bytes (limit=%s bytes)",
+                        doc.file_size,
+                        max_doc_bytes,
+                    )
                     return
 
                 # Telegram may deliver screenshots/photos as documents. If the
@@ -4195,11 +4225,48 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
-                # Download and cache
-                file_obj = await doc.get_file()
-                doc_bytes = await file_obj.download_as_bytearray()
-                raw_bytes = bytes(doc_bytes)
-                cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
+                # Download/cache. With a self-hosted Bot API in local_mode,
+                # get_file() returns a server-local file_path; copying it is faster
+                # and avoids large in-memory bytearrays/timeouts for 90MB+ PDFs.
+                file_obj = await doc.get_file(
+                    read_timeout=300,
+                    write_timeout=300,
+                    connect_timeout=30,
+                    pool_timeout=30,
+                )
+                raw_bytes: Optional[bytes] = None
+                local_file_path = getattr(file_obj, "file_path", None)
+                if local_file_path and not str(local_file_path).startswith(("http://", "https://")):
+                    source_path = _Path(str(local_file_path))
+                    if source_path.is_file():
+                        cache_dir = get_document_cache_dir()
+                        safe_name = _Path(original_filename or f"document{ext}").name.replace("\x00", "").strip()
+                        if not safe_name or safe_name in {".", ".."}:
+                            safe_name = f"document{ext}"
+                        cached_path_obj = cache_dir / f"doc_{file_obj.file_unique_id}_{safe_name}"
+                        if not cached_path_obj.resolve().is_relative_to(cache_dir.resolve()):
+                            raise ValueError(f"Path traversal rejected: {original_filename!r}")
+                        shutil.copyfile(source_path, cached_path_obj)
+                        cached_path = str(cached_path_obj)
+                    else:
+                        logger.warning("[Telegram] Local Bot API file path is not readable: %s", local_file_path)
+                        doc_bytes = await file_obj.download_as_bytearray(
+                            read_timeout=300,
+                            write_timeout=300,
+                            connect_timeout=30,
+                            pool_timeout=30,
+                        )
+                        raw_bytes = bytes(doc_bytes)
+                        cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
+                else:
+                    doc_bytes = await file_obj.download_as_bytearray(
+                        read_timeout=300,
+                        write_timeout=300,
+                        connect_timeout=30,
+                        pool_timeout=30,
+                    )
+                    raw_bytes = bytes(doc_bytes)
+                    cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
                 mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
@@ -4207,8 +4274,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in {".md", ".txt"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if ext in {".md", ".txt"} and doc.file_size <= MAX_TEXT_INJECT_BYTES:
                     try:
+                        if raw_bytes is None:
+                            raw_bytes = _Path(cached_path).read_bytes()
                         text_content = raw_bytes.decode("utf-8")
                         display_name = original_filename or f"document{ext}"
                         display_name = re.sub(r'[^\w.\- ]', '_', display_name)
@@ -4225,6 +4294,13 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                await self.send(
+                    event.source.chat_id,
+                    "Не смогла получить файл из Telegram. Файл не передан агенту, поэтому сжатие не запускала. "
+                    "Перешлите PDF ещё раз; если ошибка повторится — попробуем уменьшить лимит/размер или проверим Bot API.",
+                    reply_to=event.message_id,
+                )
+                return
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2132,6 +2132,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
         profile_arg = _profile_arg(hermes_home)
+        profile_env = f'Environment="HERMES_PROFILE={profile_arg.split(" ", 1)[1]}"\n' if profile_arg else ""
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.
@@ -2163,7 +2164,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+{profile_env}Restart=always
 RestartSec=60
 RestartMaxDelaySec=300
 RestartSteps=5
@@ -2181,6 +2182,7 @@ WantedBy=multi-user.target
 
     hermes_home = str(get_hermes_home().resolve())
     profile_arg = _profile_arg(hermes_home)
+    profile_env = f'Environment="HERMES_PROFILE={profile_arg.split(" ", 1)[1]}"\n' if profile_arg else ""
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
@@ -2198,7 +2200,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+{profile_env}Restart=always
 RestartSec=60
 RestartMaxDelaySec=300
 RestartSteps=5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ anthropic = ["anthropic==0.86.0"]
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
 parallel-web = ["parallel-web==0.4.2"]
+# Microsoft Office document extraction (.docx/.pptx/.xlsx) — optional so
+# restricted profiles can enable it without broad shell/code_execution access.
+office = ["python-docx==1.2.0", "python-pptx==1.0.2", "openpyxl==3.1.5"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick
@@ -192,6 +195,7 @@ all = [
   "hermes-agent[exa]",
   "hermes-agent[firecrawl]",
   "hermes-agent[parallel-web]",
+  "hermes-agent[office]",
   "hermes-agent[fal]",
   "hermes-agent[edge-tts]",
   "hermes-agent[modal]",

--- a/tests/tools/test_office_extract_tool.py
+++ b/tests/tools/test_office_extract_tool.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+
+from tools.office_extract_tool import office_extract, check_office_extract_requirements
+from toolsets import get_toolset, resolve_toolset
+
+
+def _load(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_office_extract_reads_docx_text_and_tables(tmp_path):
+    docx = pytest.importorskip("docx")
+    path = tmp_path / "brief.docx"
+    doc = docx.Document()
+    doc.add_heading("Client Brief", level=1)
+    doc.add_paragraph("Launch a summer grill campaign for Miratorg.")
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).text = "Audience"
+    table.cell(0, 1).text = "Families"
+    table.cell(1, 0).text = "Tone"
+    table.cell(1, 1).text = "Warm"
+    doc.save(path)
+
+    result = _load(office_extract(str(path)))
+
+    assert result["success"] is True
+    assert result["format"] == "docx"
+    assert result["file_path"] == str(path)
+    assert "# Client Brief" in result["markdown"]
+    assert "Launch a summer grill campaign" in result["markdown"]
+    assert "Audience | Families" in result["markdown"]
+    assert result["metadata"]["paragraph_count"] >= 2
+    assert result["metadata"]["table_count"] == 1
+
+
+def test_office_extract_reads_pptx_slide_text(tmp_path):
+    pptx = pytest.importorskip("pptx")
+    path = tmp_path / "deck.pptx"
+    presentation = pptx.Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[1])
+    slide.shapes.title.text = "Big idea"
+    slide.placeholders[1].text = "Fire + family + weekend ritual"
+    presentation.save(path)
+
+    result = _load(office_extract(str(path)))
+
+    assert result["success"] is True
+    assert result["format"] == "pptx"
+    assert "## Slide 1" in result["markdown"]
+    assert "Big idea" in result["markdown"]
+    assert "weekend ritual" in result["markdown"]
+    assert result["metadata"]["slide_count"] == 1
+
+
+def test_office_extract_reads_xlsx_sheets(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl")
+    path = tmp_path / "budget.xlsx"
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Plan"
+    sheet.append(["Channel", "Budget"])
+    sheet.append(["Telegram", 100000])
+    sheet.append(["Outdoor", 250000])
+    workbook.save(path)
+
+    result = _load(office_extract(str(path)))
+
+    assert result["success"] is True
+    assert result["format"] == "xlsx"
+    assert "## Sheet: Plan" in result["markdown"]
+    assert "Channel | Budget" in result["markdown"]
+    assert "Telegram | 100000" in result["markdown"]
+    assert result["metadata"]["sheet_count"] == 1
+
+
+def test_office_extract_rejects_legacy_binary_office_formats(tmp_path):
+    path = tmp_path / "legacy.doc"
+    path.write_bytes(b"not really a doc")
+
+    result = _load(office_extract(str(path)))
+
+    assert result["success"] is False
+    assert result["error_code"] == "unsupported_legacy_format"
+    assert ".docx" in result["error"]
+
+
+def test_office_extract_toolset_is_registered_when_requirements_are_available():
+    assert check_office_extract_requirements() is True
+    assert "office_extract" in get_toolset("office")["tools"]
+    assert "office_extract" in resolve_toolset("office")

--- a/tools/office_extract_tool.py
+++ b/tools/office_extract_tool.py
@@ -1,0 +1,319 @@
+"""Safe Microsoft Office text extraction tool.
+
+Narrow, read-only extractor for uploaded Office documents.  This deliberately
+avoids shelling out to LibreOffice/pandoc so restricted gateway profiles can
+read client briefs without enabling terminal or code_execution.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from tools.registry import registry, tool_error
+
+SUPPORTED_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+LEGACY_EXTENSIONS = {".doc", ".ppt", ".xls"}
+DEFAULT_MAX_CHARS = 80_000
+DEFAULT_MAX_ROWS_PER_SHEET = 200
+DEFAULT_MAX_COLS_PER_SHEET = 40
+
+
+def _json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _clip(text: str, max_chars: int) -> tuple[str, bool]:
+    if max_chars <= 0:
+        max_chars = DEFAULT_MAX_CHARS
+    if len(text) <= max_chars:
+        return text, False
+    marker = "\n\n[TRUNCATED: office_extract output exceeded max_chars]"
+    return text[: max(0, max_chars - len(marker))].rstrip() + marker, True
+
+
+def _error(message: str, *, error_code: str, file_path: str | None = None) -> str:
+    payload: dict[str, Any] = {
+        "success": False,
+        "error": message,
+        "error_code": error_code,
+    }
+    if file_path is not None:
+        payload["file_path"] = file_path
+    return _json(payload)
+
+
+def _iter_nonempty(values: Iterable[Any]) -> list[str]:
+    return [str(value).strip() for value in values if value is not None and str(value).strip()]
+
+
+def _markdown_table(rows: list[list[str]]) -> list[str]:
+    if not rows:
+        return []
+    width = max(len(row) for row in rows)
+    normalized = [row + [""] * (width - len(row)) for row in rows]
+    lines = [" | ".join(normalized[0])]
+    if len(normalized) > 1:
+        lines.append(" | ".join(["---"] * width))
+        lines.extend(" | ".join(row) for row in normalized[1:])
+    return lines
+
+
+def _extract_docx(path: Path) -> tuple[str, dict[str, Any]]:
+    try:
+        import docx
+    except ImportError as exc:  # pragma: no cover - exercised by check_fn in normal use
+        raise RuntimeError("python-docx is not installed") from exc
+
+    document = docx.Document(str(path))
+    lines: list[str] = []
+
+    paragraphs = 0
+    headings = 0
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if not text:
+            continue
+        paragraphs += 1
+        style_name = getattr(getattr(paragraph, "style", None), "name", "") or ""
+        if style_name.lower().startswith("heading"):
+            level = 1
+            for token in style_name.split():
+                if token.isdigit():
+                    level = max(1, min(6, int(token)))
+                    break
+            lines.append(f"{'#' * level} {text}")
+            headings += 1
+        else:
+            lines.append(text)
+
+    table_count = 0
+    for index, table in enumerate(document.tables, start=1):
+        rows: list[list[str]] = []
+        for row in table.rows:
+            cells = [cell.text.replace("\n", " ").strip() for cell in row.cells]
+            if any(cells):
+                rows.append(cells)
+        if not rows:
+            continue
+        table_count += 1
+        lines.append(f"\nTable {index}:")
+        lines.extend(_markdown_table(rows))
+
+    metadata = {
+        "paragraph_count": paragraphs,
+        "heading_count": headings,
+        "table_count": table_count,
+    }
+    return "\n\n".join(lines).strip(), metadata
+
+
+def _extract_pptx(path: Path) -> tuple[str, dict[str, Any]]:
+    try:
+        import pptx
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("python-pptx is not installed") from exc
+
+    presentation = pptx.Presentation(str(path))
+    lines: list[str] = []
+    nonempty_slides = 0
+
+    for slide_index, slide in enumerate(presentation.slides, start=1):
+        slide_lines: list[str] = []
+        for shape in slide.shapes:
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            text = "\n".join(_iter_nonempty(par.text for par in shape.text_frame.paragraphs))
+            if text:
+                slide_lines.append(text)
+
+        # python-pptx exposes notes on demand; some decks have no notes part.
+        try:
+            notes_frame = slide.notes_slide.notes_text_frame
+            notes = "\n".join(_iter_nonempty(par.text for par in notes_frame.paragraphs))
+            if notes:
+                slide_lines.append(f"Speaker notes:\n{notes}")
+        except Exception:
+            pass
+
+        if slide_lines:
+            nonempty_slides += 1
+            lines.append(f"## Slide {slide_index}\n" + "\n\n".join(slide_lines))
+
+    metadata = {
+        "slide_count": len(presentation.slides),
+        "nonempty_slide_count": nonempty_slides,
+    }
+    return "\n\n".join(lines).strip(), metadata
+
+
+def _extract_xlsx(
+    path: Path,
+    *,
+    max_rows_per_sheet: int = DEFAULT_MAX_ROWS_PER_SHEET,
+    max_cols_per_sheet: int = DEFAULT_MAX_COLS_PER_SHEET,
+) -> tuple[str, dict[str, Any]]:
+    try:
+        import openpyxl
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("openpyxl is not installed") from exc
+
+    workbook = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
+    lines: list[str] = []
+    sheet_meta: list[dict[str, Any]] = []
+
+    for sheet in workbook.worksheets:
+        rows: list[list[str]] = []
+        for row_index, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+            if row_index > max_rows_per_sheet:
+                break
+            cells = ["" if cell is None else str(cell).strip() for cell in row[:max_cols_per_sheet]]
+            # Keep header-like rows and rows with at least one populated cell.
+            if any(cells):
+                rows.append(cells)
+
+        if rows:
+            lines.append(f"## Sheet: {sheet.title}")
+            lines.extend(_markdown_table(rows))
+
+        sheet_meta.append(
+            {
+                "name": sheet.title,
+                "max_row": sheet.max_row,
+                "max_column": sheet.max_column,
+                "extracted_rows": len(rows),
+                "truncated_rows": sheet.max_row > max_rows_per_sheet,
+                "truncated_columns": sheet.max_column > max_cols_per_sheet,
+            }
+        )
+
+    workbook.close()
+    metadata = {
+        "sheet_count": len(sheet_meta),
+        "sheets": sheet_meta,
+        "max_rows_per_sheet": max_rows_per_sheet,
+        "max_cols_per_sheet": max_cols_per_sheet,
+    }
+    return "\n\n".join(lines).strip(), metadata
+
+
+def office_extract(
+    file_path: str,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    max_rows_per_sheet: int = DEFAULT_MAX_ROWS_PER_SHEET,
+    max_cols_per_sheet: int = DEFAULT_MAX_COLS_PER_SHEET,
+    task_id: str | None = None,
+) -> str:
+    """Extract readable text/markdown from .docx, .pptx, or .xlsx files."""
+    if not file_path or not str(file_path).strip():
+        return _error("file_path is required", error_code="missing_file_path")
+
+    path = Path(file_path).expanduser()
+    if not path.exists():
+        return _error(f"File not found: {file_path}", error_code="file_not_found", file_path=str(path))
+    if not path.is_file():
+        return _error(f"Path is not a file: {file_path}", error_code="not_a_file", file_path=str(path))
+
+    suffix = path.suffix.lower()
+    if suffix in LEGACY_EXTENSIONS:
+        return _error(
+            f"Legacy binary Office format '{suffix}' is not supported safely. "
+            "Ask for .docx/.pptx/.xlsx or PDF instead.",
+            error_code="unsupported_legacy_format",
+            file_path=str(path),
+        )
+    if suffix not in SUPPORTED_EXTENSIONS:
+        return _error(
+            "Unsupported file type. Supported: .docx, .pptx, .xlsx. "
+            "Legacy .doc/.ppt/.xls require conversion first.",
+            error_code="unsupported_format",
+            file_path=str(path),
+        )
+
+    try:
+        if suffix == ".docx":
+            markdown, metadata = _extract_docx(path)
+        elif suffix == ".pptx":
+            markdown, metadata = _extract_pptx(path)
+        else:
+            markdown, metadata = _extract_xlsx(
+                path,
+                max_rows_per_sheet=max_rows_per_sheet,
+                max_cols_per_sheet=max_cols_per_sheet,
+            )
+    except Exception as exc:
+        return tool_error(
+            f"Failed to extract Office document '{path.name}': {exc}",
+            success=False,
+        )
+
+    clipped, truncated = _clip(markdown, max_chars)
+    return _json(
+        {
+            "success": True,
+            "file_path": str(path),
+            "format": suffix.lstrip("."),
+            "markdown": clipped,
+            "truncated": truncated,
+            "metadata": metadata,
+        }
+    )
+
+
+def check_office_extract_requirements() -> bool:
+    return all(importlib.util.find_spec(name) is not None for name in ("docx", "pptx", "openpyxl"))
+
+
+OFFICE_EXTRACT_SCHEMA = {
+    "name": "office_extract",
+    "description": (
+        "Read Microsoft Office files from local paths and extract markdown/text. "
+        "Supports .docx, .pptx, and .xlsx. Use this when a user uploads a Word, "
+        "PowerPoint, or Excel file and you need its contents before answering. "
+        "Does not execute macros and does not support legacy .doc/.ppt/.xls."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "file_path": {
+                "type": "string",
+                "description": "Absolute or relative path to a .docx, .pptx, or .xlsx file.",
+            },
+            "max_chars": {
+                "type": "integer",
+                "description": "Maximum characters of markdown to return. Default 80000.",
+                "default": DEFAULT_MAX_CHARS,
+            },
+            "max_rows_per_sheet": {
+                "type": "integer",
+                "description": "For .xlsx only: max rows to extract per sheet. Default 200.",
+                "default": DEFAULT_MAX_ROWS_PER_SHEET,
+            },
+            "max_cols_per_sheet": {
+                "type": "integer",
+                "description": "For .xlsx only: max columns to extract per sheet. Default 40.",
+                "default": DEFAULT_MAX_COLS_PER_SHEET,
+            },
+        },
+        "required": ["file_path"],
+    },
+}
+
+
+registry.register(
+    name="office_extract",
+    toolset="office",
+    schema=OFFICE_EXTRACT_SCHEMA,
+    handler=lambda args, **kwargs: office_extract(
+        file_path=args.get("file_path", ""),
+        max_chars=args.get("max_chars", DEFAULT_MAX_CHARS),
+        max_rows_per_sheet=args.get("max_rows_per_sheet", DEFAULT_MAX_ROWS_PER_SHEET),
+        max_cols_per_sheet=args.get("max_cols_per_sheet", DEFAULT_MAX_COLS_PER_SHEET),
+        task_id=kwargs.get("task_id"),
+    ),
+    check_fn=check_office_extract_requirements,
+    description=OFFICE_EXTRACT_SCHEMA["description"],
+    emoji="📄",
+)

--- a/tools/pdf_compress_tool.py
+++ b/tools/pdf_compress_tool.py
@@ -1,0 +1,241 @@
+"""Safe dedicated PDF compression tool for restricted bot profiles.
+
+This tool intentionally avoids shell execution and does not inherit the agent's
+secret-filled environment. It is meant for narrow Telegram bots that should only
+compress user-provided PDFs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+
+DEFAULT_MAX_INPUT_MB = 750.0
+DEFAULT_MAX_TARGET_MB = 200.0
+DEFAULT_TIMEOUT_SECONDS = 1800
+DEFAULT_CPU_SECONDS = 1200
+DEFAULT_MEMORY_GB = 5
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+PDF_COMPRESS_SCHEMA = {
+    "name": "compress_pdf",
+    "description": (
+        "Compress a user-provided PDF to a target size using the profile's "
+        "pdf-compress skill. This is a restricted wrapper: PDF input only, no "
+        "shell, no network, no inherited API secrets. Returns an output PDF path."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "input_path": {
+                "type": "string",
+                "description": "Absolute local path to the uploaded PDF file.",
+            },
+            "target_mb": {
+                "type": "number",
+                "description": "Desired target size in MB. Defaults to 20. Allowed range: 1..200 by default.",
+            },
+        },
+        "required": ["input_path"],
+    },
+}
+
+
+def _json_error(message: str, **extra) -> str:
+    payload = {"success": False, "error": message}
+    payload.update(extra)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _is_pdf(path: Path) -> bool:
+    if path.suffix.lower() != ".pdf":
+        return False
+    try:
+        with path.open("rb") as f:
+            return f.read(5) == b"%PDF-"
+    except OSError:
+        return False
+
+
+def _safe_filename(path: Path) -> str:
+    stem = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in path.stem)
+    stem = stem[:80].strip("._") or "document"
+    return f"{stem}.pdf"
+
+
+def _skill_paths(home: Path) -> tuple[Path, Path]:
+    skill_dir = home / "skills" / "utilities" / "pdf-compress"
+    script = skill_dir / "scripts" / "pdf_compress.py"
+    venv_python = skill_dir / ".venv" / "bin" / "python"
+    python = venv_python if venv_python.exists() else Path(sys.executable)
+    return script, python
+
+
+def _preexec_limits():
+    """Best-effort resource limits for the child process (Linux/Unix)."""
+    try:
+        import resource
+
+        cpu_seconds = _env_int("HERMES_PDF_COMPRESS_CPU_SECONDS", DEFAULT_CPU_SECONDS)
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds + 60))
+        # Large presentation PDFs can legitimately need several GiB while still
+        # being bounded enough to prevent silly DoS cases.
+        mem_gb = _env_int("HERMES_PDF_COMPRESS_MEMORY_GB", DEFAULT_MEMORY_GB)
+        mem = mem_gb * 1024 * 1024 * 1024
+        resource.setrlimit(resource.RLIMIT_AS, (mem, mem))
+        # 2 GiB max output file size.
+        fsize = 2 * 1024 * 1024 * 1024
+        resource.setrlimit(resource.RLIMIT_FSIZE, (fsize, fsize))
+    except Exception:
+        pass
+
+
+def compress_pdf(input_path: str, target_mb: float | int | None = None) -> str:
+    home = Path(get_hermes_home()).resolve()
+    source_raw = Path(str(input_path)).expanduser()
+
+    try:
+        source = source_raw.resolve(strict=True)
+    except FileNotFoundError:
+        return _json_error("PDF file not found")
+    except OSError as exc:
+        return _json_error(f"Invalid PDF path: {exc}")
+
+    if not source.is_file():
+        return _json_error("Input is not a file")
+    if not _is_pdf(source):
+        return _json_error("Мне нужен PDF-файл.")
+
+    size_mb = source.stat().st_size / (1024 * 1024)
+    max_input_mb = _env_float("HERMES_PDF_MAX_INPUT_MB", DEFAULT_MAX_INPUT_MB)
+    if size_mb > max_input_mb:
+        return _json_error(
+            "PDF is too large for safe compression",
+            input_size_mb=round(size_mb, 2),
+            max_mb=round(max_input_mb, 2),
+        )
+
+    try:
+        target = 20.0 if target_mb is None else float(target_mb)
+    except (TypeError, ValueError):
+        return _json_error("Invalid target size")
+    max_target_mb = _env_float("HERMES_PDF_MAX_TARGET_MB", DEFAULT_MAX_TARGET_MB)
+    if not (1 <= target <= max_target_mb):
+        return _json_error(f"Target size must be between 1 and {max_target_mb:g} MB")
+
+    script, python = _skill_paths(home)
+    if not script.exists():
+        return _json_error("pdf-compress skill script not found", expected=str(script))
+    if not python.exists():
+        return _json_error("Python interpreter for pdf-compress not found", expected=str(python))
+
+    jobs_dir = home / "pdf_jobs"
+    jobs_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    job_dir = jobs_dir / uuid.uuid4().hex
+    job_dir.mkdir(mode=0o700)
+
+    local_input = job_dir / _safe_filename(source)
+    output = job_dir / f"{local_input.stem} (compressed).pdf"
+    shutil.copy2(source, local_input)
+
+    if size_mb <= target:
+        shutil.copy2(local_input, output)
+        return json.dumps(
+            {
+                "success": True,
+                "input_path": str(source),
+                "output_path": str(output),
+                "input_size_mb": round(size_mb, 2),
+                "output_size_mb": round(output.stat().st_size / (1024 * 1024), 2),
+                "target_mb": target,
+                "message": "Input is already under target size. Send it to the user by including MEDIA:<output_path> in the final response.",
+            },
+            ensure_ascii=False,
+        )
+
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "PYTHONNOUSERSITE": "1",
+        "HOME": str(home),
+        "HERMES_HOME": str(home),
+        "TMPDIR": str(job_dir),
+    }
+
+    cmd = [str(python), str(script), str(local_input), "--target", str(target), "--output", str(output)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(script.parent),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_env_int("HERMES_PDF_COMPRESS_TIMEOUT", DEFAULT_TIMEOUT_SECONDS),
+            preexec_fn=_preexec_limits if os.name == "posix" else None,
+        )
+    except subprocess.TimeoutExpired:
+        return _json_error("Compression timed out", input_size_mb=round(size_mb, 2))
+
+    stdout = (proc.stdout or "")[-4000:]
+    stderr = (proc.stderr or "")[-4000:]
+    if proc.returncode != 0 or not output.exists():
+        return _json_error(
+            "Compression failed",
+            returncode=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    output_size_mb = output.stat().st_size / (1024 * 1024)
+    return json.dumps(
+        {
+            "success": True,
+            "input_path": str(source),
+            "output_path": str(output),
+            "input_size_mb": round(size_mb, 2),
+            "output_size_mb": round(output_size_mb, 2),
+            "target_mb": target,
+            "message": "Send the compressed PDF to the user by including MEDIA:<output_path> in the final response.",
+            "stdout": stdout,
+        },
+        ensure_ascii=False,
+    )
+
+
+registry.register(
+    name="compress_pdf",
+    toolset="pdf_compress",
+    schema=PDF_COMPRESS_SCHEMA,
+    handler=lambda args, **kw: compress_pdf(
+        input_path=args.get("input_path", ""),
+        target_mb=args.get("target_mb"),
+    ),
+    check_fn=lambda: (Path(get_hermes_home()) / "skills" / "utilities" / "pdf-compress" / "scripts" / "pdf_compress.py").exists(),
+    description="Restricted PDF compression wrapper",
+    emoji="🗜️",
+    max_result_size_chars=6000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,6 +35,8 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
+    # Microsoft Office document extraction
+    "office_extract",
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
@@ -174,6 +176,12 @@ TOOLSETS = {
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
         "tools": ["read_file", "write_file", "patch", "search_files"],
+        "includes": []
+    },
+
+    "office": {
+        "description": "Read Microsoft Office files (.docx, .pptx, .xlsx) from local paths without shell access",
+        "tools": ["office_extract"],
         "includes": []
     },
     

--- a/uv.lock
+++ b/uv.lock
@@ -1395,6 +1395,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exa-py"
 version = "2.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2005,12 +2014,15 @@ all = [
     { name = "mcp" },
     { name = "modal" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "parallel-web" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-split" },
     { name = "pytest-xdist" },
+    { name = "python-docx" },
+    { name = "python-pptx" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "qrcode" },
@@ -2104,6 +2116,11 @@ messaging = [
 ]
 modal = [
     { name = "modal" },
+]
+office = [
+    { name = "openpyxl" },
+    { name = "python-docx" },
+    { name = "python-pptx" },
 ]
 parallel-web = [
     { name = "parallel-web" },
@@ -2242,6 +2259,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["messaging"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["messaging"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["modal"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["office"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["parallel-web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'termux'" },
@@ -2270,6 +2288,7 @@ requires-dist = [
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
+    { name = "openpyxl", marker = "extra == 'office'", specifier = "==3.1.5" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
@@ -2280,7 +2299,9 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "pytest-split", marker = "extra == 'dev'", specifier = "==0.11.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
+    { name = "python-docx", marker = "extra == 'office'", specifier = "==1.2.0" },
     { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-pptx", marker = "extra == 'office'", specifier = "==1.0.2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = "==2.0.15" },
@@ -2309,7 +2330,7 @@ requires-dist = [
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "rl", "yc-bench", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "office", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2877,6 +2898,108 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/0c/62a0fdc5adae6d205338f9239175aa6a93818e58b75cf000a9c7214a3d9f/litellm-1.81.15.tar.gz", hash = "sha256:a8a6277a53280762051c5818ebc76dd5f036368b9426c6f21795ae7f1ac6ebdc", size = 16597039, upload-time = "2026-02-24T06:52:50.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/fd/da11826dda0d332e360b9ead6c0c992d612ecb85b00df494823843cfcda3/litellm-1.81.15-py3-none-any.whl", hash = "sha256:2fa253658702509ce09fe0e172e5a47baaadf697fb0f784c7fd4ff665ae76ae1", size = 14682123, upload-time = "2026-02-24T06:52:48.084Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
 ]
 
 [[package]]
@@ -3577,6 +3700,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -4491,6 +4626,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4523,6 +4671,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/56/652349f97dc2ce6d1aed43481d179c775f565e68796517836406fb7794c7/python_olm-3.2.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16bbb209d43d62135450696526ed0a811150e9de9df32ed91542bf9434e79030", size = 293671, upload-time = "2023-11-28T19:25:21.525Z" },
     { url = "https://files.pythonhosted.org/packages/39/ee/1e15304ac67d3a7ebecbcac417d6479abb7186aad73c6a035647938eaa8e/python_olm-3.2.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e76b3f5060a5cf8451140d6c7e3b438f972ff432b6f39d0ca2c7f2296509bb", size = 301030, upload-time = "2023-11-28T19:25:26.634Z" },
     { url = "https://files.pythonhosted.org/packages/79/93/f6729f10149305262194774d6c8b438c0b084740cf239f48ab97b4df02fa/python_olm-3.2.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a5e68a2f4b5a2bfa5fdb5dbfa22396a551730df6c4a572235acaa96e997d3f", size = 297000, upload-time = "2023-11-28T19:25:31.045Z" },
+]
+
+[[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
 ]
 
 [[package]]
@@ -5961,6 +6124,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Use configurable Telegram max_document_mb instead of hardcoded 20 MB
- Avoid passing document download/limit errors into the LLM as user text
- Copy local Bot API files directly in local_mode to avoid large download timeouts
- Increase document fetch/download timeouts for large files

## Test Plan
- python -m py_compile gateway/platforms/telegram.py
- Restarted bizbot gateway and verified Telegram connection