### PR TITLE
fix(codex): avoid extra_headers on Codex backend

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -159,22 +159,12 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
-            prompt_cache_key = kwargs.get("prompt_cache_key")
-            cache_scope_id = str(prompt_cache_key or session_id or "").strip()
-            if cache_scope_id:
-                existing_extra_headers = kwargs.get("extra_headers")
-                merged_extra_headers: Dict[str, str] = {}
-                if isinstance(existing_extra_headers, dict):
-                    merged_extra_headers.update(
-                        {
-                            str(key): str(value)
-                            for key, value in existing_extra_headers.items()
-                            if key and value is not None
-                        }
-                    )
-                merged_extra_headers["session_id"] = cache_scope_id
-                merged_extra_headers["x-client-request-id"] = cache_scope_id
-                kwargs["extra_headers"] = merged_extra_headers
+            # The chatgpt.com/backend-api/codex Responses surface now rejects
+            # `extra_headers` when it appears in the serialized request body
+            # (HTTP 400: Unsupported parameter). Keep cache affinity on the
+            # body-supported prompt_cache_key only; do not inject the legacy
+            # session_id / x-client-request-id headers for this backend.
+            kwargs.pop("extra_headers", None)
 
         max_tokens = params.get("max_tokens")
         if max_tokens is not None and not is_codex_backend:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -155,6 +155,16 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    def test_codex_backend_does_not_inject_extra_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            session_id="codex-session-123",
+            is_codex_backend=True,
+        )
+        assert kw.get("prompt_cache_key") == "codex-session-123"
+        assert "extra_headers" not in kw
+
     def test_xai_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- Stop injecting `session_id` / `x-client-request-id` via `extra_headers` for the chatgpt.com Codex Responses backend.
- Keep Codex cache affinity on the existing `prompt_cache_key` body field.
- Add a regression test that ensures Codex backend kwargs no longer include `extra_headers`, while adjacent xAI header behavior remains covered by existing tests.

Closes #26599

## Root cause
`ResponsesApiTransport.build_kwargs(..., is_codex_backend=True)` added `extra_headers` from the session/cache key. The Codex backend now rejects that field when it appears in the serialized Responses request payload with `HTTP 400: Unsupported parameter: extra_headers`.

## Test Plan
- RED: `python -m pytest tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_codex_backend_does_not_inject_extra_headers -q` failed because `extra_headers` was still present.
- GREEN: `python -m pytest tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_codex_backend_does_not_inject_extra_headers -q` → 1 passed.
- `python -m pytest tests/agent/transports/test_codex_transport.py -q` → 40 passed.
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q` → 63 passed.
- `python -m ruff check agent/transports/codex.py tests/agent/transports/test_codex_transport.py` → all checks passed.
- `git diff --check` → passed.
