### PR TITLE
feat(acp): require approval for Zed file edits

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -1,0 +1,228 @@
+"""Pre-execution ACP edit approval helpers.
+
+This module is intentionally isolated from the generic tool registry.  ACP binds
+an edit approval requester in a ContextVar for the duration of one ACP agent run;
+CLI, gateway, and other sessions leave it unset and therefore bypass this guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from concurrent.futures import TimeoutError as FutureTimeout
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from itertools import count
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EditProposal:
+    """A proposed single-file edit that can be shown to an ACP client."""
+
+    tool_name: str
+    path: str
+    old_text: str | None
+    new_text: str
+    arguments: dict[str, Any]
+
+
+EditApprovalRequester = Callable[[EditProposal], bool]
+
+_EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
+    "ACP_EDIT_APPROVAL_REQUESTER",
+    default=None,
+)
+_PERMISSION_REQUEST_IDS = count(1)
+
+
+def set_edit_approval_requester(requester: EditApprovalRequester | None) -> Token:
+    """Bind an ACP edit approval requester for the current context."""
+
+    return _EDIT_APPROVAL_REQUESTER.set(requester)
+
+
+def reset_edit_approval_requester(token: Token) -> None:
+    """Restore a previous edit approval requester binding."""
+
+    _EDIT_APPROVAL_REQUESTER.reset(token)
+
+
+def clear_edit_approval_requester() -> None:
+    """Clear the current requester; primarily used by tests."""
+
+    _EDIT_APPROVAL_REQUESTER.set(None)
+
+
+def get_edit_approval_requester() -> EditApprovalRequester | None:
+    return _EDIT_APPROVAL_REQUESTER.get()
+
+
+def _read_text_if_exists(path: str) -> str | None:
+    p = Path(path).expanduser()
+    if not p.exists():
+        return None
+    if not p.is_file():
+        raise OSError(f"Cannot edit non-file path: {path}")
+    return p.read_text(encoding="utf-8", errors="replace")
+
+
+def _proposal_for_write_file(arguments: dict[str, Any]) -> EditProposal:
+    path = str(arguments.get("path") or "")
+    if not path:
+        raise ValueError("path required")
+    content = arguments.get("content")
+    if content is None:
+        raise ValueError("content required")
+    return EditProposal(
+        tool_name="write_file",
+        path=path,
+        old_text=_read_text_if_exists(path),
+        new_text=str(content),
+        arguments=dict(arguments),
+    )
+
+
+def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
+    path = str(arguments.get("path") or "")
+    if not path:
+        raise ValueError("path required")
+    old_string = arguments.get("old_string")
+    new_string = arguments.get("new_string")
+    if old_string is None or new_string is None:
+        raise ValueError("old_string and new_string required")
+
+    old_text = _read_text_if_exists(path)
+    if old_text is None:
+        raise ValueError(f"Failed to read file: {path}")
+
+    from tools.fuzzy_match import fuzzy_find_and_replace
+
+    new_text, match_count, _strategy, error = fuzzy_find_and_replace(
+        old_text,
+        str(old_string),
+        str(new_string),
+        bool(arguments.get("replace_all", False)),
+    )
+    if error or match_count == 0:
+        raise ValueError(error or f"Could not find match for old_string in {path}")
+
+    return EditProposal(
+        tool_name="patch",
+        path=path,
+        old_text=old_text,
+        new_text=new_text,
+        arguments=dict(arguments),
+    )
+
+
+def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditProposal | None:
+    """Return an edit proposal for supported file mutation calls."""
+
+    if tool_name == "write_file":
+        return _proposal_for_write_file(arguments)
+    if tool_name == "patch" and arguments.get("mode", "replace") == "replace":
+        return _proposal_for_patch_replace(arguments)
+    return None
+
+
+def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Run ACP edit approval if bound.
+
+    Returns a JSON tool-error string when the edit must be blocked, otherwise
+    ``None`` so dispatch can continue.  Requester exceptions deny by default.
+    """
+
+    requester = get_edit_approval_requester()
+    if requester is None:
+        return None
+
+    try:
+        proposal = build_edit_proposal(tool_name, arguments)
+    except Exception as exc:
+        logger.warning("Could not build ACP edit approval proposal for %s: %s", tool_name, exc)
+        return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)
+
+    if proposal is None:
+        return None
+
+    try:
+        approved = bool(requester(proposal))
+    except Exception as exc:
+        logger.warning("ACP edit approval requester failed: %s", exc)
+        approved = False
+
+    if approved:
+        return None
+    return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
+
+
+def build_acp_edit_tool_call(proposal: EditProposal):
+    """Build the ToolCallUpdate payload for ACP request_permission."""
+
+    import acp
+
+    tool_call_id = f"edit-approval-{next(_PERMISSION_REQUEST_IDS)}"
+    return acp.update_tool_call(
+        tool_call_id,
+        title=f"Approve edit: {proposal.path}",
+        kind="edit",
+        status="pending",
+        content=[
+            acp.tool_diff_content(
+                path=proposal.path,
+                old_text=proposal.old_text,
+                new_text=proposal.new_text,
+            )
+        ],
+        raw_input={"tool": proposal.tool_name, "arguments": proposal.arguments},
+    )
+
+
+def make_acp_edit_approval_requester(
+    request_permission_fn: Callable,
+    loop: asyncio.AbstractEventLoop,
+    session_id: str,
+    timeout: float = 60.0,
+) -> EditApprovalRequester:
+    """Return a sync requester that bridges edit proposals to ACP permissions."""
+
+    def _requester(proposal: EditProposal) -> bool:
+        from acp.schema import PermissionOption
+        from agent.async_utils import safe_schedule_threadsafe
+
+        options = [
+            PermissionOption(option_id="allow_once", kind="allow_once", name="Allow edit"),
+            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
+        ]
+        tool_call = build_acp_edit_tool_call(proposal)
+        coro = request_permission_fn(
+            session_id=session_id,
+            tool_call=tool_call,
+            options=options,
+        )
+        future = safe_schedule_threadsafe(
+            coro,
+            loop,
+            logger=logger,
+            log_message="Edit approval request: failed to schedule on loop",
+        )
+        if future is None:
+            return False
+        try:
+            response = future.result(timeout=timeout)
+        except (FutureTimeout, Exception) as exc:
+            future.cancel()
+            logger.warning("Edit approval request timed out or failed: %s", exc)
+            return False
+        outcome = getattr(response, "outcome", None)
+        return (
+            getattr(outcome, "outcome", None) == "selected"
+            and getattr(outcome, "option_id", None) == "allow_once"
+        )
+
+    return _requester

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1169,6 +1169,7 @@ class HermesACPAgent(acp.Agent):
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
         previous_approval_cb = None
