### PR TITLE
fix(agent): preserve plugin context through compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10387,6 +10387,39 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
+    @staticmethod
+    def _last_user_message_index(messages: list) -> int:
+        for idx in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[idx], dict) and messages[idx].get("role") == "user":
+                return idx
+        return -1
+
+    def _compress_context_for_turn(
+        self,
+        messages: list,
+        system_message: str,
+        *,
+        approx_tokens: int = None,
+        task_id: str = "default",
+        focus_topic: str = None,
+    ) -> tuple:
+        compress_kwargs = {
+            "approx_tokens": approx_tokens,
+            "task_id": task_id,
+        }
+        if focus_topic is not None:
+            compress_kwargs["focus_topic"] = focus_topic
+        compressed, new_system_prompt = self._compress_context(
+            messages,
+            system_message,
+            **compress_kwargs,
+        )
+        return (
+            compressed,
+            new_system_prompt,
+            self._last_user_message_index(compressed),
+        )
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -11848,7 +11881,6 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
-                    or queuing follow-up prefetch work.
 
         Returns:
             Dict: Complete conversation result with final response and message history
@@ -12133,7 +12165,11 @@ class AIAgent:
                 # context windows (each pass summarises the middle N turns).
                 for _pass in range(3):
                     _orig_len = len(messages)
-                    messages, active_system_prompt = self._compress_context(
+                    (
+                        messages,
+                        active_system_prompt,
+                        current_turn_user_idx,
+                    ) = self._compress_context_for_turn(
                         messages, system_message, approx_tokens=_preflight_tokens,
                         task_id=effective_task_id,
                     )
@@ -12165,9 +12201,9 @@ class AIAgent:
                         break  # Under threshold
 
         # Plugin hook: pre_llm_call
-        # Fired once per turn before the tool-calling loop.  Plugins can
-        # return a dict with a ``context`` key (or a plain string) whose
-        # value is appended to the current turn's user message.
+        # Fired once per turn before the tool-calling loop. Plugins can return
+        # a dict with a ``context`` key (or a plain string) whose value is
+        # appended to the current turn's user message.
         #
         # Context is ALWAYS injected into the user message, never the
         # system prompt.  This preserves the prompt cache prefix — the
@@ -12415,6 +12451,7 @@ class AIAgent:
                     repaired_seq,
                     self.session_id or "-",
                 )
+                current_turn_user_idx = self._last_user_message_index(messages)
 
             api_messages = []
             for idx, msg in enumerate(messages):
@@ -12422,7 +12459,7 @@ class AIAgent:
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks
-                # with target="user_message" (the default).  Both are
+                # with target="user_message" (the default). Both are
                 # API-call-time only — the original message in `messages` is
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
@@ -12435,8 +12472,13 @@ class AIAgent:
                         _injections.append(_plugin_user_context)
                     if _injections:
                         _base = api_msg.get("content", "")
+                        _context_text = "\n\n".join(_injections)
                         if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                            api_msg["content"] = _base + "\n\n" + _context_text
+                        elif isinstance(_base, list):
+                            api_msg["content"] = list(_base) + [
+                                {"type": "text", "text": _context_text}
+                            ]
 
                 # For ALL assistant messages, pass reasoning back to the API
                 # This ensures multi-turn reasoning context is preserved
@@ -12469,7 +12511,7 @@ class AIAgent:
             # NOTE: Plugin context from pre_llm_call hooks is injected into the
             # user message (see injection block above), NOT the system prompt.
             # This is intentional — system prompt modifications break the prompt
-            # cache prefix.  The system prompt is reserved for Hermes internals.
+            # cache prefix. The system prompt is reserved for Hermes internals.
             #
             # Hermes invariant: the system prompt is built ONCE per session
             # (cached on ``_cached_system_prompt``) and replayed verbatim on
@@ -13960,7 +14002,11 @@ class AIAgent:
                         compression_attempts += 1
                         if compression_attempts <= max_compression_attempts:
                             original_len = len(messages)
