### PR TITLE
fix(install.ps1): restore EAP=Continue around uv python install, skip Store stub

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -145,19 +145,39 @@ function Test-Python {
     # Python not found — use uv to install it (no admin needed!)
     Write-Info "Python $PythonVersion not found, installing via uv..."
     try {
+        # Temporarily relax ErrorActionPreference: uv writes download progress
+        # ("Downloading cpython-3.11.15-windows-x86_64-none (24.5MiB)") to
+        # stderr.  With $ErrorActionPreference = "Stop" (set at the top of this
+        # script) PowerShell wraps stderr lines from native commands as
+        # ErrorRecord objects when captured via 2>&1, then throws a terminating
+        # exception on the first one — even though uv exits 0 and Python was
+        # installed successfully.  Verify success via `uv python find`
+        # afterwards, which is the reliable signal regardless of exit-code
+        # semantics or stderr noise.  This fix was previously landed as
+        # commit ec1714e71 and then lost in a release squash; reapplied here.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         $uvOutput = & $UvCmd python install $PythonVersion 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $pythonPath = & $UvCmd python find $PythonVersion 2>$null
-            if ($pythonPath) {
-                $ver = & $pythonPath --version 2>$null
-                Write-Success "Python installed: $ver"
-                return $true
-            }
-        } else {
+        $uvExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+
+        # Check if Python is now available (more reliable than exit code
+        # since uv may return non-zero due to "already installed" etc.)
+        $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        if ($pythonPath) {
+            $ver = & $pythonPath --version 2>$null
+            Write-Success "Python installed: $ver"
+            return $true
+        }
+
+        # uv ran but Python still not findable — show what happened
+        if ($uvExitCode -ne 0) {
             Write-Warn "uv python install output:"
             Write-Host $uvOutput -ForegroundColor DarkGray
         }
     } catch {
+        # Restore EAP in case the try block threw before the assignment
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
         Write-Warn "uv python install error: $_"
     }
 
@@ -175,15 +195,42 @@ function Test-Python {
         } catch { }
     }
 
-    # Fallback: try system python
-    if (Get-Command python -ErrorAction SilentlyContinue) {
-        $sysVer = python --version 2>$null
-        if ($sysVer -match "3\.(1[0-9]|[1-9][0-9])") {
-            Write-Success "Using system Python: $sysVer"
-            return $true
+    # Fallback: try system python — but skip the Microsoft Store stub.
+    # On Windows, %LOCALAPPDATA%\Microsoft\WindowsApps\python.exe is a 0-byte
+    # reparse-point stub that prints "Python was not found; run without
+    # arguments to install from the Microsoft Store..." to stdout and exits
+    # non-zero.  Get-Command finds it; invoking it produces a confusing error
+    # that the user sees as our installer crashing.
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        $isStoreStub = $false
+        try {
+            $pythonSource = $pythonCmd.Source
+            if ($pythonSource -and $pythonSource -like "*\WindowsApps\*") {
+                $isStoreStub = $true
+            } else {
+                # Even outside WindowsApps, a 0-byte file is the stub
+                $item = Get-Item $pythonSource -ErrorAction SilentlyContinue
+                if ($item -and $item.Length -eq 0) { $isStoreStub = $true }
+            }
+        } catch { }
+
+        if (-not $isStoreStub) {
+            try {
+                $prevEAP2 = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                $sysVer = & python --version 2>&1
+                $ErrorActionPreference = $prevEAP2
+                if ($sysVer -match "Python 3\.(1[0-9]|[1-9][0-9])") {
+                    Write-Success "Using system Python: $sysVer"
+                    return $true
+                }
+            } catch {
+                if ($prevEAP2) { $ErrorActionPreference = $prevEAP2 }
+            }
         }
     }
-    
+
     Write-Err "Failed to install Python $PythonVersion"
     Write-Info "Install Python 3.11 manually, then re-run this script:"
     Write-Info "  https://www.python.org/downloads/"


### PR DESCRIPTION
## Summary
Fresh Windows installs via the one-liner work again. Two regressions compounded: `uv python install` progress on stderr was throwing under EAP=Stop, and the system-python fallback then invoked the Microsoft Store stub which produced the visible crash.

## Root cause
1. **EAP=Stop swallows uv stderr.** uv writes `Downloading cpython-3.11.15-windows-x86_64-none (24.5MiB)` to stderr. With `$ErrorActionPreference = 'Stop'` set at the top of the script plus `2>&1` capture, PowerShell wraps each stderr line as an ErrorRecord and throws on the first one — even though uv exits 0 and Python was installed successfully. This was previously fixed in commit `ec1714e71` (May 8) but lost in the May 12 release squash (`413990c94`).
2. **System-python fallback invokes the Microsoft Store stub.** `%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe` is a 0-byte reparse stub that prints `Python was not found; run without arguments to install from the Microsoft Store...` to stdout and exits non-zero. `Get-Command` matches it, and the resulting error message is what the user sees as the final crash.

## Changes
- `scripts/install.ps1` Test-Python: save/restore EAP around `uv python install`, verify success via `uv python find` regardless of exit code (reapplies the lost ec1714e71 fix).
- `scripts/install.ps1` Test-Python: detect Microsoft Store stub by `\WindowsApps\` path or 0-byte file size, skip the `python --version` call when it's the stub. Wrap the real-Python case in its own EAP=Continue block.

## User-reported symptom (the trigger for this fix)
```
→ Python 3.11 not found, installing via uv...
⚠ uv python install error: Downloading cpython-3.11.15-windows-x86_64-none (download) (24.5MiB)
→ Trying to find any existing Python 3.10+...
✗ Installation failed: Python was not found; run without arguments to install from the Microsoft Store...
```

## Validation
Code walkthrough + brace/paren balance check. No Windows machine on hand for live install; symptoms exactly match the previously-fixed ec1714e71 case so the reapplied pattern is proven. Please verify with `irm .../install.ps1 | iex` on a clean Windows VM before merge.