### PR TITLE
fix(update): pre-stop gateway on low-memory hosts to avoid OOM (#26770)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -68,7 +68,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 
 def _add_accept_hooks_flag(parser) -> None:
@@ -7734,6 +7734,84 @@ def _cmd_update_pip(args):
     print("✓ Update complete! Restart hermes to use the new version.")
 
 
+# Default threshold for "low memory" host that needs pre-stop before pip
+# install. Set just above the 1.6 GB Alibaba-Lightweight class that the
+# original report (#26770) hit — those boxes OOM-kill the gateway when
+# pip's resolver runs alongside an active Python+Node gateway process.
+# Servers with > 2 GB available comfortably tolerate the overlap, so we
+# only pre-stop when memory is actually tight.
+_UPDATE_PRESTOP_DEFAULT_THRESHOLD_MB = 2048
+
+
+def _available_memory_mb() -> Optional[int]:
+    """Best-effort available-RAM probe in MB. Returns None when unsupported.
+
+    Prefers ``psutil`` (already a hard dependency on every platform).  Falls
+    back to ``/proc/meminfo`` on Linux for the rare environment where psutil
+    is unavailable.  Any failure returns ``None`` so the caller can treat
+    "unknown" as "do not pre-stop" (preserve current behaviour). (#26770)
+    """
+    try:
+        import psutil  # type: ignore
+
+        return int(psutil.virtual_memory().available / (1024 * 1024))
+    except Exception:
+        pass
+
+    try:
+        with open("/proc/meminfo", "r") as fp:
+            for line in fp:
+                if line.startswith("MemAvailable:"):
+                    # `MemAvailable:    1234 kB`
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _should_prestop_gateway_for_update(gateway_mode: bool) -> Tuple[bool, str]:
+    """Decide whether to stop the current-profile gateway BEFORE pip install.
+
+    Returns ``(should_stop, reason)``.  The reason is human-readable and
+    surfaced in the update log when we do stop, or kept for debug
+    otherwise.
+
+    Hard guards:
+    - When ``gateway_mode`` is True the update process IS the gateway's
+      child (spawned by the gateway's ``/update`` command).  Stopping the
+      gateway would kill us before pip even starts.  Never pre-stop in
+      that mode.
+    - Operator override via ``HERMES_UPDATE_PRESTOP_GATEWAY`` — set to
+      ``1``/``true``/``yes`` to force, ``0``/``false``/``no`` to skip.
+
+    Otherwise: stop iff available memory is below the threshold.  The
+    threshold is configurable via ``HERMES_UPDATE_PRESTOP_THRESHOLD_MB``
+    (defaults to ``_UPDATE_PRESTOP_DEFAULT_THRESHOLD_MB``).
+    """
+    if gateway_mode:
+        return False, "running inside gateway"
+
+    override = os.environ.get("HERMES_UPDATE_PRESTOP_GATEWAY", "").strip().lower()
+    if override in {"1", "true", "yes", "on"}:
+        return True, "HERMES_UPDATE_PRESTOP_GATEWAY=1 (operator override)"
+    if override in {"0", "false", "no", "off"}:
+        return False, "HERMES_UPDATE_PRESTOP_GATEWAY=0 (operator override)"
+
+    avail = _available_memory_mb()
+    if avail is None:
+        return False, "available memory unknown"
+
+    threshold_raw = os.environ.get("HERMES_UPDATE_PRESTOP_THRESHOLD_MB", "")
+    try:
+        threshold = int(threshold_raw) if threshold_raw else _UPDATE_PRESTOP_DEFAULT_THRESHOLD_MB
+    except ValueError:
+        threshold = _UPDATE_PRESTOP_DEFAULT_THRESHOLD_MB
+
+    if avail < threshold:
+        return True, f"available memory {avail} MB < {threshold} MB threshold"
+    return False, f"available memory {avail} MB ≥ {threshold} MB threshold"
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -7991,6 +8069,37 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras
         # individually so update does not silently strip working capabilities.
+
+        # On low-memory hosts (e.g. 1–2 GB lightweight VMs), keeping the gateway
+        # alive while pip's resolver runs causes an OOM-kill (#26770).  Pre-stop
+        # the current-profile gateway here when available memory is below the
+        # threshold; the auto-restart block at the end of this function will
+        # bring it back up after deps land.  Skipped when running inside the
+        # gateway (we would kill our own parent) and when the operator opted
+        # out via HERMES_UPDATE_PRESTOP_GATEWAY=0.
+        _prestop_did_stop = False
+        try:
+            _prestop_decision, _prestop_reason = _should_prestop_gateway_for_update(
+                gateway_mode
+            )
+            if _prestop_decision:
+                try:
+                    from hermes_cli.gateway import stop_profile_gateway as _stop_profile_gateway
+                    print(
+                        f"→ Stopping gateway before dependency install ({_prestop_reason})..."
+                    )
+                    if _stop_profile_gateway():
+                        _prestop_did_stop = True
+                        print("  ✓ Gateway stopped; will be restarted after update")
+                    else:
+                        print("  ℹ No running gateway found for this profile")
+                except Exception as _stop_exc:
+                    logger.debug("Pre-update gateway stop failed: %s", _stop_exc)
+            else:
+                logger.debug("Pre-update gateway pre-stop skipped: %s", _prestop_reason)
+        except Exception as _decision_exc:
+            logger.debug("Pre-update gateway pre-stop decision failed: %s", _decision_exc)
+
         print("→ Updating Python dependencies...")
         pip_cmd = [sys.executable, "-m", "pip"]
         uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)

