### PR TITLE
fix(cli): tolerate unreadable dirs when building systemd PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2103,6 +2103,19 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
+def _path_usable_bindir(path: Path) -> bool:
+    """True iff ``path`` exists as a dir and we could stat/read it.
+
+    systemd unit generation may run under simulated ``sudo`` in tests via
+    ``Path.home()`` → ``/root``; unprivileged users get ``PermissionError`` on
+    ``/root/.hermes/…`` probes. Missing/unreadable dirs are treated as absent.
+    """
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
@@ -2111,21 +2124,21 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _path_usable_bindir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _path_usable_bindir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _path_usable_bindir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _path_usable_bindir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2104,11 +2104,16 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
 
 
 def _path_usable_bindir(path: Path) -> bool:
-    """True iff ``path`` exists as a dir and we could stat/read it.
+    """True iff ``path.is_dir()`` succeeds and returns True.
+
+    This is a stat-style directory existence check (whatever ``Path.is_dir()``
+    resolves to on the platform); it does not iterate the directory or validate
+    readability beyond that probe.
 
     systemd unit generation may run under simulated ``sudo`` in tests via
     ``Path.home()`` → ``/root``; unprivileged users get ``PermissionError`` on
-    ``/root/.hermes/…`` probes. Missing/unreadable dirs are treated as absent.
+    ``/root/.hermes/…`` probes. Any ``OSError`` from ``is_dir()`` is treated as
+    "not usable" so PATH construction skips the entry instead of aborting.
     """
     try:
         return path.is_dir()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1197,6 +1197,29 @@ class TestDetectVenvDir:
         assert result is None
 
 
+class TestPathUsableBindir:
+    """Regression: optional PATH probes must not crash on inaccessible paths."""
+
+    def test_returns_false_when_is_dir_raises_permission_error(self):
+        from unittest.mock import MagicMock
+
+        p = MagicMock()
+        p.is_dir.side_effect = PermissionError(13, "Permission denied")
+        assert gateway_cli._path_usable_bindir(p) is False
+
+    def test_returns_false_when_is_dir_raises_oserror(self):
+        from unittest.mock import MagicMock
+
+        p = MagicMock()
+        p.is_dir.side_effect = OSError(5, "Input/output error")
+        assert gateway_cli._path_usable_bindir(p) is False
+
+    def test_returns_true_for_existing_directory(self, tmp_path):
+        d = tmp_path / "bin"
+        d.mkdir()
+        assert gateway_cli._path_usable_bindir(d) is True
+
+
 class TestSystemUnitHermesHome:
     """HERMES_HOME in system units must reference the target user, not root."""
 


### PR DESCRIPTION
## What does this PR do?

`generate_systemd_unit` calls `_build_service_path_dirs()`, which probes optional PATH entries via `Path.is_dir()`. Unit tests simulate `sudo` by patching `Path.home()` to `/root`, so Hermes paths resolve under `/root/.hermes/...`. Normal users cannot `stat` `/root`; that raised `PermissionError` and broke `TestSystemUnitHermesHome` (and CI on Linux runners).

Treat unreadable/absent probes like “not usable”: `_path_usable_bindir` wraps `.is_dir()` with `except OSError` so PATH construction skips those entries instead of failing.

## Related Issue

_CI-only / test breakage; no ticket linked._

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — add `_path_usable_bindir()`; use it in `_build_service_path_dirs()` instead of bare `.is_dir()`.

## How to Test

1. `pytest tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome -q`
2. Optional full suite sanity: ensure no regression in systemd unit generation PATH contents on a real Hermes checkout.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Ubuntu / WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

_Not applicable._

## Screenshots / Logs

_N/A_