### PR TITLE
test(whatsapp): cover npm install timeout

### DIFF
--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -214,17 +214,18 @@ class TestFileHandleClosedOnError:
 class TestConnectCleanup:
     """Verify failure paths release the scoped session lock."""
 
+    @staticmethod
+    def _path_exists_for_missing_node_modules(path_obj):
+        return not str(path_obj).endswith("node_modules")
+
     @pytest.mark.asyncio
     async def test_releases_lock_when_npm_install_fails(self):
         adapter = _make_adapter()
 
-        def _path_exists(path_obj):
-            return not str(path_obj).endswith("node_modules")
-
         install_result = MagicMock(returncode=1, stderr="install failed")
 
         with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
-             patch.object(Path, "exists", autospec=True, side_effect=_path_exists), \
+             patch.object(Path, "exists", autospec=True, side_effect=self._path_exists_for_missing_node_modules), \
              patch("subprocess.run", return_value=install_result), \
              patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
              patch("gateway.status.release_scoped_lock") as mock_release:
@@ -233,6 +234,39 @@ class TestConnectCleanup:
         assert result is False
         mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
         assert adapter._platform_lock_identity is None
+
+    @pytest.mark.asyncio
+    async def test_npm_install_uses_five_minute_default_timeout(self, monkeypatch):
+        """Slow NAS/container hosts need more than the old 60s default."""
+        adapter = _make_adapter()
+        monkeypatch.delenv("WHATSAPP_NPM_INSTALL_TIMEOUT", raising=False)
+        install_result = MagicMock(returncode=1, stderr="install failed")
+
+        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", autospec=True, side_effect=self._path_exists_for_missing_node_modules), \
+             patch("subprocess.run", return_value=install_result) as mock_run, \
+             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
+             patch("gateway.status.release_scoped_lock"):
+            result = await adapter.connect()
+
+        assert result is False
+        assert mock_run.call_args.kwargs["timeout"] == 300
+
+    @pytest.mark.asyncio
+    async def test_npm_install_timeout_can_be_overridden(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("WHATSAPP_NPM_INSTALL_TIMEOUT", "600")
+        install_result = MagicMock(returncode=1, stderr="install failed")
+
+        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", autospec=True, side_effect=self._path_exists_for_missing_node_modules), \
+             patch("subprocess.run", return_value=install_result) as mock_run, \
+             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
+             patch("gateway.status.release_scoped_lock"):
+            result = await adapter.connect()
+
+        assert result is False
+        assert mock_run.call_args.kwargs["timeout"] == 600
 
 
 class TestBridgeRuntimeFailure:


### PR DESCRIPTION
## What does this PR do?

The WhatsApp gateway bridge runs `npm install` to set up its Node dependencies on first connect. That call previously used the default 60s subprocess timeout, which fired on slower NAS/container hosts and aborted the install partway through. The default was raised to 300s and an env override (`WHATSAPP_NPM_INSTALL_TIMEOUT`) was added; this PR adds regression coverage so neither change can silently regress.

## Related Issue

Fixes #14980

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/gateway/test_whatsapp_connect.py`:
  - Extract the `node_modules`-missing predicate into a shared `TestConnectCleanup` static helper to deduplicate setup across the new tests.
  - Add `test_npm_install_uses_default_timeout` — asserts `subprocess.run` is called with `timeout=300` when `WHATSAPP_NPM_INSTALL_TIMEOUT` is unset.
  - Add `test_npm_install_honors_env_override` — asserts `WHATSAPP_NPM_INSTALL_TIMEOUT=600` overrides the default and is passed through to `subprocess.run`.

## How to Test

1. `python -m pytest tests/gateway/test_whatsapp_connect.py -q -o 'addopts='`
2. Both new tests pass; existing tests in the file are unaffected.
3. `git diff --check` is clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(whatsapp):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted test file and it passes
- [x] I've added tests for my changes (this PR *is* the tests)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (test-only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — tests stub `subprocess.run`, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_whatsapp_connect.py -q -o 'addopts='
... all tests pass ...
```
