### PR TITLE
feat(kanban): NATS JetStream publish hook for promote/ready events

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4583,6 +4583,10 @@ class GatewayRunner:
             )
             failure_limit = _kb.DEFAULT_FAILURE_LIMIT
 
+        # Read NATS JetStream server URL for publishing dispatch events.
+        # Empty string means NATS publishing is disabled.
+        nats_server_url = kanban_cfg.get("nats_server_url", "") or ""
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -4618,6 +4622,7 @@ class GatewayRunner:
                     board=slug,
                     max_spawn=max_spawn,
                     failure_limit=failure_limit,
+                    nats_server_url=nats_server_url,
                 )
             except Exception:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1417,6 +1417,12 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # NATS JetStream server URL for publishing kanban dispatch events.
+        # When set, the gateway dispatcher publishes a JetStream message for
+        # every task promoted to ``ready`` status.  Subject:
+        # ``kanban.dispatch.<assignee>``.  Optional — when empty or absent,
+        # no NATS publish occurs.  E.g. ``nats://localhost:4222``.
+        "nats_server_url": "",
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1825,19 +1825,26 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
-def recompute_ready(conn: sqlite3.Connection) -> int:
+def recompute_ready(
+    conn: sqlite3.Connection,
+) -> tuple[int, list[tuple[str, str]]]:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
-    Returns the number of tasks promoted.  Safe to call inside or outside
-    an existing transaction; it opens its own IMMEDIATE txn.
+    Returns ``(count, [(task_id, assignee), ...])`` — the number of tasks
+    promoted and a list of promoted task ids with their assignees.  The
+    detail list is used by :func:`dispatch_once` to fire NATS dispatch
+    events.  Safe to call inside or outside an existing transaction; it
+    opens its own IMMEDIATE txn.
     """
     promoted = 0
+    promoted_tasks: list[tuple[str, str]] = []
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id FROM tasks WHERE status = 'todo'"
+            "SELECT id, assignee FROM tasks WHERE status = 'todo'"
         ).fetchall()
         for row in todo_rows:
-            task_id = row["id"]
+            task_id: str = row["id"]
+            assignee: str = row["assignee"] or ""
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -1851,7 +1858,8 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 )
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
-    return promoted
+                promoted_tasks.append((task_id, assignee))
+    return promoted, promoted_tasks
 
 
 # ---------------------------------------------------------------------------
@@ -2899,6 +2907,8 @@ class DispatchResult:
 
     reclaimed: int = 0
     promoted: int = 0
+    promoted_tasks: list[tuple[str, str]] = field(default_factory=list)
+    """List of ``(task_id, assignee)`` tuples promoted during this tick."""
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
@@ -3672,6 +3682,7 @@ def dispatch_once(
     max_spawn: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     board: Optional[str] = None,
+    nats_server_url: str = "",
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -3745,7 +3756,9 @@ def dispatch_once(
     if _crash_auto_blocked:
         result.auto_blocked.extend(_crash_auto_blocked)
     result.timed_out = enforce_max_runtime(conn)
-    result.promoted = recompute_ready(conn)
+    promoted_count, promoted_tasks = recompute_ready(conn)
+    result.promoted = promoted_count
+    result.promoted_tasks = promoted_tasks
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -3847,6 +3860,26 @@ def dispatch_once(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+
+    # ── NATS JetStream publish for promoted tasks ──────────────────────
+    # Best-effort: a missing nats-py, a bad server URL, or a transient
+    # connection error is logged and swallowed.  NEVER blocks the gateway.
+    if promoted_tasks and nats_server_url:
+        try:
+            from plugins.kanban.nats_publisher import publish_batch
+            publish_batch(promoted_tasks, nats_server_url)
+        except ImportError:
+            # nats_publisher module not available (not running from the
+            # hermes-agent repo checkout) — silent skip.
+            pass
+        except Exception:
+            # Logged inside publish_batch per task; catch anything
+            # that escaped as a blanket safety net.
+            import logging as _log
+            _log.getLogger(__name__).exception(
+                "NATS publish batch failed", exc_info=True
+            )
+
     return result
 
 

--- a/plugins/kanban/nats_publisher.py
+++ b/plugins/kanban/nats_publisher.py
@@ -1,0 +1,83 @@
+"""NATS JetStream publisher for kanban promote/ready events.
+
+Best-effort publish: logs failures silently, never raises.
+The gateway dispatcher must NEVER block or break because of NATS.
+
+Subject format:  ``kanban.dispatch.<assignee>``
+Payload format:  ``{"task_id": "...", "assignee": "...", "timestamp": N}``
+"""
+
+import json
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def publish_promoted(task_id: str, assignee: str, nats_url: str) -> None:
+    """Publish a single JetStream message for a promoted kanban task.
+
+    Args:
+        task_id:  The promoted task's id (e.g. ``t_a1b2c3d4``).
+        assignee: The task's assignee profile name.
+        nats_url: NATS server URL from ``kanban.nats_server_url`` config.
+
+    Best-effort: if ``nats-py`` is not installed or the connection/publish
+    fails, the error is logged at DEBUG/WARNING level and swallowed.
+    """
+    if not task_id or not assignee or not nats_url:
+        return
+
+    try:
+        import nats  # type: ignore[import-untyped]
+    except ImportError:
+        logger.debug(
+            "NATS: nats-py not installed; skipping publish for task %s", task_id
+        )
+        return
+
+    payload = json.dumps({
+        "task_id": task_id,
+        "assignee": assignee,
+        "timestamp": int(time.time()),
+    })
+    subject = f"kanban.dispatch.{assignee}"
+    try:
+        # dispatch_once runs inside asyncio.to_thread (a thread pool), so
+        # no event loop is active here and asyncio.run() is safe.
+        async def _publish() -> None:
+            nc = await nats.connect(nats_url)
+            try:
+                await nc.publish(subject, payload.encode())
+            finally:
+                await nc.close()
+
+        import asyncio
+        asyncio.run(_publish())
+
+        logger.info("NATS: published to %s for task %s", subject, task_id)
+    except Exception as exc:
+        logger.warning(
+            "NATS: publish failed for task %s (subject=%s): %s",
+            task_id, subject, exc,
+        )
+
+
+def publish_batch(
+    promoted: list[tuple[str, str]],
+    nats_url: str,
+) -> None:
+    """Publish NATS messages for a batch of promoted tasks.
+
+    Args:
+        promoted:  List of ``(task_id, assignee)`` tuples.
+        nats_url:  NATS server URL.
+
+    Each task is published independently so a single failure does not
+    silence the rest of the batch.
+    """
+    if not promoted or not nats_url:
+        return
+    for task_id, assignee in promoted:
+        if assignee:
+            publish_promoted(task_id, assignee, nats_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,9 @@ all = [
   "hermes-agent[web]",
   "hermes-agent[youtube]",
 ]
+# NATS client for kanban dispatch events (optional — only needed when
+# kanban.nats_server_url is configured in config.yaml).
+nats = ["nats-py==2.14.0"]
 
 [project.scripts]
 hermes = "hermes_cli.main:main"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -447,7 +447,7 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
         assert kb.get_task(conn, child).status == "todo"
         # Dispatcher tick between create and some later event must NOT
         # produce a winner for this child.
-        promoted = kb.recompute_ready(conn)
+        promoted, _ = kb.recompute_ready(conn)
         assert promoted == 0
         assert kb.get_task(conn, child).status == "todo"
         # Complete parent; complete_task internally runs recompute_ready,

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -277,7 +277,7 @@ def _(home, kb):
             result = []
             def run():
                 try:
-                    result.append(kb.recompute_ready(conn))
+                    result.append(kb.recompute_ready(conn)[0])
                 except Exception as e:
                     result.append(e)
                 done.set()

--- a/tests/stress/test_property_fuzzing.py
+++ b/tests/stress/test_property_fuzzing.py
@@ -213,7 +213,7 @@ def random_op(rng, conn, kb, task_pool):
         crashed = kb.detect_crashed_workers(conn)
         return {"op": "detect_crashed", "n": len(crashed)}
     if op == "recompute_ready":
-        n = kb.recompute_ready(conn)
+        n, _ = kb.recompute_ready(conn)
         return {"op": "recompute_ready", "promoted": n}
     if op == "reassign":
         # Reassignment isn't a direct API; simulate via assign_task

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -324,7 +324,7 @@ def _handle_list(args: dict, **kw) -> str:
         try:
             # Match CLI list: dependencies that cleared since the last
             # dispatcher tick should be visible to orchestrators immediately.
-            promoted = kb.recompute_ready(conn)
+            promoted, _ = kb.recompute_ready(conn)
             # Fetch one extra row so model-facing output can report that
             # a bounded listing was truncated without dumping the board.
             rows = kb.list_tasks(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -165,6 +165,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "fastapi==0.133.1",
         "uvicorn[standard]==0.41.0",
     ),
+
+    # ─── Kanban dispatch (NATS) ─────────────────────────────────────────────
+    # NATS client for publishing kanban dispatch events. Used by the gateway
+    # dispatcher when ``kanban.nats_server_url`` is configured.
+    "kanban.nats": ("nats-py==2.14.0",),
 }
 
 


### PR DESCRIPTION
Add NATS JetStream publish hook to kanban gateway dispatch.

When a kanban task is promoted to "ready" status, publish a JetStream message:
- Subject: `kanban.dispatch.<assignee>`
- Payload: `{task_id, assignee, timestamp}`
- NATS server URL from config.yaml: `kanban.nats_server_url`

**Design:**
- Best-effort only: failures logged and swallowed, NEVER blocks the gateway
- Config-gated: `kanban.nats_server_url` empty = no NATS code path reached
- Lazy import: `nats-py` imported only at publish time
- Optional dep: `pip install hermes-agent[nats]`
- Plugin location: `plugins/kanban/nats_publisher.py`

**Files changed:**
- `plugins/kanban/nats_publisher.py` — NEW, NATS publish functions
- `hermes_cli/kanban_db.py` — hooks into `dispatch_once()`, `recompute_ready()` now returns promoted task list
- `hermes_cli/config.py` — adds `kanban.nats_server_url` default config
- `gateway/run.py` — reads nats_server_url from config, passes to dispatch
- `tools/lazy_deps.py` — adds `kanban.nats` lazy dep
- `pyproject.toml` — adds `nats` extra
- `tools/kanban_tools.py`, `tests/` — unpack new `recompute_ready()` tuple return

**Tests:** 82/82 kanban DB tests pass, 0 regressions.