### PR TITLE
feat: add OpenRouter image generation backend plugin

### DIFF
--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -1,0 +1,313 @@
+"""OpenRouter image generation backend.
+
+Uses OpenRouter's chat completions API with multimodal image-output models.
+Supported models:
+
+    google/gemini-3.1-flash-image-preview  ~5s   fast, cheap, good quality
+    google/gemini-3-pro-image-preview       ~10s  best quality, slower
+    openai/gpt-5.4-image-2                  ~20s  highest fidelity
+
+All models return base64 image data via chat completions with
+``modalities: ["image", "text"]``. Output saved under
+``$HERMES_HOME/cache/images/``.
+
+Selection precedence (first hit wins):
+1. ``OPENROUTER_IMAGE_MODEL`` env var
+2. ``image_gen.openrouter.model`` in ``config.yaml``
+3. ``image_gen.model`` in ``config.yaml``
+4. ``DEFAULT_MODEL`` — ``google/gemini-3.1-flash-image-preview``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "google/gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image",
+        "speed": "~5s",
+        "strengths": "Fast, cheap, good quality — daily driver",
+    },
+    "google/gemini-3-pro-image-preview": {
+        "display": "Gemini 3 Pro Image",
+        "speed": "~10s",
+        "strengths": "Best quality, slower — for important images",
+    },
+    "openai/gpt-5.4-image-2": {
+        "display": "GPT-5.4 Image 2",
+        "speed": "~20s",
+        "strengths": "Highest fidelity, best prompt adherence",
+    },
+}
+
+DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview"
+
+_ASPECT_TO_SIZE: Dict[str, str] = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
+
+OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+
+
+def _load_openrouter_config() -> Dict[str, Any]:
+    """Read ``image_gen`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use."""
+    env_override = os.environ.get("OPENROUTER_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_openrouter_config()
+    openrouter_cfg = cfg.get("openrouter") if isinstance(cfg.get("openrouter"), dict) else {}
+
+    candidate: Optional[str] = None
+    if isinstance(openrouter_cfg, dict):
+        value = openrouter_cfg.get("model")
+        if isinstance(value, str) and value in _MODELS:
+            candidate = value
+
+    if candidate is None:
+        top = cfg.get("model")
+        if isinstance(top, str) and top in _MODELS:
+            candidate = top
+
+    if candidate is not None:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _extract_image_from_response(resp_data: dict) -> Optional[str]:
+    """Extract base64 image data from an OpenRouter chat completion response.
+
+    Handles both ``images`` array (Gemini-style) and ``content`` parts (GPT-style).
+    Returns base64 data URL string or None.
+    """
+    choices = resp_data.get("choices", [])
+    if not choices:
+        return None
+    msg = choices[0].get("message", {})
+
+    # Gemini-style: images array
+    images = msg.get("images", [])
+    if images:
+        img = images[0]
+        if isinstance(img, dict):
+            url = img.get("image_url", {}).get("url", "") or img.get("url", "")
+        else:
+            url = str(img)
+        if url.startswith("data:"):
+            return url
+
+    # GPT-style: content array with image_url parts
+    content = msg.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if part.get("type") == "image_url":
+                url = part["image_url"].get("url", "")
+                if url.startswith("data:"):
+                    return url
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class OpenRouterImageGenProvider(ImageGenProvider):
+    """OpenRouter image generation via chat completions with multimodal models."""
+
+    @property
+    def name(self) -> str:
+        return "openrouter"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenRouter"
+
+    def is_available(self) -> bool:
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            return False
+        return True
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": "varies",
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "OpenRouter",
+            "badge": "paid",
+            "tag": "Multimodal image generation via OpenRouter (Gemini, GPT-5.4, etc.)",
+            "env_vars": [
+                {
+                    "key": "OPENROUTER_API_KEY",
+                    "prompt": "OpenRouter API key",
+                    "url": "https://openrouter.ai/keys",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required",
+                error_type="invalid_argument",
+                provider="openrouter",
+                aspect_ratio=aspect,
+            )
+
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            return error_response(
+                error="OPENROUTER_API_KEY not set. Run `hermes setup` to add the key.",
+                error_type="auth_required",
+                provider="openrouter",
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model()
+        size = _ASPECT_TO_SIZE.get(aspect, "1024x1024")
+
+        payload = {
+            "model": model_id,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"Generate an image: {prompt}. Size: {size}.",
+                }
+            ],
+            "modalities": ["image", "text"],
+            "max_tokens": 4096,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            resp = requests.post(
+                f"{OPENROUTER_BASE}/chat/completions",
+                json=payload,
+                headers=headers,
+                timeout=120,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:
+            logger.debug("OpenRouter image generation failed", exc_info=True)
+            return error_response(
+                error=f"OpenRouter API error: {exc}",
+                error_type="api_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        b64_url = _extract_image_from_response(data)
+        if not b64_url:
+            # Try error in response
+            err = data.get("error", {})
+            if err:
+                return error_response(
+                    error=f"OpenRouter: {err.get('message', str(err))}",
+                    error_type="api_error",
+                    provider="openrouter",
+                    model=model_id,
+                )
+            return error_response(
+                error="OpenRouter returned no image data",
+                error_type="empty_response",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            # b64_url is like "data:image/png;base64,..."
+            header, b64data = b64_url.split(",", 1)
+            saved_path = save_b64_image(b64data, prefix=f"openrouter_{model_id.replace('/', '_')}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image: {exc}",
+                error_type="io_error",
+                provider="openrouter",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="openrouter",
+            extra={"model_full": model_id, "size": size},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point."""
+    ctx.register_image_gen_provider(OpenRouterImageGenProvider())

--- a/plugins/image_gen/openrouter/plugin.yaml
+++ b/plugins/image_gen/openrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: openrouter
+version: 1.0.0
+description: "OpenRouter image generation via chat completions (gemini-image, gpt-image-2, etc.). Uses OpenRouter API key from OPENROUTER_API_KEY env var."
+author: custom
+kind: backend

--- a/tests/plugins/image_gen/test_openrouter_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_provider.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Tests for OpenRouter image generation provider."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure OPENROUTER_API_KEY is set for all tests."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        assert provider.name == "openrouter"
+
+    def test_display_name(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        assert provider.display_name == "OpenRouter"
+
+    def test_is_available_with_key(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        models = provider.list_models()
+        assert len(models) == 3
+        model_ids = [m["id"] for m in models]
+        assert "google/gemini-3.1-flash-image-preview" in model_ids
+        assert "openai/gpt-5.4-image-2" in model_ids
+
+    def test_default_model(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        assert provider.default_model() == "google/gemini-3.1-flash-image-preview"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "OpenRouter"
+        assert schema["badge"] == "paid"
+        assert schema["env_vars"][0]["key"] == "OPENROUTER_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.openrouter import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "google/gemini-3.1-flash-image-preview"
+        assert meta["display"] == "Gemini 3.1 Flash Image"
+
+    def test_env_override_model(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "openai/gpt-5.4-image-2")
+        from plugins.image_gen.openrouter import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "openai/gpt-5.4-image-2"
+        assert meta["display"] == "GPT-5.4 Image 2"
+
+    def test_invalid_env_model_falls_back(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "nonexistent/model")
+        from plugins.image_gen.openrouter import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "google/gemini-3.1-flash-image-preview"
+
+
+# ---------------------------------------------------------------------------
+# Image extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractImage:
+    def test_gemini_style_images_array(self):
+        from plugins.image_gen.openrouter import _extract_image_from_response
+
+        data = {
+            "choices": [{
+                "message": {
+                    "images": [{
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,/9j/test"}
+                    }]
+                }
+            }]
+        }
+        result = _extract_image_from_response(data)
+        assert result == "data:image/jpeg;base64,/9j/test"
+
+    def test_gpt_style_content_parts(self):
+        from plugins.image_gen.openrouter import _extract_image_from_response
+
+        data = {
+            "choices": [{
+                "message": {
+                    "content": [{
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}
+                    }]
+                }
+            }]
+        }
+        result = _extract_image_from_response(data)
+        assert result == "data:image/png;base64,iVBORw0KGgo="
+
+    def test_no_choices(self):
+        from plugins.image_gen.openrouter import _extract_image_from_response
+
+        result = _extract_image_from_response({"choices": []})
+        assert result is None
+
+    def test_no_image_data(self):
+        from plugins.image_gen.openrouter import _extract_image_from_response
+
+        data = {
+            "choices": [{
+                "message": {"content": "Just a text response"}
+            }]
+        }
+        result = _extract_image_from_response(data)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+        assert result["error_type"] == "auth_required"
+
+    def test_empty_prompt(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        provider = OpenRouterImageGenProvider()
+        result = provider.generate(prompt="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_successful_gemini_generation(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{
+                "message": {
+                    "images": [{
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,dGVzdA=="}
+                    }]
+                }
+            }]
+        }
+
+        with patch("plugins.image_gen.openrouter.requests.post", return_value=mock_resp):
+            with patch("plugins.image_gen.openrouter.save_b64_image", return_value="/tmp/test.png"):
+                provider = OpenRouterImageGenProvider()
+                result = provider.generate(prompt="A cat on a router")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/test.png"
+        assert result["provider"] == "openrouter"
+        assert result["model"] == "google/gemini-3.1-flash-image-preview"
+
+    def test_api_error_response(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "error": {"message": "Rate limit exceeded", "code": 429}
+        }
+
+        with patch("plugins.image_gen.openrouter.requests.post", return_value=mock_resp):
+            provider = OpenRouterImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert "Rate limit exceeded" in result["error"]
+        assert result["error_type"] == "api_error"
+
+    def test_http_error(self):
+        from plugins.image_gen.openrouter import OpenRouterImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("HTTP 500")
+
+        with patch("plugins.image_gen.openrouter.requests.post", return_value=mock_resp):
+            provider = OpenRouterImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert "HTTP 500" in result["error"]


### PR DESCRIPTION
Adds a new image_gen provider that uses OpenRouter's chat completions API with multimodal models (Gemini Flash/PRO Image, GPT-5.4 Image 2).

- plugin.yaml: backend declaration requiring OPENROUTER_API_KEY
- __init__.py: OpenRouterImageGenProvider implementation
  - Model resolution: OPENROUTER_IMAGE_MODEL env → config → default
  - Handles both Gemini-style (msg.images) and GPT-style (content parts)
  - Aspect ratio to size mapping (landscape/square/portrait)
  - 120s timeout for slower models like GPT-5.4 Image 2
- 19 unit tests covering provider class, config, image extraction, and generate scenarios

Closes: image generation via OpenRouter

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

