### PR TITLE
fix(cli): honor --ignore-rules in oneshot mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12361,6 +12361,7 @@ Examples:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                ignore_rules=getattr(args, "ignore_rules", False),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -5,7 +5,8 @@ no stderr chatter.  Just the agent's final text to stdout.
 
 Toolsets = explicit --toolsets when provided, otherwise whatever the user has
 configured for "cli" in `hermes tools`.
-Rules / memory / AGENTS.md / preloaded skills = same as a normal chat turn.
+Rules / memory / AGENTS.md / preloaded skills = same as a normal chat turn
+unless --ignore-rules / HERMES_IGNORE_RULES is set.
 Approvals = auto-bypassed (HERMES_YOLO_MODE=1 is set for the call).
 Working directory = the user's CWD (AGENTS.md etc. resolve from there as usual).
 
@@ -126,6 +127,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    ignore_rules: bool = False,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -137,6 +139,7 @@ def run_oneshot(
             HERMES_INFERENCE_PROVIDER env var, then config.yaml's model.provider,
             then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        ignore_rules: Skip AGENTS.md/SOUL.md/.cursorrules and memory injection.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -165,6 +168,7 @@ def run_oneshot(
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
+    effective_ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
@@ -184,6 +188,7 @@ def run_oneshot(
                 provider=provider,
                 toolsets=explicit_toolsets,
                 use_config_toolsets=use_config_toolsets,
+                ignore_rules=effective_ignore_rules,
             )
     finally:
         try:
@@ -221,6 +226,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    ignore_rules: bool = False,
 ) -> str:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns the final response string."""
@@ -301,6 +307,7 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
+    effective_ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),
@@ -312,6 +319,8 @@ def _run_agent(
         quiet_mode=True,
         platform="cli",
         session_db=session_db,
+        skip_context_files=effective_ignore_rules,
+        skip_memory=effective_ignore_rules,
         credential_pool=runtime.get("credential_pool"),
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -257,7 +257,9 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
     import hermes_cli.config as config_mod
 
     monkeypatch.setattr(
-        sys, "argv", ["hermes", "-z", "hello", "--toolsets", "web,terminal"]
+        sys,
+        "argv",
+        ["hermes", "-z", "hello", "--ignore-rules", "--toolsets", "web,terminal"],
     )
     monkeypatch.setitem(
         sys.modules,
@@ -298,6 +300,7 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "model": None,
         "provider": None,
         "toolsets": "web,terminal",
+        "ignore_rules": True,
     }
 
 
@@ -419,6 +422,20 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
     assert "mcp-off" in err
 
 
+def test_run_oneshot_passes_ignore_rules_env(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot_mod
+
+    captured = {}
+    monkeypatch.setenv("HERMES_IGNORE_RULES", "1")
+    monkeypatch.setattr(oneshot_mod, "_run_agent", lambda prompt, **kwargs: captured.update({"prompt": prompt, **kwargs}) or "ok")
+
+    assert oneshot_mod.run_oneshot("hello") == 0
+
+    assert captured["prompt"] == "hello"
+    assert captured["ignore_rules"] is True
+    assert capsys.readouterr().out == "ok\n"
+
+
 def test_oneshot_wires_session_db_for_recall(monkeypatch):
     """hermes -z bypasses HermesCLI, but recall still needs SessionDB."""
     from hermes_cli.oneshot import _run_agent
@@ -479,9 +496,11 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
 
-    assert _run_agent("recall this") == "ok"
+    assert _run_agent("recall this", ignore_rules=True) == "ok"
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
+    assert captured["skip_context_files"] is True
+    assert captured["skip_memory"] is True
     assert captured["prompt"] == "recall this"
 
 


### PR DESCRIPTION
## Summary
- Forward top-level `--ignore-rules` into the `hermes -z` oneshot path.
- Teach `run_oneshot()` / `_run_agent()` to honor either the explicit flag or `HERMES_IGNORE_RULES=1`.
- Pass `skip_context_files=True` and `skip_memory=True` to `AIAgent` when rules are ignored.

Closes #26633

## Root cause
The CLI parser and startup path already set `HERMES_IGNORE_RULES=1`, but the oneshot path bypassed `cli.py` and never forwarded or consumed that value before constructing `AIAgent`. As a result, `hermes -z --ignore-rules` silently kept injecting rules and memory.

## Test Plan
- RED: `python -m pytest tests/hermes_cli/test_tui_resume_flow.py::test_main_top_level_oneshot_accepts_toolsets tests/hermes_cli/test_tui_resume_flow.py::test_run_oneshot_passes_ignore_rules_env tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_wires_session_db_for_recall -q` → failed before implementation (`ignore_rules` missing / `_run_agent()` did not accept it).
- GREEN: same focused command → 3 passed.
- `python -m pytest tests/hermes_cli/test_tui_resume_flow.py -q` → 20 passed.
- `python -m pytest tests/hermes_cli/test_ignore_user_config_flags.py -q` → 11 passed.
- `python -m ruff check hermes_cli/oneshot.py hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py` → all checks passed.
- `git diff --check` → passed.
