### PR TITLE
fix(agent): preserve MiMo thinking blocks on Anthropic replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,53 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+_XIAOMI_MIMO_MODEL_PREFIXES = (
+    "mimo-",
+    "mimo_",
+    "xiaomi-mimo-",
+    "xiaomi_mimo_",
+)
+
+
+def _model_name_is_xiaomi_mimo(model: str | None) -> bool:
+    """Return True when *model* belongs to the Xiaomi MiMo family."""
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    # Check bare prefixes after stripping the deepest namespace component.
+    if "/" in m:
+        leaf = m.rsplit("/", 1)[-1]
+    else:
+        leaf = m
+    if leaf.startswith(_XIAOMI_MIMO_MODEL_PREFIXES):
+        return True
+    # Defence-in-depth: catch deeper-namespaced forms like
+    # ``vendor/sub/mimo-v3`` that a single rsplit may not cover when
+    # the provider layer inserts its own prefix.
+    return "/mimo-" in m or "/xiaomi-mimo-" in m
+
+
+def _is_xiaomi_mimo_anthropic_endpoint(base_url: str | None, model: str | None = None) -> bool:
+    """Return True for Xiaomi MiMo Anthropic-compatible endpoints.
+
+    MiMo thinking mode follows the same replay contract as Kimi/DeepSeek: when
+    conversation history contains an assistant tool call, the full
+    reasoning_content from that assistant message must be passed back on
+    subsequent turns. In the Anthropic Messages protocol this is represented
+    as an unsigned ``thinking`` block before the ``tool_use`` block.
+
+    See hermes-agent#24465, #24726.
+    """
+    if _model_name_is_xiaomi_mimo(model):
+        return True
+    for _domain in ("xiaomimimo.com", "mimo.com"):
+        if base_url_host_matches(base_url or "", _domain):
+            return True
+    return False
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1479,11 +1526,12 @@ def convert_messages_to_anthropic(
     Anthropic-proprietary — third-party endpoints cannot validate them and will
     reject them with HTTP 400 "Invalid signature in thinking block".
 
-    When *model* is provided and matches the Kimi / Moonshot family (or
-    *base_url* is a Kimi / Moonshot host), unsigned thinking blocks
-    synthesised from ``reasoning_content`` are preserved on replayed
-    assistant tool-call messages — Kimi requires the field to exist, even
-    if empty.
+    When *model* / *base_url* identifies a provider with strict thinking
+    replay validation (Kimi / Moonshot, DeepSeek /anthropic, Xiaomi MiMo),
+    unsigned thinking blocks synthesised from ``reasoning_content`` are
+    preserved on replayed assistant tool-call messages.  These providers
+    require the prior reasoning payload to round-trip when thinking mode is
+    enabled.
     """
     system = None
     result = []
@@ -1532,15 +1580,17 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
-            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
-            # tool-call messages to carry reasoning_content when thinking is
-            # enabled server-side.  Preserve it as a thinking block so Kimi
-            # can validate the message history.  See hermes-agent#13848.
+            # Strict thinking-replay providers (Kimi / Moonshot, DeepSeek
+            # /anthropic, Xiaomi MiMo) require assistant tool-call messages to
+            # carry the prior reasoning payload when thinking mode is enabled.
+            # Preserve Hermes's provider-facing reasoning_content as an
+            # unsigned Anthropic ``thinking`` block so the upstream can
+            # validate the message history on the next request.  See
+            # hermes-agent#13848, #16748, #24465.
             #
-            # Accept empty string "" — _copy_reasoning_content_for_api()
-            # injects "" as a tier-3 fallback for Kimi tool-call messages
-            # that had no reasoning.  Kimi requires the field to exist, even
-            # if empty.
+            # Accept empty/blank strings — _copy_reasoning_content_for_api()
+            # injects a single-space fallback for strict thinking providers
+            # when stale or cross-provider history lacks real reasoning.
             #
             # Prepend (not append): Anthropic protocol requires thinking
             # blocks before text and tool_use blocks.
@@ -1557,6 +1607,25 @@ def convert_messages_to_anthropic(
             )
             if isinstance(reasoning_content, str) and not _already_has_thinking:
                 blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
+            elif (
+                (
+                    _is_kimi_family_endpoint(base_url, model)
+                    or _is_deepseek_anthropic_endpoint(base_url)
+                    or _is_xiaomi_mimo_anthropic_endpoint(base_url, model)
+                )
+                and not _already_has_thinking
+                and any(isinstance(b, dict) and b.get("type") == "tool_use" for b in blocks)
+            ):
+                # Strict thinking-replay providers (MiMo, Kimi, DeepSeek)
+                # require every assistant tool-use turn to carry a thinking
+                # block — even when the persisted history has no
+                # reasoning_content at all (e.g. sessions migrated from
+                # another provider or replayed from Anthropic-format dumps
+                # that predate the thinking-replay fix).  Inject a
+                # single-space placeholder so the upstream API does not
+                # reject the replay with HTTP 400.  See hermes-agent#24465
+                # and #24726 (akaDRJ live repro).
+                blocks.insert(0, {"type": "thinking", "thinking": " "})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":
@@ -1750,10 +1819,12 @@ def convert_messages_to_anthropic(
     # synthesised from reasoning_content round-trip on subsequent turns when
     # thinking is enabled.  Signed Anthropic blocks still have to be stripped
     # (neither endpoint can validate Anthropic's signatures); unsigned blocks
-    # are preserved.  See hermes-agent#13848 (Kimi) and #16748 (DeepSeek).
+    # are preserved.  See hermes-agent#13848 (Kimi), #16748 (DeepSeek),
+    # #24465 (Xiaomi MiMo).
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_mimo_anthropic_endpoint(base_url, model)
     )
 
     last_assistant_idx = None

--- a/tests/agent/test_xiaomi_mimo_anthropic_thinking.py
+++ b/tests/agent/test_xiaomi_mimo_anthropic_thinking.py
@@ -1,0 +1,277 @@
+"""Regression guard: preserve MiMo thinking history on Xiaomi's Anthropic endpoint.
+
+Xiaomi MiMo's Anthropic-compatible endpoint recently tightened thinking-mode
+validation.  Once thinking mode is enabled, prior assistant turns that contain
+``tool_use`` must replay their full ``reasoning_content`` on subsequent
+requests.  If Hermes treats MiMo like a generic third-party Anthropic endpoint,
+the signature-stripping pass removes the unsigned thinking block synthesized
+from ``reasoning_content`` and MiMo returns HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the API.
+
+MiMo follows the same replay contract as Kimi / DeepSeek: strip
+Anthropic-signed thinking blocks that Xiaomi cannot validate, but preserve
+unsigned blocks that Hermes synthesized from ``reasoning_content``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestXiaomiMiMoAnthropicPreservesThinking:
+    """convert_messages_to_anthropic must replay MiMo thinking blocks."""
+
+    @pytest.mark.parametrize(
+        "base_url,model",
+        [
+            ("https://token-plan-sgp.xiaomimimo.com/anthropic", "mimo-v2.5-pro"),
+            ("https://token-plan-sgp.xiaomimimo.com/anthropic/v1", "mimo-v2.5-pro"),
+            ("https://TOKEN-PLAN-SGP.XIAOMIMIMO.COM/anthropic", "mimo-v2.5-pro"),
+            ("https://llm.example.com/anthropic", "xiaomi-mimo-v2.5-pro"),
+            ("https://llm.example.com/anthropic", "xiaomi/mimo-v2.5-pro"),
+        ],
+    )
+    def test_unsigned_thinking_block_survives_replay(
+        self, base_url: str, model: str
+    ) -> None:
+        """Unsigned thinking synthesized from reasoning_content must be preserved."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "planning the MiMo tool call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "skill_view", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url=base_url, model=model
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b
+            for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0]["thinking"] == "planning the MiMo tool call"
+        assert "signature" not in thinking_blocks[0]
+
+    def test_signed_anthropic_thinking_block_is_stripped(self) -> None:
+        """Anthropic-signed thinking leaked from another provider must be stripped."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "anthropic signed payload",
+                        "signature": "anthropic-sig-xyz",
+                    },
+                    {"type": "text", "text": "hello"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://token-plan-sgp.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b
+            for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == []
+
+    def test_non_mimo_third_party_still_strips_unsigned_thinking(self) -> None:
+        """Generic third-party Anthropic endpoints keep strip-all behavior."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r1",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url="https://api.minimax.io/anthropic", model="MiniMax-M2.7"
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b
+            for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == []
+
+    def test_mimo_keeps_anthropic_thinking_request_parameter(self) -> None:
+        """MiMo still receives Anthropic thinking when reasoning is enabled."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="mimo-v2.5-pro",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="https://token-plan-sgp.xiaomimimo.com/anthropic",
+        )
+
+        assert kwargs["thinking"]["type"] == "enabled"
+        assert kwargs["temperature"] == 1
+
+    def test_mimo_anthropic_tool_use_without_thinking_gets_placeholder(self) -> None:
+        """Anthropic-format assistant turns with tool_use but no thinking must
+        receive a placeholder thinking block on MiMo replay.
+
+        This reproduces akaDRJ's live failure (#24726): 29 assistant tool-use
+        turns in Anthropic content-block form, zero with thinking/reasoning
+        data, causing HTTP 400 on MiMo's /anthropic endpoint.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "run a command"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_abc",
+                        "name": "terminal",
+                        "input": {"command": "echo hello"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_abc", "content": "hello"},
+            {"role": "user", "content": "result"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        blocks = assistant_msg["content"]
+        thinking_blocks = [b for b in blocks if isinstance(b, dict) and b.get("type") == "thinking"]
+        tool_use_blocks = [b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+        assert len(thinking_blocks) == 1, "Must have exactly one placeholder thinking block"
+        assert thinking_blocks[0]["thinking"] == " "
+        assert "signature" not in thinking_blocks[0]
+        assert len(tool_use_blocks) == 1
+        # Thinking block must come before tool_use (Anthropic protocol)
+        assert blocks.index(thinking_blocks[0]) < blocks.index(tool_use_blocks[0])
+
+    def test_non_mimo_tool_use_without_thinking_no_placeholder(self) -> None:
+        """Generic third-party endpoints should NOT inject thinking placeholders."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "run"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_xyz",
+                        "name": "terminal",
+                        "input": {"command": "ls"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_xyz", "content": "file.txt"},
+            {"role": "user", "content": "ok"},
+        ]
+
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.minimax.io/anthropic",
+            model="MiniMax-M2.7",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == []
+
+
+class TestLookalikeModelNamesDoNotMatchMiMo:
+    """Ensure adjacent model families are not falsely enrolled into MiMo enforcement."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "minimax-text-01",
+            "MiniMax-M2.7",
+            "mistralai/mistral-medium",
+            "microsoft/phi-4",
+            "phi-4-mimo-style",
+            "openrouter/mistralai/mistral-medium",
+        ],
+    )
+    def test_lookalike_models_are_not_mimo(self, model: str) -> None:
+        from agent.anthropic_adapter import _model_name_is_xiaomi_mimo
+
+        assert _model_name_is_xiaomi_mimo(model) is False, (
+            f"{model!r} should NOT be detected as Xiaomi MiMo"
+        )
+
+    def test_mimowave_is_not_mimo(self) -> None:
+        """mimowave-7b does not match any MiMo prefix (no dash after 'mimo')."""
+        from agent.anthropic_adapter import _model_name_is_xiaomi_mimo
+
+        assert _model_name_is_xiaomi_mimo("mimowave-7b") is False
+
+
+class TestDeepNamespacedModelNames:
+    """Deep-namespaced model names like vendor/sub/mimo-v3 must still match."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "vendor/sub/mimo-v3",
+            "a/b/c/xiaomi-mimo-v2.5-pro",
+            "openrouter/xiaomi/mimo-v2.5-pro",
+        ],
+    )
+    def test_deep_namespace_matches(self, model: str) -> None:
+        from agent.anthropic_adapter import _model_name_is_xiaomi_mimo
+
+        assert _model_name_is_xiaomi_mimo(model) is True, (
+            f"{model!r} should be detected as Xiaomi MiMo"
+        )

