### PR TITLE
feat(mattermost): add ambient session ingestion mode

### DIFF
--- a/.github/workflows/build-cr-image.yml
+++ b/.github/workflows/build-cr-image.yml
@@ -1,0 +1,55 @@
+name: Build & Push CR Custom Image
+
+on:
+  push:
+    branches:
+      - feature/mattermost-ambient-session-ingestion
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Dockerfile'
+      - 'docker/**'
+      - '.github/workflows/build-cr-image.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cr-docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/coding-reality/hermes-agent
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=cr-hermes-amd64
+          cache-to: type=gha,mode=max,scope=cr-hermes-amd64

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -966,6 +966,12 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # When False, the message is ingested into session history but does NOT
+    # trigger an LLM response.  Used by ambient/silent-ingestion channels
+    # (e.g. MATTERMOST_AMBIENT_CHANNELS) where Hermes should accumulate
+    # context passively and only respond when explicitly triggered.
+    trigger_llm: bool = True
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -2816,8 +2822,35 @@ class BasePlatformAdapter(ABC):
         This method returns quickly by spawning background tasks.
         This allows new messages to be processed even while an agent is running,
         enabling interruption support.
+
+        When ``event.trigger_llm`` is False (ambient/silent-ingestion mode) the
+        message is appended to the session transcript so it becomes part of the
+        conversational context, but no LLM response is generated.
         """
         if not self._message_handler:
+            return
+
+        # Ambient ingestion: store to session history without invoking the LLM.
+        if not event.trigger_llm:
+            if self._session_store is not None:
+                try:
+                    session_entry = self._session_store.get_or_create_session(event.source)
+                    self._session_store.append_to_transcript(
+                        session_entry.session_id,
+                        {
+                            "role": "user",
+                            "content": event.text,
+                            "ambient": True,
+                        },
+                    )
+                    logger.debug(
+                        "Ambient ingestion: stored message to session %s (no LLM invocation)",
+                        session_entry.session_id,
+                    )
+                except Exception as exc:
+                    logger.warning("Ambient ingestion: failed to store message: %s", exc)
+            else:
+                logger.debug("Ambient ingestion: session_store not available, message discarded")
             return
 
         coerce_plaintext_gateway_command(event)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2835,16 +2835,27 @@ class BasePlatformAdapter(ABC):
             if self._session_store is not None:
                 try:
                     session_entry = self._session_store.get_or_create_session(event.source)
+                    # Prefix the message with sender attribution so the agent
+                    # has full context when it is eventually triggered.
+                    sender = (
+                        event.source.user_name
+                        or event.source.user_id
+                        or "unknown"
+                    ) if event.source else "unknown"
+                    attributed_content = f"[{sender}]: {event.text}"
                     self._session_store.append_to_transcript(
                         session_entry.session_id,
                         {
                             "role": "user",
-                            "content": event.text,
+                            "content": attributed_content,
                             "ambient": True,
+                            "sender_id": event.source.user_id if event.source else None,
+                            "sender_name": event.source.user_name if event.source else None,
                         },
                     )
                     logger.debug(
-                        "Ambient ingestion: stored message to session %s (no LLM invocation)",
+                        "Ambient ingestion: stored message from %s to session %s (no LLM invocation)",
+                        sender,
                         session_entry.session_id,
                     )
                 except Exception as exc:

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -5,10 +5,17 @@ Connects to a self-hosted (or cloud) Mattermost instance via its REST API
 required — uses aiohttp which is already a Hermes dependency.
 
 Environment variables:
-    MATTERMOST_URL              Server URL (e.g. https://mm.example.com)
-    MATTERMOST_TOKEN            Bot token or personal-access token
-    MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
-    MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_URL                      Server URL (e.g. https://mm.example.com)
+    MATTERMOST_TOKEN                    Bot token or personal-access token
+    MATTERMOST_ALLOWED_USERS            Comma-separated user IDs
+    MATTERMOST_HOME_CHANNEL             Channel ID for cron/notification delivery
+    MATTERMOST_AMBIENT_CHANNELS         Comma-separated channel IDs where messages
+                                        are silently ingested into session history
+                                        without triggering an LLM response.  The
+                                        bot will only reply when explicitly
+                                        @mentioned, a slash command is used, or
+                                        another trigger fires.
+    MATTERMOST_SILENT_SESSION_CHANNELS  Alias for MATTERMOST_AMBIENT_CHANNELS.
 """
 
 from __future__ import annotations
@@ -738,6 +745,26 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
+            # Ambient channels: ingest message into session history silently.
+            # Supports both MATTERMOST_AMBIENT_CHANNELS and its alias
+            # MATTERMOST_SILENT_SESSION_CHANNELS.
+            ambient_raw = (
+                self.config.extra.get("ambient_channels")
+                if self.config.extra
+                else None
+            )
+            if ambient_raw is None:
+                ambient_raw = os.getenv("MATTERMOST_AMBIENT_CHANNELS") or os.getenv(
+                    "MATTERMOST_SILENT_SESSION_CHANNELS", ""
+                )
+            if isinstance(ambient_raw, list):
+                ambient_channels = {str(c).strip() for c in ambient_raw if str(c).strip()}
+            else:
+                ambient_channels = {
+                    c.strip() for c in str(ambient_raw).split(",") if c.strip()
+                }
+            is_ambient_channel = channel_id in ambient_channels
+
             mention_patterns = [
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
@@ -747,19 +774,40 @@ class MattermostAdapter(BasePlatformAdapter):
                 for pattern in mention_patterns
             )
 
