### PR TITLE
fix(kanban-dashboard): surface failed Ready-transition with blocking parent detail (#26744)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -51,6 +51,24 @@
     return str;
   }
 
+  // ``fetchJSON`` throws ``Error("<status>: <raw body>")`` on non-2xx, and
+  // FastAPI bodies look like ``{"detail":"<message>"}``.  Pull the
+  // human-readable message out so banners/toasts don't have to leak HTTP
+  // plumbing at the user (e.g. ``409: {"detail":"…"}``).  See #26744.
+  function parseApiErrorMessage(err) {
+    const raw = (err && err.message) ? String(err.message) : String(err || "");
+    const m = raw.match(/^(\d{3}):\s*(.*)$/s);
+    const body = m ? m[2] : raw;
+    try {
+      const parsed = JSON.parse(body);
+      if (parsed && typeof parsed.detail === "string") return parsed.detail;
+      if (parsed && parsed.detail && typeof parsed.detail.message === "string") {
+        return parsed.detail.message;
+      }
+    } catch (_e) { /* not JSON — fall through to raw body */ }
+    return body || raw;
+  }
+
   // Order matches BOARD_COLUMNS in plugin_api.py.
   const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
@@ -633,7 +651,7 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patch),
       }).catch(function (err) {
-        setError(tx(t, "moveFailed", "Move failed: ") + (err.message || err));
+        setError(tx(t, "moveFailed", "Move failed: ") + parseApiErrorMessage(err));
         loadBoard();
       });
     }, [loadBoard, board, t]);
@@ -2300,6 +2318,11 @@
     const [data, setData] = useState(null);
     const [loading, setLoading] = useState(true);
     const [err, setErr] = useState(null);
+    // Surface PATCH failures (e.g. 409 "parent not done") right next to
+    // the drawer's action row — without it, the drawer's only error
+    // surface (``err``) is hidden behind the loaded ``data`` and the
+    // Ready/Block/Complete buttons feel like no-ops.  See #26744.
+    const [patchErr, setPatchErr] = useState(null);
     const [newComment, setNewComment] = useState("");
     const [editing, setEditing] = useState(false);
     // Home-channel notification toggles. homeChannels is the list of platforms
@@ -2311,7 +2334,7 @@
 
     const load = useCallback(function () {
       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug))
-        .then(function (d) { setData(d); setErr(null); })
+        .then(function (d) { setData(d); setErr(null); setPatchErr(null); })
         .catch(function (e) { setErr(String(e.message || e)); })
         .finally(function () { setLoading(false); });
     }, [props.taskId, boardSlug]);
@@ -2355,11 +2378,13 @@
       }
       const finalPatch = withCompletionSummary(patch, 1);
       if (!finalPatch) return Promise.resolve();
+      setPatchErr(null);
       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(finalPatch),
-      }).then(function () { load(); props.onRefresh(); });
+      }).then(function () { load(); props.onRefresh(); })
+        .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
     };
 
     // Triage specifier — calls the auxiliary LLM to flesh out a rough
