### PR TITLE
cron: add router-first review loop

### DIFF
--- a/.workflow/plan.md
+++ b/.workflow/plan.md
@@ -1,0 +1,10 @@
+# Plan: Hermes Router-First Review Loop
+
+**Status:** Approved
+**Date:** 2026-05-15
+**Source:** `docs/plans/router-first-autonomous-cron-orchestration-2026-05-15.md`
+
+## Work Item
+**Status:** Implemented; targeted Hermes router review tests reported passing.
+
+Add the smallest Hermes review-loop endpoint/job support for router-first routing outcomes, using explicit ACK/ESCALATION_NOTICE semantics and local endpoint assumptions from the plan.

--- a/.workflow/prd.md
+++ b/.workflow/prd.md
@@ -1,0 +1,6 @@
+# PRD: Hermes Router-First Review Loop
+
+**Status:** Approved
+**Date:** 2026-05-15
+
+Hermes should supervise router-first autonomous jobs by reviewing routing outcomes against policy and surfacing ACK/escalation notices.

--- a/cron/router_review.py
+++ b/cron/router_review.py
@@ -558,10 +558,16 @@ def format_review_prompt(
                 "within the review window. No policy violations detectable."
             )
     else:
-        router_first = [o for o in outcomes if o.selected_model == "blockrun/auto"]
-        pinned = [o for o in outcomes if o.selected_model and o.selected_model != "blockrun/auto"]
+        router_first = [o for o in outcomes if _is_router_first_outcome(o)]
+        pinned = [
+            o
+            for o in outcomes
+            if o.selected_model
+            and o.selected_model != "blockrun/auto"
+            and not _is_router_first_outcome(o)
+        ]
         missing_resolved = [
-            o for o in outcomes if o.selected_model == "blockrun/auto" and o.resolved_model is None
+            o for o in outcomes if _is_router_first_outcome(o) and o.resolved_model is None
         ]
         lines.append(
             f"Router-first jobs: {len(router_first)}.  "
@@ -618,8 +624,8 @@ Do not require selectedModel to equal blockrun/auto for routing-decisions.json.
 → [warning] (ClawRouter may not be exposing the upstream model).
 4. Job with consecutive_local_failures >= {_CONSECUTIVE_LOCAL_FAILURE_THRESHOLD} \
 → [critical] (GN100 / local inference down).
-5. Explicit model pin (selected_model != blockrun/auto) with no \
-[router-pin: <reason>] marker for a non-coding job → [warning].
+5. Explicit model pin (selected_model != blockrun/auto and not a gateway/current routing-decision) \
+with no [router-pin: <reason>] marker for a non-coding job → [warning].
 
 If {ROUTING_DECISIONS_PATH} does not exist, also check {ROUTING_OUTCOMES_PATH} \
 (JSONL, one record per cron job — written by OpenClaw Items 1-4, may not yet exist).

--- a/cron/router_review.py
+++ b/cron/router_review.py
@@ -114,6 +114,21 @@ _LOCAL_MODEL_PREFIXES = ("gn100", "local/", "ollama", "qwen", "llama", "mistral"
 #: Job types where escalation to a cloud model is expected.
 _ESCALATION_EXPECTED_TYPES = ("coding", "tool-heavy", "reasoning")
 
+#: Gateway complexity-tier suffixes/values mapped into cron review policy types.
+_GATEWAY_TIER_TO_JOB_TYPE = {
+    "simple": "simple",
+    "low": "simple",
+    "coding": "coding",
+    "code": "coding",
+    "tool-heavy": "tool-heavy",
+    "tool_heavy": "tool-heavy",
+    "tools": "tool-heavy",
+    "reasoning": "reasoning",
+    "medium": "reasoning",
+    "high": "reasoning",
+    "complex": "reasoning",
+}
+
 #: Threshold for "repeated local failures" policy check.
 _CONSECUTIVE_LOCAL_FAILURE_THRESHOLD = 3
 
@@ -245,10 +260,10 @@ def load_routing_decisions(
 
     - ``agentId`` → ``job_name`` (``"gateway/<agentId>"`` or
       ``"gateway-decision"`` when absent)
-    - ``complexityTier`` → ``job_type`` (passed through; OpenClaw tiers such as
-      ``"research:reasoning"`` differ from cron job types — policy checks that
-      require exact values like ``"simple"`` or ``"coding"`` will not fire on
-      unrecognised tier values)
+    - ``complexityTier`` → normalized ``job_type`` (for example
+      ``"research:reasoning"`` and ``"research:medium"`` map to
+      ``"reasoning"`` so gateway decisions hit the same policy checks as
+      cron JSONL outcomes)
     - ``selectedModel`` → ``selected_model``
     - ``resolvedModel`` → ``resolved_model``
     - ``router_pin``, ``consecutive_local_failures``, ``error`` → defaults
@@ -310,7 +325,7 @@ def load_routing_decisions(
                 job_id="",
                 selected_model=record.get("selectedModel") or None,
                 resolved_model=record.get("resolvedModel") or None,
-                job_type=record.get("complexityTier") or None,
+                job_type=classify_job_type(record.get("complexityTier") or None),
                 router_pin=None,
                 timestamp=ts_str,
                 error=None,
@@ -325,6 +340,28 @@ def load_routing_decisions(
 # ---------------------------------------------------------------------------
 # Policy checks
 # ---------------------------------------------------------------------------
+
+
+def classify_job_type(job_type: Optional[str]) -> Optional[str]:
+    """Normalize cron job types and OpenClaw complexity tiers for policy checks."""
+    if not job_type:
+        return None
+
+    raw = job_type.strip().lower()
+    if not raw:
+        return None
+
+    candidates = [raw]
+    if ":" in raw:
+        candidates.append(raw.rsplit(":", 1)[-1])
+    if "/" in raw:
+        candidates.append(raw.rsplit("/", 1)[-1])
+
+    for candidate in candidates:
+        normalized = _GATEWAY_TIER_TO_JOB_TYPE.get(candidate)
+        if normalized:
+            return normalized
+    return raw
 
 
 def _is_local_model(model: Optional[str]) -> bool:
@@ -365,11 +402,13 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
     violations: List[PolicyViolation] = []
 
     for o in outcomes:
+        job_type = classify_job_type(o.job_type)
+
         # ------------------------------------------------------------------
         # Check 1 — simple work routed to cloud without justification
         # ------------------------------------------------------------------
         if (
-            o.job_type == "simple"
+            job_type == "simple"
             and o.selected_model == "blockrun/auto"
             and _is_cloud_model(o.resolved_model)
             and not o.router_pin
@@ -390,7 +429,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
         # Check 2 — coding/reasoning work not escalating
         # ------------------------------------------------------------------
         if (
-            o.job_type in _ESCALATION_EXPECTED_TYPES
+            job_type in _ESCALATION_EXPECTED_TYPES
             and o.selected_model == "blockrun/auto"
             and _is_local_model(o.resolved_model)
         ):
@@ -398,7 +437,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
                 PolicyViolation(
                     severity="warning",
                     message=(
-                        f"{o.job_type.capitalize()} job did not escalate: "
+                        f"{job_type.capitalize()} job did not escalate: "
                         f"resolved to local {o.resolved_model!r}. "
                         "Expected cloud escalation for this job type."
                     ),
@@ -447,7 +486,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
             and not o.router_pin
             # Coding pins are expected in phase one per the plan — only flag
             # non-coding job types where an unexplained pin is a surprise.
-            and o.job_type not in _ESCALATION_EXPECTED_TYPES
+            and job_type not in _ESCALATION_EXPECTED_TYPES
         ):
             violations.append(
                 PolicyViolation(
@@ -558,9 +597,10 @@ Each decision has at minimum: timestamp, selectedModel, resolvedModel, agentId, 
 
 Apply the following policy checks to decisions from the last 60 minutes:
 
-1. Simple jobs (job_type=simple, selected_model=blockrun/auto) resolved to \
+1. Simple jobs (job_type/simple gateway tier, selected_model=blockrun/auto) resolved to \
 cloud model without router_pin → [warning].
-2. Coding/tool-heavy/reasoning jobs (selected_model=blockrun/auto) resolved \
+2. Coding/tool-heavy/reasoning jobs and gateway tiers such as research:reasoning \
+or research:medium (selected_model=blockrun/auto) resolved \
 to local model instead of escalating → [warning].
 3. Router-first job (selected_model=blockrun/auto) with no resolved_model \
 recorded → [warning] (ClawRouter may not be exposing the upstream model).

--- a/cron/router_review.py
+++ b/cron/router_review.py
@@ -380,6 +380,16 @@ def _is_cloud_model(model: Optional[str]) -> bool:
     return any(m.startswith(p) for p in _CLOUD_MODEL_PREFIXES)
 
 
+def _is_gateway_decision(o: RoutingOutcome) -> bool:
+    """Return True when *o* came from current OpenClaw routing-decisions.json."""
+    return o.job_name == "gateway-decision" or o.job_name.startswith("gateway/")
+
+
+def _is_router_first_outcome(o: RoutingOutcome) -> bool:
+    """Return True when route metadata shows the record used router-first policy."""
+    return o.selected_model == "blockrun/auto" or _is_gateway_decision(o)
+
+
 def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
     """Apply routing policy checks to a list of recent outcomes.
 
@@ -409,7 +419,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
         # ------------------------------------------------------------------
         if (
             job_type == "simple"
-            and o.selected_model == "blockrun/auto"
+            and _is_router_first_outcome(o)
             and _is_cloud_model(o.resolved_model)
             and not o.router_pin
         ):
@@ -430,7 +440,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
         # ------------------------------------------------------------------
         if (
             job_type in _ESCALATION_EXPECTED_TYPES
-            and o.selected_model == "blockrun/auto"
+            and _is_router_first_outcome(o)
             and _is_local_model(o.resolved_model)
         ):
             violations.append(
@@ -448,7 +458,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
         # ------------------------------------------------------------------
         # Check 3 — missing resolved_model metadata
         # ------------------------------------------------------------------
-        if o.selected_model == "blockrun/auto" and o.resolved_model is None:
+        if _is_router_first_outcome(o) and o.resolved_model is None:
             violations.append(
                 PolicyViolation(
                     severity="warning",
@@ -483,6 +493,7 @@ def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
         if (
             o.selected_model
             and o.selected_model != "blockrun/auto"
+            and not _is_router_first_outcome(o)
             and not o.router_pin
             # Coding pins are expected in phase one per the plan — only flag
             # non-coding job types where an unexplained pin is a surprise.
@@ -597,13 +608,14 @@ Each decision has at minimum: timestamp, selectedModel, resolvedModel, agentId, 
 
 Apply the following policy checks to decisions from the last 60 minutes:
 
-1. Simple jobs (job_type/simple gateway tier, selected_model=blockrun/auto) resolved to \
-cloud model without router_pin → [warning].
+1. Simple jobs (job_type/simple gateway tier) resolved to cloud model without \
+router_pin → [warning]. Current routing-decisions.json may store the actual \
+upstream model in selectedModel/resolvedModel rather than blockrun/auto.
 2. Coding/tool-heavy/reasoning jobs and gateway tiers such as research:reasoning \
-or research:medium (selected_model=blockrun/auto) resolved \
-to local model instead of escalating → [warning].
-3. Router-first job (selected_model=blockrun/auto) with no resolved_model \
-recorded → [warning] (ClawRouter may not be exposing the upstream model).
+or research:medium resolved to local model instead of escalating → [warning]. \
+Do not require selectedModel to equal blockrun/auto for routing-decisions.json.
+3. Router-first job or gateway decision with no resolved_model recorded \
+→ [warning] (ClawRouter may not be exposing the upstream model).
 4. Job with consecutive_local_failures >= {_CONSECUTIVE_LOCAL_FAILURE_THRESHOLD} \
 → [critical] (GN100 / local inference down).
 5. Explicit model pin (selected_model != blockrun/auto) with no \

--- a/cron/router_review.py
+++ b/cron/router_review.py
@@ -1,0 +1,586 @@
+"""Router-first routing outcome review for Hermes supervisor.
+
+Reads routing decision records from OpenClaw and applies policy checks,
+producing [REVIEW_REQUEST] prompt text for the Hermes supervisor agent to
+evaluate as [ACK] or [ESCALATION_NOTICE].
+
+Endpoint assumption
+-------------------
+``blockrun/auto`` routes through ``openclaw-cli-proxy`` on this machine at::
+
+    http://127.0.0.1:11435/v1
+
+This is the canonical deployed endpoint per the router-first plan
+(docs/plans/router-first-autonomous-cron-orchestration-2026-05-15.md §Item 6).
+Use 11435 (proxy) unless a direct-8402 probe explicitly validates that path.
+
+Primary source — routing-decisions.json
+---------------------------------------
+OpenClaw persists gateway-level routing decisions (written by
+``src/agents/routing-decisions.ts``) to::
+
+    ~/.openclaw/routing-decisions.json
+
+The envelope shape is::
+
+    {
+        "decisions": [
+            {
+                "timestamp": "<ISO-8601>",
+                "agentId": "<agent>" (optional),
+                "complexityTier": "<tier>",
+                "selectedModel": "<model>" (optional),
+                "resolvedModel": "<upstream>" (optional),
+                ...
+            }
+        ],
+        "stats": {...},
+        "updatedAt": "<ISO-8601>"
+    }
+
+This file exists as soon as the gateway starts making routing decisions.
+``load_routing_decisions`` reads it and returns ``(outcomes, file_was_present)``
+so callers can distinguish "file absent" from "file present with no recent
+activity".
+
+Secondary source — routing-outcomes.jsonl (future)
+--------------------------------------------------
+When OpenClaw Items 1-4 land, cron runs will write per-job JSONL records to::
+
+    ~/.openclaw/routing-outcomes.jsonl
+
+Each record contains at minimum:
+  - ``job_name`` (str)
+  - ``job_id`` (str)
+  - ``selected_model`` (str | null) — e.g. "blockrun/auto"
+  - ``resolved_model`` (str | null) — e.g. "gn100/qwen3.6:35b-a3b"
+  - ``job_type`` (str | null) — "simple", "coding", "tool-heavy", "reasoning"
+  - ``router_pin`` (str | null) — [router-pin: <reason>] text if present
+  - ``timestamp`` (ISO-8601 str)
+  - ``error`` (str | null)
+  - ``consecutive_local_failures`` (int, default 0)
+
+``load_routing_outcomes`` handles this JSONL format and is retained for
+forward-compatibility once Items 1-4 land.
+
+Usage (from a cron job)
+-----------------------
+The Hermes scheduler cannot execute arbitrary Python in a job prompt, so the
+review job uses the static ``REVIEW_JOB_STATIC_PROMPT`` as its ``prompt``
+field.  That prompt instructs the Hermes agent (which has file tools available)
+to load the decisions file and apply the policy checks.
+
+For programmatic use (integration tests, operator scripts)::
+
+    from cron.router_review import load_routing_decisions, review_outcomes, format_review_prompt
+    outcomes, present = load_routing_decisions()
+    violations = review_outcomes(outcomes)
+    prompt = format_review_prompt(outcomes, violations, source_present=present)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Canonical blockrun/auto endpoint — openclaw-cli-proxy on this machine.
+#: Plan assumption: use 11435 unless direct-8402 probe explicitly validates.
+BLOCKRUN_AUTO_ENDPOINT = "http://127.0.0.1:11435/v1"
+
+#: Primary source: OpenClaw gateway routing decisions (JSON envelope, written by
+#: src/agents/routing-decisions.ts). Exists as soon as the gateway makes decisions.
+ROUTING_DECISIONS_PATH = Path.home() / ".openclaw" / "routing-decisions.json"
+
+#: Secondary/future source: per-cron-job routing outcomes (JSONL, written by
+#: OpenClaw Items 1-4, not yet landed). Kept for forward-compatibility.
+ROUTING_OUTCOMES_PATH = Path.home() / ".openclaw" / "routing-outcomes.jsonl"
+
+#: Model prefixes that indicate cloud/strong inference (escalation path).
+_CLOUD_MODEL_PREFIXES = ("claude", "anthropic", "openai", "gemini", "codex", "gpt")
+
+#: Model prefixes that indicate local inference (GN100 / Sparky path).
+_LOCAL_MODEL_PREFIXES = ("gn100", "local/", "ollama", "qwen", "llama", "mistral")
+
+#: Job types where escalation to a cloud model is expected.
+_ESCALATION_EXPECTED_TYPES = ("coding", "tool-heavy", "reasoning")
+
+#: Threshold for "repeated local failures" policy check.
+_CONSECUTIVE_LOCAL_FAILURE_THRESHOLD = 3
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RoutingOutcome:
+    """A single routing outcome record from an OpenClaw cron run."""
+
+    job_name: str
+    job_id: str
+    selected_model: Optional[str]
+    resolved_model: Optional[str]
+    job_type: Optional[str]
+    router_pin: Optional[str]
+    timestamp: str
+    error: Optional[str] = None
+    consecutive_local_failures: int = 0
+
+
+@dataclass
+class PolicyViolation:
+    """A routing policy violation detected by ``review_outcomes``."""
+
+    severity: str  # "warning" | "critical"
+    message: str
+    job_name: str
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def load_routing_outcomes(
+    path: Optional[Path] = None,
+    max_age_minutes: int = 60,
+) -> List[RoutingOutcome]:
+    """Load recent routing outcome records from the OpenClaw JSONL file.
+
+    This is the future per-cron-job format written by OpenClaw Items 1-4.
+    The file does not exist until those items land; this function returns an
+    empty list when the file is absent — use ``load_routing_decisions`` for
+    the currently-available source.
+
+    Args:
+        path: Override for ``ROUTING_OUTCOMES_PATH`` (useful in tests).
+        max_age_minutes: Discard records older than this many minutes.
+
+    Returns:
+        List of ``RoutingOutcome`` objects, newest-first, filtered to the
+        requested time window.  Returns an empty list when the file is absent
+        or unreadable.
+    """
+    outcomes_path = path if path is not None else ROUTING_OUTCOMES_PATH
+    if not outcomes_path.exists():
+        logger.debug("Routing outcomes file not found at %s", outcomes_path)
+        return []
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=max_age_minutes)
+    outcomes: List[RoutingOutcome] = []
+
+    try:
+        with outcomes_path.open(encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "Skipping malformed routing outcome on line %d: %s", lineno, exc
+                    )
+                    continue
+
+                ts_str = record.get("timestamp", "")
+                if ts_str:
+                    try:
+                        ts = datetime.fromisoformat(ts_str)
+                        if ts.tzinfo is None:
+                            ts = ts.replace(tzinfo=timezone.utc)
+                        if ts < cutoff:
+                            continue
+                    except ValueError:
+                        logger.warning("Unrecognised timestamp %r on line %d", ts_str, lineno)
+                        continue
+
+                outcomes.append(
+                    RoutingOutcome(
+                        job_name=str(record.get("job_name") or "unknown"),
+                        job_id=str(record.get("job_id") or ""),
+                        selected_model=record.get("selected_model") or None,
+                        resolved_model=record.get("resolved_model") or None,
+                        job_type=record.get("job_type") or None,
+                        router_pin=record.get("router_pin") or None,
+                        timestamp=ts_str,
+                        error=record.get("error") or None,
+                        consecutive_local_failures=int(
+                            record.get("consecutive_local_failures") or 0
+                        ),
+                    )
+                )
+    except OSError as exc:
+        logger.warning("Could not read routing outcomes from %s: %s", outcomes_path, exc)
+
+    # Return newest-first so callers see the most recent events first.
+    outcomes.sort(key=lambda o: o.timestamp, reverse=True)
+    return outcomes
+
+
+def load_routing_decisions(
+    path: Optional[Path] = None,
+    max_age_minutes: int = 60,
+) -> tuple[List[RoutingOutcome], bool]:
+    """Load routing decisions from OpenClaw's routing-decisions.json.
+
+    OpenClaw persists gateway-level routing decisions (not per-cron-job
+    outcomes) to this file via ``src/agents/routing-decisions.ts``. The
+    envelope shape is ``{"decisions": [...], "stats": {...}, "updatedAt": "..."}``,
+    where each decision carries at minimum ``timestamp``, ``selectedModel``,
+    ``resolvedModel``, ``agentId``, and ``complexityTier``.
+
+    Field mapping to ``RoutingOutcome``:
+
+    - ``agentId`` → ``job_name`` (``"gateway/<agentId>"`` or
+      ``"gateway-decision"`` when absent)
+    - ``complexityTier`` → ``job_type`` (passed through; OpenClaw tiers such as
+      ``"research:reasoning"`` differ from cron job types — policy checks that
+      require exact values like ``"simple"`` or ``"coding"`` will not fire on
+      unrecognised tier values)
+    - ``selectedModel`` → ``selected_model``
+    - ``resolvedModel`` → ``resolved_model``
+    - ``router_pin``, ``consecutive_local_failures``, ``error`` → defaults
+      (None / 0) — not recorded at the gateway layer
+
+    Args:
+        path: Override for ``ROUTING_DECISIONS_PATH`` (useful in tests).
+        max_age_minutes: Discard decisions older than this many minutes.
+
+    Returns:
+        ``(outcomes, file_was_present)`` — ``file_was_present`` is ``False``
+        only when the file does not exist on disk; it is ``True`` even when
+        the file is present but contains no decisions within the time window.
+        This lets callers distinguish "file absent" from "file present with no
+        recent activity" when constructing review prompts.
+    """
+    decisions_path = path if path is not None else ROUTING_DECISIONS_PATH
+    if not decisions_path.exists():
+        logger.debug("Routing decisions file not found at %s", decisions_path)
+        return [], False
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=max_age_minutes)
+    outcomes: List[RoutingOutcome] = []
+
+    try:
+        with decisions_path.open(encoding="utf-8") as fh:
+            envelope = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Could not read routing decisions from %s: %s", decisions_path, exc
+        )
+        # File exists but is unreadable; report as present so the prompt can
+        # surface the read error rather than silently claiming "file absent".
+        return [], True
+
+    raw_decisions = envelope.get("decisions") or []
+    for record in raw_decisions:
+        if not isinstance(record, dict):
+            continue
+
+        ts_str = record.get("timestamp", "")
+        if ts_str:
+            try:
+                ts = datetime.fromisoformat(ts_str)
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
+            except ValueError:
+                logger.warning(
+                    "Unrecognised timestamp %r in routing decisions file", ts_str
+                )
+                continue
+
+        agent_id = record.get("agentId") or None
+        outcomes.append(
+            RoutingOutcome(
+                job_name=(f"gateway/{agent_id}" if agent_id else "gateway-decision"),
+                job_id="",
+                selected_model=record.get("selectedModel") or None,
+                resolved_model=record.get("resolvedModel") or None,
+                job_type=record.get("complexityTier") or None,
+                router_pin=None,
+                timestamp=ts_str,
+                error=None,
+                consecutive_local_failures=0,
+            )
+        )
+
+    outcomes.sort(key=lambda o: o.timestamp, reverse=True)
+    return outcomes, True
+
+
+# ---------------------------------------------------------------------------
+# Policy checks
+# ---------------------------------------------------------------------------
+
+
+def _is_local_model(model: Optional[str]) -> bool:
+    """Return True if *model* indicates local/GN100 inference."""
+    if not model:
+        return False
+    m = model.lower()
+    return any(m.startswith(p) for p in _LOCAL_MODEL_PREFIXES)
+
+
+def _is_cloud_model(model: Optional[str]) -> bool:
+    """Return True if *model* indicates cloud/strong inference."""
+    if not model:
+        return False
+    m = model.lower()
+    return any(m.startswith(p) for p in _CLOUD_MODEL_PREFIXES)
+
+
+def review_outcomes(outcomes: List[RoutingOutcome]) -> List[PolicyViolation]:
+    """Apply routing policy checks to a list of recent outcomes.
+
+    The five checks (from plan Item 4 / Item 6 done-when criteria):
+
+    1. **Local not used for simple work** — ``job_type=="simple"`` resolved to
+       a cloud model without a ``router_pin`` marker.
+    2. **No escalation for complex work** — ``job_type`` in coding/tool-heavy/
+       reasoning resolved to a local model instead of cloud.
+    3. **Missing resolved_model metadata** — router-first job ran but
+       ``resolved_model`` is ``None`` (OpenClaw Items 1-4 not yet wired).
+    4. **Repeated local failures** — ``consecutive_local_failures`` at or
+       above the threshold; GN100 / local inference may be down.
+    5. **Unexplained opt-out pin** — explicit non-router model with no
+       ``router_pin`` marker (for non-coding job types where a pin is
+       unexpected and should be documented).
+
+    Returns a list of ``PolicyViolation`` objects (may be empty).
+    """
+    violations: List[PolicyViolation] = []
+
+    for o in outcomes:
+        # ------------------------------------------------------------------
+        # Check 1 — simple work routed to cloud without justification
+        # ------------------------------------------------------------------
+        if (
+            o.job_type == "simple"
+            and o.selected_model == "blockrun/auto"
+            and _is_cloud_model(o.resolved_model)
+            and not o.router_pin
+        ):
+            violations.append(
+                PolicyViolation(
+                    severity="warning",
+                    message=(
+                        f"Simple job resolved to cloud model {o.resolved_model!r} "
+                        f"(selected: {o.selected_model!r}). "
+                        "Local GN100 expected for simple work; check ClawRouter classification."
+                    ),
+                    job_name=o.job_name,
+                )
+            )
+
+        # ------------------------------------------------------------------
+        # Check 2 — coding/reasoning work not escalating
+        # ------------------------------------------------------------------
+        if (
+            o.job_type in _ESCALATION_EXPECTED_TYPES
+            and o.selected_model == "blockrun/auto"
+            and _is_local_model(o.resolved_model)
+        ):
+            violations.append(
+                PolicyViolation(
+                    severity="warning",
+                    message=(
+                        f"{o.job_type.capitalize()} job did not escalate: "
+                        f"resolved to local {o.resolved_model!r}. "
+                        "Expected cloud escalation for this job type."
+                    ),
+                    job_name=o.job_name,
+                )
+            )
+
+        # ------------------------------------------------------------------
+        # Check 3 — missing resolved_model metadata
+        # ------------------------------------------------------------------
+        if o.selected_model == "blockrun/auto" and o.resolved_model is None:
+            violations.append(
+                PolicyViolation(
+                    severity="warning",
+                    message=(
+                        "Router-first job has no resolved_model recorded. "
+                        "OpenClaw Items 1-4 integration may not yet be active, "
+                        "or ClawRouter is not exposing the upstream model."
+                    ),
+                    job_name=o.job_name,
+                )
+            )
+
+        # ------------------------------------------------------------------
+        # Check 4 — repeated local model failures
+        # ------------------------------------------------------------------
+        if o.consecutive_local_failures >= _CONSECUTIVE_LOCAL_FAILURE_THRESHOLD:
+            violations.append(
+                PolicyViolation(
+                    severity="critical",
+                    message=(
+                        f"Job has {o.consecutive_local_failures} consecutive local model failures. "
+                        "GN100 / local inference may be unavailable. "
+                        "Verify ai.openclaw.claude-cli-proxy at 11435 and GN100 tunnel at 11436."
+                    ),
+                    job_name=o.job_name,
+                )
+            )
+
+        # ------------------------------------------------------------------
+        # Check 5 — unexplained explicit pin (non-router model, no marker)
+        # ------------------------------------------------------------------
+        if (
+            o.selected_model
+            and o.selected_model != "blockrun/auto"
+            and not o.router_pin
+            # Coding pins are expected in phase one per the plan — only flag
+            # non-coding job types where an unexplained pin is a surprise.
+            and o.job_type not in _ESCALATION_EXPECTED_TYPES
+        ):
+            violations.append(
+                PolicyViolation(
+                    severity="warning",
+                    message=(
+                        f"Explicit model pin {o.selected_model!r} has no "
+                        "[router-pin: <reason>] marker in the job description. "
+                        "Add a marker or migrate to blockrun/auto."
+                    ),
+                    job_name=o.job_name,
+                )
+            )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+
+def format_review_prompt(
+    outcomes: List[RoutingOutcome],
+    violations: List[PolicyViolation],
+    *,
+    source_present: bool = True,
+) -> str:
+    """Build a ``[REVIEW_REQUEST]`` prompt for the Hermes supervisor agent.
+
+    The returned string contains inline routing decision data so the agent can
+    decide ``[ACK]`` (all-clear) or ``[ESCALATION_NOTICE]`` (action needed)
+    without needing to call file-read tools.
+
+    Args:
+        outcomes: Recent routing outcomes/decisions to review.
+        violations: Policy violations detected by ``review_outcomes``.
+        source_present: Whether the source file was found on disk.  Pass the
+            second element of ``load_routing_decisions()``'s return value.  When
+            ``False`` and ``outcomes`` is empty, the prompt explicitly says the
+            file is absent; when ``True`` and ``outcomes`` is empty, it says the
+            file is present but no fresh decisions were found in the review window.
+    """
+    lines: List[str] = [
+        "[REVIEW_REQUEST] Router-first routing outcome review.",
+        f"Endpoint assumption: {BLOCKRUN_AUTO_ENDPOINT} (openclaw-cli-proxy).",
+        f"Outcomes reviewed: {len(outcomes)}.",
+    ]
+
+    if not outcomes:
+        if not source_present:
+            lines.append(
+                f"Source file not found at {ROUTING_DECISIONS_PATH}. "
+                "OpenClaw gateway has not yet written any routing decisions."
+            )
+        else:
+            lines.append(
+                "Source file is present but contains no router-first decisions "
+                "within the review window. No policy violations detectable."
+            )
+    else:
+        router_first = [o for o in outcomes if o.selected_model == "blockrun/auto"]
+        pinned = [o for o in outcomes if o.selected_model and o.selected_model != "blockrun/auto"]
+        missing_resolved = [
+            o for o in outcomes if o.selected_model == "blockrun/auto" and o.resolved_model is None
+        ]
+        lines.append(
+            f"Router-first jobs: {len(router_first)}.  "
+            f"Pinned (explicit model): {len(pinned)}.  "
+            f"Missing resolved_model: {len(missing_resolved)}."
+        )
+
+    if not violations:
+        lines.append("Policy checks: all passed.")
+    else:
+        critical = [v for v in violations if v.severity == "critical"]
+        warnings = [v for v in violations if v.severity == "warning"]
+        lines.append(
+            f"Policy violations: {len(critical)} critical, {len(warnings)} warning."
+        )
+        for v in violations:
+            lines.append(f"  [{v.severity.upper()}] {v.job_name}: {v.message}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Static job prompt template
+# ---------------------------------------------------------------------------
+
+#: Static prompt for the ``router-first-review`` cron job entry.
+#:
+#: The Hermes cron scheduler sends this verbatim to the Hermes agent.  With
+#: file tools enabled (``enabled_toolsets: ["file"]``), the agent reads
+#: ``ROUTING_DECISIONS_PATH`` directly and applies the policy checks.  The
+#: future per-job JSONL source (``ROUTING_OUTCOMES_PATH``) is checked as a
+#: supplementary fallback once Items 1-4 land in clawdbot.
+#:
+#: For programmatic use prefer:
+#:   outcomes, present = load_routing_decisions()
+#:   prompt = format_review_prompt(outcomes, review_outcomes(outcomes), source_present=present)
+REVIEW_JOB_STATIC_PROMPT = f"""\
+[REVIEW_REQUEST] Router-first routing outcome review.
+Endpoint assumption: {BLOCKRUN_AUTO_ENDPOINT} (openclaw-cli-proxy).
+
+Read the routing decisions file at {ROUTING_DECISIONS_PATH} if it exists.
+The file is a JSON envelope: {{"decisions": [...], "stats": {{...}}, "updatedAt": "..."}}.
+Each decision has at minimum: timestamp, selectedModel, resolvedModel, agentId, complexityTier.
+
+Apply the following policy checks to decisions from the last 60 minutes:
+
+1. Simple jobs (job_type=simple, selected_model=blockrun/auto) resolved to \
+cloud model without router_pin → [warning].
+2. Coding/tool-heavy/reasoning jobs (selected_model=blockrun/auto) resolved \
+to local model instead of escalating → [warning].
+3. Router-first job (selected_model=blockrun/auto) with no resolved_model \
+recorded → [warning] (ClawRouter may not be exposing the upstream model).
+4. Job with consecutive_local_failures >= {_CONSECUTIVE_LOCAL_FAILURE_THRESHOLD} \
+→ [critical] (GN100 / local inference down).
+5. Explicit model pin (selected_model != blockrun/auto) with no \
+[router-pin: <reason>] marker for a non-coding job → [warning].
+
+If {ROUTING_DECISIONS_PATH} does not exist, also check {ROUTING_OUTCOMES_PATH} \
+(JSONL, one record per cron job — written by OpenClaw Items 1-4, may not yet exist).
+
+If neither file exists, output:
+[ACK] No routing decisions yet. OpenClaw gateway has not written any decisions.
+
+If the file exists but contains no decisions in the last 60 minutes, output:
+[ACK] Routing decisions file present. No decisions in the review window.
+
+If all checks pass, output:
+[ACK] Routing decisions reviewed. All policy checks passed.
+
+If any violation is found, output:
+[ESCALATION_NOTICE] <brief summary of highest-severity violation and agent/job name>.
+"""

--- a/docs/plans/router-first-autonomous-cron-orchestration-2026-05-15.md
+++ b/docs/plans/router-first-autonomous-cron-orchestration-2026-05-15.md
@@ -1,0 +1,244 @@
+# Router-First Autonomous Cron Orchestration: Plan
+
+## Goal
+Move routine autonomous work — cron maintenance, agent heartbeats, Zulip cleanup, Paperclip queue execution, and Hermes supervision — to a router-first model where `blockrun/auto` can use Sparky/GN100 local inference for simple work and escalate automatically to stronger models for coding, tool-heavy, or reasoning-heavy work, with Hermes reviewing routing outcomes.
+
+## Background
+
+### Locked decisions
+- Broad migration target: router-first with explicit opt-out pins, not a narrow lightweight-only migration.
+- `exec` jobs are not model work by themselves. Leave plain script-only exec jobs alone; model routing matters when those scripts spawn or wake agent work.
+- Escalation policy: allow automatic escalation to stronger models when classification requires it, with routing logs and Hermes review so the supervisor can improve over time.
+- CronRouter remains scheduler/executor/hint layer; OpenClaw/ClawRouter own actual model/provider selection.
+
+### Current GN100/Sparky routing state
+- GN100 is reachable through the Mac-local Ollama tunnel at `127.0.0.1:11436`, with `qwen3.6:35b-a3b` installed.
+- OpenClaw has a direct provider `gn100/qwen3.6:35b-a3b` in `~/.openclaw/openclaw.json`.
+- OpenClaw default agent model was set to `blockrun/auto` with direct GN100 and stronger cloud/CLI fallbacks.
+- `openclaw-cli-proxy` is launched by `ai.openclaw.claude-cli-proxy` and now uses `OLLAMA_API_BASE=http://127.0.0.1:11436`; existing local aliases like `tool-local` and `local/ollama-qwen3.5-*` resolve to the GN100 model in the runtime-main worktree.
+- Hermes uses `.hermes/config.yaml` with `model.default: "blockrun/auto"` and `provider: "openrouter"`; `.hermes/.env` routes OpenAI/OpenRouter-compatible calls through `http://127.0.0.1:11435/v1`. Treat `11435` as the deployed canonical Hermes endpoint unless the validation step proves direct `8402` should replace it.
+
+### Cron execution seams
+- Cron payloads are a discriminated union of `systemEvent`, `agentTurn`, and `exec` in `src/cron/types.ts:145`; `agentTurn` carries optional `model`, `fallbacks`, `thinking`, `timeoutSeconds`, `lightContext`, and `toolsAllow` in `src/cron/types.ts:168`; `exec` carries `command`, `workdir`, `env`, and `timeoutSeconds` in `src/cron/types.ts:136`.
+- Main-session cron jobs use `executeMainSessionCronJob`; detached jobs use `executeDetachedCronJob` in `src/cron/service/timer.ts:1106`. Non-main `exec` jobs call `runDeterministicExecJob` in `src/cron/service/timer.ts:1272`; non-main `agentTurn` jobs call `runIsolatedAgentJob` in `src/cron/service/timer.ts:1285`.
+- Isolated cron agent turns are prepared in `src/cron/isolated-agent/run.ts:220`, then dispatched through `executeCronRun` in `src/cron/isolated-agent/run-executor.ts:273`.
+- `createCronPromptExecutor` wraps execution in `runWithModelFallback(...)` in `src/cron/isolated-agent/run-executor.ts:115`, then chooses CLI-backed execution via `runCliAgent(...)` in `src/cron/isolated-agent/run-executor.ts:139` or embedded provider execution via `runEmbeddedPiAgent(...)` in `src/cron/isolated-agent/run-executor.ts:174`.
+- Model selection starts with configured defaults in `src/cron/isolated-agent/model-selection.ts:55`, then applies agent/subagent overrides, hook overrides, explicit `payload.model`, session overrides, and `pacing.providerTarget`/inferred routing in `src/cron/isolated-agent/model-selection.ts:81`, `:108`, `:133`, `:178`, and `:220`.
+- Current guardrail rejects/filters unattended `auto` and `blockrun/auto` in `src/cron/model-guard.ts:9`; this is the central contradiction with router-first unattended cron.
+- `payload.fallbacks` wins when present; otherwise fallback policy depends on selection source in `src/cron/isolated-agent/run-fallback-policy.ts:17` and `:25`.
+
+### CronRouter and routing hint seams
+- CronRouter supports `routingHints` with `budget` and `modelChain`, but treats them as advisory metadata only; runtime model selection belongs downstream in OpenClaw/ClawRouter (`lionroot-cronrouter/src/registry/job-types.ts:12`).
+- Gateway cron loading preserves `task`, `source`, `budget`, and `modelChain` from `~/.openclaw/cron/jobs.json` in `lionroot-cronrouter/src/registry/jobs-gateway.ts:141`.
+- Paperclip maintenance jobs are generated from a central `PAPERCLIP_MAINTENANCE_SPECS` table and tagged as gateway/paperclip/maintenance in `lionroot-cronrouter/src/registry/jobs.ts:17`.
+- Prior plans explicitly state CronRouter is a scheduler/executor router, not a model router; OpenClaw/ClawRouter own provider/model selection (`docs/plans/local-worker-pool-capacity-routing-2026-05-14.md:29`, `:47`, `:168`; `docs/plans/model-burndown-routing-2026-05-09.md:245`).
+
+### Paperclip and Hermes seams
+- Paperclip maintenance dispatch enters through `lionroot-command-post/command-post/dashboard/app/api/paperclip/maintenance/dispatch/route.ts:25-65` and calls `dispatchMaintenanceWork(...)`.
+- `TASK_CONFIG` maps task kind to tracker, assignee, runner, repo selection, and Zulip target in `lionroot-command-post/command-post/dashboard/lib/paperclip/maintenance-bridge.ts:65-225`.
+- `paperclip-heartbeat` work wakes an existing Paperclip/OpenClaw agent via `invokeAgentHeartbeat(assignee.id)` in `maintenance-bridge.ts:960-974`; this should inherit OpenClaw router-first defaults.
+- `worker-repoprompt` work enqueues maintenance execution via `maintenance-bridge.ts:978-1038` and `maintenance-worker-client.ts:75-117`; the worker accepts `/api/paperclip/maintenance/execute` in `scripts/maintenance-worker.ts:604-632`.
+- Worker execution currently defaults safe remediation provider order to `codex`, then `claude`, overridable by `SAFE_REMEDIATION_PROVIDER_ORDER` in `repoprompt-executor.ts:315-332`; Codex uses CLI defaults at `:286-296`, while Claude pins `--model sonnet` at `:298-307`.
+- Hermes supports model aliases as exact `(model, provider, base_url)` tuples in `.hermes/hermes-agent/hermes_cli/model_switch.py:157-214`, and direct alias `base_url` can override runtime base URL in `.hermes/hermes-agent/hermes_cli/model_switch.py:850-860`.
+
+### Prior art and constraints
+- `docs/plans/model-burndown-routing-2026-05-09.md:16` describes the existing control loop: Command Post/CodexBar telemetry → routing hints file → OpenClaw fallback ordering/filtering → agent/cron execution.
+- `docs/plans/model-burndown-routing-2026-05-09.md:72` and `:88` keep Codex preferred for coding while allowing unattended/non-coding automation to shift across Claude/Gemini/local based on capability and burndown state.
+- `.workflow/multi-machine-plan-v2-skeleton-2026-05-04.md:76` called out that CronRouter had zero burndown awareness and gateway jobs fired LLM calls regardless of burndown.
+- `.workflow/orchestration-2026-05-03-cron-gateway-sweep.md:79` records a standalone cron linter validating session target, payload kind, and schedule shape.
+- `.workflow/item-7-fn6-paperclip-rollout-guide.md:172` defines Paperclip bounded parallel dispatch with per-repo lanes, blocker-aware waves, telemetry, and rollout monitoring; `PAPERCLIP_MAX_PARALLEL_ISSUES=1` remains the safety default in `.workflow/item-7-fn6-paperclip-rollout-guide.md:3`.
+
+## Approach
+
+Implement router-first orchestration by changing the existing OpenClaw cron policy and observability seams, not by adding a second model router. `blockrun/auto` becomes an allowed unattended cron model route; raw `auto` remains blocked as ambiguous. Existing explicit non-router model selections become auditable opt-out pins using the marker syntax `[router-pin: <reason>]` in the cron job description or payload message.
+
+The first migration wave should make normal cron `agentTurn`, main-session wake, Paperclip heartbeat, and Hermes supervisor work router-first. Plain deterministic `exec` jobs remain script jobs. Coding-heavy Paperclip worker remediation remains pinned to Codex/Claude in phase one because it currently depends on deterministic code-edit CLIs and sandbox behavior, but that pin must become visible in execution summaries and policy checks.
+
+Hermes should review routing outcomes, not approve every escalation synchronously. Automatic escalation through ClawRouter/OpenClaw is allowed when classification indicates coding, tool-heavy, or reasoning-heavy work. Hermes receives logs/status and flags routing failures: simple work not using local when available, coding work failing to escalate, missing resolved-model metadata, repeated local failures, or unexplained explicit pins.
+
+## Work Items
+
+### Item 1 — Lock router-first cron guard semantics
+**Goal:** Replace the current all-auto cron block with a narrower policy: raw `auto` is ambiguous and blocked; `blockrun/auto` is an allowed router-first model ref.
+
+**Done when:**
+- `src/cron/model-guard.ts` exposes a single shared classifier used by cron selection, fallback filtering, and policy doctor.
+- Recommended helper shape is available or equivalently covered: `classifyCronModelRef`, `isAllowedCronRouterRef`, and `isAmbiguousCronAutoRef`.
+- `blockrun/auto` and `BLOCKRUN/AUTO` are preserved in fallback lists and allowed as selected model.
+- Raw `auto` remains rejected or filtered everywhere unattended cron currently needs protection.
+- Empty or undefined model refs continue to mean “no explicit override,” not an error.
+
+**Key files:**
+- `src/cron/model-guard.ts:9`
+- `src/cron/isolated-agent/run-fallback-policy.ts:17`
+- `src/cron/isolated-agent/run-fallback-policy.test.ts`
+- `src/cron/isolated-agent/run.payload-fallbacks.test.ts`
+
+**Dependencies:** None.
+
+**Size:** S.
+
+### Item 2 — Preserve router-first default through cron model selection
+**Goal:** Ensure cron model selection does not immediately override a router-first default with inferred or pacing-derived Claude/Codex/Gemini targets.
+
+**Done when:**
+- `resolveCronModelSelection` allows selected provider/model `blockrun/auto`.
+- When current/default selection is router-first, `pacing.providerTarget` and inferred provider routing are advisory metadata, not forced model replacement.
+- Explicit model sources still pin the selected model.
+- Tests prove router-first default survives providerTarget inference and raw `auto` remains rejected.
+
+**Key files:**
+- `src/cron/isolated-agent/model-selection.ts:55`
+- `src/cron/isolated-agent/model-selection.ts:220`
+- `src/cron/provider-routing.ts:66`
+- `src/gateway/protocol/schema/cron.ts:69`
+- `src/cron/isolated-agent/run.cron-model-override.test.ts`
+
+**Dependencies:** Item 1.
+
+**Size:** M.
+
+### Item 3 — Update cron fallback and policy-doctor behavior
+**Goal:** Make policy validation and fallback behavior match router-first semantics.
+
+**Done when:**
+- `payload.fallbacks` can include `blockrun/auto`; only raw `auto` is filtered.
+- Policy doctor uses the shared Item 1 classifier, not duplicated string matching.
+- Policy doctor reports raw `auto` as critical.
+- Policy doctor reports explicit non-router `payload.model` as an opt-out pin warning unless job text contains `[router-pin: <reason>]`.
+- Policy doctor warns when router-first jobs have no usable fallback chain.
+- Existing delivery, timeout, session target, and payload-shape checks remain unchanged.
+
+**Key files:**
+- `src/cron/isolated-agent/run-fallback-policy.ts:17`
+- `src/cron/policy-doctor.ts`
+- `src/cron/policy-doctor.test.ts`
+- `.workflow/orchestration-2026-05-03-cron-gateway-sweep.md:79`
+
+**Dependencies:** Items 1 and 2.
+
+**Size:** M.
+
+### Item 4 — Add routing outcome observability for Hermes review
+**Goal:** Make router decisions inspectable enough for Hermes to review whether work used local GN100 when appropriate and escalated when required.
+
+**Done when:**
+- Before loosening production schedules, a live probe confirms whether ClawRouter/openclaw-cli-proxy returns the resolved upstream model in OpenAI-compatible responses.
+- If the resolved upstream model is exposed, OpenClaw calls `updateLastDecisionResolvedModel()` at the response-parsing/fallback call site.
+- If it is not exposed, the implementation adds a small protocol/logging seam before broad cron migration proceeds.
+- Router-first cron runs record selected model (`blockrun/auto`) and resolved upstream model when available.
+- Missing resolved-model metadata is detectable as a warning condition, not silently accepted.
+
+**Key files:**
+- `src/agents/routing-decisions.ts`
+- `src/agents/model-fallback.ts:411`
+- `src/cron/isolated-agent/run-executor.ts:115`
+- `src/cron/isolated-agent/run.ts:486`
+
+**Dependencies:** Items 1-3.
+
+**Size:** M, or L if the live probe shows ClawRouter needs a protocol/logging addition.
+
+### Item 5 — Make Paperclip routing policy explicit
+**Goal:** Keep Paperclip heartbeat work router-first and make coding-heavy worker remediation an explicit, visible opt-out pin.
+
+**Done when:**
+- Paperclip heartbeat dispatch responses/reporting identify routing policy as router-first intent and explain that the actual model is resolved by OpenClaw/ClawRouter defaults.
+- If Item 4 resolved-model evidence is available, Paperclip reports include or link to it; if not, Paperclip marks the field as policy intent only.
+- `worker-repoprompt` / safe remediation output identifies routing policy as pinned with `[router-pin: safe remediation requires deterministic Codex/Claude CLI]` or equivalent structured reason.
+- `SAFE_REMEDIATION_PROVIDER_ORDER` remains supported.
+- No plain deterministic `exec` job is rewritten just to add model routing.
+- A follow-up issue or plan note captures any future `router-agent` worker provider work; it is not part of phase one.
+
+**Key files:**
+- `lionroot-command-post/command-post/dashboard/lib/paperclip/types.ts:206`
+- `lionroot-command-post/command-post/dashboard/lib/paperclip/maintenance-bridge.ts:65`
+- `lionroot-command-post/command-post/dashboard/lib/paperclip/maintenance-bridge.ts:960`
+- `lionroot-command-post/command-post/dashboard/lib/paperclip/repoprompt-executor.ts:315`
+- `lionroot-command-post/command-post/dashboard/scripts/maintenance-worker.ts:604`
+
+**Dependencies:** Items 3 and 4.
+
+**Size:** M.
+
+### Item 6 — Add Hermes routing review loop
+**Goal:** Have Hermes supervise router outcomes without blocking automatic escalation.
+
+**Done when:**
+- Hermes config makes the deployed `blockrun/auto` endpoint explicit. On this machine the starting assumption is `http://127.0.0.1:11435/v1` through `openclaw-cli-proxy`.
+- Endpoint validation probes both `http://127.0.0.1:11435/v1/models` and `http://127.0.0.1:8402/v1/models` when both are present; choose `11435` unless direct `8402` is intentionally the supported deployment route.
+- A scheduled Hermes review job inspects routing outcomes and reports `[ACK]` or `[ESCALATION_NOTICE]` using the existing supervisor protocol.
+- The review checks for: local-capable simple work not using local, coding/reasoning work not escalating, missing resolved model, repeated local failures, and unexplained opt-out pins.
+- Hermes remains a verifier/router supervisor, not a content-generation worker.
+
+**Key files:**
+- `.hermes/config.yaml:1`
+- `.hermes/cron/jobs.json`
+- `.hermes/hermes-agent/hermes_cli/model_switch.py:157`
+- `.hermes/hermes-agent/hermes_cli/model_switch.py:850`
+- `.hermes/hermes-agent/website/docs/integrations/providers.md:1008`
+
+**Dependencies:** Item 4.
+
+**Size:** M.
+
+### Item 7 — Operational migration, CronRouter regression, and smoke verification
+**Goal:** Apply the policy to enabled jobs, preserve CronRouter boundaries, and prove router-first orchestration works before leaving it unattended.
+
+**Done when:**
+- Enabled cron jobs are audited after Items 1-4 land and classified as router-first eligible, explicit opt-out pin, script-only exec, or exec that wakes/spawns agent work.
+- Router-first eligible jobs either inherit default `blockrun/auto` or explicitly use it where needed.
+- Explicit pins have `[router-pin: <reason>]` markers.
+- CronRouter docs/tests confirm it preserves hints and does not inject `payload.model` or choose runtime models.
+- Runtime smoke proves: simple prompt resolves to GN100/Sparky local path; coding/reasoning-heavy prompt escalates; Hermes review reports healthy or actionable status; Paperclip heartbeat uses router-first policy; worker remediation remains pinned and visible.
+- Rollback is tested on one sample job by re-pinning an affected cron `agentTurn` job to its previous explicit model.
+
+**Key files:**
+- `~/.openclaw/cron/jobs.json`
+- `~/.openclaw/openclaw.json`
+- `.hermes/cron/jobs.json`
+- `lionroot-cronrouter/docs/architecture.md`
+- `lionroot-cronrouter/src/registry/job-types.ts:12`
+- `lionroot-cronrouter/src/registry/jobs-gateway.ts:141`
+- `lionroot-cronrouter/src/executors/gateway-executor.ts`
+- `lionroot-cronrouter/src/registry/paperclip-automation-jobs.test.ts`
+- `docs/plans/router-first-autonomous-cron-orchestration-2026-05-15.md`
+
+**Dependencies:** Items 1-6.
+
+**Size:** L.
+
+## Verification Plan
+- OpenClaw targeted tests:
+  - `pnpm test src/cron/isolated-agent/run.cron-model-override.test.ts`
+  - `pnpm test src/cron/isolated-agent/run.payload-fallbacks.test.ts`
+  - `pnpm test src/cron/isolated-agent/run-fallback-policy.test.ts`
+  - `pnpm test src/cron/policy-doctor.test.ts`
+- CronRouter targeted tests:
+  - Run the existing Paperclip automation and gateway executor tests in `lionroot-cronrouter`.
+- Command Post targeted tests:
+  - Run Paperclip maintenance bridge/worker tests that cover dispatch, worker execution, and response shape.
+- Runtime smoke:
+  - Direct GN100 route: OpenClaw model run against `gn100/qwen3.6:35b-a3b`.
+  - Router simple route: `blockrun/auto` prompt that should resolve to local/GN100.
+  - Router escalation route: coding/tool-heavy prompt that should escalate to Codex/Claude/Gemini.
+  - Hermes route: supervisor prompt using its configured endpoint.
+  - Paperclip heartbeat: one safe maintenance heartbeat or dry-run showing router-first policy metadata.
+
+## Rollback
+- Re-pin affected cron `agentTurn` jobs by setting explicit `payload.model` to the previous Claude/Gemini/Codex model.
+- Restore OpenClaw default model from the pre-migration backup.
+- Disable the Hermes routing review cron job if it creates noisy false positives.
+- Keep CronRouter unchanged; do not roll back by moving model routing into CronRouter.
+- For Paperclip worker failures, keep or restore `SAFE_REMEDIATION_PROVIDER_ORDER=codex,claude` and leave heartbeat router-first migration intact.
+
+## Open Questions
+- Which exact existing cron jobs should remain explicit opt-out pins after the inventory is produced?
+- Does ClawRouter currently expose the resolved upstream model in a way OpenClaw can persist for Hermes review, or does Item 4 need a small protocol/logging addition?
+
+## References
+- `docs/plans/model-burndown-routing-2026-05-09.md`
+- `docs/plans/local-worker-pool-capacity-routing-2026-05-14.md`
+- `.workflow/multi-machine-plan-v2-skeleton-2026-05-04.md`
+- `.workflow/orchestration-2026-05-03-cron-gateway-sweep.md`
+- `.workflow/item-7-fn6-paperclip-rollout-guide.md`

--- a/plans/router-review-job.yaml
+++ b/plans/router-review-job.yaml
@@ -66,8 +66,9 @@ prompt: |
      (Items 1-4 not yet integrated).
   4. Job with consecutive_local_failures >= 3 → [critical]
      (GN100 / local inference down).
-  5. Explicit model pin (selected_model != blockrun/auto) with no
-     [router-pin: <reason>] marker for a non-coding job → [warning].
+  5. Explicit model pin (selected_model != blockrun/auto and not a gateway/current
+     routing-decision) with no [router-pin: <reason>] marker for a non-coding job
+     → [warning].
 
   If ~/.openclaw/routing-decisions.json does not exist, also check
   ~/.openclaw/routing-outcomes.jsonl as a supplementary future source. Do not output

--- a/plans/router-review-job.yaml
+++ b/plans/router-review-job.yaml
@@ -2,7 +2,7 @@
 #
 # PURPOSE
 # -------
-# Supervise router-first routing outcomes for OpenClaw cron runs.
+# Supervise router-first routing decisions for OpenClaw cron runs.
 # Hermes reviews whether blockrun/auto resolved correctly (local for simple
 # work, cloud escalation for coding/reasoning) and emits [ACK] or
 # [ESCALATION_NOTICE].
@@ -16,8 +16,8 @@
 # ACTIVATION
 # ----------
 # This job is disabled by default.  Enable it as part of Item 7 operational
-# migration, after Items 1-4 land in clawdbot and routing outcome records are
-# being written to ~/.openclaw/routing-outcomes.jsonl.
+# migration, after OpenClaw routing decisions are being written to
+# ~/.openclaw/routing-decisions.json.
 #
 # STATIC PROMPT
 # -------------
@@ -27,7 +27,7 @@
 # FILE TOOLSET
 # ------------
 # enabled_toolsets: ["file"] gives the Hermes agent read access to
-# ~/.openclaw/routing-outcomes.jsonl.  Remove this once the review cron
+# ~/.openclaw/routing-decisions.json.  Remove this once the review cron
 # switches to inline prompt generation via format_review_prompt().
 #
 # REGISTRATION
@@ -44,16 +44,23 @@ deliver: local
 enabled_toolsets:
   - file
 prompt: |
-  [REVIEW_REQUEST] Router-first routing outcome review.
+  [REVIEW_REQUEST] Router-first routing decision review.
   Endpoint assumption: http://127.0.0.1:11435/v1 (openclaw-cli-proxy).
 
-  Read the routing outcomes file at ~/.openclaw/routing-outcomes.jsonl if it exists.
-  Apply the following policy checks to records from the last 60 minutes:
+  Read the routing decisions file at ~/.openclaw/routing-decisions.json if it exists.
+  The file is a JSON envelope: {"decisions": [...], "stats": {...}, "updatedAt": "..."}.
+  Each decision has at minimum: timestamp, selectedModel, resolvedModel, agentId, complexityTier.
 
-  1. Simple jobs (job_type=simple, selected_model=blockrun/auto) resolved to
+  Apply the following policy checks to decisions from the last 60 minutes. Normalize
+  complexityTier values before checking policy: use the suffix after ':' when present;
+  map medium/high/complex/reasoning tiers to reasoning, low/simple tiers to simple,
+  and keep coding/tool-heavy tiers as coding/tool-heavy.
+
+  1. Simple jobs (job_type/simple gateway tier, selected_model=blockrun/auto) resolved to
      cloud model without router_pin → [warning].
-  2. Coding/tool-heavy/reasoning jobs (selected_model=blockrun/auto) resolved
-     to local model instead of escalating → [warning].
+  2. Coding/tool-heavy/reasoning jobs and gateway tiers such as research:reasoning
+     or research:medium (selected_model=blockrun/auto) resolved to local model
+     instead of escalating → [warning].
   3. Router-first job (selected_model=blockrun/auto) with no resolved_model
      recorded → [warning] (Items 1-4 not yet integrated).
   4. Job with consecutive_local_failures >= 3 → [critical]
@@ -61,11 +68,19 @@ prompt: |
   5. Explicit model pin (selected_model != blockrun/auto) with no
      [router-pin: <reason>] marker for a non-coding job → [warning].
 
-  If the file does not exist, output:
-  [ACK] No routing outcomes yet. Items 1-4 integration pending.
+  If ~/.openclaw/routing-decisions.json does not exist, also check
+  ~/.openclaw/routing-outcomes.jsonl as a supplementary future source. Do not output
+  an ACK solely because routing-outcomes.jsonl is absent when routing-decisions.json
+  is present.
+
+  If neither file exists, output:
+  [ACK] No routing decisions yet. OpenClaw gateway has not written any decisions.
+
+  If the decisions file exists but contains no decisions in the last 60 minutes, output:
+  [ACK] Routing decisions file present. No decisions in the review window.
 
   If all checks pass, output:
-  [ACK] Routing outcomes reviewed. All policy checks passed.
+  [ACK] Routing decisions reviewed. All policy checks passed.
 
   If any violation is found, output:
   [ESCALATION_NOTICE] <brief summary of highest-severity violation and job name>.

--- a/plans/router-review-job.yaml
+++ b/plans/router-review-job.yaml
@@ -1,0 +1,71 @@
+# Reference job definition: router-first-review
+#
+# PURPOSE
+# -------
+# Supervise router-first routing outcomes for OpenClaw cron runs.
+# Hermes reviews whether blockrun/auto resolved correctly (local for simple
+# work, cloud escalation for coding/reasoning) and emits [ACK] or
+# [ESCALATION_NOTICE].
+#
+# ENDPOINT ASSUMPTION
+# -------------------
+# blockrun/auto routes through openclaw-cli-proxy at http://127.0.0.1:11435/v1.
+# Use 11435 unless a live probe of http://127.0.0.1:8402/v1/models explicitly
+# validates direct-8402 as the supported deployment path (see plan Item 6).
+#
+# ACTIVATION
+# ----------
+# This job is disabled by default.  Enable it as part of Item 7 operational
+# migration, after Items 1-4 land in clawdbot and routing outcome records are
+# being written to ~/.openclaw/routing-outcomes.jsonl.
+#
+# STATIC PROMPT
+# -------------
+# The prompt below is the canonical text from REVIEW_JOB_STATIC_PROMPT in
+# cron/router_review.py.  If the policy checks change, update both.
+#
+# FILE TOOLSET
+# ------------
+# enabled_toolsets: ["file"] gives the Hermes agent read access to
+# ~/.openclaw/routing-outcomes.jsonl.  Remove this once the review cron
+# switches to inline prompt generation via format_review_prompt().
+#
+# REGISTRATION
+# ------------
+# Register with the live Hermes gateway via:
+#   hermes cron add --name router-first-review --schedule "*/30 * * * *" \
+#     --prompt-file plans/router-review-job.yaml --enabled false
+# Or via the Hermes API: POST /api/cron/jobs with the fields below.
+
+name: router-first-review
+schedule: "*/30 * * * *"
+enabled: false
+deliver: local
+enabled_toolsets:
+  - file
+prompt: |
+  [REVIEW_REQUEST] Router-first routing outcome review.
+  Endpoint assumption: http://127.0.0.1:11435/v1 (openclaw-cli-proxy).
+
+  Read the routing outcomes file at ~/.openclaw/routing-outcomes.jsonl if it exists.
+  Apply the following policy checks to records from the last 60 minutes:
+
+  1. Simple jobs (job_type=simple, selected_model=blockrun/auto) resolved to
+     cloud model without router_pin → [warning].
+  2. Coding/tool-heavy/reasoning jobs (selected_model=blockrun/auto) resolved
+     to local model instead of escalating → [warning].
+  3. Router-first job (selected_model=blockrun/auto) with no resolved_model
+     recorded → [warning] (Items 1-4 not yet integrated).
+  4. Job with consecutive_local_failures >= 3 → [critical]
+     (GN100 / local inference down).
+  5. Explicit model pin (selected_model != blockrun/auto) with no
+     [router-pin: <reason>] marker for a non-coding job → [warning].
+
+  If the file does not exist, output:
+  [ACK] No routing outcomes yet. Items 1-4 integration pending.
+
+  If all checks pass, output:
+  [ACK] Routing outcomes reviewed. All policy checks passed.
+
+  If any violation is found, output:
+  [ESCALATION_NOTICE] <brief summary of highest-severity violation and job name>.

--- a/plans/router-review-job.yaml
+++ b/plans/router-review-job.yaml
@@ -56,13 +56,14 @@ prompt: |
   map medium/high/complex/reasoning tiers to reasoning, low/simple tiers to simple,
   and keep coding/tool-heavy tiers as coding/tool-heavy.
 
-  1. Simple jobs (job_type/simple gateway tier, selected_model=blockrun/auto) resolved to
-     cloud model without router_pin → [warning].
+  1. Simple jobs (job_type/simple gateway tier) resolved to cloud model without
+     router_pin → [warning]. Current routing-decisions.json may store the actual
+     upstream model in selectedModel/resolvedModel rather than blockrun/auto.
   2. Coding/tool-heavy/reasoning jobs and gateway tiers such as research:reasoning
-     or research:medium (selected_model=blockrun/auto) resolved to local model
-     instead of escalating → [warning].
-  3. Router-first job (selected_model=blockrun/auto) with no resolved_model
-     recorded → [warning] (Items 1-4 not yet integrated).
+     or research:medium resolved to local model instead of escalating → [warning].
+     Do not require selectedModel to equal blockrun/auto for routing-decisions.json.
+  3. Router-first job or gateway decision with no resolved_model recorded → [warning]
+     (Items 1-4 not yet integrated).
   4. Job with consecutive_local_failures >= 3 → [critical]
      (GN100 / local inference down).
   5. Explicit model pin (selected_model != blockrun/auto) with no

--- a/tests/cron/test_router_review.py
+++ b/tests/cron/test_router_review.py
@@ -28,6 +28,7 @@ from cron.router_review import (
     PolicyViolation,
     RoutingOutcome,
     format_review_prompt,
+    classify_job_type,
     load_routing_decisions,
     load_routing_outcomes,
     review_outcomes,
@@ -115,6 +116,27 @@ def _outcome(
         error=error,
         consecutive_local_failures=consecutive_local_failures,
     )
+
+
+# ---------------------------------------------------------------------------
+# classify_job_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("simple", "simple"),
+        ("routing:simple", "simple"),
+        ("research:reasoning", "reasoning"),
+        ("research:medium", "reasoning"),
+        ("coding", "coding"),
+        ("tool-heavy", "tool-heavy"),
+        (None, None),
+    ],
+)
+def test_classify_job_type_maps_gateway_tiers(raw: str | None, expected: str | None):
+    assert classify_job_type(raw) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +283,7 @@ class TestLoadRoutingDecisions:
         assert len(outcomes) == 1
         o = outcomes[0]
         assert o.job_name == "gateway/archie"
-        assert o.job_type == "research:reasoning"
+        assert o.job_type == "reasoning"
         assert o.selected_model == "blockrun/auto"
         assert o.resolved_model == "gn100/qwen3.6:35b-a3b"
 
@@ -386,7 +408,7 @@ class TestLoadRoutingDecisions:
         assert len(outcomes) == 1
         o = outcomes[0]
         assert o.job_name == "gateway/archie"
-        assert o.job_type == "research:reasoning"
+        assert o.job_type == "reasoning"
         assert o.selected_model == "blockrun/auto"
         assert o.resolved_model == "blockrun/auto"
 
@@ -445,17 +467,17 @@ class TestCheck1SimpleWorkNotLocal:
         check1 = [v for v in violations if "Simple job" in v.message]
         assert check1 == []
 
-    def test_gateway_complexity_tier_not_simple_not_flagged(self):
-        """OpenClaw tiers like 'research:reasoning' are not 'simple' — check 1 should not fire."""
+    def test_gateway_simple_tier_cloud_resolved_warns(self):
+        """OpenClaw tiers like 'routing:simple' should be classified as simple."""
         o = _outcome(
-            job_type="research:reasoning",
+            job_type="routing:simple",
             selected_model="blockrun/auto",
             resolved_model="claude-sonnet-4-5",
             router_pin=None,
         )
         violations = review_outcomes([o])
         check1 = [v for v in violations if "Simple job" in v.message]
-        assert check1 == []
+        assert len(check1) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -498,16 +520,16 @@ class TestCheck2EscalationExpected:
         check2 = [v for v in violations if "did not escalate" in v.message]
         assert check2 == []
 
-    def test_gateway_tier_not_in_escalation_types_not_flagged(self):
-        """Gateway-specific tiers like 'research:medium' are not in escalation types."""
+    @pytest.mark.parametrize("gateway_tier", ["research:reasoning", "research:medium"])
+    def test_gateway_tier_classified_for_escalation_checks(self, gateway_tier: str):
         o = _outcome(
-            job_type="research:medium",
+            job_type=gateway_tier,
             selected_model="blockrun/auto",
             resolved_model="gn100/qwen3.6:35b-a3b",
         )
         violations = review_outcomes([o])
         check2 = [v for v in violations if "did not escalate" in v.message]
-        assert check2 == []
+        assert len(check2) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -663,8 +685,8 @@ class TestCheck5UnexplainedPin:
         check5 = [v for v in violations if "router-pin" in v.message]
         assert check5 == []
 
-    def test_gateway_tier_not_in_escalation_types_pin_fires(self):
-        """Gateway-specific tier not in escalation types + explicit pin = check 5 fires."""
+    def test_gateway_reasoning_tier_pin_not_flagged(self):
+        """Gateway reasoning tiers are escalation types, so explicit pins are expected."""
         o = RoutingOutcome(
             job_name="gateway/archie",
             job_id="",
@@ -676,7 +698,7 @@ class TestCheck5UnexplainedPin:
         )
         violations = review_outcomes([o])
         check5 = [v for v in violations if "router-pin" in v.message]
-        assert len(check5) == 1
+        assert check5 == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_router_review.py
+++ b/tests/cron/test_router_review.py
@@ -789,12 +789,14 @@ class TestFormatReviewPrompt:
         outcomes = [
             _outcome(job_name="rf", selected_model="blockrun/auto",
                      resolved_model="gn100/qwen", job_type="simple"),
+            _outcome(job_name="gateway/archie", selected_model="gemini/pro",
+                     resolved_model="gemini/pro", job_type="research:medium"),
             _outcome(job_name="pinned", selected_model="claude-sonnet-4-5",
                      resolved_model=None, job_type="coding",
                      router_pin="[router-pin: coding]"),
         ]
         prompt = format_review_prompt(outcomes, [])
-        assert "Router-first jobs: 1" in prompt
+        assert "Router-first jobs: 2" in prompt
         assert "Pinned (explicit model): 1" in prompt
 
     def test_source_present_false_with_outcomes_still_works(self):

--- a/tests/cron/test_router_review.py
+++ b/tests/cron/test_router_review.py
@@ -387,10 +387,10 @@ class TestLoadRoutingDecisions:
                     "enforcement": "soft",
                     "routingMode": "balanced",
                     "originalOrder": ["blockrun/auto", "gemini/pro"],
-                    "finalOrder": ["blockrun/auto", "gemini/pro"],
-                    "reordered": False,
-                    "selectedModel": "blockrun/auto",
-                    "resolvedModel": "blockrun/auto",
+                    "finalOrder": ["gemini/pro", "blockrun/auto"],
+                    "reordered": True,
+                    "selectedModel": "gemini/pro",
+                    "resolvedModel": "gemini/pro",
                 }
             ],
             "stats": {
@@ -409,8 +409,8 @@ class TestLoadRoutingDecisions:
         o = outcomes[0]
         assert o.job_name == "gateway/archie"
         assert o.job_type == "reasoning"
-        assert o.selected_model == "blockrun/auto"
-        assert o.resolved_model == "blockrun/auto"
+        assert o.selected_model == "gemini/pro"
+        assert o.resolved_model == "gemini/pro"
 
 
 # ---------------------------------------------------------------------------
@@ -470,14 +470,17 @@ class TestCheck1SimpleWorkNotLocal:
     def test_gateway_simple_tier_cloud_resolved_warns(self):
         """OpenClaw tiers like 'routing:simple' should be classified as simple."""
         o = _outcome(
+            job_name="gateway/archie",
             job_type="routing:simple",
-            selected_model="blockrun/auto",
+            selected_model="claude-sonnet-4-5",
             resolved_model="claude-sonnet-4-5",
             router_pin=None,
         )
         violations = review_outcomes([o])
         check1 = [v for v in violations if "Simple job" in v.message]
+        check5 = [v for v in violations if "Explicit model pin" in v.message]
         assert len(check1) == 1
+        assert check5 == []
 
 
 # ---------------------------------------------------------------------------
@@ -523,13 +526,16 @@ class TestCheck2EscalationExpected:
     @pytest.mark.parametrize("gateway_tier", ["research:reasoning", "research:medium"])
     def test_gateway_tier_classified_for_escalation_checks(self, gateway_tier: str):
         o = _outcome(
+            job_name="gateway/archie",
             job_type=gateway_tier,
-            selected_model="blockrun/auto",
+            selected_model="gn100/qwen3.6:35b-a3b",
             resolved_model="gn100/qwen3.6:35b-a3b",
         )
         violations = review_outcomes([o])
         check2 = [v for v in violations if "did not escalate" in v.message]
+        check5 = [v for v in violations if "Explicit model pin" in v.message]
         assert len(check2) == 1
+        assert check5 == []
 
 
 # ---------------------------------------------------------------------------
@@ -571,11 +577,11 @@ class TestCheck3MissingResolvedModel:
         assert check3 == []
 
     def test_gateway_decision_resolved_model_none_fires_check3(self):
-        """Gateway decisions with selectedModel=blockrun/auto but no resolvedModel trigger check 3."""
+        """Gateway decisions with actual selectedModel but no resolvedModel trigger check 3."""
         o = RoutingOutcome(
             job_name="gateway/archie",
             job_id="",
-            selected_model="blockrun/auto",
+            selected_model="gemini/pro",
             resolved_model=None,
             job_type="research:reasoning",
             router_pin=None,

--- a/tests/cron/test_router_review.py
+++ b/tests/cron/test_router_review.py
@@ -1,0 +1,818 @@
+"""Tests for cron/router_review.py — routing outcome policy checks.
+
+Covers:
+  - load_routing_outcomes: missing file, malformed lines, timestamp filtering,
+    timezone-naive timestamps, newest-first ordering
+  - load_routing_decisions: missing file (file_was_present=False), valid JSON
+    envelope, field mapping (camelCase→snake_case, agentId→job_name,
+    complexityTier→job_type), age filtering, malformed/unreadable file
+  - review_outcomes: all five policy checks, edge cases (no outcomes, empty model)
+  - format_review_prompt: file absent vs. present-with-no-fresh-decisions,
+    clean run, violations, source_present kwarg
+  - BLOCKRUN_AUTO_ENDPOINT: value matches plan assumption
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from cron.router_review import (
+    BLOCKRUN_AUTO_ENDPOINT,
+    ROUTING_DECISIONS_PATH,
+    ROUTING_OUTCOMES_PATH,
+    REVIEW_JOB_STATIC_PROMPT,
+    PolicyViolation,
+    RoutingOutcome,
+    format_review_prompt,
+    load_routing_decisions,
+    load_routing_outcomes,
+    review_outcomes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(offset_minutes: int = 0) -> str:
+    """Return a recent ISO-8601 UTC timestamp offset by *offset_minutes*."""
+    dt = datetime.now(timezone.utc) - timedelta(minutes=offset_minutes)
+    return dt.isoformat()
+
+
+def _write_outcomes(tmp_path: Path, records: list[dict]) -> Path:
+    """Write *records* as JSONL to a temp file and return the path."""
+    p = tmp_path / "routing-outcomes.jsonl"
+    with p.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return p
+
+
+def _write_decisions(tmp_path: Path, decisions: list[dict], updated_at: str | None = None) -> Path:
+    """Write *decisions* as a routing-decisions.json envelope and return the path."""
+    p = tmp_path / "routing-decisions.json"
+    envelope = {
+        "decisions": decisions,
+        "stats": {"totalDecisions": len(decisions), "reorderedCount": 0, "tierBreakdown": {}, "topSelectedModels": []},
+        "updatedAt": updated_at or _ts(),
+    }
+    p.write_text(json.dumps(envelope), encoding="utf-8")
+    return p
+
+
+def _decision(
+    *,
+    agent_id: str | None = "archie",
+    complexity_tier: str = "research:medium",
+    selected_model: str | None = "blockrun/auto",
+    resolved_model: str | None = "gn100/qwen3.6:35b-a3b",
+    offset_minutes: int = 0,
+) -> dict:
+    """Build a minimal OpenClaw routing-decisions.json record."""
+    record: dict = {
+        "timestamp": _ts(offset_minutes),
+        "complexityTier": complexity_tier,
+        "enforcement": "soft",
+        "routingMode": "balanced",
+        "originalOrder": [selected_model or "blockrun/auto"],
+        "finalOrder": [selected_model or "blockrun/auto"],
+        "reordered": False,
+    }
+    if agent_id is not None:
+        record["agentId"] = agent_id
+    if selected_model is not None:
+        record["selectedModel"] = selected_model
+    if resolved_model is not None:
+        record["resolvedModel"] = resolved_model
+    return record
+
+
+def _outcome(
+    *,
+    job_name: str = "test-job",
+    selected_model: str | None = "blockrun/auto",
+    resolved_model: str | None = None,
+    job_type: str | None = "simple",
+    router_pin: str | None = None,
+    error: str | None = None,
+    consecutive_local_failures: int = 0,
+    offset_minutes: int = 0,
+) -> RoutingOutcome:
+    """Construct a ``RoutingOutcome`` for testing."""
+    return RoutingOutcome(
+        job_name=job_name,
+        job_id="test-id",
+        selected_model=selected_model,
+        resolved_model=resolved_model,
+        job_type=job_type,
+        router_pin=router_pin,
+        timestamp=_ts(offset_minutes),
+        error=error,
+        consecutive_local_failures=consecutive_local_failures,
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_routing_outcomes (JSONL — future Items 1-4 format)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRoutingOutcomes:
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        outcomes = load_routing_outcomes(path=tmp_path / "nonexistent.jsonl")
+        assert outcomes == []
+
+    def test_empty_file_returns_empty(self, tmp_path: Path):
+        p = tmp_path / "outcomes.jsonl"
+        p.write_text("", encoding="utf-8")
+        assert load_routing_outcomes(path=p) == []
+
+    def test_loads_recent_record(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {
+                "job_name": "my-job",
+                "job_id": "abc123",
+                "selected_model": "blockrun/auto",
+                "resolved_model": "gn100/qwen3.6:35b-a3b",
+                "job_type": "simple",
+                "router_pin": None,
+                "timestamp": _ts(5),
+            }
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+        assert outcomes[0].job_name == "my-job"
+        assert outcomes[0].selected_model == "blockrun/auto"
+        assert outcomes[0].resolved_model == "gn100/qwen3.6:35b-a3b"
+
+    def test_filters_old_records(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "old", "job_id": "x", "timestamp": _ts(120),
+             "selected_model": "blockrun/auto", "resolved_model": None},
+            {"job_name": "recent", "job_id": "y", "timestamp": _ts(10),
+             "selected_model": "blockrun/auto", "resolved_model": None},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+        assert outcomes[0].job_name == "recent"
+
+    def test_skips_malformed_json_lines(self, tmp_path: Path):
+        p = tmp_path / "outcomes.jsonl"
+        p.write_text(
+            'not-json\n'
+            + json.dumps({"job_name": "ok", "job_id": "1", "timestamp": _ts(1),
+                           "selected_model": "blockrun/auto"}) + "\n",
+            encoding="utf-8",
+        )
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+        assert outcomes[0].job_name == "ok"
+
+    def test_skips_bad_timestamp(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "bad-ts", "job_id": "x", "timestamp": "not-a-date",
+             "selected_model": "blockrun/auto"},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert outcomes == []
+
+    def test_timezone_naive_timestamp_accepted(self, tmp_path: Path):
+        # Naive timestamps (no tzinfo) should be treated as UTC and accepted
+        naive_ts = datetime.utcnow().isoformat()
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "naive-job", "job_id": "n1", "timestamp": naive_ts,
+             "selected_model": "blockrun/auto"},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+
+    def test_returns_newest_first(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "older", "job_id": "a", "timestamp": _ts(20),
+             "selected_model": "blockrun/auto"},
+            {"job_name": "newer", "job_id": "b", "timestamp": _ts(5),
+             "selected_model": "blockrun/auto"},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert outcomes[0].job_name == "newer"
+        assert outcomes[1].job_name == "older"
+
+    def test_consecutive_local_failures_defaults_to_zero(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "j", "job_id": "1", "timestamp": _ts(1),
+             "selected_model": "blockrun/auto"},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert outcomes[0].consecutive_local_failures == 0
+
+    def test_optional_fields_default_to_none(self, tmp_path: Path):
+        p = _write_outcomes(tmp_path, [
+            {"job_name": "minimal", "job_id": "m1", "timestamp": _ts(1)},
+        ])
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert outcomes[0].selected_model is None
+        assert outcomes[0].resolved_model is None
+        assert outcomes[0].job_type is None
+        assert outcomes[0].router_pin is None
+        assert outcomes[0].error is None
+
+    def test_blank_lines_skipped(self, tmp_path: Path):
+        p = tmp_path / "outcomes.jsonl"
+        p.write_text(
+            "\n\n"
+            + json.dumps({"job_name": "ok", "job_id": "1", "timestamp": _ts(1),
+                           "selected_model": "blockrun/auto"})
+            + "\n\n",
+            encoding="utf-8",
+        )
+        outcomes = load_routing_outcomes(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+
+
+# ---------------------------------------------------------------------------
+# load_routing_decisions (JSON envelope — current OpenClaw format)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRoutingDecisions:
+    def test_missing_file_returns_empty_and_not_present(self, tmp_path: Path):
+        outcomes, present = load_routing_decisions(path=tmp_path / "nonexistent.json")
+        assert outcomes == []
+        assert present is False
+
+    def test_valid_file_returns_present_true(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [_decision(offset_minutes=5)])
+        _, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert present is True
+
+    def test_loads_recent_decision(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [
+            _decision(agent_id="archie", complexity_tier="research:reasoning",
+                      selected_model="blockrun/auto", resolved_model="gn100/qwen3.6:35b-a3b",
+                      offset_minutes=5)
+        ])
+        outcomes, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert present is True
+        assert len(outcomes) == 1
+        o = outcomes[0]
+        assert o.job_name == "gateway/archie"
+        assert o.job_type == "research:reasoning"
+        assert o.selected_model == "blockrun/auto"
+        assert o.resolved_model == "gn100/qwen3.6:35b-a3b"
+
+    def test_absent_agent_id_uses_fallback_job_name(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [_decision(agent_id=None, offset_minutes=1)])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+        assert outcomes[0].job_name == "gateway-decision"
+
+    def test_fields_not_in_gateway_decisions_have_defaults(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [_decision(offset_minutes=1)])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        o = outcomes[0]
+        assert o.router_pin is None
+        assert o.consecutive_local_failures == 0
+        assert o.error is None
+        assert o.job_id == ""
+
+    def test_filters_old_decisions(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [
+            _decision(agent_id="old", offset_minutes=120),
+            _decision(agent_id="recent", offset_minutes=5),
+        ])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+        assert outcomes[0].job_name == "gateway/recent"
+
+    def test_returns_newest_first(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [
+            _decision(agent_id="older", offset_minutes=30),
+            _decision(agent_id="newer", offset_minutes=5),
+        ])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes[0].job_name == "gateway/newer"
+        assert outcomes[1].job_name == "gateway/older"
+
+    def test_empty_decisions_array_returns_empty_outcomes_present_true(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [])
+        outcomes, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes == []
+        assert present is True
+
+    def test_all_old_decisions_returns_empty_outcomes_present_true(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [_decision(offset_minutes=120)])
+        outcomes, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes == []
+        assert present is True
+
+    def test_malformed_json_returns_empty_present_true(self, tmp_path: Path):
+        p = tmp_path / "routing-decisions.json"
+        p.write_text("not-json{{{", encoding="utf-8")
+        outcomes, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes == []
+        assert present is True  # file exists, just unreadable
+
+    def test_absent_selected_model_maps_to_none(self, tmp_path: Path):
+        rec = _decision(offset_minutes=1)
+        del rec["selectedModel"]
+        p = _write_decisions(tmp_path, [rec])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes[0].selected_model is None
+
+    def test_absent_resolved_model_maps_to_none(self, tmp_path: Path):
+        rec = _decision(offset_minutes=1)
+        del rec["resolvedModel"]
+        p = _write_decisions(tmp_path, [rec])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes[0].resolved_model is None
+
+    def test_bad_timestamp_skipped(self, tmp_path: Path):
+        rec = _decision(offset_minutes=1)
+        rec["timestamp"] = "not-a-date"
+        p = _write_decisions(tmp_path, [rec])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert outcomes == []
+
+    def test_timezone_naive_timestamp_accepted(self, tmp_path: Path):
+        rec = _decision(offset_minutes=0)
+        rec["timestamp"] = datetime.utcnow().isoformat()  # naive
+        p = _write_decisions(tmp_path, [rec])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert len(outcomes) == 1
+
+    def test_multiple_decisions_all_loaded(self, tmp_path: Path):
+        p = _write_decisions(tmp_path, [
+            _decision(agent_id="a", offset_minutes=10),
+            _decision(agent_id="b", offset_minutes=20),
+            _decision(agent_id="c", offset_minutes=30),
+        ])
+        outcomes, _ = load_routing_decisions(path=p, max_age_minutes=60)
+        assert len(outcomes) == 3
+
+    def test_real_file_shape_parses(self, tmp_path: Path):
+        """Exercise the exact shape from routing-decisions.ts output."""
+        real_shape = {
+            "decisions": [
+                {
+                    "timestamp": _ts(3),
+                    "agentId": "archie",
+                    "complexityTier": "research:reasoning",
+                    "enforcement": "soft",
+                    "routingMode": "balanced",
+                    "originalOrder": ["blockrun/auto", "gemini/pro"],
+                    "finalOrder": ["blockrun/auto", "gemini/pro"],
+                    "reordered": False,
+                    "selectedModel": "blockrun/auto",
+                    "resolvedModel": "blockrun/auto",
+                }
+            ],
+            "stats": {
+                "totalDecisions": 1,
+                "reorderedCount": 0,
+                "tierBreakdown": {"research:reasoning": 1},
+                "topSelectedModels": [{"model": "blockrun/auto", "count": 1}],
+            },
+            "updatedAt": _ts(),
+        }
+        p = tmp_path / "routing-decisions.json"
+        p.write_text(json.dumps(real_shape), encoding="utf-8")
+        outcomes, present = load_routing_decisions(path=p, max_age_minutes=60)
+        assert present is True
+        assert len(outcomes) == 1
+        o = outcomes[0]
+        assert o.job_name == "gateway/archie"
+        assert o.job_type == "research:reasoning"
+        assert o.selected_model == "blockrun/auto"
+        assert o.resolved_model == "blockrun/auto"
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — Check 1: simple work not using local
+# ---------------------------------------------------------------------------
+
+
+class TestCheck1SimpleWorkNotLocal:
+    def test_simple_job_cloud_resolved_no_pin_warns(self):
+        o = _outcome(
+            job_type="simple",
+            selected_model="blockrun/auto",
+            resolved_model="claude-sonnet-4-5",
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        # resolved_model is set so check 3 (missing resolved) does NOT fire.
+        # Only check 1 fires: simple job routed to cloud without pin.
+        assert len(violations) == 1
+        assert violations[0].severity == "warning"
+        assert "Simple job" in violations[0].message
+        assert violations[0].severity == "warning"
+        assert "cloud model" in violations[0].message
+        assert violations[0].job_name == "test-job"
+
+    def test_simple_job_cloud_resolved_with_pin_no_violation(self):
+        o = _outcome(
+            job_type="simple",
+            selected_model="blockrun/auto",
+            resolved_model="claude-sonnet-4-5",
+            router_pin="[router-pin: claude required for structured output]",
+        )
+        violations = review_outcomes([o])
+        check1 = [v for v in violations if "Simple job" in v.message]
+        assert check1 == []
+
+    def test_simple_job_local_resolved_no_violation(self):
+        o = _outcome(
+            job_type="simple",
+            selected_model="blockrun/auto",
+            resolved_model="gn100/qwen3.6:35b-a3b",
+        )
+        violations = review_outcomes([o])
+        check1 = [v for v in violations if "Simple job" in v.message]
+        assert check1 == []
+
+    def test_non_simple_job_type_not_flagged(self):
+        o = _outcome(
+            job_type="coding",
+            selected_model="blockrun/auto",
+            resolved_model="claude-sonnet-4-5",
+        )
+        violations = review_outcomes([o])
+        check1 = [v for v in violations if "Simple job" in v.message]
+        assert check1 == []
+
+    def test_gateway_complexity_tier_not_simple_not_flagged(self):
+        """OpenClaw tiers like 'research:reasoning' are not 'simple' — check 1 should not fire."""
+        o = _outcome(
+            job_type="research:reasoning",
+            selected_model="blockrun/auto",
+            resolved_model="claude-sonnet-4-5",
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        check1 = [v for v in violations if "Simple job" in v.message]
+        assert check1 == []
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — Check 2: coding/reasoning not escalating
+# ---------------------------------------------------------------------------
+
+
+class TestCheck2EscalationExpected:
+    @pytest.mark.parametrize("job_type", ["coding", "tool-heavy", "reasoning"])
+    def test_complex_job_local_resolved_warns(self, job_type: str):
+        o = _outcome(
+            job_type=job_type,
+            selected_model="blockrun/auto",
+            resolved_model="gn100/qwen3.6:35b-a3b",
+        )
+        violations = review_outcomes([o])
+        check2 = [v for v in violations if "did not escalate" in v.message]
+        assert len(check2) == 1
+        assert check2[0].severity == "warning"
+        assert job_type.capitalize() in check2[0].message or job_type in check2[0].message.lower()
+
+    def test_coding_job_cloud_resolved_no_violation(self):
+        o = _outcome(
+            job_type="coding",
+            selected_model="blockrun/auto",
+            resolved_model="claude-sonnet-4-5",
+        )
+        violations = review_outcomes([o])
+        check2 = [v for v in violations if "did not escalate" in v.message]
+        assert check2 == []
+
+    def test_simple_job_local_not_escalation_flagged(self):
+        """Simple jobs routing local are expected — don't fire check 2."""
+        o = _outcome(
+            job_type="simple",
+            selected_model="blockrun/auto",
+            resolved_model="gn100/qwen3.6:35b-a3b",
+        )
+        violations = review_outcomes([o])
+        check2 = [v for v in violations if "did not escalate" in v.message]
+        assert check2 == []
+
+    def test_gateway_tier_not_in_escalation_types_not_flagged(self):
+        """Gateway-specific tiers like 'research:medium' are not in escalation types."""
+        o = _outcome(
+            job_type="research:medium",
+            selected_model="blockrun/auto",
+            resolved_model="gn100/qwen3.6:35b-a3b",
+        )
+        violations = review_outcomes([o])
+        check2 = [v for v in violations if "did not escalate" in v.message]
+        assert check2 == []
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — Check 3: missing resolved_model
+# ---------------------------------------------------------------------------
+
+
+class TestCheck3MissingResolvedModel:
+    def test_router_first_no_resolved_warns(self):
+        o = _outcome(selected_model="blockrun/auto", resolved_model=None)
+        violations = review_outcomes([o])
+        check3 = [v for v in violations if "resolved_model" in v.message]
+        assert len(check3) == 1
+        assert check3[0].severity == "warning"
+
+    def test_pinned_job_no_resolved_no_violation(self):
+        """Pinned (non-router) jobs are not expected to have resolved_model."""
+        o = _outcome(
+            selected_model="claude-sonnet-4-5",
+            resolved_model=None,
+            router_pin="[router-pin: coding work]",
+            job_type="coding",
+        )
+        violations = review_outcomes([o])
+        check3 = [v for v in violations if "resolved_model" in v.message]
+        assert check3 == []
+
+    def test_router_first_with_resolved_no_violation(self):
+        o = _outcome(selected_model="blockrun/auto", resolved_model="gn100/qwen3.6:35b-a3b")
+        violations = review_outcomes([o])
+        check3 = [v for v in violations if "resolved_model" in v.message]
+        assert check3 == []
+
+    def test_no_selected_model_no_check3(self):
+        """Missing selected_model entirely should not trigger check 3."""
+        o = _outcome(selected_model=None, resolved_model=None)
+        violations = review_outcomes([o])
+        check3 = [v for v in violations if "resolved_model" in v.message]
+        assert check3 == []
+
+    def test_gateway_decision_resolved_model_none_fires_check3(self):
+        """Gateway decisions with selectedModel=blockrun/auto but no resolvedModel trigger check 3."""
+        o = RoutingOutcome(
+            job_name="gateway/archie",
+            job_id="",
+            selected_model="blockrun/auto",
+            resolved_model=None,
+            job_type="research:reasoning",
+            router_pin=None,
+            timestamp=_ts(1),
+        )
+        violations = review_outcomes([o])
+        check3 = [v for v in violations if "resolved_model" in v.message]
+        assert len(check3) == 1
+        assert check3[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — Check 4: repeated local failures
+# ---------------------------------------------------------------------------
+
+
+class TestCheck4RepeatedLocalFailures:
+    def test_three_consecutive_failures_critical(self):
+        o = _outcome(consecutive_local_failures=3, selected_model="blockrun/auto")
+        violations = review_outcomes([o])
+        check4 = [v for v in violations if "consecutive local model failures" in v.message]
+        assert len(check4) == 1
+        assert check4[0].severity == "critical"
+        assert "3" in check4[0].message
+
+    def test_two_failures_not_critical(self):
+        o = _outcome(consecutive_local_failures=2, selected_model="blockrun/auto")
+        violations = review_outcomes([o])
+        check4 = [v for v in violations if "consecutive local model failures" in v.message]
+        assert check4 == []
+
+    def test_zero_failures_no_violation(self):
+        o = _outcome(consecutive_local_failures=0)
+        violations = review_outcomes([o])
+        check4 = [v for v in violations if "consecutive local model failures" in v.message]
+        assert check4 == []
+
+    def test_high_failure_count_still_critical(self):
+        o = _outcome(consecutive_local_failures=10, selected_model="blockrun/auto")
+        violations = review_outcomes([o])
+        check4 = [v for v in violations if "consecutive local model failures" in v.message]
+        assert len(check4) == 1
+        assert "10" in check4[0].message
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — Check 5: unexplained opt-out pin
+# ---------------------------------------------------------------------------
+
+
+class TestCheck5UnexplainedPin:
+    def test_pinned_non_coding_job_no_marker_warns(self):
+        o = _outcome(
+            selected_model="claude-sonnet-4-5",
+            resolved_model=None,
+            job_type="simple",
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert len(check5) == 1
+        assert check5[0].severity == "warning"
+
+    def test_pinned_coding_job_no_marker_not_flagged(self):
+        """Coding pins are expected in phase one — don't flag them."""
+        o = _outcome(
+            selected_model="codex/sonnet",
+            resolved_model=None,
+            job_type="coding",
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert check5 == []
+
+    @pytest.mark.parametrize("job_type", ["coding", "tool-heavy", "reasoning"])
+    def test_pinned_escalation_type_not_flagged(self, job_type: str):
+        o = _outcome(
+            selected_model="claude-sonnet-4-5",
+            resolved_model=None,
+            job_type=job_type,
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert check5 == []
+
+    def test_pinned_with_marker_no_violation(self):
+        o = _outcome(
+            selected_model="claude-sonnet-4-5",
+            resolved_model=None,
+            job_type="simple",
+            router_pin="[router-pin: structured output requires claude]",
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert check5 == []
+
+    def test_blockrun_auto_not_flagged_as_pin(self):
+        o = _outcome(
+            selected_model="blockrun/auto",
+            resolved_model=None,
+            job_type="simple",
+            router_pin=None,
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert check5 == []
+
+    def test_gateway_tier_not_in_escalation_types_pin_fires(self):
+        """Gateway-specific tier not in escalation types + explicit pin = check 5 fires."""
+        o = RoutingOutcome(
+            job_name="gateway/archie",
+            job_id="",
+            selected_model="gemini/pro",  # explicit non-auto pin
+            resolved_model=None,
+            job_type="research:medium",  # not in _ESCALATION_EXPECTED_TYPES
+            router_pin=None,
+            timestamp=_ts(1),
+        )
+        violations = review_outcomes([o])
+        check5 = [v for v in violations if "router-pin" in v.message]
+        assert len(check5) == 1
+
+
+# ---------------------------------------------------------------------------
+# review_outcomes — multi-check and no-outcome cases
+# ---------------------------------------------------------------------------
+
+
+class TestReviewOutcomesEdgeCases:
+    def test_empty_outcomes_no_violations(self):
+        assert review_outcomes([]) == []
+
+    def test_multiple_outcomes_multiple_violations(self):
+        outcomes = [
+            # Check 3 fires: router-first with no resolved_model
+            _outcome(job_name="job-a", selected_model="blockrun/auto", resolved_model=None),
+            # Check 4 fires: repeated local failures
+            _outcome(job_name="job-b", consecutive_local_failures=5,
+                     selected_model="blockrun/auto", resolved_model="gn100/qwen"),
+            # Check 5 fires: unexplained pin, simple job
+            _outcome(job_name="job-c", selected_model="gemini-pro",
+                     resolved_model=None, job_type="simple", router_pin=None),
+        ]
+        violations = review_outcomes(outcomes)
+        job_names_with_violations = {v.job_name for v in violations}
+        assert "job-a" in job_names_with_violations
+        assert "job-b" in job_names_with_violations
+        assert "job-c" in job_names_with_violations
+
+
+# ---------------------------------------------------------------------------
+# format_review_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReviewPrompt:
+    def test_no_outcomes_file_absent_mentions_not_found(self):
+        """source_present=False: prompt says file is absent."""
+        prompt = format_review_prompt([], [], source_present=False)
+        assert "[REVIEW_REQUEST]" in prompt
+        assert "Outcomes reviewed: 0" in prompt
+        assert "not found" in prompt.lower() or "absent" in prompt.lower()
+
+    def test_no_outcomes_file_present_no_fresh_decisions(self):
+        """source_present=True (default), no outcomes: prompt says no decisions in window."""
+        prompt = format_review_prompt([], [])
+        assert "[REVIEW_REQUEST]" in prompt
+        assert "Outcomes reviewed: 0" in prompt
+        # Should NOT say "not found" — file IS present
+        assert "not found" not in prompt.lower()
+        # Should say something about the window or no decisions
+        assert "present" in prompt.lower() or "no" in prompt.lower()
+
+    def test_no_violations_all_passed(self):
+        o = _outcome(
+            selected_model="blockrun/auto",
+            resolved_model="gn100/qwen3.6:35b-a3b",
+            job_type="simple",
+        )
+        prompt = format_review_prompt([o], [])
+        assert "all passed" in prompt.lower()
+        assert "[REVIEW_REQUEST]" in prompt
+
+    def test_violations_included_in_prompt(self):
+        o = _outcome(selected_model="blockrun/auto", resolved_model=None)
+        violations = review_outcomes([o])
+        prompt = format_review_prompt([o], violations)
+        assert "Policy violations:" in prompt
+        assert "warning" in prompt.lower() or "WARNING" in prompt
+
+    def test_critical_violation_shown(self):
+        o = _outcome(consecutive_local_failures=5, selected_model="blockrun/auto",
+                     resolved_model="gn100/qwen")
+        violations = review_outcomes([o])
+        prompt = format_review_prompt([o], violations)
+        assert "CRITICAL" in prompt or "critical" in prompt.lower()
+
+    def test_endpoint_assumption_included(self):
+        prompt = format_review_prompt([], [])
+        assert BLOCKRUN_AUTO_ENDPOINT in prompt
+
+    def test_router_first_vs_pinned_counts(self):
+        outcomes = [
+            _outcome(job_name="rf", selected_model="blockrun/auto",
+                     resolved_model="gn100/qwen", job_type="simple"),
+            _outcome(job_name="pinned", selected_model="claude-sonnet-4-5",
+                     resolved_model=None, job_type="coding",
+                     router_pin="[router-pin: coding]"),
+        ]
+        prompt = format_review_prompt(outcomes, [])
+        assert "Router-first jobs: 1" in prompt
+        assert "Pinned (explicit model): 1" in prompt
+
+    def test_source_present_false_with_outcomes_still_works(self):
+        """source_present=False is informational only — outcomes are still reviewed."""
+        o = _outcome(selected_model="blockrun/auto", resolved_model="gn100/qwen")
+        violations = review_outcomes([o])
+        prompt = format_review_prompt([o], violations, source_present=False)
+        assert "[REVIEW_REQUEST]" in prompt
+        # Outcomes present, so counts line should appear even with source_present=False
+        assert "Router-first jobs:" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_blockrun_auto_endpoint_is_proxy(self):
+        """Plan says use 11435 (openclaw-cli-proxy) as the canonical endpoint."""
+        assert BLOCKRUN_AUTO_ENDPOINT == "http://127.0.0.1:11435/v1"
+
+    def test_routing_decisions_path_points_to_json(self):
+        assert ROUTING_DECISIONS_PATH.name == "routing-decisions.json"
+        assert ".openclaw" in str(ROUTING_DECISIONS_PATH)
+
+    def test_routing_outcomes_path_points_to_jsonl(self):
+        assert ROUTING_OUTCOMES_PATH.name == "routing-outcomes.jsonl"
+        assert ".openclaw" in str(ROUTING_OUTCOMES_PATH)
+
+    def test_review_job_static_prompt_has_review_request(self):
+        assert "[REVIEW_REQUEST]" in REVIEW_JOB_STATIC_PROMPT
+
+    def test_review_job_static_prompt_has_endpoint(self):
+        assert BLOCKRUN_AUTO_ENDPOINT in REVIEW_JOB_STATIC_PROMPT
+
+    def test_review_job_static_prompt_references_decisions_file(self):
+        """Static prompt should reference the JSON decisions file (primary source)."""
+        assert "routing-decisions.json" in REVIEW_JOB_STATIC_PROMPT
+
+    def test_review_job_static_prompt_covers_all_checks(self):
+        """The static prompt should mention all 5 policy checks."""
+        prompt = REVIEW_JOB_STATIC_PROMPT
+        # Check 3: missing resolved_model
+        assert "resolved_model" in prompt
+        # Check 4: consecutive failures
+        assert "consecutive_local_failures" in prompt
+        # Check 5: router-pin marker
+        assert "router-pin" in prompt


### PR DESCRIPTION
## Summary
- Adds Hermes router-first review policy module and disabled reference cron job.
- Reads OpenClaw routing decisions and emits ACK/ESCALATION_NOTICE-style review prompts.
- Keeps live job activation deferred.

## Test Plan
- `uv run --extra dev pytest tests/cron/test_router_review.py -v` passed.