### PR TITLE
feat(cli,gateway): add /panic command for coordinated emergency halt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5136,6 +5136,24 @@ class HermesCLI:
         killed = process_registry.kill_all()
         print(f"  ✅ Stopped {killed} process(es).")
 
+    def _handle_panic_command(self):
+        """Handle /panic — emergency halt: interrupt agent, kill processes, exit."""
+        import sys
+
+        # Interrupt running agent if any
+        if getattr(self, "_agent_running", False) and hasattr(self, "agent") and self.agent:
+            self.agent.interrupt("panic")
+            _cprint(f"  {_BOLD}⛔ Agent interrupted.{_RST}")
+
+        # Kill all background processes
+        from tools.process_registry import process_registry
+        killed = process_registry.kill_all()
+        if killed:
+            _cprint(f"  {_BOLD}⛔ Killed {killed} background process(es).{_RST}")
+
+        _cprint(f"  {_BOLD}🚨 Panic — exiting immediately (code 75).{_RST}")
+        sys.exit(75)
+
     def _handle_agents_command(self):
         """Handle /agents — show background processes and agent status."""
         from tools.process_registry import format_uptime_short, process_registry
@@ -7980,6 +7998,8 @@ class HermesCLI:
             self._handle_snapshot_command(cmd_original)
         elif canonical == "stop":
             self._handle_stop_command()
+        elif canonical == "panic":
+            self._handle_panic_command()
         elif canonical == "agents":
             self._handle_agents_command()
         elif canonical == "background":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6647,6 +6647,9 @@ class GatewayRunner:
         
         if canonical == "stop":
             return await self._handle_stop_command(event)
+
+        if canonical == "panic":
+            return await self._handle_panic_command(event)
         
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
@@ -8906,6 +8909,50 @@ class GatewayRunner:
             return EphemeralReply(t("gateway.stop.stopped"))
         else:
             return t("gateway.stop.no_active")
+
+    async def _handle_panic_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /panic command - emergency halt: interrupt ALL agents and shut down the gateway.
+
+        Unlike /stop (which only interrupts the current session's agent),
+        /panic interrupts every running agent across all sessions and then
+        initiates a clean gateway shutdown.  Use when the agent is in a
+        destructive loop, burning tokens, or producing harmful output and
+        a simple /stop is insufficient.
+        """
+        # Interrupt all running agents across all sessions
+        interrupted = 0
+        for session_key, agent in list(self._running_agents.items()):
+            if agent is _AGENT_PENDING_SENTINEL:
+                await self._interrupt_and_clear_session(
+                    session_key,
+                    None,
+                    interrupt_reason="panic",
+                    invalidation_reason="panic_command",
+                )
+                interrupted += 1
+            elif agent:
+                agent.interrupt("panic")
+                await self._interrupt_and_clear_session(
+                    session_key,
+                    None,
+                    interrupt_reason="panic",
+                    invalidation_reason="panic_command",
+                )
+                interrupted += 1
+
+        logger.warning(
+            "PANIC: emergency halt triggered by user %s on %s — interrupted %d agent(s)",
+            event.source.user_id if event.source else "?",
+            event.source.platform.value if event.source and event.source.platform else "?",
+            interrupted,
+        )
+
+        # Request clean gateway shutdown
+        self._request_clean_exit("panic")
+
+        if interrupted:
+            return EphemeralReply(t("gateway.panic.halted", count=interrupted))
+        return EphemeralReply(t("gateway.panic.no_agents"))
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:
         """Handle ``/platform list|pause|resume [name]`` — surface and

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -90,6 +90,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
                cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
     CommandDef("stop", "Kill all running background processes", "Session"),
+    CommandDef("panic", "Emergency halt: interrupt all agents and shut down the gateway", "Session"),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command", "Session",
@@ -340,6 +341,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "restart",
         "status",
         "steer",
+        "panic",
         "stop",
         "update",
     }


### PR DESCRIPTION
## Summary

Add a `/panic` command (CLI + gateway) that interrupts ALL running agents across all sessions and initiates a clean gateway shutdown. This is the emergency brake for when the agent enters a destructive loop, burns tokens on a hallucinated task, or produces harmful output and a simple `/stop` is insufficient.

Closes #26383

## Problem

When an autonomous agent enters a bad state, the only way to stop it is `Ctrl+C` (CLI) or `/stop` (messaging). Neither coordinates across components:
- `/stop` only interrupts the **current session's** agent
- The gateway keeps accepting messages from other sessions
- In-flight tool executions in other sessions continue
- Background tasks keep running
- No clean state flush

There is no single command that halts everything safely across a multi-session gateway.

## Solution

Add `/panic` as a new slash command in both CLI and gateway:

**CLI** (`cli.py`):
- Interrupts the running agent (if any)
- Kills all background processes via `process_registry.kill_all()`
- Exits with code 75 (so process supervisors know it was intentional)

**Gateway** (`gateway/run.py`):
- Iterates ALL running agents across ALL sessions and interrupts each
- Clears session locks for pending/running agents
- Calls `_request_clean_exit("panic")` for graceful shutdown with state flush
- Logs the panic event with user/platform info for audit trail

**Command registry** (`hermes_cli/commands.py`):
- Registered as `CommandDef("panic", ...)` in `COMMAND_REGISTRY`
- Added to `ACTIVE_SESSION_BYPASS_COMMANDS` (dispatched immediately, even with an agent running)

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/commands.py` | Register `/panic` in COMMAND_REGISTRY + ACTIVE_SESSION_BYPASS_COMMANDS |
| `gateway/run.py` | Add `_handle_panic_command()` handler + dispatch routing |
| `cli.py` | Add `_handle_panic_command()` handler + dispatch routing |

## Test Results

```
832 passed, 0 failed, 33 warnings in 70.19s
```

All existing tests pass (including gateway command dispatch, slash access, and bypass tests).

## Design Decisions

1. **No new dependencies** — uses existing `agent.interrupt()`, `process_registry.kill_all()`, and `_request_clean_exit()` infrastructure
2. **Scope: panic only** — the issue also proposes `/resume` and `--teardown` but these are significantly more complex and can be separate PRs
3. **Exit code 75** — follows the convention used by `/restart` for service-manager-aware exits, so systemd/supervisord can distinguish intentional halts from crashes
4. **Logs panic events** — `logger.warning` with user ID and platform for post-incident review
5. **Follows `/stop` pattern** — same structure as existing `_handle_stop_command` but broader scope (all sessions vs current session)
