### PR TITLE
fix(agent): harden title generation prompt and surface empty LLM responses

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -20,9 +20,10 @@ FailureCallback = Callable[[str, BaseException], None]
 TitleCallback = Callable[[str], None]
 
 _TITLE_PROMPT = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "You are a conversation titler. Given a User/Assistant exchange, output a "
+    "3-7 word title describing the topic or user intent.\n"
+    "Rules: no quotes, no trailing punctuation, no prefix like 'Title:'. "
+    "Output only the title."
 )
 
 
@@ -50,7 +51,16 @@ def generate_title(
 
     messages = [
         {"role": "system", "content": _TITLE_PROMPT},
-        {"role": "user", "content": f"User: {user_snippet}\n\nAssistant: {assistant_snippet}"},
+        {
+            "role": "user",
+            "content": (
+                "The following is the conversation to title:\n\n"
+                "---\n"
+                f"User: {user_snippet}\n\n"
+                f"Assistant: {assistant_snippet}\n"
+                "---"
+            ),
+        },
     ]
 
     try:
@@ -62,7 +72,9 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        raw_content = response.choices[0].message.content or ""
+        finish_reason = getattr(response.choices[0], "finish_reason", None)
+        title = raw_content.strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):
@@ -70,7 +82,13 @@ def generate_title(
         # Enforce reasonable length
         if len(title) > 80:
             title = title[:77] + "..."
-        return title if title else None
+        if not title:
+            logger.warning(
+                "Title generation produced empty title: finish_reason=%r raw_len=%d raw=%r",
+                finish_reason, len(raw_content), raw_content[:200],
+            )
+            return None
+        return title
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.


### PR DESCRIPTION
## What does this PR do?

Hardens the auxiliary title generation prompt in `agent/title_generator.py`
to prevent the upstream LLM from treating the user's first turn as an
instruction instead of as dialog content to be titled. Also adds a
WARNING log on the empty-content path so empty-response failures are
visible in `agent.log`.

## Related Issue / Prior Art

- Replaces the prompt-only portion of closed PR #26285 (which was rejected
  for bundling with an unrelated multi-agent feature). This branch contains
  **only** the title_generator change, rebased on latest `main`.
- Independent of PR #26389 (title dedup) — different file region, different
  failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking)

## Problem

The original prompt fused instruction and dialog content in a single user
message without delimiters. The upstream LLM occasionally interpreted the
user's first turn as a directive rather than as data, producing:

1. **Hallucinated titles** based on the model's own identity (e.g.
   "Claude Self-Introduction" for a Chinese conversation)
2. **Meta-commentary** as the title (e.g. "我已经在上一条消息中介绍了自己...")
3. **Instruction echo** (e.g. literal "Title only.")

## Fix

- Restructure system prompt as explicit role + rules:
  `"You are a conversation titler. ... Rules: ..."`
- Wrap dialog content in the user message with a header and `---` fences
  so the LLM treats it as input data, not instructions
- Add WARNING log on the empty-title path recording
  `finish_reason / raw_len / raw[:200]` to make upstream LLM
  empty-content responses visible

## Test Methodology

Ran 10× independent fresh-DM iterations against a local Matrix homeserver,
each creating a new room with the gateway bot, sending `"你是谁?"`, waiting
22s, and reading the auto-generated title from the sessions DB. Repeated
the run three times across prompt variants:

| Variant | Hallucination | Meta-leak | Long-truncated | None | Pass |
|---|---|---|---|---|---|
| Original prompt (baseline) | 1/10 | 1/10 | 1/10 | 0/10 | **7/10** |
| New prompt only | 0/10 | 0/10 | 0/10 | 2/10 | **8/10** |
| New prompt + WARNING | 0/10 | 0/10 | 0/10 | 1/10 | **9/10** |

The residual None cases were investigated using the new WARNING log and
confirmed to be upstream LLM returning empty content with
`finish_reason='stop', raw_len=0` — not a prompt deficiency. These are
transient and visible to operators after this PR.

## How to Test Manually

1. `pytest tests/agent/test_title_generator.py -v` — all 20 existing tests
   pass unchanged
2. Start a fresh session and send a generic identity question
   (e.g. "你是谁?"); the auto-generated title should describe the topic
   rather than echo the assistant's reply or hallucinate a name
3. Grep `agent.log` for `Title generation produced empty title` to surface
   transient upstream empty responses (previously silent)

## Scope

- One file: `agent/title_generator.py`
- +24 / -6 lines
- No changes to: SOUL prompt, skills, memory, main agent prompt,
  auxiliary_client routing
- Return type unchanged (`str | None`); callers untouched

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits message
- [x] No duplicate PR (prior #26285 was closed for bundling)
- [x] PR contains only changes related to this fix
- [x] `pytest tests/agent/test_title_generator.py -v` — 20/20 pass
- [x] Manually tested on Ubuntu via Matrix gateway, 30 iterations total