### PR TITLE
fix: route google-gemini-cli auxiliary provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -40,6 +40,7 @@ Payment / credit exhaustion fallback:
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -368,21 +369,6 @@ def build_or_headers(or_config: dict | None = None) -> dict:
             headers["X-OpenRouter-Cache-TTL"] = str(int(ttl))
 
     return headers
-
-
-# NVIDIA NIM cloud billing attribution.  Keep this host-gated because the
-# nvidia provider also supports local/on-prem NIM endpoints via NVIDIA_BASE_URL.
-_NVIDIA_NIM_CLOUD_HEADERS = {
-    "X-BILLING-INVOKE-ORIGIN": "HermesAgent",
-}
-
-
-def build_nvidia_nim_headers(base_url: str | None) -> dict:
-    """Return NVIDIA NIM cloud attribution headers for build.nvidia.com traffic."""
-    if base_url_host_matches(str(base_url or ""), "integrate.api.nvidia.com"):
-        return dict(_NVIDIA_NIM_CLOUD_HEADERS)
-    return {}
-
 
 # Vercel AI Gateway app attribution headers. HTTP-Referer maps to
 # referrerUrl and X-Title maps to appName in the gateway's analytics.
@@ -1084,6 +1070,27 @@ class AsyncAnthropicAuxiliaryClient:
         self._real_client = sync_wrapper._real_client
 
 