--- a/tests/hermes_cli/test_update_prestop_low_memory.py
+++ b/tests/hermes_cli/test_update_prestop_low_memory.py
@@ -1,0 +1,164 @@
+"""Tests for the low-memory pre-stop guard in ``hermes update``.
+
+Regression tests for #26770: on low-memory hosts (1–2 GB lightweight VMs)
+keeping the gateway alive while pip's resolver runs OOM-kills it.  The
+update flow now stops the current-profile gateway BEFORE the dep install
+when available memory is below threshold, and lets the existing
+auto-restart block bring it back up afterwards.
+
+These tests verify the decision helper ``_should_prestop_gateway_for_update``
+and the memory probe ``_available_memory_mb`` — both pure-Python and
+exercisable without any real subprocess / systemd interaction.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import hermes_cli.main as cli_main
+
+
+# ---------------------------------------------------------------------------
+# _available_memory_mb
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableMemoryMb:
+    def test_uses_psutil_when_available(self):
+        class _FakeVM:
+            available = 4096 * 1024 * 1024  # 4 GB
+
+        with patch("psutil.virtual_memory", return_value=_FakeVM()):
+            assert cli_main._available_memory_mb() == 4096
+
+    def test_returns_none_when_psutil_raises_and_no_proc_meminfo(self, monkeypatch):
+        # Force psutil import path to raise, and make /proc/meminfo unreadable.
+        def _boom():
+            raise RuntimeError("nope")
+
+        with patch("psutil.virtual_memory", side_effect=_boom):
+            # On macOS / Windows there is no /proc/meminfo so the fallback
+            # naturally returns None.  On Linux runners we still want None
+            # here, so monkeypatch ``open`` to raise FileNotFoundError when
+            # /proc/meminfo is requested.
+            real_open = open
+
+            def _fake_open(path, *a, **kw):
+                if path == "/proc/meminfo":
+                    raise FileNotFoundError(path)
+                return real_open(path, *a, **kw)
+
+            monkeypatch.setattr("builtins.open", _fake_open)
+            assert cli_main._available_memory_mb() is None
+
+    def test_falls_back_to_proc_meminfo_on_linux(self, monkeypatch):
+        # psutil unavailable; /proc/meminfo readable.
+        def _boom():
+            raise RuntimeError("no psutil")
+
+        meminfo = (
+            "MemTotal:        2048000 kB\n"
+            "MemFree:          200000 kB\n"
+            "MemAvailable:    1572864 kB\n"   # 1.5 GiB → 1536 MB
+            "Buffers:           50000 kB\n"
+        )
+
+        from io import StringIO
+
+        real_open = open
+
+        def _fake_open(path, *a, **kw):
+            if path == "/proc/meminfo":
+                return StringIO(meminfo)
+            return real_open(path, *a, **kw)
+
+        with patch("psutil.virtual_memory", side_effect=_boom):
+            monkeypatch.setattr("builtins.open", _fake_open)
+            assert cli_main._available_memory_mb() == 1536
+
+
+# ---------------------------------------------------------------------------
+# _should_prestop_gateway_for_update
+# ---------------------------------------------------------------------------
+
+
+class TestShouldPrestopGatewayForUpdate:
+    def test_never_prestop_when_running_inside_gateway(self, monkeypatch):
+        """gateway_mode=True is the ``hermes update --gateway`` flow spawned
+        by the gateway's /update command; pre-stopping would kill us."""
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        # Even with very low memory we must refuse when gateway_mode=True.
+        with patch.object(cli_main, "_available_memory_mb", return_value=256):
+            should, reason = cli_main._should_prestop_gateway_for_update(True)
+        assert should is False
+        assert "gateway" in reason.lower()
+
+    def test_low_memory_triggers_prestop(self, monkeypatch):
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_THRESHOLD_MB", raising=False)
+        # 1024 MB available, default threshold 2048 → should stop.
+        with patch.object(cli_main, "_available_memory_mb", return_value=1024):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is True
+        assert "1024" in reason
+        assert "2048" in reason
+
+    def test_high_memory_skips_prestop(self, monkeypatch):
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_THRESHOLD_MB", raising=False)
+        with patch.object(cli_main, "_available_memory_mb", return_value=8192):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is False
+        assert "8192" in reason
+
+    def test_unknown_memory_skips_prestop(self, monkeypatch):
+        """Probe failure → preserve current behaviour (no pre-stop)."""
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        with patch.object(cli_main, "_available_memory_mb", return_value=None):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is False
+        assert "unknown" in reason.lower()
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes"])
+    def test_env_force_on(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_UPDATE_PRESTOP_GATEWAY", value)
+        # Even with plenty of memory the override forces a stop.
+        with patch.object(cli_main, "_available_memory_mb", return_value=16384):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is True
+        assert "override" in reason.lower()
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "No"])
+    def test_env_force_off(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_UPDATE_PRESTOP_GATEWAY", value)
+        # Even with very low memory the override skips the stop.
+        with patch.object(cli_main, "_available_memory_mb", return_value=128):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is False
+        assert "override" in reason.lower()
+
+    def test_env_override_still_skips_inside_gateway(self, monkeypatch):
+        """The gateway_mode guard wins over the env-var override — refusing
+        to kill ourselves is non-negotiable."""
+        monkeypatch.setenv("HERMES_UPDATE_PRESTOP_GATEWAY", "1")
+        with patch.object(cli_main, "_available_memory_mb", return_value=256):
+            should, _reason = cli_main._should_prestop_gateway_for_update(True)
+        assert should is False
+
+    def test_custom_threshold_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        # 3 GB available, threshold raised to 4 GB → stop.
+        monkeypatch.setenv("HERMES_UPDATE_PRESTOP_THRESHOLD_MB", "4096")
+        with patch.object(cli_main, "_available_memory_mb", return_value=3072):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is True
+        assert "4096" in reason
+
+    def test_malformed_threshold_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delenv("HERMES_UPDATE_PRESTOP_GATEWAY", raising=False)
+        monkeypatch.setenv("HERMES_UPDATE_PRESTOP_THRESHOLD_MB", "not-a-number")
+        # 1 GB available, garbled threshold → default 2048 still kicks in.
+        with patch.object(cli_main, "_available_memory_mb", return_value=1024):
+            should, reason = cli_main._should_prestop_gateway_for_update(False)
+        assert should is True
+        assert "2048" in reason


### PR DESCRIPTION
## Summary

Fixes #26770. `hermes update` keeps the gateway alive while pip's resolver runs, then restarts it at the end. On lightweight 1–2 GB cloud instances this overlap exceeds physical RAM and the kernel OOM-kills the gateway mid-update — the exact failure the reporter hit on a 1.6 GB / 2 GB-swap Alibaba Lightweight box.

## Approach

Implements **Option B** from the issue (memory-aware pre-stop). Adds a guarded pre-stop step in `_cmd_update_impl`: when available memory is below threshold we stop the current-profile gateway before the dep install, and let the existing auto-restart block bring it back up.

### Decision logic (`_should_prestop_gateway_for_update`)

| Condition | Decision |
|---|---|
| `gateway_mode=True` (i.e. `hermes update --gateway` from the gateway's `/update` command) | **Never pre-stop** — would kill our own parent. Wins over the env override. |
| `HERMES_UPDATE_PRESTOP_GATEWAY=1` / `true` / `yes` / `on` | Force pre-stop |
| `HERMES_UPDATE_PRESTOP_GATEWAY=0` / `false` / `no` / `off` | Skip pre-stop |
| Otherwise, available memory < `HERMES_UPDATE_PRESTOP_THRESHOLD_MB` (default 2048) | Pre-stop |
| Otherwise (memory OK or probe failed) | Skip pre-stop |

### Memory probe (`_available_memory_mb`)

Prefers `psutil` (already a hard dep on every supported platform). Falls back to `/proc/meminfo` `MemAvailable:` on Linux for the rare environment where psutil is unavailable. Returns `None` on failure → caller treats unknown as "do not pre-stop", preserving today's behaviour on unsupported platforms.

### Why this scope

- **Behaviour-preserving for every user above ~2 GB available RAM** and every `hermes update --gateway` invocation. No new downtime on healthy hosts.
- **Reuses `stop_profile_gateway()`** so the pre-stop respects HERMES_HOME isolation (current profile only) and writes the same `planned_stop_marker` the existing graceful-restart path uses.
- **No changes to the auto-restart block** at the end of `_cmd_update_impl` — it already handles the "service is stopped, please start it" case (`launchctl kickstart` / `systemctl start` / `launch_detached_profile_gateway_restart`).

## What I deliberately did NOT do

- **Did not stop gateways across all profiles** — the reported failure was a single-profile single-gateway box, and stopping every profile on a multi-profile box would be more invasive than the report calls for. If a follow-up multi-profile OOM gets reported, the pre-stop helper can be widened then.
- **Did not change the order on healthy boxes** — keeping the gateway up through pip install means no downtime when memory is plentiful.
- **Did not pick Option A** (unconditional pre-stop) because it adds a 30s–2min downtime window for every user, including 64 GB workstations where the OOM never happens.

## Test plan

22 new regression tests in `tests/hermes_cli/test_update_prestop_low_memory.py`:

| Test class | Covers |
|---|---|
| `TestAvailableMemoryMb` (3) | psutil happy path; psutil failure + no `/proc/meminfo` → `None`; `/proc/meminfo` fallback parses `MemAvailable:` correctly |
| `TestShouldPrestopGatewayForUpdate` (19) | `gateway_mode` always wins; low-mem triggers; high-mem skips; unknown-mem skips; env force-on (`1`/`true`/`yes`/`on`); env force-off (`0`/`false`/`no`/`off`); env override still skips inside gateway; custom threshold via env; malformed threshold falls back to default |

```
$ python -m pytest tests/hermes_cli/test_update_prestop_low_memory.py -v
========================== 22 passed in 5.68s ==========================

$ python -m pytest tests/hermes_cli/test_update_gateway_restart.py \
    tests/hermes_cli/test_update_hangup_protection.py \
    tests/hermes_cli/test_update_yes_flag.py \
    tests/hermes_cli/test_update_autostash.py \
    tests/hermes_cli/test_update_config_clears_custom_fields.py -q
======================= 92 passed, 1 skipped in 31.40s ========================
```

All tests run in an isolated venv against an isolated `HERMES_HOME` — no touch of the developer's live `~/.hermes`.

## Files

- `hermes_cli/main.py` — `+115 / -1` (typing import update, `_available_memory_mb`, `_should_prestop_gateway_for_update`, wired into `_cmd_update_impl` before the pip-install block)
- `tests/hermes_cli/test_update_prestop_low_memory.py` — `+164` (new file, 22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)