### PR TITLE
feat(dashboard): per-profile cron toggle UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2677,6 +2677,7 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "path": path_str,
         "is_default": bool(_profile_attr(info, "is_default", False)),
         "is_active": bool(resolved) and resolved == _active_profile_path_str(),
+        "gateway_running": bool(_profile_attr(info, "gateway_running", False)),
         "model": _profile_attr(info, "model"),
         "provider": _profile_attr(info, "provider"),
         "has_env": bool(_profile_attr(info, "has_env", False)),
@@ -2699,6 +2700,9 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
         except Exception:
             return False
 
+    def _is_gateway_running(path: Path) -> bool:
+        return _safe(lambda: profiles_mod._check_gateway_running(path), False)
+
     profiles: List[Dict[str, Any]] = []
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
@@ -2708,6 +2712,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             "path": str(default_home),
             "is_default": True,
             "is_active": _is_active(default_home),
+            "gateway_running": _is_gateway_running(default_home),
             "model": model,
             "provider": provider,
             "has_env": (default_home / ".env").exists(),
@@ -2725,6 +2730,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "path": str(entry),
                 "is_default": False,
                 "is_active": _is_active(entry),
+                "gateway_running": _is_gateway_running(entry),
                 "model": model,
                 "provider": provider,
                 "has_env": (entry / ".env").exists(),
@@ -3092,6 +3098,424 @@ async def toggle_profile_skill(name: str, body: SkillToggle):
     skills_cfg["disabled"] = sorted(disabled)
     _save_profile_raw_config(profile_dir, config)
     return {"ok": True, "name": body.name, "enabled": body.enabled, "profile": name}