--- a/tests/run_agent/test_xiaomi_mimo_reasoning_replay.py
+++ b/tests/run_agent/test_xiaomi_mimo_reasoning_replay.py
@@ -1,0 +1,138 @@
+"""Regression guard: MiMo thinking history needs reasoning_content padding.
+
+Xiaomi MiMo rejects replayed assistant tool-call messages in thinking mode when
+``reasoning_content`` is missing.  Old sessions and cross-provider model
+switches can produce such assistant messages, so the provider-facing API copy
+must receive a single-space placeholder rather than omitting the field.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _agent(provider: str = "xiaomi", model: str = "mimo-v2.5-pro", base_url: str = "") -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    return agent
+
+
+class TestXiaomiMiMoReasoningReplayPadding:
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("xiaomi", "mimo-v2.5-pro", "https://token-plan-sgp.xiaomimimo.com/anthropic"),
+            ("mimo", "mimo-v2.5-pro", ""),
+            ("custom", "mimo-v2.5-pro", ""),
+            ("custom", "xiaomi-mimo-v2.5-pro", ""),
+            ("custom", "xiaomi_mimo_v2.5_pro", ""),
+            ("custom", "xiaomi/mimo-v2.5-pro", ""),
+            ("custom", "openrouter/xiaomi-mimo-v2.5-pro", ""),
+            ("custom", "other-model", "https://token-plan-sgp.xiaomimimo.com/anthropic"),
+        ],
+    )
+    def test_mimo_provider_requires_thinking_reasoning_pad(
+        self, provider: str, model: str, base_url: str
+    ) -> None:
+        agent = _agent(provider=provider, model=model, base_url=base_url)
+
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_mimo_missing_reasoning_content_is_padded_on_api_copy(self) -> None:
+        agent = _agent()
+        source_msg = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+        }
+        api_msg = {"role": "assistant", "content": "", "tool_calls": source_msg["tool_calls"]}
+
+        agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+        assert api_msg["reasoning_content"] == " "
+
+    def test_mimo_empty_reasoning_content_is_upgraded_to_space(self) -> None:
+        agent = _agent()
+        source_msg = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+        }
+        api_msg = {"role": "assistant", "content": "", "tool_calls": source_msg["tool_calls"]}
+
+        agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+        assert api_msg["reasoning_content"] == " "
+
+    def test_non_mimo_provider_does_not_pad_missing_reasoning_content(self) -> None:
+        agent = _agent(provider="openrouter", model="anthropic/claude-sonnet-4", base_url="")
+        source_msg = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+        }
+        api_msg = {"role": "assistant", "content": "", "tool_calls": source_msg["tool_calls"]}
+
+        agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+        assert "reasoning_content" not in api_msg
+
+
+class TestLookalikeModelsNotDetectedAsMiMo:
+    """Adjacent model families must NOT trigger MiMo's reasoning enforcement."""
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("openrouter", "minimax-text-01", ""),
+            ("openrouter", "MiniMax-M2.7", ""),
+            ("openrouter", "mistralai/mistral-medium", ""),
+            ("openrouter", "microsoft/phi-4", ""),
+        ],
+    )
+    def test_lookalike_not_mimo(
+        self, provider: str, model: str, base_url: str
+    ) -> None:
+        agent = _agent(provider=provider, model=model, base_url=base_url)
+        assert agent._needs_mimo_tool_reasoning() is False
+
+
+class TestDeepNamespacedMiMoModels:
+    """Deep-namespaced model names must still be detected as MiMo."""
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("custom", "vendor/sub/mimo-v3", ""),
+            ("custom", "a/b/c/xiaomi-mimo-v2.5-pro", ""),
+            ("custom", "openrouter/xiaomi/mimo-v2.5-pro", ""),
+        ],
+    )
+    def test_deep_namespace_detected(
+        self, provider: str, model: str, base_url: str
+    ) -> None:
+        agent = _agent(provider=provider, model=model, base_url=base_url)
+        assert agent._needs_mimo_tool_reasoning() is True