@@ -2468,7 +2493,11 @@
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
-        data ? h(TaskDetail, {
+        patchErr ? h("div", {
+          className: "px-4 pt-2 text-sm text-destructive",
+          role: "alert",
+        }, patchErr) : null,
+        !loading && !err && data ? h(TaskDetail, {
           data, editing, setEditing,
           renderMarkdown: props.renderMarkdown,
           allTasks: props.allTasks,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -633,6 +633,23 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
             if not ok:
+                # For ``ready``, name the blocking parent(s) so the dashboard
+                # can render an actionable toast instead of a silent no-op.
+                # See #26744.
+                if s == "ready":
+                    blockers = _parents_blocking_ready(conn, task_id)
+                    if blockers:
+                        names = ", ".join(
+                            f"{p['title']!r} ({p['id']}, status={p['status']})"
+                            for p in blockers
+                        )
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"Cannot move to 'ready': blocked by parent(s) "
+                                f"not done — {names}"
+                            ),
+                        )
                 raise HTTPException(
                     status_code=409,
                     detail=f"status transition to {s!r} not valid from current state",
@@ -678,6 +695,29 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         return {"task": _task_dict(updated) if updated else None}
     finally:
         conn.close()
+
+
+def _parents_blocking_ready(
+    conn: sqlite3.Connection, task_id: str,
+) -> list:
+    """Return parent rows (``id``, ``title``, ``status``) that aren't ``done``
+    and therefore prevent ``task_id`` from being promoted to ``ready``.
+
+    Used to enrich the 409 response from :func:`update_task` so the
+    dashboard can show an actionable toast (#26744) instead of a silent
+    no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
+    parents, or all parents already done).
+    """
+    rows = conn.execute(
+        "SELECT t.id, t.title, t.status FROM tasks t "
+        "JOIN task_links l ON l.parent_id = t.id "
+        "WHERE l.child_id = ? AND t.status != 'done'",
+        (task_id,),
+    ).fetchall()
+    return [
+        {"id": r["id"], "title": r["title"], "status": r["status"]}
+        for r in rows
+    ]
 
 
 def _set_status_direct(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -258,6 +258,18 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     )
     assert r.status_code == 409
 
+    # The 409 detail must name the blocking parent so the dashboard can
+    # render an actionable toast instead of a silent no-op (#26744).
+    detail = r.json()["detail"]
+    assert "Cannot move to 'ready'" in detail
+    assert parent["id"] in detail
+    assert "'p'" in detail
+    assert "status=" in detail
+    # Whatever non-``done`` status the parent currently has must show up
+    # so the operator knows what to fix.
+    assert f"status={parent['status']}" in detail
+    assert parent["status"] != "done"
+
     # Complete the parent.
     r = client.patch(
         f"/api/plugins/kanban/tasks/{parent['id']}",
@@ -721,6 +733,34 @@ def test_dashboard_done_actions_prompt_for_completion_summary():
     assert "result: summary" in bundle
     assert "body: JSON.stringify(patch)" in bundle
     assert "body: JSON.stringify(finalPatch)" in bundle
+
+
+def test_dashboard_surfaces_ready_blocked_error_inline():
+    """Regression for #26744: failed status transitions must be surfaced
+    inline, not swallowed.  The drag/drop banner and the drawer's action
+    row each render the parsed API ``detail`` so operators see *why*
+    their click did nothing.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    # Helper that strips ``"409: {\"detail\":\"…\"}"`` down to the
+    # human-readable message before it lands in any banner.
+    assert "function parseApiErrorMessage(err)" in bundle
+    assert "parsed.detail" in bundle
+
+    # Drag/drop banner now uses the parsed message instead of raw
+    # ``err.message`` so it no longer leaks HTTP plumbing.
+    assert "setError(tx(t, \"moveFailed\", \"Move failed: \") + parseApiErrorMessage(err))" in bundle
+
+    # Drawer action row has its own visible error surface and clears it
+    # on success/refresh so stale failures don't follow the operator
+    # around.
+    assert "const [patchErr, setPatchErr] = useState(null);" in bundle
+    assert "setPatchErr(parseApiErrorMessage(e))" in bundle
+    assert "setPatchErr(null)" in bundle
 
 
 def test_dashboard_dependency_selects_use_value_change_handler():


### PR DESCRIPTION
## What does this PR do?

Stops the Kanban dashboard from silently dropping a "→ Ready" attempt when a parent dependency isn't `done`.

Issue [#26744](https://github.com/NousResearch/hermes-agent/issues/26744) reported that drag-to-Ready and the drawer's **Ready** button looked like no-ops when the backend rejected the transition because a parent wasn't done. The backend was already returning HTTP 409 in `plugins/kanban/dashboard/plugin_api.py::update_task`, but two things went wrong on the way to the operator:

1. The 409 `detail` was a generic `"status transition to 'ready' not valid from current state"` — even if the dashboard had surfaced it, the operator still wouldn't know which parent to fix.
2. The dashboard didn't surface it cleanly anyway. The drag/drop path raised a tiny `text-xs` banner above the columns with the raw `"409: {"detail":"…"}"` string; the drawer's `doPatch` had **no `.catch` at all**, so clicking "→ Ready" was a complete silent failure.

This PR closes both gaps:

- **Backend.** A new `_parents_blocking_ready(conn, task_id)` helper returns the offending parent rows (`id`, `title`, `status`) and is called from the failure path in `update_task` to enrich the 409 detail to e.g. `Cannot move to 'ready': blocked by parent(s) not done — 'Design API' (t_a1b2c3, status=ready)`.
- **Frontend.** A new `parseApiErrorMessage` helper turns `fetchJSON`'s `"<status>: <raw body>"` shape into just the `detail` string, the drag/drop banner runs through it (no more leaked HTTP plumbing), and the drawer gets a visible `patchErr` surface that renders right under its header — directly next to the action row whose button the operator just clicked. The error clears on the next successful PATCH and when the operator switches tasks.

## Related Issue

Fixes #26744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py` — add `_parents_blocking_ready(conn, task_id)` helper that returns parent rows whose status isn't `done`. In `update_task`'s `not ok` failure branch, when the requested status was `ready`, build a richer 409 detail listing each blocking parent's quoted title, id, and current status. Other transition failures still raise the existing generic 409 detail. No schema or response-shape changes — `detail` remains a string so any downstream substring matching keeps working.
- `plugins/kanban/dashboard/dist/index.js`:
  - Add a top-level `parseApiErrorMessage(err)` helper that strips `"<status>: "` and pulls the `detail` field out of the JSON body when present, with safe fallbacks.
  - Route `KanbanPage.moveTask`'s `.catch` through it so the drag/drop banner shows just the human-readable reason, not `409: {"detail":"…"}`.
  - Give `TaskDrawer` its own `patchErr` state, set it from `doPatch`'s newly-added `.catch`, clear it on each successful PATCH and on every task switch, and render it inline under the drawer header (so it sits next to the Ready/Block/Complete row instead of hiding behind the loaded card body).
- `tests/plugins/test_kanban_dashboard_plugin.py`:
  - Tighten `test_patch_drag_drop_move_todo_to_ready` to assert the enriched 409 detail names the blocking parent (id, quoted title, current status).
  - New `test_dashboard_surfaces_ready_blocked_error_inline` bundle assertion that pins the helper exists, the drag/drop banner uses it, and the drawer keeps a visible `patchErr` surface that's cleared between PATCHes/tasks.

## How to Test

```bash
# 1. Kanban dashboard suite passes (existing + new tests)
./scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py
# expected: 82 passed

# 2. Manual reproduction of #26744 via the API
python -c "
import json
from fastapi.testclient import TestClient
from plugins.kanban.dashboard.plugin_api import router
from fastapi import FastAPI
app = FastAPI(); app.include_router(router, prefix='/api/plugins/kanban')
c = TestClient(app)

parent = c.post('/api/plugins/kanban/tasks', json={'title': 'Design API'}).json()['task']
child  = c.post('/api/plugins/kanban/tasks',
                json={'title': 'Implement', 'parents': [parent['id']]}).json()['task']

r = c.patch(f'/api/plugins/kanban/tasks/{child[\"id\"]}', json={'status': 'ready'})
print('status:', r.status_code)
print('detail:', json.dumps(r.json()['detail'], indent=2))
"
# expected:
# status: 409
# detail: "Cannot move to 'ready': blocked by parent(s) not done — 'Design API' (t_…, status=ready)"

# 3. End-to-end via the dashboard
#    a. Open the Kanban dashboard, create parent task A, then child task B
#       with A as a dependency, then drag B onto the Ready column. The card
#       snaps back AND the banner now reads:
#          Move failed: Cannot move to 'ready': blocked by parent(s) not done
#                       — 'A' (t_…, status=ready)
#    b. Open B's drawer and click "→ ready". The button stays in place AND
#       a destructive inline message appears right under the drawer header
#       with the same explanation (was completely silent before).
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban-api):`, `fix(kanban-dashboard):`, `test(kanban-dashboard):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `./scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py` and all 82 tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (UX-visible only, no doc-visible surface changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python + plain IIFE bundle, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool/schema change; HTTP response shape kept `{"detail": <string>}` for compat)

## Screenshots / Logs

Before the fix (issue #26744 reproduction):

```
# Drag a child onto Ready while the parent is still ready/todo
PATCH /api/plugins/kanban/tasks/t_child_abc {"status":"ready"}
  → 409  {"detail":"status transition to 'ready' not valid from current state"}

UI:
  • Card snaps back to original column.
  • Tiny gray text above the columns reads:
      Move failed: 409: {"detail":"status transition to 'ready' not valid…
  • Drawer "→ ready" button: click → nothing happens, no error shown.
```

After the fix:

```
# Same request — backend now identifies the blocker
PATCH /api/plugins/kanban/tasks/t_child_abc {"status":"ready"}
  → 409  {"detail":"Cannot move to 'ready': blocked by parent(s) not done
                    — 'Design API' (t_parent_xyz, status=ready)"}

UI:
  • Card snaps back AND the banner reads (plain text, no HTTP plumbing):
      Move failed: Cannot move to 'ready': blocked by parent(s) not done
                   — 'Design API' (t_parent_xyz, status=ready)
  • Drawer "→ ready" button: click → visible destructive message right
                                       under the drawer header with the
                                       same explanation. Clears on the
                                       next successful PATCH or task
                                       switch.
```
