### PR TITLE
fix: resolve TUI resume to session tips

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -292,8 +292,11 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def get_session(self, _sid):
             return {"id": "20260409_010101_abc123"}
 
-        def get_session_by_title(self, _title):
+        def resolve_session_by_title(self, _title):
             return None
+
+        def resolve_resume_session_id(self, sid):
+            return sid
 
         def reopen_session(self, _sid):
             return None
@@ -328,6 +331,83 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         {"role": "assistant", "text": "yo"},
         {"role": "tool", "name": "tool", "context": ""},
     ]
+
+
+def test_session_resume_title_uses_latest_lineage_variant(server, monkeypatch):
+    resumed = []
+
+    class _DB:
+        def get_session(self, sid):
+            if sid == "s3":
+                return {"id": "s3", "title": "Project #3"}
+            return None
+
+        def resolve_session_by_title(self, title):
+            assert title == "Project"
+            return "s3"
+
+        def resolve_resume_session_id(self, sid):
+            return sid
+
+        def reopen_session(self, sid):
+            resumed.append(sid)
+
+        def get_messages_as_conversation(self, sid, include_ancestors=False):
+            assert sid == "s3"
+            return [{"role": "user", "content": "latest"}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: object())
+    monkeypatch.setattr(server, "_init_session", lambda sid, key, agent, history, cols=80: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {"id": "r-title", "method": "session.resume", "params": {"session_id": "Project"}}
+    )
+
+    assert "error" not in resp
+    assert resp["result"]["resumed"] == "s3"
+    assert resumed == ["s3"]
+
+
+def test_session_resume_id_redirects_to_compression_tip(server, monkeypatch):
+    initialized = []
+
+    class _DB:
+        def get_session(self, sid):
+            if sid in {"root", "tip"}:
+                return {"id": sid}
+            return None
+
+        def resolve_session_by_title(self, _title):
+            return None
+
+        def resolve_resume_session_id(self, sid):
+            assert sid == "root"
+            return "tip"
+
+        def reopen_session(self, _sid):
+            return None
+
+        def get_messages_as_conversation(self, sid, include_ancestors=False):
+            assert sid == "tip"
+            return [{"role": "user", "content": "continued"}]
+
+    def fake_init(sid, key, agent, history, cols=80):
+        initialized.append((key, history))
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: object())
+    monkeypatch.setattr(server, "_init_session", fake_init)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {"id": "r-tip", "method": "session.resume", "params": {"session_id": "root"}}
+    )
+
+    assert "error" not in resp
+    assert resp["result"]["resumed"] == "tip"
+    assert initialized == [("tip", [{"role": "user", "content": "continued"}])]
 
 
 # ── Config I/O ───────────────────────────────────────────────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2250,11 +2250,25 @@ def _(rid, params: dict) -> dict:
         return _db_unavailable_error(rid, code=5000)
     found = db.get_session(target)
     if not found:
-        found = db.get_session_by_title(target)
-        if found:
-            target = found["id"]
-        else:
+        resolved_id = db.resolve_session_by_title(target)
+        if not resolved_id:
             return _err(rid, 4007, "session not found")
+        target = str(resolved_id)
+        found = db.get_session(target)
+        if not found:
+            return _err(rid, 4007, "session not found")
+
+    try:
+        resolved_target = db.resolve_resume_session_id(target)
+    except Exception:
+        logger.exception("session.resume continuation resolution failed for %r", target)
+        resolved_target = target
+    if resolved_target and resolved_target != target:
+        target = str(resolved_target)
+        found = db.get_session(target)
+        if not found:
+            return _err(rid, 4007, "session not found")
+
     sid = uuid.uuid4().hex[:8]
     _enable_gateway_prompts()
     try:


### PR DESCRIPTION
## Summary
- Resolve TUI `session.resume` titles through `SessionDB.resolve_session_by_title()` so `/resume Project` selects the latest numbered lineage variant.
- Resolve the chosen session through `SessionDB.resolve_resume_session_id()` so compressed session heads resume at the transcript-holding descendant.
- Add TUI gateway regression coverage for title lineage and compression-tip redirection.

## Test Plan
- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py::test_session_resume_returns_hydrated_messages tests/tui_gateway/test_protocol.py::test_session_resume_title_uses_latest_lineage_variant tests/tui_gateway/test_protocol.py::test_session_resume_id_redirects_to_compression_tip -q`
- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py -q`
- `scripts/run_tests.sh tests/hermes_state/test_resolve_resume_session_id.py tests/test_hermes_state.py::TestTitleLineage -q`
- Patch dry-run: `git apply --check` and `git am --3way` against a fresh `origin/main` worktree, then focused new TUI regression tests.

## Notes
- This keeps the change scoped to `tui_gateway/server.py` plus protocol tests.
- CLI resume already uses the session-tip resolver; this aligns TUI resume with that existing behavior.
