### PR TITLE
fix(title-gen): omit unsupported temperature override

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -58,7 +58,10 @@ def generate_title(
             task="title_generation",
             messages=messages,
             max_tokens=500,
-            temperature=0.3,
+            # Some reasoning/frontier models (notably OpenAI GPT-5-style
+            # models) reject non-default sampling values. Title generation
+            # does not require custom sampling, so omit temperature and let
+            # the provider default apply.
             timeout=timeout,
             main_runtime=main_runtime,
         )

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -113,6 +113,23 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_omits_temperature_for_provider_defaults(self):
+        """Title generation should not force sampling params unsupported by some models."""
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Short Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer") == "Short Title"
+
+        assert captured_kwargs["task"] == "title_generation"
+        assert "temperature" not in captured_kwargs
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""


### PR DESCRIPTION
## Summary
- omit the hard-coded title-generation temperature override so providers/models that reject non-default sampling parameters can use their defaults
- add a regression test covering the title-generation call kwargs

## Tests
- python -m pytest tests/agent/test_title_generator.py -q -o addopts=