### PR TITLE
fix(cli): await run_in_terminal futures to prevent RuntimeWarning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6482,7 +6482,12 @@ class HermesCLI:
             self._status_bar_visible = False
             self._app.invalidate()
             try:
-                run_in_terminal(_pick)
+                _future = run_in_terminal(_pick)
+                # run_in_terminal returns an Awaitable/Future in prompt_toolkit 3.0+.
+                # Block until it completes so the coroutine isn't orphaned.
+                _done = threading.Event()
+                _future.add_done_callback(lambda f: _done.set())
+                _done.wait(timeout=60)
             finally:
                 self._status_bar_visible = was_visible
                 self._app.invalidate()
@@ -6519,7 +6524,12 @@ class HermesCLI:
             self._status_bar_visible = False
             self._app.invalidate()
             try:
-                run_in_terminal(_ask)
+                _future = run_in_terminal(_ask)
+                # run_in_terminal returns an Awaitable/Future in prompt_toolkit 3.0+.
+                # Block until it completes so the coroutine isn't orphaned.
+                _done = threading.Event()
+                _future.add_done_callback(lambda f: _done.set())
+                _done.wait(timeout=60)
             except Exception:
                 # WSL / Warp / certain terminal emulators silently drop the
                 # scheduled coroutine.  Fall back to a direct input() so the


### PR DESCRIPTION
## Problem

`prompt_toolkit.application.run_in_terminal()` returns an `Awaitable[_T]` (an `asyncio.Future`) since prompt_toolkit 3.0+. Hermes discards the return value at two call sites, triggering:

```
RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited
```

Affects `/new`, `/reset`, `/undo` slash commands dispatched from the `process_loop` daemon thread.

## Fix

Capture the returned Future and block until completion via `threading.Event` + `add_done_callback`, with a 60s timeout.

### Changed
- `_run_curses_picker()` — block on `_pick()` future
- `_prompt_text_input()` — block on `_ask()` future

### Why not `asyncio.ensure_future()`?
These call sites depend on `result[0]` being set before returning, so fire-and-forget is insufficient. The `threading.Event` pattern ensures the scheduled coroutine completes before we read the result.

### Related
- Fixes #23297
- Fixes #22970
- Complements Bartok9's #23302 (which fixes `_pt_print_safe._schedule` via `ensure_future`)