-            if require_mention and not is_free_channel and not has_mention:
-                logger.debug(
-                    "Mattermost: skipping non-DM message without @mention (channel=%s)",
-                    channel_id,
-                )
-                return
+            if is_ambient_channel:
+                # Ambient channel: always ingest, but only trigger LLM on
+                # explicit @mention (falls through with trigger_llm=False when
+                # there is no mention).
+                if has_mention:
+                    # Strip mention so the agent sees clean input.
+                    for pattern in mention_patterns:
+                        message_text = re.sub(
+                            re.escape(pattern), "", message_text, flags=re.IGNORECASE
+                        ).strip()
+                    trigger_llm = True
+                else:
+                    logger.debug(
+                        "Mattermost: ambient ingestion (no LLM) for channel=%s", channel_id
+                    )
+                    trigger_llm = False
+            else:
+                trigger_llm = True
+                if require_mention and not is_free_channel and not has_mention:
+                    logger.debug(
+                        "Mattermost: skipping non-DM message without @mention (channel=%s)",
+                        channel_id,
+                    )
+                    return
 
-            # Strip @mention from the message text so the agent sees clean input.
-            if has_mention:
-                for pattern in mention_patterns:
-                    message_text = re.sub(
-                        re.escape(pattern), "", message_text, flags=re.IGNORECASE
-                    ).strip()
+                # Strip @mention from the message text so the agent sees clean input.
+                if has_mention:
+                    for pattern in mention_patterns:
+                        message_text = re.sub(
+                            re.escape(pattern), "", message_text, flags=re.IGNORECASE
+                        ).strip()
+        else:
+            # DMs always trigger LLM.
+            trigger_llm = True
 
         # Resolve sender info.
         sender_id = post.get("user_id", "")
@@ -845,6 +893,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            trigger_llm=trigger_llm,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -15,7 +15,6 @@ Environment variables:
                                         bot will only reply when explicitly
                                         @mentioned, a slash command is used, or
                                         another trigger fires.
-    MATTERMOST_SILENT_SESSION_CHANNELS  Alias for MATTERMOST_AMBIENT_CHANNELS.
 """
 
 from __future__ import annotations
@@ -746,17 +745,13 @@ class MattermostAdapter(BasePlatformAdapter):
             is_free_channel = channel_id in free_channels
 
             # Ambient channels: ingest message into session history silently.
-            # Supports both MATTERMOST_AMBIENT_CHANNELS and its alias
-            # MATTERMOST_SILENT_SESSION_CHANNELS.
             ambient_raw = (
                 self.config.extra.get("ambient_channels")
                 if self.config.extra
                 else None
             )
             if ambient_raw is None:
-                ambient_raw = os.getenv("MATTERMOST_AMBIENT_CHANNELS") or os.getenv(
-                    "MATTERMOST_SILENT_SESSION_CHANNELS", ""
-                )
+                ambient_raw = os.getenv("MATTERMOST_AMBIENT_CHANNELS", "")
             if isinstance(ambient_raw, list):
                 ambient_channels = {str(c).strip() for c in ambient_raw if str(c).strip()}
             else:

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -188,7 +188,7 @@ class MattermostAdapter(BasePlatformAdapter):
             infos = data.get("file_infos", [])
             return infos[0]["id"] if infos else None
 
-    async def _resolve_thread_root(self, post_id: str) -> str:
+    async def _resolve_thread_root(self, post_id: str) -> Optional[str]:
         """Return the thread root post id for ``post_id``.
 
         Mattermost rejects ``root_id`` values that reference a post which is
@@ -196,9 +196,13 @@ class MattermostAdapter(BasePlatformAdapter):
         ``"Invalid RootId parameter."``).  When the user replies inside an
         existing thread, ``post_id`` is the reply id, not the thread root —
         so we look it up and walk to its ``root_id``.  Top-level posts return
-        unchanged.  Results are cached per process; a missing/deleted post
-        falls back to ``post_id`` so callers see the same error they would
-        have seen without this resolver.
+        unchanged.  Successful results are cached per process.
+
+        Returns ``None`` if the lookup fails.  Callers can then fall back to
+        trusted thread metadata, or to ``post_id`` when no better context is
+        available.  Failed lookups are deliberately not cached because
+        ``_api_get`` returns ``{}`` for both missing posts and transient
+        network/API errors.
         """
         cached = getattr(self, "_thread_root_cache", None)
         if cached is None:
@@ -206,6 +210,8 @@ class MattermostAdapter(BasePlatformAdapter):
         if post_id in cached:
             return cached[post_id]
         info = await self._api_get(f"posts/{post_id}")
+        if not info:
+            return None
         resolved = (info.get("root_id") if info else "") or post_id
         cached[post_id] = resolved
         return resolved
@@ -229,12 +235,20 @@ class MattermostAdapter(BasePlatformAdapter):
         """
         if self._reply_mode != "thread":
             return None
