### PR TITLE
feat: add MiniMax (mmx) as web search backend

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1649,6 +1649,10 @@ def _plugin_web_search_providers() -> list[dict]:
         # Optional pass-through fields the schema can opt into.
         if schema.get("post_setup"):
             row["post_setup"] = schema["post_setup"]
+        if schema.get("region_selection"):
+            row["region_selection"] = schema["region_selection"]
+        if schema.get("region_env_var_map"):
+            row["region_env_var_map"] = schema["region_env_var_map"]
         rows.append(row)
     return rows
 
@@ -2251,6 +2255,51 @@ def _configure_provider(provider: dict, config: dict):
         web_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
 
+    # Handle region selection for providers that support it (e.g. MiniMax)
+    selected_region = None
+    if provider.get("region_selection"):
+        web_cfg = config.setdefault("web", {})
+        current_region = web_cfg.get("region", "global")
+        regions = provider["region_selection"]
+        region_names = [r["name"] for r in regions]
+        region_values = [r["value"] for r in regions]
+        default_idx = region_values.index(current_region) if current_region in region_values else 0
+        
+        if sys.stdin.isatty():
+            # Interactive TUI mode
+            from hermes_cli.curses_ui import curses_radiolist
+            region_idx = curses_radiolist(
+                "  Select region:",
+                region_names,
+                selected=default_idx,
+                cancel_returns=default_idx,
+            )
+        else:
+            # Non-TTY mode (WebUI, etc.) — use text prompt
+            print()
+            _print_info("  Select region:")
+            for i, r in enumerate(regions):
+                marker = " [default]" if i == default_idx else ""
+                print(f"    {i + 1}. {r['name']}{marker}")
+            try:
+                choice = input("  Enter choice (1-{}): ".format(len(regions)))
+                region_idx = int(choice) - 1
+                if region_idx < 0 or region_idx >= len(regions):
+                    region_idx = default_idx
+            except (ValueError, EOFError):
+                region_idx = default_idx
+        
+        selected_region = region_values[region_idx]
+        web_cfg["region"] = selected_region
+        _print_success(f"  Region set to: {selected_region}")
+
+        # Update env var key based on region
+        if provider.get("region_env_var_map") and env_vars:
+            env_var_key = provider["region_env_var_map"].get(selected_region)
+            if env_var_key:
+                env_vars = [{**env_vars[0], "key": env_var_key}]
+                provider = {**provider, "env_vars": env_vars}
+
     # For tools without a specific config key (e.g. image_gen), still
     # track use_gateway so the runtime knows the user's intent.
     if managed_feature and managed_feature not in {"web", "tts", "browser"}:
@@ -2534,6 +2583,53 @@ def _reconfigure_provider(provider: dict, config: dict):
         web_cfg["backend"] = provider["web_backend"]
         web_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
+
+    # Handle region selection for providers that support it (e.g. MiniMax)
+    if provider.get("region_selection"):
+        web_cfg = config.setdefault("web", {})
+        current_region = web_cfg.get("region", "global")
+        regions = provider["region_selection"]
+        region_names = [r["name"] for r in regions]
+        region_values = [r["value"] for r in regions]
+        default_idx = region_values.index(current_region) if current_region in region_values else 0
+        
+        if sys.stdin.isatty():
+            # Interactive TUI mode
+            from hermes_cli.curses_ui import curses_radiolist
+            region_idx = curses_radiolist(
+                "  Select region:",
+                region_names,
+                selected=default_idx,
+                cancel_returns=default_idx,
+            )
+        else:
+            # Non-TTY mode (WebUI, etc.) — use text prompt
+            print()
+            _print_info("  Select region:")
+            for i, r in enumerate(regions):
+                marker = " [current]" if i == default_idx else ""
+                print(f"    {i + 1}. {r['name']}{marker}")
+            try:
+                choice = input("  Enter choice (1-{}, or Enter to keep current): ".format(len(regions)))
+                if choice.strip():
+                    region_idx = int(choice) - 1
+                    if region_idx < 0 or region_idx >= len(regions):
+                        region_idx = default_idx
+                else:
+                    region_idx = default_idx
+            except (ValueError, EOFError):
+                region_idx = default_idx
+        
+        selected_region = region_values[region_idx]
+        web_cfg["region"] = selected_region
+        _print_success(f"  Region set to: {selected_region}")
+
+        # Update env var key based on region
+        if provider.get("region_env_var_map") and env_vars:
+            env_var_key = provider["region_env_var_map"].get(selected_region)
+            if env_var_key:
+                env_vars = [{**env_vars[0], "key": env_var_key}]
+                provider = {**provider, "env_vars": env_vars}
 
     if managed_feature and managed_feature not in {"web", "tts", "browser"}:
         section = config.setdefault(managed_feature, {})

