### PR TITLE
fix(auxiliary_client): use threading.local for runtime main state

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1572,7 +1572,7 @@ def _read_main_model() -> str:
     that gate on "the active main model" (e.g. ``vision_analyze``'s native
     fast path) see the live runtime, not the persisted config default.
     """
-    override = _RUNTIME_MAIN_MODEL
+    override = getattr(_RUNTIME_MAIN, "model", "")
     if isinstance(override, str) and override.strip():
         return override.strip()
     try:
@@ -1599,7 +1599,7 @@ def _read_main_provider() -> str:
     Runtime override: see ``_read_main_model`` — same mechanism for the
     provider half of the runtime tuple.
     """
-    override = _RUNTIME_MAIN_PROVIDER
+    override = getattr(_RUNTIME_MAIN, "provider", "")
     if isinstance(override, str) and override.strip():
         return override.strip().lower()
     try:
@@ -1615,10 +1615,10 @@ def _read_main_provider() -> str:
     return ""
 
 
-# Process-local override set by AIAgent at session/turn start. Single-threaded
-# per turn — no lock needed. Cleared by ``clear_runtime_main()``.
-_RUNTIME_MAIN_PROVIDER: str = ""
-_RUNTIME_MAIN_MODEL: str = ""
+# Thread-local override set by AIAgent at session/turn start.
+# gateway runs each session in a thread-pool thread via run_in_executor;
+# module-level globals would let concurrent sessions overwrite each other.
+_RUNTIME_MAIN: threading.local = threading.local()
 
 
 def set_runtime_main(provider: str, model: str) -> None:
@@ -1629,16 +1629,14 @@ def set_runtime_main(provider: str, model: str) -> None:
     ``_read_main_provider`` / ``_read_main_model`` reflect CLI/gateway
     overrides instead of the stale config.yaml default.
     """
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
-    _RUNTIME_MAIN_PROVIDER = (provider or "").strip().lower()
-    _RUNTIME_MAIN_MODEL = (model or "").strip()
+    _RUNTIME_MAIN.provider = (provider or "").strip().lower()
+    _RUNTIME_MAIN.model = (model or "").strip()
 
 
 def clear_runtime_main() -> None:
     """Clear the runtime override (e.g. on session end)."""
-    global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
-    _RUNTIME_MAIN_PROVIDER = ""
-    _RUNTIME_MAIN_MODEL = ""
+    _RUNTIME_MAIN.provider = ""
+    _RUNTIME_MAIN.model = ""
 
 
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:


### PR DESCRIPTION
## Problem

`_RUNTIME_MAIN_PROVIDER` and `_RUNTIME_MAIN_MODEL` are module-level globals written by `set_runtime_main()` at the start of each turn. The original comment says *"Single-threaded per turn — no lock needed"*, which holds for the CLI.

In the **gateway**, however, `run_conversation` is dispatched via `loop.run_in_executor(None, run_sync)`, which runs each session in a thread-pool thread. Two concurrent sessions can therefore race on these globals:

```
Thread A: set_runtime_main("openai",   "gpt-4o")   → _RUNTIME_MAIN_PROVIDER = "openai"
Thread B: set_runtime_main("alibaba",  "qwen-max") → _RUNTIME_MAIN_PROVIDER = "alibaba"
Thread A: _read_main_provider() → returns "alibaba"   ← wrong session's value
```

## Root Cause

`agent/auxiliary_client.py` → module scope → `_RUNTIME_MAIN_PROVIDER: str = ""` / `_RUNTIME_MAIN_MODEL: str = ""`

These are shared across all threads in the process; gateway sessions clobber each other.

## Fix

Replace both globals with a single `threading.local()` instance. Each thread pool thread carries its own isolated copy; CLI behaviour is unchanged (single thread = single local).

```python
_RUNTIME_MAIN: threading.local = threading.local()
```

`threading` is already imported. `set_runtime_main`, `clear_runtime_main`, `_read_main_provider`, and `_read_main_model` updated to use `getattr(..., "")` for safe first-access. No API change.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `agent/auxiliary_client.py`: replace `_RUNTIME_MAIN_PROVIDER` / `_RUNTIME_MAIN_MODEL` globals with `threading.local()`

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single fix only | Platform: macOS