### PR TITLE
fix(gateway): treat stat-error on PATH probes as missing dir, not crash

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2103,6 +2103,23 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
+def _safe_is_dir(path: Path) -> bool:
+    """Return ``True`` iff ``path`` is a directory we can stat.
+
+    Wraps :meth:`pathlib.Path.is_dir` to treat unreachable paths
+    (``PermissionError``, broken symlinks, network mounts that error out
+    on ``stat``) as "not a directory" rather than crashing the caller.
+    ``generate_systemd_unit`` runs at install / setup time when the
+    target host may have a partially-locked-down ``~/.hermes`` (CI
+    sandboxes, multi-user systemd setups), so a stat failure must not
+    prevent unit generation.
+    """
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
@@ -2111,21 +2128,21 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _safe_is_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _safe_is_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _safe_is_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _safe_is_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -35,21 +35,23 @@ def test_service_path_treats_permission_error_as_missing(tmp_path):
     """A ``PermissionError`` from ``is_dir()`` must not crash unit
     generation — treat the path as missing and continue.
 
-    Reproduces the CI baseline (#26622 audit): on Ubuntu runners executing
-    as root, ``stat('/root/.hermes/node/bin')`` can raise ``EACCES`` even
-    though the calling user owns ``/root``. Before the guard,
-    ``generate_systemd_unit()`` and ``generate_launchd_plist()`` would
-    propagate the ``OSError`` and refuse to produce any unit at all.
+    Reproduces the CI baseline (#26622 audit): on locked-down Ubuntu
+    runners, ``stat('/root/.hermes/node/bin')`` returns ``EACCES`` from
+    the sandboxed filesystem layer even when the path is otherwise
+    reachable. Before the guard, ``generate_systemd_unit()`` and
+    ``generate_launchd_plist()`` propagated the ``OSError`` and refused
+    to produce any unit at all.
     """
     from hermes_cli.gateway import _build_service_path_dirs
 
     real_is_dir = Path.is_dir
+    target = tmp_path / ".hermes" / "node" / "bin"
 
     def fake_is_dir(self):
         # Only the hermes_home node/bin probe trips EACCES; other paths
         # must keep their real behavior so the rest of the function is
         # exercised normally.
-        if str(self).endswith("/.hermes/node/bin"):
+        if self == target:
             raise PermissionError(13, "Permission denied", str(self))
         return real_is_dir(self)
 
@@ -57,7 +59,7 @@ def test_service_path_treats_permission_error_as_missing(tmp_path):
          patch.object(Path, "is_dir", fake_is_dir):
         dirs = _build_service_path_dirs(project_root=tmp_path)
 
-    assert str(tmp_path / ".hermes" / "node" / "bin") not in dirs
+    assert str(target) not in dirs
 
 
 def test_service_path_treats_oserror_as_missing(tmp_path):
@@ -67,9 +69,10 @@ def test_service_path_treats_oserror_as_missing(tmp_path):
     from hermes_cli.gateway import _build_service_path_dirs
 
     real_is_dir = Path.is_dir
+    target = tmp_path / ".hermes" / "node_modules" / ".bin"
 
     def fake_is_dir(self):
-        if str(self).endswith("/.hermes/node_modules/.bin"):
+        if self == target:
             raise OSError(5, "Input/output error", str(self))
         return real_is_dir(self)
 
@@ -77,4 +80,4 @@ def test_service_path_treats_oserror_as_missing(tmp_path):
          patch.object(Path, "is_dir", fake_is_dir):
         dirs = _build_service_path_dirs(project_root=tmp_path)
 
-    assert str(tmp_path / ".hermes" / "node_modules" / ".bin") not in dirs
+    assert str(target) not in dirs

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -29,3 +29,52 @@ def test_service_path_includes_hermes_home_node_modules(tmp_path):
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     assert str(hermes_nm) in dirs
+
+
+def test_service_path_treats_permission_error_as_missing(tmp_path):
+    """A ``PermissionError`` from ``is_dir()`` must not crash unit
+    generation — treat the path as missing and continue.
+
+    Reproduces the CI baseline (#26622 audit): on Ubuntu runners executing
+    as root, ``stat('/root/.hermes/node/bin')`` can raise ``EACCES`` even
+    though the calling user owns ``/root``. Before the guard,
+    ``generate_systemd_unit()`` and ``generate_launchd_plist()`` would
+    propagate the ``OSError`` and refuse to produce any unit at all.
+    """
+    from hermes_cli.gateway import _build_service_path_dirs
+
+    real_is_dir = Path.is_dir
+
+    def fake_is_dir(self):
+        # Only the hermes_home node/bin probe trips EACCES; other paths
+        # must keep their real behavior so the rest of the function is
+        # exercised normally.
+        if str(self).endswith("/.hermes/node/bin"):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_is_dir(self)
+
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"), \
+         patch.object(Path, "is_dir", fake_is_dir):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+
+    assert str(tmp_path / ".hermes" / "node" / "bin") not in dirs
+
+
+def test_service_path_treats_oserror_as_missing(tmp_path):
+    """Broken-symlink / unreachable network mount probes (``OSError``)
+    must also be treated as "directory not present" rather than crashing.
+    """
+    from hermes_cli.gateway import _build_service_path_dirs
+
+    real_is_dir = Path.is_dir
+
+    def fake_is_dir(self):
+        if str(self).endswith("/.hermes/node_modules/.bin"):
+            raise OSError(5, "Input/output error", str(self))
+        return real_is_dir(self)
+
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"), \
+         patch.object(Path, "is_dir", fake_is_dir):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+
+    assert str(tmp_path / ".hermes" / "node_modules" / ".bin") not in dirs


