### PR TITLE
feat(mission): add dry-run mission preview CLI

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4356,6 +4356,13 @@ def cmd_project(args):
     return projects_command(args)
 
 
+def cmd_mission(args):
+    """Mission Control dry-run preview wrapper."""
+    from hermes_cli.mission import mission_command
+
+    sys.exit(mission_command(args))
+
+
 def cmd_hooks(args):
     """Shell-hook inspection and management."""
     from hermes_cli.hooks import hooks_command
@@ -12699,7 +12706,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
-        "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
+        "mission", "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
         "project", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
@@ -13491,6 +13498,14 @@ def main():
 
     project_parser = _build_project_parser(subparsers)
     project_parser.set_defaults(func=cmd_project)
+
+    # =========================================================================
+    # mission command — dry-run Mission Control graph preview
+    # =========================================================================
+    from hermes_cli.mission import build_parser as _build_mission_parser
+
+    mission_parser = _build_mission_parser(subparsers)
+    mission_parser.set_defaults(func=cmd_mission)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/hermes_cli/mission.py
+++ b/hermes_cli/mission.py
@@ -1,0 +1,255 @@
+"""Mission Control dry-run preview CLI.
+
+The first Mission Control slice is intentionally preview-only.  It turns a
+small graph spec into a deterministic "would create" envelope that can be
+reviewed before any Kanban tasks, cron jobs, subscriptions, or live sends are
+created.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:  # PyYAML is an optional runtime dependency in some minimal installs.
+    import yaml
+except Exception:  # pragma: no cover - exercised only when yaml is absent
+    yaml = None  # type: ignore[assignment]
+
+
+class MissionSpecError(ValueError):
+    """Raised when a mission spec cannot be safely previewed."""
+
+
+def _read_spec_text(path: str | None) -> str:
+    if path is None or path == "-":
+        return sys.stdin.read()
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        # Never surface the raw OSError: it embeds the local filesystem path
+        # (and, for permission errors, can hint at what's on disk).
+        raise MissionSpecError("mission spec file could not be read") from exc
+
+
+def load_spec(path: str | None) -> dict[str, Any]:
+    """Load a JSON/YAML mission spec from *path* or stdin.
+
+    JSON is attempted first so the command works even without PyYAML.  YAML is
+    accepted when the dependency is present.
+    """
+
+    text = _read_spec_text(path)
+    if not text.strip():
+        raise MissionSpecError("mission spec is empty")
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        if yaml is None:
+            raise MissionSpecError("mission spec is not valid JSON and PyYAML is unavailable")
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            # yaml.YAMLError messages can echo back offending file content
+            # (including secret-like values); keep the CLI-facing error generic.
+            raise MissionSpecError("mission spec is not valid JSON/YAML") from exc
+
+    if not isinstance(data, dict):
+        raise MissionSpecError("mission spec must be a JSON/YAML object")
+    return data
+
+
+def _as_mapping(value: Any, name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise MissionSpecError(f"{name} must be an object")
+    return value
+
+
+def _as_list(value: Any, name: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise MissionSpecError(f"{name} must be a list")
+    return value
+
+
+def _stringish(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    raise MissionSpecError("mission string fields must be strings")
+
+
+def _task_preview(raw: Any, index: int) -> dict[str, Any]:
+    if isinstance(raw, str):
+        raw = {"title": raw}
+    if not isinstance(raw, dict):
+        raise MissionSpecError(f"task #{index + 1} must be an object or string")
+
+    title = _stringish(raw.get("title") or raw.get("name") or raw.get("task"))
+    if not title:
+        raise MissionSpecError(f"task #{index + 1} is missing title/name/task")
+
+    depends_on = raw.get("depends_on", raw.get("needs", []))
+    if isinstance(depends_on, str):
+        depends_on = [depends_on]
+    if not isinstance(depends_on, list):
+        raise MissionSpecError(f"task #{index + 1} depends_on must be a string or list")
+    normalized_deps = []
+    for dep in depends_on:
+        try:
+            normalized_dep = _stringish(dep)
+        except MissionSpecError as exc:
+            raise MissionSpecError(
+                f"task #{index + 1} depends_on entries must be non-empty strings"
+            ) from exc
+        if not normalized_dep:
+            raise MissionSpecError(f"task #{index + 1} depends_on entries must be non-empty strings")
+        normalized_deps.append(normalized_dep)
+
+    out: dict[str, Any] = {
+        "index": index + 1,
+        "title": title,
+        "assignee": _stringish(raw.get("assignee") or raw.get("profile")),
+        "depends_on": normalized_deps,
+    }
+    task_id = _stringish(raw.get("id"))
+    if task_id:
+        out["id"] = task_id
+    body = _stringish(raw.get("body") or raw.get("description"))
+    if body:
+        out["body"] = body
+    return out
+
+
+def build_preview(spec: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic dry-run mission preview.
+
+    The accepted input is deliberately small and upstream-generic:
+
+    - top-level ``mission`` object for metadata, or metadata at the root
+    - ``graph``/``tasks`` list for task previews
+    - optional ``ack`` and ``watchdog`` objects
+    """
+
+    mission = _as_mapping(spec.get("mission"), "mission")
+    root = {**spec, **mission}
+    graph = _as_list(root.get("graph", root.get("tasks")), "graph/tasks")
+    if not graph:
+        raise MissionSpecError("mission spec must include at least one graph/task item")
+
+    origin = _stringish(root.get("origin"))
+    return_to = _stringish(root.get("return_to") or root.get("returnTo") or origin)
+    name = _stringish(root.get("name") or root.get("title") or root.get("objective")) or "unnamed mission"
+    objective = _stringish(root.get("objective") or root.get("description")) or name
+
+    ack = _as_mapping(root.get("ack"), "ack")
+    watchdog = _as_mapping(root.get("watchdog"), "watchdog")
+    task_previews = [_task_preview(item, index) for index, item in enumerate(graph)]
+    final_task = _stringish(ack.get("final_task") or ack.get("task_id"))
+    if final_task is None and task_previews:
+        final_task = task_previews[-1].get("id") or task_previews[-1]["title"]
+
+    return {
+        "status": "mission_dry_run_preview",
+        "sent": False,
+        "created": False,
+        "live_dispatch": False,
+        "mission": {
+            "name": name,
+            "objective": objective,
+            "origin": origin,
+            "return_to": return_to,
+        },
+        "would_create_tasks": task_previews,
+        "would_subscribe_final_ack": {
+            "enabled": bool(return_to),
+            "origin": origin,
+            "return_to": return_to,
+            "final_task": final_task,
+            "verdict_schema": ack.get("verdict_schema", ["GO", "BLOCK", "NEED_MORE"]),
+        },
+        "would_create_watchdog": {
+            "enabled": bool(watchdog),
+            "schedule": watchdog.get("schedule"),
+            "material_change_only": watchdog.get("material_change_only", True),
+            "deliver": watchdog.get("deliver", return_to),
+        },
+        "safety": {
+            "dry_run_only": True,
+            "would_send": False,
+            "would_write_kanban": False,
+            "would_create_cron": False,
+            "would_trigger_agent": False,
+        },
+    }
+
+
+def mission_create(args: argparse.Namespace) -> int:
+    if not getattr(args, "dry_run", False):
+        print(
+            "Error: mission create currently supports preview only; pass --dry-run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        preview = build_preview(load_spec(getattr(args, "file", None)))
+    except MissionSpecError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(preview, indent=2, sort_keys=True))
+    else:
+        mission = preview["mission"]
+        print(f"Mission dry-run: {mission['name']}")
+        print(f"Objective: {mission['objective']}")
+        print(f"Origin: {mission.get('origin') or '-'}")
+        print(f"Return-to: {mission.get('return_to') or '-'}")
+        print("Would create tasks:")
+        for task in preview["would_create_tasks"]:
+            assignee = f" [{task['assignee']}]" if task.get("assignee") else ""
+            deps = f" depends_on={task['depends_on']}" if task.get("depends_on") else ""
+            print(f"  {task['index']}. {task['title']}{assignee}{deps}")
+        ack = preview["would_subscribe_final_ack"]
+        print(f"Would subscribe final ACK: {ack['enabled']} -> {ack.get('return_to') or '-'}")
+        wd = preview["would_create_watchdog"]
+        print(f"Would create watchdog: {wd['enabled']} schedule={wd.get('schedule') or '-'}")
+    return 0
+
+
+def mission_command(args: argparse.Namespace) -> int:
+    command = getattr(args, "mission_command", None)
+    if command == "create":
+        return mission_create(args)
+    print("usage: hermes mission create --dry-run --file SPEC", file=sys.stderr)
+    return 2
+
+
+def build_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "mission",
+        help="Preview Mission Control task graphs and ACK/watchdog contracts",
+        description="Mission Control preview wrapper for durable task graphs",
+    )
+    mission_subparsers = parser.add_subparsers(dest="mission_command")
+
+    create = mission_subparsers.add_parser(
+        "create",
+        help="Preview a mission graph without creating tasks, subscriptions, or watchdogs",
+    )
+    create.add_argument("--dry-run", action="store_true", help="Preview only; required in M0")
+    create.add_argument("--file", "-f", help="JSON/YAML mission spec path; omit or '-' for stdin")
+    create.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.set_defaults(func=mission_command)
+    return parser

