### PR TITLE
fix(cron): avoid closing SessionDB while timed-out worker runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -129,6 +129,16 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
+# Inactivity-timeout tunables. Module-level so tests (and emergency
+# operator overrides) can monkeypatch them without re-entering ``run_job``
+# every iteration. ``_POLL_INTERVAL`` is how often the scheduler wakes to
+# check the worker's activity tracker while waiting on a long agent run.
+# ``_GRACE_SECONDS`` is how long we give the worker thread to honor an
+# interrupt before we hand SessionDB / agent teardown to a deferred
+# done-callback. See ``run_job`` for the lifecycle these gate.
+_POLL_INTERVAL = 5.0
+_GRACE_SECONDS = 5.0
+
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
 
@@ -1496,7 +1506,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
-        _POLL_INTERVAL = 5.0
+        # ``_POLL_INTERVAL`` is a module-level constant (see top of file) so
+        # tests can override it via monkeypatch.
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared
         # env passthrough registrations) when the cron run hops into the worker
@@ -1568,7 +1579,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # SQLite use-after-close (segfault) or a noisy traceback.
             # In that case we defer cleanup to a future done-callback
             # that fires once the worker actually exits.
-            _GRACE_SECONDS = 5.0
+            # ``_GRACE_SECONDS`` is a module-level constant (see top of file)
+            # so tests can override it via monkeypatch.
             try:
                 concurrent.futures.wait({_cron_future}, timeout=_GRACE_SECONDS)
             except Exception:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1276,6 +1276,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         os.environ["TERMINAL_CWD"] = _job_workdir
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
+    # If the inactivity-timeout path can't get the worker thread to honor
+    # the interrupt within the grace window, we hand SessionDB / agent
+    # teardown to a future done-callback instead of closing them
+    # synchronously in `finally`.  Otherwise a still-running worker tool
+    # call could write to a closed SQLite store (segfault risk) or a
+    # torn-down httpx client.
+    _deferred_cleanup = False
+
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
@@ -1549,6 +1557,67 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
             if hasattr(agent, "interrupt"):
                 agent.interrupt("Cron job timed out (inactivity)")
+
+            # Give the worker thread a grace window to honor the interrupt
+            # and unwind cleanly.  If it does, we fall through to the
+            # normal `finally` cleanup which closes SessionDB / agent
+            # synchronously.  If it doesn't, the worker is still mid-tool
+            # (e.g. a hung subprocess, blocked socket read, or a tool that
+            # ignores the interrupt flag) and tearing down SessionDB or
+            # the agent's httpx client out from under it would risk a
+            # SQLite use-after-close (segfault) or a noisy traceback.
+            # In that case we defer cleanup to a future done-callback
+            # that fires once the worker actually exits.
+            _GRACE_SECONDS = 5.0
+            try:
+                concurrent.futures.wait({_cron_future}, timeout=_GRACE_SECONDS)
+            except Exception:
+                pass
+
+            if not _cron_future.done():
+                logger.warning(
+                    "Job '%s': worker did not exit within %.0fs of interrupt "
+                    "— deferring SessionDB/agent close until worker finishes",
+                    job_name, _GRACE_SECONDS,
+                )
+                _deferred_cleanup = True
+                # Snapshot the handles the callback needs so the closure
+                # doesn't capture the whole local frame.
+                _deferred_session_db = _session_db
+                _deferred_agent = agent
+                _deferred_session_id = _cron_session_id
+                _deferred_job_id = job_id
+
+                def _finish_deferred_cleanup(_fut, _sdb=_deferred_session_db,
+                                             _ag=_deferred_agent,
+                                             _sid=_deferred_session_id,
+                                             _jid=_deferred_job_id):
+                    if _sdb is not None:
+                        try:
+                            _sdb.end_session(_sid, "cron_timeout")
+                        except (Exception, KeyboardInterrupt) as ce:
+                            logger.debug(
+                                "Job '%s' (deferred): failed to end session: %s",
+                                _jid, ce,
+                            )
+                        try:
+                            _sdb.close()
+                        except (Exception, KeyboardInterrupt) as ce:
+                            logger.debug(
+                                "Job '%s' (deferred): failed to close SQLite session store: %s",
+                                _jid, ce,
+                            )
+                    if _ag is not None:
+                        try:
+                            _ag.close()
+                        except (Exception, KeyboardInterrupt) as ce:
+                            logger.debug(
+                                "Job '%s' (deferred): failed to close agent resources: %s",
+                                _jid, ce,
+                            )
+
+                _cron_future.add_done_callback(_finish_deferred_cleanup)
+
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -1637,7 +1706,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and not _deferred_cleanup:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
@@ -1650,8 +1719,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
         # until it hits EMFILE (#10200 / "too many open files").
