### PR TITLE
feat(gateway): mark plugin skill invocations with 🔌 in tool-progress

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -159,6 +159,30 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
     return default
 
 
+def format_skill_progress(args: dict | None) -> str | None:
+    """Render a tool-progress line for plugin (TAP-installed) skills.
+
+    Native ``skill_view`` calls render as ``📚 skill_view: "axolotl"`` via
+    the standard emoji + preview pipeline.  Skills installed via TAP
+    plugins arrive with qualified names like ``bp-shopify:seo-reports``,
+    and surfacing them with a 🔌 plug glyph lets users distinguish plugin
+    skills from native ones at a glance in tool-progress messages.
+
+    Returns the formatted message string for plugin skills, or ``None``
+    for native skills / malformed input (caller falls through to the
+    default render).  Pure function — no registry lookups or I/O.
+    """
+    if not args:
+        return None
+    name = args.get("name")
+    if not isinstance(name, str) or ":" not in name:
+        return None
+    namespace, _, bare = name.partition(":")
+    if not namespace or not bare:
+        return None
+    return f"🔌 {namespace} · {bare}"
+
+
 # =========================================================================
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14714,12 +14714,22 @@ class GatewayRunner:
             last_tool[0] = tool_name
             
             # Build progress message with primary argument preview
-            from agent.display import get_tool_emoji
+            from agent.display import format_skill_progress, get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
-            
+
+            # Plugin-skill override: when the agent invokes a TAP-installed
+            # skill via skill_view, surface it with the 🔌 plug glyph and
+            # qualified name so plugin skills are visually distinct from
+            # native (📚) ones in Slack tool-progress.
+            _plugin_skill_msg = (
+                format_skill_progress(args) if tool_name == "skill_view" else None
+            )
+
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":
-                if args:
+                if _plugin_skill_msg is not None:
+                    msg = _plugin_skill_msg
+                elif args:
                     from agent.display import get_tool_preview_max_len
                     _pl = get_tool_preview_max_len()
                     args_str = json.dumps(args, ensure_ascii=False, default=str)
@@ -14735,11 +14745,13 @@ class GatewayRunner:
                     msg = f"{emoji} {tool_name}..."
                 progress_queue.put(msg)
                 return
-            
+
             # "all" / "new" modes: short preview, respects tool_preview_length
             # config (defaults to 40 chars when unset to keep gateway messages
             # compact — unlike CLI spinners, these persist as permanent messages).
-            if preview:
+            if _plugin_skill_msg is not None:
+                msg = _plugin_skill_msg
+            elif preview:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40

--- a/tests/agent/test_display_emoji.py
+++ b/tests/agent/test_display_emoji.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch as mock_patch, MagicMock
 
-from agent.display import get_tool_emoji
+from agent.display import format_skill_progress, get_tool_emoji
 
 
 class TestGetToolEmoji:
@@ -121,3 +121,47 @@ class TestSkinConfigToolEmojis:
         data = {"name": "minimal"}
         skin = _build_skin_config(data)
         assert skin.tool_emojis == {}
+
+
+class TestFormatSkillProgress:
+    """Verify the 🔌 plugin-skill override for tool-progress messages."""
+
+    def test_plugin_skill_qualified_name(self):
+        """Qualified ``namespace:bare`` renders as ``🔌 namespace · bare``."""
+        result = format_skill_progress({"name": "bp-shopify:seo-reports"})
+        assert result == "🔌 bp-shopify · seo-reports"
+
+    def test_native_skill_no_namespace(self):
+        """Bare names (native skills) fall through to default render."""
+        assert format_skill_progress({"name": "axolotl"}) is None
+
+    def test_native_skill_categorized_path(self):
+        """Native skills with category-path slashes still fall through."""
+        assert format_skill_progress({"name": "fine-tuning/axolotl"}) is None
+
+    def test_empty_args(self):
+        assert format_skill_progress({}) is None
+
+    def test_none_args(self):
+        assert format_skill_progress(None) is None
+
+    def test_missing_name(self):
+        assert format_skill_progress({"file_path": "foo.md"}) is None
+
+    def test_non_string_name(self):
+        assert format_skill_progress({"name": 42}) is None
+        assert format_skill_progress({"name": None}) is None
+        assert format_skill_progress({"name": ["a", "b"]}) is None
+
+    def test_empty_namespace(self):
+        """Defensive: leading colon means no namespace — fall through."""
+        assert format_skill_progress({"name": ":seo-reports"}) is None
+
+    def test_empty_bare(self):
+        """Defensive: trailing colon means no bare name — fall through."""
+        assert format_skill_progress({"name": "bp-shopify:"}) is None
+
+    def test_multi_colon_partitions_on_first(self):
+        """If a skill name contains multiple colons, split on the first."""
+        result = format_skill_progress({"name": "foo:bar:baz"})
+        assert result == "🔌 foo · bar:baz"


### PR DESCRIPTION
## What does this PR do?
Skills loaded via TAP plugins arrive with qualified names like
`bp-shopify:seo-reports`, but tool-progress messages render every
`skill_view` call identically as `📚 skill_view: "<name>"` — giving users
no visual cue whether they're watching a native skill or a plugin one.

Add `format_skill_progress(args)` in `agent/display.py` that detects
qualified plugin names and returns a `🔌 <namespace> · <bare>` override.
Wire it into the gateway progress callback so the plug glyph replaces
the standard render for plugin skills in `all`, `new`, and `verbose`
modes. Native skills are unaffected.

## Related Issue
N/A — UX improvement, no open issue.

## Type of Change
- [x] ✨ New feature (non-breaking change)

## Changes Made
- `agent/display.py`: new `format_skill_progress(args)` pure helper.
- `gateway/run.py`: progress callback consults the helper before falling
  through to the default emoji + preview render.
- `tests/agent/test_display_emoji.py`: 10 new tests covering plugin/native
  dispatch, malformed inputs, and the multi-colon edge case.

## How to Test
1. \`scripts/run_tests.sh tests/agent/test_display_emoji.py -v\` — 20 pass.
2. Manual: in a profile with a TAP plugin installed (e.g. \`bp-shopify\`),
   ask the agent to load a plugin skill. The Slack progress message
   reads \`🔌 bp-shopify · seo-reports\` instead of \`📚 skill_view: "…"\`.
3. Manual: load a native skill (\`axolotl\`). Render is unchanged.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits
- [x] Searched existing PRs for duplicates
- [x] PR contains only this feature
- [x] \`scripts/run_tests.sh tests/agent/\` — patch-related tests pass; pre-existing
      failures in \`test_anthropic_adapter.py\` reproduced on clean \`upstream/main\`
- [x] Added unit tests for the new helper
- [x] Tested on macOS 15.x

### Documentation & Housekeeping
- [x] No public docs / config / CLI surface changes — N/A
- [x] No cross-platform-sensitive code touched — N/A
- [x] No tool descriptions/schemas changed — N/A