### PR TITLE
fix(gateway): skip background memory/skill review in group chats

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -28,6 +28,16 @@ from agent.thread_scoped_output import thread_scoped_silence
 logger = logging.getLogger(__name__)
 
 
+# Empty preserves CLI agents; aliases support non-gateway direct-chat callers.
+_DIRECT_CHAT_TYPES = frozenset({"", "dm", "direct", "private"})
+
+
+def background_review_allowed(chat_type: Any) -> bool:
+    """Return whether automatic owner-scoped background review is safe."""
+    normalized = "" if chat_type is None else str(chat_type).strip().lower()
+    return normalized in _DIRECT_CHAT_TYPES
+
+
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
 #

--- a/run_agent.py
+++ b/run_agent.py
@@ -1611,7 +1611,14 @@ class AIAgent:
         here so existing tests that patch ``run_agent.threading.Thread``
         keep working.
         """
-        from agent.background_review import spawn_background_review_thread
+        from agent.background_review import (
+            background_review_allowed,
+            spawn_background_review_thread,
+        )
+
+        if not background_review_allowed(getattr(self, "_chat_type", False)):
+            return
+
         from tools.thread_context import propagate_context_to_thread
         target, _prompt = spawn_background_review_thread(
             self,

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
+import pytest
+
+import agent.background_review as background_review
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -29,6 +34,7 @@ def _bare_agent() -> AIAgent:
     agent.background_review_callback = None
     agent.status_callback = None
     agent._safe_print = lambda *_args, **_kwargs: None
+    agent._chat_type = None
     return agent
 
 
@@ -38,6 +44,64 @@ class ImmediateThread:
 
     def start(self):
         self._target()
+
+
+@pytest.mark.parametrize(
+    ("chat_type", "expected"),
+    [
+        (None, True),
+        ("", True),
+        (False, False),
+        (0, False),
+        ("dm", True),
+        (" DM ", True),
+        ("direct", True),
+        ("private", True),
+        ("group", False),
+        ("channel", False),
+        ("forum", False),
+        ("thread", False),
+        ("room", False),
+        ("webhook", False),
+        ("unknown", False),
+    ],
+)
+def test_background_review_allowed_for_direct_chats_only(chat_type, expected):
+    assert background_review.background_review_allowed(chat_type) is expected
+
+
+@pytest.mark.parametrize(
+    "chat_type",
+    ["group", "channel", "forum", "thread", "room", "webhook", "unknown"],
+)
+def test_background_review_does_not_start_for_multi_user_chat(monkeypatch, chat_type):
+    thread = Mock()
+    monkeypatch.setattr(run_agent_module.threading, "Thread", thread)
+
+    agent = _bare_agent()
+    agent._chat_type = chat_type
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    thread.assert_not_called()
+
+
+def test_background_review_does_not_start_without_chat_type(monkeypatch):
+    thread = Mock()
+    monkeypatch.setattr(run_agent_module.threading, "Thread", thread)
+
+    agent = _bare_agent()
+    del agent._chat_type
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    thread.assert_not_called()
 
 
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -21,6 +21,7 @@ def _make_agent_stub(agent_cls):
     agent.platform = "test"
     agent.provider = "openai"
     agent.session_id = "sess-123"
+    agent._chat_type = None
     agent.quiet_mode = True
     agent._memory_store = None
     agent._memory_enabled = True

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -23,6 +23,7 @@ def _make_agent_stub(agent_cls):
     agent.platform = "test"
     agent.provider = "openai"
     agent.session_id = "sess-123"
+    agent._chat_type = None
     agent.quiet_mode = True
     agent._memory_store = None
     agent._memory_enabled = True

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -304,6 +304,36 @@ class TestRunConversationCodexPath:
         # Counter should be reset after the review fires
         assert agent._iters_since_skill == 0
 
+    def test_group_review_guard_preserves_external_memory_sync(self, monkeypatch):
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                tool_iterations=10,
+                turn_id="t1",
+                thread_id="th1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "th1"
+        )
+
+        agent = _make_codex_agent(chat_type="group")
+        agent._skill_nudge_interval = 10
+        agent._iters_since_skill = 0
+        agent.valid_tool_names = set(getattr(agent, "valid_tool_names", set()))
+        agent.valid_tool_names.add("skill_manage")
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+
+        with patch.object(run_agent.threading, "Thread") as thread:
+            result = agent.run_conversation("do tool work")
+
+        thread.assert_not_called()
+        agent._memory_manager.sync_all.assert_called_once()
+        assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
+
     def test_background_review_signature_never_breaks(self, fake_session):
         """Even when no trigger fires, the helper must never call
         _spawn_background_review with the wrong signature. Run a turn,


### PR DESCRIPTION
## Problem

Built-in memory (MEMORY.md + USER.md + fact_store) is designed for 1-on-1 conversations. In group chats, any member's message can trigger background review, causing identity pollution (e.g., a group member's self-introduction incorrectly written to USER.md as if it were the owner's identity).

External memory plugins (Honcho, Supermemory) handle per-user scoping, but built-in memory lacks this isolation. Since many users rely on built-in memory without external plugins, group chats pose a real privacy/identity risk.

## Solution

Add `chat_type` guard to both memory and skill background review triggers. When `chat_type` is `"group"` or `"channel"`, skip automatic background review entirely.

DMs (`"dm"`) and CLI sessions continue to review normally.

## Scope

- `run_agent.py`: `_should_review_memory` (~line 12279)
- `run_agent.py`: `_should_review_skills` (~line 15932)

No changes to:
- Manual memory/skill tool calls (user-initiated writes still work)
- External memory plugins
- Cron jobs or CLI mode

## Testing

- Verified `chat_type` values across platforms: Telegram ("dm"/"group"/"channel"/"forum"), LINE ("dm"/"group"/"channel"), Discord, Matrix, Signal all use consistent taxonomy.
- Local test: group messages no longer trigger background review threads.