### PR TITLE
fix(feishu): use interactive card with schema 2.0 for full markdown rendering

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -558,6 +558,30 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
+def _build_markdown_interactive_payload(content: str) -> str:
+    """Build a Feishu interactive card with a markdown element.
+
+    Feishu's interactive cards support full markdown including tables,
+    unlike the post-type 'md' tag which has limited formatting.
+
+    https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-components/content-components/markdown
+    """
+    return json.dumps(
+        {
+            "schema": "2.0",
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": content,
+                    }
+                ],
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
@@ -1724,9 +1748,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type not in ("post", "interactive"):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] %s payload rejected by API; falling back to plain text", msg_type)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1735,11 +1759,12 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type not in ("text",)
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    and (_POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                         or "card" in str(getattr(response, "msg", "") or "").lower())
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] %s payload rejected by API response; falling back to plain text", msg_type)
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1773,8 +1798,11 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and msg_type not in ("text",) and (
+                _POST_CONTENT_INVALID_RE.search(result.error or "")
+                or "card" in (result.error or "").lower()
+            ):
+                logger.warning("[Feishu] %s update payload rejected by API; falling back to plain text", msg_type)
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -4175,14 +4203,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+        # Feishu interactive cards support full markdown (headings, bold, italic,
+        # code blocks, links, AND tables). Use them for all markdown content.
+        # Plain text without any markdown stays as msg_type "text" for simplicity.
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
+            return "interactive", _build_markdown_interactive_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 


### PR DESCRIPTION
Currently `_build_outbound_payload` falls back to `msg_type: "text"` when a markdown table is detected, because Feishu's post-type `md` tag doesn't render tables. This drops **all** formatting — bold, italic, code blocks, links — for the entire message.

## Changes
- Add `_build_markdown_interactive_payload()` using Feishu interactive cards with `schema: "2.0"` and `body` wrapper
- Route all markdown content (including tables) to `msg_type: "interactive"`
- Update fallback/error-handling logic to handle `"interactive"` alongside `"post"`
- Plain text messages without formatting remain as `msg_type: "text"`

## Before/After

| Content | Before | After |
|---------|--------|-------|
| Bold, italic, inline code | ✅ | ✅ |
| Code blocks | ✅ | ✅ |
| Links | ✅ | ✅ |
| Tables | ❌ entire msg raw | ✅ |
| Plain text | ✅ | ✅ |