### PR TITLE
fix(gateway): honor SOUL.md and agent.personality in gateway sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -971,6 +971,24 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+def _resolve_personality_prompt(value: Any) -> str:
+    """Flatten a personality entry to its system-prompt string.
+
+    Keeps the same shape contract as `/personality`'s inline resolver
+    (gateway/run.py:_handle_personality_command) so a personality named
+    in config.yaml at startup yields the same text as one selected via
+    the slash command at runtime.
+    """
+    if isinstance(value, dict):
+        parts = [str(value.get("system_prompt", "") or "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(p for p in parts if p)
+    return str(value or "")
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -2288,9 +2306,15 @@ class GatewayRunner:
     @staticmethod
     def _load_ephemeral_system_prompt() -> str:
         """Load ephemeral system prompt from config or env var.
-        
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+
+        Resolution order (first non-empty wins):
+          1. HERMES_EPHEMERAL_SYSTEM_PROMPT env var
+          2. agent.system_prompt in ~/.hermes/config.yaml
+          3. agent.personalities[agent.personality] in ~/.hermes/config.yaml
+
+        agent.system_prompt is preferred over agent.personality because an
+        explicit prompt is a stronger signal than a named reference; stacking
+        the two risks duplicated or contradictory identity.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
@@ -2301,7 +2325,13 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
-                return (cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+                explicit = (cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+                if explicit:
+                    return explicit
+                name = (cfg_get(cfg, "agent", "personality", default="") or "").strip()
+                personalities = cfg_get(cfg, "agent", "personalities", default={}) or {}
+                if name and isinstance(personalities, dict) and name in personalities:
+                    return _resolve_personality_prompt(personalities[name]).strip()
         except Exception:
             pass
         return ""
@@ -13803,6 +13833,7 @@ class GatewayRunner:
         enabled_toolsets: list,
         ephemeral_prompt: str,
         cache_keys: dict | None = None,
+        load_soul_identity: bool = False,
     ) -> str:
         """Compute a stable string key from agent config values.
 
@@ -13840,6 +13871,7 @@ class GatewayRunner:
                 # cached agent and doesn't affect system prompt or tools.
                 ephemeral_prompt or "",
                 _cache_keys_sorted,
+                bool(load_soul_identity),
             ],
             sort_keys=True,
             default=str,
@@ -15242,6 +15274,7 @@ class GatewayRunner:
                 enabled_toolsets,
                 combined_ephemeral,
                 cache_keys=self._extract_cache_busting_config(user_config),
+                load_soul_identity=True,
             )
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -15273,6 +15306,7 @@ class GatewayRunner:
                     disabled_toolsets=disabled_toolsets,
                     ephemeral_system_prompt=combined_ephemeral or None,
                     prefill_messages=self._prefill_messages or None,
+                    load_soul_identity=True,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),

