### PR TITLE
fix(gateway): treat zombie scoped lock holders as stale

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -639,9 +639,12 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     live_cmdline = _read_process_cmdline(existing_pid)
                     if live_cmdline is not None or not _record_looks_like_gateway(existing):
                         stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still appear alive to _pid_exists but are not
-                # actually running. Treat them as stale so --replace works.
+                # Check if process is stopped (Ctrl+Z / SIGTSTP) or a zombie
+                # awaiting wait(2).  Both still satisfy ``_pid_exists`` because
+                # the kernel keeps the PID slot allocated, but neither is doing
+                # any work, so the lock must be treated as stale or future
+                # restarts deadlock waiting for a process that will never run
+                # again (issue #26651).
                 if not stale:
                     try:
                         _proc_status = Path(f"/proc/{existing_pid}/status")
@@ -649,7 +652,9 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                             for _line in _proc_status.read_text(encoding="utf-8").splitlines():
                                 if _line.startswith("State:"):
                                     _state = _line.split()[1]
-                                    if _state in {"T", "t"}:  # stopped or tracing stop
+                                    # T/t: stopped or tracing stop.
+                                    # Z/z: zombie / dead awaiting reap.
+                                    if _state in {"T", "t", "Z", "z"}:
                                         stale = True
                                     break
                     except (OSError, PermissionError):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -531,6 +531,88 @@ class TestScopedLocks:
         assert acquired is False
         assert existing["pid"] == 99999
 
+    @staticmethod
+    def _install_fake_proc_state(monkeypatch, target_pid: int, state_line: str) -> None:
+        """Make ``Path('/proc/<target_pid>/status').read_text()`` return
+        a synthetic block with the requested ``State:`` line, leaving
+        every other Path I/O (the test's own lock file etc.) untouched.
+        """
+        _proc_status = f"/proc/{target_pid}/status"
+        real_exists = status.Path.exists
+        real_read_text = status.Path.read_text
+
+        def fake_exists(self):
+            if str(self) == _proc_status:
+                return True
+            return real_exists(self)
+
+        def fake_read_text(self, encoding=None, errors=None):
+            if str(self) == _proc_status:
+                return f"Name:\tpython\n{state_line}\nTgid:\t{target_pid}\n"
+            kwargs = {}
+            if encoding is not None:
+                kwargs["encoding"] = encoding
+            if errors is not None:
+                kwargs["errors"] = errors
+            return real_read_text(self, **kwargs)
+
+        monkeypatch.setattr(status.Path, "exists", fake_exists)
+        monkeypatch.setattr(status.Path, "read_text", fake_read_text)
+
+    def test_acquire_scoped_lock_treats_zombie_pid_holder_as_stale(self, tmp_path, monkeypatch):
+        """Linux regression: zombie/dead processes are not eligible owners.
+
+        ``_pid_exists`` (psutil) returns True for ``Z``/``z`` state processes
+        because the kernel keeps the PID slot allocated until the parent
+        reaps the child.  A zombie is not running and cannot service any
+        platform — leaving its lock in place forces every subsequent
+        ``gateway run`` to fall back to ``--replace`` (issue #26651).
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 2611,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        self._install_fake_proc_state(monkeypatch, 2611, "State:\tZ (zombie)")
+
+        acquired, _ = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"},
+        )
+
+        assert acquired is True, "zombie-held lock must be reclaimable without --replace"
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+    def test_acquire_scoped_lock_treats_stopped_pid_holder_as_stale(self, tmp_path, monkeypatch):
+        """Pre-existing T/t coverage — kept alongside the zombie case so a
+        regression that drops one state from the set is obvious."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 4242,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        self._install_fake_proc_state(monkeypatch, 4242, "State:\tT (stopped)")
+
+        acquired, _ = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"},
+        )
+
+        assert acquired is True
+
     def test_acquire_scoped_lock_replaces_stale_record(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
         lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"


### PR DESCRIPTION
## What does this PR do?

Treats Linux `Z`/`z` zombie process states as stale owners for gateway scoped locks, so a crashed gateway whose PID still appears in the lock file but is actually a zombie (reaped state) no longer blocks new gateways from acquiring the scoped lock.

The existing stopped-process stale handling is preserved unchanged.

## Related Issue

Closes #26651

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Gateway scoped-lock owner check — `Z`/`z` zombie states now classified as stale, matching existing stopped-state handling
- Regression coverage for zombie-held and stopped PID-held scoped locks

## How to Test

1. `python3 -m pytest tests/gateway/test_status.py -q -n0`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
