### PR TITLE
fix: preserve discover_models in _normalize_custom_provider_entry

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2873,6 +2873,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "discover_models",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -2962,6 +2963,10 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    discover_models = entry.get("discover_models")
+    if isinstance(discover_models, bool):
+        normalized["discover_models"] = discover_models
 
     return normalized
 


### PR DESCRIPTION
## Problem

`/api/model/options` takes ~24s when `custom_providers` include unreachable endpoints with `discover_models: false`.

## Root Cause

`_normalize_custom_provider_entry()` (hermes_cli/config.py) has two bugs:

1. `discover_models` is not in `_KNOWN_KEYS`, so it is logged as an unknown key and discarded.
2. The function builds the normalized dict by explicitly copying known fields — even without the warning, `discover_models` is never carried through to the output.

Downstream, `model_switch.py` calls `entry.get("discover_models", True)` and gets the default `True`, triggering `/models` HTTP probes on every custom_provider endpoint. Unreachable endpoints each timeout ~6s; with 4 such endpoints the total is ~24s.

## Fix

1. Add `"discover_models"` to `_KNOWN_KEYS` (suppresses the unknown-key warning).
2. Copy `discover_models` into the normalized dict when present and boolean.

## Result

`/api/model/options` response time: **24.5s → 0.4s**