### PR TITLE
fix: accept entry-exports.js as hermes ink bundle

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -971,9 +971,14 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    dist_dir = ink_root / "dist"
+    bundle = dist_dir / "ink-bundle.js"
     if not bundle.exists():
-        return True
+        alt_bundle = dist_dir / "entry-exports.js"
+        if alt_bundle.exists():
+            bundle = alt_bundle
+        else:
+            return True
     bm = bundle.stat().st_mtime
     skip = frozenset({"node_modules", "dist"})
     for dirpath, dirnames, filenames in os.walk(ink_root, topdown=True):


### PR DESCRIPTION
## Summary
- treat `packages/hermes-ink/dist/entry-exports.js` as a valid built Hermes Ink bundle
- avoid unnecessary TUI rebuilds when `ink-bundle.js` is absent but the current build output exists

## Why
- current dashboard/TUI flow can trigger repeated rebuilds because `_hermes_ink_bundle_stale()` only checks `ink-bundle.js`
- current builds may emit `entry-exports.js` instead, causing false stale detection

## Validation
- `python3 -m py_compile hermes_cli/main.py`
