### PR TITLE
feat: add native Nia retrieval toolset

### DIFF
--- a/docs/plans/2026-05-16-nia-integration-design.md
+++ b/docs/plans/2026-05-16-nia-integration-design.md
@@ -1,0 +1,108 @@
+# Nia integration design
+
+## Goal
+
+Make Nia a first-class Hermes retrieval layer for external knowledge: GitHub repositories, documentation sites, papers, datasets, and web/deep research. Nia should not replace local file tools, browser automation, or durable memory.
+
+## Routing policy
+
+Use the cheapest authoritative layer first:
+
+1. **Local workspace/files** → `search_files`, `read_file`, `patch`, `terminal`.
+   - Use for files already present in the active workdir or explicitly provided paths.
+2. **Hermes/Gbrain memory** → memory/session/brain tools.
+   - Use for durable decisions, summaries, reports, and previously synthesized conclusions.
+3. **Nia** → external retrieval and indexed source search.
+   - Use when the target is a remote repo, documentation site, package, paper, dataset, or cross-source research corpus.
+   - Use before broad web search when a source is likely already indexed or indexable.
+4. **Web/browser** → current unknowns, sites that require live interaction, or UI/QA flows.
+5. **Gstack** → browser/product QA, design review, benchmark/canary, shipping workflows.
+
+Important synthesized results from Nia research should be saved back into durable memory/brain. Nia is retrieval; Gbrain remains source of truth for conclusions.
+
+## Native toolset
+
+Toolset name: `nia`. It is intentionally separate from the core default bundle: users/platforms enable it explicitly with `hermes tools enable nia` or `--toolsets nia`, and the runtime `check_fn` hides it when credentials are missing.
+
+Initial tools:
+
+- `nia_usage` — account limits and usage.
+- `nia_repos` — repository actions: `list`, `index`, `status`, `tree`, `grep`, `read`, `delete`, `rename`.
+- `nia_sources` — documentation/source actions: `list`, `index`, `get`, `resolve`, `sync`, `tree`, `ls`, `grep`, `read`, `delete`, `rename`.
+- `nia_search` — `query`, `web`, `deep`, `universal` search modes.
+
+Future tools after API stabilization:
+
+- `nia_oracle` — async oracle jobs/status/results.
+- `nia_tracer` — trace entities/claims across sources.
+- `nia_contexts` — save/search reusable source contexts.
+- `nia_mcp` — compatibility adapter, not the primary integration path.
+
+## Secret handling
+
+Credential resolution order:
+
+1. `NIA_API_KEY` environment variable.
+2. `~/.config/nia/api_key`.
+3. Optional config field later, if Hermes adopts a central external-service credential schema.
+
+Rules:
+
+- Never expose the key in schemas, tool output, exceptions, logs, or PR/docs.
+- Tool output must redact bearer tokens and common API-key assignment forms defensively.
+- Tool availability is gated by a `check_fn` so Nia tools appear only when a key exists.
+
+## Indexing privacy policy
+
+Default posture: private and reversible.
+
+- Repository indexing defaults to **private**: `add_as_global_source` omitted unless the caller explicitly passes `add_global=true`.
+- Documentation/source indexing also defaults to private at the Hermes layer, even if Nia scripts historically defaulted differently.
+- Destructive actions (`delete`) require explicit action names and source/repo identifiers; no bulk delete in the initial toolset.
+- Public/global indexing should be opt-in and visible in the tool result.
+
+## Output format
+
+All tools return JSON strings with stable keys:
+
+- Success: raw Nia JSON plus `_meta` with `service`, `action`, and redaction-safe request metadata where useful.
+- Failure: `{"error": "...", "http_status": <int|null>}`.
+- File reads may return raw text in `content` when Nia provides content.
+
+Agents should cite source paths, URLs, repo refs, and line ranges when Nia returns them. Do not claim certainty beyond retrieved evidence.
+
+## Bart/OpenClaw compatibility
+
+For Bart/OpenClaw, keep the existing Nia skill scripts as a working bridge. The native Hermes toolset should share the same semantics so later adapters can be thin wrappers.
+
+Recommended order:
+
+1. Native Hermes `nia` toolset.
+2. Document policy in skill/docs.
+3. Optional local MCP server that wraps the same Python client if first-class tool discovery is needed outside Hermes.
+
+## MCP adapter phase
+
+MCP is phase 2/3, not phase 1. It does not decide routing policy and adds another failure mode. Build it only after native semantics stabilize.
+
+Adapter should expose the same operations as the native toolset and reuse the same credential resolution, redaction, privacy defaults, and tests.
+
+## Tests/checks
+
+Minimum test coverage:
+
+- Credential resolution: env key, fallback key file, missing key.
+- Request builder: auth header set, key not leaked.
+- Repository actions: list/index/read/grep/tree URL and body shape.
+- Source actions: list/index/read/grep/tree URL and body shape.
+- Search modes: query/web/deep/universal body shape.
+- Error handling: HTTP errors and non-JSON bodies return redacted JSON errors.
+- Toolset wiring: `nia` exists in `toolsets.py`, tools are registered and available when key check passes.
+
+Targeted checks:
+
+```bash
+python -m pytest tests/tools/test_nia_tool.py -q -o 'addopts='
+python -m pytest tests/tools/test_nia_tool.py tests/test_yuanbao_integration.py -q -o 'addopts='
+python -m py_compile tools/nia_tool.py toolsets.py
+```

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -76,6 +76,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
+    ("nia",              "🧭 Nia Retrieval",             "external repo/docs/source search"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
 ]
 
