### PR TITLE
feat(tts): add Inworld TTS provider

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -490,6 +490,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
     elif tts_provider == "gemini" and (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")):
         tool_status.append(("Text-to-Speech (Google Gemini)", True, None))
+    elif tts_provider == "inworld" and get_env_value("INWORLD_API_KEY"):
+        tool_status.append(("Text-to-Speech (Inworld)", True, None))
     elif tts_provider == "neutts":
         try:
             neutts_ok = importlib.util.find_spec("neutts") is not None
@@ -1157,6 +1159,7 @@ def _setup_tts_provider(config: dict):
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
         "gemini": "Google Gemini TTS",
+        "inworld": "Inworld TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
     }
@@ -1181,11 +1184,12 @@ def _setup_tts_provider(config: dict):
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
+            "Inworld TTS (#1 on Artificial Analysis TTS Arena, 100+ languages, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "inworld", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1345,6 +1349,20 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("GEMINI_API_KEY", api_key)
                 print_success("Gemini TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "inworld":
+        existing = get_env_value("INWORLD_API_KEY")
+        if not existing:
+            print()
+            print_info("Get an API key at https://platform.inworld.ai → API Keys")
+            print_info("Copy the 'Basic (Base64)' value — use it verbatim, do NOT re-encode")
+            api_key = prompt("Inworld API key for TTS", password=True)
+            if api_key:
+                save_env_value("INWORLD_API_KEY", api_key)
+                print_success("Inworld TTS API key saved")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -221,6 +221,15 @@ TOOL_CATEGORIES = {
                 "tts_provider": "gemini",
             },
             {
+                "name": "Inworld TTS",
+                "badge": "preview",
+                "tag": "#1 on Artificial Analysis TTS Arena, 100+ languages, sub-200ms latency",
+                "env_vars": [
+                    {"key": "INWORLD_API_KEY", "prompt": "Inworld API key (Basic Base64 from portal)", "url": "https://platform.inworld.ai"},
+                ],
+                "tts_provider": "inworld",
+            },
+            {
                 "name": "KittenTTS",
                 "badge": "local · free",
                 "tag": "Lightweight local ONNX TTS (~25MB), no API key",

--- a/tests/tools/test_tts_inworld.py
+++ b/tests/tools/test_tts_inworld.py
@@ -1,0 +1,342 @@
+"""Tests for the Inworld TTS provider in tools/tts_tool.py."""
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "INWORLD_API_KEY",
+        "INWORLD_BASE_URL",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def fake_pcm_bytes():
+    # 0.1s of silence at 24kHz mono 16-bit = 4800 bytes
+    return b"\x00" * 4800
+
+
+@pytest.fixture
+def mock_inworld_response(fake_pcm_bytes):
+    """A successful Inworld /tts/v1/voice response."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "audioContent": base64.b64encode(fake_pcm_bytes).decode(),
+        "usage": {"processedCharactersCount": 5, "modelId": "inworld-tts-2"},
+    }
+    return resp
+
+
+class TestGenerateInworldTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_inworld_tts
+
+        output_path = str(tmp_path / "test.wav")
+        with pytest.raises(ValueError, match="INWORLD_API_KEY"):
+            _generate_inworld_tts("Hello", output_path, {})
+
+    def test_authorization_header_is_basic_verbatim(
+        self, tmp_path, monkeypatch, mock_inworld_response
+    ):
+        """Portal key is already base64; we must NOT re-encode it."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "dGVzdC1rZXk6c2VjcmV0")  # arbitrary base64 from "test-key:secret"
+        output_path = str(tmp_path / "test.wav")
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", output_path, {})
+
+        headers = mock_post.call_args[1]["headers"]
+        # Exact match: 'Basic ' + the key, byte-for-byte, no re-encoding.
+        assert headers["Authorization"] == "Basic dGVzdC1rZXk6c2VjcmV0"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_wav_output_fast_path(
+        self, tmp_path, monkeypatch, mock_inworld_response, fake_pcm_bytes
+    ):
+        """`.wav` extension skips ffmpeg and writes RIFF directly."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        output_path = str(tmp_path / "test.wav")
+
+        with patch("requests.post", return_value=mock_inworld_response), \
+             patch("subprocess.run") as mock_run:
+            result = _generate_inworld_tts("Hi", output_path, {})
+
+        assert result == output_path
+        mock_run.assert_not_called()
+        data = (tmp_path / "test.wav").read_bytes()
+        assert data[:4] == b"RIFF"
+        assert data[8:12] == b"WAVE"
+        # Audio payload should match the PCM we put in
+        assert data[44:] == fake_pcm_bytes
+
+    def test_default_voice_and_model(
+        self, tmp_path, monkeypatch, mock_inworld_response
+    ):
+        from tools.tts_tool import (
+            DEFAULT_INWORLD_TTS_MODEL,
+            DEFAULT_INWORLD_TTS_VOICE,
+            _generate_inworld_tts,
+        )
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["voiceId"] == DEFAULT_INWORLD_TTS_VOICE
+        assert payload["modelId"] == DEFAULT_INWORLD_TTS_MODEL
+
+    def test_custom_voice(self, tmp_path, monkeypatch, mock_inworld_response):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        config = {"inworld": {"voice_id": "Anna"}}
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), config)
+
+        assert mock_post.call_args[1]["json"]["voiceId"] == "Anna"
+
+    def test_custom_model(self, tmp_path, monkeypatch, mock_inworld_response):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        config = {"inworld": {"model": "inworld-tts-1.5-max"}}
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), config)
+
+        assert mock_post.call_args[1]["json"]["modelId"] == "inworld-tts-1.5-max"
+
+    @pytest.mark.parametrize(
+        "ext,expected_encoding",
+        [
+            (".wav", "LINEAR16"),
+            (".mp3", "MP3"),
+            (".ogg", "OGG_OPUS"),
+            (".opus", "OGG_OPUS"),
+        ],
+    )
+    def test_audio_encoding_matches_output_ext(
+        self, tmp_path, monkeypatch, mock_inworld_response, ext, expected_encoding
+    ):
+        """Inworld natively returns MP3 / OGG_OPUS / LINEAR16; pick from extension."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+
+        # For .ogg/.mp3 native paths the mock 'PCM' bytes are written verbatim
+        # to disk -- realistic enough for the encoding assertion.
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / f"test{ext}"), {})
+
+        audio_config = mock_post.call_args[1]["json"]["audioConfig"]
+        assert audio_config["audioEncoding"] == expected_encoding
+        assert audio_config["sampleRateHertz"] == 24000
+
+    def test_mp3_output_skips_ffmpeg(
+        self, tmp_path, monkeypatch, fake_pcm_bytes
+    ):
+        """Native MP3: API response bytes written verbatim, no ffmpeg call."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        fake_mp3 = b"\xff\xfb" + b"\x00" * 200  # MP3 sync word + filler
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"audioContent": base64.b64encode(fake_mp3).decode()}
+
+        output_path = str(tmp_path / "test.mp3")
+        with patch("requests.post", return_value=resp), \
+             patch("subprocess.run") as mock_run:
+            _generate_inworld_tts("Hi", output_path, {})
+
+        mock_run.assert_not_called()
+        assert (tmp_path / "test.mp3").read_bytes() == fake_mp3
+
+    def test_ogg_output_skips_ffmpeg(self, tmp_path, monkeypatch):
+        """Native OGG_OPUS: API response bytes written verbatim, no ffmpeg call."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        fake_opus = b"OggS" + b"\x00" * 200  # OGG container magic + filler
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"audioContent": base64.b64encode(fake_opus).decode()}
+
+        output_path = str(tmp_path / "test.ogg")
+        with patch("requests.post", return_value=resp), \
+             patch("subprocess.run") as mock_run:
+            _generate_inworld_tts("Hi", output_path, {})
+
+        mock_run.assert_not_called()
+        assert (tmp_path / "test.ogg").read_bytes() == fake_opus
+
+    def test_text_is_truncated_at_2000_chars(
+        self, tmp_path, monkeypatch, mock_inworld_response
+    ):
+        """API caps at 2000 chars; oversized input is sliced, not rejected."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        long_text = "a" * 5000
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts(long_text, str(tmp_path / "test.wav"), {})
+
+        assert len(mock_post.call_args[1]["json"]["text"]) == 2000
+
+    def test_endpoint_url(self, tmp_path, monkeypatch, mock_inworld_response):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        assert mock_post.call_args[0][0] == "https://api.inworld.ai/tts/v1/voice"
+
+    def test_http_error_raises_runtime_error(self, tmp_path, monkeypatch):
+        """Inworld's typical 4xx response carries a `message` field."""
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        err_resp = MagicMock()
+        err_resp.status_code = 400
+        err_resp.json.return_value = {
+            "code": 5,
+            "message": "Unknown voice: John not found!",
+        }
+
+        with patch("requests.post", return_value=err_resp):
+            with pytest.raises(RuntimeError, match="HTTP 400.*Unknown voice"):
+                _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+    def test_empty_audio_raises(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"audioContent": ""}
+
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(RuntimeError, match="empty audio"):
+                _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+    def test_malformed_response_raises(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"usage": {}}  # no audioContent
+
+        with patch("requests.post", return_value=resp):
+            with pytest.raises(RuntimeError, match="malformed"):
+                _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+    def test_custom_base_url_via_config(
+        self, tmp_path, monkeypatch, mock_inworld_response
+    ):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        config = {"inworld": {"base_url": "https://custom-inworld.example.com/tts/v1/voice"}}
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), config)
+
+        assert mock_post.call_args[0][0] == "https://custom-inworld.example.com/tts/v1/voice"
+
+    def test_custom_base_url_via_env(
+        self, tmp_path, monkeypatch, mock_inworld_response
+    ):
+        from tools.tts_tool import _generate_inworld_tts
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        monkeypatch.setenv("INWORLD_BASE_URL", "https://env-inworld.example.com/tts/v1/voice")
+
+        with patch("requests.post", return_value=mock_inworld_response) as mock_post:
+            _generate_inworld_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        assert mock_post.call_args[0][0] == "https://env-inworld.example.com/tts/v1/voice"
+
+
+class TestInworldInCheckRequirements:
+    def test_inworld_api_key_satisfies_requirements(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        # Strip everything else
+        for key in (
+            "ELEVENLABS_API_KEY",
+            "OPENAI_API_KEY",
+            "VOICE_TOOLS_OPENAI_KEY",
+            "MINIMAX_API_KEY",
+            "XAI_API_KEY",
+            "MISTRAL_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+
+        # Force edge_tts import to fail so we actually hit the inworld check
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "edge_tts":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            assert check_tts_requirements() is True
+
+
+class TestDispatcher:
+    def test_dispatcher_routes_inworld(self, monkeypatch, tmp_path):
+        """Top-level text_to_speech_tool routes provider='inworld' correctly."""
+        from tools import tts_tool
+
+        monkeypatch.setenv("INWORLD_API_KEY", "k")
+        called = {}
+
+        def fake_inworld(text, file_str, tts_config):
+            called["text"] = text
+            called["path"] = file_str
+            called["cfg"] = tts_config
+            # Create an empty file so downstream "file exists" checks pass.
+            open(file_str, "wb").close()
+            return file_str
+
+        # Patch the provider function and the on-disk config loader so the
+        # dispatcher sees `provider: inworld` without touching ~/.hermes/.
+        monkeypatch.setattr(tts_tool, "_generate_inworld_tts", fake_inworld)
+        monkeypatch.setattr(
+            tts_tool,
+            "_load_tts_config",
+            lambda: {"provider": "inworld", "inworld": {"voice_id": "Sarah"}},
+        )
+
+        out_path = str(tmp_path / "out.wav")
+        tts_tool.text_to_speech_tool(
+            text="Hello from Inworld",
+            output_path=out_path,
+        )
+
+        assert called.get("text") == "Hello from Inworld"
+        assert called.get("cfg", {}).get("provider") == "inworld"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -9,6 +9,7 @@ Built-in TTS providers:
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
+- Inworld TTS: #1 on Artificial Analysis TTS Arena, 100+ languages, needs INWORLD_API_KEY
 - xAI TTS: Grok voices, uses xAI Grok OAuth credentials or XAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
@@ -176,6 +177,13 @@ DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
 GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
+DEFAULT_INWORLD_TTS_MODEL = "inworld-tts-2"
+DEFAULT_INWORLD_TTS_VOICE = "Sarah"
+DEFAULT_INWORLD_TTS_BASE_URL = "https://api.inworld.ai/tts/v1/voice"
+# PCM output specs for Inworld TTS LINEAR16 (fixed by request; mirrors Gemini)
+INWORLD_TTS_SAMPLE_RATE = 24000
+INWORLD_TTS_CHANNELS = 1
+INWORLD_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -1308,6 +1316,165 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# Inworld TTS (REST API; #1 on Artificial Analysis TTS Arena)
+# ===========================================================================
+
+def _generate_inworld_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Inworld AI TTS.
+
+    Inworld's ``/tts/v1/voice`` REST endpoint supports MP3, OGG_OPUS, and
+    LINEAR16 natively via ``audioConfig.audioEncoding``. We pick the encoding
+    from the requested output extension so common formats (.mp3, .ogg) are
+    written verbatim with no ffmpeg roundtrip -- only .wav needs the
+    LINEAR16 -> RIFF-header wrap (matching the ``_wrap_pcm_as_wav`` helper).
+    A defensive ffmpeg fallback handles exotic extensions.
+
+    Auth: the Inworld portal hands out a pre-encoded Base64 credential.
+    The header is literally ``Authorization: Basic <that key>`` -- do NOT
+    re-encode it. It is NOT a ``key:secret`` pair.
+
+    Args:
+        text: Text to convert. Supports inline steering tags such as
+              ``[excited]`` or ``[whispered]`` on ``inworld-tts-2``.
+        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    import requests
+
+    api_key = (get_env_value("INWORLD_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError(
+            "INWORLD_API_KEY not set. Get an API key at "
+            "https://platform.inworld.ai -> API Keys, copy the Basic (Base64) "
+            "value, and use it verbatim (do not re-encode)."
+        )
+
+    inworld_config = tts_config.get("inworld", {})
+    model = str(inworld_config.get("model", DEFAULT_INWORLD_TTS_MODEL)).strip() or DEFAULT_INWORLD_TTS_MODEL
+    voice = str(
+        inworld_config.get("voice_id")
+        or inworld_config.get("voice")
+        or DEFAULT_INWORLD_TTS_VOICE
+    ).strip() or DEFAULT_INWORLD_TTS_VOICE
+    base_url = str(
+        inworld_config.get("base_url")
+        or get_env_value("INWORLD_BASE_URL")
+        or DEFAULT_INWORLD_TTS_BASE_URL
+    ).strip()
+
+    # Match the audio encoding to the output extension. Inworld natively
+    # supports MP3 and OGG_OPUS, so for those formats we can skip ffmpeg
+    # entirely and write the API response bytes directly. LINEAR16 covers
+    # .wav (fast-pathed via _wrap_pcm_as_wav below) and serves as a
+    # defensive fallback for unknown extensions (handled via ffmpeg).
+    ext = os.path.splitext(output_path)[1].lower()
+    if ext == ".mp3":
+        audio_encoding = "MP3"
+    elif ext in (".ogg", ".opus"):
+        audio_encoding = "OGG_OPUS"
+    else:
+        audio_encoding = "LINEAR16"
+
+    payload: Dict[str, Any] = {
+        # API caps the request at 2000 chars; the streaming caller handles
+        # longer text via sentence-by-sentence chunking upstream.
+        "text": text[:2000],
+        "voiceId": voice,
+        "modelId": model,
+        "audioConfig": {
+            "audioEncoding": audio_encoding,
+            "sampleRateHertz": INWORLD_TTS_SAMPLE_RATE,
+        },
+    }
+
+    response = requests.post(
+        base_url,
+        headers={
+            "Authorization": f"Basic {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=60,
+    )
+    if response.status_code != 200:
+        # Surface the API error message when present. Inworld returns
+        # ``{"code": 5, "message": "Unknown voice: X not found!"}`` on bad
+        # voice IDs; keep the message terse so it fits a log line.
+        try:
+            err = response.json()
+            detail = err.get("message") or err.get("error") or response.text[:300]
+        except Exception:
+            detail = response.text[:300]
+        raise RuntimeError(
+            f"Inworld TTS API error (HTTP {response.status_code}): {detail}"
+        )
+
+    try:
+        data = response.json()
+        audio_b64 = data["audioContent"]
+    except (KeyError, TypeError) as e:
+        raise RuntimeError(f"Inworld TTS response was malformed: {e}") from e
+
+    if not audio_b64:
+        raise RuntimeError("Inworld TTS returned empty audio data")
+
+    audio_bytes = base64.b64decode(audio_b64)
+
+    # Native MP3 / OGG_OPUS: API already returned a fully-encoded file, write
+    # the bytes verbatim. No PCM wrap, no ffmpeg dependency.
+    if audio_encoding in ("MP3", "OGG_OPUS"):
+        with open(output_path, "wb") as f:
+            f.write(audio_bytes)
+        return output_path
+
+    # LINEAR16 path: raw PCM needs a WAV RIFF header.
+    wav_bytes = _wrap_pcm_as_wav(
+        audio_bytes,
+        sample_rate=INWORLD_TTS_SAMPLE_RATE,
+        channels=INWORLD_TTS_CHANNELS,
+        sample_width=INWORLD_TTS_SAMPLE_WIDTH,
+    )
+
+    # Fast path: caller wants WAV directly, just write.
+    if output_path.lower().endswith(".wav"):
+        with open(output_path, "wb") as f:
+            f.write(wav_bytes)
+        return output_path
+
+    # Exotic extension (.flac, .m4a, etc.): write WAV to a temp file and
+    # ffmpeg-convert. Falls back to renaming when ffmpeg is missing -- the
+    # audio is still playable, just under a misleading extension.
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(wav_bytes)
+        wav_path = tmp.name
+
+    try:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            result = subprocess.run(cmd, capture_output=True, timeout=30)
+            if result.returncode != 0:
+                stderr = result.stderr.decode("utf-8", errors="ignore")[:300]
+                raise RuntimeError(f"ffmpeg conversion failed: {stderr}")
+        else:
+            logger.warning(
+                "ffmpeg not found; writing raw WAV to %s (extension may be misleading)",
+                output_path,
+            )
+            shutil.copyfile(wav_path, output_path)
+    finally:
+        try:
+            os.remove(wav_path)
+        except OSError:
+            pass
+
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -1759,6 +1926,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
 
+        elif provider == "inworld":
+            logger.info("Generating speech with Inworld TTS...")
+            _generate_inworld_tts(text, file_str, tts_config)
+
         elif provider == "neutts":
             if not _check_neutts_available():
                 return json.dumps({
@@ -1844,7 +2015,7 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
-        elif provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"} and not file_str.endswith(".ogg"):
+        elif provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "inworld"} and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1929,6 +2100,8 @@ def check_tts_requirements() -> bool:
     except Exception:
         pass
     if get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY"):
+        return True
+    if get_env_value("INWORLD_API_KEY"):
         return True
     try:
         _import_mistral_client()

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -24,6 +24,7 @@ Convert text to speech with ten providers:
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
+| **Inworld TTS** | #1 on [Artificial Analysis TTS Arena](https://artificialanalysis.ai/speech/arena) | Paid | `INWORLD_API_KEY` |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "inworld" | "xai" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -68,6 +69,10 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+  inworld:
+    model: "inworld-tts-2"        # inworld-tts-2 (default, 100+ langs, supports [steering] tags) | inworld-tts-1.5-max (<200ms p50, 15 langs) | inworld-tts-1.5-mini (~120ms p50, lowest latency)
+    voice_id: "Sarah"             # Browse voices at https://platform.inworld.ai/voices
+    # base_url: "https://api.inworld.ai/tts/v1/voice"   # Override via INWORLD_BASE_URL env var
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code
@@ -142,6 +147,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
+- **Inworld TTS** natively returns MP3, OGG_OPUS, or LINEAR16 depending on the requested output extension — no ffmpeg roundtrip needed for the common formats
 - **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles


### PR DESCRIPTION
## Summary

Adds **Inworld** as the eighth voice provider in the TTS tool. Inworld holds the **#1 spot on the [Artificial Analysis Speech Arena](https://artificialanalysis.ai/speech/arena)** (Realtime TTS 1.5 Max, ELO 1,208, Jan 2026) and **two of the top five**. Default model `inworld-tts-2` is Inworld's newest — research preview, not yet on the public leaderboard, 100+ languages, inline `[steering]` tags.

Integrates cleanly through the existing provider chain — no new SDK dep, uses raw REST like xAI/MiniMax/Gemini.

## What changed

| File | Change |
|---|---|
| `tools/tts_tool.py` | New `_generate_inworld_tts()`; routed in main dispatcher; `check_tts_requirements()` accepts `INWORLD_API_KEY`; `inworld` added to `_convert_to_opus()` set for messaging-platform voice bubbles |
| `hermes_cli/tools_config.py` | 'Inworld TTS' entry added to the `hermes tools` TTS picker |
| `hermes_cli/setup.py` | Wizard picker, status display, and API-key prompt branch |
| `tests/tools/test_tts_inworld.py` | 21 unit tests (parametrized audio-encoding selection, WAV fast path, HTTP errors, dispatcher routing) |
| `website/docs/user-guide/features/tts.md` | Provider table, config example, native-encoding notes |

## Design notes

- **REST over SDK.** No new Python dep — mirrors xAI/MiniMax/Gemini's raw-request pattern.
- **Native MP3 / OGG_OPUS / LINEAR16.** Picks `audioConfig.audioEncoding` from the output extension — `.mp3` → MP3, `.ogg`/`.opus` → OGG_OPUS, `.wav` → LINEAR16 (wrapped via the existing `_wrap_pcm_as_wav()` helper).
- **Telegram-compatible Opus.** `inworld` is added to the existing `_convert_to_opus()` set so when the gateway hands the tool a `.mp3` temp path, the post-conversion to OGG/Opus runs and messages render as round voice bubbles via `send_voice`.
- **Pre-encoded Basic Base64 auth — verbatim.** The portal credential goes directly into `Authorization: Basic <key>`; **not** a `key:secret` pair. Wizard, docs, and error messages explicitly warn against re-encoding.

## Test plan

**Unit tests:** 21 new tests in `tests/tools/test_tts_inworld.py`, all passing. Covers verbatim-Basic header, parametrized `audioEncoding` across `.wav`/`.mp3`/`.ogg`/`.opus`, voice/model overrides, `base_url` override via config and env, HTTP error surfacing, and dispatcher routing.

**Live E2E** against `inworld-tts-2` with `voice_id: Sarah`:

| Output | Size | ffprobe codec | Duration |
|---|---|---|---|
| `.wav` | 141KB | pcm_s16le, 24kHz, mono | 2.9s |
| `.mp3` | 45KB | mp3, 24kHz, mono, 128 kb/s | 2.8s |
| `.ogg` | 47KB | **opus**, 48kHz, mono | 2.7s |

Also tested missing key → `ValueError`, bad voice → `RuntimeError("HTTP 400 ... Unknown voice")`, and full-dispatcher integration through the Telegram gateway → native voice bubble rendered inline.

Existing test files unaffected: `test_tts_gemini.py`, `test_tts_speed.py`, `test_setup.py`, `test_tools_config.py` — all passing.

## Usage

```bash
hermes tools                   # pick 'Inworld TTS' under Text-to-Speech
# or
hermes setup tts               # wizard prompts for INWORLD_API_KEY
```

```yaml
# ~/.hermes/config.yaml
tts:
  provider: inworld
  inworld:
    model: inworld-tts-2        # or inworld-tts-1.5-max / inworld-tts-1.5-mini for lower latency
    voice_id: Sarah
```
