### PR TITLE
fix(gateway/status): keep PID file during --replace handoff when lock file is briefly absent (#26643)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -924,7 +924,15 @@ def get_running_pid(
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
     if not lock_active:
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        # Only force-cleanup when there is on-disk evidence (a lock file
+        # that nobody holds) that a dead process left things behind.  When
+        # the lock file is simply missing — e.g. mid-handoff during
+        # ``hermes update --replace`` — a live gateway may still own the
+        # PID file, and unlinking it here is what causes ``send_message``
+        # to disappear from CLI sessions until the next manual restart
+        # (#26643).
+        if resolved_lock_path.exists():
+            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 
     primary_record = _read_pid_record(resolved_pid_path)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -167,6 +167,35 @@ class TestGatewayPidState:
 
         assert status.is_gateway_runtime_lock_active() is False
 
+    def test_get_running_pid_preserves_pid_file_when_lock_file_missing(self, tmp_path, monkeypatch):
+        """Regression for #26643.
+
+        During a ``hermes update --replace`` handoff the lock file can be
+        briefly absent from disk while a live gateway still owns the PID
+        file.  ``get_running_pid()`` must not interpret that as
+        "stale PID record" and unlink the new gateway's PID file —
+        doing so makes ``is_gateway_running()`` flip to False and hides
+        the ``send_message`` tool from CLI sessions for ~24h.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        # No lock file on disk → can't verify the live gateway, but
+        # also can't prove the PID file is stale.  Return None without
+        # destroying state a live gateway may own.
+        assert status.get_running_pid() is None
+        assert pid_path.exists()
+
     def test_get_running_pid_cleans_stale_metadata_from_dead_foreign_pid(self, tmp_path, monkeypatch):
         """Stale PID file from a *different* PID (crashed process) must still be cleaned.
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -48,6 +48,11 @@ class TestGatewayPidState:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"
         pid_path.write_text(str(os.getpid()))
+        # Drop a lock file alongside so cleanup can prove the metadata is
+        # stale (lock exists but nobody holds it → dead process aftermath).
+        # See #26643 for why the absence of a lock file is no longer
+        # treated as proof of staleness.
+        (tmp_path / "gateway.lock").write_text("")
 
         assert status.get_running_pid() is None
         assert not pid_path.exists()
@@ -66,6 +71,11 @@ class TestGatewayPidState:
             "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
             "start_time": 111,
         }))
+        # Crashed gateways leave the lock file on disk (the OS releases
+        # the kernel-level flock but does not unlink the inode), so the
+        # "dead process" scenario the test pins includes a present lock
+        # file alongside the stale PID record.
+        (tmp_path / "gateway.lock").write_text("")
 
         def _dead_process(pid, sig):
             raise ProcessLookupError

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -167,23 +167,6 @@ class TestGatewayPidState:
 
         assert status.is_gateway_runtime_lock_active() is False
 
