### PR TITLE
fix: persist goal task snapshots and stall gateway continuations

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9443,6 +9443,101 @@ class GatewayRunner:
         except Exception:
             return 20
 
+    def _goal_stall_timeout_minutes_from_config(self) -> int:
+        """Resolve the no-progress timeout for gateway /goal stall detection."""
+        try:
+            gateway_cfg = (
+                (self.config or {}).get("gateway", {})
+                if isinstance(self.config, dict)
+                else getattr(self.config, "gateway", {}) or {}
+            )
+            if not gateway_cfg:
+                from hermes_cli.config import load_config
+
+                gateway_cfg = (load_config() or {}).get("gateway") or {}
+            value = int(gateway_cfg.get("goal_stall_timeout_minutes", 15) or 15)
+            return max(value, 1)
+        except Exception:
+            return 15
+
+    @staticmethod
+    def _goal_task_source_fields(source: Any) -> dict[str, Any]:
+        if source is None:
+            return {}
+        platform = getattr(source, "platform", None)
+        return {
+            "platform": getattr(platform, "value", platform),
+            "chat_id": getattr(source, "chat_id", None),
+            "thread_id": getattr(source, "thread_id", None),
+            "owner_agent": "gateway",
+        }
+
+    async def _maybe_mark_stalled_goal_before_continuation(self, *, session_id: str, source: Any) -> bool:
+        """Return True when a queued /goal continuation may proceed.
+
+        If the durable goal snapshot shows the active goal has gone too long
+        without verified progress, mark it stalled, persist a one-shot notice
+        marker, emit one actionable status message, and suppress the queued
+        continuation.
+        """
+        if not session_id:
+            return False
+        try:
+            from hermes_cli.goals import GoalManager, load_goal_task_snapshot, update_goal_task_snapshot
+        except Exception as exc:
+            logger.debug("goal continuation: stall-check imports unavailable: %s", exc)
+            return False
+
+        mgr = GoalManager(session_id=session_id)
+        if not mgr.is_active():
+            return False
+
+        snapshot = load_goal_task_snapshot(session_id)
+        if snapshot is None:
+            return True
+        if str(snapshot.status or "") == "stalled":
+            return False
+
+        last_progress = float(snapshot.last_verified_progress_at or 0.0)
+        if last_progress <= 0:
+            return True
+
+        now = time.time()
+        timeout_seconds = float(self._goal_stall_timeout_minutes_from_config()) * 60.0
+        if now - last_progress < timeout_seconds:
+            return True
+
+        if snapshot.stall_notified_at:
+            update_goal_task_snapshot(
+                session_id,
+                **self._goal_task_source_fields(source),
+                status="stalled",
+                next_action="check provider/tool failure or ask user for guidance",
+                _now=now,
+            )
+            return False
+
+        age_minutes = max((now - last_progress) / 60.0, 0.0)
+        update_goal_task_snapshot(
+            session_id,
+            **self._goal_task_source_fields(source),
+            status="stalled",
+            last_reason=f"no verified progress for {age_minutes:.1f} minutes",
+            next_action="check provider/tool failure or ask user for guidance",
+            stall_notified_at=now,
+            last_user_visible_update_at=now,
+            _now=now,
+        )
+        objective = snapshot.objective or (mgr.state.goal if mgr.state else "standing goal")
+        await self._send_goal_status_notice(
+            source,
+            (
+                f"⏸ Goal stalled: {objective} — no verified progress for {age_minutes:.1f} minutes. "
+                "Next action: check provider/tool failure or ask user for guidance."
+            ),
+        )
+        return False
+
     def _get_goal_manager_for_event(self, event: "MessageEvent"):
         """Return a GoalManager bound to the session for this gateway event.
 
@@ -9488,8 +9583,20 @@ class GatewayRunner:
 
         if lower == "pause":
             state = mgr.pause(reason="user-paused")
+            sid = getattr(session_entry, "session_id", None)
             if state is None:
                 return t("gateway.goal.no_goal_set")
+            if sid:
+                try:
+                    from hermes_cli.goals import update_goal_task_snapshot
+
+                    update_goal_task_snapshot(
+                        sid,
+                        objective=state.goal,
+                        **self._goal_task_source_fields(event.source),
+                    )
+                except Exception as exc:
+                    logger.debug("goal pause: snapshot sync failed: %s", exc)
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
                 _quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -9501,13 +9608,38 @@ class GatewayRunner:
 
         if lower == "resume":
             state = mgr.resume()
+            sid = getattr(session_entry, "session_id", None)
             if state is None:
                 return t("gateway.goal.no_resume")
+            if sid:
+                try:
+                    from hermes_cli.goals import update_goal_task_snapshot
+
+                    update_goal_task_snapshot(
+                        sid,
+                        objective=state.goal,
+                        **self._goal_task_source_fields(event.source),
+                    )
+                except Exception as exc:
+                    logger.debug("goal resume: snapshot sync failed: %s", exc)
             return t("gateway.goal.resumed", goal=state.goal)
 
         if lower in {"clear", "stop", "done"}:
             had = mgr.has_goal()
+            sid = getattr(session_entry, "session_id", None)
+            goal_text = mgr.state.goal if mgr.state else ""
             mgr.clear()
+            if sid:
+                try:
+                    from hermes_cli.goals import update_goal_task_snapshot
+
+                    update_goal_task_snapshot(
+                        sid,
+                        objective=goal_text,
+                        **self._goal_task_source_fields(event.source),
+                    )
+                except Exception as exc:
+                    logger.debug("goal clear: snapshot sync failed: %s", exc)
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
                 _quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -9522,6 +9654,19 @@ class GatewayRunner:
             state = mgr.set(args)
         except ValueError as exc:
             return t("gateway.goal.invalid", error=str(exc))
+
+        sid = getattr(session_entry, "session_id", None)
+        if sid:
+            try:
+                from hermes_cli.goals import update_goal_task_snapshot
+
+                update_goal_task_snapshot(
+                    sid,
+                    objective=state.goal,
+                    **self._goal_task_source_fields(event.source),
+                )
+            except Exception as exc:
+                logger.debug("goal set: snapshot sync failed: %s", exc)
 
         # Queue the goal text as an immediate first turn so the agent
         # starts making progress. The post-turn hook takes over after.
@@ -9673,7 +9818,7 @@ class GatewayRunner:
         queue and takes priority naturally.
         """
         try:
