### PR TITLE
ci: add uv caching and e2e Python matrix to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+            ${{ runner.os }}-
+
       - name: Set up Python 3.11
         run: uv python install 3.11
 
@@ -56,6 +66,10 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -66,12 +80,22 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-
+            ${{ runner.os }}-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          uv venv .venv --python 3.11
+          uv venv .venv --python ${{ matrix.python-version }}
           source .venv/bin/activate
           uv pip install -e ".[all,dev]"
 


### PR DESCRIPTION
Complements PR #22225 (which adds the Python matrix to the `test` job). This PR adds:

- **uv caching** to the `test` job with `${{ matrix.python-version }}` in the cache key (works with or without the matrix — forward-compatible with #22225)
- **Python version matrix + uv caching** to the `e2e` job (`['3.11', '3.12', '3.13']`) with `fail-fast: false`
- Tiered `restore-keys` for cache fallback

Both the cache key and uv/python-setup steps use `${{ matrix.python-version }}` so this is ready to run alongside #22225 without conflicts.

Part of #22005.