+
+
+# ---------------------------------------------------------------------------
+# Per-profile cron endpoints
+#
+# The legacy /api/cron/jobs routes above operate on the active profile
+# (whichever HERMES_HOME the dashboard process was launched under, via the
+# module-global ``cron.jobs.JOBS_FILE``). The routes below let the UI list
+# and mutate cron jobs for any installed profile without spawning a second
+# dashboard daemon per profile.
+#
+# Reads/writes go directly against the profile's ``cron/jobs.json`` rather
+# than through ``cron.jobs.load_jobs`` / ``cron.jobs.save_jobs`` — those
+# functions are bound to the process-level HERMES_HOME via the resolved
+# ``JOBS_FILE`` and can't be reused for cross-profile mutation without
+# invasive global-state changes (same constraint the per-profile skills
+# routes work around for ``load_config`` / ``save_config``).
+#
+# Trigger requests against a profile whose gateway is not running return
+# 409 Conflict: the dispatcher tick is what actually picks up triggered
+# jobs, so writing ``next_run_at = now`` without a live tick is a silent
+# no-op. The frontend disables the button as the primary UX; this server-
+# side check covers the race where the gateway dies between page load and
+# click.
+# ---------------------------------------------------------------------------
+
+
+# Per-profile in-process locks to serialise dashboard writes to the same
+# profile's jobs.json. Cross-process races with a sub-profile's own
+# dispatcher are handled by ``_save_profile_jobs``'s atomic-replace; this
+# dict-of-locks only protects against two concurrent dashboard requests
+# clobbering each other.
+_profile_jobs_locks: Dict[str, threading.Lock] = {}
+_profile_jobs_locks_guard = threading.Lock()
+
+
+def _profile_jobs_lock(name: str) -> threading.Lock:
+    with _profile_jobs_locks_guard:
+        lock = _profile_jobs_locks.get(name)
+        if lock is None:
+            lock = threading.Lock()
+            _profile_jobs_locks[name] = lock
+        return lock
+
+
+def _profile_cron_jobs_path(profile_dir: Path) -> Path:
+    """Return ``<profile_dir>/cron/jobs.json``.
+
+    ``hermes_cli.profiles.get_profile_dir("default")`` already returns
+    HERMES_HOME itself (not ``HERMES_HOME/profiles/default``), so this
+    yields ``~/.hermes/cron/jobs.json`` for the default profile — matching
+    ``cron.jobs.JOBS_FILE`` for the active-default case — and
+    ``~/.hermes/profiles/<name>/cron/jobs.json`` for sub-profiles.
+    """
+    return profile_dir / "cron" / "jobs.json"
+
+
+def _load_profile_jobs(profile_dir: Path) -> List[Dict[str, Any]]:
+    """Load a profile's cron jobs list. Returns ``[]`` if the file is missing.
+
+    Matches ``cron.jobs.load_jobs``'s return shape (the bare list, not the
+    ``{"jobs": [...]}`` on-disk wrapper) so route bodies can mirror the
+    legacy cron routes one-to-one.
+    """
+    jobs_file = _profile_cron_jobs_path(profile_dir)
+    if not jobs_file.exists():
+        return []
+    try:
+        with open(jobs_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read cron/jobs.json: {e}")
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail=f"Could not parse cron/jobs.json: {e}")
+    if not isinstance(data, dict):
+        return []
+    jobs = data.get("jobs", [])
+    return jobs if isinstance(jobs, list) else []
+
+
+def _save_profile_jobs(profile_dir: Path, jobs: List[Dict[str, Any]]) -> None:
+    """Atomically write a profile's cron jobs list.
+
+    Mirrors ``cron.jobs.save_jobs``'s tempfile + atomic-replace semantics
+    so a concurrent dispatcher read never sees a partially-written file.
+    """
+    import tempfile
+    from hermes_time import now as _hermes_now
+    from utils import atomic_replace
+
+    jobs_file = _profile_cron_jobs_path(profile_dir)
+    try:
+        jobs_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not create cron/ dir: {e}")
+
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(jobs_file.parent), suffix=".tmp", prefix=".jobs_"
+        )
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not create temp file: {e}")
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, jobs_file)
+    except OSError as e:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise HTTPException(status_code=500, detail=f"Could not write cron/jobs.json: {e}")
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# --- Per-profile CRUD helpers (mirror cron/jobs.py's CRUD functions but
+# parametrised on profile_dir; reuse cron.jobs's pure helpers for schedule
+# parsing, next-run computation, and record normalisation) ---
+
+
+def _profile_create_job(
+    profile_dir: Path,
+    *,
+    prompt: str,
+    schedule: str,
+    name: Optional[str] = None,
+    deliver: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a cron job in ``profile_dir``'s jobs.json. Returns the new job."""
+    import uuid
+    from cron.jobs import (
+        compute_next_run,
+        parse_schedule,
+        _apply_skill_fields,
+        _normalize_job_record,
+    )
+    from hermes_time import now as _hermes_now
+
+    parsed_schedule = parse_schedule(schedule)
+    now_iso = _hermes_now().isoformat()
+    job = _apply_skill_fields({
+        "id": str(uuid.uuid4())[:8],
+        "name": (name or "").strip(),
+        "prompt": str(prompt or ""),
+        "skills": [],
+        "skill": None,
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "script": None,
+        "no_agent": False,
+        "context_from": None,
+        "schedule": parsed_schedule,
+        "schedule_display": parsed_schedule.get("display", schedule),
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "created_at": now_iso,
+        "next_run_at": compute_next_run(parsed_schedule),
+        "last_run_at": None,
+        "last_status": None,
+        "last_error": None,
+        "last_delivery_error": None,
+        "deliver": deliver or "local",
+        "origin": None,
+        "enabled_toolsets": None,
+        "workdir": None,
+    })
+    jobs = _load_profile_jobs(profile_dir)
+    jobs.append(job)
+    _save_profile_jobs(profile_dir, jobs)
+    return _normalize_job_record(job)
+
+
+def _profile_update_job(
+    profile_dir: Path, job_id: str, updates: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Apply ``updates`` to a job in ``profile_dir``. Returns the updated job
+    or ``None`` if ``job_id`` is not present. Mirrors cron.jobs.update_job."""
+    from cron.jobs import (
+        compute_next_run,
+        parse_schedule,
+        _apply_skill_fields,
+        _normalize_job_record,
+        _normalize_skill_list,
+        _normalize_workdir,
+    )
+
+    jobs = _load_profile_jobs(profile_dir)
+    for i, job in enumerate(jobs):
+        if job.get("id") != job_id:
+            continue
+
+        if "workdir" in updates:
+            wd = updates["workdir"]
+            if wd in {None, "", False}:
+                updates["workdir"] = None
+            else:
+                updates["workdir"] = _normalize_workdir(wd)
+
+        updated = _apply_skill_fields({**job, **updates})
+        schedule_changed = "schedule" in updates
+
+        if "skills" in updates or "skill" in updates:
+            normalized_skills = _normalize_skill_list(
+                updated.get("skill"), updated.get("skills")
+            )
+            updated["skills"] = normalized_skills
+            updated["skill"] = normalized_skills[0] if normalized_skills else None
+
+        if schedule_changed:
+            updated_schedule = updated["schedule"]
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
+            updated["schedule_display"] = updates.get(
+                "schedule_display",
+                updated_schedule.get("display", updated.get("schedule_display")),
+            )
+            if updated.get("state") != "paused":
+                updated["next_run_at"] = compute_next_run(updated_schedule)
+
+        if (
+            updated.get("enabled", True)
+            and updated.get("state") != "paused"
+            and not updated.get("next_run_at")
+        ):
+            updated["next_run_at"] = compute_next_run(updated["schedule"])
+
+        jobs[i] = updated
+        _save_profile_jobs(profile_dir, jobs)
+        return _normalize_job_record(jobs[i])
+    return None
+
+
+def _profile_pause_job(
+    profile_dir: Path, job_id: str, reason: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    from hermes_time import now as _hermes_now
+    return _profile_update_job(
+        profile_dir,
+        job_id,
+        {
+            "enabled": False,
+            "state": "paused",
+            "paused_at": _hermes_now().isoformat(),
+            "paused_reason": reason,
+        },
+    )
+
+
+def _profile_resume_job(profile_dir: Path, job_id: str) -> Optional[Dict[str, Any]]:
+    from cron.jobs import compute_next_run
+
+    jobs = _load_profile_jobs(profile_dir)
+    target = next((j for j in jobs if j.get("id") == job_id), None)
+    if target is None:
+        return None
+    return _profile_update_job(
+        profile_dir,
+        job_id,
+        {
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "next_run_at": compute_next_run(target.get("schedule") or {}),
+        },
+    )
+
+
+def _profile_trigger_job(profile_dir: Path, job_id: str) -> Optional[Dict[str, Any]]:
+    from hermes_time import now as _hermes_now
+    return _profile_update_job(
+        profile_dir,
+        job_id,
+        {
+            "enabled": True,
+            "state": "scheduled",
+            "paused_at": None,
+            "paused_reason": None,
+            "next_run_at": _hermes_now().isoformat(),
+        },
+    )
+
+
+def _profile_remove_job(profile_dir: Path, job_id: str) -> bool:
+    import shutil
+
+    jobs = _load_profile_jobs(profile_dir)
+    remaining = [j for j in jobs if j.get("id") != job_id]
+    if len(remaining) == len(jobs):
+        return False
+    _save_profile_jobs(profile_dir, remaining)
+    # Clean up the profile's own output directory for this job so deleted
+    # sub-profile jobs don't leave orphaned output dirs accumulating.
+    output_dir = profile_dir / "cron" / "output" / job_id
+    if output_dir.exists():
+        try:
+            shutil.rmtree(output_dir)
+        except OSError:
+            _log.warning("Could not remove cron output dir %s", output_dir)
+    return True
+
+
+# --- Per-profile cron routes (mirror /api/cron/jobs* shape) ---
+
+
+@app.get("/api/profiles/{name}/cron/jobs")
+async def list_profile_cron_jobs(name: str):
+    from cron.jobs import _normalize_job_record
+    profile_dir = _resolve_profile_dir(name)
+    jobs = _load_profile_jobs(profile_dir)
+    return [_normalize_job_record(j) for j in jobs]
+
+
+@app.get("/api/profiles/{name}/cron/jobs/{job_id}")
+async def get_profile_cron_job(name: str, job_id: str):
+    from cron.jobs import _normalize_job_record
+    profile_dir = _resolve_profile_dir(name)
+    jobs = _load_profile_jobs(profile_dir)
+    for j in jobs:
+        if j.get("id") == job_id:
+            return _normalize_job_record(j)
+    raise HTTPException(status_code=404, detail="Job not found")
+
+
+@app.post("/api/profiles/{name}/cron/jobs")
+async def create_profile_cron_job(name: str, body: CronJobCreate):
+    profile_dir = _resolve_profile_dir(name)
+    try:
+        with _profile_jobs_lock(name):
+            return _profile_create_job(
+                profile_dir,
+                prompt=body.prompt,
+                schedule=body.schedule,
+                name=body.name,
+                deliver=body.deliver,
+            )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        _log.exception("POST /api/profiles/%s/cron/jobs failed", name)
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.put("/api/profiles/{name}/cron/jobs/{job_id}")
+async def update_profile_cron_job(name: str, job_id: str, body: CronJobUpdate):
+    profile_dir = _resolve_profile_dir(name)
+    try:
+        with _profile_jobs_lock(name):
+            job = _profile_update_job(profile_dir, job_id, body.updates)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@app.post("/api/profiles/{name}/cron/jobs/{job_id}/pause")
+async def pause_profile_cron_job(name: str, job_id: str):
+    profile_dir = _resolve_profile_dir(name)
+    with _profile_jobs_lock(name):
+        job = _profile_pause_job(profile_dir, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@app.post("/api/profiles/{name}/cron/jobs/{job_id}/resume")
+async def resume_profile_cron_job(name: str, job_id: str):
+    profile_dir = _resolve_profile_dir(name)
+    with _profile_jobs_lock(name):
+        job = _profile_resume_job(profile_dir, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@app.post("/api/profiles/{name}/cron/jobs/{job_id}/trigger")
+async def trigger_profile_cron_job(name: str, job_id: str):
+    from hermes_cli.profiles import _check_gateway_running
+    profile_dir = _resolve_profile_dir(name)
+    if not _check_gateway_running(profile_dir):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Gateway not running for profile '{name}'. "
+                   "Start the gateway to dispatch this job.",
+        )
+    with _profile_jobs_lock(name):
+        job = _profile_trigger_job(profile_dir, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@app.delete("/api/profiles/{name}/cron/jobs/{job_id}")
+async def delete_profile_cron_job(name: str, job_id: str):
+    profile_dir = _resolve_profile_dir(name)
+    with _profile_jobs_lock(name):
+        removed = _profile_remove_job(profile_dir, job_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {"ok": True}
 
 
 @app.get("/api/tools/toolsets")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2657,11 +2657,26 @@ def _profile_attr(info, name: str, default: Any = None) -> Any:
         return default
 
 
+def _active_profile_path_str() -> str:
+    """Resolved HERMES_HOME of the running dashboard process, for is_active comparison."""
+    from hermes_constants import get_hermes_home
+    try:
+        return str(get_hermes_home().resolve())
+    except Exception:
+        return ""
+
+
 def _profile_to_dict(info) -> Dict[str, Any]:
+    path_str = str(_profile_attr(info, "path", ""))
+    try:
+        resolved = str(Path(path_str).resolve()) if path_str else ""
+    except Exception:
+        resolved = path_str
     return {
         "name": _profile_attr(info, "name", ""),
-        "path": str(_profile_attr(info, "path", "")),
+        "path": path_str,
         "is_default": bool(_profile_attr(info, "is_default", False)),
+        "is_active": bool(resolved) and resolved == _active_profile_path_str(),
         "model": _profile_attr(info, "model"),
         "provider": _profile_attr(info, "provider"),
         "has_env": bool(_profile_attr(info, "has_env", False)),
@@ -2676,6 +2691,14 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
         except Exception:
             return default
 
+    active_path_str = _active_profile_path_str()
+
+    def _is_active(path: Path) -> bool:
+        try:
+            return bool(active_path_str) and str(path.resolve()) == active_path_str
+        except Exception:
+            return False
+
     profiles: List[Dict[str, Any]] = []
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
@@ -2684,6 +2707,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             "name": "default",
             "path": str(default_home),
             "is_default": True,
+            "is_active": _is_active(default_home),
             "model": model,
             "provider": provider,
             "has_env": (default_home / ".env").exists(),
@@ -2700,6 +2724,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "name": entry.name,
                 "path": str(entry),
                 "is_default": False,
+                "is_active": _is_active(entry),
                 "model": model,
                 "provider": provider,
                 "has_env": (entry / ".env").exists(),
@@ -2915,6 +2940,158 @@ async def toggle_skill(body: SkillToggle):
         disabled.add(body.name)
     save_disabled_skills(config, disabled)
     return {"ok": True, "name": body.name, "enabled": body.enabled}
+
+
+# ---------------------------------------------------------------------------
+# Per-profile skills endpoints
+#
+# The legacy /api/skills routes above operate on the active profile
+# (whichever HERMES_HOME the dashboard process was launched under). The
+# routes below let the UI list and toggle skills for any installed profile
+# without spawning a second dashboard daemon per profile.
+#
+# Reads/writes go directly against the profile's config.yaml (skills.disabled
+# key) rather than through load_config / save_config — those helpers are
+# bound to the process-level HERMES_HOME via get_config_path().
+# ---------------------------------------------------------------------------
+
+
+def _profile_config_path(profile_dir: Path) -> Path:
+    return profile_dir / "config.yaml"
+
+
+def _load_profile_raw_config(profile_dir: Path) -> Dict[str, Any]:
+    """Read a profile's config.yaml as raw YAML. Returns {} if missing/empty."""
+    config_path = _profile_config_path(profile_dir)
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml as _yaml
+        with open(config_path, encoding="utf-8") as f:
+            data = _yaml.safe_load(f)
+        return data if isinstance(data, dict) else {}
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read config.yaml: {e}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Could not parse config.yaml: {e}")
+
+
+def _save_profile_raw_config(profile_dir: Path, config: Dict[str, Any]) -> None:
+    from utils import atomic_yaml_write
+    try:
+        atomic_yaml_write(_profile_config_path(profile_dir), config)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not write config.yaml: {e}")
+
+
+def _find_skills_in_profile(profile_dir: Path) -> List[Dict[str, Any]]:
+    """Scan profile_dir/skills/ for SKILL.md files and return the same shape
+    as ``tools.skills_tool._find_all_skills`` (without external_dirs).
+
+    External-dir scanning is intentionally omitted for v1 — the dropdown is
+    aimed at toggling profile-installed skills. Skills loaded via
+    ``skills.external_dirs`` are still respected at gateway runtime.
+
+    Category is derived from the directory layout under the profile's own
+    skills/ root (matching the convention used by
+    ``tools.skills_tool._get_category_from_path``, which is hardcoded to the
+    process-level SKILLS_DIR and therefore can't be reused here).
+    """
+    from tools.skills_tool import (
+        MAX_DESCRIPTION_LENGTH,
+        MAX_NAME_LENGTH,
+        _EXCLUDED_SKILL_DIRS,
+        _parse_frontmatter,
+        skill_matches_platform,
+    )
+    from agent.skill_utils import iter_skill_index_files
+
+    skills_dir = profile_dir / "skills"
+    if not skills_dir.is_dir():
+        return []
+
+    def _category(skill_md_path: Path) -> Optional[str]:
+        try:
+            rel = skill_md_path.relative_to(skills_dir)
+        except ValueError:
+            return None
+        # rel like "mlops/axolotl/SKILL.md" → "mlops"; "airtable/SKILL.md" → None
+        return rel.parts[0] if len(rel.parts) >= 3 else None
+
+    out: List[Dict[str, Any]] = []
+    seen: set = set()
+    for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
+        if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")[:4000]
+            frontmatter, body = _parse_frontmatter(content)
+            if not skill_matches_platform(frontmatter):
+                continue
+            name = frontmatter.get("name", skill_md.parent.name)[:MAX_NAME_LENGTH]
+            if name in seen:
+                continue
+            description = frontmatter.get("description", "")
+            if not description:
+                for line in body.strip().split("\n"):
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        description = line
+                        break
+            if len(description) > MAX_DESCRIPTION_LENGTH:
+                description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
+            seen.add(name)
+            out.append({
+                "name": name,
+                "description": description,
+                "category": _category(skill_md),
+                "path": str(skill_md.parent),
+            })
+        except (OSError, UnicodeDecodeError):
+            continue
+    out.sort(key=lambda s: s["name"].lower())
+    return out
+
+
+def _profile_disabled_skills(config: Dict[str, Any]) -> set:
+    skills_cfg = config.get("skills") if isinstance(config, dict) else None
+    if not isinstance(skills_cfg, dict):
+        return set()
+    disabled = skills_cfg.get("disabled", [])
+    if not isinstance(disabled, list):
+        return set()
+    return {str(x) for x in disabled}
+
+
+@app.get("/api/profiles/{name}/skills")
+async def get_profile_skills(name: str):
+    profile_dir = _resolve_profile_dir(name)
+    config = _load_profile_raw_config(profile_dir)
+    disabled = _profile_disabled_skills(config)
+    skills = _find_skills_in_profile(profile_dir)
+    for s in skills:
+        s["enabled"] = s["name"] not in disabled
+    return skills
+
+
+@app.put("/api/profiles/{name}/skills/toggle")
+async def toggle_profile_skill(name: str, body: SkillToggle):
+    profile_dir = _resolve_profile_dir(name)
+    config = _load_profile_raw_config(profile_dir)
+    skills_cfg = config.setdefault("skills", {}) if isinstance(config, dict) else None
+    if not isinstance(skills_cfg, dict):
+        # The skills key existed but wasn't a dict — overwrite with a fresh mapping.
+        config["skills"] = {}
+        skills_cfg = config["skills"]
+    raw_disabled = skills_cfg.get("disabled", [])
+    disabled = {str(x) for x in raw_disabled} if isinstance(raw_disabled, list) else set()
+    if body.enabled:
+        disabled.discard(body.name)
+    else:
+        disabled.add(body.name)
+    skills_cfg["disabled"] = sorted(disabled)
+    _save_profile_raw_config(profile_dir, config)
+    return {"ok": True, "name": body.name, "enabled": body.enabled, "profile": name}
 
 
 @app.get("/api/tools/toolsets")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -957,6 +957,312 @@ class TestNewEndpoints:
         assert resp.status_code == 400
         assert "Invalid profile name" in resp.json()["detail"]
 
+    # --- Per-profile cron ---
+
+    def test_profiles_list_reports_gateway_running(self, monkeypatch):
+        """``GET /api/profiles`` should surface ``gateway_running`` for every
+        profile. A freshly-created sub-profile has no live gateway, so it
+        should report ``gateway_running=False`` regardless of whether the
+        running daemon's own profile reports True."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "gw-flag-prof"})
+        try:
+            data = self.client.get("/api/profiles").json()
+        finally:
+            self.client.delete("/api/profiles/gw-flag-prof")
+        by_name = {p["name"]: p for p in data["profiles"]}
+        # The field is present on every row, even if False.
+        for p in data["profiles"]:
+            assert "gateway_running" in p
+            assert isinstance(p["gateway_running"], bool)
+        if "gw-flag-prof" in by_name:
+            assert by_name["gw-flag-prof"]["gateway_running"] is False
+
+    def test_profile_cron_jobs_list_empty_for_new_profile(self, monkeypatch):
+        """A freshly-created profile with no cron/jobs.json yet should return
+        an empty list with 200 — not 404 and not 500."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "empty-cron-prof"})
+        try:
+            resp = self.client.get("/api/profiles/empty-cron-prof/cron/jobs")
+            assert resp.status_code == 200
+            assert resp.json() == []
+        finally:
+            self.client.delete("/api/profiles/empty-cron-prof")
+
+    def test_profile_cron_jobs_create_list_get(self, monkeypatch):
+        """POST a job to a sub-profile, then GET against the same profile
+        returns the job and GET against the default profile does not."""
+        from pathlib import Path
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "cron-create-prof"})
+        try:
+            created = self.client.post(
+                "/api/profiles/cron-create-prof/cron/jobs",
+                json={"prompt": "hello world", "schedule": "every 30m", "name": "tick"},
+            )
+            assert created.status_code == 200, created.text
+            body = created.json()
+            assert body["name"] == "tick"
+            assert body["prompt"] == "hello world"
+            job_id = body["id"]
+
+            # Read it back via the per-profile list and single-get routes.
+            listed = self.client.get("/api/profiles/cron-create-prof/cron/jobs")
+            assert listed.status_code == 200
+            assert any(j["id"] == job_id for j in listed.json())
+
+            single = self.client.get(
+                f"/api/profiles/cron-create-prof/cron/jobs/{job_id}"
+            )
+            assert single.status_code == 200
+            assert single.json()["id"] == job_id
+
+            # The job is written to the profile's own jobs.json.
+            profile_dir = Path(profiles_mod.get_profile_dir("cron-create-prof"))
+            assert (profile_dir / "cron" / "jobs.json").exists()
+
+            # The default profile's cron list does not see the sub-profile's
+            # job (cross-profile isolation).
+            default_list = self.client.get("/api/cron/jobs").json()
+            assert all(j["id"] != job_id for j in default_list)
+        finally:
+            self.client.delete("/api/profiles/cron-create-prof")
+
+    def test_profile_cron_jobs_pause_resume_trigger_delete(self, monkeypatch):
+        """Pause → resume toggles the enabled flag in jobs.json; trigger
+        succeeds when the gateway is reported running and 409s when it
+        isn't; delete removes the job and a subsequent GET returns 404."""
+        import hermes_cli.profiles as profiles_mod
+        import hermes_cli.web_server as web_server_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "cron-lifecycle-prof"})
+        try:
+            created = self.client.post(
+                "/api/profiles/cron-lifecycle-prof/cron/jobs",
+                json={"prompt": "pause me", "schedule": "every 1h"},
+            )
+            job_id = created.json()["id"]
+
+            paused = self.client.post(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}/pause"
+            )
+            assert paused.status_code == 200
+            assert paused.json()["enabled"] is False
+            assert paused.json()["state"] == "paused"
+
+            resumed = self.client.post(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}/resume"
+            )
+            assert resumed.status_code == 200
+            assert resumed.json()["enabled"] is True
+            assert resumed.json()["state"] == "scheduled"
+
+            # Trigger with the gateway running → 200.
+            monkeypatch.setattr(
+                "hermes_cli.profiles._check_gateway_running",
+                lambda profile_dir: True,
+            )
+            triggered = self.client.post(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}/trigger"
+            )
+            assert triggered.status_code == 200, triggered.text
+
+            # Trigger when the gateway is reported down → 409.
+            monkeypatch.setattr(
+                "hermes_cli.profiles._check_gateway_running",
+                lambda profile_dir: False,
+            )
+            blocked = self.client.post(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}/trigger"
+            )
+            assert blocked.status_code == 409
+            assert "Gateway not running" in blocked.json()["detail"]
+
+            # Delete it; subsequent GET 404s.
+            deleted = self.client.delete(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}"
+            )
+            assert deleted.status_code == 200
+            assert deleted.json() == {"ok": True}
+
+            missing = self.client.get(
+                f"/api/profiles/cron-lifecycle-prof/cron/jobs/{job_id}"
+            )
+            assert missing.status_code == 404
+        finally:
+            self.client.delete("/api/profiles/cron-lifecycle-prof")
+
+    def test_profile_cron_job_update_persists(self, monkeypatch):
+        """PUT applies arbitrary updates dict and the changes round-trip."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "cron-edit-prof"})
+        try:
+            created = self.client.post(
+                "/api/profiles/cron-edit-prof/cron/jobs",
+                json={"prompt": "old prompt", "schedule": "every 10m", "name": "old"},
+            )
+            job_id = created.json()["id"]
+
+            updated = self.client.put(
+                f"/api/profiles/cron-edit-prof/cron/jobs/{job_id}",
+                json={"updates": {"name": "new", "prompt": "new prompt"}},
+            )
+            assert updated.status_code == 200
+            assert updated.json()["name"] == "new"
+            assert updated.json()["prompt"] == "new prompt"
+
+            single = self.client.get(
+                f"/api/profiles/cron-edit-prof/cron/jobs/{job_id}"
+            ).json()
+            assert single["name"] == "new"
+            assert single["prompt"] == "new prompt"
+        finally:
+            self.client.delete("/api/profiles/cron-edit-prof")
+
+    def test_profile_cron_job_multiline_prompt_roundtrip(self, monkeypatch):
+        """A prompt containing newlines, embedded quotes, and backslashes
+        survives create → list → get verbatim. Closes the
+        ``hermes cron edit --prompt`` multiline foot-gun for the dashboard
+        write path."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        gnarly = 'line 1\nline 2 with "quotes"\nline 3 with \\backslash\\\nfinal'
+        self.client.post("/api/profiles", json={"name": "cron-multi-prof"})
+        try:
+            created = self.client.post(
+                "/api/profiles/cron-multi-prof/cron/jobs",
+                json={"prompt": gnarly, "schedule": "every 1d"},
+            )
+            assert created.status_code == 200, created.text
+            assert created.json()["prompt"] == gnarly
+            job_id = created.json()["id"]
+
+            single = self.client.get(
+                f"/api/profiles/cron-multi-prof/cron/jobs/{job_id}"
+            ).json()
+            assert single["prompt"] == gnarly
+        finally:
+            self.client.delete("/api/profiles/cron-multi-prof")
+
+    def test_profile_cron_job_recurring_vs_oneshot_schedule(self, monkeypatch):
+        """'every 4320m' parses as recurring (kind=interval); '4320m' parses
+        as one-shot (kind=once). Closes the schedule-prefix foot-gun at
+        the API boundary."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "cron-schedkind-prof"})
+        try:
+            recurring = self.client.post(
+                "/api/profiles/cron-schedkind-prof/cron/jobs",
+                json={"prompt": "loop", "schedule": "every 4320m"},
+            )
+            assert recurring.status_code == 200, recurring.text
+            assert recurring.json()["schedule"]["kind"] == "interval"
+
+            once = self.client.post(
+                "/api/profiles/cron-schedkind-prof/cron/jobs",
+                json={"prompt": "single", "schedule": "4320m"},
+            )
+            assert once.status_code == 200, once.text
+            assert once.json()["schedule"]["kind"] == "once"
+        finally:
+            self.client.delete("/api/profiles/cron-schedkind-prof")
+
+    def test_profile_cron_unknown_profile_404(self):
+        """Any per-profile cron route called against a missing profile
+        returns 404 with the same ``detail`` shape the skills routes use."""
+        resp = self.client.get("/api/profiles/nonexistent/cron/jobs")
+        assert resp.status_code == 404
+        resp2 = self.client.post(
+            "/api/profiles/nonexistent/cron/jobs",
+            json={"prompt": "x", "schedule": "every 5m"},
+        )
+        assert resp2.status_code == 404
+        resp3 = self.client.post(
+            "/api/profiles/nonexistent/cron/jobs/anything/pause"
+        )
+        assert resp3.status_code == 404
+
+    def test_profile_cron_invalid_name_400(self):
+        resp = self.client.get("/api/profiles/Bad@Name/cron/jobs")
+        assert resp.status_code == 400
+        assert "Invalid profile name" in resp.json()["detail"]
+
+    def test_profile_cron_job_id_not_found_404(self, monkeypatch):
+        """Operating on a bogus job_id against a real profile returns 404."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+        # Pretend the gateway is up so trigger reaches the job-id lookup
+        # rather than short-circuiting on the gateway-not-running gate.
+        monkeypatch.setattr(
+            "hermes_cli.profiles._check_gateway_running",
+            lambda profile_dir: True,
+        )
+
+        self.client.post("/api/profiles", json={"name": "cron-bogus-id-prof"})
+        try:
+            for route in (
+                ("GET", "/api/profiles/cron-bogus-id-prof/cron/jobs/bogus"),
+                ("POST", "/api/profiles/cron-bogus-id-prof/cron/jobs/bogus/pause"),
+                ("POST", "/api/profiles/cron-bogus-id-prof/cron/jobs/bogus/resume"),
+                ("POST", "/api/profiles/cron-bogus-id-prof/cron/jobs/bogus/trigger"),
+                ("DELETE", "/api/profiles/cron-bogus-id-prof/cron/jobs/bogus"),
+            ):
+                method, path = route
+                resp = self.client.request(method, path)
+                assert resp.status_code == 404, f"{method} {path} → {resp.status_code} {resp.text}"
+        finally:
+            self.client.delete("/api/profiles/cron-bogus-id-prof")
+
+    def test_profile_cron_gateway_running_consistent_with_profiles_list(
+        self, monkeypatch
+    ):
+        """The same ``_check_gateway_running`` helper backs both
+        ``GET /api/profiles`` (``gateway_running`` field) and the trigger
+        route's 409 gate. Verifies there's no skew: when one says the
+        gateway is down, the other agrees."""
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        # Force every gateway check to report False for the duration of
+        # this test, then create a job and try to trigger it.
+        monkeypatch.setattr(
+            "hermes_cli.profiles._check_gateway_running",
+            lambda profile_dir: False,
+        )
+
+        self.client.post("/api/profiles", json={"name": "cron-consist-prof"})
+        try:
+            data = self.client.get("/api/profiles").json()
+            by_name = {p["name"]: p for p in data["profiles"]}
+            # Both the new profile and the default profile should report
+            # gateway_running=False under the monkeypatch.
+            assert by_name["cron-consist-prof"]["gateway_running"] is False
+
+            created = self.client.post(
+                "/api/profiles/cron-consist-prof/cron/jobs",
+                json={"prompt": "x", "schedule": "every 5m"},
+            )
+            job_id = created.json()["id"]
+            resp = self.client.post(
+                f"/api/profiles/cron-consist-prof/cron/jobs/{job_id}/trigger"
+            )
+            assert resp.status_code == 409
+        finally:
+            self.client.delete("/api/profiles/cron-consist-prof")
+
     def test_toolsets_list(self):
         resp = self.client.get("/api/tools/toolsets")
         assert resp.status_code == 200

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -853,6 +853,110 @@ class TestNewEndpoints:
             },
         ]
 
