### PR TITLE
fix(cli): treat named custom providers as aggregators

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -609,6 +609,7 @@ def run_doctor(args):
                 and "/" in default_model
                 and provider_for_policy
                 and provider_for_policy not in providers_accepting_vendor_slugs
+                and not provider_for_policy.startswith("custom:")
             ):
                 check_warn(
                     f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -495,6 +495,8 @@ def get_label(provider_id: str) -> str:
 
 def is_aggregator(provider: str) -> bool:
     """Return True when the provider is a multi-model aggregator."""
+    if provider and provider.startswith("custom:"):
+        return True
     pdef = get_provider(provider)
     return pdef.is_aggregator if pdef else False
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -474,6 +474,47 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_vendor_slug_for_named_custom_provider(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:zenmux\n"
+        "  default: z-ai/glm-5.1\n"
+        "custom_providers:\n"
+        "  - name: zenmux\n"
+        "    base_url: https://zenmux.example/v1\n"
+        "    model: z-ai/glm-5.1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'custom:zenmux' is not a recognised provider" not in out
+    assert "model.default 'z-ai/glm-5.1' uses a vendor/model slug" not in out
+
+
 @pytest.mark.parametrize(
     ("provider", "default_model"),
     [

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -474,47 +474,6 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
-def test_run_doctor_accepts_vendor_slug_for_named_custom_provider(monkeypatch, tmp_path):
-    home = tmp_path / ".hermes"
-    home.mkdir(parents=True, exist_ok=True)
-    (home / "config.yaml").write_text(
-        "model:\n"
-        "  provider: custom:zenmux\n"
-        "  default: z-ai/glm-5.1\n"
-        "custom_providers:\n"
-        "  - name: zenmux\n"
-        "    base_url: https://zenmux.example/v1\n"
-        "    model: z-ai/glm-5.1\n",
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
-    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
-    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-    (tmp_path / "project").mkdir(exist_ok=True)
-
-    fake_model_tools = types.SimpleNamespace(
-        check_tool_availability=lambda *a, **kw: ([], []),
-        TOOLSET_REQUIREMENTS={},
-    )
-    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
-
-    try:
-        from hermes_cli import auth as _auth_mod
-        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
-        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
-    except Exception:
-        pass
-
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        doctor_mod.run_doctor(Namespace(fix=False))
-
-    out = buf.getvalue()
-    assert "model.provider 'custom:zenmux' is not a recognised provider" not in out
-    assert "model.default 'z-ai/glm-5.1' uses a vendor/model slug" not in out
-
-
 @pytest.mark.parametrize(
     ("provider", "default_model"),
     [
@@ -566,6 +525,47 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out
         )
+
+
+def test_run_doctor_accepts_vendor_slug_for_named_custom_provider(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:zenmux\n"
+        "  default: z-ai/glm-5.1\n"
+        "custom_providers:\n"
+        "  - name: zenmux\n"
+        "    base_url: https://zenmux.example/v1\n"
+        "    model: z-ai/glm-5.1\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'custom:zenmux' is not a recognised provider" not in out
+    assert "model.default 'z-ai/glm-5.1' uses a vendor/model slug" not in out
 
 
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -65,6 +65,11 @@ def test_resolve_provider_full_finds_named_custom_provider():
     assert resolved.source == "user-config"
 
 
+def test_named_custom_provider_is_aggregator():
+    """Named custom providers accept vendor/model slugs like aggregators."""
+    assert providers_mod.is_aggregator("custom:zenmux") is True
+
+
 def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     """Shared /model switch pipeline should accept --provider for custom_providers."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Treat named custom providers like `custom:zenmux` as aggregators for model alias resolution.
- Suppress the false-positive doctor vendor-prefix warning for named custom providers.
- Add regressions for `is_aggregator("custom:zenmux")` and `hermes doctor` with `custom:zenmux` + `z-ai/glm-5.1`.

Fixes #26578.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py::test_named_custom_provider_is_aggregator tests/hermes_cli/test_doctor.py::test_run_doctor_accepts_vendor_slug_for_named_custom_provider`
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_doctor.py`
- `git diff --check`
- `python -m py_compile hermes_cli/providers.py hermes_cli/doctor.py`
