### PR TITLE
fix: preserve thinking blocks for Xiaomi MiMo models via Anthropic relay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -399,6 +399,15 @@ _KIMI_FAMILY_MODEL_PREFIXES = (
     "k25", "k2.5",
 )
 
+# Model-name prefixes that identify the Xiaomi MiMo family.
+# MiMo models use an extended-thinking / reasoning mode that requires
+# ``reasoning_content`` (thinking blocks) to round-trip on subsequent
+# requests when accessed through Anthropic-compatible relays.
+# Matched case-insensitively, same as the Kimi family above.
+_MIMO_FAMILY_MODEL_PREFIXES = (
+    "mimo-", "mimo_",
+)
+
 
 def _model_name_is_kimi_family(model: str | None) -> bool:
     if not isinstance(model, str):
@@ -410,6 +419,22 @@ def _model_name_is_kimi_family(model: str | None) -> bool:
     if "/" in m:
         m = m.rsplit("/", 1)[-1]
     return m.startswith(_KIMI_FAMILY_MODEL_PREFIXES)
+
+
+def _model_name_is_mimo_family(model: str | None) -> bool:
+    """Return True for Xiaomi MiMo model names that use extended thinking.
+
+    MiMo's reasoning mode returns ``reasoning_content`` that must be passed
+    back on subsequent API calls, same contract as Kimi/DeepSeek thinking.
+    """
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    return m.startswith(_MIMO_FAMILY_MODEL_PREFIXES)
 
 
 def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> bool:
@@ -1754,6 +1779,7 @@ def convert_messages_to_anthropic(
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _model_name_is_mimo_family(model)
     )
 
     last_assistant_idx = None


### PR DESCRIPTION
## What

Preserve unsigned thinking blocks for Xiaomi MiMo reasoning models when accessed through Anthropic-compatible relays.

## Why

MiMo models (e.g. `mimo-v2.5-pro`) use an extended-thinking mode that returns `reasoning_content` which **must** be passed back on subsequent API calls — the same contract as Kimi (#13848) and DeepSeek (#16748). Without this, multi-turn tool-use conversations through Anthropic-compatible relays fail with HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

Currently, Hermes strips ALL thinking blocks for generic third-party Anthropic endpoints, only preserving them for Kimi and DeepSeek specifically. MiMo models accessed through relays fall into the generic third-party path and hit this error.

## How

- Added `_MIMO_FAMILY_MODEL_PREFIXES` (prefixes: `mimo-`, `mimo_`) — same pattern as `_KIMI_FAMILY_MODEL_PREFIXES`
- Added `_model_name_is_mimo_family()` detection function
- Extended `_preserve_unsigned_thinking` to include MiMo detection

## Testing

- ✅ Single-turn conversation: works
- ✅ Multi-turn with 4 tool calls via Anthropic relay (markhub.top → MiMo): works (was HTTP 400)
- ✅ Model detection: `mimo-v2.5-pro` → True, `kimi-k2.5` → False, `claude-sonnet-4` → False

Fixes #26774