### PR TITLE
fix(doctor): SSH connectivity check ignores TERMINAL_SSH_USER / PORT / KEY

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1047,10 +1047,20 @@ def run_doctor(args):
     if terminal_env == "ssh":
         ssh_host = os.getenv("TERMINAL_SSH_HOST")
         if ssh_host:
+            ssh_user = os.getenv("TERMINAL_SSH_USER")
+            ssh_port = os.getenv("TERMINAL_SSH_PORT")
+            ssh_key = os.getenv("TERMINAL_SSH_KEY")
+            target = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
+            cmd = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+            if ssh_port:
+                cmd += ["-p", ssh_port]
+            if ssh_key:
+                cmd += ["-i", os.path.expanduser(ssh_key)]
+            cmd += [target, "echo ok"]
             # Try to connect
             try:
                 result = subprocess.run(
-                    ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", ssh_host, "echo ok"],
+                    cmd,
                     capture_output=True,
                     text=True,
                     timeout=15


### PR DESCRIPTION
## Bug

When `TERMINAL_ENV=ssh` is set, `hermes doctor` tests SSH connectivity with:

```
ssh -o ConnectTimeout=5 -o BatchMode=yes <TERMINAL_SSH_HOST> echo ok
```

This ignores `TERMINAL_SSH_USER`, `TERMINAL_SSH_PORT`, and `TERMINAL_SSH_KEY`, so the check connects as the current OS user on port 22 with no specific identity file. If the remote requires a different user or key (the common case), the check always fails with `Permission denied` — even though the agent itself connects successfully.

## Root cause

`doctor.py` line 1053 only reads `TERMINAL_SSH_HOST` and passes it directly to `ssh`, discarding the other three `TERMINAL_SSH_*` env vars that the terminal tool itself uses.

## Fix

Build the `ssh` command using all four env vars — `user@host`, `-p PORT`, and `-i KEY` — to match the connection parameters the agent actually uses.

```python
ssh_user = os.getenv("TERMINAL_SSH_USER")
ssh_port = os.getenv("TERMINAL_SSH_PORT")
ssh_key  = os.getenv("TERMINAL_SSH_KEY")
target   = f"{ssh_user}@{ssh_host}" if ssh_user else ssh_host
cmd      = ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
if ssh_port: cmd += ["-p", ssh_port]
if ssh_key:  cmd += ["-i", os.path.expanduser(ssh_key)]
cmd += [target, "echo ok"]
```

## Test

Before the fix — with `TERMINAL_SSH_USER=carry` configured:
```
✗ SSH connection to 10.8.0.5
```

After the fix:
```
✓ SSH connection to 10.8.0.5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)