### PR TITLE
fix(bedrock): increase read_timeout + route iteration-limit summary through Converse API

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -62,11 +62,26 @@ def _get_bedrock_runtime_client(region: str):
     """Get or create a cached ``bedrock-runtime`` client for the given region.
 
     Uses the default AWS credential chain (env vars → profile → instance role).
+
+    The client is configured with a generous ``read_timeout`` (default 900s,
+    overridable via ``HERMES_BEDROCK_READ_TIMEOUT``) because large prompts can
+    take significant time before Bedrock returns the first byte — especially
+    for high-capability models like Opus processing 100K+ token contexts.
+    The boto3 default of 60s is insufficient for agentic workloads.
     """
     if region not in _bedrock_runtime_client_cache:
         boto3 = _require_boto3()
+        from botocore.config import Config as BotoConfig
+
+        _read_timeout = int(os.environ.get("HERMES_BEDROCK_READ_TIMEOUT", 900))
+        _connect_timeout = int(os.environ.get("HERMES_BEDROCK_CONNECT_TIMEOUT", 10))
         _bedrock_runtime_client_cache[region] = boto3.client(
             "bedrock-runtime", region_name=region,
+            config=BotoConfig(
+                read_timeout=_read_timeout,
+                connect_timeout=_connect_timeout,
+                retries={"max_attempts": 2},
+            ),
         )
     return _bedrock_runtime_client_cache[region]
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -12053,6 +12053,22 @@ class AIAgent:
                     summary_response = self._anthropic_messages_create(_ant_kw)
                     _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_summary_result.content or "").strip()
+                elif self.api_mode == "bedrock_converse":
+                    from agent.bedrock_adapter import (
+                        _get_bedrock_runtime_client,
+                        normalize_converse_response,
+                    )
+                    _bsum_transport = self._get_transport()
+                    _bsum_kwargs = _bsum_transport.build_kwargs(
+                        model=self.model, messages=api_messages, tools=None,
+                        max_tokens=self.max_tokens, region=getattr(self, "_bedrock_region", None) or "us-east-1",
+                    )
+                    _bsum_region = _bsum_kwargs.pop("__bedrock_region__", "us-east-1")
+                    _bsum_kwargs.pop("__bedrock_converse__", None)
+                    _bsum_client = _get_bedrock_runtime_client(_bsum_region)
+                    _bsum_raw = _bsum_client.converse(**_bsum_kwargs)
+                    _bsum_result = _bsum_transport.normalize_response(normalize_converse_response(_bsum_raw))
+                    final_response = (_bsum_result.content or "").strip()
                 else:
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                     _summary_result = self._get_transport().normalize_response(summary_response)
@@ -12083,6 +12099,22 @@ class AIAgent:
                     retry_response = self._anthropic_messages_create(_ant_kw2)
                     _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_retry_result.content or "").strip()
