### PR TITLE
fix: harden URL safety and cron ticker watchdog

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16359,6 +16359,67 @@ class GatewayRunner:
         return response
 
 
+def _spawn_cron_ticker_thread(
+    stop_event: threading.Event,
+    adapters=None,
+    loop=None,
+    interval: int = 60,
+) -> threading.Thread:
+    """Start a cron ticker thread and return it."""
+    thread = threading.Thread(
+        target=_start_cron_ticker,
+        args=(stop_event,),
+        kwargs={"adapters": adapters, "loop": loop, "interval": interval},
+        daemon=True,
+        name="cron-ticker",
+    )
+    thread.start()
+    return thread
+
+
+def _cron_ticker_watchdog_step(
+    stop_event: threading.Event,
+    ticker_state: dict,
+    restart_ticker,
+) -> bool:
+    """Check whether the cron ticker is still alive and restart if needed.
+
+    Returns False when the watchdog should stop (shutdown requested), otherwise
+    True so the caller can keep monitoring.
+    """
+    if stop_event.is_set():
+        return False
+
+    ticker_thread = ticker_state.get("thread")
+    if ticker_thread is None or ticker_thread.is_alive():
+        return True
+
+    logger.critical("Cron ticker watchdog detected a dead ticker thread; restarting it")
+    new_thread = restart_ticker()
+    ticker_state["thread"] = new_thread
+    logger.info("Cron ticker watchdog restarted the cron ticker thread")
+    return True
+
+
+def _start_cron_ticker_watchdog(
+    stop_event: threading.Event,
+    ticker_state: dict,
+    restart_ticker,
+    check_interval: int = 30,
+):
+    """Monitor the cron ticker thread and restart it if it dies unexpectedly."""
+    logger.info("Cron ticker watchdog started (interval=%ds)", check_interval)
+    try:
+        while not stop_event.wait(timeout=check_interval):
+            _cron_ticker_watchdog_step(stop_event, ticker_state, restart_ticker)
+    except Exception as exc:
+        logger.critical("Cron ticker watchdog failed: %s", exc, exc_info=True)
+        stop_event.set()
+        os._exit(1)
+    finally:
+        logger.info("Cron ticker watchdog stopped")
+
+
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
     """
     Background thread that ticks the cron scheduler at a regular interval.
@@ -16775,14 +16836,30 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Start background cron ticker so scheduled jobs fire automatically.
     # Pass the event loop so cron delivery can use live adapters (E2EE support).
     cron_stop = threading.Event()
-    cron_thread = threading.Thread(
-        target=_start_cron_ticker,
-        args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
+    event_loop = asyncio.get_running_loop()
+    cron_thread_state = {
+        "thread": _spawn_cron_ticker_thread(
+            cron_stop,
+            adapters=runner.adapters,
+            loop=event_loop,
+        ),
+    }
+    cron_watchdog_thread = threading.Thread(
+        target=_start_cron_ticker_watchdog,
+        args=(
+            cron_stop,
+            cron_thread_state,
+            lambda: _spawn_cron_ticker_thread(
+                cron_stop,
+                adapters=runner.adapters,
+                loop=event_loop,
+            ),
+        ),
+        kwargs={"check_interval": 30},
         daemon=True,
-        name="cron-ticker",
+        name="cron-ticker-watchdog",
     )
-    cron_thread.start()
+    cron_watchdog_thread.start()
     
     # Wait for shutdown
     await runner.wait_for_shutdown()
@@ -16794,7 +16871,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     
     # Stop cron ticker cleanly
     cron_stop.set()
-    cron_thread.join(timeout=5)
+    cron_thread_state["thread"].join(timeout=5)
+    cron_watchdog_thread.join(timeout=5)
 
     # Close MCP server connections
     try:

--- a/tests/gateway/test_cron_ticker_watchdog.py
+++ b/tests/gateway/test_cron_ticker_watchdog.py
@@ -1,0 +1,52 @@
+"""Tests for the cron ticker watchdog used by the gateway."""
+
+import threading
+from unittest.mock import MagicMock
+
+from gateway.run import _cron_ticker_watchdog_step
+
+
+class FakeThread:
+    def __init__(self, alive: bool):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+class TestCronTickerWatchdogStep:
+    def test_live_ticker_does_not_restart(self):
+        stop_event = threading.Event()
+        ticker_thread = FakeThread(True)
+        ticker_state = {"thread": ticker_thread}
+        restart_ticker = MagicMock()
+
+        result = _cron_ticker_watchdog_step(stop_event, ticker_state, restart_ticker)
+
+        assert result is True
+        restart_ticker.assert_not_called()
+        assert ticker_state["thread"] is ticker_thread
+
+    def test_dead_ticker_is_restarted(self):
+        stop_event = threading.Event()
+        old_thread = FakeThread(False)
+        new_thread = FakeThread(True)
+        ticker_state = {"thread": old_thread}
+        restart_ticker = MagicMock(return_value=new_thread)
+
+        result = _cron_ticker_watchdog_step(stop_event, ticker_state, restart_ticker)
+
+        assert result is True
+        restart_ticker.assert_called_once()
+        assert ticker_state["thread"] is new_thread
+
+    def test_shutdown_event_stops_watchdog_step(self):
+        stop_event = threading.Event()
+        stop_event.set()
+        ticker_state = {"thread": FakeThread(False)}
+        restart_ticker = MagicMock()
+
+        result = _cron_ticker_watchdog_step(stop_event, ticker_state, restart_ticker)
+
+        assert result is False
+        restart_ticker.assert_not_called()

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -75,6 +75,27 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("http://[::1]:8080/") is False
 
+    def test_ipv6_scope_id_is_stripped_and_blocked(self):
+        """IPv6 scope IDs should not bypass SSRF checks."""
+        real_ip_address = ipaddress.ip_address
+
+        def fake_ip_address(value):
+            if "%" in value:
+                raise ValueError("scope IDs are not accepted by this parser")
+            return real_ip_address(value)
+
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("fe80::1%eth0", 0, 0, 2)),
+        ]), patch("tools.url_safety.ipaddress.ip_address", side_effect=fake_ip_address):
+            assert is_safe_url("http://[fe80::1%25eth0]/") is False
+
+    def test_unparseable_ipv6_after_scope_strip_blocks(self):
+        """If the normalized IP is still invalid, fail closed."""
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("not-an-ip%eth0", 0, 0, 2)),
+        ]), patch("tools.url_safety.ipaddress.ip_address", side_effect=ValueError("bad ip")):
+            assert is_safe_url("http://invalid.example/") is False
+
     def test_dns_failure_blocked(self):
         """DNS failures now fail closed — block the request."""
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -135,6 +135,20 @@ def _reset_allow_private_cache() -> None:
     _cached_allow_private = False
 
 
+def _normalize_ip_candidate(ip_str: str) -> str:
+    """Strip IPv6 scope IDs before parsing.
+
+    Some platforms surface link-local IPv6 addresses as ``fe80::1%eth0`` or
+    similar scope-qualified strings. ``ipaddress.ip_address()`` accepts some of
+    these forms, but not all interpreter / stdlib combinations do. We normalize
+    them to the bare address first so the security check behaves consistently.
+    """
+    candidate = (ip_str or "").strip()
+    if "%" in candidate:
+        candidate = candidate.split("%", 1)[0].strip()
+    return candidate
+
+
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True if the IP should be blocked for SSRF protection."""
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
@@ -290,10 +304,15 @@ def is_safe_url(url: str) -> bool:
 
         for family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
