### PR TITLE
gateway: bridge whatsapp.bridge_port from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -841,6 +841,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
+                if plat == Platform.WHATSAPP and "bridge_port" in platform_cfg:
+                    bridged["bridge_port"] = platform_cfg["bridge_port"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -79,6 +79,20 @@ class TestConfigYamlBridging:
         wa_config = config.platforms.get(Platform.WHATSAPP)
         assert "reply_prefix" not in wa_config.extra
 
+    def test_bridge_port_bridged_from_yaml(self, tmp_path):
+        """whatsapp.bridge_port in config.yaml sets PlatformConfig.extra."""
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("whatsapp:\n  bridge_port: 3999\n")
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+            with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+                config = load_gateway_config()
+
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("bridge_port") == 3999
+
 
 # ---------------------------------------------------------------------------
 # WhatsAppAdapter __init__


### PR DESCRIPTION
## What does this PR do?

Fixes WhatsApp gateway config bridging so `whatsapp.bridge_port` from `config.yaml` is actually respected.

Before this change, `gateway/config.py` bridged several WhatsApp-specific settings into `PlatformConfig.extra`, but `bridge_port` was missing. As a result, users could set `whatsapp.bridge_port` in `config.yaml` and the WhatsApp adapter would still fall back to its default port.

This approach is the right fix because the WhatsApp adapter already reads `bridge_port` from `config.extra`, so the bug was in the YAML-to-platform bridge, not in the adapter.

## Related Issue

- N/A 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added WhatsApp-specific bridging for `bridge_port` in [gateway/config.py](/Users/nicolasmelo/workspaces/personal/hermes-agent/gateway/config.py:844)
- Added a regression test for `whatsapp.bridge_port` in [tests/gateway/test_whatsapp_reply_prefix.py](/Users/nicolasmelo/workspaces/personal/hermes-agent/
tests/gateway/test_whatsapp_reply_prefix.py:82)

## How to Test

1. Add the following to `~/.hermes/config.yaml`:
```yaml
 whatsapp:
   bridge_port: 3999
```

2. Load gateway config and verify `config.platforms[Platform.WHATSAPP].extra["bridge_port"] == 3999`.

3. Run:

```sh
 $ scripts/run_tests.sh tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_group_gating.py
```

4. Confirm the targeted suite passes.

## Checklist

### Code

- [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
  (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification run:

```sh
$ scripts/run_tests.sh tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_group_gating.py
```

Result:

- 35 passed