### PR TITLE
fix(slack): stop consuming slash reply context outside slash sends

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -424,9 +424,9 @@ class SlackAdapter(BasePlatformAdapter):
         Uses the ``_slash_user_id`` ContextVar (set in ``_handle_slash_command``)
         to match the exact ``(channel_id, user_id)`` key.  This prevents a
         concurrent slash command from a different user on the same channel from
-        stealing another user's ephemeral context.  Falls back to a
-        channel-only scan when the ContextVar is unset (e.g. send() called
-        from a non-slash code path — should not match anything).
+        stealing another user's ephemeral context. When the ContextVar is
+        unset (e.g. send() called from a non-slash code path), do not match
+        anything — otherwise normal sends can steal a pending slash reply.
         """
         now = time.monotonic()
         # Clean up stale entries on every lookup — dict is small.
@@ -442,16 +442,7 @@ class SlackAdapter(BasePlatformAdapter):
         if uid:
             return self._slash_command_contexts.pop((chat_id, uid), None)
 
-        # Fallback: channel-only scan (only reachable when ContextVar is
-        # unset, i.e. send() called outside a slash-command async context).
-        match_key = None
-        for key in list(self._slash_command_contexts):
-            if key[0] == chat_id:
-                match_key = key
-                break
-        if match_key is None:
-            return None
-        return self._slash_command_contexts.pop(match_key)
+        return None
 
     async def _send_slash_ephemeral(
         self,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2942,12 +2942,18 @@ class TestSlashEphemeralAck:
     async def test_pop_slash_context_returns_and_removes(self, adapter):
         """_pop_slash_context returns the context and removes it."""
         import time
+        from gateway.platforms.slack import _slash_user_id
+
         adapter._slash_command_contexts[("C1", "U1")] = {
             "response_url": "https://hooks.slack.com/test",
             "ts": time.monotonic(),
         }
 
-        ctx = adapter._pop_slash_context("C1")
+        token = _slash_user_id.set("U1")
+        try:
+            ctx = adapter._pop_slash_context("C1")
+        finally:
+            _slash_user_id.reset(token)
         assert ctx is not None
         assert ctx["response_url"] == "https://hooks.slack.com/test"
         # Must be removed after pop
@@ -2976,6 +2982,8 @@ class TestSlashEphemeralAck:
     async def test_send_uses_response_url_when_context_exists(self, adapter):
         """send() should POST to response_url for slash command replies."""
         import time
+        from gateway.platforms.slack import _slash_user_id
+
         adapter._slash_command_contexts[("C_SLASH", "U_SLASH")] = {
             "response_url": "https://hooks.slack.com/commands/T123/456/abc",
             "ts": time.monotonic(),
@@ -2991,8 +2999,12 @@ class TestSlashEphemeralAck:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
-            result = await adapter.send("C_SLASH", "Queued for the next turn.")
+        token = _slash_user_id.set("U_SLASH")
+        try:
+            with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
+                result = await adapter.send("C_SLASH", "Queued for the next turn.")
+        finally:
+            _slash_user_id.reset(token)
 
         assert result.success is True
         # Verify response_url was POSTed to
@@ -3022,6 +3034,8 @@ class TestSlashEphemeralAck:
     async def test_send_slash_ephemeral_fallback_on_post_failure(self, adapter):
         """_send_slash_ephemeral returns success=True even if POST fails."""
         import time
+        from gateway.platforms.slack import _slash_user_id
+
         adapter._slash_command_contexts[("C1", "U1")] = {
             "response_url": "https://hooks.slack.com/commands/bad",
             "ts": time.monotonic(),
@@ -3038,8 +3052,12 @@ class TestSlashEphemeralAck:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
-            result = await adapter.send("C1", "Some response")
+        token = _slash_user_id.set("U1")
+        try:
+            with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
+                result = await adapter.send("C1", "Some response")
+        finally:
+            _slash_user_id.reset(token)
 
         # Still success — the user saw the initial ack already
         assert result.success is True
@@ -3048,6 +3066,8 @@ class TestSlashEphemeralAck:
     async def test_send_slash_ephemeral_fallback_on_exception(self, adapter):
         """_send_slash_ephemeral returns success=True even if aiohttp raises."""
         import time
+        from gateway.platforms.slack import _slash_user_id
+
         adapter._slash_command_contexts[("C1", "U1")] = {
             "response_url": "https://hooks.slack.com/commands/timeout",
             "ts": time.monotonic(),
@@ -3058,8 +3078,12 @@ class TestSlashEphemeralAck:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
-            result = await adapter.send("C1", "Some response")
+        token = _slash_user_id.set("U1")
+        try:
+            with patch("gateway.platforms.slack.aiohttp.ClientSession", return_value=mock_session):
+                result = await adapter.send("C1", "Some response")
+        finally:
+            _slash_user_id.reset(token)
 
         assert result.success is True
 
@@ -3173,7 +3197,24 @@ class TestSlashEphemeralAck:
         # ContextVar is unset (default=None) — simulates a normal message send.
         assert _slash_user_id.get() is None
         ctx = adapter._pop_slash_context("C1")
-        # Fallback scan still finds it (channel-only) — this is fine for
-        # the normal single-user case; the ContextVar path is the precise one.
-        # The key invariant is: when the ContextVar IS set, it matches exactly.
-        assert ctx is not None  # fallback path finds the entry
+        assert ctx is None
+        assert ("C1", "U1") in adapter._slash_command_contexts
+
+    @pytest.mark.asyncio
+    async def test_send_without_contextvar_preserves_pending_slash_context(self, adapter):
+        """Normal channel sends must not consume a pending slash reply context."""
+        import time
+        from gateway.platforms.slack import _slash_user_id
+
+        adapter._slash_command_contexts[("C1", "U1")] = {
+            "response_url": "https://hooks.slack.com/test",
+            "ts": time.monotonic(),
+        }
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678", "ok": True})
+
+        assert _slash_user_id.get() is None
+        result = await adapter.send("C1", "public follow-up")
+
+        assert result.success is True
+        adapter._app.client.chat_postMessage.assert_awaited_once()
+        assert ("C1", "U1") in adapter._slash_command_contexts


### PR DESCRIPTION
## Summary

Fix Slack slash-command ephemeral reply routing so normal channel sends cannot consume a pending slash `response_url`.

Previously, `SlackAdapter._pop_slash_context()` fell back to a channel-only lookup when `_slash_user_id` was unset. That meant any non-slash `send()` call on the same channel could steal a pending slash reply context and incorrectly route a normal message as an ephemeral slash replacement.

This change makes slash context consumption strict:
- If `_slash_user_id` is set, match the exact `(channel_id, user_id)` key.
- If `_slash_user_id` is unset, do not consume any pending slash context.

## Why this is safe

The slash handler already stores contexts by `(channel_id, user_id)` and sets `_slash_user_id` around command dispatch, so the strict lookup matches the intended contract and removes cross-message bleed.

## Changes

- Update Slack slash-context lookup to return `None` when no slash user context is active.
- Update slash-ephemeral tests to set `_slash_user_id` explicitly when simulating real slash flows.
- Add a regression test proving that a normal `send()` call does not consume a pending slash context.

## Files changed

- `gateway/platforms/slack.py`
- `tests/gateway/test_slack.py`

## Validation

- Passed: `uv run pytest tests/gateway/test_slack.py -k slash`
- Relevant slash tests passed cleanly: `30 passed`
- Full-file failures observed locally were unrelated to this patch and caused by missing `httpx` in the test environment.
- No additional production code paths were changed outside Slack slash-context routing.

+-----------------------------+-----------------------------------------------+
| Item                        | Result                                        |
+-----------------------------+-----------------------------------------------+
| Scope                       | Small bug fix                                 |
| User-visible impact         | Prevents wrong ephemeral/public Slack replies |
| Behavioral risk             | Low                                           |
| Relevant tests              | Passed                                        |
| Unrelated local env issue   | `httpx` missing for 3 non-target tests        |
+-----------------------------+-----------------------------------------------+