### PR TITLE
feat(plugins): add startup advisory API

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4539,6 +4539,18 @@ class HermesCLI:
             # logged at DEBUG by the advisory module.
             pass
 
+    def _show_plugin_startup_advisories(self):
+        """Render plugin startup advisories in the banner-to-welcome slot."""
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            advisories = get_plugin_manager().get_startup_advisories()
+            for advisory in advisories:
+                print(advisory, file=sys.stderr, flush=True)
+        except Exception:
+            # Plugin advisories are best-effort and must never block startup.
+            pass
+
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
@@ -11560,6 +11572,9 @@ class HermesCLI:
         # Surface any active supply-chain security advisories right after the
         # welcome banner. Quiet/single-query paths call this themselves.
         self._show_security_advisories()
+        # Give plugins the same visible startup slot for update/auth/config
+        # notices without injecting messages into the LLM conversation.
+        self._show_plugin_startup_advisories()
         # If resuming a session, load history and display it immediately
         # so the user has context before typing their first message.
         if self._resumed:
@@ -14154,6 +14169,7 @@ def main(
             # Surface security advisories before the agent runs — short
             # banner, doesn't depend on the welcome banner being shown.
             cli._show_security_advisories()
+            cli._show_plugin_startup_advisories()
             cli.chat(query, images=single_query_images or None)
             cli._print_exit_summary()
         return

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -382,6 +382,22 @@ class PluginContext:
             cli._pending_input.put(msg)
         return True
 
+    # -- startup advisories -------------------------------------------------
+
+    def register_startup_advisory(self, callback: Callable[[], Any]) -> None:
+        """Register a one-line advisory rendered during interactive startup.
+
+        The callback is evaluated after the CLI banner and before the welcome
+        text, giving plugins a visible place for update, auth, or config
+        notices without injecting messages into the LLM conversation.
+        """
+        self._manager._startup_advisories.append((self.manifest.name, callback))
+        logger.debug(
+            "Plugin %s registered startup advisory: %s",
+            self.manifest.name,
+            getattr(callback, "__name__", repr(callback)),
+        )
+
     # -- CLI command registration --------------------------------------------
 
     def register_cli_command(
@@ -750,6 +766,7 @@ class PluginManager:
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
         self._plugin_skills: Dict[str, Dict[str, Any]] = {}
+        self._startup_advisories: List[tuple[str, Callable[[], Any]]] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -771,6 +788,7 @@ class PluginManager:
             self._cli_commands.clear()
             self._plugin_commands.clear()
             self._plugin_skills.clear()
+            self._startup_advisories.clear()
             self._context_engine = None
         self._discovered = True
 
@@ -1297,6 +1315,31 @@ class PluginManager:
                 )
         return results
 
+    def get_startup_advisories(self) -> List[str]:
+        """Return visible one-line startup advisories registered by plugins.
+
+        Each plugin callback is isolated so a broken advisory cannot block
+        startup. Empty or ``None`` values are ignored. Newlines are collapsed
+        so the startup slot remains compact and predictable.
+        """
+        advisories: List[str] = []
+        for plugin_name, callback in list(self._startup_advisories):
+            try:
+                value = callback()
+            except Exception as exc:
+                logger.warning(
+                    "Plugin '%s' startup advisory callback raised: %s",
+                    plugin_name,
+                    exc,
+                )
+                continue
+            if value is None:
+                continue
+            text = " ".join(str(value).split()).strip()
+            if text:
+                advisories.append(text)
+        return advisories
+
     # -----------------------------------------------------------------------
     # Introspection
     # -----------------------------------------------------------------------
@@ -1375,6 +1418,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+def get_startup_advisories() -> List[str]:
+    """Return startup advisories from all loaded plugins."""
+    return get_plugin_manager().get_startup_advisories()
 
 
 

--- a/tests/cli/test_plugin_startup_advisories.py
+++ b/tests/cli/test_plugin_startup_advisories.py
@@ -1,0 +1,23 @@
+"""Tests for rendering plugin startup advisories in the interactive CLI."""
+
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+def test_cli_prints_plugin_startup_advisories_between_banner_and_welcome(monkeypatch, capsys):
+    """Plugin advisories should have a visible startup slot before welcome text."""
+    shell = HermesCLI.__new__(HermesCLI)
+    manager = MagicMock()
+    manager.get_startup_advisories.return_value = [
+        "⚠ Update available: 0.3.8 → 0.3.10",
+        "stale auth token",
+    ]
+    monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+    shell._show_plugin_startup_advisories()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "⚠ Update available: 0.3.8 → 0.3.10" in captured.err
+    assert "stale auth token" in captured.err

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -494,6 +494,51 @@ class TestPluginHooks:
         assert any("on_banana" in record.message for record in caplog.records)
 
 
+class TestPluginStartupAdvisories:
+    """Tests for plugin-registered startup advisories."""
+
+    def test_register_startup_advisory_collects_visible_message(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "update_plugin",
+            register_body=(
+                'ctx.register_startup_advisory('
+                'lambda: "⚠ Update available: 0.3.8 → 0.3.10")'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert mgr.get_startup_advisories() == ["⚠ Update available: 0.3.8 → 0.3.10"]
+
+    def test_startup_advisories_ignore_empty_values_and_survive_exceptions(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "mixed_plugin",
+            register_body=(
+                'ctx.register_startup_advisory(lambda: "")\n'
+                '    ctx.register_startup_advisory(lambda: None)\n'
+                '    ctx.register_startup_advisory(lambda: 1/0)\n'
+                '    ctx.register_startup_advisory(lambda: "stale auth token")'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            assert mgr.get_startup_advisories() == ["stale auth token"]
+
+        assert any("startup advisory" in record.message for record in caplog.records)
+
+
 class TestPreToolCallBlocking:
     """Tests for the pre_tool_call block directive helper."""
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -102,6 +102,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Add slash commands | `ctx.register_command(name, handler, description)` — adds `/name` in CLI and gateway sessions |
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
+| Show startup advisories | `ctx.register_startup_advisory(callback)` — prints one-line CLI startup notices before the welcome text |
 | Inject messages | `ctx.inject_message(content, role="user")` — see [Injecting Messages](#injecting-messages) |
 | Ship data files | `Path(__file__).parent / "data" / "file.yaml"` |
 | Bundle skills | `ctx.register_skill(name, path)` — namespaced as `plugin:skill`, loaded via `skill_view("plugin:skill")` |
@@ -225,6 +226,7 @@ The table above shows the four plugin categories, but within "General plugins" t
 | A **lifecycle hook** (pre/post LLM, session start/end, tool filter) | Python plugin — `ctx.register_hook()` | [Hooks reference](/docs/user-guide/features/hooks) · [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin) |
 | A **slash command** for the CLI / gateway | Python plugin — `ctx.register_command()` | [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin) · [Extending the CLI](/docs/developer-guide/extending-the-cli) |
 | A **subcommand** for `hermes <thing>` | Python plugin — `ctx.register_cli_command()` | [Extending the CLI](/docs/developer-guide/extending-the-cli) |
+| A **visible CLI startup notice** that should not become an LLM message | Python plugin — `ctx.register_startup_advisory()` | [Startup Advisories](#startup-advisories) |
 | A bundled **skill** that your plugin ships | Python plugin — `ctx.register_skill()` | [Creating Skills](/docs/developer-guide/creating-skills) |
 | An **inference backend** (LLM provider: OpenAI-compat, Codex, Anthropic-Messages, Bedrock) | Provider plugin — `register_provider(ProviderProfile(...))` in `plugins/model-providers/<name>/` | **[Model Provider Plugins](/docs/developer-guide/model-provider-plugin)** · [Adding Providers](/docs/developer-guide/adding-providers) |
 | A **gateway channel** (Discord / Telegram / IRC / Teams / etc.) | Platform plugin — `ctx.register_platform()` in `plugins/platforms/<name>/` | [Adding Platform Adapters](/docs/developer-guide/adding-platform-adapters) |
@@ -319,6 +321,26 @@ Plugins occupy one of three states:
 The default for a newly-installed or bundled plugin is `not enabled`. `hermes plugins list` shows all three distinct states so you can tell what's been explicitly turned off vs. what's just waiting to be enabled.
 
 In a running session, `/plugins` shows which plugins are currently loaded.
+
+## Startup Advisories
+
+Plugins can register a one-line startup notice using `ctx.register_startup_advisory()`:
+
+```python
+def register(ctx):
+    ctx.register_startup_advisory(
+        lambda: "⚠ Update available: 0.3.8 → 0.3.10. Run: hermes plugins update my-plugin"
+    )
+```
+
+**Signature:** `ctx.register_startup_advisory(callback: Callable[[], str | None]) -> None`
+
+How it works:
+
+- Hermes evaluates advisory callbacks during CLI startup after the banner/security advisories and before the welcome text.
+- Notices are printed to stderr so they are visible but are not injected into the conversation or sent to the LLM.
+- Empty or `None` return values are ignored, so plugins can cheaply check whether a notice is needed.
+- Exceptions are logged and skipped; a broken advisory never blocks startup.
 
 ## Injecting Messages
 


### PR DESCRIPTION
## Summary
- Adds `ctx.register_startup_advisory(callback)` for plugins to expose one-line CLI startup notices.
- Collects advisories through `PluginManager.get_startup_advisories()` with exception isolation and empty-value filtering.
- Renders plugin advisories after the banner/security advisories and before welcome text in interactive and single-query startup paths.
- Documents the new plugin API and adds regression tests for manager/context and CLI rendering behavior.

Closes #26785

## Test Plan
- `python -m pytest tests/hermes_cli/test_plugins.py::TestPluginStartupAdvisories tests/cli/test_plugin_startup_advisories.py -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_startup_plugin_gating.py tests/hermes_cli/test_plugin_cli_registration.py -q -o 'addopts='`
- `python -m pytest tests/cli/test_cli_provider_resolution.py tests/test_cli_skin_integration.py -q -o 'addopts='`
- `python -m py_compile cli.py hermes_cli/plugins.py`
