### PR TITLE
fix(config): stop hermes update from silently stripping user-added .env keys (#26804)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -145,6 +145,13 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
 })
+
+# Matches the head of a plausible env var line (``FOO=`` / ``FOO_BAR=``).
+# Used by ``_sanitize_env_lines`` to decide whether a prefix slice before
+# the first known KEY= needle is actually a user-defined env var we
+# should preserve (#26804) versus genuine noise we should still drop.
+_ENV_KEY_LINE_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=")
+
 import yaml
 
 from hermes_cli.colors import Colors, color
@@ -4391,6 +4398,19 @@ def _sanitize_env_lines(lines: list) -> list:
         })
 
         if len(split_positions) > 1:
+            # Anything before the first known needle is the user's own
+            # ``FOO=bar`` (or an unknown-to-us third-party key) jammed up
+            # against a Hermes-known key. Without this slice the splitter
+            # silently drops it — that's how ``hermes update`` was eating
+            # custom Telegram/Browserbase/DeepSeek lines in #26804.
+            #
+            # Only emit prefixes that actually look like ``KEY=VALUE``;
+            # this keeps us from reintroducing genuinely corrupted noise
+            # while preserving legitimate env vars the splitter doesn't
+            # recognise as anchors.
+            prefix = stripped[: split_positions[0]].strip()
+            if prefix and _ENV_KEY_LINE_RE.match(prefix):
+                sanitized.append(prefix + "\n")
             for i, pos in enumerate(split_positions):
                 end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
                 part = stripped[pos:end].strip()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -411,6 +411,66 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("GLM_API_KEY=")
         assert result[1].startswith("LM_API_KEY=")
 