-    def test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        pid_path = tmp_path / "gateway.pid"
-        pid_path.write_text(json.dumps({
-            "pid": os.getpid(),
-            "kind": "hermes-gateway",
-            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
-            "start_time": 123,
-        }))
-
-        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
-        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
-        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
-
-        assert status.get_running_pid() is None
-        assert not pid_path.exists()
-
     def test_get_running_pid_cleans_stale_metadata_from_dead_foreign_pid(self, tmp_path, monkeypatch):
         """Stale PID file from a *different* PID (crashed process) must still be cleaned.
 


### PR DESCRIPTION
## What does this PR do?

Fixes #26643. After every `hermes update` (or the daily midnight auto-update) the gateway PID + lock files end up deleted from disk while the gateway process is still running — visible in `/proc/<pid>/fd/` as `(deleted)`. `is_gateway_running()` then returns `False`, which gates `_check_send_message()` in CLI mode, so the `send_message` tool silently disappears from CLI sessions for ~24h until the next manual `hermes gateway restart`.

The destructive cleanup lives in `gateway/status.py::get_running_pid()`: whenever `is_gateway_runtime_lock_active()` returns `False`, the function force-unlinks both `gateway.pid` and `gateway.lock`. That heuristic is only safe for the "dead process left state behind" case. During a `hermes update --replace` handoff the lock file is briefly absent on disk while a live gateway still owns the PID file — and the cleanup nukes the new gateway's PID record before it has a chance to recreate its lock.

This PR gates the destructive cleanup on `resolved_lock_path.exists()` (the suggested fix in the issue): we still return `None` when we can't verify the lock, but we no longer destroy state a live gateway may own. The second cleanup call site — where the lock IS held but no record matches — is unchanged, because a held lock proves something exists.

## Related Issue

Fixes #26643 — `gateway.pid` and `gateway.lock` deleted after update restart, hiding `send_message` from CLI.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/status.py` (+9/-1):
  - Wrap the first `_cleanup_invalid_pid_path()` call in `get_running_pid()` with `if resolved_lock_path.exists():`. When the lock file is missing on disk we can no longer prove staleness, so we return `None` without unlinking the PID file. The inline comment cites #26643 so a future refactor doesn't quietly revert the heuristic.
- `tests/gateway/test_status.py` (+33/-3):
  - Updates the two adjacent "stale cleanup" tests (`test_get_running_pid_rejects_live_non_gateway_pid`, `test_get_running_pid_cleans_stale_record_from_dead_process`) to drop a lock file alongside the stale PID record — that's the real "dead process aftermath" they're meant to pin, and it makes them pass under both the old and new contract so the prep commit is reviewable on its own.
  - Drops the prior `test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock` test which encoded the buggy heuristic, and replaces it with `test_get_running_pid_preserves_pid_file_when_lock_file_missing` — the explicit #26643 regression: PID file pointing at a live process, no lock file, and `get_running_pid()` returns `None` without unlinking the record.

No other call sites or behaviour changed. Live-lock callers (`acquire_scoped_lock`, `is_gateway_runtime_lock_active`, `get_running_pid` fallback record lookups) are untouched.

## How to Test

1. Activate the project venv:
   ```
   source .venv/bin/activate
   ```
2. Run the focused regression suite:
   ```
   scripts/run_tests.sh tests/gateway/test_status.py -v
   ```
   Expected: 50 passed (49 pre-existing + 1 new regression in place of the old buggy-contract test).
3. Run the broader update / gateway-restart suites to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_status.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway.py tests/gateway/test_runner_startup_failures.py
   ```
   Expected: 133 passed.
4. Optional manual repro of the original bug:
   - With a running gateway, in another terminal:
     ```
     rm ~/.hermes/gateway.lock
     python -c "from gateway import status; print(status.is_gateway_running())"
     ls ~/.hermes/gateway.pid
     ```
   - Before the fix: prints `False` and `ls` shows the PID file is gone.
   - After the fix: prints `False` (we still can't verify) but `gateway.pid` is preserved, so the next caller that lands after the gateway re-creates its lock sees a healthy state again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(gateway/status): ...`, `fix(gateway/status): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_status.py` and all tests pass
- [x] I've added tests for my changes (one new regression test for #26643, two adjacent tests tightened to match the new contract)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comment on the new branch points at #26643; no external docs describe the old destructive heuristic
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is a pure `Path.exists()` guard; same semantics on POSIX and Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, internal gateway state

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_status.py -v
============================== 50 passed in 1.91s ==============================

$ scripts/run_tests.sh tests/gateway/test_status.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway.py tests/gateway/test_runner_startup_failures.py
============================== 133 passed in 51.18s ============================

$ git diff --stat main..HEAD
 gateway/status.py            | 10 +++++++++-
 tests/gateway/test_status.py | 26 ++++++++++++++++++++++++--
 2 files changed, 33 insertions(+), 3 deletions(-)

$ git log --oneline main..HEAD
c60fe9aed test(gateway/status): pin #26643 — preserve PID file when lock file missing
39f37d4be fix(gateway/status): require lock file on disk before unlinking PID file (#26643)
3bd0190eb test(gateway/status): pin lock-file presence in stale-cleanup tests
```
