### PR TITLE
fix(tui): swallow degraded SGR mouse bursts instead of leaking to prompt

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -133,4 +133,26 @@ describe('fragmented SGR mouse recovery', () => {
 
     expect(key).toMatchObject({ kind: 'key', sequence: '1234;56;78M9;10;11M' })
   })
+
+  it('swallows degraded windows-terminal mouse bursts without leaking to the prompt', () => {
+    // Real capture from Windows Terminal during a wheel-scroll storm: button
+    // codes / ESC[< prefixes have been chewed off, leaving pure mouse-leak
+    // alphabet with many M/m terminators.
+    const leak =
+      ';76;50mM1M68;36M;73;35M;74;38M74;41M75;41M66;38M37M2;38M;49;38M35;40;39M9M5;37;39M39M;32;39M29;39M0M0MM6MMMMM'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, leak)
+    const visibleKeys = events.filter(e => e.kind === 'key' && !e.isPasted)
+
+    expect(visibleKeys).toEqual([])
+  })
+
+  it('swallows a degraded mouse burst that surrounds a real fragment with leak chars', () => {
+    // Real fragment in the middle, noise on both sides — the surrounding
+    // noise should not leak as typed keys.
+    const text = ';12;34m<32;76;50M;78;52M;99;9M0MM'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, text)
+    const visibleKeys = events.filter(e => e.kind === 'key' && !e.isPasted)
+
+    expect(visibleKeys).toEqual([])
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -155,4 +155,13 @@ describe('fragmented SGR mouse recovery', () => {
 
     expect(visibleKeys).toEqual([])
   })
+
+  it.each(['Mmm', 'MMM', 'Mmmmm', 'mmm yum'])(
+    'keeps plain text %p that lacks digits/separators despite many M/m chars',
+    text => {
+      const [[key]] = parseMultipleKeypresses(INITIAL_STATE, text)
+
+      expect(key).toMatchObject({ kind: 'key', sequence: text })
+    }
+  )
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -64,6 +64,14 @@ const XTVERSION_RE = /^\x1bP>\|(.*?)(?:\x07|\x1b\\)$/s
 // eslint-disable-next-line no-control-regex
 const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/
 const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4]\d|25[0-5]);\d+;\d+[Mm]/g