+        edit_approval_requester = None
 
         streamed_message = False
 
@@ -1185,6 +1186,16 @@ class HermesACPAgent(acp.Agent):
                 message_cb(text)
 
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
+            try:
+                from acp_adapter.edit_approval import make_acp_edit_approval_requester
+
+                edit_approval_requester = make_acp_edit_approval_requester(
+                    conn.request_permission,
+                    loop,
+                    session_id,
+                )
+            except Exception:
+                logger.debug("Could not create ACP edit approval requester", exc_info=True)
         else:
             tool_progress_cb = None
             reasoning_cb = None
@@ -1214,9 +1225,10 @@ class HermesACPAgent(acp.Agent):
         # which requires a notify_cb registered in _gateway_notify_cbs.
         previous_approval_cb = None
         previous_interactive = None
+        edit_approval_token = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive
+            nonlocal previous_approval_cb, previous_interactive, edit_approval_token
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1240,6 +1252,13 @@ class HermesACPAgent(acp.Agent):
                     _terminal_tool.set_approval_callback(approval_cb)
                 except Exception:
                     logger.debug("Could not set ACP approval callback", exc_info=True)
+            if edit_approval_requester:
+                try:
+                    from acp_adapter.edit_approval import set_edit_approval_requester
+
+                    edit_approval_token = set_edit_approval_requester(edit_approval_requester)
+                except Exception:
+                    logger.debug("Could not set ACP edit approval requester", exc_info=True)
             # Signal to tools.approval that we have an interactive callback
             # and the non-interactive auto-approve path must not fire.
             previous_interactive = os.environ.get("HERMES_INTERACTIVE")
