### PR TITLE
fix(line): respect proxy env vars in LINE adapter HTTP sessions

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -447,7 +447,7 @@ class _LineClient:
     async def reply(self, reply_token: str, messages: List[Dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.post(
                 LINE_REPLY_URL,
                 headers=self._headers,
@@ -460,7 +460,7 @@ class _LineClient:
     async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.post(
                 LINE_PUSH_URL,
                 headers=self._headers,
@@ -479,7 +479,7 @@ class _LineClient:
         clamped = max(5, min(60, (seconds // 5) * 5 or 5))
         try:
             timeout = aiohttp.ClientTimeout(total=5.0)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
                 await session.post(
                     LINE_LOADING_URL,
                     headers=self._headers,
@@ -493,7 +493,7 @@ class _LineClient:
         import aiohttp
         url = LINE_CONTENT_URL_FMT.format(message_id=message_id)
         timeout = aiohttp.ClientTimeout(total=30.0)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.get(url, headers={"Authorization": f"Bearer {self._token}"}) as resp:
                 if resp.status >= 400:
                     raise RuntimeError(f"LINE content {resp.status}")
@@ -504,7 +504,7 @@ class _LineClient:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=10.0)
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
                 async with session.get(LINE_BOT_INFO_URL, headers=self._headers) as resp:
                     if resp.status >= 400:
                         return None


### PR DESCRIPTION
## Problem

All five `aiohttp.ClientSession` instances in `_LineClient` ignore proxy
environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`). Users
running Hermes behind a corporate or transparent proxy see every LINE API
call fail — `reply`, `push`, `loading`, `fetch_content`, and
`get_bot_user_id` all bypass the system proxy.

## Root Cause

`aiohttp.ClientSession` defaults to `trust_env=False`. Without this flag
the session ignores proxy env vars and goes direct even when the host
network requires a proxy.

All five session constructions in `_LineClient` omit the flag:

```python
# reply(), push(), loading(), fetch_content(), get_bot_user_id()
async with aiohttp.ClientSession(timeout=timeout) as session:  # ← no trust_env
```

## Fix

Add `trust_env=True` to each of the five `aiohttp.ClientSession()` calls
in `_LineClient`. Symmetric with the `wecom` (`wecom.py:276`) and `weixin`
(`weixin.py:1055`, `1268`, `1274`) adapters, which already set this flag.

```python
async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
```

No behavior change for users not running behind a proxy.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `plugins/platforms/line/adapter.py`: add `trust_env=True` to all five `aiohttp.ClientSession()` calls in `_LineClient`

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single fix only | Platform: macOS