### PR TITLE
feat(skills): configure llm-wiki path

### DIFF
--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -10,6 +10,11 @@ metadata:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]
     category: research
     related_skills: [obsidian, arxiv]
+    config:
+      - key: wiki_path
+        description: Path to the LLM Wiki markdown knowledge base directory.
+        default: "~/wiki"
+        prompt: LLM Wiki directory path
 ---
 
 # Karpathy's LLM Wiki
@@ -35,11 +40,25 @@ Use this skill when the user:
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `~/.hermes/.env`).
+**Location:** Prefer `skills.config.wiki_path` in `~/.hermes/config.yaml`.
+Hermes setup/status discovers this from `metadata.hermes.config`, and when the
+skill loads Hermes injects the resolved value as `wiki_path = ...` in the
+`[Skill config]` block.
 
-If unset, defaults to `~/wiki`.
+Set it with:
 
 ```bash
+hermes config set skills.config.wiki_path ~/wiki
+```
+
+Legacy `WIKI_PATH` environment variable support is preserved for existing users
+and one-off shell overrides. Resolution order: `WIKI_PATH` env var >
+`skills.config.wiki_path` (`wiki_path` in the injected skill config block) >
+`~/wiki`.
+
+```bash
+# If the injected Skill config says `wiki_path = /path/to/wiki`, use that as
+# the fallback below. The default injected value is ~/wiki.
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 ```
 
@@ -78,6 +97,8 @@ When the user has an existing wiki, **always orient yourself before doing anythi
 ③ **Scan recent `log.md`** — read the last 20-30 entries to understand recent activity.
 
 ```bash
+# Prefer WIKI_PATH when set; otherwise use the injected `wiki_path` skill config
+# value (default ~/wiki) as the fallback.
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 # Orientation reads at session start
 read_file "$WIKI/SCHEMA.md"
@@ -98,7 +119,7 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path (from `$WIKI_PATH` env var, then injected `wiki_path` skill config, default `~/wiki`; ask only if the user needs a different location)
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -460,6 +460,38 @@ Generate some audio.
         assert "test-skill" in msg
         assert "do stuff" in msg
 
+    def test_injects_declared_skill_config_values(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n"
+            "  config:\n"
+            "    wiki_path: /tmp/research-wiki\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "config-skill",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    config:\n"
+                    "      - key: wiki_path\n"
+                    "        description: Wiki path\n"
+                    "        default: ~/wiki\n"
+                    "        prompt: Wiki directory path\n"
+                ),
+            )
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/config-skill", "open wiki")
+
+        assert msg is not None
+        assert "[Skill config" in msg
+        assert "wiki_path = /tmp/research-wiki" in msg
+
     def test_returns_none_for_unknown(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             scan_skill_commands()

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,14 @@
-"""Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
+"""Tests for agent/skill_utils.py — skill frontmatter metadata handling."""
 
-from agent.skill_utils import extract_skill_conditions
+from pathlib import Path
+
+from agent.skill_utils import (
+    discover_all_skill_config_vars,
+    extract_skill_conditions,
+    extract_skill_config_vars,
+    parse_frontmatter,
+    resolve_skill_config_values,
+)
 
 
 def test_metadata_as_dict_with_hermes():
@@ -56,3 +64,46 @@ def test_metadata_missing_entirely():
         "fallback_for_tools": [],
         "requires_tools": [],
     }
+
+
+def test_llm_wiki_declares_wiki_path_skill_config():
+    """The bundled llm-wiki skill should participate in setup/status config discovery."""
+    skill_path = Path(__file__).resolve().parents[2] / "skills" / "research" / "llm-wiki" / "SKILL.md"
+    content = skill_path.read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter(content)
+
+    config_vars = extract_skill_config_vars(frontmatter)
+
+    assert config_vars == [
+        {
+            "key": "wiki_path",
+            "description": "Path to the LLM Wiki markdown knowledge base directory.",
+            "default": "~/wiki",
+            "prompt": "LLM Wiki directory path",
+        }
+    ]
+    assert "skills.config.wiki_path" in body
+    assert "WIKI_PATH" in body
+
+
+def test_llm_wiki_config_is_discoverable_and_resolves_from_config_yaml(tmp_path, monkeypatch):
+    """Discovery returns logical keys, while resolution reads skills.config.<key>."""
+    repo_skills_dir = Path(__file__).resolve().parents[2] / "skills"
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n"
+        "  config:\n"
+        "    wiki_path: ~/research-wiki\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [repo_skills_dir])
+    monkeypatch.setattr("agent.skill_utils.get_disabled_skill_names", lambda: set())
+
+    discovered = discover_all_skill_config_vars()
+    llm_wiki_var = next(var for var in discovered if var.get("skill") == "llm-wiki")
+    resolved = resolve_skill_config_values([llm_wiki_var])
+
+    assert llm_wiki_var["key"] == "wiki_path"
+    assert resolved["wiki_path"] == str(Path.home() / "research-wiki")

--- a/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
+++ b/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
@@ -52,11 +52,25 @@ Use this skill when the user:
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `~/.hermes/.env`).
+**Location:** Prefer `skills.config.wiki_path` in `~/.hermes/config.yaml`.
+Hermes setup/status discovers this from `metadata.hermes.config`, and when the
+skill loads Hermes injects the resolved value as `wiki_path = ...` in the
+`[Skill config]` block.
 
-If unset, defaults to `~/wiki`.
+Set it with:
 
 ```bash
+hermes config set skills.config.wiki_path ~/wiki
+```
+
+Legacy `WIKI_PATH` environment variable support is preserved for existing users
+and one-off shell overrides. Resolution order: `WIKI_PATH` env var >
+`skills.config.wiki_path` (`wiki_path` in the injected skill config block) >
+`~/wiki`.
+
+```bash
+# If the injected Skill config says `wiki_path = /path/to/wiki`, use that as
+# the fallback below. The default injected value is ~/wiki.
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 ```
 
@@ -97,6 +111,8 @@ When the user has an existing wiki, **always orient yourself before doing anythi
 ③ **Scan recent `log.md`** — read the last 20-30 entries to understand recent activity.
 
 ```bash
+# Prefer WIKI_PATH when set; otherwise use the injected `wiki_path` skill config
+# value (default ~/wiki) as the fallback.
 WIKI="${WIKI_PATH:-$HOME/wiki}"
 # Orientation reads at session start
 read_file "$WIKI/SCHEMA.md"
@@ -117,7 +133,7 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path (from `$WIKI_PATH` env var, then injected `wiki_path` skill config, default `~/wiki`; ask only if the user needs a different location)
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)


### PR DESCRIPTION
## ⚠️ Obsolete policy direction — please do not merge

This PR is being closed because current `main` deliberately adopted the opposite policy for the bundled `llm-wiki` skill.

Commit `80855f964e4d626857ee1ded783c247ffa50427e` removed `metadata.hermes.config` from `llm-wiki` because bundled skills are enabled by default and the metadata caused unsolicited, repeated update/migration prompts for users who never activated the skill.

Current behavior uses:

- `WIKI_PATH` when explicitly configured;
- `~/wiki` as the runtime default;
- no `config.yaml` migration prompt for the bundled skill.

Reintroducing `skills.config.wiki_path` through this branch would restore the prompt loop that current `main` intentionally removed. A future configuration UX would first need explicit skill-activation scoping and should be proposed separately.

Closing this PR unmerged. The branch is left intact for reference.
