### PR TITLE
fix(install): use shared uv Python dirs for root FHS installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -309,6 +309,21 @@ get_hermes_command_path() {
     fi
 }
 
+configure_uv_python_dirs() {
+    # Root Linux installs use the FHS code layout under /usr/local/lib, but
+    # uv's default managed-Python location still lives under /root/.local.
+    # That makes the venv interpreter path root-home scoped and non-root users
+    # can fail to execute the shared /usr/local/bin/hermes shim. Point uv's
+    # managed Python dirs at a world-readable system location instead. (#21457)
+    if [ "$ROOT_FHS_LAYOUT" != true ]; then
+        return 0
+    fi
+
+    export UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"
+    export UV_PYTHON_BIN_DIR="/usr/local/share/uv/bin"
+    log_info "Root FHS install: using shared uv Python dir at $UV_PYTHON_INSTALL_DIR"
+}
+
 # ============================================================================
 # System detection
 # ============================================================================
@@ -1979,6 +1994,7 @@ main() {
 
     detect_os
     resolve_install_layout
+    configure_uv_python_dirs
     install_uv
     check_python
     check_git

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -13,7 +13,7 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def test_install_script_unsets_pythonpath_and_pythonhome_early() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     # During install, inherited Python env must be sanitized before pip/venv use.
     assert 'unset PYTHONPATH' in text
@@ -21,7 +21,7 @@ def test_install_script_unsets_pythonpath_and_pythonhome_early() -> None:
 
 
 def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     # Wrapper should clear env and forward args untouched to the venv entrypoint.
     assert 'cat > "$command_link_dir/hermes" <<EOF' in text

--- a/tests/test_install_sh_root_uv_paths.py
+++ b/tests/test_install_sh_root_uv_paths.py
@@ -1,0 +1,44 @@
+"""Regression tests for root FHS uv-managed Python placement in install.sh.
+
+When install.sh runs as root on Linux, it prefers the FHS code layout under
+``/usr/local/lib/hermes-agent`` and exposes the launcher at
+``/usr/local/bin/hermes``. Without overriding uv's managed-Python directories,
+``uv python install`` still uses ``/root/.local/share/uv/python`` and the venv
+interpreter can end up rooted in the root home. Non-root users then fail to
+execute the shared launcher because its interpreter path is not world-readable.
+"""
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_root_fhs_installs_export_shared_uv_python_dirs() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert "configure_uv_python_dirs()" in text
+    assert 'if [ "$ROOT_FHS_LAYOUT" != true ]; then' in text
+    assert 'export UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"' in text
+    assert 'export UV_PYTHON_BIN_DIR="/usr/local/share/uv/bin"' in text
+
+
+def test_root_uv_python_dir_override_runs_before_uv_bootstrap() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    match = re.search(r"main\(\) \{(?P<body>.*?)^\}", text, re.DOTALL | re.MULTILINE)
+    assert match is not None, "Could not locate main() in scripts/install.sh"
+    body = match["body"]
+
+    resolve_idx = body.find("resolve_install_layout")
+    configure_idx = body.find("configure_uv_python_dirs")
+    install_uv_idx = body.find("install_uv")
+    check_python_idx = body.find("check_python")
+
+    assert -1 not in (resolve_idx, configure_idx, install_uv_idx, check_python_idx)
+    assert resolve_idx < configure_idx < install_uv_idx < check_python_idx, (
+        "main() must configure shared uv Python dirs immediately after "
+        "resolve_install_layout(), before uv install/Python discovery."
+    )

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -15,7 +15,9 @@ in ``command_link_dir`` and the venv entry point is left intact.
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -29,7 +31,7 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 def _extract_setup_path_shim_block() -> str:
     """Return the install.sh shim-write block used by setup_path()."""
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
     match = re.search(
         r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
         text,
@@ -74,6 +76,9 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
       * ``venv/bin/hermes`` still contains its original pip-script body
       * ``local_bin/hermes`` is a regular file (not a symlink) holding the shim
     """
+    if shutil.which("bash") is None:
+        pytest.skip("bash is required to execute the install.sh shim block")
+
     venv_bin = tmp_path / "venv" / "bin"
     venv_bin.mkdir(parents=True)
     pip_entry = venv_bin / "hermes"
@@ -86,7 +91,12 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
     shim_path = command_link_dir / "hermes"
     # Reproduce the prior-install state: shim path is a symlink to the
     # pip-generated entry point.
-    shim_path.symlink_to(pip_entry)
+    try:
+        shim_path.symlink_to(pip_entry)
+    except OSError as exc:
+        if os.name == "nt":
+            pytest.skip(f"symlink creation is unavailable on this Windows session: {exc}")
+        raise
     assert shim_path.is_symlink()
 
     block = _extract_setup_path_shim_block()


### PR DESCRIPTION
## Summary

Fix root-mode Linux installs to place uv-managed Python in a shared system path when Hermes uses the FHS layout.

Without this, `install.sh` can create the venv against a Python under `/root/.local/share/uv/python/...`, which leaves the shared `/usr/local/bin/hermes` launcher pointing at a root-home-scoped interpreter. Non-root users can then fail to run the launcher with `bad interpreter: Permission denied`.

## What changed

- Added `configure_uv_python_dirs()` in `scripts/install.sh`
- When `ROOT_FHS_LAYOUT=true`, export:
  - `UV_PYTHON_INSTALL_DIR=/usr/local/share/uv/python`
  - `UV_PYTHON_BIN_DIR=/usr/local/share/uv/bin`
- Invoke that helper immediately after `resolve_install_layout()` and before `install_uv` / `check_python`

This keeps the fix scoped to new root Linux FHS installs and leaves legacy non-FHS installs unchanged.

## Tests

Added:
- `tests/test_install_sh_root_uv_paths.py`

Updated for cross-platform stability:
- `tests/test_install_sh_pythonpath_sanitization.py`
- `tests/test_install_sh_symlink_stomp.py`

Validation run:
- `python -m pytest tests/test_install_sh_root_uv_paths.py -q`
- `python -m pytest tests/test_install_sh_symlink_stomp.py -q`
  - passes on Windows with the symlink-dependent behavioral case skipped when symlink privileges / bash are unavailable
- `python -m pytest tests/test_install_sh_pythonpath_sanitization.py -q`

## Why this is safe

- Only applies to `ROOT_FHS_LAYOUT` installs
- Does not change non-root installs
- Does not change legacy root installs kept under `$HERMES_HOME/hermes-agent`
- Backed by a narrow regression test for call ordering and exported uv paths
