### PR TITLE
docs(hermes_tools_mcp_server): align scope docstring with EXPOSED_TOOLS

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -14,20 +14,28 @@ the user gets full Hermes capability inside a Codex turn.
 Scope (what we expose):
   - web_search, web_extract              — Firecrawl, no codex equivalent
   - browser_navigate / _click / _type /  — Camofox/Browserbase automation
-    _snapshot / _screenshot / _scroll / _back / _press / _vision
-  - delegate_task                        — Hermes subagents
+    _snapshot / _scroll / _back / _press /
+    _get_images / _console / _vision
   - vision_analyze                       — image inspection by vision model
   - image_generate                       — image generation
-  - memory                               — Hermes' persistent memory store
   - skill_view, skills_list              — Hermes' skill library
-  - session_search                       — cross-session search
   - text_to_speech                       — TTS
+  - kanban_* (complete/block/comment/    — kanban worker + orchestrator
+    heartbeat/show/list/create/            handoff (stateless: read env var,
+    unblock/link)                          write ~/.hermes/kanban.db)
 
-What we DO NOT expose (codex has equivalents):
+What we DO NOT expose:
   - terminal / shell                     — codex's own shell tool
   - read_file / write_file / patch       — codex's apply_patch + shell
   - search_files / process               — codex's shell
-  - clarify, todo                        — codex's own UX
+  - clarify                              — codex's own UX
+  - delegate_task / memory /             — `_AGENT_LOOP_TOOLS` in Hermes
+    session_search / todo                  (model_tools.py). They require
+                                           the running AIAgent context to
+                                           dispatch (mid-loop state), so a
+                                           stateless MCP callback can't
+                                           drive them. See the inline
+                                           comment on EXPOSED_TOOLS below.
 
 Run with: python -m agent.transports.hermes_tools_mcp_server
 Spawned by: CodexAppServerSession.ensure_started() when the runtime is


### PR DESCRIPTION
## Summary
The top-of-file scope docstring in `agent/transports/hermes_tools_mcp_server.py` listed `delegate_task`, `memory`, and `session_search` as exposed tools, but `EXPOSED_TOOLS` deliberately omits them (they're `_AGENT_LOOP_TOOLS` and require the running AIAgent context to dispatch). Kanban tools, which ARE exposed, were missing from the docstring entirely.

Doc-only fix per option 1 of #26567.

## Changes
- Drop `delegate_task` / `memory` / `session_search` from the 'expose' list.
- Add the `kanban_*` family to the 'expose' list (matches the actual tuple).
- Move `delegate_task` / `memory` / `session_search` / `todo` into 'DO NOT expose' with the `_AGENT_LOOP_TOOLS` rationale, pointing at the existing inline comment.
- Drop the stale `_screenshot` browser tool name; add the ones we actually expose (`_get_images`, `_console`, `_vision`).

## Validation
```
EXPOSED_TOOLS count: 26
Memory in tuple: False
delegate_task in tuple: False
session_search in tuple: False
text_to_speech in tuple: True
```
Docstring now matches.

## Follow-up
Options 2 / 3 from #26567 (shimming `memory` and `session_search` through `MemoryStore` / `SessionDB` so the codex_app_server runtime gets parity) are deferred. They want a careful audit of plugin-memory backends (Honcho, mem0) that may assume in-process state, and cross-process `MEMORY.md` / `USER.md` file locking. I'll open a separate issue for that.

Fixes #26567.