### PR TITLE
perf(skills): list categories in system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1165,48 +1165,42 @@ def build_skills_system_prompt(
         index_lines = []
         for category in sorted(skills_by_category.keys()):
             cat_desc = category_descriptions.get(category, "")
+            unique_skill_count = len({name for name, _desc in skills_by_category[category]})
+            count_suffix = f" ({unique_skill_count} skill{'s' if unique_skill_count != 1 else ''})"
             if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
+                index_lines.append(f"  {category}: {cat_desc}{count_suffix}")
             else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                index_lines.append(f"  {category}:{count_suffix}")
 
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+            "Before replying, scan the skill categories below. If a category matches or is even partially relevant "
+            "to your task, you MUST call skills_list(category=...) to inspect the available skills, then load "
+            "matching skills with skill_view(name) and follow their instructions. "
             "Err on the side of loading — it is always better to have context you don't need "
             "than to miss critical steps, pitfalls, or established workflows. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
+            "and proven workflows that outperform general-purpose approaches. Load relevant skills "
             "even if you think you could handle the task with basic tools like web_search or terminal. "
             "Skills also encode the user's preferred approach, conventions, and quality standards "
             "for tasks like code review, planning, and testing — load them even for tasks you "
             "already know how to do, because the skill defines how it should be done here.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+            "skills, voice, gateway, plugins, or any feature — call skills_list(category='autonomous-ai-agents') "
+            "if needed, then load the `hermes-agent` skill first. It has the actual commands "
+            "(e.g. `hermes config set …`, `hermes tools`, `hermes setup`) so you don't have "
+            "to guess or invent workarounds.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"
             "\n"
-            "<available_skills>\n"
+            "<available_skill_categories>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
+            "</available_skill_categories>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "Only proceed without loading a skill if genuinely no category is relevant to the task."
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -254,7 +254,7 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert result == ""
 
-    def test_builds_index_with_skills(self, monkeypatch, tmp_path):
+    def test_builds_category_only_index_with_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         skills_dir = tmp_path / "skills" / "coding" / "python-debug"
         skills_dir.mkdir(parents=True)
@@ -262,9 +262,11 @@ class TestBuildSkillsSystemPrompt:
             "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
         )
         result = build_skills_system_prompt()
-        assert "python-debug" in result
-        assert "Debug Python scripts" in result
-        assert "available_skills" in result
+        assert "  coding:" in result
+        assert "python-debug" not in result
+        assert "Debug Python scripts" not in result
+        assert "skills_list(category=...)" in result
+        assert "available_skill_categories" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -274,8 +276,11 @@ class TestBuildSkillsSystemPrompt:
             d.mkdir(parents=True, exist_ok=True)
             (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
         result = build_skills_system_prompt()
-        # "search" should appear only once per category
-        assert result.count("- search") == 1
+        # Skill names are intentionally omitted from the category-only index;
+        # duplicate skills should still collapse into a single category count.
+        assert "  tools: (1 skill)" in result
+        assert "- search" not in result
+        assert "Search stuff" not in result
 
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
@@ -303,7 +308,8 @@ class TestBuildSkillsSystemPrompt:
             mock_sys.platform = "linux"
             result = build_skills_system_prompt()
 
-        assert "web-search" in result
+        assert "  apple: (1 skill)" in result
+        assert "web-search" not in result
         assert "imessage" not in result
 
     def test_includes_matching_platform_skills(self, monkeypatch, tmp_path):
@@ -322,8 +328,9 @@ class TestBuildSkillsSystemPrompt:
             mock_sys.platform = "darwin"
             result = build_skills_system_prompt()
 
-        assert "imessage" in result
-        assert "Send iMessages" in result
+        assert "  apple: (1 skill)" in result
+        assert "imessage" not in result
+        assert "Send iMessages" not in result
 
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
@@ -351,7 +358,8 @@ class TestBuildSkillsSystemPrompt:
         ):
             result = build_skills_system_prompt()
 
-        assert "web-search" in result
+        assert "  tools: (1 skill)" in result
+        assert "web-search" not in result
         assert "old-tool" not in result
 
     def test_rebuilds_prompt_when_disabled_skills_change(self, monkeypatch, tmp_path):
@@ -363,14 +371,15 @@ class TestBuildSkillsSystemPrompt:
         )
 
         first = build_skills_system_prompt()
-        assert "cached-skill" in first
+        assert "  tools: (1 skill)" in first
+        assert "cached-skill" not in first
 
         (tmp_path / "config.yaml").write_text(
             "skills:\n  disabled: [cached-skill]\n"
         )
 
         second = build_skills_system_prompt()
-        assert "cached-skill" not in second
+        assert second == ""
 
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -391,8 +400,9 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "free-skill" in result
-        assert "gated-skill" in result
+        assert "  media: (2 skills)" in result
+        assert "free-skill" not in result
+        assert "gated-skill" not in result
 
     def test_includes_skills_with_met_prerequisites(self, monkeypatch, tmp_path):
         """Skills with satisfied prerequisites should appear normally."""
@@ -408,7 +418,8 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "ready-skill" in result
+        assert "  media: (1 skill)" in result
+        assert "ready-skill" not in result
 
     def test_non_local_backend_keeps_skill_visible_without_probe(
         self, monkeypatch, tmp_path
@@ -426,7 +437,8 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "backend-skill" in result
+        assert "  media: (1 skill)" in result
+        assert "backend-skill" not in result
 
 
 class TestBuildNousSubscriptionPrompt:
@@ -1037,7 +1049,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "duckduckgo" in result
+        assert "  search: (1 skill)" in result
+        assert "duckduckgo" not in result
 
     def test_requires_skill_hidden_when_toolset_missing(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1063,7 +1076,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets={"terminal"},
         )
-        assert "openhue" in result
+        assert "  iot: (1 skill)" in result
+        assert "openhue" not in result
 
     def test_unconditional_skill_always_shown(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1076,7 +1090,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "notes" in result
+        assert "  general: (1 skill)" in result
+        assert "notes" not in result
 
     def test_no_args_shows_all_skills(self, monkeypatch, tmp_path):
         """Backward compat: calling with no args shows everything."""
@@ -1087,7 +1102,8 @@ class TestBuildSkillsSystemPromptConditional:
             "---\nname: duckduckgo\ndescription: Free web search\nmetadata:\n  hermes:\n    fallback_for_toolsets: [web]\n---\n"
         )
         result = build_skills_system_prompt()
-        assert "duckduckgo" in result
+        assert "  search: (1 skill)" in result
+        assert "duckduckgo" not in result
 
     def test_null_metadata_does_not_crash(self, monkeypatch, tmp_path):
         """Regression: metadata key present but null should not AttributeError."""
@@ -1102,7 +1118,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "safe-skill" in result
+        assert "  general: (1 skill)" in result
+        assert "safe-skill" not in result
 
     def test_null_hermes_under_metadata_does_not_crash(self, monkeypatch, tmp_path):
         """Regression: metadata.hermes present but null should not crash."""
@@ -1116,7 +1133,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "nested-null" in result
+        assert "  general: (1 skill)" in result
+        assert "nested-null" not in result
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- Replace the full per-skill system-prompt index with a category-level index and skill counts.
- Instruct agents to call `skills_list(category=...)` before loading matching skills with `skill_view(...)`.
- Update prompt-builder tests for category-only rendering, filtering, and conditional skill visibility.

## Test Plan
- [x] `python -m pytest tests/agent/test_prompt_builder.py -q -o 'addopts='`

Closes #26786