### PR TITLE
feat: add Kimi WebBridge toolset

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,7 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
+    ("kimi_webbridge",  "🌉 Kimi WebBridge",           "real browser control via Kimi extension"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
@@ -94,7 +95,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "kimi_webbridge"}
 
 
 def _xai_credentials_present() -> bool:

--- a/tests/tools/test_kimi_webbridge.py
+++ b/tests/tools/test_kimi_webbridge.py
@@ -1,0 +1,215 @@
+"""Tests for the Kimi WebBridge toolset."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.kimi_webbridge import (
+    _check_bridge,
+    _get_daemon_url,
+    _validate_screenshot_path,
+    kimi_webbridge_click,
+    kimi_webbridge_close_session,
+    kimi_webbridge_close_tab,
+    kimi_webbridge_evaluate,
+    kimi_webbridge_fill,
+    kimi_webbridge_find_tab,
+    kimi_webbridge_list_tabs,
+    kimi_webbridge_navigate,
+    kimi_webbridge_save_pdf,
+    kimi_webbridge_save_screenshot,
+    kimi_webbridge_screenshot,
+    kimi_webbridge_snapshot,
+)
+
+
+def _mock_response(data: dict, status_code: int = 200) -> MagicMock:
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestGetDaemonUrl:
+    def test_default_fallback(self):
+        with patch("hermes_cli.config.load_config", side_effect=Exception("no config")):
+            assert _get_daemon_url() == "http://127.0.0.1:10086"
+
+    def test_from_config(self):
+        fake_cfg = {"providers": {"kimi_webbridge": {"base_url": "http://localhost:9999"}}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            assert _get_daemon_url() == "http://localhost:9999"
+
+    def test_trailing_slash_stripped(self):
+        fake_cfg = {"providers": {"kimi_webbridge": {"base_url": "http://localhost:9999/"}}}
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            assert _get_daemon_url() == "http://localhost:9999"
+
+
+class TestCheckBridge:
+    def test_true_when_daemon_responds(self):
+        with patch("tools.kimi_webbridge.requests.post", return_value=_mock_response({})):
+            assert _check_bridge() is True
+
+    def test_false_when_request_fails(self):
+        with patch("tools.kimi_webbridge.requests.post", side_effect=Exception("connection refused")):
+            assert _check_bridge() is False
+
+    def test_false_when_non_200(self):
+        resp = _mock_response({}, status_code=500)
+        with patch("tools.kimi_webbridge.requests.post", return_value=resp):
+            assert _check_bridge() is False
+
+
+class TestValidateScreenshotPath:
+    def test_default_path(self):
+        path = _validate_screenshot_path(None)
+        assert str(path).startswith("/tmp/kimi-webbridge-screenshots/")
+        assert path.suffix == ".png"
+
+    def test_valid_tmp_path(self):
+        path = _validate_screenshot_path("/tmp/foo.png")
+        assert str(path) == "/tmp/foo.png"
+
+    def test_valid_home_path(self):
+        path = _validate_screenshot_path("~/foo.png")
+        assert "foo.png" in str(path)
+
+    def test_invalid_path_rejected(self):
+        with pytest.raises(ValueError, match="must be under /tmp or home directory"):
+            _validate_screenshot_path("/etc/passwd")
+
+
+class TestNavigate:
+    def test_navigate_success(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "url": "https://example.com", "tabId": 42}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_navigate("https://example.com"))
+        assert result["ok"] is True
+        assert result["data"]["url"] == "https://example.com"
+
+    def test_navigate_with_group_title(self):
+        mock = _mock_response({"ok": True, "data": {"success": True}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock) as post:
+            kimi_webbridge_navigate("https://example.com", group_title="my-group")
+            call_args = post.call_args[1]["json"]
+            assert call_args["args"]["group_title"] == "my-group"
+
+
+class TestSnapshot:
+    def test_snapshot_returns_tree(self):
+        mock = _mock_response({"ok": True, "data": {"url": "https://example.com", "title": "Example", "tree": []}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_snapshot())
+        assert result["data"]["title"] == "Example"
+
+
+class TestClick:
+    def test_click_by_selector(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "tag": "button", "text": "Submit"}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_click("@e5"))
+        assert result["data"]["tag"] == "button"
+
+
+class TestFill:
+    def test_fill_input(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "tag": "input", "mode": "value"}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_fill("@e3", "hello"))
+        assert result["data"]["mode"] == "value"
+
+
+class TestEvaluate:
+    def test_evaluate_js(self):
+        mock = _mock_response({"ok": True, "data": {"type": "string", "value": "42"}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_evaluate("document.title"))
+        assert result["data"]["value"] == "42"
+
+
+class TestListTabs:
+    def test_list_tabs(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "tabs": [{"tabId": 1, "url": "https://a.com"}]}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_list_tabs())
+        assert len(result["data"]["tabs"]) == 1
+
+
+class TestCloseTab:
+    def test_close_tab(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "closed": True}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_close_tab())
+        assert result["data"]["closed"] is True
+
+
+class TestCloseSession:
+    def test_close_session(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "closed": 3}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_close_session())
+        assert result["data"]["closed"] == 3
+
+
+class TestFindTab:
+    def test_find_tab(self):
+        mock = _mock_response({"ok": True, "data": {"success": True, "url": "https://kimi.com", "tabId": 7}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_find_tab("https://kimi.com", active=True))
+        assert result["data"]["tabId"] == 7
+
+
+class TestSavePdf:
+    def test_save_pdf(self):
+        mock = _mock_response({"ok": True, "data": {"path": "/tmp/test.pdf", "sizeBytes": 1234}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_save_pdf(file_name="test.pdf"))
+        assert result["data"]["path"] == "/tmp/test.pdf"
+
+
+class TestScreenshot:
+    def test_screenshot_strips_base64(self):
+        mock = _mock_response({"ok": True, "data": {"format": "png", "dataLength": 50000, "data": "iVBORw0KGgo" * 1000}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_screenshot())
+        inner = result["data"]
+        assert "base64 image data" in inner["data"]
+
+
+class TestSaveScreenshot:
+    def test_save_screenshot_success(self, tmp_path):
+        fake_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        mock = _mock_response({"ok": True, "data": {"format": "png", "dataLength": len(fake_b64), "data": fake_b64}})
+        output = tmp_path / "shot.png"
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_save_screenshot(str(output)))
+        assert result["success"] is True
+        assert result["path"] == str(output)
+        assert output.exists()
+
+    def test_save_screenshot_failure_no_data(self):
+        mock = _mock_response({"ok": True, "data": {"format": "png"}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_save_screenshot())
+        assert "error" in result
+
+    def test_save_screenshot_invalid_path(self):
+        fake_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        mock = _mock_response({"ok": True, "data": {"format": "png", "dataLength": len(fake_b64), "data": fake_b64}})
+        with patch("tools.kimi_webbridge.requests.post", return_value=mock):
+            result = json.loads(kimi_webbridge_save_screenshot("/etc/evil.png"))
+        assert "error" in result
+        assert "must be under /tmp or home directory" in result.get("message", "")
+
+
+class TestErrorHandling:
+    def test_request_exception_returns_error_dict(self):
+        import requests
+        with patch("tools.kimi_webbridge.requests.post", side_effect=requests.ConnectionError("boom")):
+            result = json.loads(kimi_webbridge_navigate("https://example.com"))
+        assert result["error"] is True
+        assert "boom" in result["message"]

--- a/tools/kimi_webbridge.py
+++ b/tools/kimi_webbridge.py
@@ -1,0 +1,470 @@
+"""Kimi WebBridge integration for Hermes Agent.
+
+Provides browser automation via the local Kimi WebBridge daemon. Unlike the
+built-in ``browser`` toolset (which uses Playwright/Browserbase/Camofox),
+this controls the user's REAL browser with their actual login sessions.
+
+Configuration
+-------------
+Add to ``~/.hermes/config.yaml``::
+
+    providers:
+      kimi_webbridge:
+        base_url: http://127.0.0.1:10086
+
+If omitted, ``base_url`` defaults to ``http://127.0.0.1:10086``.
+
+The toolset is off by default (``_DEFAULT_OFF_TOOLSETS``) because it requires
+the Kimi WebBridge browser extension + daemon to be installed separately.
+See https://www.kimi.com/features/webbridge for setup instructions.
+"""
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from tools.registry import registry
+
+_DEFAULT_DAEMON_URL = "http://127.0.0.1:10086"
+_DEFAULT_SESSION = "hermes"
+_COMMAND_ENDPOINT = "/command"
+
+
+def _get_daemon_url() -> str:
+    """Resolve daemon URL from config or fallback."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        url = cfg.get("providers", {}).get("kimi_webbridge", {}).get("base_url")
+        if url:
+            return url.rstrip("/")
+    except Exception:
+        pass
+    return _DEFAULT_DAEMON_URL
+
+
+def _bridge_call(action: str, args: Optional[dict] = None, session: Optional[str] = None) -> dict:
+    """POST a command to the Kimi WebBridge daemon."""
+    url = _get_daemon_url() + _COMMAND_ENDPOINT
+    payload = {
+        "action": action,
+        "args": args or {},
+        "session": session or _DEFAULT_SESSION,
+    }
+    try:
+        resp = requests.post(url, json=payload, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        return {"error": True, "message": str(exc)}
+
+
+def _check_bridge() -> bool:
+    """Return True if the Kimi WebBridge daemon is reachable."""
+    url = _get_daemon_url() + _COMMAND_ENDPOINT
+    try:
+        resp = requests.post(
+            url,
+            json={"action": "list_tabs", "args": {}, "session": _DEFAULT_SESSION},
+            timeout=3,
+        )
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _validate_screenshot_path(output_path: Optional[str]) -> Path:
+    """Ensure screenshot path is safe and within allowed directories."""
+    if output_path is None:
+        return Path(f"/tmp/kimi-webbridge-screenshots/{_DEFAULT_SESSION}_{os.getpid()}.png")
+
+    path = Path(output_path).resolve()
+    allowed_roots = [
+        Path("/tmp").resolve(),
+        Path.home().resolve(),
+    ]
+    if not any(str(path).startswith(str(root)) for root in allowed_roots):
+        raise ValueError(f"Screenshot path must be under /tmp or home directory, got: {output_path}")
+    return path
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tool handlers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def kimi_webbridge_navigate(
+    url: str,
+    new_tab: bool = True,
+    group_title: Optional[str] = None,
+    session: Optional[str] = None,
+) -> str:
+    """Navigate to a URL in the user's real browser."""
+    args: dict = {"url": url, "newTab": new_tab}
+    if group_title:
+        args["group_title"] = group_title
+    return json.dumps(_bridge_call("navigate", args, session))
+
+
+def kimi_webbridge_find_tab(
+    url: str,
+    active: bool = False,
+    session: Optional[str] = None,
+) -> str:
+    """Find and reuse an already-open tab by URL or domain."""
+    return json.dumps(_bridge_call("find_tab", {"url": url, "active": active}, session))
+
+
+def kimi_webbridge_snapshot(session: Optional[str] = None) -> str:
+    """Get an accessibility tree snapshot of the current page with @e refs."""
+    return json.dumps(_bridge_call("snapshot", {}, session))
+
+
+def kimi_webbridge_click(selector: str, session: Optional[str] = None) -> str:
+    """Click an element by @e ref or CSS selector."""
+    return json.dumps(_bridge_call("click", {"selector": selector}, session))
+
+
+def kimi_webbridge_fill(
+    selector: str,
+    value: str,
+    session: Optional[str] = None,
+) -> str:
+    """Fill an input, textarea, or contenteditable element. Clears existing content."""
+    return json.dumps(_bridge_call("fill", {"selector": selector, "value": value}, session))
+
+
+def kimi_webbridge_evaluate(code: str, session: Optional[str] = None) -> str:
+    """Evaluate JavaScript in the current page. Supports async/await."""
+    return json.dumps(_bridge_call("evaluate", {"code": code}, session))
+
+
+def kimi_webbridge_screenshot(
+    format: str = "png",
+    quality: int = 90,
+    selector: Optional[str] = None,
+    session: Optional[str] = None,
+) -> str:
+    """Take a screenshot.
+
+    Returns a lightweight result. The actual image data is stripped from context
+    to avoid flooding the token window; use ``kimi_webbridge_save_screenshot``
+    when you need the file on disk.
+    """
+    args: dict = {"format": format, "quality": quality}
+    if selector:
+        args["selector"] = selector
+    result = _bridge_call("screenshot", args, session)
+    inner = result.get("data", {}) if isinstance(result.get("data"), dict) else result
+    b64 = inner.get("data") if isinstance(inner, dict) else None
+    if b64 and isinstance(b64, str) and len(b64) > 1000:
+        inner["data"] = f"<base64 image data, {len(b64)} chars — use kimi_webbridge_save_screenshot instead>"
+    return json.dumps(result)
+
+
+def kimi_webbridge_save_screenshot(
+    output_path: Optional[str] = None,
+    format: str = "png",
+    quality: int = 90,
+    session: Optional[str] = None,
+) -> str:
+    """Take a screenshot and save it to disk, returning only the file path."""
+    args: dict = {"format": format, "quality": quality}
+    result = _bridge_call("screenshot", args, session)
+    inner = result.get("data", {}) if isinstance(result.get("data"), dict) else result
+    b64 = inner.get("data") if isinstance(inner, dict) else None
+    if not b64 or not isinstance(b64, str):
+        return json.dumps({"error": "screenshot failed", "details": result})
+
+    try:
+        path = _validate_screenshot_path(output_path)
+    except ValueError as exc:
+        return json.dumps({"error": "invalid path", "message": str(exc)})
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(base64.b64decode(b64))
+    return json.dumps({"success": True, "path": str(path), "size_bytes": path.stat().st_size})
+
+
+def kimi_webbridge_list_tabs(session: Optional[str] = None) -> str:
+    """List all tabs in the current session."""
+    return json.dumps(_bridge_call("list_tabs", {}, session))
+
+
+def kimi_webbridge_close_tab(session: Optional[str] = None) -> str:
+    """Close the current tab."""
+    return json.dumps(_bridge_call("close_tab", {}, session))
+
+
+def kimi_webbridge_close_session(session: Optional[str] = None) -> str:
+    """Close all tabs in the session. Call at the end of a task."""
+    return json.dumps(_bridge_call("close_session", {}, session))
+
+
+def kimi_webbridge_save_pdf(
+    paper_format: str = "letter",
+    landscape: bool = False,
+    scale: float = 1.0,
+    print_background: bool = True,
+    file_name: Optional[str] = None,
+    session: Optional[str] = None,
+) -> str:
+    """Save the current page as a PDF."""
+    args: dict = {
+        "paper_format": paper_format,
+        "landscape": landscape,
+        "scale": scale,
+        "print_background": print_background,
+    }
+    if file_name:
+        args["file_name"] = file_name
+    return json.dumps(_bridge_call("save_as_pdf", args, session))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Registry
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_SCHEMA_BASE = {
+    "type": "object",
+    "properties": {
+        "session": {"type": "string", "default": "hermes", "description": "Session name for tab isolation"},
+    },
+}
+
+
+def _schema(required: list, extra_props: dict) -> dict:
+    props = {**_SCHEMA_BASE["properties"], **extra_props}
+    return {"type": "object", "properties": props, "required": required}
+
+
+registry.register(
+    name="kimi_webbridge_navigate",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_navigate",
+        "description": "Navigate the user's real browser to a URL via Kimi WebBridge. Uses the user's actual login sessions.",
+        "parameters": _schema(
+            ["url"],
+            {
+                "url": {"type": "string", "description": "URL to navigate to"},
+                "new_tab": {"type": "boolean", "description": "Open in a new tab", "default": True},
+                "group_title": {"type": "string", "description": "Visible label for the tab group"},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_navigate(
+        url=args["url"],
+        new_tab=args.get("new_tab", True),
+        group_title=args.get("group_title"),
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_find_tab",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_find_tab",
+        "description": "Find and reuse an already-open tab by URL or domain. Use when the user refers to an existing page.",
+        "parameters": _schema(
+            ["url"],
+            {
+                "url": {"type": "string", "description": "URL or domain to match"},
+                "active": {"type": "boolean", "description": "Pick the currently-viewed tab", "default": False},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_find_tab(
+        url=args["url"],
+        active=args.get("active", False),
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_snapshot",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_snapshot",
+        "description": "Get an accessibility tree snapshot of the current page. Returns interactive elements with @e refs for clicking/filling.",
+        "parameters": _schema([], {}),
+    },
+    handler=lambda args, **kw: kimi_webbridge_snapshot(session=args.get("session")),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_click",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_click",
+        "description": "Click an element by @e ref or CSS selector. Use @e refs from kimi_webbridge_snapshot when available.",
+        "parameters": _schema(
+            ["selector"],
+            {"selector": {"type": "string", "description": "@e ref (e.g. @e5) or CSS selector"}},
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_click(
+        selector=args["selector"],
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_fill",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_fill",
+        "description": "Fill an input, textarea, or contenteditable element. Clears existing content before inserting.",
+        "parameters": _schema(
+            ["selector", "value"],
+            {
+                "selector": {"type": "string", "description": "@e ref or CSS selector"},
+                "value": {"type": "string", "description": "Text to insert"},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_fill(
+        selector=args["selector"],
+        value=args["value"],
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_evaluate",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_evaluate",
+        "description": "Evaluate JavaScript in the current page. Supports async/await. Use for scrolling, extracting data, or complex interactions.",
+        "parameters": _schema(
+            ["code"],
+            {"code": {"type": "string", "description": "JavaScript code to run"}},
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_evaluate(
+        code=args["code"],
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_screenshot",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_screenshot",
+        "description": "Take a screenshot. Returns a lightweight result — base64 data is stripped to avoid context flooding.",
+        "parameters": _schema(
+            [],
+            {
+                "format": {"type": "string", "enum": ["png", "jpeg"], "default": "png"},
+                "quality": {"type": "integer", "default": 90},
+                "selector": {"type": "string", "description": "Optional CSS selector or @e ref to capture only that element"},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_screenshot(
+        format=args.get("format", "png"),
+        quality=args.get("quality", 90),
+        selector=args.get("selector"),
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_save_screenshot",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_save_screenshot",
+        "description": "Take a screenshot and save it to disk. Returns only the file path — safe for context windows.",
+        "parameters": _schema(
+            [],
+            {
+                "output_path": {"type": "string", "description": "Where to save the image (default: auto-generated in /tmp)"},
+                "format": {"type": "string", "enum": ["png", "jpeg"], "default": "png"},
+                "quality": {"type": "integer", "default": 90},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_save_screenshot(
+        output_path=args.get("output_path"),
+        format=args.get("format", "png"),
+        quality=args.get("quality", 90),
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_list_tabs",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_list_tabs",
+        "description": "List all tabs in the current session.",
+        "parameters": _schema([], {}),
+    },
+    handler=lambda args, **kw: kimi_webbridge_list_tabs(session=args.get("session")),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_close_tab",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_close_tab",
+        "description": "Close the current tab.",
+        "parameters": _schema([], {}),
+    },
+    handler=lambda args, **kw: kimi_webbridge_close_tab(session=args.get("session")),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_close_session",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_close_session",
+        "description": "Close all tabs in the session. Call at the end of a task.",
+        "parameters": _schema([], {}),
+    },
+    handler=lambda args, **kw: kimi_webbridge_close_session(session=args.get("session")),
+    check_fn=_check_bridge,
+)
+
+registry.register(
+    name="kimi_webbridge_save_pdf",
+    toolset="kimi_webbridge",
+    schema={
+        "name": "kimi_webbridge_save_pdf",
+        "description": "Save the current page as a PDF.",
+        "parameters": _schema(
+            [],
+            {
+                "paper_format": {"type": "string", "default": "letter"},
+                "landscape": {"type": "boolean", "default": False},
+                "scale": {"type": "number", "default": 1.0},
+                "print_background": {"type": "boolean", "default": True},
+                "file_name": {"type": "string", "description": "Custom filename; defaults to page title"},
+            },
+        ),
+    },
+    handler=lambda args, **kw: kimi_webbridge_save_pdf(
+        paper_format=args.get("paper_format", "letter"),
+        landscape=args.get("landscape", False),
+        scale=args.get("scale", 1.0),
+        print_background=args.get("print_background", True),
+        file_name=args.get("file_name"),
+        session=args.get("session"),
+    ),
+    check_fn=_check_bridge,
+)


### PR DESCRIPTION
Add browser automation via Kimi WebBridge daemon (local HTTP on :10086).
Unlike Playwright-based browser tools, this controls the user's REAL browser
with their actual login sessions.

**Tools:**
- kimi_webbridge_navigate, find_tab, snapshot, click, fill, evaluate
- kimi_webbridge_screenshot, save_screenshot, save_pdf
- kimi_webbridge_list_tabs, close_tab, close_session

**Config:** providers.kimi_webbridge.base_url (defaults to 127.0.0.1:10086)
Off by default (requires separate extension + daemon install).

**Tests:** 26 tests with mocked daemon responses. All passing.

**Branch:** clean single commit on top of upstream main.