### PR TITLE
fix(feishu): refetch stubbed card messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3464,6 +3464,10 @@ class FeishuAdapter(BasePlatformAdapter):
             mentions=getattr(message, "mentions", None),
             bot=self._bot_identity(),
         )
+        if self._should_refetch_interactive_message(raw_content, normalized) and message_id:
+            fetched = await self._fetch_message_normalized(message_id)
+            if self._should_prefer_fetched_message(normalized, fetched):
+                normalized = fetched
         media_urls, media_types = await self._download_feishu_message_resources(
             message_id=message_id,
             normalized=normalized,
@@ -3873,35 +3877,92 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to fetch bot names for %s", bot_ids, exc_info=True)
             return None
 
-    async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+    async def _fetch_message_normalized(self, message_id: str) -> Optional[FeishuNormalizedMessage]:
         if not self._client or not message_id:
             return None
-        if message_id in self._message_text_cache:
-            return self._message_text_cache[message_id]
         try:
             request = self._build_get_message_request(message_id)
             response = await asyncio.to_thread(self._client.im.v1.message.get, request)
             if not response or getattr(response, "success", lambda: False)() is False:
                 code = getattr(response, "code", "unknown")
                 msg = getattr(response, "msg", "message lookup failed")
-                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+                logger.warning("[Feishu] Failed to fetch message %s: [%s] %s", message_id, code, msg)
                 return None
             items = getattr(getattr(response, "data", None), "items", None) or []
-            parent = items[0] if items else None
-            body = getattr(parent, "body", None)
-            msg_type = getattr(parent, "msg_type", "") or ""
-            raw_content = getattr(body, "content", "") or ""
-            parent_mentions = getattr(parent, "mentions", None) if parent else None
-            text = self._extract_text_from_raw_content(
-                msg_type=msg_type,
-                raw_content=raw_content,
-                mentions=parent_mentions,
+            item = items[0] if items else None
+            if item is None:
+                return None
+            body = getattr(item, "body", None)
+            msg_type = (
+                getattr(item, "msg_type", "")
+                or getattr(item, "message_type", "")
+                or ""
             )
-            self._message_text_cache[message_id] = text
-            return text
+            raw_content = (
+                getattr(body, "content", "")
+                or getattr(item, "content", "")
+                or ""
+            )
+            mentions = getattr(item, "mentions", None)
+            return normalize_feishu_message(
+                message_type=msg_type,
+                raw_content=raw_content,
+                mentions=mentions,
+                bot=self._bot_identity(),
+            )
         except Exception:
-            logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
+            logger.warning("[Feishu] Failed to fetch message %s", message_id, exc_info=True)
             return None
+
+    @staticmethod
+    def _should_refetch_interactive_message(raw_content: str, normalized: FeishuNormalizedMessage) -> bool:
+        if normalized.raw_type not in {"interactive", "card"}:
+            return False
+        text = (normalized.text_content or "").strip()
+        if not text or text == FALLBACK_INTERACTIVE_TEXT:
+            return True
+        payload = _load_feishu_payload(raw_content)
+        card_payload = payload.get("card") if isinstance(payload.get("card"), dict) else payload
+        if not isinstance(card_payload, dict):
+            return True
+        return not any(key in card_payload for key in ("elements", "body", "i18n_elements"))
+
+    @staticmethod
+    def _should_prefer_fetched_message(
+        current: FeishuNormalizedMessage,
+        fetched: Optional[FeishuNormalizedMessage],
+    ) -> bool:
+        if fetched is None:
+            return False
+        fetched_text = (fetched.text_content or "").strip()
+        if not fetched_text:
+            return False
+        current_text = (current.text_content or "").strip()
+        if not current_text:
+            return True
+        if current_text == FALLBACK_INTERACTIVE_TEXT and fetched_text != current_text:
+            return True
+        if current.raw_type in {"interactive", "card"} and fetched.raw_type in {"interactive", "card"}:
+            return fetched_text != current_text and (
+                len(fetched_text) > len(current_text)
+                or ("\n" in fetched_text and "\n" not in current_text)
+            )
+        return False
+
+    async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+        if not self._client or not message_id:
+            return None
+        if message_id in self._message_text_cache:
+            return self._message_text_cache[message_id]
+        normalized = await self._fetch_message_normalized(message_id)
+        if normalized is None:
+            return None
+        text = normalized.text_content
+        if not text:
+            placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
+            text = str(placeholder).strip() if placeholder else ""
+        self._message_text_cache[message_id] = text
+        return text
 
     def _extract_text_from_raw_content(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1293,6 +1293,72 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, [])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_interactive_message_refetches_full_card_when_event_has_only_title(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def get(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        items=[
+                            SimpleNamespace(
+                                msg_type="interactive",
+                                body=SimpleNamespace(
+                                    content=json.dumps(
+                                        {
+                                            "card": {
+                                                "header": {"title": {"tag": "plain_text", "content": "saber-cn"}},
+                                                "elements": [
+                                                    {
+                                                        "tag": "div",
+                                                        "text": {
+                                                            "tag": "plain_text",
+                                                            "content": "完整卡片内容",
+                                                        },
+                                                    },
+                                                    {
+                                                        "tag": "action",
+                                                        "actions": [
+                                                            {
+                                                                "tag": "button",
+                                                                "text": {"tag": "plain_text", "content": "Open"},
+                                                            }
+                                                        ],
+                                                    },
+                                                ],
+                                            }
+                                        }
+                                    )
+                                ),
+                                mentions=None,
+                            )
+                        ]
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+        message = SimpleNamespace(
+            message_type="interactive",
+            content=json.dumps({"title": "saber-cn"}),
+            message_id="om_interactive_title_only",
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(text, "saber-cn\n完整卡片内容\nOpen\nActions: Open")
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_image_message_downloads_and_caches(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -1422,6 +1488,55 @@ class TestAdapterBehavior(unittest.TestCase):
 
         self.assertEqual(shared, "Shared chat: Platform Ops\nChat ID: oc_shared")
         self.assertEqual(attachment, "[Attachment: report.pdf]")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_fetch_message_text_handles_interactive_card_message_type_field(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _MessageAPI:
+            def get(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(
+                        items=[
+                            SimpleNamespace(
+                                message_type="interactive",
+                                body=SimpleNamespace(
+                                    content=json.dumps(
+                                        {
+                                            "card": {
+                                                "header": {"title": {"tag": "plain_text", "content": "Quoted Card"}},
+                                                "elements": [
+                                                    {
+                                                        "tag": "div",
+                                                        "text": {
+                                                            "tag": "plain_text",
+                                                            "content": "引用卡片正文",
+                                                        },
+                                                    }
+                                                ],
+                                            }
+                                        }
+                                    )
+                                ),
+                                mentions=None,
+                            )
+                        ]
+                    ),
+                )
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            text = asyncio.run(adapter._fetch_message_text("om_card_parent"))
+
+        self.assertEqual(text, "Quoted Card\n引用卡片正文")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_message_starting_with_slash_becomes_command(self):


### PR DESCRIPTION
## Summary
- Refetch inbound Feishu interactive/card messages via `im.v1.message.get` when receive events only include a card stub such as a title or `[Interactive message]`.
- Share the fetched-message normalization path with `reply_to_text` extraction so referenced/quoted card messages parse card bodies reliably.
- Add regression coverage for title-only card receive events and referenced card messages returned with a `message_type` field.

## Test plan
- `pytest tests/gateway/test_feishu.py::TestAdapterBehavior::test_extract_interactive_message_refetches_full_card_when_event_has_only_title -q` (fails before the implementation, passes after)
- `pytest tests/gateway/test_feishu.py::TestAdapterBehavior::test_extract_interactive_message_refetches_full_card_when_event_has_only_title tests/gateway/test_feishu.py::TestAdapterBehavior::test_fetch_message_text_handles_interactive_card_message_type_field tests/gateway/test_feishu.py::TestAdapterBehavior::test_extract_interactive_message_as_text_summary tests/gateway/test_feishu.py::TestAdapterBehavior::test_extract_text_from_raw_content_uses_relation_message_fallbacks -q`
- `pytest tests/gateway/test_feishu.py -q`
- `python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py`

## Review
- Codex code review: APPROVE