-                            messages, active_system_prompt = self._compress_context(
+                            (
+                                messages,
+                                active_system_prompt,
+                                current_turn_user_idx,
+                            ) = self._compress_context_for_turn(
                                 messages, system_message,
                                 approx_tokens=approx_tokens,
                                 task_id=effective_task_id,
@@ -14094,7 +14140,11 @@ class AIAgent:
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
-                        messages, active_system_prompt = self._compress_context(
+                        (
+                            messages,
+                            active_system_prompt,
+                            current_turn_user_idx,
+                        ) = self._compress_context_for_turn(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -14251,7 +14301,11 @@ class AIAgent:
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
-                        messages, active_system_prompt = self._compress_context(
+                        (
+                            messages,
+                            active_system_prompt,
+                            current_turn_user_idx,
+                        ) = self._compress_context_for_turn(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
                         )
@@ -15023,7 +15077,11 @@ class AIAgent:
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
                         self._safe_print("  ⟳ compacting context…")
-                        messages, active_system_prompt = self._compress_context(
+                        (
+                            messages,
+                            active_system_prompt,
+                            current_turn_user_idx,
+                        ) = self._compress_context_for_turn(
                             messages, system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,
                             task_id=effective_task_id,

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -78,6 +78,15 @@ def _make_413_error(*, use_status_code=True, message="Request entity too large")
     return err
 
 
+EPHEMERAL_CONTEXT = "EPHEMERAL USER CONTEXT"
+
+
+def _plugin_context_hook(hook_name, **kwargs):
+    if hook_name == "pre_llm_call":
+        return [{"context": EPHEMERAL_CONTEXT}]
+    return []
+
+
 @pytest.fixture()
 def agent():
     with (
@@ -108,6 +117,44 @@ def agent():
 class TestHTTP413Compression:
     """413 errors should trigger compression, not abort as generic 4xx."""
 
+    def test_compress_context_for_turn_supports_legacy_override_signature(self):
+        """The wrapper must not pass new optional kwargs to old overrides."""
+
+        class LegacyCompressionAgent(AIAgent):
+            def _compress_context(
+                self,
+                messages,
+                system_message,
+                approx_tokens=None,
+                task_id=None,
+            ):
+                self.received = (messages, system_message, approx_tokens, task_id)
+                return (
+                    [
+                        {"role": "assistant", "content": "summary"},
+                        {"role": "user", "content": "current"},
+                    ],
+                    "legacy prompt",
+                )
+
+        agent = LegacyCompressionAgent.__new__(LegacyCompressionAgent)
+        compressed, system_prompt, current_user_idx = agent._compress_context_for_turn(
+            [{"role": "user", "content": "hello"}],
+            "system",
+            approx_tokens=123,
+            task_id="task-1",
+        )
+
+        assert compressed[-1] == {"role": "user", "content": "current"}
+        assert system_prompt == "legacy prompt"
+        assert current_user_idx == 1
+        assert agent.received == (
+            [{"role": "user", "content": "hello"}],
+            "system",
+            123,
+            "task-1",
+        )
+
     def test_413_triggers_compression(self, agent):
         """A 413 error should call _compress_context and retry, not abort."""
         # First call raises 413; second call succeeds after compression.
@@ -137,6 +184,41 @@ class TestHTTP413Compression:
         mock_compress.assert_called_once()
         assert result["completed"] is True
         assert result["final_response"] == "Success after compression"
+
+    def test_413_retry_preserves_ephemeral_user_context(self, agent):
+        """Compressed retry requests keep API-call-time user context."""
+        err_413 = _make_413_error()
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_413, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_plugin_context_hook),
+        ):
+            mock_compress.return_value = (
+                [
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
+                    {"role": "user", "content": "hello"},
+                ],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        assert result["completed"] is True
+        retry_messages = agent.client.chat.completions.create.call_args_list[-1].kwargs["messages"]
+        current_user = [m for m in retry_messages if m.get("role") == "user"][-1]
+        assert "hello" in current_user["content"]
+        assert current_user["content"].endswith(
+            f"\n\n{EPHEMERAL_CONTEXT}"
+        )
 
     def test_413_not_treated_as_generic_4xx(self, agent):
         """413 must NOT hit the generic 4xx abort path; it should attempt compression."""
@@ -493,6 +575,45 @@ class TestPreflightCompression:
             for ev, msg in status_messages
         )
 
+    def test_preflight_compression_preserves_ephemeral_user_context(self, agent):
+        """Ephemeral user context must survive preflight message replacement."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 2000
+        agent.context_compressor.threshold_tokens = 200
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} " + "x" * 40})
+            big_history.append({"role": "assistant", "content": f"Response {i} " + "y" * 40})
+
+        ok_resp = _mock_response(content="After preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.estimate_request_tokens_rough", side_effect=[500, 50]),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_plugin_context_hook),
+        ):
+            mock_compress.return_value = (
+                [
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
+                    {"role": "user", "content": "hello"},
+                ],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        assert result["completed"] is True
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        current_user = [m for m in sent_messages if m.get("role") == "user"][-1]
+        assert "hello" in current_user["content"]
+        assert current_user["content"].endswith(
+            f"\n\n{EPHEMERAL_CONTEXT}"
+        )
+
     def test_no_preflight_when_under_threshold(self, agent):
         """When history fits within context, no preflight compression needed."""
         agent.compression_enabled = True
@@ -584,6 +705,53 @@ class TestToolResultPreflightCompression:
 
         mock_compress.assert_called_once()
         assert result["completed"] is True
+
+    def test_post_tool_compression_preserves_ephemeral_user_context(self, agent):
+        """Post-tool auto-compression keeps user context on the next request."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 130_000
+        agent.context_compressor.last_prompt_tokens = 130_000
+        agent.context_compressor.last_completion_tokens = 5_000
+
+        tc = SimpleNamespace(
+            id="tc1", type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"query":"test"}'),
+        )
+        tool_resp = _mock_response(
+            content=None, finish_reason="stop", tool_calls=[tc],
+            usage={"prompt_tokens": 130_000, "completion_tokens": 5_000, "total_tokens": 135_000},
+        )
+        ok_resp = _mock_response(
+            content="Done after compression", finish_reason="stop",
+            usage={"prompt_tokens": 50_000, "completion_tokens": 100, "total_tokens": 50_100},
+        )
+        agent.client.chat.completions.create.side_effect = [tool_resp, ok_resp]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="x" * 100_000),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_plugin_context_hook),
+        ):
+            mock_compress.return_value = (
+                [
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"},
+                    {"role": "user", "content": "hello"},
+                ],
+                "compressed prompt",
+            )
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        retry_messages = agent.client.chat.completions.create.call_args_list[-1].kwargs["messages"]
+        current_user = [m for m in retry_messages if m.get("role") == "user"][-1]
+        assert "hello" in current_user["content"]
+        assert current_user["content"].endswith(
+            f"\n\n{EPHEMERAL_CONTEXT}"
+        )
 
     def test_anthropic_prompt_too_long_safety_net(self, agent):
         """Anthropic 'prompt is too long' error triggers compression as safety net."""

--- a/tests/run_agent/test_ephemeral_user_context.py
+++ b/tests/run_agent/test_ephemeral_user_context.py
@@ -1,0 +1,78 @@
+"""Tests for ephemeral user-context injection."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+EPHEMERAL_CONTEXT = "EPHEMERAL USER CONTEXT"
+
+
+def _tool_defs():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "web_search tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _mock_response(content="ok"):
+    message = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _plugin_context_hook(hook_name, **kwargs):
+    if hook_name == "pre_llm_call":
+        return [{"context": EPHEMERAL_CONTEXT}]
+    return []
+
+
+def test_ephemeral_user_context_appends_text_part_to_multimodal_turn():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _mock_response()
+
+    user_message = [
+        {"type": "text", "text": "what changed?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+    ]
+    with (
+        patch.object(agent, "_model_supports_vision", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook", side_effect=_plugin_context_hook),
+    ):
+        agent.run_conversation(user_message)
+
+    sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    current_user = [msg for msg in sent if msg.get("role") == "user"][-1]
+
+    assert current_user["content"][:-1] == user_message
+    assert current_user["content"][-1] == {
+        "type": "text",
+        "text": EPHEMERAL_CONTEXT,
+    }


### PR DESCRIPTION
## What does this PR do?

This fixes existing `pre_llm_call` ephemeral user-context injection in `run_agent.py` so it survives the compression paths in `run_conversation()`: preflight compression, 413/context-length retries, and post-tool auto-compression. It also handles multimodal current turns by appending plugin-supplied context as a text content part when the current user message content is a list.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a helper in `run_agent.py` to refresh the current-turn user index after context compression while preserving legacy `_compress_context` override signatures.
- Preserved `pre_llm_call` plugin context through preflight, retry, and post-tool compression paths.
- Added multimodal/list-content support for plugin context injection.
- Added focused tests in `tests/run_agent/test_413_compression.py` and `tests/run_agent/test_ephemeral_user_context.py`.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/run_agent/test_ephemeral_user_context.py tests/run_agent/test_anthropic_error_handling.py::test_prompt_too_long_triggers_compression
   ```
2. These cover preflight, retry, post-tool compression, multimodal turns, and legacy compression overrides.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

Ran `scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/run_agent/test_ephemeral_user_context.py tests/run_agent/test_anthropic_error_handling.py::test_prompt_too_long_triggers_compression`; full-suite green is not claimed locally.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