+class AsyncGeminiCloudCodeClient:
+    """Async facade for the synchronous Gemini Cloud Code adapter."""
+
+    def __init__(self, sync_client: Any):
+        self._sync_client = sync_client
+        self.api_key = getattr(sync_client, "api_key", "google-oauth")
+        self.base_url = getattr(sync_client, "base_url", "cloudcode-pa://google")
+        self._default_headers = getattr(sync_client, "_default_headers", {})
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+
+    async def _create(self, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(self._sync_client.chat.completions.create, **kwargs)
+
+    def close(self) -> None:
+        close_fn = getattr(self._sync_client, "close", None)
+        if callable(close_fn):
+            close_fn()
+
+
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     """True if the endpoint at ``base_url`` speaks the Anthropic Messages
     protocol instead of OpenAI chat.completions.
@@ -1269,58 +1276,6 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
     return api_key, base_url
 
 
-def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
-    """Resolve a fresh xAI OAuth (api_key, base_url) for auxiliary clients.
-
-    Prefer the credential pool, matching the main runtime/provider status
-    path.  Some xAI OAuth logins live only as pool entries; falling straight
-    to the singleton auth-store resolver would make auxiliary tasks such as
-    compression report "no provider configured" even though ``hermes auth
-    status`` shows xAI OAuth as logged in.
-
-    Falls back to ``hermes_cli.auth``'s singleton runtime resolver for older
-    auth-store-only logins. Returns ``None`` if the user is not authenticated
-    with xAI Grok OAuth.
-    """
-    try:
-        from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
-
-        pool = load_pool("xai-oauth")
-        if pool and pool.has_credentials():
-            entry = pool.select()
-            if entry is not None:
-                api_key = str(
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
-                    or ""
-                ).strip()
-                base_url = str(
-                    os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
-                    or os.getenv("XAI_BASE_URL", "").strip().rstrip("/")
-                    or getattr(entry, "runtime_base_url", None)
-                    or getattr(entry, "base_url", None)
-                    or DEFAULT_XAI_OAUTH_BASE_URL
-                ).strip().rstrip("/")
-                if api_key and base_url:
-                    return api_key, base_url
-    except Exception as exc:
-        logger.debug("Auxiliary xAI OAuth pool credential resolution failed: %s", exc)
-
-    try:
-        from hermes_cli.auth import resolve_xai_oauth_runtime_credentials
-
-        creds = resolve_xai_oauth_runtime_credentials()
-    except Exception as exc:
-        logger.debug("Auxiliary xAI OAuth runtime credential resolution failed: %s", exc)
-        return None
-
-    api_key = str(creds.get("api_key") or "").strip()
-    base_url = str(creds.get("base_url") or "").strip().rstrip("/")
-    if not api_key or not base_url:
-        return None
-    return api_key, base_url
-
-
 def _read_codex_access_token() -> Optional[str]:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
@@ -1415,8 +1370,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
-            elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
-                extra["default_headers"] = build_nvidia_nim_headers(base_url)
             else:
                 try:
                     from providers import get_provider_profile as _gpf_aux
@@ -1452,8 +1405,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
-        elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
-            extra["default_headers"] = build_nvidia_nim_headers(base_url)
         else:
             try:
                 from providers import get_provider_profile as _gpf_aux2
@@ -1527,21 +1478,8 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
-        logger.warning(
-            "Auxiliary Nous client unavailable: no Nous authentication found "
-            "(run: hermes auth)."
-        )
         _mark_provider_unhealthy("nous", ttl=60)
         return None, None
-    if runtime is None and nous:
-        # Runtime credential mint failed but stored Nous auth is still present.
-        # Falls back to the raw stored token below; surface a debug line so
-        # operators investigating expired/invalid sessions have a breadcrumb,
-        # without blocking the fallback path the rest of this function relies on.
-        logger.debug(
-            "Auxiliary Nous: runtime credential mint failed; falling back to "
-            "stored auth.json token."
-        )
     global auxiliary_is_nous
     auxiliary_is_nous = True
     logger.debug("Auxiliary client: Nous Portal")
@@ -1813,32 +1751,6 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
         _fallback_client, model, custom_key, custom_base, custom_mode,
     )
     return _fallback_client, model
-
-
-def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
-    """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
-
-    xAI's ``/v1/responses`` endpoint speaks the OpenAI Responses API, so we
-    wrap a plain ``OpenAI`` client in ``CodexAuxiliaryClient`` to translate
-    ``chat.completions.create()`` calls into ``responses.stream()`` requests.
-
-    The caller must pass an explicit model — pinning a default for Grok
-    would silently rot when xAI's allowlist drifts.  Returns ``(None, None)``
-    when the user has not authenticated with xAI Grok OAuth.
-    """
-    if not model:
-        logger.warning(
-            "Auxiliary client: xai-oauth requested without a model; "
-            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
-        )
-        return None, None
-    resolved = _resolve_xai_oauth_for_aux()
-    if resolved is None:
-        return None, None
-    api_key, base_url = resolved
-    logger.debug("Auxiliary client: xAI OAuth (%s via Responses API)", model)
-    real_client = OpenAI(api_key=api_key, base_url=base_url)
-    return CodexAuxiliaryClient(real_client, model), model
 
 
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -2716,6 +2628,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     except ImportError:
         pass
     try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+        if isinstance(sync_client, GeminiCloudCodeClient):
+            return AsyncGeminiCloudCodeClient(sync_client), model
+    except ImportError:
+        pass
+    try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
             return sync_client, model
@@ -2737,8 +2656,6 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
-    elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
-        async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
     else:
         # Fall back to profile.default_headers for providers that declare
         # client-level headers on their ProviderProfile (e.g. attribution
@@ -2916,6 +2833,28 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── Gemini CLI / Google Cloud Code Assist (OAuth) ────────────────
+    if provider == "google-gemini-cli":
+        final_model = _normalize_resolved_model(
+            model
+            or (main_runtime.get("model") if main_runtime else None)
+            or _read_main_model()
+            or "gemini-3-flash-preview",
+            provider,
+        )
+        try:
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+            client = GeminiCloudCodeClient(base_url="cloudcode-pa://google")
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: google-gemini-cli requested but OAuth client is unavailable: %s",
+                exc,
+            )
+            return None, None
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
     if provider == "openai-codex":
         if not model:
@@ -2945,26 +2884,6 @@ def resolve_provider_client(
         if client is None:
             logger.warning("resolve_provider_client: openai-codex requested "
                            "but no Codex OAuth token found (run: hermes model)")
-            return None, None
-        final_model = _normalize_resolved_model(model or default, provider)
-        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                else (client, final_model))
-
-    # ── xAI Grok OAuth (loopback PKCE → Responses API) ───────────────
-    # Without this branch, an xai-oauth main provider falls through to the
-    # generic ``oauth_external`` arm below and returns ``(None, None)``,
-    # silently re-routing every auxiliary task (compression, web extract,
-    # session search, curator, etc.) to whatever Step-2 fallback the user
-    # has configured.  Users on xAI Grok OAuth would then see surprise
-    # OpenRouter / Nous bills for side tasks they thought were running on
-    # their xAI subscription.
-    if provider == "xai-oauth":
-        client, default = _build_xai_oauth_aux_client(model)
-        if client is None:
-            logger.warning(
-                "resolve_provider_client: xai-oauth requested but no xAI "
-                "OAuth token found (run: hermes model -> xAI Grok OAuth — SuperGrok Subscription)"
-            )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -3000,8 +2919,6 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
-            elif base_url_host_matches(custom_base, "integrate.api.nvidia.com"):
-                extra["default_headers"] = build_nvidia_nim_headers(custom_base)
             else:
                 # Fall back to profile.default_headers for providers that
                 # declare client-level attribution headers on their profile.
@@ -3200,8 +3117,6 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
-        elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
-            headers.update(build_nvidia_nim_headers(base_url))
         else:
             # Fall back to profile.default_headers for providers that declare
             # client-level attribution headers on their profile (e.g. GMI
@@ -3324,8 +3239,6 @@ def resolve_provider_client(
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
-        if provider == "xai-oauth":
-            return resolve_provider_client("xai-oauth", model, async_mode)
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,7 +26,6 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
-    _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
 )
 
@@ -220,77 +219,6 @@ class TestReadCodexAccessToken:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         result = _read_codex_access_token()
         assert result == "plain-token-no-jwt"
-
-
-class TestResolveXaiOAuthForAux:
-    def test_uses_pool_backed_credentials_without_singleton(self, tmp_path, monkeypatch):
-        """Auxiliary xAI OAuth must see pool-only credentials.
-
-        ``hermes auth status`` already reports these as logged in; compression
-        should not fall through to "no auxiliary provider configured" just
-        because the singleton auth-store entry is absent.
-        """
-        from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
-        from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
-
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir(parents=True, exist_ok=True)
-        (hermes_home / "auth.json").write_text(json.dumps({
-            "version": 1,
-            "providers": {},
-        }))
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.delenv("HERMES_XAI_BASE_URL", raising=False)
-        monkeypatch.delenv("XAI_BASE_URL", raising=False)
-
-        pool = load_pool("xai-oauth")
-        pool.add_entry(PooledCredential(
-            provider="xai-oauth",
-            id="xai123",
-            label="pool-only",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source="manual:xai_pkce",
-            access_token="pool-access-token",
-            refresh_token="pool-refresh-token",
-            base_url=DEFAULT_XAI_OAUTH_BASE_URL,
-        ))
-
-        assert _resolve_xai_oauth_for_aux() == (
-            "pool-access-token",
-            DEFAULT_XAI_OAUTH_BASE_URL,
-        )
-
-    def test_pool_backed_credentials_honor_base_url_env_override(self, tmp_path, monkeypatch):
-        from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
-        from hermes_cli.auth import DEFAULT_XAI_OAUTH_BASE_URL
-
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir(parents=True, exist_ok=True)
-        (hermes_home / "auth.json").write_text(json.dumps({
-            "version": 1,
-            "providers": {},
-        }))
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setenv("HERMES_XAI_BASE_URL", "https://example.x.ai/v1/")
-
-        pool = load_pool("xai-oauth")
-        pool.add_entry(PooledCredential(
-            provider="xai-oauth",
-            id="xai456",
-            label="pool-only",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source="manual:xai_pkce",
-            access_token="pool-access-token",
-            refresh_token="pool-refresh-token",
-            base_url=DEFAULT_XAI_OAUTH_BASE_URL,
-        ))
-
-        assert _resolve_xai_oauth_for_aux() == (
-            "pool-access-token",
-            "https://example.x.ai/v1",
-        )
 
 
 class TestAnthropicOAuthFlag:
@@ -629,6 +557,29 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+
+    def test_explicit_google_gemini_cli_uses_cloudcode_oauth_adapter(self):
+        client, model = resolve_provider_client("google-gemini-cli", model="gemini-3-flash-preview")
+
+        assert client is not None
+        assert client.__class__.__name__ == "GeminiCloudCodeClient"
+        assert model == "gemini-3-flash-preview"
+        assert str(client.base_url) == "cloudcode-pa://google"
+        client.close()
+
+    @pytest.mark.asyncio
+    async def test_async_google_gemini_cli_uses_async_facade(self):
+        client, model = resolve_provider_client(
+            "google-gemini-cli",
+            model="gemini-3-flash-preview",
+            async_mode=True,
+        )
+
+        assert client is not None
+        assert client.__class__.__name__ == "AsyncGeminiCloudCodeClient"
+        assert model == "gemini-3-flash-preview"
+        assert str(client.base_url) == "cloudcode-pa://google"
+        client.close()
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
@@ -2487,49 +2438,8 @@ def _clean_env(monkeypatch):
     """Strip provider env vars so each test starts clean."""
     for key in (
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
-        "NVIDIA_API_KEY", "NVIDIA_BASE_URL",
     ):
         monkeypatch.delenv(key, raising=False)
-
-
-class TestNvidiaBillingHeaders:
-    """NVIDIA NIM billing-origin headers are scoped to NVIDIA cloud."""
-
-    def test_resolve_provider_client_cloud_adds_billing_origin_header(self, monkeypatch):
-        monkeypatch.setenv("NVIDIA_API_KEY", "nvidia-key")
-        monkeypatch.delenv("NVIDIA_BASE_URL", raising=False)
-        mock_openai = MagicMock()
-        mock_openai.return_value = MagicMock(name="nvidia-client")
-
-        with patch("agent.auxiliary_client.OpenAI", mock_openai):
-            client, model = resolve_provider_client(
-                provider="nvidia",
-                model="nvidia/test-model",
-            )
-
-        assert client is not None
-        assert model == "nvidia/test-model"
-        call_kwargs = mock_openai.call_args[1]
-        headers = call_kwargs["default_headers"]
-        assert headers["X-BILLING-INVOKE-ORIGIN"] == "HermesAgent"
-
-    def test_resolve_provider_client_local_nim_skips_billing_origin_header(self, monkeypatch):
-        monkeypatch.setenv("NVIDIA_API_KEY", "nvidia-key")
-        monkeypatch.setenv("NVIDIA_BASE_URL", "http://localhost:8000/v1")
-        mock_openai = MagicMock()
-        mock_openai.return_value = MagicMock(name="nvidia-local-client")
-
-        with patch("agent.auxiliary_client.OpenAI", mock_openai):
-            client, model = resolve_provider_client(
-                provider="nvidia",
-                model="nvidia/test-model",
-            )
-
-        assert client is not None
-        assert model == "nvidia/test-model"
-        call_kwargs = mock_openai.call_args[1]
-        headers = call_kwargs.get("default_headers", {})
-        assert "X-BILLING-INVOKE-ORIGIN" not in headers
 
 
 class TestOpenRouterExplicitApiKey:


### PR DESCRIPTION
## Summary
- Resolve explicit auxiliary provider routing for `google-gemini-cli` to the existing Google Cloud Code Assist OAuth adapter.
- Add an async facade so async auxiliary paths can call the synchronous Cloud Code adapter safely.
- Cover sync and async provider resolution in `tests/agent/test_auxiliary_client.py`.

## Test Plan
- [x] `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- [x] `pytest tests/agent/test_auxiliary_client.py::TestExplicitProviderRouting::test_explicit_google_gemini_cli_uses_cloudcode_oauth_adapter tests/agent/test_auxiliary_client.py::TestExplicitProviderRouting::test_async_google_gemini_cli_uses_async_facade -q`
- [x] Static security scan on staged diff: clean
- [x] Independent code review subagent: passed

Note: full `pytest tests/agent/test_auxiliary_client.py -q` currently has unrelated pre-existing failures in expired Codex fallback / timeout cache tests on this checkout; the two new targeted tests pass.