+    def test_profiles_list_marks_default_profile_active(self):
+        """The default profile (whose HERMES_HOME the dashboard process is bound
+        to) should report is_active=True; sub-profiles created during the test
+        should not."""
+        import hermes_cli.profiles as profiles_mod
+        # Sub-profile creation paths sometimes call into the gateway service
+        # cleanup helper — stub it out so the test stays hermetic.
+        # (mirrors test_profile_soul_round_trip)
+        try:
+            import pytest  # noqa: F401
+        except ImportError:
+            pass
+        profiles_mod_orig = profiles_mod._cleanup_gateway_service
+        profiles_mod._cleanup_gateway_service = lambda *a, **kw: None
+        try:
+            self.client.post("/api/profiles", json={"name": "active-test-prof"})
+            data = self.client.get("/api/profiles").json()
+        finally:
+            self.client.delete("/api/profiles/active-test-prof")
+            profiles_mod._cleanup_gateway_service = profiles_mod_orig
+        by_name = {p["name"]: p for p in data["profiles"]}
+        assert by_name["default"]["is_active"] is True
+        if "active-test-prof" in by_name:
+            assert by_name["active-test-prof"]["is_active"] is False
+
+    def test_profile_skills_list_picks_up_profile_dir(self, monkeypatch):
+        """GET /api/profiles/{name}/skills should scan the profile's own
+        skills/ directory, not the process-level HERMES_HOME."""
+        from pathlib import Path
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "skill-scope-prof"})
+        try:
+            profile_dir = Path(profiles_mod.get_profile_dir("skill-scope-prof"))
+            skill_dir = profile_dir / "skills" / "productivity" / "ben-only-skill"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\n"
+                "name: ben-only-skill\n"
+                "description: A skill that exists only in skill-scope-prof.\n"
+                "---\n"
+                "# Body\n",
+                encoding="utf-8",
+            )
+            resp = self.client.get("/api/profiles/skill-scope-prof/skills")
+            assert resp.status_code == 200
+            skills = resp.json()
+            found = [s for s in skills if s["name"] == "ben-only-skill"]
+            assert len(found) == 1, f"expected 1 ben-only-skill, got {skills}"
+            assert found[0]["enabled"] is True
+            assert found[0]["category"] == "productivity"
+            assert found[0]["description"].startswith("A skill that exists")
+        finally:
+            self.client.delete("/api/profiles/skill-scope-prof")
+
+    def test_profile_skill_toggle_persists_to_profile_config(self, monkeypatch):
+        """PUT /api/profiles/{name}/skills/toggle should write to the profile's
+        own config.yaml, leaving the dashboard's active profile untouched."""
+        from pathlib import Path
+        import yaml
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "toggle-prof"})
+        try:
+            put = self.client.put(
+                "/api/profiles/toggle-prof/skills/toggle",
+                json={"name": "fake-skill", "enabled": False},
+            )
+            assert put.status_code == 200
+            assert put.json()["profile"] == "toggle-prof"
+            assert put.json()["enabled"] is False
+
+            profile_cfg = Path(profiles_mod.get_profile_dir("toggle-prof")) / "config.yaml"
+            assert profile_cfg.exists()
+            parsed = yaml.safe_load(profile_cfg.read_text(encoding="utf-8")) or {}
+            assert parsed.get("skills", {}).get("disabled") == ["fake-skill"]
+
+            # Re-enable removes the entry rather than leaving a stale flag.
+            put2 = self.client.put(
+                "/api/profiles/toggle-prof/skills/toggle",
+                json={"name": "fake-skill", "enabled": True},
+            )
+            assert put2.status_code == 200
+            parsed2 = yaml.safe_load(profile_cfg.read_text(encoding="utf-8")) or {}
+            assert parsed2.get("skills", {}).get("disabled") == []
+        finally:
+            self.client.delete("/api/profiles/toggle-prof")
+
+    def test_profile_skills_unknown_profile_404(self):
+        resp = self.client.get("/api/profiles/nonexistent/skills")
+        assert resp.status_code == 404
+        resp2 = self.client.put(
+            "/api/profiles/nonexistent/skills/toggle",
+            json={"name": "x", "enabled": False},
+        )
+        assert resp2.status_code == 404
+
+    def test_profile_skills_invalid_name_400(self):
+        resp = self.client.get("/api/profiles/Bad@Name/skills")
+        assert resp.status_code == 400
+        assert "Invalid profile name" in resp.json()["detail"]
+
     def test_toolsets_list(self):
         resp = self.client.get("/api/tools/toolsets")
         assert resp.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -203,6 +203,20 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name, enabled }),
     }),