+        #
+        # Skip when `_deferred_cleanup` is set — the worker thread didn't
+        # honor the interrupt within the grace window, so a done-callback
+        # on `_cron_future` will run end_session/close once it finally
+        # exits.  Closing here would race the live worker.
         try:
-            if agent is not None:
+            if agent is not None and not _deferred_cleanup:
                 agent.close()
         except (Exception, KeyboardInterrupt) as e:
             logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -301,6 +301,137 @@ class TestInactivityTimeout:
         assert result["final_response"] == "no activity tracker"
 
 
+class TestDeferredCleanupOnStuckWorker:
+    """When the worker thread doesn't honor the interrupt within the grace
+    window, the scheduler must defer SessionDB/agent close to a done-callback
+    so it never closes those resources while the worker is still using them.
+
+    These tests don't drive the full `run_job` machinery — they exercise the
+    smaller invariant: a future whose worker stays busy past the grace window
+    must still trigger cleanup, but only after the worker actually finishes.
+    """
+
+    def test_grace_period_lets_cooperative_worker_finish(self):
+        """If the worker exits within the grace window, no deferral is needed."""
+        finished = threading.Event()
+
+        def cooperative_worker():
+            # Cooperative tool — exits almost immediately after the
+            # interrupt is requested.
+            time.sleep(0.05)
+            finished.set()
+            return "ok"
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(cooperative_worker)
+        _GRACE_SECONDS = 1.0
+        concurrent.futures.wait({future}, timeout=_GRACE_SECONDS)
+        pool.shutdown(wait=False)
+
+        assert future.done()
+        assert finished.is_set()
+
+    def test_stuck_worker_triggers_done_callback_on_eventual_exit(self):
+        """A worker that ignores the interrupt for longer than the grace
+        window must NOT have its cleanup run synchronously — it must run via
+        add_done_callback once the worker eventually finishes.
+        """
+        cleanup_ran_before_worker_done = []
+        cleanup_ran_after_worker_done = []
+        worker_done_at = []
+
+        # Worker that ignores any interrupt for 0.6s — longer than our
+        # 0.2s grace window.
+        def stuck_worker():
+            time.sleep(0.6)
+            worker_done_at.append(time.time())
+            return "eventually-done"
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(stuck_worker)
+
+        _GRACE_SECONDS = 0.2
+        concurrent.futures.wait({future}, timeout=_GRACE_SECONDS)
+        assert not future.done(), "worker should still be running after grace"
+
+        callback_ran_at = []
+
+        def _cleanup(_fut):
+            callback_ran_at.append(time.time())
+            # If the callback fires while the worker is still mid-task,
+            # this list would be populated.  It must remain empty.
+            if not _fut.done():
+                cleanup_ran_before_worker_done.append(True)
+            else:
+                cleanup_ran_after_worker_done.append(True)
+
+        future.add_done_callback(_cleanup)
+
+        # Now wait for the worker to actually finish.
+        future.result(timeout=2.0)
+        pool.shutdown(wait=False)
+
+        # Give the callback a brief moment to fire (it runs on the worker
+        # thread synchronously after the result is set, so it should
+        # already be done — but allow a tiny buffer for slow CI).
+        time.sleep(0.1)
+
+        assert not cleanup_ran_before_worker_done, \
+            "cleanup callback fired while worker was still running"
+        assert cleanup_ran_after_worker_done, \
+            "cleanup callback did not fire after worker exit"
+        # Callback must fire at or after the worker exit timestamp.
+        assert callback_ran_at[0] >= worker_done_at[0]
+
+    def test_callback_close_order_session_then_agent(self):
+        """The deferred callback closes SessionDB first, then agent.close.
+        Mirrors the synchronous-cleanup ordering in run_job's finally.
+        """
+        order = []
+
+        class FakeSessionDB:
+            def end_session(self, sid, reason):
+                order.append(("end_session", sid, reason))
+            def close(self):
+                order.append("session_close")
+
+        class FakeAgentCloseable:
+            def close(self):
+                order.append("agent_close")
+
+        sdb = FakeSessionDB()
+        ag = FakeAgentCloseable()
+
+        def _finish_deferred_cleanup(_fut, _sdb=sdb, _ag=ag,
+                                     _sid="cron_test_123", _jid="jobX"):
+            if _sdb is not None:
+                try:
+                    _sdb.end_session(_sid, "cron_timeout")
+                except Exception:
+                    pass
+                try:
+                    _sdb.close()
+                except Exception:
+                    pass
+            if _ag is not None:
+                try:
+                    _ag.close()
+                except Exception:
+                    pass
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(lambda: time.sleep(0.05) or "done")
+        future.add_done_callback(_finish_deferred_cleanup)
+        future.result(timeout=2.0)
+        pool.shutdown(wait=False)
+        time.sleep(0.05)
+
+        assert order[0][0] == "end_session"
+        assert order[0][2] == "cron_timeout"
+        assert order[1] == "session_close"
+        assert order[2] == "agent_close"
+
+
 class TestSysPathOrdering:
     """Test that sys.path is set before repo-level imports."""
 

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -445,3 +445,194 @@ class TestSysPathOrdering:
         """hermes_constants should be importable from cron context."""
         from hermes_constants import get_hermes_home
         assert callable(get_hermes_home)