--- a/tests/hermes_cli/test_mission_cli.py
+++ b/tests/hermes_cli/test_mission_cli.py
@@ -1,0 +1,280 @@
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import mission
+
+
+def test_build_preview_has_ack_watchdog_and_no_side_effects():
+    spec = {
+        "mission": {
+            "name": "overnight mission wrapper dry-run",
+            "origin": "discord:#hermes-main",
+            "return_to": "discord:#hermes-main",
+        },
+        "graph": [
+            {"id": "impl", "title": "Implement dry-run", "assignee": "ccsupervisor"},
+            {"id": "review", "title": "Review dry-run", "assignee": "ccreviewer", "depends_on": ["impl"]},
+        ],
+        "ack": {"final_task": "review"},
+        "watchdog": {"schedule": "every 15m"},
+    }
+
+    preview = mission.build_preview(spec)
+
+    assert preview["status"] == "mission_dry_run_preview"
+    assert preview["sent"] is False
+    assert preview["created"] is False
+    assert preview["live_dispatch"] is False
+    assert preview["safety"] == {
+        "dry_run_only": True,
+        "would_send": False,
+        "would_write_kanban": False,
+        "would_create_cron": False,
+        "would_trigger_agent": False,
+    }
+    assert [task["id"] for task in preview["would_create_tasks"]] == ["impl", "review"]
+    assert preview["would_subscribe_final_ack"] == {
+        "enabled": True,
+        "origin": "discord:#hermes-main",
+        "return_to": "discord:#hermes-main",
+        "final_task": "review",
+        "verdict_schema": ["GO", "BLOCK", "NEED_MORE"],
+    }
+    assert preview["would_create_watchdog"] == {
+        "enabled": True,
+        "schedule": "every 15m",
+        "material_change_only": True,
+        "deliver": "discord:#hermes-main",
+    }
+
+
+def test_create_requires_dry_run_before_reading_file(capsys):
+    args = argparse.Namespace(dry_run=False, file="/path/that/should/not/be/read.yml", json=True)
+
+    rc = mission.mission_create(args)
+
+    assert rc == 2
+    assert "pass --dry-run" in capsys.readouterr().err
+
+
+def test_create_dry_run_json_from_yaml_file(tmp_path, capsys):
+    spec = tmp_path / "mission.yml"
+    spec.write_text(
+        """
+mission:
+  name: Agent OS MISSION-M0
+  objective: overnight mission wrapper dry-run
+  origin: discord:#hermes-main
+  return_to: discord:#hermes-mission-control
+graph:
+  - id: create
+    title: hermes mission create --dry-run
+    assignee: ccsupervisor
+  - id: review
+    title: review preview contract
+    assignee: ccreviewer
+    depends_on: create
+watchdog:
+  schedule: every 15m
+""".strip(),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(dry_run=True, file=str(spec), json=True)
+
+    rc = mission.mission_create(args)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["mission"]["name"] == "Agent OS MISSION-M0"
+    assert out["mission"]["return_to"] == "discord:#hermes-mission-control"
+    assert out["would_create_tasks"][1]["depends_on"] == ["create"]
+    assert out["would_create_watchdog"]["enabled"] is True
+    assert out["safety"]["would_create_cron"] is False
+
+
+def test_malformed_yaml_error_is_sanitized(tmp_path, capsys):
+    spec = tmp_path / "secret-mission.yml"
+    spec.write_text(
+        "graph:\n  - title: ok\nsecret_token: sk-live-should-not-echo: [",
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(dry_run=True, file=str(spec), json=True)
+
+    rc = mission.mission_create(args)
+
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "mission spec is not valid JSON/YAML" in err
+    assert str(spec) not in err
+    assert "sk-live-should-not-echo" not in err
+    assert "Traceback" not in err
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ('["not", "a", "mapping"]', "mission spec must be a JSON/YAML object"),
+        ('{"graph": {"title": "not a list"}}', "graph/tasks must be a list"),
+        ('{"graph": []}', "mission spec must include at least one graph/task item"),
+    ],
+)
+def test_invalid_schema_reports_validation_error(tmp_path, capsys, content, expected):
+    spec = tmp_path / "mission.json"
+    spec.write_text(content, encoding="utf-8")
+    args = argparse.Namespace(dry_run=True, file=str(spec), json=True)
+
+    rc = mission.mission_create(args)
+
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert expected in err
+    assert "Traceback" not in err
+
+
+def test_missing_file_error_is_sanitized(tmp_path, capsys):
+    missing = tmp_path / "private" / "mission.yml"
+    args = argparse.Namespace(dry_run=True, file=str(missing), json=True)
+
+    rc = mission.mission_create(args)
+
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "mission spec file could not be read" in err
+    assert str(missing) not in err
+    assert "Traceback" not in err
+
+
+def test_build_parser_wires_create_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    mission.build_parser(subparsers)
+
+    args = parser.parse_args(["mission", "create", "--dry-run", "--json"])
+
+    assert args.command == "mission"
+    assert args.mission_command == "create"
+    assert args.dry_run is True
+    assert args.json is True
+    assert args.func is mission.mission_command
+
+
+def test_valid_preview_json_is_deterministic(tmp_path, capsys):
+    spec = tmp_path / "mission.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "graph": [{"title": "review preview", "assignee": "ccreviewer"}],
+                "return_to": "discord:#ops",
+                "name": "M0",
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(dry_run=True, file=str(spec), json=True)
+
+    first_rc = mission.mission_create(args)
+    first = capsys.readouterr().out
+    second_rc = mission.mission_create(args)
+    second = capsys.readouterr().out
+
+    assert first_rc == second_rc == 0
+    assert first == second
+    assert json.loads(first)["safety"]["would_trigger_agent"] is False
+
+
+def test_depends_on_entries_must_be_stringish():
+    spec = {
+        "graph": [
+            {"id": "one", "title": "one"},
+            {"id": "two", "title": "two", "depends_on": [{"nested": "not allowed"}]},
+        ]
+    }
+
+    with pytest.raises(mission.MissionSpecError, match="depends_on entries"):
+        mission.build_preview(spec)
+
+
+def test_top_level_cli_missing_dry_run_exits_nonzero(tmp_path):
+    spec = tmp_path / "mission.json"
+    spec.write_text('{"graph": ["preview only"]}', encoding="utf-8")
+    env = {**os.environ, "HERMES_HOME": str(tmp_path / "hermes-home")}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "mission",
+            "create",
+            "--file",
+            str(spec),
+            "--json",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "pass --dry-run" in result.stderr
+
+
+def test_top_level_cli_valid_preview_has_no_side_effect_files(tmp_path):
+    spec = tmp_path / "mission.json"
+    spec.write_text('{"graph": ["preview only"], "return_to": "discord:#ops"}', encoding="utf-8")
+    home = tmp_path / "hermes-home"
+    env = {**os.environ, "HERMES_HOME": str(home)}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "mission",
+            "create",
+            "--dry-run",
+            "--file",
+            str(spec),
+            "--json",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["created"] is False
+    assert out["sent"] is False
+    assert not (home / "kanban.db").exists()
+    assert not (home / "cron").exists()
+    assert not (home / "webhooks").exists()
+
+
+def test_mission_is_not_shared_slash_command():
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+    assert resolve_command("mission") is None
+    assert "mission" not in GATEWAY_KNOWN_COMMANDS
+
+
+def test_mission_top_level_subcommand_skips_plugin_discovery_fast_path():
+    from unittest.mock import patch
+
+    from hermes_cli.main import _BUILTIN_SUBCOMMANDS, _plugin_cli_discovery_needed
+
+    assert "mission" in _BUILTIN_SUBCOMMANDS
+    with patch.object(sys, "argv", ["hermes", "mission", "create", "--dry-run"]):
+        assert _plugin_cli_discovery_needed() is False


