### PR TITLE
feat(acp): advertise embedded prompt context

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -753,7 +753,7 @@ class HermesACPAgent(acp.Agent):
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
                 load_session=True,
-                prompt_capabilities=PromptCapabilities(image=True),
+                prompt_capabilities=PromptCapabilities(image=True, embedded_context=True),
                 session_capabilities=SessionCapabilities(
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),

--- a/docs/plans/2026-05-15-acp-zed-embedded-context-capability.md
+++ b/docs/plans/2026-05-15-acp-zed-embedded-context-capability.md
@@ -1,0 +1,86 @@
+# ACP Zed Embedded Context Capability Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Advertise Hermes ACP support for embedded prompt context so Zed can send richer `@file`, `@selection`, and resource context blocks.
+
+**Architecture:** Hermes already converts `EmbeddedResourceContentBlock` and `ResourceContentBlock` into model input parts in `acp_adapter/server.py`. This PR should only advertise `PromptCapabilities(embedded_context=True)` and add tests proving the wire key is `embeddedContext`.
+
+**Tech Stack:** Python, ACP Python SDK, Zed ACP prompt capabilities, pytest via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Add capability tests
+
+**Objective:** Lock the advertised capability and JSON alias.
+
+**Files:**
+- Modify: `tests/acp/test_server.py`
+
+**Step 1: Extend existing initialize capability test**
+
+In `TestInitialize.test_initialize_returns_capabilities`, add:
+
+```python
+assert caps.prompt_capabilities is not None
+assert caps.prompt_capabilities.image is True
+assert caps.prompt_capabilities.embedded_context is True
+```
+
+In `test_initialize_capabilities_wire_format`, add:
+
+```python
+prompt_caps = payload["promptCapabilities"]
+assert prompt_caps["image"] is True
+assert prompt_caps["embeddedContext"] is True
+```
+
+**Step 2: Run failing test**
+
+```bash
+scripts/run_tests.sh tests/acp/test_server.py::TestInitialize -q
+```
+
+Expected: FAIL on `embedded_context`.
+
+### Task 2: Advertise embedded context
+
+**Objective:** Tell ACP clients Hermes can receive embedded resources.
+
+**Files:**
+- Modify: `acp_adapter/server.py:initialize`
+
+Change:
+
+```python
+prompt_capabilities=PromptCapabilities(image=True),
+```
+
+to:
+
+```python
+prompt_capabilities=PromptCapabilities(image=True, embedded_context=True),
+```
+
+Do not change prompt parsing in this PR unless tests prove it is broken; keep scope tight.
+
+### Task 3: Add one conversion regression if missing
+
+**Objective:** Make sure advertised support matches actual behavior.
+
+**Files:**
+- Modify: `tests/acp_adapter/test_acp_images.py` or `tests/acp/test_server.py` depending on existing prompt-conversion tests
+
+Add a focused test that passes an embedded text resource into `_content_blocks_to_openai_user_content(...)` and asserts the resulting text includes the embedded resource text/name.
+
+### Task 4: Verify
+
+Run:
+
+```bash
+scripts/run_tests.sh tests/acp/test_server.py tests/acp_adapter/test_acp_images.py -q
+```
+
+Expected: PASS.
+
+Manual Zed check: mention a file/selection in the ACP prompt and confirm Hermes receives the content rather than only the visible mention text.

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -82,6 +82,9 @@ class TestInitialize:
         assert caps.session_capabilities.fork is not None
         assert caps.session_capabilities.list is not None
         assert caps.session_capabilities.resume is not None
+        assert caps.prompt_capabilities is not None
+        assert caps.prompt_capabilities.image is True
+        assert caps.prompt_capabilities.embedded_context is True
 
     @pytest.mark.asyncio
     async def test_initialize_capabilities_wire_format(self, agent):
@@ -89,6 +92,9 @@ class TestInitialize:
         resp = await agent.initialize(protocol_version=1)
         payload = resp.agent_capabilities.model_dump(by_alias=True, exclude_none=True)
         assert payload["loadSession"] is True
+        prompt_caps = payload["promptCapabilities"]
+        assert prompt_caps["image"] is True
+        assert prompt_caps["embeddedContext"] is True
         session_caps = payload["sessionCapabilities"]
         assert "fork" in session_caps
         assert "list" in session_caps


### PR DESCRIPTION
## Summary
- Advertise ACP prompt embedded context support alongside image support
- Assert the SDK attribute and wire alias (`embeddedContext`) in initialize capability tests
- Keep prompt parsing unchanged; existing embedded resource conversion tests already cover actual input handling

## Test Plan
- `scripts/run_tests.sh tests/acp/test_server.py::TestInitialize tests/acp_adapter/test_acp_images.py -q`
- `scripts/run_tests.sh tests/acp/test_server.py tests/acp_adapter/test_acp_images.py -q`
