### PR TITLE
fix(run_agent): guard memory provider init against empty/whitespace string

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2007,7 +2007,7 @@ class AIAgent:
             try:
                 _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 
-                if _mem_provider_name:
+                if _mem_provider_name and _mem_provider_name.strip():
                     from agent.memory_manager import MemoryManager as _MemoryManager
                     from plugins.memory import load_memory_provider as _load_mem
                     self._memory_manager = _MemoryManager()


### PR DESCRIPTION
## Problem

When `memory.provider` is configured as an empty string or whitespace-only string in config.yaml, the memory provider init is silently skipped with no warning. This makes it appear that Mnemosyne (or any provider) is active when it isn't.

## Fix

`run_agent.py` line 1998: guard `if _mem_provider_name:` with `and _mem_provider_name.strip()` so empty and whitespace-only strings are treated the same as no provider.

## Testing

Trivial one-line change with no side effects — the original condition already handles `None`/falsy; this extends it to cover the edge case of `provider: ''` or `provider: ' '` in config.
