### PR TITLE
docs(auth): prefer IPv4 for OAuth SSH tunnels

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2619,7 +2619,7 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
     print("browser is on a different machine, forward the port first from your")
     print("local machine in a separate terminal:")
     print()
-    print(f"  ssh -N -L {port}:127.0.0.1:{port} <user>@<this-host>")
+    print(f"  ssh -N -4 -L {port}:127.0.0.1:{port} <user>@<this-host>")
     print()
     print("Then open the authorize URL above in your local browser.")
     if docs_url:

--- a/tests/hermes_cli/test_auth_loopback_ssh_hint.py
+++ b/tests/hermes_cli/test_auth_loopback_ssh_hint.py
@@ -35,8 +35,8 @@ def test_loopback_ssh_hint_prints_tunnel_command_on_ssh(monkeypatch):
     out = _cap(lambda: auth_mod._print_loopback_ssh_hint(
         "http://127.0.0.1:56121/callback", docs_url=auth_mod.XAI_OAUTH_DOCS_URL
     ))
-    # Must include the exact ssh -L command with the port from the redirect URI
-    assert "ssh -N -L 56121:127.0.0.1:56121" in out
+    # Must include the exact IPv4 ssh -L command with the port from the redirect URI
+    assert "ssh -N -4 -L 56121:127.0.0.1:56121" in out
     # Must include the provider-specific docs URL
     assert auth_mod.XAI_OAUTH_DOCS_URL in out
     # Must always include the cross-provider SSH guide
@@ -51,7 +51,7 @@ def test_loopback_ssh_hint_uses_actual_bound_port(monkeypatch):
     out = _cap(lambda: auth_mod._print_loopback_ssh_hint(
         "http://127.0.0.1:51234/callback", docs_url=auth_mod.XAI_OAUTH_DOCS_URL
     ))
-    assert "ssh -N -L 51234:127.0.0.1:51234" in out
+    assert "ssh -N -4 -L 51234:127.0.0.1:51234" in out
     assert "56121" not in out
 
 
@@ -78,7 +78,7 @@ def test_loopback_ssh_hint_works_without_provider_docs_url(monkeypatch):
     out = _cap(lambda: auth_mod._print_loopback_ssh_hint(
         "http://127.0.0.1:43827/spotify/callback"
     ))
-    assert "ssh -N -L 43827:127.0.0.1:43827" in out
+    assert "ssh -N -4 -L 43827:127.0.0.1:43827" in out
     # Generic SSH guide is always present even without a provider-specific URL
     assert auth_mod.OAUTH_OVER_SSH_DOCS_URL in out
     # Should not falsely show "Provider docs:" when no docs_url was passed
@@ -92,4 +92,4 @@ def test_loopback_ssh_hint_accepts_localhost_hostname(monkeypatch):
     out = _cap(lambda: auth_mod._print_loopback_ssh_hint(
         "http://localhost:56121/callback"
     ))
-    assert "ssh -N -L 56121:127.0.0.1:56121" in out
+    assert "ssh -N -4 -L 56121:127.0.0.1:56121" in out

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -16,7 +16,7 @@ The fix is a one-line SSH local-forward.
 
 ```bash
 # On your local machine (laptop), in a separate terminal:
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
+ssh -N -4 -L 56121:127.0.0.1:56121 user@remote-host
 
 # In your existing SSH session on the remote machine:
 hermes auth add xai-oauth --no-browser
@@ -49,10 +49,10 @@ xAI and Spotify both validate the `redirect_uri` parameter against an allowlist.
 
 ```bash
 # xAI Grok OAuth (port 56121)
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
+ssh -N -4 -L 56121:127.0.0.1:56121 user@remote-host
 
 # Or for Spotify (port 43827)
-ssh -N -L 43827:127.0.0.1:43827 user@remote-host
+ssh -N -4 -L 43827:127.0.0.1:43827 user@remote-host
 ```
 
 `-N` means "don't open a remote shell, just hold the tunnel open." Keep this terminal running for the duration of the login.
@@ -79,7 +79,7 @@ You can tear down the tunnel (Ctrl+C in the first terminal) once you see the suc
 If you reach Hermes through a bastion / jump host, use SSH's built-in `-J` (ProxyJump):
 
 ```bash
-ssh -N -L 56121:127.0.0.1:56121 -J jump-user@jump-host user@final-host
+ssh -N -4 -L 56121:127.0.0.1:56121 -J jump-user@jump-host user@final-host
 ```
 
 This chains a SSH connection through the jump host without putting the loopback port on the jump box itself. The local `127.0.0.1:56121` on your laptop tunnels straight through to `127.0.0.1:56121` on the final remote host.
@@ -101,7 +101,7 @@ If you use `ssh -o ControlMaster=auto`, port forwards on a multiplexed connectio
 
 ```bash
 ssh -O exit user@remote-host
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
+ssh -N -4 -L 56121:127.0.0.1:56121 user@remote-host
 ```
 
 ## Troubleshooting

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -65,7 +65,7 @@ On servers, containers, or SSH sessions where no browser is available, Hermes de
 
 ```bash
 # In a separate terminal on your local machine:
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
+ssh -N -4 -L 56121:127.0.0.1:56121 user@remote-host
 
 # Then in your SSH session on the remote machine:
 hermes auth add xai-oauth --no-browser
@@ -195,7 +195,7 @@ On SSH or container sessions Hermes prints the authorization URL instead of open
 
 ```bash
 # Local machine, separate terminal:
-ssh -N -L 56121:127.0.0.1:56121 user@remote-host
+ssh -N -4 -L 56121:127.0.0.1:56121 user@remote-host
 
 # Remote machine:
 hermes auth add xai-oauth --no-browser


### PR DESCRIPTION
## Summary
- Add `-4` to OAuth-over-SSH tunnel examples so SSH binds IPv4 and avoids noisy/misleading IPv6 bind warnings.
- Keep the runtime remote-login hint and regression tests aligned with the docs.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_auth_loopback_ssh_hint.py -q -o 'addopts='`
- [x] `git diff --check`

Closes #26641