### PR TITLE
fix: improve gateway mention and Feishu delivery handling

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -589,10 +589,6 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
-        # In-memory cache of the bot's last message ID per channel, used by
-        # history backfill to skip the full scan on hot paths.  Falls back to
-        # scanning channel.history() on cache miss (cold start / restart).
-        self._last_self_message_id: Dict[str, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1462,12 +1458,6 @@ class DiscordAdapter(BasePlatformAdapter):
                     else:
                         raise
                 message_ids.append(str(msg.id))
-
-            # Track the last message we sent in this channel for history
-            # backfill — avoids a full channel.history() scan on hot paths.
-            if message_ids:
-                _target_id = thread_id or chat_id
-                self._last_self_message_id[_target_id] = message_ids[-1]
 
             return SendResult(
                 success=True,
@@ -3606,134 +3596,6 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
 
-    def _discord_history_backfill(self) -> bool:
-        """Return whether history backfill is enabled for shared sessions."""
-        configured = self.config.extra.get("history_backfill")
-        if configured is not None:
-            if isinstance(configured, str):
-                return configured.lower() not in ("false", "0", "no", "off")
-            return bool(configured)
-        return os.getenv("DISCORD_HISTORY_BACKFILL", "true").lower() in ("true", "1", "yes")
-
-    def _discord_history_backfill_limit(self) -> int:
-        """Return the max number of messages to scan backwards for context.
-
-        In practice the scan usually stops much earlier — at the bot's own
-        last message in the channel (the natural partition point).  This
-        limit is a safety cap for cold starts and long gaps where no prior
-        bot message exists in recent history.
-        """
-        configured = self.config.extra.get("history_backfill_limit")
-        if configured is not None:
-            try:
-                return int(configured)
-            except (ValueError, TypeError):
-                pass
-        raw = os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT", "50")
-        try:
-            return int(raw)
-        except (ValueError, TypeError):
-            return 50
-
-    async def _fetch_channel_context(
-        self,
-        channel: Any,
-        before: "DiscordMessage",
-    ) -> str:
-        """Fetch recent channel messages for conversational context.
-
-        Scans backwards from *before* and collects messages until it hits
-        a message sent by this bot (the natural partition point between
-        bot turns) or reaches ``history_backfill_limit``.
-
-        Returns a formatted block like::
-
-            [Recent channel messages]
-            [Alice] some message
-            [Bob [bot]] another message
-
-        Returns an empty string if no context is available.
-        """
-        limit = self._discord_history_backfill_limit()
-        if limit <= 0:
-            return ""
-
-        # Determine which bot messages to include in context
-        allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-        include_other_bots = allow_bots_raw != "none"
-
-        # Use the in-memory cache to narrow the fetch window on hot paths.
-        # If we know our last message ID in this channel, pass it as `after`
-        # to avoid scanning the full limit.  Falls back to scanning on cache
-        # miss (cold start / restart).
-        # Guard: only use the cache when it's chronologically before the
-        # trigger — Discord snowflake IDs are monotonically increasing, so
-        # a simple int comparison suffices.
-        channel_id = str(getattr(channel, "id", ""))
-        _cached_id = self._last_self_message_id.get(channel_id)
-        _after_obj = None
-        try:
-            if _cached_id and int(_cached_id) < int(before.id):
-                _after_obj = discord.Object(id=int(_cached_id))
-        except (ValueError, TypeError):
-            pass  # Malformed cache entry — fall back to cold-start scan
-
-        try:
-            collected = []
-            # IMPORTANT: pass oldest_first=False explicitly.  discord.py 2.x
-            # silently flips the default to True when `after=` is supplied,
-            # which would select the *earliest* N messages after our last
-            # response instead of the *latest* N before the trigger.  In
-            # high-traffic windows that returns stale tool traces and drops
-            # the actual final answer.  See the regression test
-            # `test_fetch_channel_context_cache_uses_latest_window_when_after_set`.
-            async for msg in channel.history(
-                limit=limit,
-                before=before,
-                after=_after_obj,
-                oldest_first=False,
-            ):
-                # Stop at our own message — this is the partition point.
-                # Everything before this is already in the session transcript.
-                # (Redundant when _after_obj is set, but needed for cold start.)
-                if msg.author == self._client.user:
-                    break
-
-                # Skip system messages (pins, joins, thread renames, etc.)
-                if msg.type not in (discord.MessageType.default, discord.MessageType.reply):
-                    continue
-
-                # Respect DISCORD_ALLOW_BOTS for other bots.
-                # For history context, "mentions" is treated as "all" — we are
-                # deciding what context to show, not whether to respond.
-                if getattr(msg.author, "bot", False) and not include_other_bots:
-                    continue
-
-                content = getattr(msg, "clean_content", msg.content) or ""
-                if not content and msg.attachments:
-                    content = "(attachment)"
-                if not content:
-                    continue
-
-                name = msg.author.display_name
-                if getattr(msg.author, "bot", False):
-                    name = f"{name} [bot]"
-                collected.append(f"[{name}] {content}")
-
-            if not collected:
-                return ""
-
-            # channel.history returns newest-first (oldest_first=False); reverse for chronological order
-            collected.reverse()
-            return "[Recent channel messages]\n" + "\n".join(collected)
-
-        except discord.Forbidden:
-            logger.debug("[%s] Missing permissions to fetch channel history", self.name)
-            return ""
-        except Exception as e:
-            logger.warning("[%s] Failed to fetch channel history: %s", self.name, e)
-            return ""
-
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
@@ -4032,84 +3894,6 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.send(embed=embed, view=view)
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
-            return SendResult(success=False, error=str(e))
-
-    async def send_clarify(
-        self,
-        chat_id: str,
-        question: str,
-        choices: Optional[list],
-        clarify_id: str,
-        session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> SendResult:
-        """Render a clarify prompt with one Discord button per choice.
-
-        Multi-choice mode (``choices`` non-empty): renders a button per option
-        plus a final "✏️ Other (type answer)" button. Picking "Other" flips
-        the clarify entry into text-capture mode so the next user message in
-        the session becomes the response. Numeric clicks resolve immediately
-        via ``resolve_gateway_clarify(clarify_id, choice_text)``.
-
-        Open-ended mode (``choices`` empty/None): renders the question as
-        plain embed text — no buttons. The gateway's text-intercept captures
-        the next message in this session and resolves the clarify.
-        """
-        if not self._client or not DISCORD_AVAILABLE:
-            return SendResult(success=False, error="Not connected")
-
-        try:
-            target_id = chat_id
-            if metadata and metadata.get("thread_id"):
-                target_id = metadata["thread_id"]
-
-            channel = self._client.get_channel(int(target_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(target_id))
-
-            # Discord embed description limit is 4096; trim conservatively.
-            max_desc = 4088
-            body = str(question or "").strip()
-            if len(body) > max_desc:
-                body = body[: max_desc - 3] + "..."
-
-            embed = discord.Embed(
-                title="❓ Hermes needs your input",
-                description=body,
-                color=discord.Color.orange(),
-            )
-
-            clean_choices = [
-                str(c).strip() for c in (choices or []) if c is not None and str(c).strip()
-            ]
-            # Discord allows up to 5 buttons per row, 5 rows per view = 25.
-            # We reserve one slot for the "Other" button, so cap at 24 choices.
-            clean_choices = clean_choices[:24]
-
-            if clean_choices:
-                embed.add_field(
-                    name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
-                    inline=False,
-                )
-                view = ClarifyChoiceView(
-                    choices=clean_choices,
-                    clarify_id=clarify_id,
-                    allowed_user_ids=self._allowed_user_ids,
-                    allowed_role_ids=self._allowed_role_ids,
-                )
-            else:
-                embed.add_field(
-                    name="Reply",
-                    value="Reply in this channel with your answer.",
-                    inline=False,
-                )
-                view = None
-
-            msg = await channel.send(embed=embed, view=view) if view else await channel.send(embed=embed)
-            return SendResult(success=True, message_id=str(msg.id))
-        except Exception as e:
-            logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
     async def send_update_prompt(
@@ -4418,6 +4202,34 @@ class DiscordAdapter(BasePlatformAdapter):
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
+
+        # Discord autocomplete can surface an app/bot role with the same display
+        # name as the bot.  Those mentions arrive as <@&role_id> in
+        # message.role_mentions, not message.mentions, so the normal bot-user
+        # mention gate above would ignore them.  Allow specific role IDs to act
+        # as aliases for this bot mention via discord.mention_role_ids or
+        # DISCORD_MENTION_ROLE_IDS (comma-separated).  Keep this opt-in so
+        # arbitrary role pings do not wake the bot.
+        role_mention_ids_raw = self.config.extra.get("mention_role_ids")
+        if role_mention_ids_raw is None:
+            role_mention_ids_raw = os.getenv("DISCORD_MENTION_ROLE_IDS", "")
+        if isinstance(role_mention_ids_raw, (list, tuple, set)):
+            mention_role_ids = {str(v).strip() for v in role_mention_ids_raw if str(v).strip()}
+        else:
+            mention_role_ids = {
+                part.strip()
+                for part in str(role_mention_ids_raw or "").split(",")
+                if part.strip()
+            }
+        if mention_role_ids:
+            role_mentions = getattr(message, "role_mentions", []) or []
+            matched_role_ids = {str(getattr(role, "id", "")) for role in role_mentions}
+            matched_role_ids &= mention_role_ids
+            if matched_role_ids:
+                mention_prefix = True
+                for role_id in matched_role_ids:
+                    normalized_content = normalized_content.replace(f"<@&{role_id}>", "").strip()
+                message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
@@ -4642,50 +4454,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
 
-        # ── History backfill ─────────────────────────────────────────
-        # When require_mention is active, the bot only processes messages
-        # that @mention it.  Messages in the channel between bot turns are
-        # invisible to the session transcript.  To recover that context,
-        # fetch recent channel history and prepend it to the user message.
-        #
-        # The fetch window is: everything after the bot's last message in
-        # the channel up to (but not including) the current trigger.  On
-        # cold start (no prior bot message found), fetch the last N messages
-        # and stop at the first self-message encountered.
-        #
-        # Threads naturally scope to thread-only history (channel.history()
-        # on a thread returns only that thread's messages).  DMs are skipped
-        # because every DM message triggers the bot — there's no mention gap
-        # to fill; the session transcript already has everything.
-        #
-        # Per-user sessions also benefit: Alice's session is missing the
-        # other-channel-participants' context, and her own messages from
-        # before she mentioned the bot.  Backfill fills that gap.
-        #
-        # Messages that arrive while the bot is processing (between trigger
-        # and response) are not captured — this is an accepted simplification
-        # to keep the partition rule clean.
-        _channel_context = None
-        _is_dm = isinstance(message.channel, discord.DMChannel)
-        if not _is_dm:
-            _needed_mention = (
-                require_mention
-                and not is_free_channel
-                and not in_bot_thread
-            )
-            _backfill_enabled = self._discord_history_backfill()
-            if _needed_mention and _backfill_enabled:
-                _backfill_text = await self._fetch_channel_context(
-                    message.channel, before=message,
-                )
-                if _backfill_text:
-                    _channel_context = _backfill_text
-
         # Defense-in-depth: prevent empty user messages from entering session
-        # (can happen when user sends @mention-only with no other text).
-        # When channel_context is present, a bare mention means "catch me up"
-        # — the context IS the message, so skip the placeholder.
-        if (not event_text or not event_text.strip()) and not _channel_context:
+        # (can happen when user sends @mention-only with no other text)
+        if not event_text or not event_text.strip():
             event_text = "(The user sent a message with no text content)"
 
         _chan = message.channel
@@ -4714,7 +4485,6 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
-            channel_context=_channel_context,
         )
 
         # Track thread participation so the bot won't require @mention for
@@ -5396,188 +5166,3 @@ if DISCORD_AVAILABLE:
         async def on_timeout(self):
             self.resolved = True
             self.clear_items()
-
-
-    class ClarifyChoiceView(discord.ui.View):
-        """Interactive button view for the clarify tool's multiple-choice prompts.
-
-        Renders one button per choice (max 24) plus a final ``✏️ Other`` button.
-        Picking a numeric choice resolves the gateway clarify entry immediately;
-        picking ``Other`` flips the entry into text-capture mode so the next
-        user message in the session becomes the response (the gateway's
-        text-intercept handles the resolution).
-
-        Auth gating mirrors ``ExecApprovalView`` — only users/roles in the
-        Discord adapter's allowlist may answer. Single-use: after the first
-        valid click all buttons disable and the embed updates to show who
-        answered and what they chose.
-        """
-
-        def __init__(
-            self,
-            choices: List[str],
-            clarify_id: str,
-            allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
-        ):
-            super().__init__(timeout=300)  # 5-minute timeout
-            self.choices = list(choices)[:24]
-            self.clarify_id = clarify_id
-            self.allowed_user_ids = allowed_user_ids
-            self.allowed_role_ids = allowed_role_ids or set()
-            self.resolved = False
-
-            for index, choice in enumerate(self.choices):
-                # Discord button labels are capped at 80 chars.
-                label_body = choice if len(choice) <= 75 else choice[:72] + "..."
-                button = discord.ui.Button(
-                    label=f"{index + 1}. {label_body}",
-                    style=discord.ButtonStyle.primary,
-                    custom_id=f"clarify:{clarify_id}:{index}",
-                )
-                button.callback = self._make_choice_callback(index, choice)
-                self.add_item(button)
-
-            other_btn = discord.ui.Button(
-                label="✏️ Other (type answer)",
-                style=discord.ButtonStyle.secondary,
-                custom_id=f"clarify:{clarify_id}:other",
-            )
-            other_btn.callback = self._on_other
-            self.add_item(other_btn)
-
-        def _check_auth(self, interaction: "discord.Interaction") -> bool:
-            return _component_check_auth(
-                interaction, self.allowed_user_ids, self.allowed_role_ids,
-            )
-
-        def _make_choice_callback(self, index: int, choice: str):
-            async def _callback(interaction: "discord.Interaction"):
-                await self._resolve_choice(interaction, index, choice)
-            return _callback
-
-        async def _resolve_choice(
-            self,
-            interaction: "discord.Interaction",
-            index: int,
-            choice: str,
-        ) -> None:
-            """Resolve the clarify with a chosen option."""
-            if self.resolved:
-                await interaction.response.send_message(
-                    "This prompt has already been answered~", ephemeral=True,
-                )
-                return
-            if not self._check_auth(interaction):
-                await interaction.response.send_message(
-                    "You're not authorized to answer this prompt~", ephemeral=True,
-                )
-                return
-
-            self.resolved = True
-            for child in self.children:
-                child.disabled = True
-
-            embed = interaction.message.embeds[0] if (
-                interaction.message and interaction.message.embeds
-            ) else None
-            if embed:
-                user = getattr(interaction, "user", None)
-                display_name = getattr(user, "display_name", "user")
-                embed.color = discord.Color.green()
-                embed.set_footer(text=f"Answered by {display_name}: {choice}")
-
-            try:
-                await interaction.response.edit_message(embed=embed, view=self)
-            except Exception:
-                logger.debug(
-                    "Discord clarify edit_message failed for %s",
-                    self.clarify_id,
-                    exc_info=True,
-                )
-                try:
-                    await interaction.response.defer()
-                except Exception:
-                    pass
-
-            # Resolve via the gateway clarify primitive — same mechanism as
-            # Telegram. Look up the canonical choice text from the entry so
-            # we round-trip the original value, not a button-label variant.
-            resolved_text: Optional[str] = None
-            try:
-                from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
-                entry = _clarify_entries.get(self.clarify_id)
-                if entry and entry.choices and 0 <= index < len(entry.choices):
-                    resolved_text = entry.choices[index]
-            except Exception:
-                resolved_text = None
-            if resolved_text is None:
-                resolved_text = choice
-
-            try:
-                from tools.clarify_gateway import resolve_gateway_clarify
-                resolved = resolve_gateway_clarify(self.clarify_id, resolved_text)
-                logger.info(
-                    "Discord clarify button resolved (id=%s, choice=%r, user=%s, ok=%s)",
-                    self.clarify_id, resolved_text,
-                    getattr(getattr(interaction, "user", None), "display_name", "?"),
-                    resolved,
-                )
-            except Exception as exc:
-                logger.error(
-                    "Discord clarify resolve_gateway_clarify failed (id=%s): %s",
-                    self.clarify_id, exc,
-                )
-
-        async def _on_other(self, interaction: "discord.Interaction") -> None:
-            """Flip the clarify entry into text-capture mode."""
-            if self.resolved:
-                await interaction.response.send_message(
-                    "This prompt has already been answered~", ephemeral=True,
-                )
-                return
-            if not self._check_auth(interaction):
-                await interaction.response.send_message(
-                    "You're not authorized to answer this prompt~", ephemeral=True,
-                )
-                return
-
-            # Don't pop the entry — the gateway's text-intercept needs it
-            # until the user actually types. Just mark it as awaiting text
-            # and disable the buttons so the user can't double-click.
-            try:
-                from tools.clarify_gateway import mark_awaiting_text
-                mark_awaiting_text(self.clarify_id)
-            except Exception as exc:
-                logger.warning(
-                    "Discord clarify mark_awaiting_text failed (id=%s): %s",
-                    self.clarify_id, exc,
-                )
-
-            self.resolved = True
-            for child in self.children:
-                child.disabled = True
-
-            embed = interaction.message.embeds[0] if (
-                interaction.message and interaction.message.embeds
-            ) else None
-            if embed:
-                user = getattr(interaction, "user", None)
-                display_name = getattr(user, "display_name", "user")
-                embed.color = discord.Color.blue()
-                embed.set_footer(
-                    text=f"Awaiting typed response from {display_name}…",
-                )
-
-            try:
-                await interaction.response.edit_message(embed=embed, view=self)
-            except Exception:
-                try:
-                    await interaction.response.defer()
-                except Exception:
-                    pass
-
-        async def on_timeout(self):
-            self.resolved = True
-            for child in self.children:
-                child.disabled = True

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -154,7 +154,8 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Feishu post-type 'md' elements do not render tables, so we wrap table blocks
+# in fenced text code blocks before sending as post markdown.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -556,6 +557,77 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _is_markdown_table_separator(line: str) -> bool:
+    stripped = line.strip()
+    return bool(
+        stripped.startswith("|")
+        and stripped.endswith("|")
+        and re.fullmatch(r"[|:\- ]+", stripped)
+    )
+
+
+def _looks_like_markdown_table_start(lines: List[str], index: int) -> bool:
+    if index + 1 >= len(lines):
+        return False
+    header = lines[index].strip()
+    if not (header.startswith("|") and header.endswith("|")):
+        return False
+    return _is_markdown_table_separator(lines[index + 1])
+
+
+def _wrap_markdown_tables_as_code_blocks(content: str) -> str:
+    """Wrap markdown table blocks in fenced text code blocks for Feishu.
+
+    Feishu post markdown does not render GitHub-Flavored Markdown tables and can
+    render them as blank content. A fenced text block is the lowest-risk fallback:
+    it keeps the table readable without changing message type to interactive
+    cards, and leaves non-table markdown outside the table intact.
+    """
+    if not content or not _MARKDOWN_TABLE_RE.search(content):
+        return content
+
+    lines = content.splitlines()
+    output: List[str] = []
+    index = 0
+    in_code_block = False
+
+    while index < len(lines):
+        line = lines[index]
+        stripped_line = line.strip()
+        is_fence = bool(
+            _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line)
+            if in_code_block
+            else _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
+        )
+        if is_fence:
+            in_code_block = not in_code_block
+            output.append(line)
+            index += 1
+            continue
+
+        if not in_code_block and _looks_like_markdown_table_start(lines, index):
+            while output and output[-1] == "":
+                output.pop()
+            output.append("```text")
+            while index < len(lines):
+                table_line = lines[index]
+                if not table_line.strip():
+                    break
+                if "|" not in table_line:
+                    break
+                output.append(table_line)
+                index += 1
+            output.append("```")
+            if index < len(lines) and not lines[index].strip():
+                index += 1
+            continue
+
+        output.append(line)
+        index += 1
+
+    return "\n".join(output)
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -2273,7 +2345,11 @@ class FeishuAdapter(BasePlatformAdapter):
                     daemon=True,
                 ).start()
             return
-        self._submit_on_loop(loop, self._handle_message_event_data(data))
+        future = asyncio.run_coroutine_threadsafe(
+            self._handle_message_event_data(data),
+            loop,
+        )
+        future.add_done_callback(self._log_background_failure)
 
     def _enqueue_pending_inbound_event(self, data: Any) -> bool:
         """Append an event to the pending-inbound queue.
@@ -2349,12 +2425,16 @@ class FeishuAdapter(BasePlatformAdapter):
                     dispatched = 0
                     requeue: List[Any] = []
                     for event in batch:
-                        if self._submit_on_loop(
-                            loop, self._handle_message_event_data(event)
-                        ):
+                        try:
+                            fut = asyncio.run_coroutine_threadsafe(
+                                self._handle_message_event_data(event),
+                                loop,
+                            )
+                            fut.add_done_callback(self._log_background_failure)
                             dispatched += 1
-                        else:
-                            # Loop closed/unavailable — requeue and poll again.
+                        except RuntimeError:
+                            # Loop closed between check and submit — requeue
+                            # and poll again.
                             requeue.append(event)
                     if requeue:
                         with self._pending_inbound_lock:
@@ -2458,10 +2538,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._loop_accepts_callbacks(loop):
             logger.warning("[Feishu] Dropping drive comment event before adapter loop is ready")
             return
-        self._submit_on_loop(
-            loop,
+        future = asyncio.run_coroutine_threadsafe(
             handle_drive_comment_event(self._client, data, self_open_id=self._bot_open_id),
+            loop,
         )
+        future.add_done_callback(self._log_background_failure)
 
     def _on_reaction_event(self, event_type: str, data: Any) -> None:
         """Route user reactions on bot messages as synthetic text events."""
@@ -2489,7 +2570,11 @@ class FeishuAdapter(BasePlatformAdapter):
             or bool(getattr(loop, "is_closed", lambda: False)())
         ):
             return
-        self._submit_on_loop(loop, self._handle_reaction_event(event_type, data))
+        future = asyncio.run_coroutine_threadsafe(
+            self._handle_reaction_event(event_type, data),
+            loop,
+        )
+        future.add_done_callback(self._log_background_failure)
 
     def _on_card_action_trigger(self, data: Any) -> Any:
         """Handle card-action callback from the Feishu SDK (synchronous).
@@ -2535,14 +2620,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _submit_on_loop(self, loop: Any, coro: Any) -> bool:
         """Schedule background work on the adapter loop with shared failure logging."""
-        from agent.async_utils import safe_schedule_threadsafe
-        future = safe_schedule_threadsafe(
-            coro, loop,
-            logger=logger,
-            log_message="[Feishu] Failed to schedule background callback work",
-            log_level=logging.WARNING,
-        )
-        if future is None:
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception:
+            coro.close()
+            logger.warning("[Feishu] Failed to schedule background callback work", exc_info=True)
             return False
         future.add_done_callback(self._log_background_failure)
         return True
@@ -4223,11 +4305,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # table content as post can appear blank. Keep the message type as post
+        # but wrap table blocks in fenced text code blocks so the content stays
+        # readable without switching to interactive cards.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            safe_content = _wrap_markdown_tables_as_code_blocks(content)
+            return "post", _build_markdown_post_payload(safe_content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
@@ -4308,7 +4391,14 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> Any:
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
-            effective_reply_to = metadata.get("reply_to_message_id")
+            # Cron / send_message explicit targets are encoded as
+            # feishu:<chat_id>:<thread_id>.  For Feishu topics the thread_id
+            # observed in inbound events is usually the root message ID
+            # (``om_...``).  The reliable API path is therefore
+            # ``message.reply(root_message_id, reply_in_thread=True)``.  Trying
+            # to create with receive_id_type="thread_id" can be rejected by
+            # Feishu with [99992402] field validation failed.
+            effective_reply_to = metadata.get("reply_to_message_id") or metadata.get("thread_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
         if effective_reply_to:
             body = self._build_reply_message_body(

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -86,12 +86,13 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None):
     author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
@@ -144,6 +145,47 @@ async def test_non_ignored_channel_processes_normally(adapter, monkeypatch):
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_configured_role_mention_satisfies_require_mention(adapter, monkeypatch):
+    """Opt-in role mentions can act as bot mention aliases."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_MENTION_ROLE_IDS", "1504407943003639891")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    role = SimpleNamespace(id=1504407943003639891)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="<@&1504407943003639891> fix bug",
+        role_mentions=[role],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "fix bug"
+    assert message.content == "fix bug"
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_role_mention_does_not_satisfy_require_mention(adapter, monkeypatch):
+    """Unconfigured role pings must not wake the bot."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_MENTION_ROLE_IDS", "1504407943003639891")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    role = SimpleNamespace(id=999)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=700),
+        content="<@&999> fix bug",
+        role_mentions=[role],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2002,6 +2002,45 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_thread_id_as_reply_target_for_cron_topic_delivery(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+            def create(self, request):  # pragma: no cover - should not be used
+                raise AssertionError("thread topic delivery should reply to the root message, not create by thread_id")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="cron update",
+                    metadata={"thread_id": "om_topic_root"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].message_id, "om_topic_root")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -2547,6 +2586,56 @@ class TestAdapterBehavior(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         elements = payload["zh_cn"]["content"][0]
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_wraps_markdown_tables_in_code_fences(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table_as_code"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "结果如下：\n\n| 名称 | 数值 |\n| --- | --- |\n| A | 1 |\n\n**结论**：正常"
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        rows = payload["zh_cn"]["content"]
+        self.assertEqual(
+            rows,
+            [
+                [{"tag": "md", "text": "结果如下："}],
+                [{"tag": "md", "text": "```text\n| 名称 | 数值 |\n| --- | --- |\n| A | 1 |\n```"}],
+                [{"tag": "md", "text": "**结论**：正常"}],
+            ],
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):


### PR DESCRIPTION
## Summary
- Allow configured Discord role mentions to satisfy the require-mention gate (`discord.mention_role_ids` / `DISCORD_MENTION_ROLE_IDS`) while ignoring unconfigured role pings.
- Keep Feishu markdown table messages as post payloads by wrapping table blocks in fenced text code blocks instead of falling back to text.
- Use Feishu topic `thread_id` as the reply target for explicit topic delivery when no `reply_to_message_id` is available.

## Test Plan
- [x] `python -m ruff check gateway/platforms/discord.py gateway/platforms/feishu.py tests/gateway/test_feishu.py tests/gateway/test_discord_channel_controls.py`
- [x] `pytest tests/gateway/test_feishu.py tests/gateway/test_discord_channel_controls.py -q` (216 passed)
- [x] Static security scan on staged diff: clean
- [x] Independent code review subagent: passed