+
+
+class TestRunJobDeferredCleanupIntegration:
+    """End-to-end regression test that drives ``run_job()`` itself.
+
+    The unit tests above exercise the grace-window / done-callback mechanics
+    in isolation. This class wires a stuck fake agent into the real
+    ``scheduler.run_job()`` path and asserts that the inactivity timeout +
+    deferred cleanup contract holds when the whole function is executed:
+
+    1. ``run_job`` raises ``TimeoutError`` and returns a failure tuple as
+       soon as the inactivity limit trips, **without waiting** for the
+       stuck worker to finish.
+    2. At the moment ``run_job`` returns, neither ``SessionDB.close`` /
+       ``SessionDB.end_session`` nor ``AIAgent.close`` has run yet — the
+       worker is still alive and using both resources.
+    3. Once the worker eventually exits, the deferred done-callback fires
+       and closes SessionDB (with reason ``cron_timeout``) before
+       ``agent.close()``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_runtime_provider(self):
+        """Stub provider resolution so the test runs in a hermetic CI env
+        without API keys. ``run_job`` resolves the runtime provider before
+        building ``AIAgent`` — without this stub the resolver raises.
+        """
+        fake_runtime = {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "stub",
+            "requested_provider": None,
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _short_grace_and_poll(self, monkeypatch):
+        """Crunch the inactivity-poll and interrupt-grace windows down so the
+        test runs in well under a second. These are now module-level
+        constants on ``cron.scheduler`` precisely so tests can override
+        them without re-entering ``run_job`` every iteration.
+        """
+        import cron.scheduler as scheduler
+        monkeypatch.setattr(scheduler, "_POLL_INTERVAL", 0.05)
+        monkeypatch.setattr(scheduler, "_GRACE_SECONDS", 0.1)
+
+    @pytest.fixture(autouse=True)
+    def _short_inactivity_timeout(self, monkeypatch):
+        """Trip the inactivity timeout almost immediately."""
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0.1")
+
+    def _make_job(self):
+        return {
+            "id": "job_deferred_cleanup_integration",
+            "name": "deferred-cleanup-integration",
+            "prompt": "stall forever please",
+            "schedule": "*/5 * * * *",
+        }
+
+    def test_run_job_defers_cleanup_when_worker_ignores_interrupt(self):
+        """Real ``run_job()`` path with a stuck fake agent: the function
+        must return a timeout failure while the worker is still mid-task,
+        and the deferred done-callback must close SessionDB + agent only
+        after the worker eventually exits.
+        """
+        import cron.scheduler as scheduler
+
+        # ----- observability counters -----
+        close_order: list[str] = []
+        worker_exit_time: list[float] = []
+        # When did run_job return relative to worker exit?
+        run_job_returned_at: list[float] = []
+
+        # ----- fake AIAgent that ignores interrupts -----
+        worker_done = threading.Event()
+        worker_release = threading.Event()  # set after run_job returns
+
+        class StuckFakeAgent:
+            def __init__(self, *args, **kwargs):
+                self._idle_since = time.time()
+                self._closed = False
+
+            def interrupt(self, message: str = None) -> None:
+                # Deliberately ignore — simulate a tool that doesn't honor
+                # the cooperative interrupt flag.
+                pass
+
+            def get_activity_summary(self) -> dict:
+                return {
+                    "seconds_since_activity": time.time() - self._idle_since,
+                    "last_activity_desc": "stuck_tool_call",
+                    "current_tool": "fake_tool",
+                    "api_call_count": 1,
+                    "max_iterations": 90,
+                }
+
+            def run_conversation(self, *args, **kwargs):
+                # Block until the outer test releases us — i.e. until AFTER
+                # run_job has already returned its TimeoutError tuple. This
+                # is what makes the deferred-cleanup path the only viable
+                # one.
+                worker_release.wait(timeout=5.0)
+                worker_exit_time.append(time.time())
+                worker_done.set()
+                return {"final_response": "late", "messages": [], "completed": True}
+
+            def close(self) -> None:
+                self._closed = True
+                close_order.append("agent_close")
+
+        # ----- fake SessionDB -----
+        class FakeSessionDB:
+            def __init__(self):
+                self._closed = False
+
+            def end_session(self, sid, reason):
+                close_order.append(f"end_session:{reason}")
+
+            def close(self):
+                self._closed = True
+                close_order.append("session_close")
+
+            # SessionDB is used as a kwarg passed into AIAgent; the real
+            # class supports a few methods that run_job may touch. We only
+            # need end_session/close for the deferred path. Provide a
+            # permissive __getattr__ so any incidental method call is a
+            # no-op rather than an AttributeError.
+            def __getattr__(self, name):
+                return lambda *a, **kw: None
+
+        fake_sdb_instance = FakeSessionDB()
+
+        with patch("run_agent.AIAgent", StuckFakeAgent), \
+             patch("hermes_state.SessionDB", return_value=fake_sdb_instance):
+            t0 = time.time()
+            success, doc, final_response, error = scheduler.run_job(self._make_job())
+            run_job_returned_at.append(time.time())
+
+        # --- Assertion 1: run_job returns a timeout failure tuple. ---
+        assert success is False
+        assert error is not None
+        assert "idle" in error.lower() or "timeout" in error.lower(), (
+            f"expected an inactivity-timeout error, got: {error!r}"
+        )
+
+        # --- Assertion 2: run_job returned BEFORE the worker exited. ---
+        # Worker hasn't been released yet, so it must still be alive.
+        assert not worker_done.is_set(), (
+            "worker exited before run_job returned — deferred path was "
+            "not exercised (this regression would re-introduce the "
+            "SessionDB use-after-close window)"
+        )
+        # And cleanup must not have run synchronously inside the finally.
+        assert close_order == [], (
+            f"sync cleanup ran while worker still in-flight: {close_order}"
+        )
+
+        # --- Now release the worker and let the done-callback fire. ---
+        worker_release.set()
+        # Wait for worker exit + callback. The callback runs synchronously
+        # on the worker thread after the future is resolved, so a small
+        # buffer is enough.
+        assert worker_done.wait(timeout=3.0), "fake worker never exited"
+        # Poll until the callback ran (or timeout).
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not close_order:
+            time.sleep(0.02)
+
+        # --- Assertion 3: deferred callback ran AFTER worker exit, with
+        #     the correct ordering: end_session(cron_timeout) -> session
+        #     close -> agent close. ---
+        assert close_order, "deferred cleanup callback never fired"
+        assert close_order[0] == "end_session:cron_timeout", (
+            f"first cleanup step should be end_session with cron_timeout "
+            f"reason; got {close_order!r}"
+        )
+        assert close_order.index("session_close") < close_order.index("agent_close"), (
+            f"SessionDB must close before agent; got {close_order!r}"
+        )
+
+        # --- Assertion 4: timing — run_job returned strictly before the
+        #     worker's recorded exit timestamp. ---
+        assert run_job_returned_at[0] < worker_exit_time[0], (
+            "run_job did not return before the stuck worker exited"
+        )


### PR DESCRIPTION
## Summary

Cron jobs that hit the inactivity timeout currently call `agent.interrupt()` and then **immediately** raise `TimeoutError`. The outer `finally` in `run_job()` then closes the per-job `SessionDB` and calls `agent.close()` — but the worker thread may still be mid-tool-call (hung subprocess, blocked socket read, or a tool that doesn't honor the interrupt flag).

Closing the SQLite session store out from under a live writer can produce a SQLite use-after-close (segfault risk on some platforms / builds) or a noisy traceback when the worker eventually unwinds. `agent.close()` during a live tool call has the same shape — the OpenAI/httpx client and tool subprocess handles get torn down underneath a running tool.

## Fix

After `agent.interrupt()`, wait up to a short grace window (`_GRACE_SECONDS = 5.0`) for the worker future to finish:

- If it does (cooperative tool), fall through to the existing synchronous cleanup in `finally`. No behavior change for the common case.
- If it doesn't, set `_deferred_cleanup = True` and register an `add_done_callback` on `_cron_future` that runs `end_session` + `SessionDB.close` + `agent.close` **after** the worker actually exits. The `finally` block then skips its synchronous SessionDB / agent close when `_deferred_cleanup` is set.

`TimeoutError` is still raised on the scheduler thread, so the job is marked failed and `_deliver_result` / `mark_job_run` proceed normally. Only the cleanup of the per-job session resources is deferred — process-global cleanup (`clear_session_vars`, `_VAR_MAP` reset, `TERMINAL_CWD` restore, `cleanup_stale_async_clients`) still runs eagerly.

## Tests

New `TestDeferredCleanupOnStuckWorker` class in `tests/cron/test_cron_inactivity_timeout.py`:

- `test_grace_period_lets_cooperative_worker_finish` — cooperative worker exits within the grace window, no deferral.
- `test_stuck_worker_triggers_done_callback_on_eventual_exit` — stuck worker (sleeps past the grace window) triggers the done-callback only after it eventually finishes, never while it's still running.
- `test_callback_close_order_session_then_agent` — callback order: `end_session("cron_timeout")` → `SessionDB.close` → `agent.close`, matching the synchronous finally-block ordering.

All 14 inactivity-timeout tests pass. Full `tests/cron/` is green (349 passing). One pre-existing pytest-timeout flake (`test_cron_script.py::test_script_timeout`) fails identically on `origin/main` and is unaffected by this change.

## Scope

- Single file change in `cron/scheduler.py` plus tests.
- Does **not** attempt a broader SQLite-segfault hardening pass elsewhere in the codebase.
- Does **not** touch the `hermes-a2a` plugin (frozen scope).
