### PR TITLE
fix(gateway/discord): force reconnect on REST liveness probe failure (#26656)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -582,6 +582,17 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        # REST-level liveness probe.  discord.py's WS reconnect handles
+        # clean drops, but a dead proxy / NAT can wedge the socket without
+        # delivering a RST — sends time out forever while start() still
+        # spins.  See #26656.  Disable with interval<=0 or threshold<=0.
+        self._liveness_interval_seconds = float(
+            os.getenv("HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS", "60")
+        )
+        self._liveness_failure_threshold = int(
+            os.getenv("HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD", "3")
+        )
+        self._liveness_task: Optional[asyncio.Task] = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -852,6 +863,7 @@ class DiscordAdapter(BasePlatformAdapter):
             await asyncio.wait_for(self._ready_event.wait(), timeout=30)
 
             self._running = True
+            self._start_liveness_probe()
             return True
 
         except asyncio.TimeoutError:
@@ -885,14 +897,98 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._liveness_task and not self._liveness_task.done():
+            self._liveness_task.cancel()
+            try:
+                await self._liveness_task
+            except asyncio.CancelledError:
+                pass
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._liveness_task = None
 
         self._release_platform_lock()
 
         logger.info("[%s] Disconnected", self.name)
+
+    def _start_liveness_probe(self) -> None:
+        """Start the periodic REST liveness probe if configured.
+
+        Idempotent: if a task is already running we leave it alone so a
+        re-entrant connect() doesn't fork two probes against the same client.
+        """
+        if self._liveness_interval_seconds <= 0 or self._liveness_failure_threshold <= 0:
+            return
+        if self._liveness_task and not self._liveness_task.done():
+            return
+        self._liveness_task = asyncio.create_task(self._liveness_loop())
+
+    async def _liveness_loop(self) -> None:
+        """Probe Discord REST periodically and force a reconnect on persistent failure.
+
+        See #26656.  ``client.start()`` reconnects internally on clean
+        WS drops, but when the underlying socket is wedged behind a dead
+        proxy the WS never sees a RST and the adapter sits in a silent
+        zombie state — process alive, sends timing out forever.  An
+        out-of-band ``fetch_user`` exercises the same REST path as
+        message delivery and lets us detect the wedge.  After
+        ``threshold`` consecutive failures we close the client, set a
+        retryable fatal error, and hand control back to the gateway's
+        platform reconnect watcher.
+        """
+        interval = self._liveness_interval_seconds
+        threshold = self._liveness_failure_threshold
+        fails = 0
+        while self._running:
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                return
+            client = self._client
+            if not self._running or client is None:
+                return
+            if hasattr(client, "is_closed") and client.is_closed():
+                return
+            user = getattr(client, "user", None)
+            if user is None:
+                continue
+            try:
+                await client.fetch_user(user.id)
+                fails = 0
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                fails += 1
+                logger.warning(
+                    "[%s] Discord liveness probe failed (%d/%d): %s",
+                    self.name, fails, threshold, exc,
+                )
+                if fails < threshold:
+                    continue
+                logger.error(
+                    "[%s] Discord client appears dead, forcing reconnect", self.name,
+                )
+                try:
+                    await client.close()
+                except Exception:
+                    logger.debug(
+                        "[%s] Error closing wedged Discord client", self.name, exc_info=True,
+                    )
+                self._set_fatal_error(
+                    "liveness_probe_failed",
+                    f"Discord REST liveness probe failed {fails} times in a row",
+                    retryable=True,
+                )
+                try:
+                    await self._notify_fatal_error()
+                except Exception:
+                    logger.debug(
+                        "[%s] Fatal-error handler raised", self.name, exc_info=True,
+                    )
+                return
 
     def _command_sync_state_path(self) -> _Path:
         from hermes_constants import get_hermes_home

--- a/tests/gateway/test_discord_liveness.py
+++ b/tests/gateway/test_discord_liveness.py
@@ -1,0 +1,147 @@
+"""Regression tests for the Discord REST liveness probe (#26656).
+
+discord.py's WebSocket reconnect handles clean drops, but a wedged proxy /
+NAT can leave the underlying socket dead without ever delivering a RST —
+sends time out forever while ``client.start()`` happily spins.  The probe
+in ``DiscordAdapter`` periodically hits Discord REST so we can detect the
+zombie state and trip the gateway's existing reconnect path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Re-use the shared discord-stub bootstrap and FakeBot from the connect
+# test module so this file doesn't duplicate the (large) mock surface.
+from tests.gateway.test_discord_connect import (  # noqa: E402
+    FakeBot,
+    _ensure_discord_mock,
+)
+
+_ensure_discord_mock()
+
+import gateway.platforms.discord as discord_platform  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+def _make_adapter(monkeypatch, *, interval=0.01, threshold=1) -> DiscordAdapter:
+    monkeypatch.setenv("HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS", str(interval))
+    monkeypatch.setenv("HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD", str(threshold))
+    return DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+async def _connect(adapter: DiscordAdapter, monkeypatch, bot_factory):
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+    assert await adapter.connect() is True
+
+
+@pytest.mark.asyncio
+async def test_liveness_probe_disabled_when_interval_zero(monkeypatch):
+    """interval<=0 must skip the probe entirely so users can opt out."""
+    adapter = _make_adapter(monkeypatch, interval=0)
+
+    bot_holder: dict = {}
+
+    def factory(**kwargs):
+        bot = FakeBot(intents=kwargs["intents"], allowed_mentions=kwargs.get("allowed_mentions"))
+        bot.fetch_user = AsyncMock()
+        bot_holder["bot"] = bot
+        return bot
+
+    await _connect(adapter, monkeypatch, factory)
+    assert adapter._liveness_task is None
+    await asyncio.sleep(0.05)
+    bot_holder["bot"].fetch_user.assert_not_called()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_liveness_probe_pings_rest_while_healthy(monkeypatch):
+    """A healthy probe keeps the adapter running and never sets a fatal error."""
+    adapter = _make_adapter(monkeypatch, interval=0.01, threshold=3)
+
+    def factory(**kwargs):
+        bot = FakeBot(intents=kwargs["intents"], allowed_mentions=kwargs.get("allowed_mentions"))
+        bot.fetch_user = AsyncMock(return_value=SimpleNamespace(id=999))
+        return bot
+
+    await _connect(adapter, monkeypatch, factory)
+    await asyncio.sleep(0.05)
+    assert adapter._client.fetch_user.await_count >= 1
+    assert adapter._running is True
+    assert adapter.has_fatal_error is False
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_liveness_probe_forces_reconnect_after_threshold(monkeypatch):
+    """Once the probe fails ``threshold`` times in a row, the adapter must
+    close the wedged client and surface a retryable fatal error so the
+    gateway's reconnect watcher (gateway/run.py) can rebuild it."""
+    adapter = _make_adapter(monkeypatch, interval=0.005, threshold=2)
+
+    close_calls = []
+
+    class WedgedBot(FakeBot):
+        async def close(self):
+            close_calls.append(True)
+
+    def factory(**kwargs):
+        bot = WedgedBot(intents=kwargs["intents"], allowed_mentions=kwargs.get("allowed_mentions"))
+        bot.fetch_user = AsyncMock(side_effect=TimeoutError("dead proxy"))
+        return bot
+
+    handler = AsyncMock()
+    adapter.set_fatal_error_handler(handler)
+    await _connect(adapter, monkeypatch, factory)
+
+    # Wait for the loop to exit (it returns after threshold consecutive
+    # failures).  Bounded by a generous timeout so a regression doesn't
+    # hang CI.
+    for _ in range(200):
+        if adapter._liveness_task and adapter._liveness_task.done():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("liveness loop did not terminate within 2s")
+
+    assert close_calls == [True]
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_code == "liveness_probe_failed"
+    assert adapter.fatal_error_retryable is True
+    handler.assert_awaited_once()
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_liveness_task(monkeypatch):
+    """``disconnect()`` must cancel the probe so the gateway can shut down
+    cleanly without leaking a background task."""
+    adapter = _make_adapter(monkeypatch, interval=60, threshold=3)
+
+    def factory(**kwargs):
+        bot = FakeBot(intents=kwargs["intents"], allowed_mentions=kwargs.get("allowed_mentions"))
+        bot.fetch_user = AsyncMock()
+        return bot
+
+    await _connect(adapter, monkeypatch, factory)
+    task = adapter._liveness_task
+    assert task is not None and not task.done()
+
+    await adapter.disconnect()
+    assert task.done()
+    assert adapter._liveness_task is None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -483,6 +483,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` | Disable the hard-coded Cloudflare fallback IPs used when DNS fails (`true`/`false`). |
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Discord text chunk (default: `0.6`). |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a Discord message exceeds the length limit (default: `2.0`). |
+| `HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS` | Interval for the Discord REST liveness probe that detects zombie clients behind dead proxies/NATs (default: `60`, set to `0` to disable). |
+| `HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD` | Consecutive probe failures before forcing a Discord reconnect (default: `3`). |
 | `HERMES_MATRIX_TEXT_BATCH_DELAY_SECONDS` / `_SPLIT_DELAY_SECONDS` | Matrix equivalents of the Telegram batch knobs. |
 | `HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS` / `_SPLIT_DELAY_SECONDS` / `_MAX_CHARS` / `_MAX_MESSAGES` | Feishu batcher tuning — delay, split delay, max chars per message, max messages per batch. |
 | `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | Feishu media flush delay. |


### PR DESCRIPTION
## What does this PR do?

Fixes #26656. The Discord adapter enters a silent zombie state after a network outage / proxy stall: the process is alive, `_client` looks open, but the underlying socket is dead and discord.py's WebSocket-level reconnect never sees a RST, so it keeps spinning while every REST send times out. The bot stays "offline" in Discord until someone runs `hermes gateway restart`.

This PR adds an out-of-band REST liveness probe in `DiscordAdapter`. Every `HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS` (default 60s) the adapter issues a cheap `fetch_user(bot_id)` — same REST path as message delivery, so it fails when the proxy/NAT is wedged. After `HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD` consecutive failures (default 3) the probe closes the wedged client and surfaces a retryable fatal error, which trips the gateway's existing `_platform_reconnect_watcher` in `gateway/run.py` and rebuilds the adapter from scratch. Operators can disable the probe entirely by setting either knob to `0`.

## Related Issue

Fixes #26656 — Discord adapter enters silent zombie state after network outage; never auto-reconnects.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` (+96):
  - New `_liveness_interval_seconds` / `_liveness_failure_threshold` instance fields, populated from `HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS` / `HERMES_DISCORD_LIVENESS_FAILURE_THRESHOLD` so operators can tune or opt out.
  - New `_start_liveness_probe()` helper called at the end of `connect()` after `_running = True`. It's idempotent so a re-entrant connect can't fork two probes against the same client.
  - New `_liveness_loop()` that sleeps `interval`, runs `fetch_user(client.user.id)`, resets the failure counter on success, logs at WARNING on each failure, and on threshold hit: closes the client, calls `_set_fatal_error("liveness_probe_failed", retryable=True)`, and notifies the fatal-error handler so the existing gateway reconnect path takes over.
  - `disconnect()` cancels the probe task and clears `_liveness_task` so shutdowns don't leak a background coroutine.
- `tests/gateway/test_discord_liveness.py` (+147, new file):
  - Re-uses the discord-stub bootstrap and `FakeBot` from `test_discord_connect.py` so we don't duplicate the (large) mock surface.
  - Covers the four contract points: probe disabled when `interval<=0`, healthy probe keeps the adapter running with no fatal error, threshold failures close the client + raise retryable fatal error + notify handler, `disconnect()` cancels the probe.
- `website/docs/reference/environment-variables.md` (+2):
  - Documents the two new env vars next to the existing `HERMES_DISCORD_TEXT_BATCH_*` knobs so operators can find them when tuning.

No behavior change when the probe stays healthy or when both knobs are set to `0`.

## How to Test

1. Activate the project venv:
   ```
   source .venv/bin/activate
   ```
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/gateway/test_discord_liveness.py -v
   ```
   Expected: 4 passed.
3. Run the full Discord connect/reconnect suite to confirm no regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_discord_connect.py tests/gateway/test_discord_liveness.py -q
   ```
   Expected: 20 passed.
4. Optional manual repro of the original bug (matches the issue's repro):
   - Run `hermes gateway` with a Discord profile configured behind an HTTP proxy you can toggle (the issue used Shadowrocket on macOS).
   - Confirm the bot is online.
   - Kill the proxy for >2 × `HERMES_DISCORD_LIVENESS_INTERVAL_SECONDS` (default >2min).
   - Expected: `gateway.log` shows three `Discord liveness probe failed (n/3)` WARN lines followed by `Discord client appears dead, forcing reconnect` ERROR, then the gateway reconnect watcher logs `✓ discord reconnected successfully` once the proxy is back. No manual `gateway restart` required.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway/discord): ...`, `test(gateway/discord): ...`, `docs(env): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_discord_connect.py tests/gateway/test_discord_liveness.py` and all tests pass
- [x] I've added tests for my changes (4 new asyncio tests pinning the probe contract)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — added the two new env vars to `website/docs/reference/environment-variables.md` and inline docstrings in the adapter
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, both knobs are env-only and follow the existing `HERMES_DISCORD_TEXT_BATCH_*` pattern
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — asyncio + discord.py only, no OS-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, internal adapter health check

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_discord_liveness.py -v
============================== 4 passed in 1.97s ===============================

$ scripts/run_tests.sh tests/gateway/test_discord_connect.py tests/gateway/test_discord_liveness.py -q
============================== 20 passed in 2.25s ==============================

$ git diff --stat main..HEAD
 gateway/platforms/discord.py                    |  96 ++++++++++++++++
 tests/gateway/test_discord_liveness.py          | 147 ++++++++++++++++++++++++
 website/docs/reference/environment-variables.md |   2 +
 3 files changed, 245 insertions(+)

$ git log --oneline main..HEAD
e0297b71b docs(env): document Discord liveness probe tunables (#26656)
0a9529930 test(gateway/discord): cover liveness probe paths (#26656)
18c801fa6 fix(gateway/discord): add REST liveness probe to detect zombie clients (#26656)
```
