### PR TITLE
fix(mcp-oauth): print SSH tunnel hint in _redirect_handler

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -10,6 +10,8 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
+import asyncio
+
 from tools.mcp_oauth import (
     HermesTokenStorage,
     OAuthNonInteractiveError,
@@ -20,6 +22,7 @@ from tools.mcp_oauth import (
     _is_interactive,
     _wait_for_callback,
     _make_callback_handler,
+    _redirect_handler,
 )
 
 
@@ -239,6 +242,64 @@ class TestUtilities:
         monkeypatch.setenv("DISPLAY", ":0")
         monkeypatch.setattr(os, "name", "posix")
         assert _can_open_browser() is True
+
+
+class TestRedirectHandlerSshHint:
+    """_redirect_handler must print an SSH tunnel hint on remote sessions."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_ssh_hint_shown_on_ssh_session(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+        monkeypatch.setattr(mco, "_oauth_port", 49200)
+        monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
+
+        self._run(_redirect_handler("https://example.com/auth?foo=bar"))
+
+        err = capsys.readouterr().err
+        assert "49200" in err
+        assert "ssh -N -L" in err
+        assert "Remote session detected" in err
+
+    def test_ssh_hint_shown_via_ssh_tty(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+        monkeypatch.setattr(mco, "_oauth_port", 49201)
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.setenv("SSH_TTY", "/dev/pts/1")
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
+
+        self._run(_redirect_handler("https://example.com/auth"))
+
+        err = capsys.readouterr().err
+        assert "49201" in err
+        assert "ssh -N -L" in err
+
+    def test_no_ssh_hint_on_local_session(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+        monkeypatch.setattr(mco, "_oauth_port", 49202)
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: True)
+        monkeypatch.setattr("webbrowser.open", lambda url, **kw: True)
+
+        self._run(_redirect_handler("https://example.com/auth"))
+
+        err = capsys.readouterr().err
+        assert "ssh -N -L" not in err
+
+    def test_no_ssh_hint_when_port_not_set(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+        monkeypatch.setattr(mco, "_oauth_port", None)
+        monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
+
+        self._run(_redirect_handler("https://example.com/auth"))
+
+        err = capsys.readouterr().err
+        assert "ssh -N -L" not in err
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -401,6 +401,23 @@ async def _redirect_handler(authorization_url: str) -> None:
     )
     print(msg, file=sys.stderr)
 
+    # On a remote SSH session the OAuth provider redirects to
+    # http://127.0.0.1:<port>/callback, which reaches the callback server on
+    # the *remote* machine — not the user's local machine where the browser
+    # opened.  Print a port-forward hint so the user knows to tunnel first.
+    if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
+        print(
+            f"  Remote session detected. The OAuth provider will redirect your browser to\n"
+            f"    http://127.0.0.1:{_oauth_port}/callback\n"
+            f"  which the callback listener on THIS machine is waiting on. If your browser\n"
+            f"  is on a different machine, forward the port first in a separate terminal:\n"
+            f"\n"
+            f"    ssh -N -L {_oauth_port}:127.0.0.1:{_oauth_port} <user>@<this-host>\n"
+            f"\n"
+            f"  Then open the URL above. See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
+            file=sys.stderr,
+        )
+
     if _can_open_browser():
         try:
             opened = webbrowser.open(authorization_url)


### PR DESCRIPTION
Sibling fix of #26592 — same missing SSH tunnel hint, same loopback callback pattern.

## Root cause

`_redirect_handler` in `tools/mcp_oauth.py` already detected SSH sessions via `_can_open_browser()` and printed `"Headless environment detected — open the URL manually."` — but gave no guidance on *how* to actually reach the callback server.

When Hermes runs on a remote host over SSH, the OAuth provider redirects the user's browser to:

```
http://127.0.0.1:<port>/callback
```

This callback server is listening on the **remote machine**. The user's local browser can't reach it without a port-forward, so the OAuth flow silently times out or returns "Could not establish connection."

## Connection to #26592

PR #26592 fixed exactly this for xAI OAuth and Spotify by introducing `_print_loopback_ssh_hint()` in `hermes_cli/auth.py`. `tools/mcp_oauth.py` uses the **identical** loopback callback pattern (`http://127.0.0.1:{_oauth_port}/callback` via `_configure_callback_port` / `_wait_for_callback`) but was not covered by that fix.

## Changes

**`tools/mcp_oauth.py`** — `_redirect_handler`:
- When `SSH_CLIENT` or `SSH_TTY` is set and `_oauth_port` is available, print the `ssh -N -L <port>:127.0.0.1:<port> <host>` command and the OAuth-over-SSH guide URL to `stderr` (consistent with the rest of the function's output).
- No new imports or dependencies — uses only `os.getenv()` and the module-level `_oauth_port` that is always set before `_redirect_handler` is ever called.

**`tests/tools/test_mcp_oauth.py`** — new `TestRedirectHandlerSshHint` class (4 tests):
- SSH_CLIENT set → hint shown with correct port
- SSH_TTY set → hint shown with correct port  
- No SSH env vars → no hint
- `_oauth_port` is None → no hint (guard against uninitialized state)

## Validation

```
uv run pytest tests/tools/test_mcp_oauth.py -v --override-ini="addopts=" -n1
# 32 passed, 1 failed (pre-existing), 9 skipped
# All 4 new TestRedirectHandlerSshHint tests: PASSED
```