+  // Per-profile skill management. The dashboard daemon edits the active
+  // profile by default; these routes let it edit other installed profiles
+  // without spawning a second daemon per profile.
+  getProfileSkills: (profile: string) =>
+    fetchJSON<SkillInfo[]>(`/api/profiles/${encodeURIComponent(profile)}/skills`),
+  toggleProfileSkill: (profile: string, name: string, enabled: boolean) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/profiles/${encodeURIComponent(profile)}/skills/toggle`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, enabled }),
+      },
+    ),
   getToolsets: () => fetchJSON<ToolsetInfo[]>("/api/tools/toolsets"),
 
   // Session search (FTS5)
@@ -505,6 +519,13 @@ export interface ProfileInfo {
   name: string;
   path: string;
   is_default: boolean;
+  /**
+   * True when this profile is the one the running dashboard process is
+   * bound to (matches HERMES_HOME). Optional for backward-compat with
+   * older gateways that don't emit the field — callers should treat
+   * undefined as false.
+   */
+  is_active?: boolean;
   model: string | null;
   provider: string | null;
   has_env: boolean;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -154,6 +154,65 @@ export const api = {
   deleteCronJob: (id: string) =>
     fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}`, { method: "DELETE" }),
 
+  // Per-profile cron jobs. The dashboard daemon manages the active profile
+  // by default via /api/cron/jobs; these routes let it read and mutate jobs
+  // for any installed profile without spawning a second daemon per profile.
+  // Trigger requests against a profile whose gateway isn't running return
+  // 409 — the UI disables the button via ProfileInfo.gateway_running.
+  getProfileCronJobs: (profile: string) =>
+    fetchJSON<CronJob[]>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs`,
+    ),
+  getProfileCronJob: (profile: string, id: string) =>
+    fetchJSON<CronJob>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}`,
+    ),
+  createProfileCronJob: (
+    profile: string,
+    job: { prompt: string; schedule: string; name?: string; deliver?: string },
+  ) =>
+    fetchJSON<CronJob>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(job),
+      },
+    ),
+  updateProfileCronJob: (
+    profile: string,
+    id: string,
+    updates: Record<string, unknown>,
+  ) =>
+    fetchJSON<CronJob>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ updates }),
+      },
+    ),
+  pauseProfileCronJob: (profile: string, id: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}/pause`,
+      { method: "POST" },
+    ),
+  resumeProfileCronJob: (profile: string, id: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}/resume`,
+      { method: "POST" },
+    ),
+  triggerProfileCronJob: (profile: string, id: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}/trigger`,
+      { method: "POST" },
+    ),
+  deleteProfileCronJob: (profile: string, id: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/profiles/${encodeURIComponent(profile)}/cron/jobs/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    ),
+
   // Profiles (minimal)
   getProfiles: () =>
     fetchJSON<{ profiles: ProfileInfo[] }>("/api/profiles"),
@@ -526,6 +585,15 @@ export interface ProfileInfo {
    * undefined as false.
    */
   is_active?: boolean;
+  /**
+   * True when this profile's gateway daemon is currently up (PID-file
+   * plus process-identity check). Used by the Cron page to gate the
+   * per-row trigger button: trigger writes ``next_run_at = now``, which
+   * is a silent no-op without a live dispatcher tick. Optional for
+   * backward-compat with older gateways — callers should treat undefined
+   * as false.
+   */
+  gateway_running?: boolean;
   model: string | null;
   provider: string | null;
   has_env: boolean;

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { Clock, Pause, Play, Plus, Trash2, X, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -6,7 +6,7 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@/components/NouiTypography";
 import { api } from "@/lib/api";
-import type { CronJob } from "@/lib/api";
+import type { CronJob, ProfileInfo } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@/hooks/useToast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
@@ -18,6 +18,20 @@ import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
+
+// Sentinel value for the dropdown's "All profiles" option. Kept as a value
+// here (not a name conflict with any installed profile) so the existing
+// profile-name validation rules — which forbid uppercase — protect it.
+const ALL_PROFILES = "ALL" as const;
+
+// Annotated row carrying the owning profile and that profile's live
+// gateway state. The "All" view merges N per-profile responses into a
+// flat list of these; the per-profile view annotates with the filter's
+// own profile + gateway_running.
+type CronJobRow = CronJob & {
+  profile: string;
+  gateway_running: boolean;
+};
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -69,6 +83,16 @@ function getJobState(job: CronJob): string {
   return asText(job.state) || (job.enabled === false ? "disabled" : "scheduled");
 }
 
+// Render the same recurrence marker `hermes cron list` shows, so the
+// "4320m" (one-shot) vs "every 4320m" (recurring) foot-gun is visible at
+// a glance. Returns "" for jobs without a recognisable schedule kind.
+function getJobRepeatLabel(job: CronJob): string {
+  const kind = job.schedule?.kind;
+  if (kind === "once") return "Repeat: 1/1";
+  if (kind === "interval" || kind === "cron") return "Repeat: ∞";
+  return "";
+}
+
 const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
   enabled: "success",
   scheduled: "success",
@@ -78,45 +102,144 @@ const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
 };
 
 export default function CronPage() {
-  const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [jobs, setJobs] = useState<CronJobRow[]>([]);
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState<string>(ALL_PROFILES);
   const [loading, setLoading] = useState(true);
+  const [jobsLoading, setJobsLoading] = useState(false);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
 
-  // New job modal state
+  // Active-profile fallback chain: is_active (modern gateways) → is_default
+  // (older gateways without is_active) → first profile (last-resort).
+  // Matches the SkillsPage pattern so the active marker stays consistent
+  // across older daemons.
+  const activeProfileName = useMemo(() => {
+    const active = profiles.find((p) => p.is_active);
+    if (active) return active.name;
+    const dflt = profiles.find((p) => p.is_default);
+    return dflt?.name ?? profiles[0]?.name ?? "";
+  }, [profiles]);
+
+  const showProfileColumn =
+    selectedProfile === ALL_PROFILES && profiles.length > 1;
+
+  // New job modal state. ``createProfile`` defaults to the active profile;
+  // when the user is filtered to a specific profile the form targets that
+  // one and hides the selector.
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [schedule, setSchedule] = useState("");
   const [name, setName] = useState("");
+  const [deliver, setDeliver] = useState("local");
+  const [createProfile, setCreateProfile] = useState("");
+  const [creating, setCreating] = useState(false);
   const closeCreateModal = useCallback(() => setCreateModalOpen(false), []);
   const createModalRef = useModalBehavior({
     open: createModalOpen,
     onClose: closeCreateModal,
   });
-  const [deliver, setDeliver] = useState("local");
-  const [creating, setCreating] = useState(false);
 
-  const loadJobs = useCallback(() => {
+  const openCreateModal = useCallback(() => {
+    setCreateProfile(
+      selectedProfile === ALL_PROFILES ? activeProfileName : selectedProfile,
+    );
+    setCreateModalOpen(true);
+  }, [selectedProfile, activeProfileName]);
+
+  // Fetch jobs for the current selection. ``profileList`` is passed in
+  // explicitly because callers (initial load + dropdown change) want to
+  // pass either freshly-fetched profiles or the already-set state.
+  const loadJobs = useCallback(
+    async (profileList: ProfileInfo[], selection: string) => {
+      setJobsLoading(true);
+      try {
+        if (selection === ALL_PROFILES) {
+          const settled = await Promise.allSettled(
+            profileList.map((p) =>
+              api
+                .getProfileCronJobs(p.name)
+                .then((rows): CronJobRow[] =>
+                  rows.map((j) => ({
+                    ...j,
+                    profile: p.name,
+                    gateway_running: Boolean(p.gateway_running),
+                  })),
+                ),
+            ),
+          );
+          const merged: CronJobRow[] = [];
+          settled.forEach((res) => {
+            if (res.status === "fulfilled") {
+              merged.push(...res.value);
+            }
+          });
+          setJobs(merged);
+        } else {
+          const target = profileList.find((p) => p.name === selection);
+          const rows = await api.getProfileCronJobs(selection);
+          setJobs(
+            rows.map((j) => ({
+              ...j,
+              profile: selection,
+              gateway_running: Boolean(target?.gateway_running),
+            })),
+          );
+        }
+      } catch (e) {
+        showToast(`${t.status.error}: ${e}`, "error");
+      } finally {
+        setJobsLoading(false);
+      }
+    },
+    [showToast, t.status.error],
+  );
+
+  // Initial load: profiles + jobs for "All" view. The "All" default differs
+  // from SkillsPage (which defaults to the active profile) because cron is
+  // operations work that benefits from cross-profile visibility; skills is
+  // per-profile config work.
+  useEffect(() => {
     api
-      .getCronJobs()
-      .then(setJobs)
+      .getProfiles()
+      .then(async ({ profiles: profileList }) => {
+        setProfiles(profileList);
+        await loadJobs(profileList, ALL_PROFILES);
+      })
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
-  }, [showToast, t.common.loading]);
+    // loadJobs depends on showToast/t.status.error — but we deliberately
+    // run this only on mount. Subsequent loads happen via the selection
+    // effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
+  // Refetch when the dropdown changes (skip the initial mount, which the
+  // load effect above already handled).
   useEffect(() => {
-    loadJobs();
-  }, [loadJobs]);
+    if (loading) return;
+    loadJobs(profiles, selectedProfile);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProfile]);
+
+  const refreshJobs = useCallback(() => {
+    loadJobs(profiles, selectedProfile);
+  }, [loadJobs, profiles, selectedProfile]);
 
   const handleCreate = async () => {
     if (!prompt.trim() || !schedule.trim()) {
       showToast(`${t.cron.prompt} & ${t.cron.schedule} required`, "error");
       return;
     }
+    const target = createProfile || activeProfileName;
+    if (!target) {
+      showToast(`${t.status.error}: no profile selected`, "error");
+      return;
+    }
     setCreating(true);
     try {
-      await api.createCronJob({
+      await api.createProfileCronJob(target, {
         prompt: prompt.trim(),
         schedule: schedule.trim(),
         name: name.trim() || undefined,
@@ -128,7 +251,7 @@ export default function CronPage() {
       setName("");
       setDeliver("local");
       setCreateModalOpen(false);
-      loadJobs();
+      refreshJobs();
     } catch (e) {
       showToast(`${t.config.failedToSave}: ${e}`, "error");
     } finally {
@@ -136,36 +259,36 @@ export default function CronPage() {
     }
   };
 
-  const handlePauseResume = async (job: CronJob) => {
+  const handlePauseResume = async (job: CronJobRow) => {
     try {
       const isPaused = getJobState(job) === "paused";
       if (isPaused) {
-        await api.resumeCronJob(job.id);
+        await api.resumeProfileCronJob(job.profile, job.id);
         showToast(
           `${t.cron.resume}: "${truncateText(getJobTitle(job), 30)}"`,
           "success",
         );
       } else {
-        await api.pauseCronJob(job.id);
+        await api.pauseProfileCronJob(job.profile, job.id);
         showToast(
           `${t.cron.pause}: "${truncateText(getJobTitle(job), 30)}"`,
           "success",
         );
       }
-      loadJobs();
+      refreshJobs();
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
   };
 
-  const handleTrigger = async (job: CronJob) => {
+  const handleTrigger = async (job: CronJobRow) => {
     try {
-      await api.triggerCronJob(job.id);
+      await api.triggerProfileCronJob(job.profile, job.id);
       showToast(
         `${t.cron.triggerNow}: "${truncateText(getJobTitle(job), 30)}"`,
         "success",
       );
-      loadJobs();
+      refreshJobs();
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
@@ -175,29 +298,27 @@ export default function CronPage() {
     onDelete: useCallback(
       async (id: string) => {
         const job = jobs.find((j) => j.id === id);
+        if (!job) return;
         try {
-          await api.deleteCronJob(id);
+          await api.deleteProfileCronJob(job.profile, id);
           showToast(
-            `${t.common.delete}: "${job ? truncateText(getJobTitle(job), 30) : id}"`,
+            `${t.common.delete}: "${truncateText(getJobTitle(job), 30)}"`,
             "success",
           );
-          loadJobs();
+          refreshJobs();
         } catch (e) {
           showToast(`${t.status.error}: ${e}`, "error");
           throw e;
         }
       },
-      [jobs, loadJobs, showToast, t.common.delete, t.status.error],
+      [jobs, refreshJobs, showToast, t.common.delete, t.status.error],
     ),
   });
 
   // Put "Create" button in page header
   useLayoutEffect(() => {
     setEnd(
-      <Button
-        size="sm"
-        onClick={() => setCreateModalOpen(true)}
-      >
+      <Button size="sm" onClick={openCreateModal}>
         <Plus className="h-3 w-3" />
         {t.common.create}
       </Button>,
@@ -205,7 +326,7 @@ export default function CronPage() {
     return () => {
       setEnd(null);
     };
-  }, [setEnd, t.common.create, loading]);
+  }, [setEnd, t.common.create, openCreateModal]);
 
   if (loading) {
     return (
@@ -218,6 +339,9 @@ export default function CronPage() {
   const pendingJob = jobDelete.pendingId
     ? jobs.find((j) => j.id === jobDelete.pendingId)
     : null;
+
+  const showProfileSelectorInCreate =
+    profiles.length > 1 && selectedProfile === ALL_PROFILES;
 
   return (
     <div className="flex flex-col gap-6">
@@ -270,6 +394,25 @@ export default function CronPage() {
             </header>
 
             <div className="p-5 grid gap-4">
+              {showProfileSelectorInCreate && (
+                <div className="grid gap-2">
+                  <Label htmlFor="cron-profile">Profile</Label>
+                  <Select
+                    id="cron-profile"
+                    value={createProfile}
+                    onValueChange={(v) => setCreateProfile(v)}
+                  >
+                    {profiles.map((p) => (
+                      <SelectOption key={p.name} value={p.name}>
+                        {p.name === activeProfileName
+                          ? `${p.name} (active)`
+                          : p.name}
+                      </SelectOption>
+                    ))}
+                  </Select>
+                </div>
+              )}
+
               <div className="grid gap-2">
                 <Label htmlFor="cron-name">{t.cron.nameOptional}</Label>
                 <Input
@@ -344,6 +487,32 @@ export default function CronPage() {
         </div>
       )}
 
+      {profiles.length > 1 && (
+        <div className="flex items-center gap-3 border border-border bg-muted/20 px-3 py-2">
+          <span className="font-mondwest text-[0.65rem] tracking-[0.12em] uppercase text-muted-foreground">
+            Profile
+          </span>
+          <Select
+            value={selectedProfile}
+            onValueChange={(v) => setSelectedProfile(v)}
+            aria-label="Profile filter"
+            className="w-48 text-xs [&>button]:h-7 [&>button]:py-0"
+          >
+            <SelectOption value={ALL_PROFILES}>All</SelectOption>
+            {profiles.map((p) => (
+              <SelectOption key={p.name} value={p.name}>
+                {p.name === activeProfileName
+                  ? `${p.name} (active)`
+                  : p.name}
+              </SelectOption>
+            ))}
+          </Select>
+          {jobsLoading ? (
+            <Spinner className="text-xs text-muted-foreground" />
+          ) : null}
+        </div>
+      )}
+
       <div className="flex flex-col gap-3">
         <H2
           variant="sm"
@@ -367,18 +536,30 @@ export default function CronPage() {
           const title = getJobTitle(job);
           const hasName = Boolean(getJobName(job));
           const deliver = asText(job.deliver);
+          const repeatLabel = getJobRepeatLabel(job);
+          const triggerDisabled = !job.gateway_running;
+          const triggerTooltip = triggerDisabled
+            ? `Gateway not running for profile ${job.profile}`
+            : t.cron.triggerNow;
 
           return (
-            <Card key={job.id}>
+            <Card key={`${job.profile}:${job.id}`}>
               <CardContent className="flex items-center gap-4 py-4">
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
+                  <div className="flex items-center gap-2 mb-1 flex-wrap">
                     <span className="font-medium text-sm truncate">
                       {title}
                     </span>
                     <Badge tone={STATUS_TONE[state] ?? "secondary"}>
                       {state}
                     </Badge>
+                    {showProfileColumn && (
+                      <Badge tone="outline">
+                        {job.profile === activeProfileName
+                          ? `${job.profile} (active)`
+                          : job.profile}
+                      </Badge>
+                    )}
                     {deliver && deliver !== "local" && (
                       <Badge tone="outline">{deliver}</Badge>
                     )}
@@ -388,8 +569,11 @@ export default function CronPage() {
                       {truncateText(promptText, 100)}
                     </p>
                   )}
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">
                     <span className="font-mono">{getJobScheduleDisplay(job)}</span>
+                    {repeatLabel && (
+                      <span className="font-mono">{repeatLabel}</span>
+                    )}
                     <span>
                       {t.cron.last}: {formatTime(job.last_run_at)}
                     </span>
@@ -423,9 +607,10 @@ export default function CronPage() {
                   <Button
                     ghost
                     size="icon"
-                    title={t.cron.triggerNow}
-                    aria-label={t.cron.triggerNow}
+                    title={triggerTooltip}
+                    aria-label={triggerTooltip}
                     onClick={() => handleTrigger(job)}
+                    disabled={triggerDisabled}
                   >
                     <Zap />
                   </Button>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -16,13 +16,14 @@ import {
   Filter,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { SkillInfo, ToolsetInfo } from "@/lib/api";
+import type { ProfileInfo, SkillInfo, ToolsetInfo } from "@/lib/api";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Switch } from "@nous-research/ui/ui/components/switch";
 import { cn } from "@/lib/utils";
@@ -96,7 +97,10 @@ function toolsetIcon(
 export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [toolsets, setToolsets] = useState<ToolsetInfo[]>([]);
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState<string>("");
   const [loading, setLoading] = useState(true);
+  const [skillsLoading, setSkillsLoading] = useState(false);
   const [search, setSearch] = useState("");
   const [view, setView] = useState<"skills" | "toolsets">("skills");
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
@@ -105,21 +109,76 @@ export default function SkillsPage() {
   const { t } = useI18n();
   const { setAfterTitle, setEnd } = usePageHeader();
 
+  // Treat the profile flagged is_active by the gateway as "the dashboard's
+  // own profile". Older gateways don't emit is_active; fall back to the
+  // is_default profile so the dropdown still reflects whichever profile the
+  // legacy /api/skills routes actually edit.
+  const activeProfileName = useMemo(() => {
+    const active = profiles.find((p) => p.is_active);
+    if (active) return active.name;
+    const dflt = profiles.find((p) => p.is_default);
+    return dflt?.name ?? profiles[0]?.name ?? "";
+  }, [profiles]);
+
+  const isOnActiveProfile =
+    !selectedProfile || selectedProfile === activeProfileName;
+
+  /* ---- Initial load: profiles, toolsets, and the active profile's skills ---- */
   useEffect(() => {
-    Promise.all([api.getSkills(), api.getToolsets()])
-      .then(([s, tsets]) => {
-        setSkills(s);
+    Promise.all([api.getProfiles(), api.getToolsets(), api.getSkills()])
+      .then(([{ profiles: profileList }, tsets, s]) => {
+        setProfiles(profileList);
         setToolsets(tsets);
+        setSkills(s);
+        const active =
+          profileList.find((p) => p.is_active) ??
+          profileList.find((p) => p.is_default) ??
+          profileList[0];
+        setSelectedProfile(active?.name ?? "");
       })
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
   }, []);
 
+  /* ---- Refetch skills when the selected profile changes ----
+   *
+   * Skipped on initial mount: the load effect above already fetched the
+   * active profile's skills via the legacy /api/skills route, which is
+   * cheaper than the profile-scoped scan and stays in sync with the
+   * gateway-resident skill index.
+   */
+  useEffect(() => {
+    if (loading || !selectedProfile) return;
+    if (selectedProfile === activeProfileName) {
+      setSkillsLoading(true);
+      api
+        .getSkills()
+        .then(setSkills)
+        .catch(() => showToast(t.common.loading, "error"))
+        .finally(() => setSkillsLoading(false));
+      return;
+    }
+    setSkillsLoading(true);
+    api
+      .getProfileSkills(selectedProfile)
+      .then(setSkills)
+      .catch(() => showToast(t.common.loading, "error"))
+      .finally(() => setSkillsLoading(false));
+  }, [selectedProfile, activeProfileName, loading]);
+
   /* ---- Toggle skill ---- */
   const handleToggleSkill = async (skill: SkillInfo) => {
     setTogglingSkills((prev) => new Set(prev).add(skill.name));
     try {
-      await api.toggleSkill(skill.name, !skill.enabled);
+      if (isOnActiveProfile) {
+        await api.toggleSkill(skill.name, !skill.enabled);
+      } else {
+        await api.toggleProfileSkill(
+          selectedProfile,
+          skill.name,
+          !skill.enabled,
+        );
+      }
       setSkills((prev) =>
         prev.map((s) =>
           s.name === skill.name ? { ...s, enabled: !s.enabled } : s,
@@ -255,7 +314,33 @@ export default function SkillsPage() {
 
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
         <aside aria-label={t.skills.title} className="sm:w-56 sm:shrink-0">
-          <div className="sm:sticky sm:top-0">
+          <div className="sm:sticky sm:top-0 flex flex-col gap-2">
+            {profiles.length > 1 ? (
+              <div className="flex flex-col gap-1 border border-border bg-muted/20 px-3 pt-2 pb-1.5">
+                <span className="font-mondwest text-[0.65rem] tracking-[0.12em] uppercase text-muted-foreground">
+                  Profile
+                </span>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={selectedProfile}
+                    onValueChange={(v) => setSelectedProfile(v)}
+                    aria-label="Profile"
+                    className="w-full text-xs [&>button]:h-7 [&>button]:py-0"
+                  >
+                    {profiles.map((p) => (
+                      <SelectOption key={p.name} value={p.name}>
+                        {p.name === activeProfileName
+                          ? `${p.name} (active)`
+                          : p.name}
+                      </SelectOption>
+                    ))}
+                  </Select>
+                  {skillsLoading ? (
+                    <Spinner className="text-xs text-muted-foreground" />
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
             <div
               className={`
                 flex flex-col