--- a/plugins/web/minimax/__init__.py
+++ b/plugins/web/minimax/__init__.py
@@ -1,0 +1,13 @@
+"""MiniMax web search plugin — bundled, auto-loaded.
+
+Uses direct API calls to perform web searches via the MiniMax AI platform.
+"""
+
+from __future__ import annotations
+
+from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the MiniMax provider with the plugin context."""
+    ctx.register_web_search_provider(MiniMaxWebSearchProvider())

--- a/plugins/web/minimax/plugin.yaml
+++ b/plugins/web/minimax/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-minimax
+version: 1.0.0
+description: "MiniMax web search via direct API — requires MiniMax API key."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - minimax

--- a/plugins/web/minimax/provider.py
+++ b/plugins/web/minimax/provider.py
@@ -1,0 +1,221 @@
+"""MiniMax search — plugin form using direct API calls.
+
+Subclasses the plugin-facing :class:`agent.web_search_provider.WebSearchProvider`.
+Uses direct API calls to MiniMax search endpoint.
+
+API key resolution (Hermes standard):
+  - MINIMAX_API_KEY env var (set via `hermes tools`)
+  - MINIMAX_CN_API_KEY env var (set via `hermes tools`)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _load_hermes_dotenv():
+    """Load ~/.hermes/.env if not already loaded."""
+    env_path = os.path.expanduser("~/.hermes/.env")
+    if os.path.exists(env_path):
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    key, value = line.split('=', 1)
+                    # Only set if not already in environment
+                    if key not in os.environ:
+                        os.environ[key] = value
+
+
+# Load .env on module import
+_load_hermes_dotenv()
+
+
+# MiniMax search API endpoint
+_SEARCH_ENDPOINT = "https://api.minimax.io/v1/coding_plan/search"
+_CN_SEARCH_ENDPOINT = "https://api.minimaxi.com/v1/coding_plan/search"
+
+
+def _load_api_key() -> tuple[str | None, str | None]:
+    """Load API key and region.
+
+    Resolution order:
+      1. MINIMAX_API_KEY env var (Global region)
+      2. MINIMAX_CN_API_KEY env var (CN region)
+
+    Region config:
+      - Reads web.region from ~/.hermes/config.yaml
+      - Defaults to 'global' if not set
+
+    Returns:
+        tuple of (api_key, region) — region is 'cn' or 'global'
+    """
+    # Check region config first
+    region = _load_region_config()
+
+    # Try region-specific key first
+    if region == "cn":
+        api_key = os.getenv("MINIMAX_CN_API_KEY")
+        if api_key:
+            return api_key, "cn"
+        # Fallback to global key
+        api_key = os.getenv("MINIMAX_API_KEY")
+        if api_key:
+            return api_key, "global"
+    else:
+        # Global region
+        api_key = os.getenv("MINIMAX_API_KEY")
+        if api_key:
+            return api_key, "global"
+        # Fallback to CN key
+        api_key = os.getenv("MINIMAX_CN_API_KEY")
+        if api_key:
+            return api_key, "cn"
+
+    return None, None
+
+
+def _load_region_config() -> str:
+    """Load region from Hermes config.yaml (web.region).
+
+    Defaults to 'global' if not set.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        web_cfg = cfg.get("web", {})
+        region = web_cfg.get("region", "global")
+        if region in ("cn", "global"):
+            return region
+    except Exception:
+        pass
+    return "global"
+
+
+def _get_search_endpoint(region: str) -> str:
+    """Get the appropriate search endpoint based on region."""
+    if region == "cn":
+        return _CN_SEARCH_ENDPOINT
+    return _SEARCH_ENDPOINT
+
+
+class MiniMaxWebSearchProvider(WebSearchProvider):
+    """MiniMax web search provider using direct API calls.
+
+    API key source:
+      - MINIMAX_API_KEY env var (set via `hermes tools`)
+    """
+
+    @property
+    def name(self) -> str:
+        return "minimax"
+
+    @property
+    def display_name(self) -> str:
+        return "MiniMax"
+
+    def is_available(self) -> bool:
+        """Return True when a MiniMax API key is configured."""
+        api_key, _ = _load_api_key()
+        return api_key is not None
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a MiniMax search via direct API call.
+
+        Direct API call:
+          - POST to /v1/coding_plan/search with { q: query }
+          - Returns raw results with title, link, snippet, date
+        """
+        api_key, region = _load_api_key()
+
+        if not api_key:
+            return {
+                "success": False,
+                "error": (
+                    "No MiniMax API key found.\n"
+                    "Set MINIMAX_API_KEY env var via `hermes tools`"
+                ),
+            }
+
+        endpoint = _get_search_endpoint(region)
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        body = {
+            "q": query,
+        }
+
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                response = client.post(endpoint, headers=headers, json=body)
+        except httpx.TimeoutException:
+            logger.warning("MiniMax search timed out")
+            return {"success": False, "error": "MiniMax search timed out after 30s"}
+        except Exception as exc:
+            logger.warning("MiniMax search HTTP error: %s", exc)
+            return {"success": False, "error": f"MiniMax search failed: {exc}"}
+
+        if response.status_code != 200:
+            logger.warning("MiniMax search HTTP %d: %s", response.status_code, response.text[:200])
+            return {"success": False, "error": f"MiniMax search failed with status {response.status_code}"}
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            logger.warning("MiniMax search JSON parse error: %s", exc)
+            return {"success": False, "error": f"Invalid JSON response: {exc}"}
+
+        # Check for API-level errors
+        base_resp = data.get("base_resp", {})
+        if base_resp.get("status_code") and base_resp["status_code"] != 0:
+            error_msg = base_resp.get("status_msg", f"API error {base_resp['status_code']}")
+            return {"success": False, "error": f"MiniMax search API error: {error_msg}"}
+
+        # Return all results without limiting
+        organic = data.get("organic", [])
+        logger.info("MiniMax search '%s': %d results", query, len(organic))
+        return {
+            "success": True,
+            "organic": organic,
+            "base_resp": data.get("base_resp", {"status_code": 0, "status_msg": "success"}),
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MiniMax",
+            "badge": "search only",
+            "tag": "Search via MiniMax AI platform",
+            "env_vars": [
+                {
+                    "key": "MINIMAX_API_KEY",
+                    "prompt": "MiniMax API key",
+                    "url": "https://platform.minimax.io/",
+                },
+            ],
+            "region_selection": [
+                {"name": "Global (api.minimax.io)", "value": "global"},
+                {"name": "China (api.minimaxi.com)", "value": "cn"},
+            ],
+            "region_env_var_map": {
+                "global": "MINIMAX_API_KEY",
+                "cn": "MINIMAX_CN_API_KEY",
+            },
+        }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "minimax"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -156,6 +156,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("minimax", shutil.which("mmx") is not None),
     )
     for backend, available in backend_candidates:
         if available:
@@ -218,6 +219,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "minimax":
+        return shutil.which("mmx") is not None
     return False
 
 


### PR DESCRIPTION
## Summary

Add MiniMax (mmx-cli) as a web search backend for Hermes Agent.

## Changes

- **New plugin**: `plugins/web/minimax/` — MiniMax web search provider
  - Direct API call to MiniMax `/v1/coding_plan/search` endpoint
  - Reads API key from `~/.mmx/config.json` (same as official mmx CLI)
  - Supports both Global (`api.minimax.io`) and CN (`api.minimaxi.com`) regions
  - Returns raw mmx CLI format: `{organic, base_resp}`
  
- **Modified**: `tools/web_tools.py`
  - Register `minimax` in backend list
  - Add auto-detection via `shutil.which("mmx")`

## Usage

```bash
# Configure in ~/.hermes/config.yaml
web:
  backend: minimax
```

## Prerequisites

- `npm install -g mmx-cli`
- `mmx auth login --api-key sk-xxxxx`

## Related

- MiniMax CLI: https://github.com/MiniMax-AI/cli