+                elif self.api_mode == "bedrock_converse":
+                    from agent.bedrock_adapter import (
+                        _get_bedrock_runtime_client,
+                        normalize_converse_response,
+                    )
+                    _bretry_transport = self._get_transport()
+                    _bretry_kwargs = _bretry_transport.build_kwargs(
+                        model=self.model, messages=api_messages, tools=None,
+                        max_tokens=self.max_tokens, region=getattr(self, "_bedrock_region", None) or "us-east-1",
+                    )
+                    _bretry_region = _bretry_kwargs.pop("__bedrock_region__", "us-east-1")
+                    _bretry_kwargs.pop("__bedrock_converse__", None)
+                    _bretry_client = _get_bedrock_runtime_client(_bretry_region)
+                    _bretry_raw = _bretry_client.converse(**_bretry_kwargs)
+                    _bretry_result = _bretry_transport.normalize_response(normalize_converse_response(_bretry_raw))
+                    final_response = (_bretry_result.content or "").strip()
                 else:
                     summary_kwargs = {
                         "model": self.model,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -892,6 +892,76 @@ class TestClientCache:
 
 
 # ---------------------------------------------------------------------------
+# Client timeout configuration
+# ---------------------------------------------------------------------------
+
+class TestBedrockClientTimeout:
+    """Bedrock runtime client must use a generous read_timeout.
+
+    The default boto3 read_timeout (60s) is too low for large-context agentic
+    workloads. Opus processing 100K+ token prompts can take >60s to return the
+    first byte. The Anthropic SDK path uses 900s — Bedrock should match.
+    """
+
+    def test_default_read_timeout_is_900(self):
+        """Without env vars, the client should use 900s read_timeout."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            _bedrock_runtime_client_cache,
+            reset_client_cache,
+        )
+        reset_client_cache()
+        # Patch env to ensure no override is set
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_BEDROCK_READ_TIMEOUT", None)
+            os.environ.pop("HERMES_BEDROCK_CONNECT_TIMEOUT", None)
+            client = _get_bedrock_runtime_client("us-west-2")
+            cfg = client._client_config
+            assert cfg.read_timeout == 900
+            assert cfg.connect_timeout == 10
+        reset_client_cache()
+
+    def test_env_var_overrides_read_timeout(self):
+        """HERMES_BEDROCK_READ_TIMEOUT should override the default."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+        with patch.dict(os.environ, {"HERMES_BEDROCK_READ_TIMEOUT": "300"}):
+            client = _get_bedrock_runtime_client("us-east-1")
+            assert client._client_config.read_timeout == 300
+        reset_client_cache()
+
+    def test_env_var_overrides_connect_timeout(self):
+        """HERMES_BEDROCK_CONNECT_TIMEOUT should override the default."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+        with patch.dict(os.environ, {"HERMES_BEDROCK_CONNECT_TIMEOUT": "30"}):
+            client = _get_bedrock_runtime_client("eu-west-1")
+            assert client._client_config.connect_timeout == 30
+        reset_client_cache()
+
+    def test_retries_configured(self):
+        """Client should have retries configured (max_attempts=2 → total_max_attempts=3)."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_BEDROCK_READ_TIMEOUT", None)
+            client = _get_bedrock_runtime_client("us-west-2")
+            # botocore transforms max_attempts=2 into total_max_attempts=3
+            # (initial attempt + 2 retries)
+            assert client._client_config.retries["total_max_attempts"] == 3
+        reset_client_cache()
+
+
+# ---------------------------------------------------------------------------
 # Streaming with callbacks
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problems

### 1. Read timeout too low (60s default)

The boto3 Bedrock runtime client is created with no `botocore.Config`, inheriting the **default `read_timeout` of 60 seconds**. This is insufficient for agentic workloads where large prompts (100K+ tokens) can take significant time before Bedrock returns the first byte — especially for high-capability models like Opus processing full conversation contexts with tool outputs, skills, and memory.

The Anthropic SDK path already uses 900s (via `httpx.Timeout`); the Bedrock path should match.

**Symptoms:**
- `botocore.exceptions.ReadTimeoutError` on large prompts
- Intermittent failures that worsen as conversation context grows
- First-token latency exceeds 60s for complex prompts on Opus-class models

**Reference:** https://www.repost.aws/questions/QU7qX5NYtmRTudM9bHS3pTMA

### 2. Iteration-limit summary fails with 401

When the agent hits the iteration limit (90 iterations) and attempts to generate a final summary, the `bedrock_converse` api_mode falls through to the `else` branch which uses `_ensure_primary_openai_client()`. This sends the AWS bearer token to OpenAI's endpoint, resulting in a 401.

**Symptoms:**
- `Error code: 401 - Incorrect API key provided: ABSKQmVk...`
- Appears at end of every long session that hits the iteration limit
- Only affects Bedrock provider users

## Solution

### Commit 1: Timeout fix
- Pass `botocore.Config(read_timeout=900, connect_timeout=10, retries={"max_attempts": 2})` to the `bedrock-runtime` client
- Support `HERMES_BEDROCK_READ_TIMEOUT` and `HERMES_BEDROCK_CONNECT_TIMEOUT` env vars for user override
- Add 4 tests covering default values, env var overrides, and retry configuration

### Commit 2: Iteration-limit summary fix  
- Add `elif self.api_mode == "bedrock_converse"` branches in both the initial summary attempt and the retry path
- Uses the same boto3 `converse()` pattern as the main agent loop

## Why 900s?

Matches the Anthropic SDK timeout set in `anthropic_adapter.py`:
```python
_read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
```

Since streaming is used (`converse_stream`), the timeout only governs time-to-first-byte, not total generation time. 900s is generous but safe.

## Test plan

- 4 new unit tests in `tests/agent/test_bedrock_adapter.py::TestBedrockClientTimeout`
- Full `test_bedrock_adapter.py` suite passes
- Syntax check passes on `run_agent.py`