-            from hermes_cli.goals import GoalManager
+            from hermes_cli.goals import GoalManager, update_goal_task_snapshot
         except Exception as exc:
             logger.debug("goal continuation: goals module unavailable: %s", exc)
             return
@@ -9689,6 +9834,14 @@ class GatewayRunner:
             return
 
         decision = mgr.evaluate_after_turn(final_response or "", user_initiated=True)
+        try:
+            update_goal_task_snapshot(
+                sid,
+                objective=(mgr.state.goal if mgr.state else None) or getattr(getattr(mgr, "state", None), "goal", None),
+                **self._goal_task_source_fields(source),
+            )
+        except Exception as exc:
+            logger.debug("goal continuation: snapshot source sync failed: %s", exc)
         msg = decision.get("message") or ""
 
         # Defer the status line until after the adapter has delivered the
@@ -16213,12 +16366,16 @@ class GatewayRunner:
                 next_channel_prompt = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
-                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
-                        logger.info(
-                            "Discarding stale goal continuation for session %s — goal is no longer active",
-                            session_key or "?",
-                        )
-                        return result
+                    if self._is_goal_continuation_event(pending_event):
+                        if not await self._maybe_mark_stalled_goal_before_continuation(
+                            session_id=session_id,
+                            source=next_source,
+                        ):
+                            logger.info(
+                                "Discarding stale goal continuation for session %s — goal is no longer active or is stalled",
+                                session_key or "?",
+                            )
+                            return result
                     next_message = await self._prepare_inbound_message_text(
                         event=pending_event,
                         source=next_source,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -191,6 +191,59 @@ class GoalState:
         return "\n".join(f"- {i}. {text}" for i, text in enumerate(self.subgoals, start=1))
 
 
+@dataclass
+class GoalTaskSnapshot:
+    """Operator-facing durable status record for /goal work."""
+
+    session_id: str
+    source: str = "goal"
+    objective: str = ""
+    status: str = "active"  # active | paused | stalled | error | complete | cleared
+    platform: Optional[str] = None
+    chat_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    owner_agent: Optional[str] = None
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    last_verified_progress_at: float = 0.0
+    last_user_visible_update_at: float = 0.0
+    last_reason: Optional[str] = None
+    next_action: Optional[str] = None
+    artifact_refs: List[str] = field(default_factory=list)
+    stall_notified_at: Optional[float] = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "GoalTaskSnapshot":
+        data = json.loads(raw)
+        artifact_refs = data.get("artifact_refs") or []
+        if not isinstance(artifact_refs, list):
+            artifact_refs = []
+        return cls(
+            session_id=str(data.get("session_id") or ""),
+            source=str(data.get("source") or "goal"),
+            objective=str(data.get("objective") or ""),
+            status=str(data.get("status") or "active"),
+            platform=data.get("platform"),
+            chat_id=data.get("chat_id"),
+            thread_id=data.get("thread_id"),
+            owner_agent=data.get("owner_agent"),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+            updated_at=float(data.get("updated_at", 0.0) or 0.0),
+            last_verified_progress_at=float(data.get("last_verified_progress_at", 0.0) or 0.0),
+            last_user_visible_update_at=float(data.get("last_user_visible_update_at", 0.0) or 0.0),
+            last_reason=data.get("last_reason"),
+            next_action=data.get("next_action"),
+            artifact_refs=[str(ref) for ref in artifact_refs if str(ref).strip()],
+            stall_notified_at=(
+                float(data.get("stall_notified_at"))
+                if data.get("stall_notified_at") not in (None, "")
+                else None
+            ),
+        )
+
 # ──────────────────────────────────────────────────────────────────────
 # Persistence (SessionDB state_meta)
 # ──────────────────────────────────────────────────────────────────────
@@ -198,6 +251,22 @@ class GoalState:
 
 def _meta_key(session_id: str) -> str:
     return f"goal:{session_id}"
+
+
+def _task_meta_key(session_id: str) -> str:
+    return f"goal-task:{session_id}"
+
+
+def _goal_task_next_action(status: str) -> str:
+    mapping = {
+        "active": "continue goal loop",
+        "paused": "await user input",
+        "stalled": "check provider/tool failure or ask user for guidance",
+        "complete": "goal complete",
+        "cleared": "goal cleared",
+        "error": "inspect failure and recover",
+    }
+    return mapping.get(status, "continue goal loop")
 
 
 _DB_CACHE: Dict[str, Any] = {}
@@ -267,6 +336,64 @@ def save_goal(session_id: str, state: GoalState) -> None:
         logger.debug("GoalManager: set_meta failed: %s", exc)
 
 
+def load_goal_task_snapshot(session_id: str) -> Optional[GoalTaskSnapshot]:
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        return None
+    try:
+        raw = db.get_meta(_task_meta_key(session_id))
+    except Exception as exc:
+        logger.debug("GoalTaskSnapshot: get_meta failed: %s", exc)
+        return None
+    if not raw:
+        return None
+    try:
+        return GoalTaskSnapshot.from_json(raw)
+    except Exception as exc:
+        logger.warning("GoalTaskSnapshot: could not parse stored snapshot for %s: %s", session_id, exc)
+        return None
+
+
+def save_goal_task_snapshot(session_id: str, snapshot: GoalTaskSnapshot) -> None:
+    if not session_id:
+        return
+    db = _get_session_db()
+    if db is None:
+        return
+    try:
+        db.set_meta(_task_meta_key(session_id), snapshot.to_json())
+    except Exception as exc:
+        logger.debug("GoalTaskSnapshot: set_meta failed: %s", exc)
+
+
+def update_goal_task_snapshot(session_id: str, **updates: Any) -> Optional[GoalTaskSnapshot]:
+    if not session_id:
+        return None
+    now = float(updates.pop("_now", time.time()))
+    snapshot = load_goal_task_snapshot(session_id)
+    if snapshot is None:
+        snapshot = GoalTaskSnapshot(
+            session_id=session_id,
+            created_at=now,
+            updated_at=now,
+            last_user_visible_update_at=now,
+            next_action=_goal_task_next_action("active"),
+        )
+    if not snapshot.created_at:
+        snapshot.created_at = now
+    for key, value in updates.items():
+        if hasattr(snapshot, key):
+            setattr(snapshot, key, value)
+    status = str(snapshot.status or "active")
+    if not snapshot.next_action:
+        snapshot.next_action = _goal_task_next_action(status)
+    snapshot.updated_at = now
+    save_goal_task_snapshot(session_id, snapshot)
+    return snapshot
+
+
 def clear_goal(session_id: str) -> None:
     """Mark a goal cleared in the DB (preserved for audit, status=cleared)."""
     state = load_goal(session_id)
@@ -274,6 +401,14 @@ def clear_goal(session_id: str) -> None:
         return
     state.status = "cleared"
     save_goal(session_id, state)
+    update_goal_task_snapshot(
+        session_id,
+        objective=state.goal,
+        status="cleared",
+        last_reason="goal cleared",
+        next_action=_goal_task_next_action("cleared"),
+        last_user_visible_update_at=time.time(),
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -517,50 +652,107 @@ class GoalManager:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        now = time.time()
         state = GoalState(
             goal=goal,
             status="active",
             turns_used=0,
             max_turns=int(max_turns) if max_turns else self.default_max_turns,
-            created_at=time.time(),
+            created_at=now,
             last_turn_at=0.0,
         )
         self._state = state
         save_goal(self.session_id, state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=goal,
+            status="active",
+            last_reason=None,
+            next_action=_goal_task_next_action("active"),
+            created_at=now,
+            last_user_visible_update_at=now,
+            last_verified_progress_at=0.0,
+            stall_notified_at=None,
+            artifact_refs=[],
+            _now=now,
+        )
         return state
 
     def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
         if not self._state:
             return None
+        now = time.time()
         self._state.status = "paused"
         self._state.paused_reason = reason
         save_goal(self.session_id, self._state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=self._state.goal,
+            status="paused",
+            last_reason=reason,
+            next_action=_goal_task_next_action("paused"),
+            last_user_visible_update_at=now,
+            _now=now,
+        )
         return self._state
 
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
         if not self._state:
             return None
+        now = time.time()
         self._state.status = "active"
         self._state.paused_reason = None
         if reset_budget:
             self._state.turns_used = 0
         save_goal(self.session_id, self._state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=self._state.goal,
+            status="active",
+            last_reason=self._state.last_reason,
+            next_action=_goal_task_next_action("active"),
+            last_user_visible_update_at=now,
+            stall_notified_at=None,
+            _now=now,
+        )
         return self._state
 
     def clear(self) -> None:
         if self._state is None:
             return
+        now = time.time()
         self._state.status = "cleared"
         save_goal(self.session_id, self._state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=self._state.goal,
+            status="cleared",
+            last_reason="goal cleared",
+            next_action=_goal_task_next_action("cleared"),
+            last_user_visible_update_at=now,
+            _now=now,
+        )
         self._state = None
 
     def mark_done(self, reason: str) -> None:
         if not self._state:
             return
+        now = time.time()
         self._state.status = "done"
         self._state.last_verdict = "done"
         self._state.last_reason = reason
         save_goal(self.session_id, self._state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=self._state.goal,
+            status="complete",
+            last_reason=reason,
+            next_action=_goal_task_next_action("complete"),
+            last_verified_progress_at=now,
+            last_user_visible_update_at=now,
+            stall_notified_at=None,
+            _now=now,
+        )
 
     # --- /subgoal user controls ---------------------------------------
 
@@ -643,8 +835,9 @@ class GoalManager:
             }
 
         # Count the turn that just finished.
+        now = time.time()
         state.turns_used += 1
-        state.last_turn_at = time.time()
+        state.last_turn_at = now
 
         verdict, reason, parse_failed = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None
@@ -663,6 +856,17 @@ class GoalManager:
         if verdict == "done":
             state.status = "done"
             save_goal(self.session_id, state)
+            update_goal_task_snapshot(
+                self.session_id,
+                objective=state.goal,
+                status="complete",
+                last_verified_progress_at=now,
+                last_user_visible_update_at=now,
+                last_reason=reason,
+                next_action=_goal_task_next_action("complete"),
+                stall_notified_at=None,
+                _now=now,
+            )
             return {
                 "status": "done",
                 "should_continue": False,
@@ -684,6 +888,16 @@ class GoalManager:
                 f"judge model returned unparseable output {state.consecutive_parse_failures} turns in a row"
             )
             save_goal(self.session_id, state)
+            update_goal_task_snapshot(
+                self.session_id,
+                objective=state.goal,
+                status="paused",
+                last_verified_progress_at=now,
+                last_user_visible_update_at=now,
+                last_reason=state.paused_reason,
+                next_action=_goal_task_next_action("paused"),
+                _now=now,
+            )
             return {
                 "status": "paused",
                 "should_continue": False,
@@ -706,6 +920,16 @@ class GoalManager:
             state.status = "paused"
             state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
             save_goal(self.session_id, state)
+            update_goal_task_snapshot(
+                self.session_id,
+                objective=state.goal,
+                status="paused",
+                last_verified_progress_at=now,
+                last_user_visible_update_at=now,
+                last_reason=state.paused_reason,
+                next_action=_goal_task_next_action("paused"),
+                _now=now,
+            )
             return {
                 "status": "paused",
                 "should_continue": False,
@@ -719,6 +943,17 @@ class GoalManager:
             }
 
         save_goal(self.session_id, state)
+        update_goal_task_snapshot(
+            self.session_id,
+            objective=state.goal,
+            status="active",
+            last_verified_progress_at=now,
+            last_user_visible_update_at=now,
+            last_reason=reason,
+            next_action=_goal_task_next_action("active"),
+            stall_notified_at=None,
+            _now=now,
+        )
         return {
             "status": "active",
             "should_continue": True,
@@ -743,6 +978,7 @@ class GoalManager:
 
 __all__ = [
     "GoalState",
+    "GoalTaskSnapshot",
     "GoalManager",
     "CONTINUATION_PROMPT_TEMPLATE",
     "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
@@ -752,5 +988,8 @@ __all__ = [
     "load_goal",
     "save_goal",
     "clear_goal",
+    "load_goal_task_snapshot",
+    "save_goal_task_snapshot",
+    "update_goal_task_snapshot",
     "judge_goal",
 ]

--- a/tests/gateway/test_goal_task_ledger.py
+++ b/tests/gateway/test_goal_task_ledger.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+class _RecordingAdapter:
+    def __init__(self) -> None:
+        self._pending_messages: dict = {}
+        self._active_sessions: dict = {}
+        self.sends: list[dict] = []
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None):
+        self.sends.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SimpleNamespace(success=True)
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self._active_sessions[session_key] = SimpleNamespace(_hermes_run_generation=generation)
+        self._callback = callback
+
+
+def _make_source(thread_id: str = "thread-123") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+        thread_id=thread_id,
+    )
+
+
+def _make_runner_with_adapter(session_id: str = "goal-task-ledger-sid"):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._queued_events = {}
+
+    src = _make_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(src),
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store._generate_session_key.return_value = build_session_key(src)
+
+    adapter = _RecordingAdapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+    return runner, adapter, session_entry, src
+
+
+@pytest.mark.asyncio
+async def test_post_turn_goal_continuation_persists_source_metadata(hermes_home):
+    from hermes_cli.goals import GoalManager, load_goal_task_snapshot
+
+    runner, _adapter, session_entry, src = _make_runner_with_adapter()
+    GoalManager(session_entry.session_id).set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "still needs work", False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="partial progress",
+        )
+
+    snap = load_goal_task_snapshot(session_entry.session_id)
+    assert snap is not None
+    assert snap.platform == Platform.TELEGRAM.value
+    assert snap.chat_id == "c1"
+    assert snap.thread_id == "thread-123"
+    assert snap.status == "active"
+    assert snap.last_reason == "still needs work"
+
+
+@pytest.mark.asyncio
+async def test_goal_stall_detection_marks_snapshot_and_sends_one_notice(hermes_home):
+    from hermes_cli.goals import GoalManager, update_goal_task_snapshot, load_goal_task_snapshot
+
+    runner, adapter, session_entry, src = _make_runner_with_adapter(session_id="goal-stalled-sid")
+    GoalManager(session_entry.session_id).set("finish the task")
+    update_goal_task_snapshot(
+        session_entry.session_id,
+        platform=Platform.TELEGRAM.value,
+        chat_id="c1",
+        thread_id="thread-123",
+        status="active",
+        last_verified_progress_at=1.0,
+    )
+
+    runner._goal_stall_timeout_minutes_from_config = MagicMock(return_value=1)
+
+    with patch("gateway.run.time.time", return_value=1.0 + 120.0):
+        should_continue = await runner._maybe_mark_stalled_goal_before_continuation(
+            session_id=session_entry.session_id,
+            source=src,
+        )
+
+    snap = load_goal_task_snapshot(session_entry.session_id)
+    assert should_continue is False
+    assert snap is not None
+    assert snap.status == "stalled"
+    assert snap.stall_notified_at == pytest.approx(121.0)
+    assert "check provider/tool failure" in snap.next_action
+    assert len(adapter.sends) == 1
+    assert adapter.sends[0]["chat_id"] == "c1"
+    assert adapter.sends[0]["content"] == (
+        "⏸ Goal stalled: finish the task — no verified progress for 2.0 minutes. "
+        "Next action: check provider/tool failure or ask user for guidance."
+    )
+    assert adapter.sends[0]["metadata"]["thread_id"] == "thread-123"
+    assert not hasattr(adapter, "_callback")
+
+    with patch("gateway.run.time.time", return_value=1.0 + 180.0):
+        should_continue_again = await runner._maybe_mark_stalled_goal_before_continuation(
+            session_id=session_entry.session_id,
+            source=src,
+        )
+
+    assert should_continue_again is False
+    assert len(adapter.sends) == 1

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,10 +252,59 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_task_snapshot_created_and_persisted(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal_task_snapshot
+
+        mgr = GoalManager(session_id="task-sid-1", default_max_turns=5)
+        mgr.set("ship the docs")
+
+        snap = load_goal_task_snapshot("task-sid-1")
+        assert snap is not None
+        assert snap.session_id == "task-sid-1"
+        assert snap.source == "goal"
+        assert snap.objective == "ship the docs"
+        assert snap.status == "active"
+        assert snap.next_action == "continue goal loop"
+        assert snap.last_verified_progress_at == 0.0
+        assert snap.last_user_visible_update_at >= snap.created_at > 0
+
+        mgr2 = GoalManager(session_id="task-sid-1")
+        snap2 = load_goal_task_snapshot("task-sid-1")
+        assert mgr2.state is not None
+        assert snap2 is not None
+        assert snap2.objective == "ship the docs"
+        assert snap2.status == "active"
+
+    def test_task_snapshot_tracks_pause_resume_clear(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal_task_snapshot
+
+        mgr = GoalManager(session_id="task-sid-2")
+        mgr.set("stabilize gateway")
+
+        mgr.pause(reason="user-paused")
+        paused = load_goal_task_snapshot("task-sid-2")
+        assert paused is not None
+        assert paused.status == "paused"
+        assert paused.last_reason == "user-paused"
+        assert paused.next_action == "await user input"
+
+        mgr.resume()
+        resumed = load_goal_task_snapshot("task-sid-2")
+        assert resumed is not None
+        assert resumed.status == "active"
+        assert resumed.next_action == "continue goal loop"
+        assert resumed.stall_notified_at is None
+
+        mgr.clear()
+        cleared = load_goal_task_snapshot("task-sid-2")
+        assert cleared is not None
+        assert cleared.status == "cleared"
+        assert cleared.next_action == "goal cleared"
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals
-        from hermes_cli.goals import GoalManager
+        from hermes_cli.goals import GoalManager, load_goal_task_snapshot
 
         mgr = GoalManager(session_id="eval-sid-1")
         mgr.set("ship it")
@@ -263,11 +312,43 @@ class TestGoalManager:
         with patch.object(goals, "judge_goal", return_value=("done", "shipped", False)):
             decision = mgr.evaluate_after_turn("I shipped the feature.")
 
+        snap = load_goal_task_snapshot("eval-sid-1")
         assert decision["verdict"] == "done"
         assert decision["should_continue"] is False
         assert decision["continuation_prompt"] is None
         assert mgr.state.status == "done"
         assert mgr.state.turns_used == 1
+        assert snap is not None
+        assert snap.status == "complete"
+        assert snap.last_reason == "shipped"
+        assert snap.next_action == "goal complete"
+        assert snap.last_verified_progress_at > 0
+
+    def test_evaluate_after_turn_refreshes_snapshot_progress(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager, load_goal_task_snapshot, update_goal_task_snapshot
+
+        mgr = GoalManager(session_id="eval-sid-progress", default_max_turns=5)
+        mgr.set("make progress")
+        update_goal_task_snapshot(
+            "eval-sid-progress",
+            status="stalled",
+            stall_notified_at=123.0,
+            last_verified_progress_at=1.0,
+        )
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False)):
+            decision = mgr.evaluate_after_turn("made some progress")
+
+        snap = load_goal_task_snapshot("eval-sid-progress")
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        assert snap is not None
+        assert snap.status == "active"
+        assert snap.last_reason == "more work"
+        assert snap.next_action == "continue goal loop"
+        assert snap.last_verified_progress_at > 1.0
+        assert snap.stall_notified_at is None
 
     def test_evaluate_after_turn_continue_under_budget(self, hermes_home):
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- persist a durable `/goal` task snapshot in session metadata for lifecycle and operator status tracking
- sync gateway source metadata into goal snapshots and mark stale continuations as stalled with a one-shot user-visible notice
- add regression coverage for snapshot persistence, lifecycle transitions, source metadata wiring, and stall notice behavior

## Testing
- scripts/run_tests.sh tests/hermes_cli/test_goals.py tests/gateway/test_goal_task_ledger.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_verdict_send.py -q

Related to #26410