@@ -86,7 +87,7 @@ CONFIGURABLE_TOOLSETS = [
 # Video gen is off by default — it's a niche, paid, slow feature. Users
 # who want it opt in via `hermes tools` → Video Generation, which walks
 # them through provider + model selection.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "nia"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -51,6 +51,14 @@ class TestToolsEnableBuiltin:
         saved = mock_save.call_args[0][0]
         assert "web" in saved["platform_toolsets"]["cli"]
 
+    def test_enable_nia_toolset_to_platform(self):
+        config = {"platform_toolsets": {"telegram": ["hermes-gateway"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["nia"], platform="telegram"))
+        saved = mock_save.call_args[0][0]
+        assert "nia" in saved["platform_toolsets"]["telegram"]
+
     def test_enable_already_present_is_idempotent(self):
         config = {"platform_toolsets": {"cli": ["web"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \

--- a/tests/tools/test_nia_tool.py
+++ b/tests/tools/test_nia_tool.py
@@ -1,0 +1,166 @@
+import importlib
+import io
+import json
+from email.message import Message
+from pathlib import Path
+from urllib.error import HTTPError
+
+
+class FakeResponse:
+    def __init__(self, body=b"{}", status=200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def reload_nia(monkeypatch, tmp_path, env_key: str | None = "test-key"):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.delenv("NIA_API_KEY", raising=False)
+    if env_key is not None:
+        monkeypatch.setenv("NIA_API_KEY", env_key)
+    import tools.nia_tool as nia_tool
+    return importlib.reload(nia_tool)
+
+
+def capture_request(monkeypatch, body=b'{"ok":true}'):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["data"] = req.data
+        captured["timeout"] = timeout
+        return FakeResponse(body)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return captured
+
+
+def decode_result(result):
+    return json.loads(result)
+
+
+def test_api_key_prefers_env_without_leaking(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path, env_key="env-secret")
+    key_file = tmp_path / ".config" / "nia" / "api_key"
+    key_file.parent.mkdir(parents=True)
+    key_file.write_text("file-secret")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert nia._get_api_key() == "env-secret"
+    assert nia._check_nia_available() is True
+
+
+def test_api_key_falls_back_to_config_file(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path, env_key=None)
+    key_file = tmp_path / ".config" / "nia" / "api_key"
+    key_file.parent.mkdir(parents=True)
+    key_file.write_text("file-secret\n")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert nia._get_api_key() == "file-secret"
+    assert nia._check_nia_available() is True
+
+
+def test_nia_usage_sends_auth_header_and_redacts_errors(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path, env_key="secret-token")
+    captured = capture_request(monkeypatch, b'{"tier":"pro"}')
+
+    result = decode_result(nia.nia_usage_tool({}))
+
+    assert result == {"tier": "pro"}
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://apigcp.trynia.ai/v2/usage"
+    assert captured["headers"]["Authorization"] == "Bearer secret-token"
+    assert "secret-token" not in json.dumps(result)
+
+
+def test_repo_index_defaults_private(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path)
+    captured = capture_request(monkeypatch, b'{"id":"repo-id"}')
+
+    result = decode_result(nia.nia_repos_tool({"action": "index", "repository": "NousResearch/hermes-agent", "ref": "main"}))
+    body = json.loads(captured["data"].decode())
+
+    assert result["id"] == "repo-id"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://apigcp.trynia.ai/v2/sources"
+    assert body == {"type": "repository", "repository": "NousResearch/hermes-agent", "ref": "main"}
+    assert "add_as_global_source" not in body
+
+
+def test_repo_grep_posts_expected_body(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path)
+    captured = capture_request(monkeypatch, b'{"matches":[]}')
+
+    nia.nia_repos_tool({
+        "action": "grep",
+        "repository": "owner/repo",
+        "pattern": "registry.register",
+        "path": "tools",
+        "max_total": 25,
+        "fixed_string": True,
+    })
+    body = json.loads(captured["data"].decode())
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://apigcp.trynia.ai/v2/sources/owner%2Frepo/grep"
+    assert body["pattern"] == "registry.register"
+    assert body["path"] == "tools"
+    assert body["max_total_matches"] == 25
+    assert body["fixed_string"] is True
+
+
+def test_source_read_preserves_content(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path)
+    captured = capture_request(monkeypatch, b'{"content":"hello"}')
+
+    result = decode_result(nia.nia_sources_tool({"action": "read", "source_id": "src123", "path": "docs/index.md", "line_start": 1, "line_end": 5}))
+
+    assert result == {"content": "hello"}
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://apigcp.trynia.ai/v2/sources/src123/content?path=docs%2Findex.md&line_start=1&line_end=5"
+
+
+def test_search_web_body(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path)
+    captured = capture_request(monkeypatch, b'{"results":[]}')
+
+    nia.nia_search_tool({"mode": "web", "query": "Hermes Agent", "num_results": 3, "category": "github"})
+    body = json.loads(captured["data"].decode())
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://apigcp.trynia.ai/v2/search"
+    assert body == {"mode": "web", "query": "Hermes Agent", "num_results": 3, "category": "github"}
+
+
+def test_http_error_is_json_and_redacted(monkeypatch, tmp_path):
+    nia = reload_nia(monkeypatch, tmp_path, env_key="secret-token")
+
+    def fake_urlopen(req, timeout=0):
+        raise HTTPError(req.full_url, 401, "Bearer secret-token rejected", Message(), io.BytesIO(b'{"error":"bad secret-token"}'))
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    result = decode_result(nia.nia_usage_tool({}))
+
+    assert result["http_status"] == 401
+    assert "secret-token" not in json.dumps(result)
+    assert "***" in json.dumps(result)
+
+
+def test_toolset_contains_nia_tools():
+    import toolsets
+
+    assert "nia" in toolsets.TOOLSETS
+    resolved = set(toolsets.resolve_toolset("nia"))
+    assert {"nia_usage", "nia_repos", "nia_sources", "nia_search"}.issubset(resolved)

--- a/tools/nia_tool.py
+++ b/tools/nia_tool.py
@@ -1,0 +1,476 @@
+"""Nia retrieval tools.
+
+Native Hermes toolset for Nia (https://trynia.ai) repositories,
+documentation sources, and web/deep search.  Credentials are resolved from
+``NIA_API_KEY`` first, then ``~/.config/nia/api_key``.  Secrets are never
+included in returned errors.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+BASE_URL = "https://apigcp.trynia.ai/v2"
+_TIMEOUT_SECONDS = 45
+
+_SECRET_PATTERNS = [
+    re.compile(r"(Bearer\s+)([^\s,;\"'}]+)", re.IGNORECASE),
+    re.compile(r"\b(api[_-]?key|auth[_-]?token|access[_-]?token|token)\s*[=:]\s*([^\s,;\"'}]+)", re.IGNORECASE),
+]
+
+
+def _redact(text: Any) -> str:
+    value = str(text)
+    key = _get_api_key()
+    if key:
+        value = value.replace(key, "***")
+    for pattern in _SECRET_PATTERNS:
+        value = pattern.sub(lambda m: f"{m.group(1)}***", value)
+    return value
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _error(message: str, http_status: Optional[int] = None) -> str:
+    payload: Dict[str, Any] = {"error": _redact(message)}
+    if http_status is not None:
+        payload["http_status"] = http_status
+    return _json(payload)
+
+
+def _get_api_key() -> str:
+    env_key = os.getenv("NIA_API_KEY", "").strip()
+    if env_key:
+        return env_key
+    try:
+        return (Path.home() / ".config" / "nia" / "api_key").read_text().strip()
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _check_nia_available() -> bool:
+    return bool(_get_api_key())
+
+
+def _quote(value: str) -> str:
+    return urllib.parse.quote(str(value), safe="")
+
+
+def _query(params: Dict[str, Any]) -> str:
+    clean = {k: v for k, v in params.items() if v is not None and v != ""}
+    return urllib.parse.urlencode(clean)
+
+
+def _request(method: str, path: str, body: Optional[Dict[str, Any]] = None) -> Any:
+    key = _get_api_key()
+    if not key:
+        return {"error": "Nia API key not configured. Set NIA_API_KEY or ~/.config/nia/api_key."}
+
+    url = path if path.startswith("http") else f"{BASE_URL}{path}"
+    data = None
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method.upper())
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            if not raw.strip():
+                return {"success": True}
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                return {"content": raw}
+    except urllib.error.HTTPError as exc:
+        raw = ""
+        try:
+            raw = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            raw = str(exc)
+        try:
+            parsed = json.loads(raw) if raw else {}
+            if isinstance(parsed, dict):
+                msg = parsed.get("error") or parsed.get("message") or raw or exc.reason
+            else:
+                msg = raw or exc.reason
+        except json.JSONDecodeError:
+            msg = raw or exc.reason
+        return {"error": _redact(msg), "http_status": exc.code}
+    except Exception as exc:  # pragma: no cover - defensive around network stack
+        return {"error": _redact(f"Nia request failed: {type(exc).__name__}: {exc}")}
+
+
+def _bool_arg(args: Dict[str, Any], name: str) -> Optional[bool]:
+    if name not in args or args.get(name) in (None, ""):
+        return None
+    value = args.get(name)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _int_arg(args: Dict[str, Any], name: str, default: Optional[int] = None) -> Optional[int]:
+    value = args.get(name, default)
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _grep_body(args: Dict[str, Any]) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "pattern": args.get("pattern", ""),
+        "context_lines": _int_arg(args, "context_lines", 3),
+        "max_total_matches": _int_arg(args, "max_total", 50),
+    }
+    if args.get("path"):
+        body["path"] = args["path"]
+    for key in ("case_sensitive", "whole_word", "fixed_string", "highlight", "exhaustive"):
+        val = _bool_arg(args, key)
+        if val is not None:
+            body[key] = val
+    if args.get("output_mode"):
+        body["output_mode"] = args["output_mode"]
+    for in_key, out_key in (("lines_after", "A"), ("lines_before", "B"), ("max_per_file", "max_matches_per_file")):
+        val = _int_arg(args, in_key)
+        if val is not None:
+            body[out_key] = val
+    return {k: v for k, v in body.items() if v is not None}
+
+
+def nia_usage_tool(args: Dict[str, Any], **kw) -> str:
+    """Return Nia account usage/limits."""
+    return _json(_request("GET", "/usage"))
+
+
+def nia_repos_tool(args: Dict[str, Any], **kw) -> str:
+    action = str(args.get("action", "list")).strip().lower()
+    repository = str(args.get("repository", "")).strip()
+
+    if action == "list":
+        return _json(_request("GET", "/sources?type=repository"))
+
+    if action == "index":
+        if not repository:
+            return _error("repository is required for action=index")
+        body: Dict[str, Any] = {"type": "repository", "repository": repository}
+        if args.get("ref"):
+            body["ref"] = args["ref"]
+        if args.get("display_name"):
+            body["display_name"] = args["display_name"]
+        add_global = _bool_arg(args, "add_global")
+        if add_global is not None:
+            body["add_as_global_source"] = add_global
+        return _json(_request("POST", "/sources", body))
+
+    if not repository:
+        return _error(f"repository is required for action={action}")
+    rid = _quote(repository)
+
+    if action == "status":
+        return _json(_request("GET", f"/sources/{rid}?type=repository"))
+    if action == "tree":
+        params = _query({
+            "type": "repository",
+            "branch": args.get("ref") or args.get("branch"),
+            "include_paths": args.get("include_paths"),
+            "exclude_paths": args.get("exclude_paths"),
+            "file_extensions": args.get("file_extensions"),
+            "exclude_extensions": args.get("exclude_extensions"),
+            "show_full_paths": _bool_arg(args, "show_full_paths"),
+        })
+        return _json(_request("GET", f"/sources/{rid}/tree" + (f"?{params}" if params else "")))
+    if action == "read":
+        if not args.get("path"):
+            return _error("path is required for action=read")
+        params = _query({"type": "repository", "path": args.get("path"), "ref": args.get("ref")})
+        return _json(_request("GET", f"/sources/{rid}/content?{params}"))
+    if action == "grep":
+        if not args.get("pattern"):
+            return _error("pattern is required for action=grep")
+        body = _grep_body(args)
+        if args.get("ref"):
+            body["ref"] = args["ref"]
+        return _json(_request("POST", f"/sources/{rid}/grep", body))
+    if action == "delete":
+        return _json(_request("DELETE", f"/sources/{rid}?type=repository"))
+    if action == "rename":
+        if not args.get("display_name"):
+            return _error("display_name is required for action=rename")
+        return _json(_request("PATCH", f"/sources/{rid}?type=repository", {"display_name": args["display_name"]}))
+
+    return _error(f"Unsupported nia_repos action: {action}")
+
+
+def nia_sources_tool(args: Dict[str, Any], **kw) -> str:
+    action = str(args.get("action", "list")).strip().lower()
+    source_id = str(args.get("source_id") or args.get("identifier") or "").strip()
+    source_type = args.get("type")
+
+    if action == "list":
+        qs = _query({"type": source_type})
+        return _json(_request("GET", "/sources" + (f"?{qs}" if qs else "")))
+    if action == "index":
+        url = str(args.get("url", "")).strip()
+        if not url:
+            return _error("url is required for action=index")
+        body: Dict[str, Any] = {
+            "type": "documentation",
+            "url": url,
+            "limit": _int_arg(args, "limit", 1000),
+            "only_main_content": _bool_arg(args, "only_main_content") if _bool_arg(args, "only_main_content") is not None else True,
+        }
+        for key in ("display_name", "focus", "url_patterns", "exclude_patterns", "llms_txt_strategy"):
+            if args.get(key):
+                out_key = "focus_instructions" if key == "focus" else key
+                body[out_key] = args[key]
+        for key in ("extract_branding", "extract_images", "is_pdf", "check_llms_txt", "include_screenshot", "add_global"):
+            val = _bool_arg(args, key)
+            if val is not None:
+                out_key = "add_as_global_source" if key == "add_global" else key
+                body[out_key] = val
+        for key in ("max_depth", "wait_for", "max_age"):
+            val = _int_arg(args, key)
+            if val is not None:
+                body[key] = val
+        return _json(_request("POST", "/sources", {k: v for k, v in body.items() if v is not None}))
+    if action == "resolve":
+        identifier = str(args.get("identifier") or source_id).strip()
+        if not identifier:
+            return _error("identifier is required for action=resolve")
+        qs = _query({"identifier": identifier, "type": source_type})
+        return _json(_request("GET", f"/sources/resolve?{qs}"))
+
+    if not source_id:
+        return _error(f"source_id or identifier is required for action={action}")
+    sid = _quote(source_id)
+    type_qs = _query({"type": source_type})
+    type_suffix = f"?{type_qs}" if type_qs else ""
+
+    if action == "get":
+        return _json(_request("GET", f"/sources/{sid}{type_suffix}"))
+    if action == "sync":
+        return _json(_request("POST", f"/sources/{sid}/sync{type_suffix}", {}))
+    if action == "tree":
+        return _json(_request("GET", f"/sources/{sid}/tree"))
+    if action == "ls":
+        qs = _query({"path": args.get("path", "/")})
+        return _json(_request("GET", f"/sources/{sid}/tree?{qs}"))
+    if action == "read":
+        if not args.get("path"):
+            return _error("path is required for action=read")
+        qs = _query({
+            "path": args.get("path"),
+            "line_start": args.get("line_start"),
+            "line_end": args.get("line_end"),
+            "max_length": args.get("max_length"),
+        })
+        return _json(_request("GET", f"/sources/{sid}/content?{qs}"))
+    if action == "grep":
+        if not args.get("pattern"):
+            return _error("pattern is required for action=grep")
+        return _json(_request("POST", f"/sources/{sid}/grep", _grep_body(args)))
+    if action == "delete":
+        return _json(_request("DELETE", f"/sources/{sid}{type_suffix}"))
+    if action == "rename":
+        if not args.get("display_name"):
+            return _error("display_name is required for action=rename")
+        return _json(_request("PATCH", f"/sources/{sid}", {"display_name": args["display_name"]}))
+
+    return _error(f"Unsupported nia_sources action: {action}")
+
+
+def _csv_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [v.strip() for v in str(value).split(",") if v.strip()]
+
+
+def nia_search_tool(args: Dict[str, Any], **kw) -> str:
+    mode = str(args.get("mode", "query")).strip().lower()
+    query = str(args.get("query", "")).strip()
+    if not query:
+        return _error("query is required")
+
+    if mode == "web":
+        body: Dict[str, Any] = {"mode": "web", "query": query, "num_results": _int_arg(args, "num_results", 5)}
+        for key in ("category", "find_similar_to"):
+            if args.get(key):
+                body[key] = args[key]
+        if args.get("days_back") not in (None, ""):
+            body["days_back"] = _int_arg(args, "days_back")
+        return _json(_request("POST", "/search", body))
+
+    if mode == "deep":
+        body = {"mode": "deep", "query": query}
+        if args.get("output_format"):
+            body["output_format"] = args["output_format"]
+        if _bool_arg(args, "verbose") is not None:
+            body["verbose"] = _bool_arg(args, "verbose")
+        return _json(_request("POST", "/search", body))
+
+    if mode == "universal":
+        body = {
+            "mode": "universal",
+            "query": query,
+            "top_k": _int_arg(args, "top_k", 20),
+            "include_repos": _bool_arg(args, "include_repos") if _bool_arg(args, "include_repos") is not None else True,
+            "include_docs": _bool_arg(args, "include_docs") if _bool_arg(args, "include_docs") is not None else True,
+            "compress_output": _bool_arg(args, "compress_output") if _bool_arg(args, "compress_output") is not None else False,
+        }
+        return _json(_request("POST", "/search", body))
+
+    if mode == "query":
+        repos = _csv_list(args.get("repos") or args.get("repositories"))
+        docs = _csv_list(args.get("docs") or args.get("data_sources"))
+        body = {
+            "mode": "query",
+            "messages": [{"role": "user", "content": query}],
+            "repositories": [{"repository": repo} for repo in repos],
+            "data_sources": docs,
+            "search_mode": args.get("search_mode") or ("repositories" if repos and not docs else "sources" if docs and not repos else "unified"),
+            "stream": False,
+            "include_sources": True,
+        }
+        for key in ("category", "reasoning_strategy", "model"):
+            if args.get(key):
+                body[key] = args[key]
+        for key in ("max_tokens",):
+            if args.get(key) not in (None, ""):
+                body[key] = _int_arg(args, key)
+        for key in ("fast_mode", "skip_llm", "bypass_semantic_cache", "include_follow_ups"):
+            val = _bool_arg(args, key)
+            if val is not None:
+                body[key] = val
+        return _json(_request("POST", "/search", body))
+
+    return _error(f"Unsupported nia_search mode: {mode}")
+
+
+NIA_USAGE_SCHEMA = {
+    "name": "nia_usage",
+    "description": "Show Nia account tier and usage limits. Use before expensive deep/oracle research.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+NIA_REPOS_SCHEMA = {
+    "name": "nia_repos",
+    "description": "Manage and search Nia-indexed GitHub repositories. Defaults to private indexing; pass add_global=true only when explicitly requested.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["list", "index", "status", "tree", "grep", "read", "delete", "rename"]},
+            "repository": {"type": "string", "description": "GitHub owner/repo or Nia source identifier."},
+            "ref": {"type": "string", "description": "Branch, tag, or commit ref."},
+            "display_name": {"type": "string"},
+            "add_global": {"type": "boolean", "description": "Opt in to public/global source indexing."},
+            "path": {"type": "string", "description": "File path or path prefix."},
+            "pattern": {"type": "string", "description": "Regex or fixed string for grep."},
+            "max_total": {"type": "integer"},
+            "fixed_string": {"type": "boolean"},
+            "case_sensitive": {"type": "boolean"},
+            "whole_word": {"type": "boolean"},
+        },
+        "required": ["action"],
+    },
+}
+
+NIA_SOURCES_SCHEMA = {
+    "name": "nia_sources",
+    "description": "Manage and search Nia-indexed documentation sources, PDFs, and URLs. Hermes defaults to private indexing unless add_global=true is provided.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["list", "index", "get", "resolve", "sync", "tree", "ls", "grep", "read", "delete", "rename"]},
+            "source_id": {"type": "string"},
+            "identifier": {"type": "string", "description": "Name, URL, or source identifier for resolve/get operations."},
+            "type": {"type": "string", "description": "Optional Nia source type filter."},
+            "url": {"type": "string", "description": "URL to index."},
+            "limit": {"type": "integer"},
+            "display_name": {"type": "string"},
+            "focus": {"type": "string"},
+            "add_global": {"type": "boolean"},
+            "path": {"type": "string"},
+            "pattern": {"type": "string"},
+            "line_start": {"type": "integer"},
+            "line_end": {"type": "integer"},
+            "max_length": {"type": "integer"},
+            "max_total": {"type": "integer"},
+            "fixed_string": {"type": "boolean"},
+        },
+        "required": ["action"],
+    },
+}
+
+NIA_SEARCH_SCHEMA = {
+    "name": "nia_search",
+    "description": "Search with Nia. Use mode=query for indexed repos/docs, web for current web, deep for synthesized research, universal for broad indexed-source retrieval.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "mode": {"type": "string", "enum": ["query", "web", "deep", "universal"]},
+            "query": {"type": "string"},
+            "repos": {"type": "string", "description": "Comma-separated repositories for mode=query."},
+            "docs": {"type": "string", "description": "Comma-separated source IDs/URLs for mode=query."},
+            "num_results": {"type": "integer"},
+            "top_k": {"type": "integer"},
+            "category": {"type": "string"},
+            "days_back": {"type": "integer"},
+            "output_format": {"type": "string"},
+            "max_tokens": {"type": "integer"},
+            "fast_mode": {"type": "boolean"},
+            "skip_llm": {"type": "boolean"},
+        },
+        "required": ["query"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="nia_usage",
+    toolset="nia",
+    schema=NIA_USAGE_SCHEMA,
+    handler=nia_usage_tool,
+    check_fn=_check_nia_available,
+    emoji="🧠",
+)
+registry.register(
+    name="nia_repos",
+    toolset="nia",
+    schema=NIA_REPOS_SCHEMA,
+    handler=nia_repos_tool,
+    check_fn=_check_nia_available,
+    emoji="🧠",
+)
+registry.register(
+    name="nia_sources",
+    toolset="nia",
+    schema=NIA_SOURCES_SCHEMA,
+    handler=nia_sources_tool,
+    check_fn=_check_nia_available,
+    emoji="🧠",
+)
+registry.register(
+    name="nia_search",
+    toolset="nia",
+    schema=NIA_SEARCH_SCHEMA,
+    handler=nia_search_tool,
+    check_fn=_check_nia_available,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -228,6 +228,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "nia": {
+        "description": "Nia external retrieval/search tools for indexed repositories, documentation sources, web, and deep research",
+        "tools": ["nia_usage", "nia_repos", "nia_sources", "nia_search"],
+        "includes": []
+    },
+
     "kanban": {
         "description": (
             "Kanban multi-agent coordination — only active when the agent "


### PR DESCRIPTION
## Summary
- Add native Nia toolset for usage, repository retrieval, source management, and query/web/deep/universal search
- Add credential handling via NIA_API_KEY with fallback to ~/.config/nia/api_key, plus redacted error handling
- Add Nia integration design doc and targeted mocked tests

## Test Plan
- python -m pytest tests/tools/test_nia_tool.py tests/test_yuanbao_integration.py -q -o 'addopts='
- python -m py_compile tools/nia_tool.py toolsets.py tests/tools/test_nia_tool.py
- Manual smoke: enabled_toolsets=['nia'] exposes nia_repos, nia_search, nia_sources, nia_usage
- Manual live smoke: nia_usage returns subscription_tier=pro and usage counts without exposing secrets