### PR DESCRIPTION
## Summary
- add `hermes mission create --dry-run --file SPEC [--json]`
- compile Mission Control specs into deterministic previews of task graph creation, final ACK subscription, and watchdog setup
- keep M0 preview-only with explicit no-side-effect safety flags for Kanban, cron, gateway sends, and agent triggers

## Why
This introduces a small upstream-friendly Mission Control primitive for planning durable multi-step work before any dispatch happens. It is intentionally not a dashboard rewrite or a live conductor: M0 only validates and previews the mission envelope.

## Duplicate / overlap check
Before opening this draft I checked related open/closed PRs and issues for `mission`, `mission control`, `ACK`, and `watchdog`.

Notable overlaps:
- #15892 `[Hackathon/WIP] Mission Control shadcn dashboard` — dashboard/UI shell work; this PR is CLI preview/spec compilation only.
- #19490 `feat: add mission control dashboard foundation` — closed dashboard/API foundation; this PR does not touch dashboard APIs.
- #18133 `fix(gateway): manage conductor mission processes` — conductor process management endpoints; this PR creates no processes and has no live dispatch.
- #9116 long-running task watchdog heartbeat — runtime heartbeat feature request; this PR only previews a future watchdog plan.
- #22135 multi-agent boardroom consensus — agent reasoning/consensus protocol; this PR is an ops envelope preview, not an execution loop.

