### PR TITLE
fix(auxiliary): detect quota keywords in _is_payment_error and allow fallback for explicit providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2098,7 +2098,9 @@ def _is_payment_error(exc: Exception) -> bool:
     if status in {402, 429, None}:
         if any(kw in err_lower for kw in ("credits", "insufficient funds",
                                            "can only afford", "billing",
-                                           "payment required")):
+                                           "payment required", "quota",
+                                           "too many tokens", "daily limit",
+                                           "tokens per day")):
             return True
     return False
 
@@ -4522,8 +4524,7 @@ def call_llm(
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -4851,8 +4852,7 @@ async def async_call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
-        is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 _mark_provider_unhealthy(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -923,6 +923,25 @@ class TestIsPaymentError:
         exc = Exception("connection reset")
         assert _is_payment_error(exc) is False
 
+    def test_429_with_quota_message(self):
+        exc = Exception("Too many tokens per day: quota exceeded")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_429_with_daily_limit_message(self):
+        exc = Exception("daily limit reached, try again tomorrow")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_429_with_too_many_tokens_message(self):
+        exc = Exception("Too many tokens requested today")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_no_status_quota_exceeded(self):
+        exc = Exception("quota exceeded for this model")
+        assert _is_payment_error(exc) is True
+
 
 class TestIsRateLimitError:
     """_is_rate_limit_error detects 429 rate-limit errors warranting fallback."""
@@ -1109,6 +1128,33 @@ class TestCallLlmPaymentFallback:
                 messages=[{"role": "user", "content": "hello"}],
             )
         # Fallback client should have been used
+        assert fallback_client.chat.completions.create.called
+
+    def test_explicit_provider_gets_fallback_on_payment_error(self, monkeypatch):
+        """Non-auto (explicit) providers should still get fallback on payment/quota errors (#26803)."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        quota_err = Exception("Too many tokens per day: quota exceeded")
+        quota_err.status_code = 429
+        primary_client.chat.completions.create.side_effect = quota_err
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "google/gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("openrouter", "google/gemini-3-flash-preview", None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "nous")):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+        # Even with explicit provider "openrouter", fallback should trigger
         assert fallback_client.chat.completions.create.called
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Auxiliary `call_llm` fallback doesn't trigger on provider rate limits (429 daily quota).

**Two root causes:**

1. `_is_payment_error()` doesn't recognize quota-related keywords in 429 responses. Providers like OpenRouter return 429 with messages like "Too many tokens per day" or "quota exceeded", but these weren't matched.

2. The fallback chain is gated on `is_auto` — explicitly configured providers are excluded from fallback even on payment/connection/rate-limit errors where the provider clearly cannot serve the request.

## Fix

1. Add quota keywords to `_is_payment_error()`: `"quota"`, `"too many tokens"`, `"daily limit"`, `"tokens per day"`.

2. Remove the `is_auto` gate on the `should_fallback` condition in both `call_llm()` and `async_call_llm()`. Since `should_fallback` already only fires for payment/connection/rate-limit errors (all indicating "this provider can't serve right now"), the auto-only restriction was overly conservative.

## Tests

- 4 new tests in `TestIsPaymentError` for quota keyword detection
- 1 new test in `TestCallLlmPaymentFallback` verifying explicit providers get fallback on quota errors

All 164 tests pass.

Fixes #26803