### PR TITLE
fix(providers): treat custom:<name> as aggregator for vendor-prefixed slugs (#26578)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -755,6 +755,7 @@ def run_doctor(args):
                 and "/" in default_model
                 and provider_for_policy
                 and provider_for_policy not in providers_accepting_vendor_slugs
+                and not provider_for_policy.startswith("custom:")
             ):
                 check_warn(
                     f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -492,7 +492,14 @@ def get_label(provider_id: str) -> str:
 
 
 def is_aggregator(provider: str) -> bool:
-    """Return True when the provider is a multi-model aggregator."""
+    """Return True when the provider is a multi-model aggregator.
+
+    Custom-named providers (``custom:<name>``) are treated as aggregators
+    because they front arbitrary upstream catalogs (LiteLLM, ZenMux, etc.)
+    that commonly expose vendor-prefixed model slugs.
+    """
+    if provider and provider.startswith("custom:"):
+        return True
     pdef = get_provider(provider)
     return pdef.is_aggregator if pdef else False
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -487,6 +487,52 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
     assert "No credentials found for provider 'openrouter'." in out
 
 
+def test_run_doctor_does_not_warn_vendor_prefix_for_custom_named_provider(
+    monkeypatch, tmp_path
+):
+    """Regression for #26578: `custom:<name>` aggregators accept vendor-prefixed
+    model slugs (just like `openrouter`), so `hermes doctor` should not raise the
+    "vendor-prefixed but provider is X" warning."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: 'custom:zenmux'\n"
+        "  default: z-ai/glm-5.1\n"
+        "custom_providers:\n"
+        "  - name: zenmux\n"
+        "    base_url: https://zenmux.example.com/v1\n"
+        "    api_key: sk-zenmux-test\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "uses a vendor/model slug but provider is 'custom:zenmux'" not in out
+    assert "is vendor-prefixed but model.provider is 'custom:zenmux'" not in out
+
+
 @pytest.mark.parametrize(
     ("provider", "default_model"),
     [

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -606,3 +606,33 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
         "gateway-model-c",
     ], "Live models must replace the static subset"
     assert gateway_prov["total_models"] == 3
+
+
+# -- is_aggregator for custom:<name> providers (regression for #26578) -------
+
+def test_is_aggregator_recognizes_custom_prefix():
+    """`custom:<name>` providers front arbitrary upstream catalogs and must be
+    treated as aggregators so vendor-prefixed model slugs (e.g.
+    ``google/gemini-3.1-flash-lite``) resolve correctly via model_switch."""
+    from hermes_cli.providers import is_aggregator
+
+    assert is_aggregator("custom:zenmux") is True
+    assert is_aggregator("custom:ollama") is True
+    assert is_aggregator("custom:local-(127.0.0.1:4141)") is True
+
+
+def test_is_aggregator_unknown_provider_still_false():
+    """Regression guard: the custom: special-case must not turn every unknown
+    provider into an aggregator — only the ``custom:`` namespace qualifies."""
+    from hermes_cli.providers import is_aggregator
+
+    assert is_aggregator("unknown-provider") is False
+    assert is_aggregator("") is False
+
+
+def test_is_aggregator_known_non_aggregator_unchanged():
+    """Built-in non-aggregator providers must keep returning False after the
+    custom: fast-path."""
+    from hermes_cli.providers import is_aggregator
+
+    assert is_aggregator("anthropic") is False


### PR DESCRIPTION
## Summary

Two places in the CLI treated `custom:<name>` providers as bare/unknown providers and broke vendor-prefixed model slugs (e.g. `google/gemini-3.1-flash-lite`, `z-ai/glm-5.1`) for users running through `custom:zenmux`, `custom:litellm`, etc.

## The bug

`custom:<name>` providers front arbitrary upstream catalogs (LiteLLM, ZenMux, etc.) and commonly accept vendor-prefixed model slugs, just like `openrouter`. But:

- `hermes_cli/providers.py:is_aggregator()` only returned `True` for providers registered in `HERMES_OVERLAYS` with `is_aggregator=True`. `custom:zenmux` fell through to `get_provider()`, which returns `None` for unknown slugs, so `is_aggregator()` returned `False`. This broke model-alias resolution in `model_switch` for vendor-prefixed model IDs when the current provider was `custom:<name>`.
- `hermes_cli/doctor.py` vendor-prefix validation included bare `"custom"` in `providers_accepting_vendor_slugs` but not the `custom:<name>` namespace, producing a false-positive warning:

  > model.default 'z-ai/glm-5.1' is vendor-prefixed but model.provider is 'custom:zenmux'. Either set model.provider to 'openrouter', or drop the vendor prefix.

  which is incorrect — `custom:zenmux` IS an aggregator.

## The fix

Short-circuit on the `custom:` prefix in both call sites:

- `is_aggregator(provider)` returns `True` when `provider.startswith("custom:")`, before falling through to the registry lookup.
- `run_doctor()`'s vendor-prefix check skips when `provider_for_policy.startswith("custom:")`.

The custom: special-case is intentionally narrow: it does NOT make every unknown provider an aggregator (covered by a regression test).

## Test plan

- [x] Focused regression tests:
  - `tests/hermes_cli/test_model_switch_custom_providers.py::test_is_aggregator_recognizes_custom_prefix` — `custom:zenmux`, `custom:ollama`, `custom:local-(127.0.0.1:4141)` → all True
  - `tests/hermes_cli/test_model_switch_custom_providers.py::test_is_aggregator_unknown_provider_still_false` — the custom: fast-path must not turn every unknown provider into an aggregator
  - `tests/hermes_cli/test_model_switch_custom_providers.py::test_is_aggregator_known_non_aggregator_unchanged` — `anthropic` still returns False
  - `tests/hermes_cli/test_doctor.py::test_run_doctor_does_not_warn_vendor_prefix_for_custom_named_provider` — `provider: custom:zenmux` + `default: z-ai/glm-5.1` does not produce the vendor-prefix warning
- [x] Adjacent suite: `test_doctor.py` + `test_model_switch_custom_providers.py` + `test_custom_provider_model_switch.py` + `test_custom_provider_context_length.py` — 83 passed locally
- [x] Regression guard: with the production diff reverted (tests-only), the two new positive-case tests fail with `AssertionError: assert False is True` for `is_aggregator("custom:zenmux")` and the vendor-prefix substring still appears in doctor output; restoring the fix makes them pass.

## Related

- Fixes #26578