### PR DESCRIPTION
## Summary

- `_build_service_path_dirs()` propagated `PermissionError` (and other `OSError`s) from `is_dir()` probes, crashing `generate_systemd_unit()` / `generate_launchd_plist()` instead of just skipping the unreachable path.
- Wrap each probe in a small `_safe_is_dir()` helper that returns False on `OSError`. Existing "skip non-existent" semantics are unchanged.
- Adds two regression tests (PermissionError + generic OSError) and verifies the change unblocks the previously-broken `TestSystemUnitHermesHome` cases on CI.

## The bug

`hermes_cli/gateway.py:2106` (`_build_service_path_dirs`, introduced by [d69eab1ef](https://github.com/NousResearch/hermes-agent/commit/d69eab1ef) on 2026-05-15) probes four candidate directories with `pathlib.Path.is_dir()` to decide what to include in the service unit's `PATH`. Two of those probes target `~/.hermes/node/bin` and `~/.hermes/node_modules/.bin` resolved through `get_hermes_home()`.

`Path.is_dir()` calls `os.stat()` and re-raises whatever `stat` returns. On CI runners executing as root, `os.stat('/root/.hermes/node/bin')` raises `EACCES` (the directory exists in a partially-locked-down layout) — and the unhandled `PermissionError` then propagates all the way up out of `generate_systemd_unit()`. Same shape would hit any production setup with a partially-locked-down `~/.hermes` (multi-user systemd installs, sandboxed services).

This is what made `tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome`'s two `_remap`/`_target_user_home` cases start failing on `origin/main` CI starting with [run 25944419334](https://github.com/NousResearch/hermes-agent/actions/runs/25944419334) — the symptom of the bug, not the cause.

```
hermes_cli/gateway.py:2125: in _build_service_path_dirs
    if hermes_node.is_dir():
...
E   PermissionError: [Errno 13] Permission denied: '/root/.hermes/node/bin'
```

## The fix

Add `_safe_is_dir(path: Path) -> bool` that wraps `path.is_dir()` in a try/except for `OSError` and returns False on stat failure. Route every `is_dir()` probe in `_build_service_path_dirs()` through it. No other semantics change — a path that succeeds at `is_dir()` is still treated identically.

## Test plan

- [x] Focused regression test (new): `test_service_path_treats_permission_error_as_missing` patches `Path.is_dir` to raise `PermissionError` only for the `/.hermes/node/bin` probe and asserts the function still returns without crashing and excludes that path. Mirror test for generic `OSError(EIO)`.
- [x] Adjacent suite: `tests/hermes_cli/test_gateway_service_paths.py` (5/5 passed) + `tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome` (5/5 passed locally).
- [x] Regression guard: with the production hunk reverted but tests kept, both new tests fail with raw `OSError`/`PermissionError` propagating out of `_build_service_path_dirs`. With the fix restored, both pass.

The other failures in `test_gateway_service.py` on local Mac (`TestSystemdServiceRefresh::*`, `TestGatewaySystemServiceRouting::*` — `UserSystemdUnavailableError`) are pre-existing baseline failures on clean `origin/main` (no systemd / `loginctl` on macOS) and unrelated to this change.

## Related

- Picks up where [d69eab1ef](https://github.com/NousResearch/hermes-agent/commit/d69eab1ef) (`fix(gateway): build service PATH from existing dirs only, include ~/.hermes/node_modules`) left off — that commit correctly introduced the existence-check pattern but didn't account for `stat`-time errors.

> Sibling code paths that may need the same fix: none located in this module — the other filesystem probes (`_detect_venv_dir`, `_build_user_local_paths`, `_build_wsl_interop_paths`) already guard or operate on paths where `EACCES` is unreachable. Intentionally left out of this PR's scope to keep the diff small — happy to widen if a sibling crash surfaces.