### PR TITLE
docs(spotify): document setup and Home Assistant speaker routing

### DIFF
--- a/website/docs/user-guide/features/spotify.md
+++ b/website/docs/user-guide/features/spotify.md
@@ -12,7 +12,7 @@ Unlike Hermes' built-in OAuth integrations (Google, GitHub Copilot, Codex), Spot
 
 ## Setup
 
-### One-shot: `hermes tools`
+### One-shot: `hermes tools` or first-run setup
 
 The fastest path. Run:
 
@@ -20,7 +20,9 @@ The fastest path. Run:
 hermes tools
 ```
 
-Scroll to `🎵 Spotify`, press space to toggle it on, then `s` to save. Hermes drops you straight into the OAuth flow — if you don't have a Spotify app yet, it walks you through creating one inline. Once you finish, the toolset is enabled AND authenticated in one pass.
+Scroll to `🎵 Spotify`, press space to toggle it on, then `s` to save. The same toggle is also available during the first-run `hermes setup` / `hermes setup tools` flow. Spotify stays opt-in, so enabling it there runs the same provider-aware configuration as `hermes tools`.
+
+Hermes drops you straight into the OAuth flow — if you don't have a Spotify app yet, it walks you through creating one inline. Once you finish, the toolset is enabled AND authenticated in one pass.
 
 If you prefer to do the steps separately (or you're re-authing later), use the two-step flow below.
 
@@ -124,6 +126,12 @@ Control and inspect playback, plus fetch recently played history.
 |--------|---------|
 | `list` | Every Spotify Connect device visible to your account |
 | `transfer` | Move playback to `device_id`. Optional `play: true` starts playback on transfer |
+
+### Home Assistant-managed speakers
+
+If Home Assistant manages speakers that already support Spotify Connect (for example Sonos, Echo, Nest, or other Connect-capable speakers), they appear in `spotify_devices list` automatically whenever Spotify can see them. Hermes does not need a Home Assistant ↔ Spotify bridge for this path — Spotify handles the device routing natively.
+
+Ask Hermes to transfer playback by the speaker's display name (for example, “transfer Spotify to the kitchen speaker”), or call `spotify_devices list` and pass the exact `device_id` to `spotify_devices transfer` when scripting. If the speaker is missing, open the Spotify app or the speaker's Spotify integration once so Spotify registers it as an active Connect target.
 
 #### `spotify_queue`
 | Action | Purpose | Premium? |


### PR DESCRIPTION
## Summary

Closes #15615.

Updates the Spotify feature guide to make the first-run `hermes setup` / `hermes setup tools` path discoverable alongside `hermes tools`, and documents that Home Assistant-managed speakers which support Spotify Connect show up through `spotify_devices list` without any Hermes-side HA↔Spotify bridge.

## Why / root cause

The current setup/tool picker on `main` already includes the `spotify` toolset and keeps it opt-in, but the user-facing Spotify guide only pointed users at `hermes tools`. The guide also did not explain the Home Assistant speaker case called out in the issue.

## Changes

- `website/docs/user-guide/features/spotify.md`: mentions the first-run setup/tools toggle and that it uses the same provider-aware configuration flow as `hermes tools`.
- `website/docs/user-guide/features/spotify.md`: adds a "Home Assistant-managed speakers" subsection explaining Spotify Connect discovery, targeting by display name, and explicit `device_id` transfer for scripts.

## Tests

- `$HOME/.hermes/hermes-agent/venv/bin/python - <<'PY' ...` verified `spotify` is present in `CONFIGURABLE_TOOLSETS` and remains in `_DEFAULT_OFF_TOOLSETS`.
- Not run: pytest (docs-only change).

## Out of scope

- No new Home Assistant↔Spotify integration; the documented path is Spotify's native Connect device discovery.
- No default-device config knob from #15611.
