### PR TITLE
fix(doctor): use query-param auth for Gemini in API-key probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1450,6 +1450,16 @@ def run_doctor(args):
             }
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
+            # Google AI Studio (generativelanguage.googleapis.com) only
+            # accepts `?key=` query-param auth. Sending Authorization: Bearer
+            # returns 401 ACCESS_TOKEN_TYPE_UNSUPPORTED, which the generic
+            # 401 branch below mislabels as "invalid API key" for every user
+            # with a working GEMINI_API_KEY. Switch auth scheme for this host
+            # so the probe reflects real key validity.
+            if base_url_host_matches(url, "generativelanguage.googleapis.com"):
+                _sep = "&" if "?" in url else "?"
+                url = f"{url}{_sep}key={key}"
+                del headers["Authorization"]
             r = httpx.get(url, headers=headers, timeout=10)
             if (
                 pname == "Alibaba/DashScope"


### PR DESCRIPTION
## Summary

`hermes doctor` falsely reports `✗ gemini (invalid API key)` for every user with a working `GEMINI_API_KEY`. Root cause: the generic `_probe_apikey_provider` in `hermes_cli/doctor.py:1412–1490` sends `Authorization: Bearer ${KEY}` to `/models`, but the gemini profile's `base_url=https://generativelanguage.googleapis.com/v1beta` only accepts `?key=…` query-param auth. Google's API gateway returns:

```
HTTP 401 ACCESS_TOKEN_TYPE_UNSUPPORTED
Request had invalid authentication credentials. Expected OAuth 2 access
token, login cookie or other valid authentication credential.
```

…which the generic 401 branch reports as `(invalid API key)`. The credential is fine — `hermes` itself uses `GeminiNativeClient` which sends auth correctly. Only the doctor probe is wrong.

## Fix

Detect `generativelanguage.googleapis.com` on the resolved URL (via the existing `base_url_host_matches` helper, same pattern used for `api.kimi.com` two lines up). When matched, rewrite the URL with `?key=…` and drop the `Authorization` header so Google's gateway accepts the request.

10 lines, additive only — no change to behavior for any other provider.

## Verification

Reproduced and verified against a real `GEMINI_API_KEY`:

```bash
# before
$ hermes doctor | grep -i gemini
  ✗ gemini               (invalid API key)

# Raw repro of the bug
$ curl -sS -H "Authorization: Bearer $KEY" \
    'https://generativelanguage.googleapis.com/v1beta/models' \
    -w '\nHTTP %{http_code}\n'
HTTP 401  →  ACCESS_TOKEN_TYPE_UNSUPPORTED

# Same key with query-param auth works
$ curl -sS \
    "https://generativelanguage.googleapis.com/v1beta/models?key=$KEY" \
    -w '\nHTTP %{http_code}\n'
HTTP 200  →  full model list returned

# generateContent also succeeds with the same key
$ curl -sS -X POST \
    "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$KEY" \
    -H "Content-Type: application/json" \
    -d '{"contents":[{"parts":[{"text":"reply with one word ok"}]}],"generationConfig":{"maxOutputTokens":5}}'
{"candidates":[{"content":{"parts":[{"text":"ok"}],"role":"model"}, …}]}

# after the patch
$ hermes doctor | grep -i gemini
  ✓ gemini
```

## Test plan

- [x] `python -c "import ast; ast.parse(open('hermes_cli/doctor.py').read())"` — syntax OK
- [x] Local smoke test: `PYTHONPATH=. python -m hermes_cli.main doctor` flips `gemini` from `✗` to `✓` against a real key
- [x] Other API-key providers (OpenRouter, DeepSeek, Alibaba/DashScope, Kimi, MiniMax, etc.) unaffected — branch only fires on `generativelanguage.googleapis.com` host
- [ ] Existing tests in `tests/hermes_cli/test_doctor.py` and `test_doctor_dedicated_provider_skip.py` pass (please run in CI)