### PR TITLE
docs(weixin): clarify allowed users setup

### DIFF
--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -142,6 +142,25 @@ WEIXIN_DM_POLICY=allowlist
 WEIXIN_ALLOWED_USERS=user_id_1,user_id_2
 ```
 
+`WEIXIN_ALLOWED_USERS` is an **inbound filter**, not an invitation system. QR
+login connects one iLink bot identity to Hermes. Other people do not scan the
+Hermes QR code with their own accounts; they must message the connected iLink
+bot/contact through WeChat, and Hermes will process the DM only if the sender's
+Weixin user ID is present in `WEIXIN_ALLOWED_USERS`.
+
+A practical setup flow is:
+
+1. Pair Hermes once with `hermes gateway setup` and note the connected iLink bot
+   account.
+2. Have each allowed user send a direct message to that bot/contact.
+3. Read the sender/user ID from the gateway logs or the inbound event payload.
+4. Add those IDs to `WEIXIN_ALLOWED_USERS`, then restart the gateway.
+
+If only the account that scanned the QR code can talk to Hermes, verify that the
+other users are messaging the iLink bot identity itself, not the personal WeChat
+account that performed the QR login. The iLink bot is a separate identity, and
+ordinary WeChat contact/group routing can be limited by Tencent's iLink behavior.
+
 ### Group Policy
 
 Controls which groups the bot responds in **when iLink delivers group events for the connected identity**. For QR-login iLink bot identities (e.g. `...@im.bot`), group events are typically not delivered at all, so this policy may have no effect — see the iLink bot limitation warning at the top of the page.


### PR DESCRIPTION
## Summary
- Clarify that `WEIXIN_ALLOWED_USERS` is an inbound sender filter, not a way for multiple accounts to scan the Hermes QR code.
- Document the practical setup flow for pairing once, having allowed users message the iLink bot identity, collecting sender IDs, and restarting the gateway.

## Test Plan
- [x] `git diff --check`

Closes #26743