### PR TITLE
fix(tools): run post_setup in _reconfigure_provider() for env-var providers

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2551,6 +2551,9 @@ def _reconfigure_provider(provider: dict, config: dict):
         else:
             _print_info("    Kept current")
 
+    if provider.get("post_setup"):
+        _run_post_setup(provider["post_setup"])
+
     # Imagegen backends prompt for model selection on reconfig too.
     plugin_name = provider.get("image_gen_plugin_name")
     if plugin_name:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -989,3 +989,30 @@ def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
     provider = {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []}
     _reconfigure_provider(provider, config)
     assert config["browser"]["use_gateway"] is False
+
+
+@pytest.mark.parametrize("provider_name,post_setup_key", [
+    ("Browserbase", "agent_browser"),
+    ("Browser Use", "agent_browser"),
+    ("Firecrawl", "agent_browser"),
+    ("Camofox", "camofox"),
+])
+def test_reconfigure_provider_runs_post_setup_for_env_var_providers(
+    monkeypatch, provider_name, post_setup_key
+):
+    """_reconfigure_provider() must call _run_post_setup() for providers that have
+    both env_vars and post_setup — parity with _configure_provider() line 2286."""
+    called = []
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: called.append(key))
+    monkeypatch.setattr("hermes_cli.tools_config.get_env_value", lambda k: None)
+    monkeypatch.setattr("hermes_cli.tools_config._prompt", lambda *a, **kw: "")
+    monkeypatch.setattr("hermes_cli.tools_config.save_env_value", lambda k, v: None)
+
+    provider = next(
+        p
+        for p in TOOL_CATEGORIES["browser"]["providers"]
+        if p["name"] == provider_name
+    )
+    _reconfigure_provider(provider, {})
+
+    assert called == [post_setup_key]


### PR DESCRIPTION
## What does this PR do?

`_configure_provider()` calls `_run_post_setup()` after collecting env vars (line 2286). `_reconfigure_provider()` — added in the same file — skips this call for providers with both `env_vars` and `post_setup` (Browserbase, Browser Use, Firecrawl, Camofox). A user who configures one of these providers via `/reconfigure tools` gets their API key saved but the `agent_browser` npm install never runs, breaking the browser tool at runtime.

One-line fix mirroring `_configure_provider`. Hooks are idempotent so no behaviour change for existing installs.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `hermes_cli/tools_config.py`: add `_run_post_setup()` call in `_reconfigure_provider()` (+2 lines)
- `tests/hermes_cli/test_tools_config.py`: parametrized regression for all four affected providers

## How to Test
```
pytest tests/hermes_cli/test_tools_config.py::test_reconfigure_provider_runs_post_setup_for_env_var_providers -v
```

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A