### PR TITLE
chore(release): map cypres0099@users.noreply.github.com to cypres0099

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1077,6 +1077,7 @@ AUTHOR_MAP = {
     "nidhi2894@gmail.com": "nidhi-singh02",  # PR #2752 salvage (slack whitespace-only IndexError guard)
     "38173192+nidhi-singh02@users.noreply.github.com": "nidhi-singh02",
     "Jaaneek@users.noreply.github.com": "Jaaneek",  # PR #26457 (xAI Grok OAuth provider)
+    "cypres0099@users.noreply.github.com": "cypres0099",
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Adds `cypres0099@users.noreply.github.com` → `cypres0099` to `AUTHOR_MAP` in `scripts/release.py`. The `check-attribution` workflow has been failing on my open PRs (e.g. #25116, #25247) because this email isn't yet mapped — same pattern as #26319 unblocking #26320.

## Related Issue

N/A — single-line AUTHOR_MAP addition, no issue required (matches the pattern of #26319, #26457, #26500, etc.).

## Type of Change

- [x] ♻️ chore (no behavior change)

## Changes Made

- `scripts/release.py`: add one AUTHOR_MAP entry mapping my git noreply email to my GitHub username.

## How to Test

`scripts/release.py` is import-tested by the existing release tooling; the dict literal change is syntax-checked by `python -m py_compile scripts/release.py`. The mapping itself is exercised by `.github/workflows/contributor-check.yml`, which will pass against this addition on subsequent PRs.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`chore(release): ...`)
- [x] Searched existing PRs for duplicates — none open for this email
- [x] PR contains only changes related to this addition
- [x] Tested on: macOS 26 (Sequoia)

### Documentation & Housekeeping
- [x] No doc / config / architecture / tool-schema changes — N/A
- [x] No OS-specific code touched — N/A