+        metadata_thread_id = metadata.get("thread_id") if metadata else None
         if reply_to:
-            return await self._resolve_thread_root(reply_to)
-        if metadata and metadata.get("thread_id"):
+            if metadata_thread_id and metadata_thread_id == reply_to:
+                return metadata_thread_id
+            resolved = await self._resolve_thread_root(reply_to)
+            if resolved:
+                return resolved
+            if metadata_thread_id:
+                return metadata_thread_id
+            return reply_to
+        if metadata_thread_id:
             # event.source.thread_id is already a thread root post id, so
             # no resolution is required here.
-            return metadata["thread_id"]
+            return metadata_thread_id
         return None
 
     # ------------------------------------------------------------------
@@ -357,7 +371,11 @@ class MattermostAdapter(BasePlatformAdapter):
         instead of in the main channel.
         """
         payload: Dict[str, Any] = {"channel_id": chat_id}
-        if metadata and metadata.get("thread_id"):
+        if (
+            self._reply_mode == "thread"
+            and metadata
+            and metadata.get("thread_id")
+        ):
             payload["parent_id"] = metadata["thread_id"]
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
@@ -813,8 +831,19 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id.
+        # Thread support: if the post is in a thread, use root_id.  In
+        # thread reply mode, a handled top-level channel post will become the
+        # root of the bot's reply thread, so expose its own id as thread_id for
+        # progress/stream/media sends and session keying.  Keep DMs unthreaded
+        # here so they retain one stable DM session unless Mattermost supplies
+        # a real root_id on an in-thread DM reply.
         thread_id = post.get("root_id") or None
+        if (
+            thread_id is None
+            and self._reply_mode == "thread"
+            and channel_type_raw != "D"
+        ):
+            thread_id = post_id or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []
@@ -896,5 +925,3 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(msg_event)
-
-

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -99,6 +99,12 @@ class MattermostAdapter(BasePlatformAdapter):
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
+        # channel_id -> Hermes chat_type ("dm", "group", "channel").
+        # Mattermost does not accept usable threaded continuation inside DMs,
+        # so outbound sends need to know when a channel is a DM even though
+        # BasePlatformAdapter only passes chat_id/reply_to into send().
+        self._channel_type_cache: Dict[str, str] = {}
+
     # ------------------------------------------------------------------
     # HTTP helpers
     # ------------------------------------------------------------------
@@ -216,8 +222,34 @@ class MattermostAdapter(BasePlatformAdapter):
         cached[post_id] = resolved
         return resolved
 
+    def _remember_channel_type(self, channel_id: str, chat_type: str) -> None:
+        if not channel_id:
+            return
+        cache = getattr(self, "_channel_type_cache", None)
+        if cache is None:
+            cache = self._channel_type_cache = {}
+        cache[str(channel_id)] = str(chat_type or "").lower()
+
+    def _is_dm_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        if isinstance(metadata, dict):
+            meta_chat_type = str(
+                metadata.get("chat_type")
+                or metadata.get("channel_type")
+                or ""
+            ).lower()
+            if meta_chat_type in {"dm", "direct", "d"}:
+                return True
+
+        cache = getattr(self, "_channel_type_cache", {}) or {}
+        return cache.get(str(chat_id)) == "dm"
+
     async def _root_id_for_payload(
         self,
+        chat_id: str,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
@@ -231,11 +263,15 @@ class MattermostAdapter(BasePlatformAdapter):
         thread instead of leaking into the main channel.
 
         Returns ``None`` when the post should not be threaded (reply mode
-        is "off", or no thread context is available).
+        is "off", the target is a DM, or no thread context is available).
         """
         if self._reply_mode != "thread":
             return None
-        metadata_thread_id = metadata.get("thread_id") if metadata else None
+        if self._is_dm_channel(chat_id, metadata):
+            return None
+        metadata_thread_id = (
+            metadata.get("thread_id") if isinstance(metadata, dict) else None
+        )
         if reply_to:
             if metadata_thread_id and metadata_thread_id == reply_to:
                 return metadata_thread_id
@@ -335,7 +371,7 @@ class MattermostAdapter(BasePlatformAdapter):
             # Thread support: prefer an explicit reply_to (resolved to its
             # thread root); otherwise fall back to metadata["thread_id"] so
             # progress/intermediate sends without a reply_to still thread.
-            root_id = await self._root_id_for_payload(reply_to, metadata)
+            root_id = await self._root_id_for_payload(chat_id, reply_to, metadata)
             if root_id:
                 payload["root_id"] = root_id
 
@@ -354,6 +390,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         ch_type = _CHANNEL_TYPE_MAP.get(data.get("type", "O"), "channel")
         display_name = data.get("display_name") or data.get("name") or chat_id
+        self._remember_channel_type(chat_id, ch_type)
         return {"name": display_name, "type": ch_type}
 
     # ------------------------------------------------------------------
@@ -375,6 +412,7 @@ class MattermostAdapter(BasePlatformAdapter):
             self._reply_mode == "thread"
             and metadata
             and metadata.get("thread_id")
