### PR TITLE
fix(bedrock): add 1M context for Opus 4.6/4.7 + Sonnet 4.6, bump anthropic SDK for bearer-token auth

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1230,9 +1230,14 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    # Anthropic Claude models on Bedrock.
+    # Opus 4.6/4.7 and Sonnet 4.6 support 1M context windows on Bedrock natively
+    # via the Converse API — no beta header needed (the context-1m-2025-08-07
+    # beta is only for Anthropic's direct API). Verified via OpenClaw's working
+    # production config at ~/.openclaw/config-backups/working-4-2026.json.
+    "anthropic.claude-opus-4-7":   1_000_000,
+    "anthropic.claude-opus-4-6":   1_000_000,
+    "anthropic.claude-sonnet-4-6": 1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1102,11 +1102,18 @@ class TestBedrockContextLength:
 
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        # Opus 4.6 supports 1M context on Bedrock natively (no beta header required)
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_opus_4_7(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Opus 4.7 supports 1M context on Bedrock
+        assert get_bedrock_context_length("us.anthropic.claude-opus-4-7") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        # Sonnet 4.6 also supports 1M context on Bedrock
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1123,7 +1130,7 @@ class TestBedrockContextLength:
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
         # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -78,7 +78,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Inference providers ───────────────────────────────────────────────
     # Native Anthropic SDK — needed when provider=anthropic (not via
     # OpenRouter / aggregators which use the openai SDK).
-    "provider.anthropic": ("anthropic==0.86.0",),
+    "provider.anthropic": ("anthropic==0.102.0",),
     # AWS Bedrock provider
     "provider.bedrock": ("boto3==1.42.89",),
 


### PR DESCRIPTION
## Summary

Bedrock natively supports 1M context windows for Claude Opus 4.6, Opus 4.7, and Sonnet 4.6 via the Converse API — no beta header needed. The `context-1m-2025-08-07` beta is only required on Anthropic's direct API, not on Bedrock.

The current `BEDROCK_CONTEXT_LENGTHS` table caps these models at 200k, which silently truncates user sessions even when running on Bedrock with plenty of headroom available. This PR fixes the table and adds the missing entry for Opus 4.7.

Also bumps the pinned `anthropic` SDK from `0.86.0` → `0.102.0` in `tools/lazy_deps.py`. The 0.86 release predates `AWS_BEARER_TOKEN_BEDROCK` support (the long-term API-key auth method AWS shipped in late 2025) and raises `could not resolve credentials from session` whenever bearer-token auth is configured. `0.102+` honors the env var. The two changes are coupled — without the SDK bump, Bedrock + bearer-token users can't reach the model at all to benefit from the larger context window.

## Changes

### `agent/bedrock_adapter.py`
- Add `anthropic.claude-opus-4-7` → `1_000_000`
- `anthropic.claude-opus-4-6`: `200_000` → `1_000_000`
- `anthropic.claude-sonnet-4-6`: `200_000` → `1_000_000`
- Comment explains that no beta header is required on Bedrock

### `tests/agent/test_bedrock_adapter.py`
- `test_claude_opus_4_6`: assert `1_000_000`
- `test_claude_opus_4_7`: **new** — covers the `us.anthropic.claude-opus-4-7` cross-region inference profile
- `test_claude_sonnet_versioned`: assert `1_000_000`
- `test_inference_profile_resolves`: assert `1_000_000`

### `tools/lazy_deps.py`
- `provider.anthropic`: `anthropic==0.86.0` → `anthropic==0.102.0`

## Reproduction (before this PR)

```bash
export AWS_BEARER_TOKEN_BEDROCK=...
hermes -m us.anthropic.claude-opus-4-7 --provider bedrock
# → "could not resolve credentials from session"  (anthropic SDK too old)
```

After SDK bump:

```bash
hermes -m us.anthropic.claude-opus-4-7 --provider bedrock
# Connects, but compaction kicks in at ~160k tokens because the table caps at 200k
# instead of 1M, costing ~800k of usable context.
```

After both fixes: full 1M context active, bearer-token auth works.

## Tests

```
tests/agent/test_bedrock_adapter.py::TestBedrockContextLength
8 passed in 1.12s
```

## Notes

- Verified against a working production Bedrock + Opus 4.7 deployment (1M context confirmed in the wild).
- The `context-1m-2025-08-07` beta header path is unchanged; this PR only corrects the Bedrock side, which is independent.
- No model-ID format change — cross-region inference profiles like `us.anthropic.claude-opus-4-7` already resolve correctly via the existing longest-prefix matcher.
