### PR TITLE
fix(process_registry): poll() must not mark completion as consumed (#10156)

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -823,7 +823,7 @@ class ProcessRegistry:
     # ----- Query Methods -----
 
     def is_completion_consumed(self, session_id: str) -> bool:
-        """Check if a completion notification was already consumed via wait/poll/log."""
+        """Check if a completion notification was already consumed via wait/read_log."""
         return session_id in self._completion_consumed
 
     def drain_notifications(self) -> "list[tuple[dict, str]]":
@@ -949,7 +949,6 @@ class ProcessRegistry:
         }
         if session.exited:
             result["exit_code"] = session.exit_code
-            self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"


### PR DESCRIPTION
Closes #10156.

## Problem

Commit f53a5a7f (#8228) added `_completion_consumed` tracking to suppress duplicate `notify_on_complete` notifications. The fix was correct for `wait()` (blocking call = output consumed), but was incorrectly extended to `poll()` (read-only query = should have no side effects).

Consequence: when the agent calls `process(action='poll')` on an exited background process, `poll()` marks the completion as consumed. The watcher thread (which checks `is_completion_consumed()` before injecting the notification) sees `True` and skips the notification. The user never sees the background process completion message.

## Fix

Two changes, both in `tools/process_registry.py`:
1. Remove `self._completion_consumed.add(session_id)` from `poll()`
2. Fix `is_completion_consumed()` docstring: poll → read_log

Only `wait()` and `read_log()` should mark completion as consumed. `poll()` is a read-only query with no side effects.