### PR TITLE
fix(web/i18n): persist Desktop language from config.yaml on startup (#26665)

### DIFF
--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -95,6 +95,11 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Turkish") == "tr"
     assert i18n._normalize_lang("tr-TR") == "tr"
     assert i18n._normalize_lang("türkçe") == "tr"
+    # Regional Portuguese tags should both land on the shared `pt` catalog
+    # rather than silently falling back to English (#26665).
+    assert i18n._normalize_lang("pt-BR") == "pt"
+    assert i18n._normalize_lang("pt-PT") == "pt"
+    assert i18n._normalize_lang("brazilian") == "pt"
 
 
 def test_normalize_lang_unknown_falls_back():

--- a/web/src/i18n/context.tsx
+++ b/web/src/i18n/context.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
 import type { Locale, Translations } from "./types";
+import { api } from "@/lib/api";
 import { en } from "./en";
 import { zh } from "./zh";
 import { zhHant } from "./zh-hant";
@@ -100,15 +101,32 @@ export function normalizeLocale(value: unknown): Locale | null {
   return null;
 }
 
-function getInitialLocale(): Locale {
+function readStoredLocale(): Locale | null {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    const normalized = stored ? normalizeLocale(stored) : null;
-    if (normalized) return normalized;
+    return stored ? normalizeLocale(stored) : null;
   } catch {
     // SSR or privacy mode
+    return null;
   }
-  return "en";
+}
+
+function getInitialLocale(): Locale {
+  return readStoredLocale() ?? "en";
+}
+
+// Read display.language from config.yaml via /api/config.  Used to seed the
+// initial UI language for users who set the value in config.yaml directly
+// (e.g. CLI setup wizard) without touching the in-browser dropdown.  See
+// issue #26665.
+async function fetchConfigLocale(): Promise<Locale | null> {
+  try {
+    const cfg = await api.getConfig();
+    const display = (cfg as { display?: { language?: unknown } }).display;
+    return normalizeLocale(display?.language);
+  } catch {
+    return null;
+  }
 }
 
 interface I18nContextValue {
@@ -125,6 +143,22 @@ const I18nContext = createContext<I18nContextValue>({
 
 export function I18nProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(getInitialLocale);
+
+  // If the user never touched the in-browser dropdown (no localStorage
+  // entry) honour display.language from config.yaml on startup.  An
+  // explicit dropdown choice — saved to localStorage — always wins.
+  useEffect(() => {
+    if (readStoredLocale()) return;
+    let cancelled = false;
+    fetchConfigLocale().then((fromConfig) => {
+      if (!cancelled && fromConfig && !readStoredLocale()) {
+        setLocaleState(fromConfig);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const setLocale = useCallback((l: Locale) => {
     setLocaleState(l);

--- a/web/src/i18n/context.tsx
+++ b/web/src/i18n/context.tsx
@@ -62,14 +62,49 @@ export const LOCALE_META: Record<Locale, { name: string; flag: string }> = {
 const SUPPORTED_LOCALES = Object.keys(TRANSLATIONS) as Locale[];
 const STORAGE_KEY = "hermes-locale";
 
+// Aliases for values users (or config.yaml) may supply that aren't bare
+// locale codes — common BCP-47 regional tags ("pt-BR", "zh-CN") plus a few
+// English/endonym names.  Mirrors agent/i18n.py so the Desktop and CLI
+// route the same input to the same catalog.
+const LOCALE_ALIASES: Record<string, Locale> = {
+  "en-us": "en", "en-gb": "en", english: "en",
+  "zh-cn": "zh", "zh-hans": "zh", "zh-sg": "zh", chinese: "zh",
+  "zh-tw": "zh-hant", "zh-hk": "zh-hant", "zh-mo": "zh-hant",
+  "ja-jp": "ja", jp: "ja", japanese: "ja",
+  "de-de": "de", "de-at": "de", "de-ch": "de", german: "de",
+  "es-es": "es", "es-mx": "es", "es-ar": "es", spanish: "es",
+  "fr-fr": "fr", "fr-be": "fr", "fr-ca": "fr", "fr-ch": "fr", french: "fr",
+  "tr-tr": "tr", turkish: "tr",
+  "uk-ua": "uk", ua: "uk", ukrainian: "uk",
+  "af-za": "af", afrikaans: "af",
+  "ko-kr": "ko", korean: "ko",
+  "it-it": "it", "it-ch": "it", italian: "it",
+  "ga-ie": "ga", irish: "ga",
+  "pt-pt": "pt", "pt-br": "pt", portuguese: "pt", brazilian: "pt",
+  "ru-ru": "ru", russian: "ru",
+  "hu-hu": "hu", hungarian: "hu",
+};
+
 function isLocale(value: string): value is Locale {
   return (SUPPORTED_LOCALES as string[]).includes(value);
+}
+
+export function normalizeLocale(value: unknown): Locale | null {
+  if (typeof value !== "string") return null;
+  const key = value.trim().toLowerCase();
+  if (!key) return null;
+  if (isLocale(key)) return key;
+  if (key in LOCALE_ALIASES) return LOCALE_ALIASES[key];
+  const base = key.split("-", 1)[0];
+  if (isLocale(base)) return base;
+  return null;
 }
 
 function getInitialLocale(): Locale {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored && isLocale(stored)) return stored;
+    const normalized = stored ? normalizeLocale(stored) : null;
+    if (normalized) return normalized;
   } catch {
     // SSR or privacy mode
   }


### PR DESCRIPTION
## What does this PR do?

Fixes #26665. Hermes Desktop ignored `display.language` from `~/.hermes/config.yaml` on startup, so non-English users (e.g. `pt-BR`) saw the UI in English on every restart even though the value was correctly saved on disk.

The React `I18nProvider` (`web/src/i18n/context.tsx`) only seeded the active locale from `localStorage`. Users who set the language via the CLI setup wizard or by editing `config.yaml` directly never populated `localStorage`, so the provider always fell back to English. The same symptom appears in browsers that wipe site data on quit even when the user used the dropdown.

This PR teaches the provider to fall back to `display.language` from `/api/config` when `localStorage` has no entry, mirrors the Python alias map (`pt-BR` → `pt`, `zh-CN` → `zh`, etc.) on the TypeScript side so the same string resolves identically across Desktop / CLI / gateway, and pins a regression test for the specific Portuguese aliases called out in the bug report. An explicit dropdown choice still wins, so the existing in-browser UX is unchanged. The fix is read-only on the config side — it never mutates `config.yaml`.

## Related Issue

Fixes #26665 — Desktop language setting resets to English on restart despite `config.yaml` having `pt-BR` saved.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/i18n/context.tsx` (+74/-4):
  - New `LOCALE_ALIASES` map covering BCP-47 regional tags and a few endonym/English aliases — mirrors `_LANGUAGE_ALIASES` in `agent/i18n.py` so Desktop, CLI, and gateway resolve user input identically.
  - New `normalizeLocale(value)` helper that accepts the alias map plus a regional-suffix strip (`zh-XX` → `zh`) and returns `null` for unknown input.
  - Refactored `getInitialLocale()` to route stored values through `normalizeLocale`.
  - New `fetchConfigLocale()` helper that calls `api.getConfig()` and reads `display.language`.
  - New `useEffect` in `I18nProvider` that, only when `localStorage` has no entry, applies the config-derived locale on mount. An explicit dropdown choice — saved to `localStorage` — always wins.
- `tests/agent/test_i18n.py` (+5):
  - Adds `pt-BR`, `pt-PT`, and `brazilian` cases to `test_normalize_lang_accepts_aliases` so future refactors of the Python alias map can't silently route Portuguese users back to English.

No backend code or config-write path touched.

## How to Test

1. Check out the branch and ensure `.venv` is set up:
   ```
   python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```
2. Run the i18n tests on their own to confirm the pinned aliases:
   ```
   scripts/run_tests.sh tests/agent/test_i18n.py -v
   ```
   Expected: 43 passed.
3. Manual repro (matches the issue's steps to reproduce):
   - Set `display.language: pt-BR` in `~/.hermes/config.yaml`.
   - Open Hermes Desktop in a fresh browser profile (no `hermes-locale` key in `localStorage`).
   - Expected: the UI renders in Portuguese without touching the dropdown.
4. Manual regression checks:
   - Pick `Français` from the dropdown, reload the page → UI stays French even though `config.yaml` still says `pt-BR` (localStorage wins).
   - Clear localStorage, leave `config.yaml` without `display.language` → UI stays English.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(web/i18n): ...`, `fix(web/i18n): ...`, `test(i18n): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_i18n.py` and all tests pass
- [x] I've added tests for my changes (regression case for `pt-BR` / `pt-PT` / `brazilian`)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior matches existing `display.language` docs, only the surface that honors it changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — frontend-only TS change, runs in the browser; backend is untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_i18n.py -v
============================== 43 passed in 2.08s ==============================

$ git diff --stat main..HEAD
 tests/agent/test_i18n.py |  5 ++++
 web/src/i18n/context.tsx | 77 +++++++++++++++++++++++++++++++++++++++++++++---
 2 files changed, 78 insertions(+), 4 deletions(-)

$ git log --oneline main..HEAD
6e68ef4ee test(i18n): pin pt-BR/pt-PT/brazilian to pt catalog (#26665)
909964b65 fix(web/i18n): seed UI language from config.yaml display.language (#26665)
073f60284 feat(web/i18n): normalize regional locale tags (pt-BR, zh-CN, etc.)
```