### PR DESCRIPTION
## What does this PR do?

Adds a Profile dropdown to the dashboard's Cron screen so jobs in every installed profile can be managed from the same dashboard daemon. Mirrors the precedent set by #25116 for the Skills page.

Until now, `/api/cron/jobs` only knew the active profile (whichever `HERMES_HOME` the dashboard process was launched under), so operators with multi-profile installs (orchestrator + worker sub-profiles, copywriter / SEO / creative bots, etc.) had to SSH to the host and run `hermes --profile <name> cron list` to see what was scheduled — easy to miss when a sub-profile's cron quietly stops firing.

**Two intentional divergences from #25116:**
- **Default view is "All", not the active profile.** Skills defaults to active because toggling skills is per-profile config work; cron is operations work that benefits from cross-profile visibility.
- **Trigger is gated to running profiles only.** Writing `next_run_at = now` is a silent no-op without a live dispatcher tick. Pause / resume / edit / delete / create are filesystem-only and work regardless of gateway state.

## Related Issue

Depends on #25116 (per-profile skills toggle UI). This PR is a sibling: it imports the `is_active`/`_active_profile_path_str` and per-profile-route patterns introduced there. The diff against `main` currently includes #25116's commits because this branch sits on top of `feat/dashboard-per-profile-skills`. Once #25116 merges, this PR's diff narrows to the cron-specific changes only. Order of merge: #25116 first, then this.

