### PR TITLE
fix(delegate): heartbeat thread orphan + guarded join (salvage #26435)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1431,7 +1431,6 @@ def _run_single_child(
                 pass
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
-    _heartbeat_thread.start()
 
     # Register the live agent in the module-level registry so the TUI can
     # target it by subagent_id (kill, pause, status queries).  Unregistered
@@ -1462,6 +1461,7 @@ def _run_single_child(
         )
 
     try:
+        _heartbeat_thread.start()
         if child_progress_cb:
             try:
                 child_progress_cb("subagent.start", preview=goal)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1836,9 +1836,13 @@ def _run_single_child(
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
-        # after the child has finished (or failed).
+        # after the child has finished (or failed).  Guard the join: .start()
+        # now lives inside the try block, so if it raised (OS thread
+        # exhaustion) the thread was never started and Thread.join() would
+        # raise RuntimeError.  ident is None until start() succeeds.
         _heartbeat_stop.set()
-        _heartbeat_thread.join(timeout=5)
+        if _heartbeat_thread.ident is not None:
+            _heartbeat_thread.join(timeout=5)
 
         # Drop the TUI-facing registry entry.  Safe to call even if the
         # child was never registered (e.g. ID missing on test doubles).


### PR DESCRIPTION
Salvage of #26435 by @sprmn24, plus a follow-up guard so we don't trade one rare bug for another.

## Summary
Closes the heartbeat-thread orphan window in `_run_single_child()` and hardens the cleanup path against the new failure mode the move introduces.

## Changes
- `tools/delegate_tool.py` `_run_single_child()`:
  - Move `_heartbeat_thread.start()` inside the `try` block so `_heartbeat_stop.set()` always runs. (sprmn24's commit, authorship preserved)
  - Guard the `finally`'s `_heartbeat_thread.join(timeout=5)` with `if _heartbeat_thread.ident is not None` — `.start()` raising (OS thread exhaustion under heavy fanout) would otherwise trip `RuntimeError("cannot join thread before it is started")`.

## Why the guard
`threading.Thread.ident` is `None` until `.start()` succeeds. Without the guard, the salvaged fix trades the orphan-daemon bug for a noisier finally-time crash when `.start()` itself fails. Verified empirically that joining a never-started thread raises and that `ident` is the correct sentinel.

## Validation
- `tests/tools/test_delegate*.py` — 144/144 passing.
- E2E: simulated `.start()` raising; guard skipped the join cleanly; real started thread still joined normally.

## Credit
Original fix by @sprmn24 in #26435. Authorship preserved via cherry-pick + rebase merge.