### PR TITLE
fix(gateway): preserve underscores in plain-text identifiers

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -168,8 +168,8 @@ class TextBatchAggregator:
 # Pre-compiled regexes for performance
 _RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
-_RE_BOLD_UNDER = re.compile(r"__(.+?)__", re.DOTALL)
-_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)
+_RE_BOLD_UNDER = re.compile(r"\b__(?![\s_])(.+?)(?<![\s_])__\b", re.DOTALL)
+_RE_ITALIC_UNDER = re.compile(r"\b_(?![\s_])(.+?)(?<![\s_])_\b", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -101,6 +101,11 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch)
         assert adapter.format_message("**Hello** `world`") == "Hello world"
 
+    def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        text = "Use /api_v2 with FEATURE_FLAG_NAME and config_file.json"
+        assert adapter.format_message(text) == text
+
     def test_strip_markdown_headers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         assert adapter.format_message("## Heading\ntext") == "Heading\ntext"


### PR DESCRIPTION
## Summary
- Preserve underscores inside identifiers when stripping Markdown for plain-text gateway senders
- Keep underscore emphasis handling for standalone `_italic_` and `__bold__` spans
- Add a BlueBubbles regression test with generic route/env-var/filename examples

## Affected senders
The changed helper is used by these plain-text paths:
- BlueBubbles/iMessage (`gateway/platforms/bluebubbles.py`)
- SMS (`gateway/platforms/sms.py`)
- Feishu text fallbacks (`gateway/platforms/feishu.py`)
- QQBot plain-text / non-Markdown mode (`gateway/platforms/qqbot/adapter.py`)

Before this fix, those senders could remove underscores from slash-command routes, environment variable names, and filenames while stripping Markdown.

## Test plan
- `python -m pytest tests/gateway/test_bluebubbles.py tests/gateway/test_sms.py -q -o 'addopts='`
