### PR TITLE
fix(doctor): flag missing OpenRouter credentials

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -105,6 +105,29 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _active_openrouter_credentials_issue(provider: str | None) -> str | None:
+    """Return a blocking doctor issue when active OpenRouter lacks credentials."""
+    if str(provider or "").strip().lower() != "openrouter":
+        return None
+
+    try:
+        from hermes_cli.auth import has_usable_secret
+    except Exception:  # pragma: no cover - auth import is best-effort in doctor
+        def has_usable_secret(value: object) -> bool:
+            return isinstance(value, str) and bool(value.strip())
+
+    for env_var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY"):
+        if has_usable_secret(os.getenv(env_var)):
+            return None
+
+    return (
+        "No credentials found for active OpenRouter provider. "
+        f"Set OPENROUTER_API_KEY (preferred) or OPENAI_API_KEY in {_DHH}/.env, "
+        "run 'hermes setup', or switch providers with "
+        "'hermes config set model.provider <name>'"
+    )
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -618,6 +641,14 @@ def run_doctor(args):
                     f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
                     "Either set model.provider to 'openrouter', or drop the vendor prefix."
                 )
+
+            openrouter_issue = _active_openrouter_credentials_issue(runtime_provider)
+            if openrouter_issue:
+                check_fail(
+                    "model.provider 'openrouter' is set but no OpenRouter credentials are configured",
+                    "(set OPENROUTER_API_KEY or OPENAI_API_KEY)",
+                )
+                issues.append(openrouter_issue)
 
             # Check credentials for the configured provider.
             # Limit to API-key providers in PROVIDER_REGISTRY — other provider

--- a/tests/hermes_cli/test_doctor_openrouter_credentials.py
+++ b/tests/hermes_cli/test_doctor_openrouter_credentials.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+
+def test_active_openrouter_without_credentials_is_blocking_issue(monkeypatch):
+    from hermes_cli import doctor
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    issue = doctor._active_openrouter_credentials_issue("openrouter")
+
+    assert issue is not None
+    assert "OpenRouter" in issue
+    assert "OPENROUTER_API_KEY" in issue
+    assert "OPENAI_API_KEY" in issue
+
+
+def test_active_openrouter_accepts_openai_key_fallback(monkeypatch):
+    from hermes_cli import doctor
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openrouter-fallback-key")
+
+    assert doctor._active_openrouter_credentials_issue("openrouter") is None
+
+
+def test_non_openrouter_provider_does_not_emit_openrouter_issue(monkeypatch):
+    from hermes_cli import doctor
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert doctor._active_openrouter_credentials_issue("anthropic") is None


### PR DESCRIPTION
## Summary
- Add an active-provider credential check for `model.provider: openrouter`.
- Treat missing `OPENROUTER_API_KEY` and missing `OPENAI_API_KEY` fallback as a blocking doctor issue.
- Keep the existing `OPENAI_API_KEY` fallback behavior recognized so legacy OpenRouter setups are not falsely flagged.

Closes #26436

## Root cause
`hermes doctor` skipped OpenRouter in the generic API-key provider credential validation because OpenRouter has a dedicated connectivity check. That dedicated check reported `OpenRouter API (not configured)` but returned no issue for the final summary, so an active OpenRouter provider without credentials could still be omitted from the actionable issue list.

## Test Plan
- RED: `python -m pytest tests/hermes_cli/test_doctor_openrouter_credentials.py -q` → failed before implementation because `_active_openrouter_credentials_issue` did not exist.
- GREEN: `python -m pytest tests/hermes_cli/test_doctor_openrouter_credentials.py -q` → 3 passed.
- `python -m pytest tests/hermes_cli/test_doctor_openrouter_credentials.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py -q` → 5 passed.
- `python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor_openrouter_credentials.py` → all checks passed.
- `git diff --check` → passed.