+            ip_candidate = _normalize_ip_candidate(ip_str)
             try:
-                ip = ipaddress.ip_address(ip_str)
+                ip = ipaddress.ip_address(ip_candidate)
             except ValueError:
-                continue
+                logger.warning(
+                    "Blocked request — unparseable address for %s: %s",
+                    hostname, ip_str,
+                )
+                return False
 
             # Always block cloud metadata IPs and link-local, even with toggle on
             if ip in _ALWAYS_BLOCKED_IPS or any(ip in net for net in _ALWAYS_BLOCKED_NETWORKS):
@@ -306,7 +325,7 @@ def is_safe_url(url: str) -> bool:
             if not allow_all_private and not allow_private_ip and _is_blocked_ip(ip):
                 logger.warning(
                     "Blocked request to private/internal address: %s -> %s",
-                    hostname, ip_str,
+                    hostname, ip_candidate,
                 )
                 return False
 

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -102,7 +102,7 @@ tick()
 
 ### Gateway Integration
 
-In gateway mode, the scheduler runs in a dedicated background thread (`_start_cron_ticker` in `gateway/run.py`) that calls `scheduler.tick()` every 60 seconds alongside message handling.
+In gateway mode, the scheduler runs in a dedicated background cron ticker thread (`_start_cron_ticker` in `gateway/run.py`) that calls `scheduler.tick()` on a periodic cycle alongside message handling. A watchdog thread monitors that ticker and restarts it automatically if it dies.
 
 In CLI mode, cron jobs only fire when `hermes cron` commands are run or during active CLI sessions.
 


### PR DESCRIPTION
## Summary
- Backport IPv6 scope-ID hardening for URL safety checks.
- Add cron ticker watchdog so a dead gateway ticker is restarted automatically.

## Verification
- `python3 -m pytest -q tests/tools/test_url_safety.py tests/gateway/test_cron_ticker_watchdog.py`
- Result: 104 passed

## Notes
- Evaluated additional web_tools changes for upstreaming, but excluded them because they do not cherry-pick cleanly against current upstream main.