### PR TITLE
feat(gateway): add global auto_skills config for per-session skill injection (#26709)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -486,6 +486,11 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Global auto-skill injection: skill names loaded on every new session
+    # regardless of platform or channel.  Per-channel bindings (Discord,
+    # Telegram topics) are merged on top; global skills come first.
+    auto_skills: List[str] = field(default_factory=list)
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -577,6 +582,7 @@ class GatewayConfig:
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
+            "auto_skills": self.auto_skills,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
         }
@@ -632,6 +638,10 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        # Global auto-skills: validated list of skill names
+        _raw_auto_skills = data.get("auto_skills") or []
+        auto_skills = [s for s in _raw_auto_skills if isinstance(s, str)] if isinstance(_raw_auto_skills, list) else []
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -647,6 +657,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            auto_skills=auto_skills,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -753,6 +764,13 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            # Global auto-skills: gateway.auto_skills in config.yaml
+            _gw_section = yaml_cfg.get("gateway", {})
+            if isinstance(_gw_section, dict):
+                _as = _gw_section.get("auto_skills")
+                if isinstance(_as, list):
+                    gw_data["auto_skills"] = [s for s in _as if isinstance(s, str)]
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7363,10 +7363,24 @@ class GatewayRunner:
             session_entry.auto_reset_reason = None
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
-        # Discord channel_skill_bindings).  Supports a single name or ordered list.
+        # Discord channel_skill_bindings) and/or global gateway.auto_skills.
+        # Supports a single name or ordered list.
         # Only inject on NEW sessions — ongoing conversations already have the
         # skill content in their conversation history from the first message.
         _auto = getattr(event, "auto_skill", None)
+        # Merge global auto_skills (from gateway config) with per-channel bindings.
+        # Global skills come first; per-channel skills are appended (deduped).
+        _global_auto = getattr(self.config, "auto_skills", None) or []
+        if _global_auto and _is_new_session:
+            _per_channel = [_auto] if isinstance(_auto, str) else list(_auto or [])
+            _merged: list[str] = []
+            for _s in _global_auto:
+                if _s not in _merged:
+                    _merged.append(_s)
+            for _s in _per_channel:
+                if _s not in _merged:
+                    _merged.append(_s)
+            _auto = _merged if _merged else None
         if _is_new_session and _auto:
             _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
             try:


### PR DESCRIPTION
## Summary

Add `gateway.auto_skills` config option for global skill injection on every new session.

Closes #26709

## Problem

Users cannot declare "inject this skill on every new session, globally." Current auto_skill only works per-channel (Discord channel_skill_bindings, Telegram topic bindings). Platforms without per-channel config (Feishu, Email, SMS) have no way to auto-inject skills.

The issue references OpenClaw's `agents.defaults.skills` pattern, which solves this cleanly.

## Solution

Add `gateway.auto_skills` list to `config.yaml`. On every new session, these skills are loaded alongside any per-channel bindings:

- **Global skills come first** in the injection order
- **Per-channel skills are appended** (deduplicated)
- **No global config = no change** — fully backward compatible

### Config format

```yaml
gateway:
  auto_skills:
    - target-skill
    - another-skill
```

### Files Changed

| File | Change |
|------|--------|
| `gateway/config.py` | Add `auto_skills: List[str]` field to `GatewayConfig`, parse from `gateway.auto_skills` in YAML, add to `from_dict`/`to_dict` |
| `gateway/run.py` | Merge `self.config.auto_skills` with per-channel `event.auto_skill` before injection (global first, deduped) |

## Implementation Details

1. **GatewayConfig** — new `auto_skills` field (default empty list). Parsed from `config.yaml` → `gateway.auto_skills` with type validation (list of strings only).

2. **gateway/run.py** — before the existing per-channel auto_skill injection block, read `self.config.auto_skills` and merge with `event.auto_skill`. The merge preserves global-first order and deduplicates by name.

3. **Backward compatible** — no config change needed for existing setups. The field defaults to `[]`, and the merge logic only activates when `auto_skills` is non-empty.

## Test Results

- 220 passed, 0 failures (1 pre-existing failure in `test_inline_shell_timeout_does_not_break_message`, unrelated)
- Code review: 0 ERROR, 0 WARNING (72 INFO — all pre-existing missing-docstring)
- Syntax check: ✅ both files pass `py_compile`

## Design Decisions

- **Global-first ordering**: Global skills load before per-channel ones so "always on" skills (like alignment checks) run before platform-specific ones
- **Deduplication by name**: If a skill is in both global and per-channel config, it's only loaded once (global position)
- **Config under `gateway:`**: Matches existing gateway config pattern (`gateway.streaming`, `gateway.restart_notification`)