--- a/tests/gateway/test_gateway_identity.py
+++ b/tests/gateway/test_gateway_identity.py
@@ -1,0 +1,200 @@
+"""Regression tests for issue #26596 — gateway must honor SOUL.md and
+agent.personality from config.yaml instead of always falling back to
+DEFAULT_AGENT_IDENTITY.
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._session_reasoning_overrides = {}
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {"final_response": "ok", "messages": [], "api_calls": 1}
+
+
+def _install_fake_agent(monkeypatch):
+    _CapturingAgent.last_init = None
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _stub_runtime(monkeypatch, hermes_home):
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+        },
+    )
+
+
+def _telegram_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_name="DM",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+class TestGatewayPassesSoulIdentity:
+    """Bug: gateway never passes load_soul_identity, so AIAgent's default
+    False causes DEFAULT_AGENT_IDENTITY to win over SOUL.md."""
+
+    def test_run_agent_passes_load_soul_identity_true(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+        _stub_runtime(monkeypatch, hermes_home)
+        _install_fake_agent(monkeypatch)
+
+        runner = _make_runner()
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="who are you",
+                context_prompt="",
+                history=[],
+                source=_telegram_source(),
+                session_id="session-1",
+                session_key="agent:main:telegram:dm",
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init.get("load_soul_identity") is True
+
+
+class TestLoadEphemeralSystemPromptPersonality:
+    """Bug: agent.personality from config.yaml never reaches the gateway
+    ephemeral prompt — only /personality slash commands wire it up."""
+
+    def _load(self, tmp_path, monkeypatch, yaml_body: str) -> str:
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+        return gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    def test_named_personality_resolves_at_startup(self, tmp_path, monkeypatch):
+        yaml_body = (
+            "agent:\n"
+            "  personality: pirate\n"
+            "  personalities:\n"
+            "    pirate: |\n"
+            "      Speak like a pirate.\n"
+        )
+        assert "pirate" in self._load(tmp_path, monkeypatch, yaml_body).lower()
+
+    def test_dict_personality_resolves_system_prompt_field(self, tmp_path, monkeypatch):
+        yaml_body = (
+            "agent:\n"
+            "  personality: scholar\n"
+            "  personalities:\n"
+            "    scholar:\n"
+            "      system_prompt: You are a careful scholar.\n"
+            "      tone: formal\n"
+        )
+        prompt = self._load(tmp_path, monkeypatch, yaml_body)
+        assert "careful scholar" in prompt
+        assert "formal" in prompt
+
+    def test_explicit_system_prompt_wins_over_personality(self, tmp_path, monkeypatch):
+        yaml_body = (
+            "agent:\n"
+            "  system_prompt: explicit-wins\n"
+            "  personality: pirate\n"
+            "  personalities:\n"
+            "    pirate: arrr\n"
+        )
+        assert self._load(tmp_path, monkeypatch, yaml_body) == "explicit-wins"
+
+    def test_unknown_personality_falls_back_to_empty(self, tmp_path, monkeypatch):
+        yaml_body = (
+            "agent:\n"
+            "  personality: missing\n"
+            "  personalities:\n"
+            "    other: noop\n"
+        )
+        assert self._load(tmp_path, monkeypatch, yaml_body) == ""
+
+    def test_env_var_still_wins(self, tmp_path, monkeypatch):
+        yaml_body = (
+            "agent:\n"
+            "  personality: pirate\n"
+            "  personalities:\n"
+            "    pirate: arrr\n"
+        )
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "from-env")
+        assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "from-env"
+
+
+class TestAgentConfigSignatureIncludesSoulFlag:
+    """When load_soul_identity flips, cached agents must rebuild — otherwise
+    the SOUL.md identity stays invisible until restart."""
+
+    def test_load_soul_identity_changes_signature(self):
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_off = gateway_run.GatewayRunner._agent_config_signature(
+            "m", runtime, [], "", load_soul_identity=False,
+        )
+        sig_on = gateway_run.GatewayRunner._agent_config_signature(
+            "m", runtime, [], "", load_soul_identity=True,
+        )
+        assert sig_off != sig_on
+
+    def test_default_signature_matches_explicit_false(self):
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_default = gateway_run.GatewayRunner._agent_config_signature(
+            "m", runtime, [], "",
+        )
+        sig_off = gateway_run.GatewayRunner._agent_config_signature(
+            "m", runtime, [], "", load_soul_identity=False,
+        )
+        assert sig_default == sig_off


### PR DESCRIPTION
## What does this PR do?

In gateway sessions (Telegram and other adapters), the per-session `AIAgent`
was constructed without `load_soul_identity`, so `SOUL.md` was never loaded
and `DEFAULT_AGENT_IDENTITY` always won. In parallel, `agent.personality`
from `~/.hermes/config.yaml` was only wired up by the `/personality` slash
command, so a personality configured at startup had no effect on the first
turn.

This PR:

- Passes `load_soul_identity=True` when the gateway instantiates its
  per-session `AIAgent` in `gateway/run.py:_run_agent`, so `SOUL.md` is
  loaded as the agent identity instead of the hardcoded default.
- Extends `GatewayRunner._load_ephemeral_system_prompt` to fall back to
  `agent.personalities[agent.personality]` from `config.yaml` when
  `agent.system_prompt` is empty. Explicit `agent.system_prompt` and
  `HERMES_EPHEMERAL_SYSTEM_PROMPT` keep precedence so we don't stack a
  named personality on top of an explicit prompt.
- Adds `load_soul_identity` to `_agent_config_signature` so cached agents
  rebuild when the flag changes.
- Adds `_resolve_personality_prompt` as a small module-level helper that
  mirrors the inline resolver used by `_handle_personality_command`, so a
  personality named in `config.yaml` at startup yields the same text as
  one selected via `/personality` at runtime.

## Related Issue

Fixes #26596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_run_agent` and the cache-hit branch now pass
  `load_soul_identity=True` to `AIAgent`; `_load_ephemeral_system_prompt`
  resolves named personalities; `_agent_config_signature` includes the
  new flag; adds `_resolve_personality_prompt` helper.
- `tests/gateway/test_gateway_identity.py` — regression tests covering
  `load_soul_identity` propagation, personality resolution (string and
  dict forms), precedence of explicit `system_prompt` and env var over
  named personality, unknown-personality fallback, and signature
  invalidation on the new flag.

## How to Test

1. Set a non-trivial `SOUL.md` in `HERMES_HOME` and start a gateway
   session — the agent should answer in that persona instead of the
   built-in default identity.
2. With `SOUL.md` removed, set `agent.personality: pirate` plus
   `agent.personalities.pirate: "Speak like a pirate."` in
   `~/.hermes/config.yaml` and start the gateway — first turn should
   already be in-persona.
3. `pytest tests/gateway/test_gateway_identity.py -q` — all 8 cases pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_gateway_identity.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior change of an existing surface; covered by docstring update on `_load_ephemeral_system_prompt`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