(Author-attribution check tracked by #26608.)

## Type of Change

- [x] ✨ Feature

## Changes Made

**Backend (`hermes_cli/web_server.py`):**
- Add 8 routes under `/api/profiles/{name}/cron/jobs*` mirroring the legacy `/api/cron/jobs*` shape: list, get-single, create, update, pause, resume, trigger, delete.
- Add web-layer `_load_profile_jobs` / `_save_profile_jobs` helpers that read/write `<profile_dir>/cron/jobs.json` atomically (tempfile + replace). `cron/jobs.py`'s module-global `JOBS_FILE` and `_jobs_file_lock` are left untouched — same constraint #25116 worked around for `load_config` / `save_config`.
- Trigger route additionally calls `_check_gateway_running(profile_dir)` and returns 409 Conflict when False (defense in depth; the UI disables the button as primary UX).
- Add `gateway_running: bool` to `ProfileInfo` response via `_profile_to_dict` and `_fallback_profile_dicts`. Reuses the existing `_check_gateway_running` helper from `hermes_cli/profiles.py` (PID-file plus process-identity verification).
- Per-profile in-process write lock (`threading.Lock` dict-of-locks keyed by profile name) serialises concurrent dashboard writes to the same profile's `jobs.json`.

**Frontend (`web/src/lib/api.ts`):**
- Add 8 profile-scoped cron client functions (`getProfileCronJobs`, `createProfileCronJob`, etc.).
- Extend `ProfileInfo` interface with `gateway_running?: boolean` (optional for backward-compat with older gateways, matching the `is_active?` posture from #25116).

**Frontend (`web/src/pages/CronPage.tsx`):**
- Profile dropdown (hidden when only one profile is installed) with `All` as the first/default option.
- "All" view aggregates jobs from every installed profile via `Promise.allSettled`; per-row owning-profile badge with the active profile annotated `(active)`.
- Single-profile filter hides the profile badge and fetches only that profile's jobs.
- Trigger button is `disabled` when `row.gateway_running === false`, with tooltip `Gateway not running for profile <name>`.
- Create form gains a Profile selector when in "All" view (defaults to the active profile); the selector is hidden when filtered to a specific profile.
- Schedule cell renders `Repeat: ∞` for recurring jobs and `Repeat: 1/1` for one-shots — verbatim what `hermes cron list` shows — so the `every`-prefix foot-gun (`'4320m'` = one-shot, `'every 4320m'` = recurring) is visible at a glance.

**Tests (`tests/hermes_cli/test_web_server.py`):**
- 13 new tests in `TestNewEndpoints` covering: list/create/get roundtrip; pause/resume/trigger/delete lifecycle; PUT update; multiline-prompt roundtrip (closes the `hermes cron edit --prompt` foot-gun for the dashboard write path); recurring-vs-one-shot schedule kind; empty-list for new profile; unknown-profile 404; invalid-name 400; trigger-when-dormant 409; job-id-not-found 404 across all routes; `gateway_running` consistency between `/api/profiles` and the trigger gate.

The legacy `/api/cron/jobs*` routes are untouched and remain the canonical path for the active profile.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestNewEndpoints -k cron` → 12 new tests pass; `-k gateway_running` covers the 13th.
2. Manual against a multi-profile install:
   - Dropdown visible when `profiles.length > 1`; first option is `All`.
   - "All" shows jobs from every profile with the per-row profile badge; active profile annotated `(active)`.
   - Filter to a profile whose gateway is running → trigger buttons enabled.
   - Filter to a profile whose gateway is dormant → trigger buttons disabled with the tooltip.
   - Create from "All" requires picking a profile; create when filtered targets that profile automatically.
3. Single-profile install: dropdown and per-row profile badge both hidden; behavior identical to today's CronPage.
4. SPA rebuild required after applying: `cd web && npm install && npm run build`.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this feature (the upstream-of-`main` `feat/dashboard-per-profile-skills` commit appears in the diff only because #25116 is not yet merged)
- [x] `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestNewEndpoints` passes
- [x] Added tests for my changes (13 new)
- [x] Tested on: macOS 26 (Sequoia)

### Documentation & Housekeeping
- [x] No new config keys / `cli-config.yaml.example` change — N/A
- [x] No `.env.example` changes — N/A
- [x] No CONTRIBUTING.md / AGENTS.md changes — N/A
- [x] Considered cross-platform impact — `_save_profile_jobs` uses `tempfile.mkstemp` + `utils.atomic_replace` (same helper `cron.jobs.save_jobs` uses on every platform); `_check_gateway_running` already cross-platform via `gateway.status.get_running_pid`; `scripts/check-windows-footguns.py` clean
- [x] No tool descriptions/schemas changed — N/A