### PR TITLE
feat(skills): native skills.auto_load config for persistent skill pre-loading

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -499,3 +499,67 @@ def build_preloaded_skills_prompt(
         loaded_names.append(skill_name)
 
     return "\n\n".join(prompt_parts), loaded_names, missing
+
+def resolve_auto_load_skills(user_config: dict | None = None) -> list[str]:
+    """Read skills.auto_load from user config and return the deduplicated list.
+
+    If user_config is None, reads from the active config file.
+    Returns an empty list if the key is missing or empty.
+    """
+    if user_config is None:
+        try:
+            from hermes_cli.config import load_cli_config as _load_hermes_config
+            user_config = _load_hermes_config()
+        except Exception:
+            return []
+
+    skills_block = user_config.get("skills", {})
+    if not isinstance(skills_block, dict):
+        return []
+    auto_load = skills_block.get("auto_load")
+    if not auto_load or not isinstance(auto_load, list):
+        return []
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in auto_load:
+        if not isinstance(entry, str):
+            continue
+        name = entry.strip()
+        if name and name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
+def build_auto_load_prompt(
+    task_id: str | None = None,
+    user_config: dict | None = None,
+) -> tuple[str, list[str], list[str]]:
+    """Load auto_load skills and build their prompt block.
+
+    Reads skills.auto_load from config, loads each skill, and returns
+    (prompt_text, loaded_names, missing_names).  Missing skills are
+    listed in ``missing_names`` rather than raising an error — callers
+    should log a warning for them.
+    """
+    auto_skills = resolve_auto_load_skills(user_config)
+    if not auto_skills:
+        return "", [], []
+
+    prompt_text, loaded, missing = build_preloaded_skills_prompt(
+        auto_skills, task_id=task_id
+    )
+
+    # Rewrite the activation note to be origin-agnostic (not CLI-specific).
+    if prompt_text:
+        prompt_text = prompt_text.replace(
+            'The user launched this CLI session with the',
+            'The',
+        )
+        prompt_text = prompt_text.replace(
+            'preloaded. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
+            'skill is auto-loaded from skills.auto_load config. Treat its instructions as active guidance for the duration of this session unless the user overrides them.]',
+        )
+
+    return prompt_text, loaded, missing

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -177,6 +177,31 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if skills_prompt:
         stable_parts.append(skills_prompt)
 
+
+    # ── Auto-load skills from skills.auto_load config ──
+    # Covers programmatic AIAgent users who don't pass --skills or
+    # system_message.  Only injected on the FIRST system prompt build
+    # (new session); resumed sessions already have the auto_load block
+    # in their conversation history.
+    # Respects HERMES_IGNORE_RULES — users who opt out of auto-injection
+    # should not get auto-injected skills.
+    _is_new_session = getattr(agent, "_cached_system_prompt", None) is None
+    _ignore_rules = os.environ.get("HERMES_IGNORE_RULES") == "1"
+    if _is_new_session and not _ignore_rules:
+        from agent.skill_commands import build_auto_load_prompt as _build_auto
+        try:
+            _auto_prompt, _auto_loaded, _auto_missing = _build_auto(
+                task_id=getattr(agent, "session_id", None),
+            )
+            if _auto_missing:
+                from hermes_logging import get_logger
+                get_logger().warning(
+                    "Auto-load skill(s) not found: %s", ", ".join(_auto_missing)
+                )
+            if _auto_prompt:
+                stable_parts.append(_auto_prompt)
+        except Exception:
+            pass  # Non-fatal — config read errors must not break session start
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
     # so the agent can correctly report which model it is (workaround for API bug).

--- a/cli.py
+++ b/cli.py
@@ -14056,6 +14056,18 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
+    # Resolve skills.auto_load for dedup. The actual injection of auto_load
+    # skills happens once in AIAgent._build_system_prompt_parts (gated on
+    # new-session). Here we only need the list so we can avoid injecting the
+    # same skill twice when --skills overlaps with auto_load, and so the
+    # "Activated skills" display reflects both sources.
+    # --ignore-rules suppresses all auto-injection (AGENTS.md, SOUL.md,
+    # memory, skills), so auto_load is skipped in that mode.
+    from agent.skill_commands import resolve_auto_load_skills
+    auto_load_skills = resolve_auto_load_skills(CLI_CONFIG) if not ignore_rules else []
+    auto_load_set = set(auto_load_skills)
+    cli_only_skills = [s for s in parsed_skills if s not in auto_load_set]
+
     # Create CLI instance
     cli = HermesCLI(
         model=model,
@@ -14072,9 +14084,9 @@ def main(
         ignore_rules=ignore_rules,
     )
 
-    if parsed_skills:
+    if cli_only_skills:
         skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
-            parsed_skills,
+            cli_only_skills,
             task_id=cli.session_id,
         )
         if missing_skills:
@@ -14084,7 +14096,16 @@ def main(
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part
             ).strip()
-            cli.preloaded_skills = loaded_skills
+
+    # Display includes both CLI --skills and auto_load (deduped, auto_load first).
+    # Functional injection of auto_load happens in AIAgent; CLI just shows the
+    # combined activated set so users see what's loaded.
+    if auto_load_skills or parsed_skills:
+        display = list(auto_load_skills)
+        for s in parsed_skills:
+            if s not in auto_load_set:
+                display.append(s)
+        cli.preloaded_skills = display
 
     # Inject worktree context into agent's system prompt
     if wt_info:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1210,6 +1210,7 @@ DEFAULT_CONFIG = {
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled
         # scripts without the agent having to join paths.
+        "auto_load": [],
         "template_vars": True,
         # Pre-execute inline shell snippets written as !`cmd` in SKILL.md
         # body.  Their stdout is inlined into the skill message before the

--- a/tests/agent/test_skills_auto_load.py
+++ b/tests/agent/test_skills_auto_load.py
@@ -1,0 +1,432 @@
+"""Tests for skills.auto_load config — persistent skill pre-loading at session start.
+
+Tests cover:
+- resolve_auto_load_skills() — config reading
+- build_auto_load_prompt() — prompt generation
+- CLI merge with --skills
+- Missing auto_load skill → warning (non-fatal)
+- AIAgent._build_system_prompt injects auto_load
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── resolve_auto_load_skills ──
+
+def test_resolve_auto_load_skills_reads_from_config():
+    """resolve_auto_load_skills reads the auto_load list from user config."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {
+        "skills": {
+            "auto_load": ["skill-a", "skill-b", "skill-c"],
+        }
+    }
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b", "skill-c"]
+
+
+def test_resolve_auto_load_skills_empty_list():
+    """Returns empty list when auto_load is empty."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": []}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_missing_key():
+    """Returns empty list when auto_load key is missing."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_no_config():
+    """Returns empty list when config is None."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    result = resolve_auto_load_skills(None)
+    assert result == []
+
+
+def test_resolve_auto_load_skills_deduplicates():
+    """Duplicate entries are deduplicated (first occurrence wins)."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["skill-a", "skill-b", "skill-a"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_filters_non_strings():
+    """Non-string entries are filtered out."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["skill-a", 123, None, "", "skill-b"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_strips_whitespace():
+    """Whitespace is stripped from skill names."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": ["  skill-a  ", "skill-b"]}}
+    result = resolve_auto_load_skills(config)
+    assert result == ["skill-a", "skill-b"]
+
+
+def test_resolve_auto_load_skills_not_a_list():
+    """Returns empty list when auto_load is not a list."""
+    from agent.skill_commands import resolve_auto_load_skills
+
+    config = {"skills": {"auto_load": "not-a-list"}}
+    result = resolve_auto_load_skills(config)
+    assert result == []
+
+
+# ── build_auto_load_prompt ──
+
+def test_build_auto_load_prompt_loads_skills(tmp_path):
+    """build_auto_load_prompt loads skills from config and builds prompt."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    # Create a real skill
+    skill_dir = tmp_path / "test-auto"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-auto\ndescription: Auto-load test.\n---\n\n# Test Auto\n\nContent.\n"
+    )
+
+    config = {"skills": {"auto_load": ["test-auto"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert missing == []
+    assert loaded == ["test-auto"]
+    assert "test-auto" in prompt
+    assert "auto-loaded from skills.auto_load config" in prompt
+
+
+def test_build_auto_load_prompt_activation_note_not_cli_specific(tmp_path):
+    """The activation note is origin-agnostic, not CLI-specific."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    skill_dir = tmp_path / "test-auto"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: test-auto\ndescription: Test.\n---\n\n# Test\n\nContent.\n"
+    )
+
+    config = {"skills": {"auto_load": ["test-auto"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, _, _ = build_auto_load_prompt(user_config=config)
+
+    # Must NOT contain the CLI-specific phrase
+    assert "launched this CLI session" not in prompt
+    # Must contain the auto_load-specific phrase
+    assert "auto-loaded from skills.auto_load config" in prompt
+
+
+def test_build_auto_load_prompt_reports_missing_non_fatal(tmp_path):
+    """Missing auto_load skills are reported in missing, not raised."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    config = {"skills": {"auto_load": ["missing-skill"]}}
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert missing == ["missing-skill"]
+    assert loaded == []
+    assert prompt == ""
+
+
+def test_build_auto_load_prompt_empty_config():
+    """Returns empty when no auto_load skills configured."""
+    from agent.skill_commands import build_auto_load_prompt
+
+    config = {"skills": {"auto_load": []}}
+    prompt, loaded, missing = build_auto_load_prompt(user_config=config)
+
+    assert prompt == ""
+    assert loaded == []
+    assert missing == []
+
+
+# ── CLI merge with --skills ──
+
+def test_cli_merges_auto_load_with_cli_skills(monkeypatch):
+    """CLI main() displays auto_load skills alongside --skills in 'Activated skills'.
+
+    Functional injection of auto_load happens in AIAgent (new-session gated);
+    the CLI display should still reflect both sources.
+    """
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-001"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    auto_load = ["auto-skill"]
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: list(auto_load))
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: (
+            "prompt", sorted(skills), [],
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="cli-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    assert "auto-skill" in cli_obj.preloaded_skills
+    assert "cli-skill" in cli_obj.preloaded_skills
+
+
+def test_cli_deduplicates_overlapping_skills(monkeypatch):
+    """When auto_load and --skills share a skill, it loads only once."""
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-002"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["shared-skill"])
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: (
+            "prompt", skills, [],
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="shared-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    # shared-skill should appear only once
+    assert cli_obj.preloaded_skills.count("shared-skill") == 1
+
+
+def test_cli_does_not_error_on_missing_auto_load_skills(monkeypatch):
+    """CLI should not raise for missing auto_load skills.
+
+    Auto_load skills are injected later by AIAgent; missing ones are reported
+    as a warning by build_auto_load_prompt (covered by
+    test_build_auto_load_prompt_reports_missing_non_fatal). The CLI must only
+    validate skills it actually injects itself (--skills).
+    """
+    import cli as cli_mod
+
+    created = {}
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-003"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+            created["cli"] = self
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: ["missing-auto"])
+    # CLI should only build prompts for --skills entries, not auto_load.
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("prompt", list(skills), []),
+    )
+
+    # Should NOT raise ValueError — missing auto_load is handled in AIAgent layer
+    with pytest.raises(SystemExit):
+        cli_mod.main(skills="valid-cli-skill", list_tools=True)
+
+    cli_obj = created["cli"]
+    # Both still appear in display
+    assert "missing-auto" in cli_obj.preloaded_skills
+    assert "valid-cli-skill" in cli_obj.preloaded_skills
+
+
+def test_cli_still_errors_for_missing_cli_skills(monkeypatch):
+    """Missing --skills still produce a ValueError (not auto_load)."""
+    import cli as cli_mod
+
+    class _DummyCLI:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session_id = "sess-004"
+            self.system_prompt = "base"
+            self.preloaded_skills = []
+
+        def show_banner(self): pass
+        def show_tools(self): pass
+        def show_toolsets(self): pass
+        def run(self): pass
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: _DummyCLI(**kw))
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+
+    import agent.skill_commands as sc_mod
+    monkeypatch.setattr(sc_mod, "resolve_auto_load_skills", lambda config: [])
+    monkeypatch.setattr(
+        cli_mod,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("", [], ["missing-cli"]),
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-cli"):
+        cli_mod.main(skills="missing-cli", list_tools=True)
+
+
+# ── AIAgent._build_system_prompt ──
+
+def test_aiagent_build_system_prompt_injects_auto_load(tmp_path):
+    """AIAgent._build_system_prompt() includes auto_load skills."""
+    from run_agent import AIAgent
+
+    # Create a real skill for auto_load
+    skill_dir = tmp_path / "buildsys-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: buildsys-skill\ndescription: Test.\n---\n\n# Buildsys\n\nContent.\n"
+    )
+
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_commands.resolve_auto_load_skills", return_value=["buildsys-skill"]), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded from skills.auto_load config" in prompt
+    assert "buildsys-skill" in prompt
+
+
+def test_aiagent_build_system_prompt_no_auto_load_when_empty(tmp_path):
+    """When auto_load is empty, no injection happens."""
+    from run_agent import AIAgent
+
+    with patch("agent.skill_commands.resolve_auto_load_skills", return_value=[]), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded from skills.auto_load config" not in prompt
+
+
+def test_aiagent_build_system_prompt_survives_config_errors(tmp_path):
+    """Config read errors in auto_load are non-fatal."""
+    from run_agent import AIAgent
+
+    with patch(
+        "agent.skill_commands.resolve_auto_load_skills",
+        side_effect=RuntimeError("config read failed"),
+    ), \
+         patch("run_agent.AIAgent._ensure_db_session"), \
+         patch("run_agent._install_safe_stdio"):
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.valid_tool_names = {"skills_list", "skill_view", "skill_manage"}
+        agent.model = "test-model"
+        agent.provider = "test"
+        agent.pass_session_id = False
+        agent.skip_context_files = True  # avoid upstream context_parts init-order bug
+        agent.load_soul_identity = False
+        agent._memory_enabled = False
+        agent._user_profile_enabled = False
+        agent._memory_manager = None
+        agent._memory_store = None
+        agent.session_id = "test-session"
+        agent.platform = "cli"
+        agent._tool_use_enforcement = False
+        agent.ephemeral_system_prompt = None
+        agent._cached_system_prompt = None
+
+        # Should NOT raise
+        prompt = agent._build_system_prompt()
+
+    assert "auto-loaded" not in prompt


### PR DESCRIPTION
## Problem

Autonomous and multi-agent (swarm) deployments need certain skills always available at session start. Currently the only mechanism is passing `--skills skill1 skill2` on every invocation, which creates fragile workarounds and setup friction in production environments.

## Solution

Add a `skills.auto_load` config key to `~/.hermes/config.yaml` that auto-injects specified skills at every session start — CLI, gateway, and programmatic AIAgent paths.

### Config
```yaml
skills:
  auto_load:
    - systematic-debugging
    - requesting-code-review
```

### Behavior
- Merged with `--skills` at invocation (union, no duplicates)
- Missing auto_load skills → warning (non-fatal)
- Missing `--skills` → ValueError (unchanged)
- Covers CLI, gateway, and programmatic AIAgent instantiation

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `auto_load: []` to DEFAULT_CONFIG[skills] |
| `agent/skill_commands.py` | Add `resolve_auto_load_skills()` and `build_auto_load_prompt()` |
| `cli.py` | Merge auto_load with --skills; warn on missing auto_load |
| `gateway/run.py` | Inject auto_load via system_message before run_conversation |
| `run_agent.py` | Inject auto_load in `_build_system_prompt()` for programmatic users |
| `tests/agent/test_skills_auto_load.py` | 19 tests: config, merging, dedup, warning, AIAgent injection, resilience |

## Tests

- **19 new tests** — all pass
- **42 existing skill tests** — zero regression

Closes #26800