So this is deliberately narrow: a dry-run Mission Control CLI contract that can later feed Kanban/cron/gateway adapters without introducing side effects in this slice.

## Safety
- `mission create` currently requires `--dry-run`; missing it exits non-zero.
- Preview output includes explicit safety fields:
  - `dry_run_only: true`
  - `would_write_kanban: false`
  - `would_create_cron: false`
  - `would_send: false`
  - `would_trigger_agent: false`
- No credentials or environment secrets are read or emitted.
- YAML support uses `yaml.safe_load`; JSON works without relying on YAML-specific syntax.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_mission_cli.py -q`
- [x] `python -m py_compile hermes_cli/mission.py hermes_cli/main.py hermes_cli/commands.py`
- [x] `python -m hermes_cli.main mission create --dry-run --file /tmp/mission-m0.yml --json | python -m json.tool`
- [x] missing `--dry-run` top-level CLI smoke exits `2`
- [x] `git diff --check origin/main...HEAD`
- [x] `python scripts/check-windows-footguns.py --diff origin/main`

## Notes for reviewers
The most important review points are:
1. CLI shape: `hermes mission create --dry-run --file SPEC [--json]`
2. Whether the preview schema is a reasonable seed for future Kanban/cron/gateway adapters
3. Whether the dry-run/no-side-effect boundary is clear enough for a first slice
