### PR TITLE
fix(compression): pass custom providers to context resolver

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -415,6 +415,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -431,6 +432,7 @@ class ContextCompressor(ContextEngine):
             model, base_url=base_url, api_key=api_key,
             config_context_length=config_context_length,
             provider=provider,
+            custom_providers=custom_providers,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
         # the percentage would suggest a lower value.  This prevents premature

--- a/run_agent.py
+++ b/run_agent.py
@@ -2365,6 +2365,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                custom_providers=_custom_providers,
             )
         self.compression_enabled = compression_enabled
 

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -226,6 +226,37 @@ class TestGetModelContextLengthHonorsOverride:
         assert ctx == DEFAULT_FALLBACK_CONTEXT
 
 
+class TestContextCompressorCustomProviderContextLength:
+    def test_forwards_custom_provider_overrides_to_context_resolver(self):
+        """Built-in compression should honor custom_providers per-model context_length.
+
+        This covers auxiliary.compression using a named custom provider: the
+        resolver already understands custom provider overrides, but the
+        compressor must forward the custom_providers list for that override to
+        be visible during startup.
+        """
+        from agent.context_compressor import ContextCompressor
+
+        custom = [
+            {
+                "name": "aiclient2api-gemini-cli",
+                "base_url": "http://aiclient2api:3000/gemini/v1",
+                "models": {"gemini-3-pro": {"context_length": 1_000_000}},
+            }
+        ]
+
+        compressor = ContextCompressor(
+            model="gemini-3-pro",
+            base_url="http://aiclient2api:3000/gemini/v1",
+            provider="custom:aiclient2api-gemini-cli",
+            custom_providers=custom,
+            quiet_mode=True,
+        )
+
+        assert compressor.context_length == 1_000_000
+        assert compressor.threshold_tokens == 500_000
+
+
 class TestContextProbeTiers:
     def test_256k_is_top_tier_and_default(self):
         """The stepdown probe starts at 256K and 256K is the new default."""


### PR DESCRIPTION
## Summary
- Pass configured custom_providers into the built-in context compressor's context-length resolver.
- Add regression coverage for auxiliary compression using a named custom provider with a per-model context_length override.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_custom_provider_context_length.py -q -o 'addopts='`
- [x] `python -m pytest tests/run_agent/test_compression_feasibility.py -q -o 'addopts='`
- [x] `git diff --check`

Closes #26548