+// Mouse-leak "alphabet": chars that can appear inside an SGR mouse burst
+// (digits, separators, terminators, prefix). Used to detect degraded bursts
+// where the tokenizer or upstream stripped enough context that no single
+// fragment matches SGR_MOUSE_FRAGMENT_RE but the run is clearly mouse noise.
+// Requires ≥3 M/m terminators — `1234;56;78M9;10;11M` (two events worth of
+// digits + 2 M's) is ambiguous and stays as text; real mouse bursts during
+// scroll/drag have many more terminators.
+const MOUSE_BURST_NOISE_RE = /^[;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*$/
 
 function createPasteKey(content: string): ParsedKey {
   return {
@@ -646,8 +654,13 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
   SGR_MOUSE_FRAGMENT_RE.lastIndex = 0
 
   const matches = [...text.matchAll(SGR_MOUSE_FRAGMENT_RE)]
+
+  // Degraded burst: no full fragment matched, but the entire text is mouse-leak
+  // alphabet with ≥2 terminators. Tokenizer/upstream stripped the button code
+  // (or the ESC[< prefix and the button), leaving e.g. `;col;rowM` or worse.
+  // Swallow rather than leak into the prompt. Bounded by alphabet + ≥2 [Mm].
   if (matches.length === 0) {
-    return null
+    return MOUSE_BURST_NOISE_RE.test(text) ? [] : null
   }
 
   const parsed: ParsedInput[] = []
@@ -673,8 +686,21 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
       continue
     }
 
-    if (first.index! > cursor) {
-      parsed.push(parseKeypress(text.slice(cursor, first.index!)))
+    // Extend the burst over adjacent mouse-leak noise. The tokenizer or
+    // upstream may have dropped button codes / extra prefixes on follow-up
+    // events, so they don't match SGR_MOUSE_FRAGMENT_RE but they're still
+    // noise we want to swallow rather than type into the prompt.
+    let burstStart = first.index!
+    while (burstStart > cursor && /[;\d<\[Mm]/.test(text[burstStart - 1]!)) {
+      burstStart--
+    }
+
+    while (runEnd < text.length && /[;\d<\[Mm]/.test(text[runEnd]!)) {
+      runEnd++
+    }
+
+    if (burstStart > cursor) {
+      parsed.push(parseKeypress(text.slice(cursor, burstStart)))
     }
 
     for (const match of run) {
@@ -686,7 +712,10 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
   }
 
   if (!consumedAny) {
-    return null
+    // Matched fragments existed but none had enough evidence to be promoted
+    // to mouse events. If the entire text is mouse-leak alphabet anyway,
+    // swallow it as noise rather than typing it into the prompt.
+    return MOUSE_BURST_NOISE_RE.test(text) ? [] : null
   }
 
   if (cursor < text.length) {

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -75,6 +75,21 @@ const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4
 // plus coordinate digits and `;` separators between params.
 const MOUSE_BURST_NOISE_RE = /^(?=[^]*\d)(?=[^]*;)[;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*$/
 
+// Charcode test for the same alphabet — avoids allocating a fresh RegExp on
+// every iteration of the burst-edge extension loops in parseTextWithSgrMouseFragments.
+function isMouseLeakChar(c: string): boolean {
+  const code = c.charCodeAt(0)
+
+  return (
+    code === 0x3b /* ; */ ||
+    code === 0x3c /* < */ ||
+    code === 0x5b /* [ */ ||
+    code === 0x4d /* M */ ||
+    code === 0x6d /* m */ ||
+    (code >= 0x30 && code <= 0x39) /* 0-9 */
+  )
+}
+
 function createPasteKey(content: string): ParsedKey {
   return {
     kind: 'key',
@@ -694,11 +709,11 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
     // events, so they don't match SGR_MOUSE_FRAGMENT_RE but they're still
     // noise we want to swallow rather than type into the prompt.
     let burstStart = first.index!
-    while (burstStart > cursor && /[;\d<\[Mm]/.test(text[burstStart - 1]!)) {
+    while (burstStart > cursor && isMouseLeakChar(text[burstStart - 1]!)) {
       burstStart--
     }
 
-    while (runEnd < text.length && /[;\d<\[Mm]/.test(text[runEnd]!)) {
+    while (runEnd < text.length && isMouseLeakChar(text[runEnd]!)) {
       runEnd++
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -68,10 +68,12 @@ const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4
 // (digits, separators, terminators, prefix). Used to detect degraded bursts
 // where the tokenizer or upstream stripped enough context that no single
 // fragment matches SGR_MOUSE_FRAGMENT_RE but the run is clearly mouse noise.
-// Requires ≥3 M/m terminators — `1234;56;78M9;10;11M` (two events worth of
-// digits + 2 M's) is ambiguous and stays as text; real mouse bursts during
-// scroll/drag have many more terminators.
-const MOUSE_BURST_NOISE_RE = /^[;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*$/
+// Requires ≥3 M/m terminators AND at least one digit AND at least one `;`
+// — plain text like `Mmm` / `MMM` (no digits, no separators) stays put;
+// `1234;56;78M9;10;11M` (only 2 terminators) is ambiguous and stays put;
+// real mouse bursts during scroll/drag/motion have many more terminators
+// plus coordinate digits and `;` separators between params.
+const MOUSE_BURST_NOISE_RE = /^(?=[^]*\d)(?=[^]*;)[;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*[Mm][;\d<\[Mm]*$/
 
 function createPasteKey(content: string): ParsedKey {
   return {
@@ -656,9 +658,10 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
   const matches = [...text.matchAll(SGR_MOUSE_FRAGMENT_RE)]
 
   // Degraded burst: no full fragment matched, but the entire text is mouse-leak
-  // alphabet with ≥2 terminators. Tokenizer/upstream stripped the button code
-  // (or the ESC[< prefix and the button), leaving e.g. `;col;rowM` or worse.
-  // Swallow rather than leak into the prompt. Bounded by alphabet + ≥2 [Mm].
+  // alphabet with ≥3 terminators plus at least one digit and one `;`. Tokenizer
+  // or upstream stripped the button code (or the ESC[< prefix and the button),
+  // leaving e.g. `;col;rowM` or worse. Swallow rather than leak into the prompt.
+  // Threshold lives on MOUSE_BURST_NOISE_RE — keep this comment in sync.
   if (matches.length === 0) {
     return MOUSE_BURST_NOISE_RE.test(text) ? [] : null
   }


### PR DESCRIPTION
## Why

Windows Terminal, during a fast wheel-scroll on WSL, intermittently produces stdin runs like

\`\`\`
;76;50mM1M68;36M;73;35M;74;38M74;41M75;41M66;38M37M2;38M;49;38M35;40;39M9M5;37;39M39M;32;39M29;39M0M0MM6MMMMM
\`\`\`

The ESC\`[<\` prefix and the button code on follow-up events have been chewed off — so neither \`parseMouseEvent\` (needs \`^\\\x1b\\[<…\`) nor \`SGR_MOUSE_FRAGMENT_RE\` (requires a leading button) catches them. Today the burst falls through to \`parseKeypress\` and gets typed into the composer:

![leak](https://github.com/user-attachments/assets/placeholder)

This is the same family of leak we've been hardening across #18113 / #18024 / #17701 etc., just with the upstream stripping a digit more than the existing regex tolerates.

## What

Two narrow extensions in \`parseTextWithSgrMouseFragments\`:

1. **Burst-noise fast path.** If the entire text token is \`[;\\d<\\[Mm]\` alphabet *and* has ≥3 \`M/m\` terminators, drop it. Threshold of 3 keeps \`see 1;2;3M for details\` (1 M, plus non-alphabet chars) and \`1234;56;78M9;10;11M\` (only 2 M's) as plain text.
2. **Burst-edge extension.** When a real fragment burst is consumed, also eat adjacent leak chars on both sides of the burst so chewed-off neighbours go away with the recognised events instead of trailing into the prompt.

Same noise alphabet on both paths so behaviour is consistent.

## Tests

- New: \`swallows degraded windows-terminal mouse bursts without leaking to the prompt\` (exact captured payload)
- New: \`swallows a degraded mouse burst that surrounds a real fragment with leak chars\`
- Existing: \`keeps isolated semicolon text that only resembles a prefixless mouse report\` and \`does not match prefixless fragments inside longer digit runs\` still pass — they test the ambiguity boundary I deliberately preserved.

\`\`\`
Test Files  71 passed (71)
Tests       778 passed (778)
\`\`\`