### PR DESCRIPTION
## Problem

Xiaomi MiMo's Anthropic-compatible endpoint recently tightened thinking-mode validation. When thinking mode is enabled, prior assistant turns containing `tool_use` must replay their full `reasoning_content` on subsequent requests. If omitted, MiMo returns **HTTP 400**:

> The reasoning_content in the thinking mode must be passed back to the API.

Generic third-party Anthropic handling strips all thinking blocks, breaking MiMo replays — same root cause as Kimi (#13848) and DeepSeek (#16748).

## Solution

MiMo follows the **same replay contract as Kimi and DeepSeek**: strip Anthropic-signed thinking blocks (third-party endpoints cannot validate signatures) but **preserve unsigned thinking blocks** synthesized from `reasoning_content`.

### Changes to `agent/anthropic_adapter.py`

- Add `_XIAOMI_MIMO_MODEL_PREFIXES` — model name prefixes (`mimo-*`, `mimo_*`, `xiaomi-mimo-*`, `xiaomi_mimo_*`)
- Add `_model_name_is_xiaomi_mimo()` — detects MiMo model names (strips vendor prefix, handles deep-namespaced forms)
- Add `_is_xiaomi_mimo_anthropic_endpoint()` — matches by model name or base_url host (`xiaomimimo.com`, `mimo.com`)
- Update `_preserve_unsigned_thinking` to include MiMo alongside Kimi/DeepSeek
- Inject **single-space placeholder** thinking block when an assistant tool-use turn has no thinking block at all — handles migrated/cross-provider history (reproduces akaDRJ's live failure from #24726)

### Tests

- `tests/agent/test_xiaomi_mimo_anthropic_thinking.py` (277 lines): unsigned thinking preservation, signed block stripping, generic third-party behavior, placeholder injection, lookalike model names, deep-namespaced models
- `tests/run_agent/test_xiaomi_mimo_reasoning_replay.py` (138 lines): reasoning padding for MiMo providers, missing/empty reasoning_content handling, lookalike detection

## Notes

- `run_agent.py` already has MiMo reasoning support (merged via #25484). This PR completes the picture by adding the corresponding `anthropic_adapter.py` changes.
- PR #24465 covered both files but has merge conflicts. This PR is rebased on latest `main` and only touches `anthropic_adapter.py` + tests.
- PR #26775 was a previous attempt closed as duplicate.

## Testing

All 38 tests pass:
```
python -m pytest tests/agent/test_xiaomi_mimo_anthropic_thinking.py tests/run_agent/test_xiaomi_mimo_reasoning_replay.py -v
# 38 passed
```

## Related

- Closes #24726 (akaDRJ live repro)
- Refs #24465 (original PR, conflicted)
- Refs #25484 (run_agent.py MiMo fix, merged)
- Refs #13848 (Kimi thinking replay)
- Refs #16748 (DeepSeek thinking replay)
- Refs #26775 (previous attempt, closed as duplicate)