### PR TITLE
fix(gateway): treat zombie processes as stale in scoped lock detection

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -594,9 +594,10 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still appear alive to _pid_exists but are not
-                # actually running. Treat them as stale so --replace works.
+                # Check if process is stopped (Ctrl+Z / SIGTSTP) or a zombie
+                # (<defunct>) — both still appear alive to _pid_exists but
+                # are not actually running. Treat them as stale so
+                # --replace works and gateway restart doesn't deadlock.
                 if not stale:
                     try:
                         _proc_status = Path(f"/proc/{existing_pid}/status")
@@ -604,7 +605,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                             for _line in _proc_status.read_text(encoding="utf-8").splitlines():
                                 if _line.startswith("State:"):
                                     _state = _line.split()[1]
-                                    if _state in {"T", "t"}:  # stopped or tracing stop
+                                    if _state in {"T", "t", "Z", "z"}:  # stopped, tracing stop, or zombie
                                         stale = True
                                     break
                     except (OSError, PermissionError):


### PR DESCRIPTION
## Problem

`acquire_scoped_lock()` in `gateway/status.py` uses `psutil.pid_exists()` to check whether a lock-holding PID is alive. This returns `True` for zombie (`<defunct>`) processes, so zombie-held locks are never cleaned up.

When a gateway process dies and leaves behind zombie children holding scoped locks (e.g., Telegram bot token locks), subsequent gateway restarts fail — the lock file appears valid and `--replace` is required to clear it manually.

## Fix

One-line change: add `"Z"` and `"z"` (zombie / zombie dead) to the set of process states recognized as stale, alongside the existing `"T"` / `"t"` (stopped / tracing stop).

## Testing

- All 43 existing tests in `tests/gateway/test_status.py` pass unchanged
- Verified against real-world occurrence: gateway restarted successfully after zombie-held lock was automatically cleaned up

Closes #26651