### PR TITLE
fix(process_registry): poll() must not mark completion as consumed (#10156)

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -318,8 +318,8 @@ class TestCompletionConsumed:
         # Now the completion is marked as consumed
         assert registry.is_completion_consumed("proc_wait")
 
-    def test_poll_marks_completion_consumed(self, registry):
-        """poll() returning exited status marks session as consumed."""
+    def test_poll_does_not_mark_completion_consumed(self, registry):
+        """poll() is a read-only query and must not mark completion as consumed."""
         s = _make_session(sid="proc_poll", notify_on_complete=True, output="done")
         s.exited = True
         s.exit_code = 0
@@ -327,7 +327,41 @@ class TestCompletionConsumed:
 
         result = registry.poll("proc_poll")
         assert result["status"] == "exited"
-        assert registry.is_completion_consumed("proc_poll")
+        assert not registry.is_completion_consumed("proc_poll")
+
+    def test_poll_then_wait_marks_consumed(self, registry):
+        """poll() must not consume; subsequent wait() must still mark consumed."""
+        s = _make_session(sid="proc_poll_then_wait", notify_on_complete=True, output="done")
+        s.exited = True
+        s.exit_code = 0
+        registry._finished[s.id] = s
+
+        # poll() — read-only, no side effect
+        poll_result = registry.poll("proc_poll_then_wait")
+        assert poll_result["status"] == "exited"
+        assert not registry.is_completion_consumed("proc_poll_then_wait")
+
+        # wait() — consumes
+        wait_result = registry.wait("proc_poll_then_wait", timeout=1)
+        assert wait_result["status"] == "exited"
+        assert registry.is_completion_consumed("proc_poll_then_wait")
+
+    def test_poll_then_read_log_marks_consumed(self, registry):
+        """poll() must not consume; subsequent read_log() must still mark consumed."""
+        s = _make_session(sid="proc_poll_then_log", notify_on_complete=True, output="line1\nline2")
+        s.exited = True
+        s.exit_code = 0
+        registry._finished[s.id] = s
+
+        # poll() — read-only, no side effect
+        poll_result = registry.poll("proc_poll_then_log")
+        assert poll_result["status"] == "exited"
+        assert not registry.is_completion_consumed("proc_poll_then_log")
+
+        # read_log() — consumes
+        log_result = registry.read_log("proc_poll_then_log")
+        assert log_result["status"] == "exited"
+        assert registry.is_completion_consumed("proc_poll_then_log")
 
     def test_log_marks_completion_consumed(self, registry):
         """read_log() on exited session marks as consumed."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -949,7 +949,6 @@ class ProcessRegistry:
         }
         if session.exited:
             result["exit_code"] = session.exit_code
-            self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"


### PR DESCRIPTION
### Problem

`poll()` in `process_registry.py` calls `_completion_consumed.add(session_id)` when the queried process has already exited. This marks the completion as consumed, which causes the gateway watcher (and `notify_on_complete` drain loops in the CLI and TUI) to suppress the completion notification — they check `is_completion_consumed()` and skip it.

`poll()` is a read-only status query, analogous to checking whether a letter has arrived without opening the envelope. It should never suppress the eventual delivery notification.

### Root cause

PR #8228 introduced `_completion_consumed` tracking to suppress duplicate completion notifications when the agent has already seen the output via `wait()` or `read_log()`. The fix correctly applied to `wait()` and `read_log()` (both are agent-facing read operations that consume the result), but incorrectly also added the mark to `poll()`.

### Fix

Remove the single line `self._completion_consumed.add(session_id)` from `poll()`. Only `wait()` and `read_log()` mark completions as consumed.

### Tests

- **`test_poll_does_not_mark_completion_consumed`** — renamed from `test_poll_marks_completion_consumed`, assertion flipped to `assert not`
- **`test_poll_then_wait_marks_consumed`** — new: poll() followed by wait() — poll() must not consume, wait() must still consume
- **`test_poll_then_read_log_marks_consumed`** — new: poll() followed by read_log() — poll() must not consume, read_log() must still consume
- Existing `test_wait_marks_completion_consumed` and `test_log_marks_completion_consumed` unchanged

Fixes #10156