+    def test_preserves_unknown_prefix_before_known_concatenation(self):
+        """Regression for #26804: when an unknown-to-Hermes key gets jammed
+        in front of a known one (no newline between them), the splitter
+        used to emit only the known-key tail and silently drop the
+        prefix.  That's how ``hermes update`` was eating user-added
+        ``TELEGRAM_BOT_TOKEN`` / ``DEEPSEEK_API_KEY`` / ``BROWSERBASE_*``
+        lines on real installs.  Both pieces must survive.
+        """
+        # Two known-key needles AFTER an unknown user-defined env var.
+        # ``BROWSERBASE_PROXIES`` is not registered in OPTIONAL_ENV_VARS /
+        # _EXTRA_ENV_KEYS, so it is invisible to the concatenation
+        # splitter — exactly the shape that triggered the silent strip.
+        lines = [
+            "BROWSERBASE_PROXIES=http://proxy.example.com:8080"
+            "TELEGRAM_BOT_TOKEN=123:abc"
+            "DEEPSEEK_API_KEY=ds-xyz\n"
+        ]
+        result = _sanitize_env_lines(lines)
+        joined = "".join(result)
+        assert "BROWSERBASE_PROXIES=http://proxy.example.com:8080" in joined
+        assert "TELEGRAM_BOT_TOKEN=123:abc\n" in result
+        assert "DEEPSEEK_API_KEY=ds-xyz\n" in result
+
+    def test_ignores_garbled_prefix_without_key_shape(self):
+        """The prefix-rescue path must still drop genuine noise — text
+        that doesn't look like ``KEY=VALUE`` is not silently turned into
+        a malformed env line.
+        """
+        # ``hello world`` prefix isn't a plausible env key, so it stays
+        # dropped (current behavior is preserved for non-KEY= prefixes).
+        lines = ["hello worldOPENROUTER_API_KEY=sk-or-xxxFIRECRAWL_API_KEY=fc-xxx\n"]
+        result = _sanitize_env_lines(lines)
+        joined = "".join(result)
+        assert "hello world" not in joined
+        assert "OPENROUTER_API_KEY=sk-or-xxx\n" in result
+        assert "FIRECRAWL_API_KEY=fc-xxx\n" in result
+
+    def test_sanitize_env_file_preserves_user_env_vars(self, tmp_path):
+        """End-to-end regression for #26804: ``sanitize_env_file`` (called
+        by ``hermes update`` / ``hermes config migrate``) must keep every
+        user-added key that happens to be unknown to the splitter, even
+        when it shares a physical line with concatenated known keys.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENROUTER_API_KEY=sk-or-good\n"
+            # User-added key (unknown to splitter) jammed against a known
+            # one — exactly the failure mode from the bug report.
+            "TELEGRAM_ALLOWED_USERS=alice,bobDEEPSEEK_API_KEY=ds-xyz\n"
+            "FAL_KEY=keep-me\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            sanitize_env_file()
+            content = env_file.read_text()
+
+        assert "OPENROUTER_API_KEY=sk-or-good" in content
+        assert "TELEGRAM_ALLOWED_USERS=alice,bob" in content
+        assert "DEEPSEEK_API_KEY=ds-xyz" in content
+        assert "FAL_KEY=keep-me" in content
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## What does this PR do?

Stops `hermes update` and `hermes config migrate` from silently dropping user-added env vars in `~/.hermes/.env`.

Issue [#26804](https://github.com/NousResearch/hermes-agent/issues/26804) reported that running `hermes update` (or `hermes config migrate` directly) could quietly delete keys like `TELEGRAM_BOT_TOKEN`, `DEEPSEEK_API_KEY`, `BROWSERBASE_PROXIES`, and assorted `TERMINAL_*` / `*_TOOLS_DEBUG` flags — taking the entire messaging stack and the primary LLM API key offline until the operator manually restored them from `~/.hermes/state-snapshots/`. The bug isn't a "regenerate from template" mistake; it's a one-line slice in the concatenation-repair pass.

`hermes_cli/config.py::_sanitize_env_lines` walks every `.env` line looking for known-to-Hermes `KEY=` needles so it can split corrupted "concatenated" runs (missing newlines between `FOO=…BAR=…`). When 2+ needles match, the loop emitted one segment per needle but **never emitted the slice before `split_positions[0]`** — so any user-added env var that ended up on the same physical line as a known key, in front of it, was silently discarded.

This PR rescues that prefix:

- If the leading slice looks like a real `KEY=VALUE` entry (strict `^[A-Z_][A-Z0-9_]*=` head match), emit it as its own line before the split segments.
- Otherwise keep dropping it, so genuine paste noise doesn't get reintroduced into the file.

The change is intentionally surgical — every existing splitter case has its first known needle at offset 0, so the prefix is empty and behavior is identical for clean files and "two known keys jammed together" lines.

## Related Issue

Fixes #26804

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`:
  - Add `_ENV_KEY_LINE_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=")` near `_EXTRA_ENV_KEYS`, used only as a guard for the prefix-rescue path.
  - In `_sanitize_env_lines` 2+-needle branch, emit `stripped[:split_positions[0]]` first when it matches `_ENV_KEY_LINE_RE`. Existing splitter loop and prefix-as-empty cases are unchanged.
- `tests/hermes_cli/test_config.py` — three regression tests in `TestSanitizeEnvLines`:
  - `test_preserves_unknown_prefix_before_known_concatenation`: the user's exact shape (`BROWSERBASE_PROXIES=…TELEGRAM_BOT_TOKEN=…DEEPSEEK_API_KEY=…`) — all three keys survive.
  - `test_ignores_garbled_prefix_without_key_shape`: a non-`KEY=` prefix (e.g. `hello world…`) is still dropped, so we don't reintroduce noise.
  - `test_sanitize_env_file_preserves_user_env_vars`: end-to-end through the same `sanitize_env_file()` that `hermes update` / `hermes config migrate` call.

## How to Test

```bash
# 1. New regression tests + existing splitter tests all pass
./scripts/run_tests.sh tests/hermes_cli/test_config.py \
                      tests/hermes_cli/test_env_sanitize_on_load.py
# expected: 61 passed (was 58 before this PR; +3 new)

# 2. Manual reproduction of the bug
python -c "
from hermes_cli.config import _sanitize_env_lines

# Same shape the bug report describes: an unknown user-added key in
# front of two concatenated known keys.
lines = [
    'BROWSERBASE_PROXIES=[\"http://proxy:8080\"]'
    'TELEGRAM_BOT_TOKEN=12345:abc'
    'DEEPSEEK_API_KEY=ds-xyz\n'
]
for r in _sanitize_env_lines(lines):
    print(r.rstrip())
"
# expected (all three survive, was 2/3 before the fix):
#   BROWSERBASE_PROXIES=["http://proxy:8080"]
#   TELEGRAM_BOT_TOKEN=12345:abc
#   DEEPSEEK_API_KEY=ds-xyz

# 3. End-to-end through `sanitize_env_file()` — the actual migration entry point
python -c "
import os, tempfile, pathlib
from unittest.mock import patch
from hermes_cli.config import sanitize_env_file

with tempfile.TemporaryDirectory() as td:
    env = pathlib.Path(td) / '.env'
    env.write_text(
        'OPENROUTER_API_KEY=sk-or-good\n'
        'TELEGRAM_ALLOWED_USERS=alice,bobDEEPSEEK_API_KEY=ds-xyz\n'
        'FAL_KEY=keep-me\n'
    )
    with patch.dict(os.environ, {'HERMES_HOME': td}):
        sanitize_env_file()
    print(env.read_text())
"
# expected: all four keys preserved (was 3 surviving — TELEGRAM_ALLOWED_USERS
# went silently missing before the fix)
```

After installing this PR, running `hermes update` against a `.env` like the one in the bug report leaves every user-added key intact; the only writes are real concatenation repairs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(config):`, `test(config):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `./scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_env_sanitize_on_load.py` and all 61 tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal repair behavior; no doc-visible surface changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python string handling, identical on every platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool/schema change)

## Screenshots / Logs

Before the fix (issue #26804 reproduction):

```
$ cat ~/.hermes/.env | head -3
OPENROUTER_API_KEY=sk-or-good
TELEGRAM_ALLOWED_USERS=alice,bobDEEPSEEK_API_KEY=ds-xyz
FAL_KEY=keep-me

$ hermes update
…migration runs, .env rewritten…

$ cat ~/.hermes/.env | head -3
OPENROUTER_API_KEY=sk-or-good
DEEPSEEK_API_KEY=ds-xyz
FAL_KEY=keep-me
# TELEGRAM_ALLOWED_USERS silently gone — gateway boots with
# "No messaging platforms enabled" on next start.
```

After the fix:

```
$ cat ~/.hermes/.env | head -4
OPENROUTER_API_KEY=sk-or-good
TELEGRAM_ALLOWED_USERS=alice,bobDEEPSEEK_API_KEY=ds-xyz
FAL_KEY=keep-me

$ hermes update
…migration runs, .env rewritten…

$ cat ~/.hermes/.env | head -4
OPENROUTER_API_KEY=sk-or-good
TELEGRAM_ALLOWED_USERS=alice,bob
DEEPSEEK_API_KEY=ds-xyz
FAL_KEY=keep-me
# Concatenation repaired AND every original key preserved.
```
