### PR TITLE
fix(agent): load tool schemas before mutating state in add_provider() (#9948)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -223,12 +223,25 @@ class MemoryManager:
                     provider.name, existing,
                 )
                 return
+
+        # Collect tool schemas BEFORE mutating state — if schema loading
+        # fails the provider must NOT be registered (fixes #9948).
+        try:
+            schemas = provider.get_tool_schemas()
+        except Exception as exc:
+            logger.error(
+                "Memory provider '%s' failed during schema loading: %s — NOT registered",
+                provider.name, exc,
+            )
+            return
+
+        if not is_builtin:
             self._has_external = True
 
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -244,7 +257,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property


### PR DESCRIPTION
## Summary

Fixes #9948. `MemoryManager.add_provider()` now loads tool schemas **before** mutating any internal state. If `get_tool_schemas()` raises, the provider is not registered — state stays clean and a subsequent external provider can still be added.

## The Bug

In the current code, `add_provider()` sets `_has_external = True` and appends the provider to `_providers` **before** calling `get_tool_schemas()`. If schema loading fails, the manager is left in an inconsistent half-registered state:
- `_has_external` is stuck at `True`, blocking all future external providers
- The failed provider remains in `_providers`
- `_tool_to_provider` is empty (no schemas to index)

## The Fix

1. Call `provider.get_tool_schemas()` inside a `try/except` block **before** any state mutation
2. On failure: log the error and return early — no state is changed
3. On success: set `_has_external`, append to `_providers`, and index tools
4. Re-use the cached `schemas` variable in the routing loop and info log instead of calling `get_tool_schemas()` twice

## Validation

The exact reproduction script from the issue now behaves correctly:

```python
mm = MemoryManager()
try:
    mm.add_provider(BrokenProvider())  # raises RuntimeError
except RuntimeError:
    pass

print([p.name for p in mm.providers])  # [] — empty
print(mm._has_external)  # False — clean slate

mm.add_provider(OkProvider())  # succeeds
print([p.name for p in mm.providers])  # ["ok"]
```

## Changes

`agent/memory_manager.py` — `add_provider()` method: 15 insertions, 2 deletions