### PR TITLE
fix(tools): refuse dispatch of tools outside the active toolset (#26568)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -727,6 +727,24 @@ def handle_function_call(
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 
+        # Refuse dispatch of tools the model wasn't actually shown. Tool
+        # handlers are registered globally at import time, so a model that
+        # remembers a tool name from earlier in the session (or hallucinates
+        # one) could otherwise drive a disabled toolset — even after the
+        # user turned it off via ``hermes tools``.  See #26568.
+        if enabled_tools is not None and function_name not in enabled_tools:
+            logger.warning(
+                "Refusing dispatch of %r — tool is not in the active toolset for this session",
+                function_name,
+            )
+            return json.dumps({
+                "error": (
+                    f"Tool '{function_name}' is not enabled for this session. "
+                    f"Enable its toolset via ``hermes tools`` or pass ``--toolsets`` "
+                    f"to use it."
+                )
+            })
+
         # Check plugin hooks for a block directive (unless caller already
         # checked — e.g. run_agent._invoke_tool passes skip=True to
         # avoid double-firing the hook).

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -40,6 +40,40 @@ class TestHandleFunctionCall:
         assert len(parsed["error"]) > 0
         assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
 
+    def test_dispatch_refuses_tools_outside_enabled_list(self):
+        """Regression for #26568: even after disabling the ``web`` toolset
+        via ``hermes tools``, the agent kept calling ``web_extract`` because
+        ``handle_function_call`` only filtered tool *schemas* — the
+        dispatcher itself never checked the active session's allowlist."""
+        with patch("model_tools.registry.dispatch") as mock_dispatch:
+            result = json.loads(handle_function_call(
+                "web_extract",
+                {"urls": ["https://example.com"]},
+                enabled_tools=["browser_navigate", "read_file"],
+            ))
+
+        assert "error" in result
+        assert "web_extract" in result["error"]
+        assert "not enabled" in result["error"]
+        mock_dispatch.assert_not_called()
+
+    def test_dispatch_allows_tools_in_enabled_list(self):
+        """When the tool is in the active toolset, dispatch proceeds."""
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}'):
+            result = handle_function_call(
+                "web_search",
+                {"query": "hello"},
+                enabled_tools=["web_search", "web_extract"],
+            )
+        assert result == '{"ok":true}'
+
+    def test_dispatch_skips_gate_when_enabled_tools_is_none(self):
+        """Non-agent callers (RL environments, MCP server, scripts) pass
+        ``enabled_tools=None`` and must keep working without an allowlist."""
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}'):
+            result = handle_function_call("web_search", {"query": "hi"})
+        assert result == '{"ok":true}'
+
     def test_tool_hooks_receive_session_and_tool_call_ids(self):
         with (
             patch("model_tools.registry.dispatch", return_value='{"ok":true}'),


### PR DESCRIPTION
## What does this PR do?

Stops the agent from invoking tools that the user has explicitly disabled via `hermes tools`.

Issue [#26568](https://github.com/NousResearch/hermes-agent/issues/26568) reported that even after disabling the `web` toolset (so `web_search` / `web_extract` were no longer shown in `hermes tools`), the agent kept calling `web_extract` and clobbering hot memory with scraped page contents. Root cause: tool handlers are registered globally at module import time, and `model_tools.handle_function_call()` only filtered the **schemas** sent to the model — the dispatcher itself never checked the per-session allowlist that `run_agent` already passes in. So a model that hallucinates a tool name, or remembers one from earlier in the session/context history, would happily reach into a disabled toolset.

This PR closes the gap at the dispatcher:

- `handle_function_call()` now refuses to dispatch when `enabled_tools` is provided and the requested function isn't in it, logging a warning and returning a structured JSON error the model can recover from on its next turn.
- Non-agent callers (RL environments, MCP server, scripts) still pass `enabled_tools=None` and keep working unchanged — the gate is opt-in by passing the allowlist, which the agent loop already does at every dispatch site.

## Related Issue

Fixes #26568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `model_tools.py` — at the top of `handle_function_call`, after the existing `_AGENT_LOOP_TOOLS` short-circuit, refuse dispatch when `enabled_tools is not None and function_name not in enabled_tools`. Returns `{"error": "Tool '<name>' is not enabled for this session…"}` and never reaches `registry.dispatch`. Defensive logging so operators can spot models that try to call disabled tools.
- `tests/test_model_tools.py` — three new tests in `TestHandleFunctionCall` pin the contract: (1) a tool absent from `enabled_tools` returns the structured error and `registry.dispatch` is never called; (2) a tool present in `enabled_tools` dispatches normally; (3) `enabled_tools=None` bypasses the gate so existing non-agent call sites stay green.

## How to Test

```bash
# 1. New regression tests pass
./scripts/run_tests.sh tests/test_model_tools.py
# expected: 27 passed

# 2. Dispatcher gate behaves correctly
python -c "
import json
from unittest.mock import patch
from model_tools import handle_function_call

# Disabled tool — refused, dispatcher never invoked
with patch('model_tools.registry.dispatch') as m:
    result = json.loads(handle_function_call(
        'web_extract', {'urls': ['https://example.com']},
        enabled_tools=['browser_navigate', 'read_file'],
    ))
print('refused error :', result['error'])
print('dispatch called:', m.called)

# Enabled tool — passes through
with patch('model_tools.registry.dispatch', return_value='{\"ok\":true}'):
    print('allowed       :', handle_function_call(
        'web_search', {'query': 'hi'},
        enabled_tools=['web_search', 'web_extract'],
    ))
"
# expected:
# refused error : Tool 'web_extract' is not enabled for this session. ...
# dispatch called: False
# allowed       : {"ok":true}

# 3. No regression in agent loop / dispatch suites
./scripts/run_tests.sh tests/test_model_tools.py \
                      tests/test_toolsets.py \
                      tests/hermes_cli/test_tools_config.py \
                      tests/run_agent/ \
                      tests/tools/test_delegate.py
# expected: all pre-existing passes still green
```

For end-to-end verification, disable the `web` toolset via `hermes tools` and start a fresh chat. Even if the model tries to call `web_search` or `web_extract` (e.g. resuming a session that previously used them, or hallucinating the name), the dispatcher now returns `Tool 'web_extract' is not enabled for this session…` and the model sees an error result on its next turn instead of silently scraping the web into hot memory.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools):`, `test(model_tools):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected test suites and they pass (27 model_tools tests + 1599-passing broader sweep)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior change only, no new user-facing surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python dispatcher gate, identical on every platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change; only enforcement of the already-filtered schema set)

## Screenshots / Logs

Before the fix (issue #26568 reproduction):

```
$ hermes tools
  ✗ disabled  web  🔍 Web Search & Scraping
  ✓ enabled  browser  🌐 Browser Automation
  ...

# In a chat session:
> search the web for "hermes agent latest release"
[assistant] I'll search the web for that.
  → calls web_search(...)        # disabled toolset, still dispatched
  → calls web_extract(...)       # disabled toolset, still dispatched
[assistant] I've also updated my hot memory with the page contents.
            # hot memory clobbered with scraped text
```

After the fix:

```
$ hermes tools
  ✗ disabled  web  🔍 Web Search & Scraping
  ✓ enabled  browser  🌐 Browser Automation
  ...

# In a chat session:
> search the web for "hermes agent latest release"
[assistant] I'll search the web for that.
  → calls web_search(...)
    → {"error": "Tool 'web_search' is not enabled for this session.
                 Enable its toolset via ``hermes tools`` or pass
                 ``--toolsets`` to use it."}
[assistant] The web toolset isn't enabled in this session; let me try a
            different approach...
            # disabled tools cannot be invoked, hot memory untouched
```