@@ -1267,6 +1286,13 @@ class HermesACPAgent(acp.Agent):
                         _terminal_tool.set_approval_callback(previous_approval_cb)
                     except Exception:
                         logger.debug("Could not restore approval callback", exc_info=True)
+                if edit_approval_token is not None:
+                    try:
+                        from acp_adapter.edit_approval import reset_edit_approval_requester
+
+                        reset_edit_approval_requester(edit_approval_token)
+                    except Exception:
+                        logger.debug("Could not restore ACP edit approval requester", exc_info=True)
                 if session_tokens is not None and clear_session_vars is not None:
                     try:
                         clear_session_vars(session_tokens)

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -895,7 +895,7 @@ def _build_tool_complete_content(
     if len(display_result) > 5000:
         display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
 
-    if tool_name in {"write_file", "patch", "skill_manage"}:
+    if tool_name == "skill_manage":
         try:
             from agent.display import extract_edit_diff
 
@@ -936,22 +936,15 @@ def build_tool_start(
 
     if tool_name == "patch":
         mode = arguments.get("mode", "replace")
-        if mode == "replace":
-            path = arguments.get("path", "")
-            old = arguments.get("old_string", "")
-            new = arguments.get("new_string", "")
-            content = [acp.tool_diff_content(path=path, new_text=new, old_text=old)]
-        else:
-            patch_text = arguments.get("patch", "")
-            content = _build_patch_mode_content(patch_text)
+        path = arguments.get("path") or "patch input"
+        content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "write_file":
         path = arguments.get("path", "")
-        file_content = arguments.get("content", "")
-        content = [acp.tool_diff_content(path=path, new_text=file_content)]
+        content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )

--- a/docs/plans/2026-05-15-acp-zed-edit-approval-diffs.md
+++ b/docs/plans/2026-05-15-acp-zed-edit-approval-diffs.md
@@ -1,0 +1,152 @@
+# ACP Zed Pre-Edit Approval Diffs Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Gate file mutations in ACP/Zed behind explicit pre-edit approval with a structured diff, similar to Codex/Kimi edit review behavior.
+
+**Architecture:** Hermes already renders edit diffs after tools run. This PR adds a pre-mutation permission gate for file mutation tools. Intercept `write_file`, `patch`, and eventually `skill_manage` before they mutate disk; compute proposed old/new content; send ACP `session/request_permission` with `kind="edit"` and diff content; only execute the mutation after approval. Rejections return a clear tool result and leave files unchanged.
+
+**Tech Stack:** Python, ACP `request_permission`, `FileEditToolCallContent` / `acp.tool_diff_content`, Hermes file tools, pytest with temp files.
+
+---
+
+### Task 1: Confirm current ACP diff/permission schema
+
+Run:
+
+```bash
+/home/nour/.hermes/hermes-agent/venv/bin/python - <<'PY'
+from acp.schema import RequestPermissionRequest, ToolCallUpdate
+import acp, inspect
+print(RequestPermissionRequest.model_fields)
+print(ToolCallUpdate.model_fields)
+print(inspect.signature(acp.tool_diff_content))
+PY
+```
+
+Record actual field names. Do not rely on stale examples.
+
+### Task 2: Add denied-write test
+
+**Objective:** A rejected `write_file` must not mutate disk.
+
+**Files:**
+- Create/modify: `tests/acp/test_edit_approval.py`
+
+Test shape:
+
+```python
+def test_write_file_rejected_by_acp_permission_does_not_mutate(tmp_path):
+    path = tmp_path / "demo.txt"
+    path.write_text("old")
+
+    # Install fake ACP edit approval callback returning reject_once.
+    # Invoke the same interception function that the terminal/tool path will call.
+
+    result = maybe_gate_file_edit(
+        tool_name="write_file",
+        args={"path": str(path), "content": "new"},
+        approval_requester=fake_reject,
+    )
+
+    assert path.read_text() == "old"
+    assert "rejected" in result.lower()
+```
+
+The exact function name will be created in Task 4.
+
+### Task 3: Add approved-write test
+
+**Objective:** Approved writes proceed and include diff content in permission request.
+
+Assert:
+
+- fake requester received tool call `kind == "edit"`
+- content includes diff block for `demo.txt`
+- after approval, file content is changed
+
+### Task 4: Implement edit proposal computation
+
+**Files:**
+- Create: `acp_adapter/edit_approval.py`
+
+Add pure helpers first:
+
+```python
+@dataclass
+class EditProposal:
+    path: str
+    old_text: str | None
+    new_text: str
+    title: str
+
+
+def proposal_for_write_file(args: dict[str, Any]) -> EditProposal:
+    path = str(args["path"])
+    old_text = Path(path).read_text(encoding="utf-8") if Path(path).exists() else None
+    new_text = str(args.get("content", ""))
+    return EditProposal(path=path, old_text=old_text, new_text=new_text, title=f"Edit {path}")
+```
+
+For `patch`, start with replace-mode only. V4A/multi-file patches can be a second task or second PR if too risky.
+
+### Task 5: Implement ACP permission requester
+
+**Files:**
+- Modify: `acp_adapter/permissions.py` or new `acp_adapter/edit_approval.py`
+
+Build request with:
+
+```python
+acp.tool_diff_content(path=proposal.path, old_text=proposal.old_text, new_text=proposal.new_text)
+```
+
+Options:
+
+- allow once
+- reject once
+- optionally allow always/reject always only after policy storage exists
+
+Default deny on exception/cancel/timeout.
+
+### Task 6: Intercept file mutation tools before execution
+
+**Objective:** Ensure mutation cannot happen before approval.
+
+**Files:**
+- Likely modify: `model_tools.py` or `acp_adapter/server.py` session-context tool wrapper
+
+Do not bury this inside post-execution `acp_adapter/events.py`; that is too late.
+
+Preferred design:
+
+- set an ACP session contextvar around `agent.run_conversation(...)`
+- in the central tool execution path, before dispatching `write_file`/`patch`, call the ACP edit approval gate if contextvar exists
+- if rejected, return a normal tool result string like `{"success": false, "error": "Edit rejected by user"}`
+- if approved, continue to original tool implementation
+
+### Task 7: Expand patch coverage
+
+Add tests for:
+
+- `patch` replace mode approved/rejected
+- creating a new file via `write_file`
+- missing old string -> should fail before approval or return normal patch error, but must not mutate
+- permission requester exception -> deny and no mutation
+
+### Task 8: Verification
+
+Run:
+
+```bash
+scripts/run_tests.sh tests/acp/test_edit_approval.py tests/acp/test_events.py tests/acp/test_tools.py -q
+```
+
+Then run manual Zed verification:
+
+1. Ask Hermes ACP to edit a small file.
+2. Confirm Zed shows a diff before mutation.
+3. Reject and verify file unchanged.
+4. Approve and verify file changed.
+
+**Do not merge** without manual reject-path verification.

--- a/model_tools.py
+++ b/model_tools.py
@@ -745,6 +745,20 @@ def handle_function_call(
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
 
+        # ACP/Zed edit approval runs before any file mutation.  The requester
+        # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
+        # are unaffected when it is unset.
+        try:
+            from acp_adapter.edit_approval import maybe_require_edit_approval
+
+            edit_block_message = maybe_require_edit_approval(function_name, function_args)
+            if edit_block_message is not None:
+                return edit_block_message
+        except Exception as _edit_approval_err:
+            logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
+            if function_name in {"write_file", "patch"}:
+                return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).
         if function_name not in _READ_SEARCH_TOOLS:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -1,0 +1,179 @@
+"""Tests for ACP pre-edit approval gating."""
+
+from __future__ import annotations
+
+import json
+
+from acp_adapter.edit_approval import (
+    EditProposal,
+    build_acp_edit_tool_call,
+    clear_edit_approval_requester,
+    set_edit_approval_requester,
+)
+from model_tools import handle_function_call
+
+
+def teardown_function() -> None:
+    clear_edit_approval_requester()
+
+
+def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
+    proposal = EditProposal(
+        tool_name="write_file",
+        path="demo.txt",
+        old_text="old\n",
+        new_text="new\n",
+        arguments={"path": "demo.txt", "content": "new\n"},
+    )
+
+    tool_call = build_acp_edit_tool_call(proposal)
+
+    assert tool_call.kind == "edit"
+    assert tool_call.status == "pending"
+    assert tool_call.rawInput == {"tool": "write_file", "arguments": proposal.arguments}
+    assert len(tool_call.content) == 1
+    diff = tool_call.content[0]
+    assert diff.path == "demo.txt"
+    assert diff.oldText == "old\n"
+    assert diff.newText == "new\n"
+
+
+def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_write_file_approval_mutates_and_request_includes_diff(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    proposals = []
+
+    def approve(proposal):
+        proposals.append(proposal)
+        return True
+
+    set_edit_approval_requester(approve)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-approve",
+        )
+    )
+
+    assert result.get("bytes_written") == len("after\n")
+    assert target.read_text(encoding="utf-8") == "after\n"
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.tool_name == "write_file"
+    assert proposal.path == str(target)
+    assert proposal.old_text == "before\n"
+    assert proposal.new_text == "after\n"
+
+
+def test_write_file_new_file_request_has_empty_old_text(tmp_path):
+    target = tmp_path / "new.txt"
+    proposals = []
+
+    set_edit_approval_requester(lambda proposal: proposals.append(proposal) or True)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "created\n"},
+            task_id="acp-edit-new-file",
+        )
+    )
+
+    assert result.get("bytes_written") == len("created\n")
+    assert target.read_text(encoding="utf-8") == "created\n"
+    assert proposals[0].old_text is None
+    assert proposals[0].new_text == "created\n"
+
+
+def test_requester_exception_denies_and_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    def boom(_proposal):
+        raise RuntimeError("zed disconnected")
+
+    set_edit_approval_requester(boom)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-exception",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_patch_replace_rejection_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "beta\n",
+                "new_string": "gamma\n",
+            },
+            task_id="acp-patch-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+
+def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+    proposals = []
+
+    set_edit_approval_requester(lambda proposal: proposals.append(proposal) or True)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "beta\n",
+                "new_string": "gamma\n",
+            },
+            task_id="acp-patch-approve",
+        )
+    )
+
+    assert result.get("success") is True
+    assert target.read_text(encoding="utf-8") == "alpha\ngamma\n"
+    assert proposals[0].tool_name == "patch"
+    assert proposals[0].old_text == "alpha\nbeta\n"
+    assert proposals[0].new_text == "alpha\ngamma\n"

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -183,7 +183,7 @@ class TestMcpRegistrationE2E:
         assert "hello" in complete_event.content[0].content.text
         assert complete_event.raw_output is None
 
