### PR TITLE
fix(gateway): honor proxy env vars in SMS, Slack, Teams, and Google Chat adapters

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -482,7 +482,7 @@ class SlackAdapter(BasePlatformAdapter):
             "text": text,
         }
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.post(
                     ctx["response_url"],
                     json=payload,

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -128,6 +128,7 @@ class SmsAdapter(BasePlatformAdapter):
         await site.start()
         self._http_session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         )
         self._running = True
 
@@ -169,6 +170,7 @@ class SmsAdapter(BasePlatformAdapter):
 
         session = self._http_session or aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=True,
         )
         try:
             for chunk in chunks:

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -3246,7 +3246,7 @@ async def _standalone_send(
         return {"error": "Google Chat standalone send: aiohttp not installed"}
 
     try:
-        async with _aiohttp.ClientSession(timeout=_aiohttp.ClientTimeout(total=30.0)) as session:
+        async with _aiohttp.ClientSession(timeout=_aiohttp.ClientTimeout(total=30.0), trust_env=True) as session:
             async with session.post(
                 url,
                 json=body,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -559,7 +559,7 @@ async def _standalone_send(
         # Per-request timeouts so a slow STS endpoint cannot starve the
         # subsequent activity POST of its budget.
         per_request_timeout = _aiohttp.ClientTimeout(total=15.0)
-        async with _aiohttp.ClientSession() as session:
+        async with _aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
                 token_url,
                 data={


### PR DESCRIPTION
## Summary

`aiohttp.ClientSession` defaults to `trust_env=False`, which silently ignores `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` environment variables. Users behind a corporate or network proxy cannot reach external APIs — all outbound requests fail with connection errors, with no indication that the proxy is the cause.

Symmetric with `wecom.py` (line 276), `weixin.py` (lines 1055/1268/1274), and `matrix.py` (no-proxy path) which already set this flag. Complements the open LINE fix (#26635) with the remaining gateway and plugin adapters.

## Root cause

Every affected session is constructed without `trust_env=True`:

| File | Session use |
|------|-------------|
| `gateway/platforms/sms.py` | Persistent Twilio REST session (`connect`) + fallback session (`send`) — both hit `https://api.twilio.com` |
| `gateway/platforms/slack.py` | Ephemeral response_url POST — hits `https://hooks.slack.com/…` callback URLs |
| `plugins/platforms/teams/adapter.py` | Standalone send session — hits `login.microsoftonline.com` (token) then Bot Framework service URL |
| `plugins/platforms/google_chat/adapter.py` | Standalone send session — hits `https://chat.googleapis.com/v1/…` |

## Changes

- `gateway/platforms/sms.py`: `trust_env=True` on the persistent Twilio session in `connect()` and on the fallback session in `send()`.
- `gateway/platforms/slack.py`: `trust_env=True` on the ephemeral `response_url` POST session.
- `plugins/platforms/teams/adapter.py`: `trust_env=True` on the standalone-send session.
- `plugins/platforms/google_chat/adapter.py`: `trust_env=True` on the standalone-send session.

WhatsApp sessions are intentionally excluded — they connect to `http://127.0.0.1:{bridge_port}` (local bridge process) and must not be routed through a system proxy.

## Validation

- `tests/gateway/test_sms.py`: 39/39 pass (sequential, `-n1`; xdist port-binding race is pre-existing)
- `tests/gateway/test_slack.py`: all pass
- `tests/gateway/test_google_chat.py`: standalone-send tests fail due to `google-auth` not installed in the local venv — identical failure on `main` without this PR (pre-existing env issue, not introduced here)
- `tests/gateway/test_teams.py`: same pre-existing env skip as Google Chat
- No behavior change for users not behind a proxy (`trust_env=True` is a no-op when no proxy env vars are set)