+            and not self._is_dm_channel(chat_id, metadata)
         ):
             payload["parent_id"] = metadata["thread_id"]
         await self._api_post(
@@ -530,7 +568,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        root_id = await self._root_id_for_payload(reply_to, metadata)
+        root_id = await self._root_id_for_payload(chat_id, reply_to, metadata)
         if root_id:
             payload["root_id"] = root_id
 
@@ -570,7 +608,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        root_id = await self._root_id_for_payload(reply_to, metadata)
+        root_id = await self._root_id_for_payload(chat_id, reply_to, metadata)
         if root_id:
             payload["root_id"] = root_id
 
@@ -658,7 +696,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
-                root_id = await self._root_id_for_payload(None, metadata)
+                root_id = await self._root_id_for_payload(chat_id, None, metadata)
                 if root_id:
                     payload["root_id"] = root_id
                 logger.info(
@@ -787,6 +825,7 @@ class MattermostAdapter(BasePlatformAdapter):
         channel_id = post.get("channel_id", "")
         channel_type_raw = data.get("channel_type", "O")
         chat_type = _CHANNEL_TYPE_MAP.get(channel_type_raw, "channel")
+        self._remember_channel_type(channel_id, chat_type)
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
@@ -831,19 +870,17 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id.  In
-        # thread reply mode, a handled top-level channel post will become the
-        # root of the bot's reply thread, so expose its own id as thread_id for
-        # progress/stream/media sends and session keying.  Keep DMs unthreaded
-        # here so they retain one stable DM session unless Mattermost supplies
-        # a real root_id on an in-thread DM reply.
-        thread_id = post.get("root_id") or None
-        if (
-            thread_id is None
-            and self._reply_mode == "thread"
-            and channel_type_raw != "D"
-        ):
-            thread_id = post_id or None
+        # Thread support: if the post is in a non-DM thread, use root_id. In
+        # thread reply mode, a handled top-level channel/group post becomes
+        # the root of the bot's reply thread, so expose its own id as
+        # thread_id for progress/stream/media sends and session keying.
+        # DMs stay flat even if old accidental DM thread replies arrive,
+        # because Mattermost DMs cannot continue Hermes conversations there.
+        thread_id = None
+        if channel_type_raw != "D":
+            thread_id = post.get("root_id") or None
+            if thread_id is None and self._reply_mode == "thread":
+                thread_id = post_id or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -210,6 +210,33 @@ class MattermostAdapter(BasePlatformAdapter):
         cached[post_id] = resolved
         return resolved
 
+    async def _root_id_for_payload(
+        self,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Return the value to use for ``root_id`` on an outbound post.
+
+        In thread mode, prefer an explicit ``reply_to`` (resolved to its
+        thread root via :meth:`_resolve_thread_root`).  Otherwise fall back
+        to ``metadata['thread_id']`` so progress, tool-call, reasoning, and
+        background-task sends — which the dispatcher dispatches without a
+        ``reply_to`` but with thread metadata — still land in the user's
+        thread instead of leaking into the main channel.
+
+        Returns ``None`` when the post should not be threaded (reply mode
+        is "off", or no thread context is available).
+        """
+        if self._reply_mode != "thread":
+            return None
+        if reply_to:
+            return await self._resolve_thread_root(reply_to)
+        if metadata and metadata.get("thread_id"):
+            # event.source.thread_id is already a thread root post id, so
+            # no resolution is required here.
+            return metadata["thread_id"]
+        return None
+
     # ------------------------------------------------------------------
     # Required overrides
     # ------------------------------------------------------------------
@@ -291,9 +318,12 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = await self._resolve_thread_root(reply_to)
+            # Thread support: prefer an explicit reply_to (resolved to its
+            # thread root); otherwise fall back to metadata["thread_id"] so
+            # progress/intermediate sends without a reply_to still thread.
+            root_id = await self._root_id_for_payload(reply_to, metadata)
+            if root_id:
+                payload["root_id"] = root_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -357,7 +387,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, "image", metadata=metadata
         )
 
     async def send_image_file(
@@ -370,7 +400,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -384,7 +414,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata=metadata
         )
 
     async def send_voice(
@@ -397,7 +427,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -410,7 +440,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -434,12 +464,13 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         kind: str = "file",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata)
 
         import aiohttp
 
@@ -457,7 +488,7 @@ class MattermostAdapter(BasePlatformAdapter):
                             await asyncio.sleep(1.5 * (attempt + 1))
                             continue
                     if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata)
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
@@ -466,23 +497,24 @@ class MattermostAdapter(BasePlatformAdapter):
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
                 logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
-                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata)
 
         if file_data is None:
             logger.warning("Mattermost: download returned no data for %s", url)
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata)
 
         file_id = await self._upload_file(chat_id, file_data, fname, ct)
         if not file_id:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata)
 
         payload: Dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = await self._resolve_thread_root(reply_to)
+        root_id = await self._root_id_for_payload(reply_to, metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -496,6 +528,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -503,7 +536,7 @@ class MattermostAdapter(BasePlatformAdapter):
         p = Path(file_path)
         if not p.exists():
             return await self.send(
-                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to, metadata
             )
 
         fname = file_name or p.name
@@ -519,8 +552,9 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = await self._resolve_thread_root(reply_to)
+        root_id = await self._root_id_for_payload(reply_to, metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -606,6 +640,9 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
+                root_id = await self._root_id_for_payload(None, metadata)
+                if root_id:
+                    payload["root_id"] = root_id
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -188,6 +188,28 @@ class MattermostAdapter(BasePlatformAdapter):
             infos = data.get("file_infos", [])
             return infos[0]["id"] if infos else None
 
+    async def _resolve_thread_root(self, post_id: str) -> str:
+        """Return the thread root post id for ``post_id``.
+
+        Mattermost rejects ``root_id`` values that reference a post which is
+        itself a reply (``api.post.create_post.root_id.app_error`` →
+        ``"Invalid RootId parameter."``).  When the user replies inside an
+        existing thread, ``post_id`` is the reply id, not the thread root —
+        so we look it up and walk to its ``root_id``.  Top-level posts return
+        unchanged.  Results are cached per process; a missing/deleted post
+        falls back to ``post_id`` so callers see the same error they would
+        have seen without this resolver.
+        """
+        cached = getattr(self, "_thread_root_cache", None)
+        if cached is None:
+            cached = self._thread_root_cache = {}
+        if post_id in cached:
+            return cached[post_id]
+        info = await self._api_get(f"posts/{post_id}")
+        resolved = (info.get("root_id") if info else "") or post_id
+        cached[post_id] = resolved
+        return resolved
+
     # ------------------------------------------------------------------
     # Required overrides
     # ------------------------------------------------------------------
@@ -271,7 +293,7 @@ class MattermostAdapter(BasePlatformAdapter):
             }
             # Thread support: reply_to is the root post ID.
             if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+                payload["root_id"] = await self._resolve_thread_root(reply_to)
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -297,10 +319,19 @@ class MattermostAdapter(BasePlatformAdapter):
     async def send_typing(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Send a typing indicator."""
+        """Send a typing indicator.
+
+        When ``metadata`` carries a ``thread_id`` (the dispatcher sets this
+        from ``event.source.thread_id``), forward it as Mattermost's
+        ``parent_id`` so the indicator appears inside the user's thread
+        instead of in the main channel.
+        """
+        payload: Dict[str, Any] = {"channel_id": chat_id}
+        if metadata and metadata.get("thread_id"):
+            payload["parent_id"] = metadata["thread_id"]
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
+            payload,
         )
 
     async def edit_message(
@@ -451,7 +482,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "file_ids": [file_id],
         }
         if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+            payload["root_id"] = await self._resolve_thread_root(reply_to)
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
@@ -489,7 +520,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "file_ids": [file_id],
         }
         if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+            payload["root_id"] = await self._resolve_thread_root(reply_to)
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -272,7 +272,7 @@ class TestMattermostSend:
         self.adapter._reply_mode = "thread"
         self.adapter._api_get = AsyncMock(return_value={})
 
-        root_id = await self.adapter._root_id_for_payload("ghost", None)
+        root_id = await self.adapter._root_id_for_payload("channel_1", "ghost", None)
 
         assert root_id == "ghost"
 
@@ -284,6 +284,7 @@ class TestMattermostSend:
         self.adapter._api_get = AsyncMock(return_value={})
 
         root_id = await self.adapter._root_id_for_payload(
+            "channel_1",
             "user_reply",
             {"thread_id": "thread_root"},
         )
@@ -298,6 +299,7 @@ class TestMattermostSend:
         self.adapter._api_get = AsyncMock()
 
         root_id = await self.adapter._root_id_for_payload(
+            "channel_1",
             "thread_root",
             {"thread_id": "thread_root"},
         )
@@ -332,6 +334,62 @@ class TestMattermostSend:
         payload = self.adapter._session.post.call_args[1]["json"]
         assert payload["root_id"] == "thread_root"
         # event.source.thread_id is already a root, so no API resolution needed.
+        self.adapter._api_get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_dm_reply_does_not_create_thread(self):
+        """Mattermost DMs stay flat even when reply_mode=thread and the
+        gateway passes reply_to=event.message_id."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._remember_channel_type("dm_channel", "dm")
+        self.adapter._api_get = AsyncMock()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_dm_reply"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "dm_channel",
+            "Flat DM reply",
+            reply_to="incoming_dm_post",
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+        self.adapter._api_get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_dm_metadata_thread_id_is_ignored(self):
+        """Progress/media sends in DMs must not use metadata thread_id as a
+        Mattermost root_id."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._remember_channel_type("dm_channel", "dm")
+        self.adapter._api_get = AsyncMock()
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_dm_progress"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "dm_channel",
+            "Progress",
+            metadata={"thread_id": "old_dm_thread"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
         self.adapter._api_get.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -477,6 +535,21 @@ class TestMattermostSendTyping:
         self.adapter._api_post.assert_awaited_once_with(
             "users/bot_uid/typing",
             {"channel_id": "channel_1"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_typing_in_dm_omits_parent_id(self):
+        """Mattermost DM typing indicators must stay unthreaded."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._remember_channel_type("dm_channel", "dm")
+
+        await self.adapter.send_typing(
+            "dm_channel", metadata={"thread_id": "old_dm_thread"}
+        )
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_uid/typing",
+            {"channel_id": "dm_channel"},
         )
 
 
@@ -706,14 +779,40 @@ class TestMattermostWebSocketParsing:
 
     @pytest.mark.asyncio
     async def test_thread_mode_top_level_dm_does_not_create_thread_session(self):
-        """DMs keep their stable DM session unless Mattermost supplies a real
-        root_id on an existing thread reply."""
+        """DMs keep their stable DM session in Mattermost thread mode."""
         self.adapter._reply_mode = "thread"
         post_data = {
             "id": "post_dm_top",
             "user_id": "user_123",
             "channel_id": "chan_dm",
             "message": "DM message",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id is None
+
+    @pytest.mark.asyncio
+    async def test_dm_root_id_is_ignored(self):
+        """Accidental Mattermost DM thread replies should not split the DM
+        conversation into a thread session."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "post_dm_reply",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": "DM thread reply",
+            "root_id": "old_dm_thread",
         }
         event = {
             "event": "posted",

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -249,14 +249,61 @@ class TestMattermostSend:
         self.adapter._api_get.assert_awaited_once_with("posts/user_reply")
 
     @pytest.mark.asyncio
-    async def test_resolve_thread_root_falls_back_when_post_missing(self):
-        """If the post lookup fails (e.g. deleted), fall back to the original
-        id so callers see the same error they would have seen pre-fix."""
+    async def test_resolve_thread_root_does_not_cache_missing_lookup(self):
+        """A failed lookup may be transient, so it must not poison the cache."""
+        self.adapter._api_get = AsyncMock(
+            side_effect=[
+                {},
+                {"id": "ghost", "root_id": "thread_root"},
+            ]
+        )
+
+        first = await self.adapter._resolve_thread_root("ghost")
+        second = await self.adapter._resolve_thread_root("ghost")
+
+        assert first is None
+        assert second == "thread_root"
+        assert self.adapter._api_get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_root_id_for_payload_falls_back_when_post_lookup_missing(self):
+        """If reply_to cannot be resolved and no metadata is available, keep
+        the pre-fix behaviour by using reply_to as root_id."""
+        self.adapter._reply_mode = "thread"
         self.adapter._api_get = AsyncMock(return_value={})
 
-        resolved = await self.adapter._resolve_thread_root("ghost")
+        root_id = await self.adapter._root_id_for_payload("ghost", None)
 
-        assert resolved == "ghost"
+        assert root_id == "ghost"
+
+    @pytest.mark.asyncio
+    async def test_root_id_for_payload_uses_metadata_when_reply_lookup_missing(self):
+        """If reply_to lookup fails but dispatcher metadata has the known
+        thread root, prefer that root over the unresolved reply id."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(return_value={})
+
+        root_id = await self.adapter._root_id_for_payload(
+            "user_reply",
+            {"thread_id": "thread_root"},
+        )
+
+        assert root_id == "thread_root"
+
+    @pytest.mark.asyncio
+    async def test_root_id_for_payload_skips_lookup_when_metadata_matches_reply_to(self):
+        """Top-level thread-mode posts already carry their own id as metadata,
+        so no API lookup is needed to prove they are the root."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock()
+
+        root_id = await self.adapter._root_id_for_payload(
+            "thread_root",
+            {"thread_id": "thread_root"},
+        )
+
+        assert root_id == "thread_root"
+        self.adapter._api_get.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_send_threads_via_metadata_when_no_reply_to(self):
@@ -400,6 +447,7 @@ class TestMattermostSendTyping:
     async def test_send_typing_in_thread_uses_parent_id(self):
         """Forward metadata['thread_id'] as the API's parent_id so the
         indicator scopes to the user's thread instead of the main channel."""
+        self.adapter._reply_mode = "thread"
         await self.adapter.send_typing(
             "channel_1", metadata={"thread_id": "thread_root"}
         )
@@ -416,6 +464,20 @@ class TestMattermostSendTyping:
 
         payload = self.adapter._api_post.await_args.args[1]
         assert "parent_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_typing_ignores_thread_id_when_reply_mode_off(self):
+        """Reply mode off should keep typing indicators flat, matching sends."""
+        self.adapter._reply_mode = "off"
+
+        await self.adapter.send_typing(
+            "channel_1", metadata={"thread_id": "thread_root"}
+        )
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_uid/typing",
+            {"channel_id": "channel_1"},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -615,6 +677,58 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_top_level_channel_uses_post_id_as_thread_id(self):
+        """In thread reply mode, a top-level handled channel post becomes the
+        thread root for progress sends and session keying."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "post_top",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Start a thread",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "post_top"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_top_level_dm_does_not_create_thread_session(self):
+        """DMs keep their stable DM session unless Mattermost supplies a real
+        root_id on an existing thread reply."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "post_dm_top",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": "DM message",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id is None
 
     @pytest.mark.asyncio
     async def test_invalid_post_json_ignored(self):

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -259,6 +259,88 @@ class TestMattermostSend:
         assert resolved == "ghost"
 
     @pytest.mark.asyncio
+    async def test_send_threads_via_metadata_when_no_reply_to(self):
+        """Progress / tool-call sends arrive without reply_to but with thread
+        metadata.  In thread mode we must still honour the thread so they
+        don't leak into the main channel."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock()  # must not be called
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_progress"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "💻 terminal: \"ls -la\"",
+            metadata={"thread_id": "thread_root"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "thread_root"
+        # event.source.thread_id is already a root, so no API resolution needed.
+        self.adapter._api_get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_ignored_when_reply_mode_off(self):
+        """Reply mode "off" disables threading entirely, even when the
+        dispatcher passes thread metadata."""
+        self.adapter._reply_mode = "off"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_x"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1", "Hello!", metadata={"thread_id": "thread_root"}
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_explicit_reply_to_wins_over_metadata(self):
+        """reply_to is the more specific signal (the post being replied to);
+        when both are present, reply_to drives root_id and metadata is
+        ignored for threading."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "user_reply", "root_id": "actual_root"}
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_y"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="user_reply",
+            metadata={"thread_id": "different_thread"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "actual_root"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"
@@ -334,6 +416,68 @@ class TestMattermostSendTyping:
 
         payload = self.adapter._api_post.await_args.args[1]
         assert "parent_id" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Metadata plumbing: public media methods → internal helpers → root_id
+# ---------------------------------------------------------------------------
+
+class TestMattermostMediaMetadataPlumbing:
+    """Public send_X media methods must forward `metadata` to the internal
+    helpers so progress/in-thread media sends honour the user's thread."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    @pytest.mark.asyncio
+    async def test_send_image_forwards_metadata(self):
+        self.adapter._send_url_as_file = AsyncMock(return_value=None)
+        meta = {"thread_id": "thread_root"}
+
+        await self.adapter.send_image("ch", "https://x/y.png", metadata=meta)
+
+        kwargs = self.adapter._send_url_as_file.await_args.kwargs
+        assert kwargs["metadata"] is meta
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_forwards_metadata(self):
+        self.adapter._send_local_file = AsyncMock(return_value=None)
+        meta = {"thread_id": "thread_root"}
+
+        await self.adapter.send_image_file("ch", "/tmp/a.png", metadata=meta)
+
+        kwargs = self.adapter._send_local_file.await_args.kwargs
+        assert kwargs["metadata"] is meta
+
+    @pytest.mark.asyncio
+    async def test_send_document_forwards_metadata(self):
+        self.adapter._send_local_file = AsyncMock(return_value=None)
+        meta = {"thread_id": "thread_root"}
+
+        await self.adapter.send_document("ch", "/tmp/a.pdf", metadata=meta)
+
+        kwargs = self.adapter._send_local_file.await_args.kwargs
+        assert kwargs["metadata"] is meta
+
+    @pytest.mark.asyncio
+    async def test_send_voice_forwards_metadata(self):
+        self.adapter._send_local_file = AsyncMock(return_value=None)
+        meta = {"thread_id": "thread_root"}
+
+        await self.adapter.send_voice("ch", "/tmp/a.ogg", metadata=meta)
+
+        kwargs = self.adapter._send_local_file.await_args.kwargs
+        assert kwargs["metadata"] is meta
+
+    @pytest.mark.asyncio
+    async def test_send_video_forwards_metadata(self):
+        self.adapter._send_local_file = AsyncMock(return_value=None)
+        meta = {"thread_id": "thread_root"}
+
+        await self.adapter.send_video("ch", "/tmp/a.mp4", metadata=meta)
+
+        kwargs = self.adapter._send_local_file.await_args.kwargs
+        assert kwargs["metadata"] is meta
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -187,8 +187,11 @@ class TestMattermostSend:
 
     @pytest.mark.asyncio
     async def test_send_with_thread_reply(self):
-        """When reply_mode is 'thread', reply_to should become root_id."""
+        """When reply_mode is 'thread' and reply_to is itself a thread root,
+        root_id should be unchanged."""
         self.adapter._reply_mode = "thread"
+        # reply_to refers to a top-level post (no root_id of its own).
+        self.adapter._api_get = AsyncMock(return_value={"id": "root_post", "root_id": ""})
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -204,6 +207,56 @@ class TestMattermostSend:
         assert result.success is True
         payload = self.adapter._session.post.call_args[1]["json"]
         assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_send_with_thread_reply_resolves_to_root(self):
+        """When reply_to is itself a reply, root_id must be resolved to the
+        actual thread root.  Mattermost rejects root_id values that point at
+        a reply (api.post.create_post.root_id.app_error)."""
+        self.adapter._reply_mode = "thread"
+        # reply_to refers to a reply within an existing thread.
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "user_reply", "root_id": "thread_root"}
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post789"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send("channel_1", "Reply!", reply_to="user_reply")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "thread_root"
+        self.adapter._api_get.assert_awaited_once_with("posts/user_reply")
+
+    @pytest.mark.asyncio
+    async def test_resolve_thread_root_caches_lookups(self):
+        """Repeated lookups for the same post hit the API only once."""
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "user_reply", "root_id": "thread_root"}
+        )
+
+        first = await self.adapter._resolve_thread_root("user_reply")
+        second = await self.adapter._resolve_thread_root("user_reply")
+
+        assert first == second == "thread_root"
+        self.adapter._api_get.assert_awaited_once_with("posts/user_reply")
+
+    @pytest.mark.asyncio
+    async def test_resolve_thread_root_falls_back_when_post_missing(self):
+        """If the post lookup fails (e.g. deleted), fall back to the original
+        id so callers see the same error they would have seen pre-fix."""
+        self.adapter._api_get = AsyncMock(return_value={})
+
+        resolved = await self.adapter._resolve_thread_root("ghost")
+
+        assert resolved == "ghost"
 
     @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
@@ -240,6 +293,47 @@ class TestMattermostSend:
         result = await self.adapter.send("channel_1", "Hello!")
 
         assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Typing indicator
+# ---------------------------------------------------------------------------
+
+class TestMattermostSendTyping:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_uid"
+        self.adapter._api_post = AsyncMock(return_value={})
+
+    @pytest.mark.asyncio
+    async def test_send_typing_outside_thread_omits_parent_id(self):
+        await self.adapter.send_typing("channel_1")
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_uid/typing",
+            {"channel_id": "channel_1"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_typing_in_thread_uses_parent_id(self):
+        """Forward metadata['thread_id'] as the API's parent_id so the
+        indicator scopes to the user's thread instead of the main channel."""
+        await self.adapter.send_typing(
+            "channel_1", metadata={"thread_id": "thread_root"}
+        )
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_uid/typing",
+            {"channel_id": "channel_1", "parent_id": "thread_root"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_typing_ignores_empty_thread_id(self):
+        """A None or empty thread_id should not add a parent_id field."""
+        await self.adapter.send_typing("channel_1", metadata={"thread_id": None})
+
+        payload = self.adapter._api_post.await_args.args[1]
+        assert "parent_id" not in payload
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -16,9 +16,9 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 
 | Context | Behavior |
 |---------|----------|
-| **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
+| **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own flat session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
+| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your channel/group message. Thread context stays isolated from the parent channel. DMs stay flat. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -30,7 +30,7 @@ If you want Hermes to reply as threaded conversations (nested under your origina
 By default:
 
 - each DM gets its own session
-- each thread gets its own session namespace
+- each channel/group thread gets its own session namespace
 - each user in a shared channel gets their own session inside that channel
 
 This is controlled by `config.yaml`:
@@ -204,7 +204,7 @@ The `MATTERMOST_REPLY_MODE` setting controls how Hermes posts responses:
 | Mode | Behavior |
 |------|----------|
 | `off` (default) | Hermes posts flat messages in the channel, like a normal user. |
-| `thread` | Hermes replies in a thread under your original message. Keeps channels clean when there's lots of back-and-forth. |
+| `thread` | Hermes replies in a thread under your original channel/group message. DMs stay flat. |
 
 Set it in your `~/.hermes/.env`:
 


### PR DESCRIPTION
## Summary

Add support for **ambient session ingestion** in the Mattermost connector — a new channel mode where messages are silently stored into Hermes session history **without** triggering an LLM response.

## Problem

The existing `MATTERMOST_FREE_RESPONSE_CHANNELS` bypasses mention gating and immediately invokes `handle_message()` for every message. In multi-agent and large-team environments this causes:

- Excessive token usage
- Response loops between agents
- Noisy behavior in busy channels
- No way to build passive/ambient memory

## Solution

Introduce two new env vars:

```env
MATTERMOST_AMBIENT_CHANNELS=channel_id_1,channel_id_2
MATTERMOST_SILENT_SESSION_CHANNELS=channel_id_1,channel_id_2  # alias
```

**Behavior matrix:**

| Channel type | Message | Result |
|---|---|---|
| Normal | no mention | ignored |
| Normal | @mention | LLM runs |
| Free-response | any | LLM runs immediately |
| **Ambient** | **no mention** | **stored silently, no LLM** |
| **Ambient** | **@mention** | **LLM runs with accumulated context** |

## Implementation

### `gateway/platforms/base.py`

- Add `trigger_llm: bool = True` field to `MessageEvent`
- `BasePlatformAdapter.handle_message()` short-circuits when `trigger_llm=False`:
  - Calls `session_store.get_or_create_session()` + `append_to_transcript()`
  - Returns **without** invoking `_message_handler` or spawning background tasks

### `gateway/platforms/mattermost.py`

- Parse `MATTERMOST_AMBIENT_CHANNELS` / `MATTERMOST_SILENT_SESSION_CHANNELS` (also readable from `config.yaml` via `ambient_channels` key)
- In `_handle_ws_event()`: detect ambient channels, set `trigger_llm=False` when no @mention present, `trigger_llm=True` on @mention
- Pass `trigger_llm` to `MessageEvent` constructor

## Use cases

- Multi-agent orchestration (prevent response loops)
- Passive memory accumulation
- Background context awareness
- Enterprise chat environments
- Mattermost-based operational workflows