### PR TITLE
fix(profiles): detect systemd-managed gateways in profile list/show

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1256,7 +1256,7 @@ _SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 
 
-def _profile_suffix() -> str:
+def _profile_suffix(hermes_home: str | Path | None = None) -> str:
     """Derive a service-name suffix from the current HERMES_HOME.
 
     Returns ``""`` for the default root, the profile name for
@@ -1266,7 +1266,7 @@ def _profile_suffix() -> str:
     import hashlib
     import re
     from hermes_constants import get_default_hermes_root
-    home = get_hermes_home().resolve()
+    home = Path(hermes_home or str(get_hermes_home())).resolve()
     default = get_default_hermes_root().resolve()
     if home == default:
         return ""
@@ -1311,22 +1311,25 @@ def _profile_arg(hermes_home: str | None = None) -> str:
     return ""
 
 
-def get_service_name() -> str:
-    """Derive a systemd service name scoped to this HERMES_HOME.
+def get_service_name(hermes_home: str | Path | None = None) -> str:
+    """Derive a systemd service name scoped to a Hermes home path.
 
     Default ``~/.hermes`` returns ``hermes-gateway`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` returns ``hermes-gateway-coder``.
     Any other HERMES_HOME appends a short hash for uniqueness.
     """
-    suffix = _profile_suffix()
+    suffix = _profile_suffix(hermes_home=hermes_home)
     if not suffix:
         return _SERVICE_BASE
     return f"{_SERVICE_BASE}-{suffix}"
 
 
 
-def get_systemd_unit_path(system: bool = False) -> Path:
-    name = get_service_name()
+def get_systemd_unit_path(
+    system: bool = False,
+    hermes_home: str | Path | None = None,
+) -> Path:
+    name = get_service_name(hermes_home=hermes_home)
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
     return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -462,9 +462,41 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     """Check if a gateway is running for a given profile directory."""
     try:
         from gateway.status import get_running_pid
-        return get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None
+        if get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None:
+            return True
     except Exception:
-        return False
+        pass
+
+    try:
+        from hermes_cli import gateway as gateway_cli
+
+        if not gateway_cli.supports_systemd_services():
+            return False
+
+        service_name = gateway_cli.get_service_name(hermes_home=profile_dir)
+        for system in (False, True):
+            unit_path = gateway_cli.get_systemd_unit_path(
+                system=system,
+                hermes_home=profile_dir,
+            )
+            if not unit_path.exists():
+                continue
+            try:
+                result = gateway_cli._run_systemctl(
+                    ["is-active", service_name],
+                    system=system,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (RuntimeError, subprocess.TimeoutExpired):
+                continue
+            if result.stdout.strip() == "active":
+                return True
+    except Exception:
+        pass
+
+    return False
 
 
 def _count_skills(profile_dir: Path) -> int:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1141,6 +1141,72 @@ class TestEdgeCases:
             cleanup_stale=False,
         )
 
+    def test_gateway_running_check_falls_back_to_active_systemd_service(self, profile_env, monkeypatch):
+        """If the pid file is absent, detect an active profile service via systemd."""
+        from hermes_cli.profiles import _check_gateway_running
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        user_unit = tmp_path / "hermes-gateway.service"
+        user_unit.write_text("[Unit]\n")
+
+        with patch("gateway.status.get_running_pid", return_value=None):
+            monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
+            monkeypatch.setattr(
+                "hermes_cli.gateway.get_systemd_unit_path",
+                lambda system=False, hermes_home=None: user_unit if not system else tmp_path / "missing.service",
+            )
+            monkeypatch.setattr(
+                "hermes_cli.gateway._run_systemctl",
+                lambda args, system=False, **kwargs: MagicMock(stdout="active\n"),
+            )
+
+            assert _check_gateway_running(default_home) is True
+
+    def test_gateway_running_check_uses_profile_scoped_service_name(self, profile_env, monkeypatch):
+        """Named profiles should probe their own suffixed systemd unit name."""
+        from hermes_cli.profiles import _check_gateway_running
+        profile_dir = create_profile("coder", no_alias=True)
+        user_unit = profile_dir.parent.parent.parent / "hermes-gateway-coder.service"
+        user_unit.write_text("[Unit]\n")
+        seen = {}
+
+        with patch("gateway.status.get_running_pid", return_value=None):
+            monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
+            monkeypatch.setattr(
+                "hermes_cli.gateway.get_systemd_unit_path",
+                lambda system=False, hermes_home=None: user_unit if not system else profile_dir / "missing.service",
+            )
+
+            def _fake_run_systemctl(args, system=False, **kwargs):
+                seen["args"] = args
+                return MagicMock(stdout="active\n")
+
+            monkeypatch.setattr("hermes_cli.gateway._run_systemctl", _fake_run_systemctl)
+
+            assert _check_gateway_running(profile_dir) is True
+            assert seen["args"] == ["is-active", "hermes-gateway-coder"]
+
+    def test_gateway_running_check_keeps_false_when_service_inactive(self, profile_env, monkeypatch):
+        """An installed but inactive service should not be reported as running."""
+        from hermes_cli.profiles import _check_gateway_running
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        user_unit = tmp_path / "hermes-gateway.service"
+        user_unit.write_text("[Unit]\n")
+
+        with patch("gateway.status.get_running_pid", return_value=None):
+            monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
+            monkeypatch.setattr(
+                "hermes_cli.gateway.get_systemd_unit_path",
+                lambda system=False, hermes_home=None: user_unit if not system else tmp_path / "missing.service",
+            )
+            monkeypatch.setattr(
+                "hermes_cli.gateway._run_systemctl",
+                lambda args, system=False, **kwargs: MagicMock(stdout="inactive\n"),
+            )
+
+            assert _check_gateway_running(default_home) is False
+
     def test_profile_name_boundary_single_char(self):
         """Single alphanumeric character is valid."""
         validate_profile_name("a")


### PR DESCRIPTION
## Summary

`hermes profile list` and `hermes profile show <name>` could report `Gateway: stopped`
even when the gateway was actually running as a systemd-managed service.

This happened because profile status checks only looked at `gateway.pid`.
For host-side systemd setups, that could miss a live gateway that other Hermes
surfaces already detected correctly.

## What changed

- Extend `hermes_cli.gateway` service-name/unit-path helpers to accept an explicit `hermes_home`
- Update `hermes_cli.profiles._check_gateway_running()` to:
  - keep the existing `gateway.pid` check first
  - fall back to systemd service status when no PID-backed gateway is found
- Add regression coverage for:
  - default profile with active systemd user service
  - named profile with profile-scoped service name
  - installed but inactive service remaining `False`

## Reproduction

1. Run Hermes Gateway as a systemd user service
2. Confirm `hermes gateway status` reports it as running
3. Run `hermes profile list` or `hermes profile show default`

Before this change:
- profile surfaces could incorrectly show `Gateway: stopped`

After this change:
- profile surfaces correctly report the gateway as running

## Files changed

- `hermes_cli/gateway.py`
- `hermes_cli/profiles.py`
- `tests/hermes_cli/test_profiles.py`

## How to test

```bash
uv run pytest tests/hermes_cli/test_profiles.py -q -n0

110 passed