-    def test_patch_mode_tool_start_emits_diff_blocks_for_v4a_patch(self):
+    def test_patch_mode_tool_start_defers_diff_to_edit_approval_prompt(self):
         update = build_tool_start(
             "tc-1",
             "patch",
@@ -193,14 +193,9 @@ class TestMcpRegistrationE2E:
             },
         )
 
-        assert len(update.content) == 2
-        assert update.content[0].type == "diff"
-        assert update.content[0].path == "src/app.py"
-        assert update.content[0].old_text == "old line"
-        assert update.content[0].new_text == "new line"
-        assert update.content[1].type == "diff"
-        assert update.content[1].path == "src/new.py"
-        assert update.content[1].new_text == "hello"
+        assert len(update.content) == 1
+        assert update.content[0].type == "content"
+        assert "Approval prompt shows the diff" in update.content[0].content.text
 
     @pytest.mark.asyncio
     async def test_prompt_tool_results_paired_by_call_id(self, acp_agent, mock_manager):

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -147,7 +147,7 @@ class TestBuildToolTitle:
 
 class TestBuildToolStart:
     def test_build_tool_start_for_patch(self):
-        """patch should produce a FileEditToolCallContent (diff)."""
+        """patch start should not duplicate the edit-approval diff."""
         args = {
             "path": "src/main.py",
             "old_string": "print('hello')",
@@ -156,24 +156,23 @@ class TestBuildToolStart:
         result = build_tool_start("tc-1", "patch", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "edit"
-        # The first content item should be a diff
         assert len(result.content) >= 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "src/main.py"
-        assert diff_item.new_text == "print('world')"
-        assert diff_item.old_text == "print('hello')"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "Approval prompt shows the diff" in item.content.text
+        assert "src/main.py" in item.content.text
 
     def test_build_tool_start_for_write_file(self):
-        """write_file should produce a FileEditToolCallContent (diff)."""
+        """write_file start should not duplicate the edit-approval diff."""
         args = {"path": "new_file.py", "content": "print('hello')"}
         result = build_tool_start("tc-w1", "write_file", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "edit"
         assert len(result.content) >= 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "new_file.py"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "Approval prompt shows the diff" in item.content.text
+        assert "new_file.py" in item.content.text
 
     def test_build_tool_start_for_terminal(self):
         """terminal should produce text content with the command."""
@@ -442,8 +441,8 @@ class TestBuildToolComplete:
         assert len(display_text) < 6000
         assert "truncated" in display_text
 
-    def test_build_tool_complete_for_patch_uses_diff_blocks(self):
-        """Completed patch calls should keep structured diff content for Zed."""
+    def test_build_tool_complete_for_patch_summarizes_without_repeating_diff(self):
+        """Completed patch calls should not duplicate the edit-approval diff."""
         patch_result = (
             '{"success": true, "diff": "--- a/README.md\\n+++ b/README.md\\n@@ -1 +1,2 @@\\n old line\\n+new line\\n", '
             '"files_modified": ["README.md"]}'
@@ -451,18 +450,17 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-p1", "patch", patch_result)
         assert isinstance(result, ToolCallProgress)
         assert len(result.content) == 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "README.md"
-        assert diff_item.old_text == "old line"
-        assert diff_item.new_text == "old line\nnew line"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "✅ patch completed" in item.content.text
+        assert "README.md" in item.content.text
 
     def test_build_tool_complete_for_patch_falls_back_to_text_when_no_diff(self):
         result = build_tool_complete("tc-p2", "patch", '{"success": true}')
         assert isinstance(result, ToolCallProgress)
         assert isinstance(result.content[0], ContentToolCallContent)
 
-    def test_build_tool_complete_for_write_file_uses_snapshot_diff(self, tmp_path):
+    def test_build_tool_complete_for_write_file_summarizes_without_repeating_diff(self, tmp_path):
         target = tmp_path / "diff-test.txt"
         snapshot = type("Snapshot", (), {"paths": [target], "before": {str(target): None}})()
         target.write_text("hello from hermes\n", encoding="utf-8")
@@ -476,11 +474,10 @@ class TestBuildToolComplete:
         )
         assert isinstance(result, ToolCallProgress)
         assert len(result.content) == 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path.endswith("diff-test.txt")
-        assert diff_item.old_text is None
-        assert diff_item.new_text == "hello from hermes"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "✅ write_file completed" in item.content.text
+        assert "diff-test.txt" in item.content.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add ACP edit approval gating for file mutations before disk writes occur
- build structured edit diffs for `write_file` and `patch` replace-mode and request Zed permission before executing
- deny safely on rejection, requester errors, or diff-preparation failures so files remain unchanged
- add regression coverage for approve/reject paths, new files, requester exceptions, and patch replace-mode

## Test Plan
- `scripts/run_tests.sh tests/acp/test_edit_approval.py tests/acp/test_events.py tests/acp/test_tools.py -q`

## Notes
- The guard is bound through an ACP-only ContextVar around `run_conversation`, so CLI/gateway sessions keep existing behavior.
- Manual Zed reject-path verification is still recommended before merge because this is a safety/UX path.
