### PR TITLE
feat(telegram): pin incoming user message for duration of agent turn

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4692,6 +4692,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
             thread_id=thread_id_str,
             chat_topic=chat_topic,
+            message_id=str(message.message_id),
         )
         
         # Extract reply context if this message is a reply.
@@ -4783,16 +4784,25 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
-        if not self._reactions_enabled():
-            return
+        """Add an in-progress reaction and pin the message when processing begins."""
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            if self._reactions_enabled():
+                await self._set_reaction(chat_id, message_id, "\U0001f440")
+            # Pin the incoming message for the duration of the turn
+            if self._bot:
+                try:
+                    await self._bot.pin_chat_message(
+                        chat_id=int(chat_id),
+                        message_id=int(message_id),
+                        disable_notification=True,
+                    )
+                except Exception:
+                    logger.debug("[Telegram] Failed to pin message %s in chat %s", message_id, chat_id)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
-        """Swap the in-progress reaction for a final success/failure reaction.
+        """Swap the in-progress reaction for a final success/failure reaction and unpin.
 
         Unlike Discord (additive reactions), Telegram's set_message_reaction
         replaces all existing reactions in one call — no remove step needed.
@@ -4804,17 +4814,25 @@ class TelegramAdapter(BasePlatformAdapter):
         another agent run to swap it to 👍/👎 — which never happens if the
         cancellation was the last activity in the chat.
         """
-        if not self._reactions_enabled():
-            return
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if not (chat_id and message_id):
             return
-        if outcome == ProcessingOutcome.CANCELLED:
-            await self._clear_reactions(chat_id, message_id)
-        else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
-            )
+        if self._reactions_enabled():
+            if outcome == ProcessingOutcome.CANCELLED:
+                await self._clear_reactions(chat_id, message_id)
+            else:
+                await self._set_reaction(
+                    chat_id,
+                    message_id,
+                    "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+                )
+        # Unpin the message when processing is complete
+        if self._bot:
+            try:
+                await self._bot.unpin_chat_message(
+                    chat_id=int(chat_id),
+                    message_id=int(message_id),
+                )
+            except Exception:
+                logger.debug("[Telegram] Failed to unpin message %s in chat %s", message_id, chat_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13004,6 +13004,7 @@ class GatewayRunner:
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            message_id=str(context.source.message_id) if context.source.message_id else "",
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -56,6 +56,7 @@ _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNS
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
@@ -72,6 +73,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
+    "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -86,6 +88,7 @@ def set_session_vars(
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    message_id: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -103,6 +106,7 @@ def set_session_vars(
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
+        _SESSION_MESSAGE_ID.set(message_id),
     ]
     return tokens
 
@@ -126,6 +130,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _SESSION_MESSAGE_ID,
     ):
         var.set("")
 


### PR DESCRIPTION
## Summary

Adds automatic pinning of incoming Telegram messages for the duration of an agent turn. When a user sends a message, it is pinned at the start of processing and unpinned when the agent finishes its response.

## Motivation

On Telegram, long-running agent turns leave the user without a clear visual indicator that their message is being worked on. Pinning the incoming message provides that signal and keeps the conversation anchored during processing.

## Behavior

- The user's incoming message is pinned when the agent begins processing
- The same message is unpinned when the turn completes (success, failure, or cancellation)
- Only the user's message is pinned -- never the agent's replies
- Pinning is silent (`disable_notification=True`)
- Failures are logged at debug level and do not interrupt message processing
- Works independently of the reactions feature

## Changes

**`gateway/platforms/telegram.py`**
- `on_processing_start`: added `pinChatMessage` call; restructured so it runs regardless of whether reactions are enabled
- `on_processing_complete`: added `unpinChatMessage` call; same restructuring
- `_build_message_event`: passes `message_id` through `SessionSource`

**`gateway/session_context.py`**
- Added `HERMES_SESSION_MESSAGE_ID` context variable following the existing pattern

**`gateway/run.py`**
- Passes `source.message_id` through `set_session_vars`

## Edge cases

- Auto-resume events (gateway restart recovery) have `message_id=None` and are skipped
- Group chats require bot admin rights to pin; DMs need no special permissions
