### PR TITLE
feat(dashboard): add Clean Dark built-in theme

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3616,6 +3616,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "clean-dark","label": "Clean Dark",     "description": "Clean dark minimal — no background image, just crisp text on black"},
 ]
 
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -183,6 +183,31 @@ export const roseTheme: DashboardTheme = {
   },
 };
 
+export const cleanDarkTheme: DashboardTheme = {
+  name: "clean-dark",
+  label: "Clean Dark",
+  description: "Clean dark minimal — no background image, just crisp text on black",
+  palette: {
+    background: { hex: "#0d1117", alpha: 1 },
+    midground: { hex: "#c9d1d9", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(88, 166, 255, 0.12)",
+    noiseOpacity: 0,
+  },
+  assets: {
+    bg: "none",
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    baseSize: "15px",
+    lineHeight: "1.6",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.375rem",
+  },
+};
+
 /**
  * Same look as ``defaultTheme`` but with a larger root font size, looser
  * line-height, and ``spacious`` density so every rem-based size in the
@@ -212,4 +237,5 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  "clean-dark": cleanDarkTheme,
 };

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -201,11 +201,24 @@ export const cleanDarkTheme: DashboardTheme = {
     ...DEFAULT_TYPOGRAPHY,
     baseSize: "15px",
     lineHeight: "1.6",
+    letterSpacing: "0",
   },
   layout: {
     ...DEFAULT_LAYOUT,
     radius: "0.375rem",
   },
+  customCSS: `
+    /* Route decorative utility fonts through Clean Dark's readable stacks
+       while this theme is active. Other themes keep the decorative fonts. */
+    .font-mondwest,
+    .font-expanded,
+    .font-compressed { font-family: var(--theme-font-sans) !important; }
+    .font-courier { font-family: var(--theme-font-mono) !important; }
+
+    /* Keep tiny uppercase labels (sidebar status strip, etc.) legible. */
+    .text-\[0\.55rem\] { font-size: 0.7rem !important; }
+    .tracking-\[0\.12em\] { letter-spacing: 0.04em !important; }
+  `,
 };
 
 /**


### PR DESCRIPTION
## What

Adds a **Clean Dark** built-in theme to the dashboard — a minimal, image-free alternative for users who find the default filler-bg0.jpg background distracting.

## Changes

- **`web/src/themes/presets.ts`** — new `cleanDarkTheme` definition
- **`hermes_cli/web_server.py`** — registered in `_BUILTIN_DASHBOARD_THEMES`

## Theme details

| Property | Value |
|----------|-------|
| Background | `#0d1117` (GitHub-dark charcoal) |
| Text | `#c9d1d9` (soft gray) |
| Background image | **none** (assets.bg = "none") |
| Noise grain | disabled (noiseOpacity = 0) |
| Warm glow | subtle blue `rgba(88,166,255,0.12)` |
| Radius | `0.375rem` |

The `assets.bg" => "none"` causes the CSS cascade to hide the `.theme-default-filler` element, giving users a clean, distraction-free dark surface with no background image.