### PR TITLE
ci: add Python 3.12/3.13 matrix and uv caching to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,22 +24,34 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep libopus0
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          uv venv .venv --python 3.11
+          uv venv .venv --python ${{ matrix.python-version }}
           source .venv/bin/activate
           uv pip install -e ".[all,dev]"
 
@@ -56,22 +68,34 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep libopus0
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          uv venv .venv --python 3.11
+          uv venv .venv --python ${{ matrix.python-version }}
           source .venv/bin/activate
           uv pip install -e ".[all,dev]"
 
@@ -79,6 +103,52 @@ jobs:
         run: |
           source .venv/bin/activate
           python -m pytest tests/e2e/ -v --tb=short
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep libopus0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python ${{ matrix.python-version }}
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run integration tests
+        run: |
+          source .venv/bin/activate
+          # Override pyproject.toml addopts: the default '-m not integration' filters
+          # out all integration tests, and '-n auto' is unsafe for tests that share
+          # real service state. Select only integration markers, force sequential.
+          python -m pytest tests/integration/ -v --tb=short -m integration -n 0
         env:
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""


### PR DESCRIPTION
## Summary

The CI workflow currently only tests Python 3.11, missing regressions in Python 3.12 and 3.13. This PR adds a strategy.matrix across all three versions to both `test` and `e2e` jobs, adds a new `integration` job, and adds uv dependency caching.

## Changes

- **Python version matrix**: `strategy.matrix.python-version: [3.11, 3.12, 3.13]` on all three jobs (test, e2e, integration)
- **uv caching**: `actions/cache@v4` keyed on `${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('`**pyproject.toml`**`', '`**uv.lock`**`') }}` with tiered restore-keys falling back to version-agnostic cache
- **New integration job**: runs `tests/integration/` with `-m integration -n 0` (sequential, marker-filtered)
- **libopus0**: added as system dependency (needed for some integration tests)
- **Parameterized Python versions**: all hardcoded `3.11` references replaced with `${{ matrix.python-version }}`

Closes #22005