### PR TITLE
fix(kanban): --severity filter uses >= comparison per documented behavior

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1403,7 +1403,7 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         sev = getattr(args, "severity", None)
         if sev:
             for tid in list(diags_by_task.keys()):
-                kept = [d for d in diags_by_task[tid] if d.severity == sev]
+                kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= kd.SEVERITY_ORDER.index(sev)]
                 if kept:
                     diags_by_task[tid] = kept
                 else:


### PR DESCRIPTION
## Summary

Fixes #26379. The `--severity` filter in `hermes kanban diagnostics` was documented as filtering "at or above this severity" but was implemented as an exact-match equality check (`d.severity == sev`). This caused `--severity warning` to silently return zero diagnostics when all existing diagnostics were `error`-severity.

## Change

Change the filter in `hermes_cli/kanban.py:1406` from:
```python
kept = [d for d in diags_by_task[tid] if d.severity == sev]
```
to:
```python
kept = [d for d in diags_by_task[tid] if kd.SEVERITY_ORDER.index(d.severity) >= kd.SEVERITY_ORDER.index(sev)]
```

## Verification

- `SEVERITY_ORDER` is already defined in `kanban_diagnostics.py` as `("warning", "error", "critical")`.
- The patch makes the implementation match the documented argparse help text: `"Only show diagnostics at or above this severity"`.

Closes #26379
