### PR TITLE
fix(dashboard): add browser security headers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -121,6 +121,27 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/plugins/rescan",
 })
 
+_DASHBOARD_CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: blob:; "
+    "font-src 'self' data:; "
+    "connect-src 'self' ws://localhost:* ws://127.0.0.1:* "
+    "wss://localhost:* wss://127.0.0.1:*; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "frame-ancestors 'none'"
+)
+
+_DASHBOARD_SECURITY_HEADERS: Dict[str, str] = {
+    "Content-Security-Policy": _DASHBOARD_CONTENT_SECURITY_POLICY,
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
 
 def _has_valid_session_token(request: Request) -> bool:
     """True if the request carries a valid dashboard session token.
@@ -244,6 +265,15 @@ async def auth_middleware(request: Request, call_next):
                 content={"detail": "Unauthorized"},
             )
     return await call_next(request)
+
+
+@app.middleware("http")
+async def dashboard_security_headers_middleware(request: Request, call_next):
+    """Attach browser security headers to dashboard and API responses."""
+    response = await call_next(request)
+    for key, value in _DASHBOARD_SECURITY_HEADERS.items():
+        response.headers.setdefault(key, value)
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -146,3 +146,47 @@ class TestHostHeaderMiddleware:
         resp = client.get("/api/status")
         # Should get through to the status endpoint, not a 400
         assert resp.status_code != 400
+
+
+class TestDashboardSecurityHeaders:
+    def test_public_dashboard_api_responses_include_security_headers(self):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        if hasattr(app.state, "bound_host"):
+            del app.state.bound_host
+
+        client = TestClient(app)
+        resp = client.get("/api/status")
+
+        assert resp.status_code == 200
+        assert resp.headers.get("Content-Security-Policy") == (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data: blob:; "
+            "font-src 'self' data:; "
+            "connect-src 'self' ws://localhost:* ws://127.0.0.1:* "
+            "wss://localhost:* wss://127.0.0.1:*; "
+            "base-uri 'self'; "
+            "form-action 'self'; "
+            "frame-ancestors 'none'"
+        )
+        assert resp.headers.get("Permissions-Policy") == "camera=(), microphone=(), geolocation=()"
+        assert resp.headers.get("Referrer-Policy") == "no-referrer"
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+        assert resp.headers.get("X-Frame-Options") == "DENY"
+
+    def test_unauthorized_dashboard_api_responses_include_security_headers(self):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        if hasattr(app.state, "bound_host"):
+            del app.state.bound_host
+
+        client = TestClient(app)
+        resp = client.get("/api/env")
+
+        assert resp.status_code == 401
+        assert resp.headers.get("Content-Security-Policy")
+        assert resp.headers.get("X-Frame-Options") == "DENY"


### PR DESCRIPTION
## Summary

- Add browser security headers to the local dashboard FastAPI server.
- Use a dashboard-compatible CSP that keeps same-origin assets, the required inline token bootstrap, and loopback WebSocket channels working while blocking framing and broad resource loading.
- Cover both public dashboard API responses and auth-denied API responses in regression tests.

Closes #16456.
Related #7487.

## Verification

Real environment tested: macOS local workstation, Python 3.11.13 via existing Hermes worktree venv, Hermes built from source at this PR head.

Commands run after this patch:

```text
scripts/run_tests.sh tests/hermes_cli/test_web_server_host_header.py
.venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_host_header.py
git diff --check
```

Evidence after fix:

```text
scripts/run_tests.sh tests/hermes_cli/test_web_server_host_header.py
10 passed in 1.36s

.venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_host_header.py
All checks passed!

git diff --check
(no output)
```

What was not tested: a live browser session against the packaged dashboard bundle; the focused tests verify the FastAPI middleware headers on public and unauthorized dashboard API responses.
