### PR TITLE
fix(api-server): add browser security headers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -481,7 +481,12 @@ else:
     body_limit_middleware = None  # type: ignore[assignment]
 
 _SECURITY_HEADERS = {
+    "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "0",
     "Referrer-Policy": "no-referrer",
 }
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -445,7 +445,12 @@ class TestHealthEndpoint:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/health")
             assert resp.status == 200
+            assert resp.headers.get("Content-Security-Policy") == "default-src 'none'; frame-ancestors 'none'"
+            assert resp.headers.get("Permissions-Policy") == "camera=(), microphone=(), geolocation=()"
+            assert resp.headers.get("Strict-Transport-Security") == "max-age=31536000; includeSubDomains"
             assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+            assert resp.headers.get("X-Frame-Options") == "DENY"
+            assert resp.headers.get("X-XSS-Protection") == "0"
             assert resp.headers.get("Referrer-Policy") == "no-referrer"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add the missing defense-in-depth browser security headers to the OpenAI-compatible API server responses.
- Keep the existing middleware behavior of using `setdefault`, so route handlers can still override a header intentionally.
- Extend the existing `/health` regression test to lock the full security header set.

Closes #7487.

## Verification

Real environment tested: macOS local workstation, Python 3.11.13 via existing Hermes worktree venv, Hermes built from source at this PR head.

Commands run after this patch:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py
.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
git diff --check
```

Evidence after fix:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py
146 passed, 95 warnings in 2.67s

.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
All checks passed!

git diff --check
(no output)
```

What was not tested: live HTTPS deployment behavior behind a reverse proxy; this patch covers the response header middleware directly through the aiohttp test server.
