### PR TITLE
fix: link compact holographic memory entities

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -89,6 +89,25 @@ _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
 )
+_KNOWN_SINGLE_TOKEN_ENTITIES = (
+    "1Password",
+    "Cloudflare",
+    "GitHub",
+    "Hermes",
+    "Matrix",
+    "OpenAI",
+    "OpenClaw",
+    "RasPi",
+    "Tailscale",
+)
+_RE_KNOWN_SINGLE_TOKEN = re.compile(
+    r"\b("
+    + "|".join(re.escape(name) for name in _KNOWN_SINGLE_TOKEN_ENTITIES)
+    + r")\b"
+)
+_RE_SLASH_ENTITY_HEAD = re.compile(
+    r"\b([A-Z][A-Za-z0-9+_.-]{2,})(?=/[A-Za-z0-9][A-Za-z0-9+_.-]*)"
+)
 
 
 def _clamp_trust(value: float) -> float:
@@ -403,6 +422,8 @@ class MemoryStore:
         2. Double-quoted terms             e.g. "Python"
         3. Single-quoted terms             e.g. 'pytest'
         4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+        5. Known single-token products     e.g. Tailscale, 1Password
+        6. Slash-separated entity heads    e.g. Neon/postgres -> Neon
 
         Returns a deduplicated list preserving first-seen order.
         """
@@ -427,6 +448,12 @@ class MemoryStore:
         for m in _RE_AKA.finditer(text):
             _add(m.group(1))
             _add(m.group(2))
+
+        for m in _RE_KNOWN_SINGLE_TOKEN.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_SLASH_ENTITY_HEAD.finditer(text):
+            _add(m.group(1))
 
         return candidates
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1060,3 +1060,57 @@ class TestHonchoCadenceTracking:
         p.on_turn_start(2, "second message")
         should_skip = p._injection_frequency == "first-turn" and p._turn_count > 1
         assert should_skip, "Second turn (turn 2) SHOULD be skipped"
+
+
+class TestHolographicEntityExtraction:
+    """Regression coverage for durable entity links on compact facts."""
+
+    def test_links_known_single_token_product_entities(self, tmp_path):
+        from plugins.memory.holographic.store import MemoryStore
+
+        store = MemoryStore(db_path=tmp_path / "memory_store.db")
+        try:
+            fact_id = store.add_fact(
+                "User devices are on Tailscale; use 1Password CSW for secrets.",
+                category="user_pref",
+            )
+            rows = store._conn.execute(
+                """
+                SELECT e.name FROM entities e
+                JOIN fact_entities fe ON fe.entity_id = e.entity_id
+                WHERE fe.fact_id = ?
+                ORDER BY e.name
+                """,
+                (fact_id,),
+            ).fetchall()
+        finally:
+            store.close()
+
+        names = {row["name"] for row in rows}
+        assert "Tailscale" in names
+        assert "1Password" in names
+
+    def test_links_slash_separated_known_product_entity(self, tmp_path):
+        from plugins.memory.holographic.store import MemoryStore
+
+        store = MemoryStore(db_path=tmp_path / "memory_store.db")
+        try:
+            fact_id = store.add_fact(
+                "User prefers automation stop and ask on Cloudflare/challenge pages; project uses Neon/postgres branching.",
+                category="user_pref",
+            )
+            rows = store._conn.execute(
+                """
+                SELECT e.name FROM entities e
+                JOIN fact_entities fe ON fe.entity_id = e.entity_id
+                WHERE fe.fact_id = ?
+                ORDER BY e.name
+                """,
+                (fact_id,),
+            ).fetchall()
+        finally:
+            store.close()
+
+        names = {row["name"] for row in rows}
+        assert "Cloudflare" in names
+        assert "Neon" in names


### PR DESCRIPTION
## Summary
- Link known single-token product entities such as Tailscale, 1Password, Cloudflare, OpenClaw, and Matrix during holographic memory extraction
- Link capitalized entity heads in slash-separated terms such as Neon/postgres
- Add regression coverage to ensure compact durable facts create fact/entity links

## Test Plan
- [x] python -m pytest tests/agent/test_memory_provider.py::TestHolographicEntityExtraction -v -o 'addopts='
- [x] python -m pytest tests/agent/test_memory_provider.py -q -o 'addopts='