### PR TITLE
fix(agent): load tool schemas before mutating state in add_provider() (#9948)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -223,12 +223,25 @@ class MemoryManager:
                     provider.name, existing,
                 )
                 return
+
+        # Collect tool schemas BEFORE mutating state — if schema loading
+        # fails the provider must NOT be registered (fixes #9948).
+        try:
+            schemas = provider.get_tool_schemas()
+        except Exception as exc:
+            logger.error(
+                "Memory provider '%s' failed during schema loading: %s — NOT registered",
+                provider.name, exc,
+            )
+            return
+
+        if not is_builtin:
             self._has_external = True
 
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -244,7 +257,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property


### PR DESCRIPTION
Closes #9948.

## Problem

`MemoryManager.add_provider()` mutates internal state (`_has_external = True`, `self._providers.append(provider)`) **before** calling `provider.get_tool_schemas()`. If `get_tool_schemas()` raises an exception (e.g. missing dependency, broken config, transient error), the external provider remains half-registered:

- `_has_external` stays `True`
- The broken provider is in `_providers`
- All subsequent `add_provider()` calls are rejected: "external provider X is already registered"

The process must be restarted to recover.

## Fix

Three changes, all inside `add_provider()` in `agent/memory_manager.py`:

1. **Move schema loading before state mutation:** `get_tool_schemas()` is called early and wrapped in `try/except`. On failure, the error is logged and the method returns immediately — no state is touched.
2. **Cache the result:** The schema list is stored in a local `schemas` variable so it can be iterated and counted without calling `get_tool_schemas()` again.
3. **Use cached schema list** for the tool-name index loop and the log count.