### PR TITLE
fix(copilot-acp): salvage #10685 — tighter deprecation detection + sharper 8K-cap hint (closes #10648)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -30,6 +30,14 @@ _DEFAULT_TIMEOUT_SECONDS = 900.0
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
+# Patterns that indicate the gh-copilot CLI extension has been deprecated.
+_DEPRECATION_PATTERNS = (
+    "has been deprecated",
+    "no commands will be executed",
+    "deprecation",
+    "copilot-cli",
+)
+
 
 def _resolve_command() -> str:
     return (
@@ -506,6 +514,18 @@ class CopilotACPClient:
 
             stderr_text = "\n".join(stderr_tail).strip()
             if proc.poll() is not None and stderr_text:
+                stderr_lower = stderr_text.lower()
+                if any(pat in stderr_lower for pat in _DEPRECATION_PATTERNS):
+                    raise RuntimeError(
+                        "The gh-copilot CLI extension has been deprecated by GitHub and "
+                        "can no longer be used for ACP mode.\n\n"
+                        "Alternatives:\n"
+                        "  1. Use the GitHub Copilot provider instead of ACP mode:\n"
+                        "     hermes setup  →  select 'GitHub Copilot' (uses Copilot Chat API)\n"
+                        "  2. Set HERMES_COPILOT_ACP_COMMAND to point to a compatible ACP server\n"
+                        "  3. Use a different provider (e.g. OpenAI, Anthropic, Nous)\n\n"
+                        f"Original error:\n{stderr_text}"
+                    )
                 raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
             raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
 

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -30,13 +30,27 @@ _DEFAULT_TIMEOUT_SECONDS = 900.0
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
-# Patterns that indicate the gh-copilot CLI extension has been deprecated.
-_DEPRECATION_PATTERNS = (
+# Stderr fingerprint of the deprecated `gh copilot` CLI extension
+# (https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension).
+# We require BOTH the literal product name ("gh-copilot") AND a deprecation
+# marker, so generic stderr from the NEW `@github/copilot` CLI — whose repo
+# is github.com/github/copilot-cli and which legitimately mentions "copilot-cli"
+# in its own banners and error messages — doesn't get misclassified as the
+# deprecated extension.
+_DEPRECATION_REQUIRED = ("gh-copilot",)
+_DEPRECATION_MARKERS = (
     "has been deprecated",
     "no commands will be executed",
-    "deprecation",
-    "copilot-cli",
 )
+
+
+def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
+    """True iff stderr looks like the deprecated gh-copilot extension's banner."""
+
+    lower = stderr_text.lower()
+    if not any(req in lower for req in _DEPRECATION_REQUIRED):
+        return False
+    return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
 def _resolve_command() -> str:
@@ -514,16 +528,19 @@ class CopilotACPClient:
 
             stderr_text = "\n".join(stderr_tail).strip()
             if proc.poll() is not None and stderr_text:
-                stderr_lower = stderr_text.lower()
-                if any(pat in stderr_lower for pat in _DEPRECATION_PATTERNS):
+                if _is_gh_copilot_deprecation_message(stderr_text):
                     raise RuntimeError(
-                        "The gh-copilot CLI extension has been deprecated by GitHub and "
-                        "can no longer be used for ACP mode.\n\n"
-                        "Alternatives:\n"
-                        "  1. Use the GitHub Copilot provider instead of ACP mode:\n"
-                        "     hermes setup  →  select 'GitHub Copilot' (uses Copilot Chat API)\n"
-                        "  2. Set HERMES_COPILOT_ACP_COMMAND to point to a compatible ACP server\n"
-                        "  3. Use a different provider (e.g. OpenAI, Anthropic, Nous)\n\n"
+                        "Hermes ACP mode requires the NEW GitHub Copilot CLI "
+                        "(github.com/github/copilot-cli), but the binary it just "
+                        "spawned is the deprecated `gh copilot` extension.\n\n"
+                        "Install the new CLI:\n"
+                        "  npm install -g @github/copilot\n"
+                        "  # then verify with: copilot --help\n\n"
+                        "If `copilot` already resolves to the new CLI but you still see this,\n"
+                        "point Hermes at it explicitly:\n"
+                        "  export HERMES_COPILOT_ACP_COMMAND=/path/to/new/copilot\n\n"
+                        "Alternative: use the `copilot` provider (no ACP, hits the Copilot API\n"
+                        "directly with a Copilot subscription token) via `hermes setup`.\n\n"
                         f"Original error:\n{stderr_text}"
                     )
                 raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -358,6 +358,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
+    "models.inference.ai.azure.com": "github-models",
     "api.fireworks.ai": "fireworks",
     "opencode.ai": "opencode-go",
     "api.x.ai": "xai",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -358,7 +358,12 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
-    "models.inference.ai.azure.com": "github-models",
+    # GitHub Models free tier (Azure-hosted prototyping endpoint) — same
+    # canonical provider as the Copilot API.  Hard per-request token cap
+    # (often 8K) makes it unusable for Hermes' system prompt, but mapping
+    # it here lets us recognize the endpoint and emit a targeted hint
+    # instead of falling through the unknown-custom-endpoint path.
+    "models.inference.ai.azure.com": "copilot",
     "api.fireworks.ai": "fireworks",
     "opencode.ai": "opencode-go",
     "api.x.ai": "xai",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2525,6 +2525,7 @@ def _is_github_models_base_url(base_url: Optional[str]) -> bool:
     return (
         normalized.startswith(COPILOT_BASE_URL)
         or normalized.startswith("https://models.github.ai/inference")
+        or normalized.startswith("https://models.inference.ai.azure.com")
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -14185,29 +14185,35 @@ class AIAgent:
                         }
                     
                     # Actionable hint for GitHub Models (Azure) 413 errors.
-                    # The free tier enforces a hard 8K token limit per request,
-                    # which Hermes' system prompt alone can exceed.  Compression
-                    # won't help — surface a clear message so the user doesn't
-                    # wait through three futile compression attempts.
+                    # The free tier enforces a hard 8K token cap per request,
+                    # which Hermes' system prompt + tool schemas alone exceed.
+                    # Compression can't help — the floor is the system prompt
+                    # itself, not the conversation — so surface a clear "not
+                    # compatible" message instead of looping into three futile
+                    # compression attempts.
                     if (
                         status_code == 413
                         and isinstance(_base, str)
                         and "models.inference.ai.azure.com" in _base
                     ):
                         self._vprint(
-                            f"{self.log_prefix}   💡 GitHub Models (Azure) enforces a hard per-request token limit (often 8K).",
+                            f"{self.log_prefix}   💡 GitHub Models free tier (models.inference.ai.azure.com) caps every",
                             force=True,
                         )
                         self._vprint(
-                            f"{self.log_prefix}      Hermes' system prompt alone may exceed this limit.  This endpoint is not",
+                            f"{self.log_prefix}      request at ~8K tokens. Hermes' system prompt + tool schemas baseline",
                             force=True,
                         )
                         self._vprint(
-                            f"{self.log_prefix}      compatible with Hermes Agent.  Use https://models.github.ai or the GitHub",
+                            f"{self.log_prefix}      exceeds that floor, so this endpoint cannot run an agentic loop.",
                             force=True,
                         )
                         self._vprint(
-                            f"{self.log_prefix}      Copilot provider instead, which have higher token limits.",
+                            f"{self.log_prefix}      Use the `copilot` provider with a Copilot subscription token (`hermes",
+                            force=True,
+                        )
+                        self._vprint(
+                            f"{self.log_prefix}      setup` → GitHub Copilot), or pick any other provider.",
                             force=True,
                         )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -14184,6 +14184,33 @@ class AIAgent:
                             "interrupted": True,
                         }
                     
+                    # Actionable hint for GitHub Models (Azure) 413 errors.
+                    # The free tier enforces a hard 8K token limit per request,
+                    # which Hermes' system prompt alone can exceed.  Compression
+                    # won't help — surface a clear message so the user doesn't
+                    # wait through three futile compression attempts.
+                    if (
+                        status_code == 413
+                        and isinstance(_base, str)
+                        and "models.inference.ai.azure.com" in _base
+                    ):
+                        self._vprint(
+                            f"{self.log_prefix}   💡 GitHub Models (Azure) enforces a hard per-request token limit (often 8K).",
+                            force=True,
+                        )
+                        self._vprint(
+                            f"{self.log_prefix}      Hermes' system prompt alone may exceed this limit.  This endpoint is not",
+                            force=True,
+                        )
+                        self._vprint(
+                            f"{self.log_prefix}      compatible with Hermes Agent.  Use https://models.github.ai or the GitHub",
+                            force=True,
+                        )
+                        self._vprint(
+                            f"{self.log_prefix}      Copilot provider instead, which have higher token limits.",
+                            force=True,
+                        )
+
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
                     # compress history and retry, not abort immediately.

--- a/tests/agent/test_copilot_acp_deprecation.py
+++ b/tests/agent/test_copilot_acp_deprecation.py
@@ -2,11 +2,12 @@
 
 import pytest
 
-from agent.copilot_acp_client import _DEPRECATION_PATTERNS
+from agent.copilot_acp_client import _is_gh_copilot_deprecation_message
 
 
 class TestDeprecationPatternDetection:
-    """Verify that stderr messages from a deprecated gh-copilot CLI are caught."""
+    """Verify that stderr from the deprecated `gh copilot` extension is caught
+    without false-positiving on the new `@github/copilot` CLI."""
 
     _REAL_DEPRECATION_STDERR = (
         "The gh-copilot extension has been deprecated in favor of the newer "
@@ -18,25 +19,40 @@ class TestDeprecationPatternDetection:
     )
 
     def test_real_deprecation_message_matches(self):
-        lower = self._REAL_DEPRECATION_STDERR.lower()
-        assert any(pat in lower for pat in _DEPRECATION_PATTERNS)
+        assert _is_gh_copilot_deprecation_message(self._REAL_DEPRECATION_STDERR)
 
     @pytest.mark.parametrize(
-        "stderr_line",
+        "stderr_text",
         [
-            "The gh-copilot extension has been deprecated",
-            "No commands will be executed.",
-            "See deprecation notice at ...",
-            "Install copilot-cli instead",
+            # The deprecation banner uses both halves of the fingerprint.
+            "The gh-copilot extension has been deprecated.",
+            "gh-copilot: no commands will be executed.",
+            # Mixed casing — match is case-insensitive.
+            "The GH-Copilot Extension HAS BEEN DEPRECATED.",
         ],
     )
-    def test_individual_patterns_match(self, stderr_line: str):
-        lower = stderr_line.lower()
-        assert any(pat in lower for pat in _DEPRECATION_PATTERNS)
+    def test_genuine_deprecation_variants_match(self, stderr_text: str):
+        assert _is_gh_copilot_deprecation_message(stderr_text)
 
-    def test_normal_stderr_does_not_match(self):
-        normal = "Error: connection refused"
-        assert not any(pat in normal.lower() for pat in _DEPRECATION_PATTERNS)
+    @pytest.mark.parametrize(
+        "stderr_text",
+        [
+            # Generic errors — no fingerprint at all.
+            "Error: connection refused",
+            "",
+            # The NEW @github/copilot CLI's repo is github.com/github/copilot-cli.
+            # Its stderr can legitimately mention "copilot-cli" or "deprecation"
+            # in unrelated contexts; neither alone should trip the detector.
+            "copilot-cli: failed to authenticate with the API",
+            "warning: the --foo flag is scheduled for deprecation in v3",
+            "See https://github.com/github/copilot-cli/issues for support",
+            # Half the fingerprint without the other half.
+            "gh-copilot: command not found",
+            "extension has been deprecated (some other extension)",
+        ],
+    )
+    def test_does_not_false_positive(self, stderr_text: str):
+        assert not _is_gh_copilot_deprecation_message(stderr_text)
 
 
 class TestGitHubModelsAzureUrl:
@@ -45,7 +61,9 @@ class TestGitHubModelsAzureUrl:
     def test_url_to_provider_contains_azure_models(self):
         from agent.model_metadata import _URL_TO_PROVIDER
 
-        assert _URL_TO_PROVIDER.get("models.inference.ai.azure.com") == "github-models"
+        # Maps to the canonical "copilot" provider (same convention as the
+        # other GitHub-family entries) — not the "github-models" alias.
+        assert _URL_TO_PROVIDER.get("models.inference.ai.azure.com") == "copilot"
 
     def test_is_github_models_base_url_recognises_azure(self):
         from hermes_cli.models import _is_github_models_base_url

--- a/tests/agent/test_copilot_acp_deprecation.py
+++ b/tests/agent/test_copilot_acp_deprecation.py
@@ -1,0 +1,59 @@
+"""Tests for gh-copilot CLI deprecation detection and GitHub Models Azure URL mapping."""
+
+import pytest
+
+from agent.copilot_acp_client import _DEPRECATION_PATTERNS
+
+
+class TestDeprecationPatternDetection:
+    """Verify that stderr messages from a deprecated gh-copilot CLI are caught."""
+
+    _REAL_DEPRECATION_STDERR = (
+        "The gh-copilot extension has been deprecated in favor of the newer "
+        "GitHub Copilot CLI.\nFor more information, visit:\n"
+        "- Copilot CLI: https://github.com/github/copilot-cli\n"
+        "- Deprecation announcement: https://github.blog/changelog/"
+        "2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension\n"
+        "No commands will be executed."
+    )
+
+    def test_real_deprecation_message_matches(self):
+        lower = self._REAL_DEPRECATION_STDERR.lower()
+        assert any(pat in lower for pat in _DEPRECATION_PATTERNS)
+
+    @pytest.mark.parametrize(
+        "stderr_line",
+        [
+            "The gh-copilot extension has been deprecated",
+            "No commands will be executed.",
+            "See deprecation notice at ...",
+            "Install copilot-cli instead",
+        ],
+    )
+    def test_individual_patterns_match(self, stderr_line: str):
+        lower = stderr_line.lower()
+        assert any(pat in lower for pat in _DEPRECATION_PATTERNS)
+
+    def test_normal_stderr_does_not_match(self):
+        normal = "Error: connection refused"
+        assert not any(pat in normal.lower() for pat in _DEPRECATION_PATTERNS)
+
+
+class TestGitHubModelsAzureUrl:
+    """Verify that the Azure GitHub Models URL is recognised."""
+
+    def test_url_to_provider_contains_azure_models(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+
+        assert _URL_TO_PROVIDER.get("models.inference.ai.azure.com") == "github-models"
+
+    def test_is_github_models_base_url_recognises_azure(self):
+        from hermes_cli.models import _is_github_models_base_url
+
+        assert _is_github_models_base_url("https://models.inference.ai.azure.com")
+        assert _is_github_models_base_url("https://models.inference.ai.azure.com/v1/chat")
+
+    def test_is_github_models_base_url_still_recognises_github_ai(self):
+        from hermes_cli.models import _is_github_models_base_url
+
+        assert _is_github_models_base_url("https://models.github.ai/inference")


### PR DESCRIPTION
Salvage of @konsisumer's #10685 onto current main with follow-up improvements.

## What this PR makes true
Spawning the deprecated `gh copilot` extension via ACP mode now surfaces an actionable error pointing the user at `npm install -g @github/copilot` (the actual CLI Hermes wants), and hitting `models.inference.ai.azure.com`'s 8K cap stops three rounds of futile compression — we tell the user the endpoint is incompatible and what to use instead.

## Cherry-picked from #10685 (authorship preserved)
- f01bf2a — detect gh-copilot deprecation, recognize Azure GitHub Models URL, emit 413 hint
- 66b4ff7 — tests for deprecation detection + URL mapping

## Follow-up commit on top (77b396a)
1. **Tightened deprecation detection.** The previous list (`'has been deprecated'`, `'no commands will be executed'`, `'deprecation'`, `'copilot-cli'`) would false-positive on stderr from the NEW `@github/copilot` CLI — whose repo is literally `github.com/github/copilot-cli` and which surfaces "copilot-cli" / "deprecation" in legitimate messages. Now requires BOTH a product fingerprint (`gh-copilot`) AND a deprecation marker.
2. **Corrected the install hint.** The user in #10648 installed `gh extension install github/gh-copilot` thinking that was what ACP needs. ACP actually spawns the new `copilot` binary from `@github/copilot`. New error message leads with `npm install -g @github/copilot` and the new CLI's repo URL; provider-switching demoted to fallback.
3. **`_URL_TO_PROVIDER` consistency.** Azure URL value changed from `'github-models'` (alias) to `'copilot'` (canonical), matching the convention used by `api.githubcopilot.com` and `models.github.ai`.
4. **Sharpened the 8K hint.** The free tier's ~8K cap is below Hermes' system-prompt + tool-schemas floor, so the endpoint is fundamentally incompatible with an agentic loop — not a 'use a different URL' problem. Says so directly.

## Validation
- `scripts/run_tests.sh tests/agent/test_copilot_acp_deprecation.py`: 14/14
- `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_api_key_providers.py`: 353/354 (1 pre-existing failure on main: `test_auto_does_not_select_copilot_from_github_token` — unrelated)
- E2E import sanity-check: real banner detected, new-CLI stderr NOT misclassified, Azure URL → `'copilot'` via `_infer_provider_from_url`, base-URL recognition covers both Azure and github.ai endpoints.

Closes #10648.