### PR TITLE
fix(api-server): rate limit request bursts

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -69,6 +69,10 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+RATE_LIMIT_WINDOW_SECONDS = 60
+RATE_LIMIT_DEFAULT_MAX = 120
+RATE_LIMIT_SENSITIVE_MAX = 30
+RATE_LIMIT_SENSITIVE_PREFIXES = ("/v1/responses/", "/api/jobs")
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -557,6 +561,56 @@ if AIOHTTP_AVAILABLE:
         return await handler(request)
 else:
     body_limit_middleware = None  # type: ignore[assignment]
+
+
+def _rate_limit_client_id(request: "web.Request") -> str:
+    if request.remote:
+        return request.remote
+    peername = request.transport.get_extra_info("peername") if request.transport else None
+    if isinstance(peername, tuple) and peername:
+        return str(peername[0])
+    return "unknown"
+
+
+def _rate_limit_bucket(path: str) -> str:
+    if any(path.startswith(prefix) for prefix in RATE_LIMIT_SENSITIVE_PREFIXES):
+        return "sensitive"
+    return path
+
+
+def _rate_limit_max(path: str) -> int:
+    if any(path.startswith(prefix) for prefix in RATE_LIMIT_SENSITIVE_PREFIXES):
+        return RATE_LIMIT_SENSITIVE_MAX
+    return RATE_LIMIT_DEFAULT_MAX
+
+
+if AIOHTTP_AVAILABLE:
+    @web.middleware
+    async def rate_limit_middleware(request, handler):
+        """Apply an in-memory sliding-window limit per client and endpoint bucket."""
+        if request.method == "OPTIONS":
+            return await handler(request)
+
+        now = time.time()
+        path = request.path
+        key = (_rate_limit_client_id(request), _rate_limit_bucket(path))
+        hits = request.app.setdefault("_api_rate_limit_hits", {})
+        window = hits.setdefault(key, [])
+        window[:] = [ts for ts in window if now - ts < RATE_LIMIT_WINDOW_SECONDS]
+
+        limit = _rate_limit_max(path)
+        if len(window) >= limit:
+            retry_after = max(1, int(RATE_LIMIT_WINDOW_SECONDS - (now - window[0])))
+            return web.json_response(
+                _openai_error("Rate limit exceeded.", code="rate_limit_exceeded"),
+                status=429,
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        window.append(now)
+        return await handler(request)
+else:
+    rate_limit_middleware = None  # type: ignore[assignment]
 
 _SECURITY_HEADERS = {
     "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
@@ -4086,9 +4140,19 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [
+                mw
+                for mw in (
+                    cors_middleware,
+                    body_limit_middleware,
+                    rate_limit_middleware,
+                    security_headers_middleware,
+                )
+                if mw is not None
+            ]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             assert self._app is not None
+            self._app["_api_rate_limit_hits"] = {}
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -32,6 +32,7 @@ from gateway.platforms.api_server import (
     _derive_chat_session_id,
     check_api_server_requirements,
     cors_middleware,
+    rate_limit_middleware,
     security_headers_middleware,
 )
 
@@ -404,9 +405,14 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    mws = [
+        mw
+        for mw in (cors_middleware, rate_limit_middleware, security_headers_middleware)
+        if mw is not None
+    ]
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
+    app["_api_rate_limit_hits"] = {}
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -496,6 +502,44 @@ class TestHealthEndpoint:
             data = await resp.json()
             assert data["status"] == "ok"
             assert data["platform"] == "hermes-agent"
+
+
+class TestRateLimitMiddleware:
+    @pytest.mark.asyncio
+    async def test_returns_429_after_default_endpoint_limit(self, adapter, monkeypatch):
+        import gateway.platforms.api_server as api_server
+
+        monkeypatch.setattr(api_server, "RATE_LIMIT_DEFAULT_MAX", 2)
+        monkeypatch.setattr(api_server, "RATE_LIMIT_WINDOW_SECONDS", 60)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            assert (await cli.get("/health")).status == 200
+            assert (await cli.get("/health")).status == 200
+            resp = await cli.get("/health")
+
+            assert resp.status == 429
+            assert resp.headers.get("Retry-After")
+            data = await resp.json()
+            assert data["error"]["code"] == "rate_limit_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_sensitive_response_lookup_uses_stricter_bucket(self, adapter, monkeypatch):
+        import gateway.platforms.api_server as api_server
+
+        monkeypatch.setattr(api_server, "RATE_LIMIT_DEFAULT_MAX", 100)
+        monkeypatch.setattr(api_server, "RATE_LIMIT_SENSITIVE_MAX", 1)
+        monkeypatch.setattr(api_server, "RATE_LIMIT_WINDOW_SECONDS", 60)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.get("/v1/responses/resp_missing")
+            second = await cli.get("/v1/responses/another_missing")
+
+            assert first.status == 404
+            assert second.status == 429
+            data = await second.json()
+            assert data["error"]["code"] == "rate_limit_exceeded"
 
     @pytest.mark.asyncio
     async def test_v1_health_alias_returns_ok(self, adapter):


### PR DESCRIPTION
## Summary

- Add an in-memory sliding-window request limiter to the OpenAI-compatible API server.
- Bucket by client and endpoint path, with a stricter shared bucket for sensitive response lookup / job endpoints.
- Return OpenAI-style `429` errors with `Retry-After` once the per-window limit is exceeded.

Closes #7483.

## Verification

Real environment tested: macOS local workstation, Python 3.11.13 via existing Hermes worktree venv, Hermes built from source at this PR head.

Commands run after this patch:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py
.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
git diff --check
```

Evidence after fix:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py
148 passed, 194 warnings in 2.47s

.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
All checks passed!

git diff --check
(no output)
```

What was not tested: distributed multi-process deployments; the limiter is intentionally process-local and covers the default single-process aiohttp API server used by Hermes.
