### PR TITLE
fix(copilot): remove gh auth token fallback

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -13,7 +13,9 @@ Credential search order (matching Copilot CLI behaviour):
   1. COPILOT_GITHUB_TOKEN env var
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
-  4. gh auth token  CLI fallback
+
+Generic ``gh auth token`` output is intentionally not used as a fallback:
+those tokens prove GitHub CLI login, not Copilot API entitlement.
 """
 
 from __future__ import annotations
@@ -81,16 +83,6 @@ def resolve_copilot_token() -> tuple[str, str]:
                 )
                 continue
             return val, env_var
-
-    # 2. Fall back to gh auth token
-    token = _try_gh_cli_token()
-    if token:
-        valid, msg = validate_copilot_token(token)
-        if not valid:
-            raise ValueError(
-                f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
-            )
-        return token, "gh auth token"
 
     return "", ""
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -346,12 +346,12 @@ class TestApiKeyProviderStatus:
         assert status["configured"] is True
         assert status["base_url"] == STEPFUN_STEP_PLAN_CN_BASE_URL
 
-    def test_copilot_status_uses_gh_cli_token(self, monkeypatch):
+    def test_copilot_status_ignores_gh_cli_token(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_gh_cli_token")
         status = get_api_key_provider_status("copilot")
-        assert status["configured"] is True
-        assert status["logged_in"] is True
-        assert status["key_source"] == "gh auth token"
+        assert status["configured"] is False
+        assert status["logged_in"] is False
+        assert status["key_source"] == ""
         assert status["base_url"] == "https://api.githubcopilot.com"
 
     def test_get_auth_status_dispatches_to_api_key(self, monkeypatch):
@@ -409,13 +409,13 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "https://api.githubcopilot.com"
         assert creds["source"] == "GITHUB_TOKEN"
 
-    def test_resolve_copilot_with_gh_cli_fallback(self, monkeypatch):
+    def test_resolve_copilot_ignores_gh_cli_fallback(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gho_cli_secret"
+        assert creds["api_key"] == ""
         assert creds["base_url"] == "https://api.githubcopilot.com"
-        assert creds["source"] == "gh auth token"
+        assert creds["source"] == "default"
 
     def test_resolve_lmstudio_uses_token_and_base_url_from_env(self, monkeypatch):
         monkeypatch.setenv("LM_API_KEY", "lm-token")
@@ -637,17 +637,17 @@ class TestRuntimeProviderResolution:
         assert result["provider"] == "kimi-coding"
         assert result["api_key"] == "auto-kimi-key"
 
-    def test_runtime_copilot_uses_gh_cli_token(self, monkeypatch):
-        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+    def test_runtime_copilot_uses_explicit_env_token(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_env_secret")
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="copilot")
         assert result["provider"] == "copilot"
         assert result["api_mode"] == "chat_completions"
-        assert result["api_key"] == "gho_cli_secret"
+        assert result["api_key"] == "gho_env_secret"
         assert result["base_url"] == "https://api.githubcopilot.com"
 
     def test_runtime_copilot_uses_responses_for_gpt_5_4(self, monkeypatch):
-        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_env_secret")
         monkeypatch.setattr(
             "hermes_cli.runtime_provider._get_model_config",
             lambda: {"provider": "copilot", "default": "gpt-5.4"},
@@ -711,15 +711,28 @@ class TestHasAnyProviderConfigured:
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is True
 
-    def test_gh_cli_token_counts(self, monkeypatch, tmp_path):
+    def test_gh_cli_token_does_not_count(self, monkeypatch, tmp_path):
         from hermes_cli import config as config_module
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        provider_env_vars = {
+            "OPENROUTER_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "OPENAI_BASE_URL",
+        }
+        for pconfig in PROVIDER_REGISTRY.values():
+            if pconfig.auth_type == "api_key":
+                provider_env_vars.update(pconfig.api_key_env_vars)
+        for var in provider_env_vars:
+            monkeypatch.delenv(var, raising=False)
         from hermes_cli.main import _has_any_provider_configured
-        assert _has_any_provider_configured() is True
+        assert _has_any_provider_configured() is False
 
     def test_claude_code_creds_ignored_on_fresh_install(self, monkeypatch, tmp_path):
         """Claude Code credentials should NOT skip the wizard when Hermes is unconfigured."""

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
 class TestTokenValidation:
@@ -77,24 +77,27 @@ class TestResolveToken:
         assert token == "gho_valid_oauth"
         assert source == "GITHUB_TOKEN"
 
-    def test_gh_cli_fallback(self, monkeypatch):
+    def test_gh_cli_token_not_used_as_copilot_fallback(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli") as mock_gh:
             token, source = resolve_copilot_token()
-        assert token == "gho_from_cli"
-        assert source == "gh auth token"
+        assert token == ""
+        assert source == ""
+        mock_gh.assert_not_called()
 
-    def test_gh_cli_classic_pat_raises(self, monkeypatch):
+    def test_gh_cli_classic_pat_not_consulted(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_classic"):
-            with pytest.raises(ValueError, match="classic PAT"):
-                resolve_copilot_token()
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_classic") as mock_gh:
+            token, source = resolve_copilot_token()
+        assert token == ""
+        assert source == ""
+        mock_gh.assert_not_called()
 
     def test_no_token_returns_empty(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token


### PR DESCRIPTION
## Summary

- Remove the implicit `gh auth token` fallback from Copilot token resolution.
- Keep explicit Copilot credential sources working (`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`).
- Update provider status, runtime resolution, and setup-wizard detection tests so generic GitHub CLI login no longer marks Copilot as configured.

Closes #25246.

## Verification

Real environment tested: macOS local workstation, Python 3.11.13 via existing Hermes worktree venv, Hermes built from source at this PR head.

Commands run after this patch:

```text
scripts/run_tests.sh tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py
.venv/bin/python -m ruff check hermes_cli/copilot_auth.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py
git diff --check
```

Evidence after fix:

```text
scripts/run_tests.sh tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py
198 passed in 7.09s

.venv/bin/python -m ruff check hermes_cli/copilot_auth.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py
All checks passed!

git diff --check
(no output)
```

What was not tested: a live GitHub Copilot API request; the focused tests cover token-source selection, provider status, runtime resolution, and setup wizard detection.
