### PR TITLE
fix(gateway): allow /status consistently under slash-access gating

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8422,7 +8422,10 @@ class GatewayRunner:
         hasn't set ``allow_admin_from`` for the scope, the policy returns
         ``enabled=False`` and this method always returns None.
         """
-        from gateway.slash_access import policy_for_source as _policy_for_source
+        from gateway.slash_access import (
+            always_allowed_commands as _always_allowed_commands,
+            policy_for_source as _policy_for_source,
+        )
 
         if not canonical_cmd:
             return None
@@ -8435,7 +8438,9 @@ class GatewayRunner:
             source.platform.value if source.platform else "?",
             source.user_id,
         )
-        allowed_preview = sorted(policy.user_allowed_commands)
+        allowed_preview = sorted(
+            set(policy.user_allowed_commands).union(_always_allowed_commands())
+        )
         if allowed_preview:
             suffix = (
                 "You can run: "
@@ -8460,7 +8465,10 @@ class GatewayRunner:
         (admin / user / unrestricted), and the slash commands they can
         actually run on this scope.
         """
-        from gateway.slash_access import policy_for_source as _policy_for_source
+        from gateway.slash_access import (
+            always_allowed_commands as _always_allowed_commands,
+            policy_for_source as _policy_for_source,
+        )
 
         source = event.source
         policy = _policy_for_source(self.config, source)
@@ -8486,7 +8494,7 @@ class GatewayRunner:
             )
 
         # Non-admin user. Show what's actually reachable.
-        floor = ["help", "whoami"]  # mirrors slash_access._ALWAYS_ALLOWED_FOR_USERS
+        floor = list(_always_allowed_commands())
         configured = sorted(policy.user_allowed_commands)
         # Combine + dedupe, preserve order: floor first, then operator additions.
         seen: set[str] = set()

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -49,8 +49,14 @@ from typing import Any, FrozenSet, Iterable, Optional, Tuple
 # additively, never restrictively).
 _ALWAYS_ALLOWED_FOR_USERS: FrozenSet[str] = frozenset({
     "help",
+    "status",
     "whoami",
 })
+
+
+def always_allowed_commands() -> tuple[str, ...]:
+    """Return the implicit read-only slash-command floor for non-admin users."""
+    return tuple(sorted(_ALWAYS_ALLOWED_FOR_USERS))
 
 
 @dataclass(frozen=True)
@@ -224,6 +230,7 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
 
 __all__ = [
     "SlashAccessPolicy",
+    "always_allowed_commands",
     "policy_from_extra",
     "policy_for_source",
 ]

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -63,12 +63,14 @@ class TestPolicyFromExtra:
         assert p.can_run("999", "kanban") is False
 
     def test_always_allowed_floor_for_non_admin(self):
-        # /help and /whoami always reachable so users can see what they can do.
+        # /help, /status, and /whoami always reachable so users can see
+        # what they can do and inspect session state.
         p = policy_from_extra(
             {"allow_admin_from": ["111"], "user_allowed_commands": []},
             "dm",
         )
         assert p.can_run("999", "help") is True
+        assert p.can_run("999", "status") is True
         assert p.can_run("999", "whoami") is True
         assert p.can_run("999", "stop") is False
 
@@ -199,6 +201,7 @@ class TestPolicyForSource:
         assert p.is_admin("111") is True
         assert p.can_run("999", "status") is True
         assert p.can_run("999", "help") is True  # always-allowed floor
+        assert p.can_run("999", "whoami") is True  # always-allowed floor
         assert p.can_run("999", "kanban") is False
 
     def test_group_chat_type_resolves_to_group_scope(self):
@@ -222,9 +225,9 @@ class TestPolicyForSource:
         assert p.is_admin("222") is True
         assert p.is_admin("111") is False  # DM admin, not group admin
         # In group scope, the only listed user command is "help"; "status"
-        # is not in the group list and should be denied for non-admins.
+        # is not in the group list, but still allowed via the floor.
         assert p.can_run("999", "help") is True
-        assert p.can_run("999", "status") is False
+        assert p.can_run("999", "status") is True
 
     def test_channel_thread_chat_types_treated_as_group_scope(self):
         # Discord channels and threads are group-scoped, not DM-scoped.

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -12,7 +12,7 @@ Coverage targets:
   - User path: user not in admin list, but command in
     ``user_allowed_commands`` → allowed.
   - User denied: command not in either list → returns the ⛔ denial.
-  - Always-allowed floor: /help and /whoami reachable for non-admins
+  - Always-allowed floor: /help, /status, and /whoami reachable for non-admins
     even with empty user_allowed_commands.
   - DM vs group scope isolation.
 """
@@ -180,10 +180,17 @@ async def test_non_admin_with_empty_user_commands_gets_floor_only():
     # /stop denied
     result = await runner._handle_message(_make_event("/stop", _make_source(user_id="999")))
     assert "⛔" in result
-    assert "No slash commands are enabled" in result
+    assert "No slash commands are enabled" not in result
+    assert "/help" in result
+    assert "/status" in result
+    assert "/whoami" in result
+    runner._handle_status_command = AsyncMock(return_value="status-handled")
+    status_result = await runner._handle_message(_make_event("/status", _make_source(user_id="999")))
+    assert status_result == "status-handled"
     # /whoami still works (always-allowed floor)
     whoami_result = await runner._handle_message(_make_event("/whoami", _make_source(user_id="999")))
     assert "Tier: user" in whoami_result
+    assert "/status" in whoami_result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix gateway slash-access so `/status` is treated consistently for non-admin users.

Before this change, `/status` was effectively always allowed only on the active-run fast path, but could still be denied on the normal idle path when `allow_admin_from` was configured and `user_allowed_commands` was empty. That made slash-access behavior depend on whether the agent happened to be busy.

## What changed

- Add `/status` to the non-admin always-allowed slash-command floor
- Centralize that floor in `gateway.slash_access`
- Reuse the same floor in gateway denial previews and `/whoami` output
- Add regression coverage for policy and idle-path dispatch behavior

## Result

Non-admin users now get consistent access to `/status` across both busy and idle gateway states, matching the intended read-only command floor.

## Tests

- ` tests/gateway/test_slash_access.py tests/gateway/test_slash_access_dispatch.py -q`

Passed locally:
- `39 passed in 4.99s`