### PR TITLE
fix(xai-oauth): surface tier-gated 403 with API-key fallback (closes #26847)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3119,12 +3119,34 @@ def refresh_xai_oauth_pure(
         )
     if response.status_code != 200:
         detail = response.text.strip()
+        # ``403`` from xAI's token endpoint is almost always a tier /
+        # entitlement gate (the OAuth grant exists but the account isn't
+        # on the allowlist for API access).  Re-running ``hermes model``
+        # won't fix that — surface a separate error code so
+        # ``format_auth_error`` doesn't append a misleading
+        # re-authenticate hint, and point users at the ``XAI_API_KEY``
+        # fallback.  See #26847.
+        if response.status_code == 403:
+            raise AuthError(
+                "xAI token refresh failed with HTTP 403."
+                + (f" Response: {detail}" if detail else "")
+                + " This OAuth account is not authorized for xAI API"
+                  " access — xAI may be restricting API/OAuth use to"
+                  " specific SuperGrok tiers despite the in-app"
+                  " subscription being active. Re-logging in won't"
+                  " change that; set ``XAI_API_KEY`` and switch to"
+                  " ``provider: xai`` (API-key path) if available, or"
+                  " upgrade your subscription at https://x.ai/grok.",
+                provider="xai-oauth",
+                code="xai_oauth_tier_denied",
+                relogin_required=False,
+            )
         raise AuthError(
             "xAI token refresh failed."
             + (f" Response: {detail}" if detail else ""),
             provider="xai-oauth",
             code="xai_refresh_failed",
-            relogin_required=(response.status_code in {400, 401, 403}),
+            relogin_required=(response.status_code in {400, 401}),
         )
     try:
         payload = response.json()
@@ -5413,6 +5435,25 @@ def _xai_oauth_loopback_login(
         ) from exc
     if response.status_code != 200:
         detail = response.text.strip()
+        # See ``refresh_xai_oauth_pure`` — token-exchange 403 also
+        # surfaces tier/entitlement gating from xAI's backend.  Avoid
+        # the misleading "re-authenticate" hint and point at the API
+        # key fallback.  See #26847.
+        if response.status_code == 403:
+            raise AuthError(
+                "xAI token exchange failed with HTTP 403."
+                + (f" Response: {detail}" if detail else "")
+                + " This OAuth account is not authorized for xAI API"
+                  " access — xAI may be restricting API/OAuth use to"
+                  " specific SuperGrok tiers despite the in-app"
+                  " subscription being active. Set ``XAI_API_KEY``"
+                  " and switch to ``provider: xai`` (API-key path) if"
+                  " available, or upgrade your subscription at"
+                  " https://x.ai/grok.",
+                provider="xai-oauth",
+                code="xai_oauth_tier_denied",
+                relogin_required=False,
+            )
         raise AuthError(
             "xAI token exchange failed."
             + (f" Response: {detail}" if detail else ""),

--- a/run_agent.py
+++ b/run_agent.py
@@ -7664,7 +7664,16 @@ class AIAgent:
             # main agent loop spins re-issuing the same 403 until the
             # user Ctrl+C's.  Surface the error instead so the friendly
             # entitlement hint from ``_summarize_api_error`` can land.
-            if self._is_entitlement_failure(error_context, status_code):
+            #
+            # Defense-in-depth for #26847: xAI's backend has been seen
+            # to 403 standard SuperGrok subscribers with bodies that
+            # don't match the existing entitlement keyword set. Any 403
+            # against ``xai-oauth`` is treated as entitlement so the
+            # refresh loop can't spin in those cases either.
+            is_entitlement = self._is_entitlement_failure(error_context, status_code)
+            if not is_entitlement and status_code == 403 and (self.provider or "") == "xai-oauth":
+                is_entitlement = True
+            if is_entitlement:
                 logger.info(
                     "Credential %s — entitlement-shaped 403 from %s; "
                     "skipping pool refresh (account lacks subscription, "

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -21,6 +21,7 @@ from hermes_cli.auth import (
     _xai_callback_cors_origin,
     _xai_oauth_build_authorize_url,
     _xai_validate_loopback_redirect_uri,
+    format_auth_error,
     get_xai_oauth_auth_status,
     refresh_xai_oauth_pure,
     resolve_provider,
@@ -487,6 +488,53 @@ def test_refresh_xai_oauth_pure_no_relogin_on_500(monkeypatch):
         )
     assert exc.value.code == "xai_refresh_failed"
     assert exc.value.relogin_required is False
+
+
+def test_refresh_xai_oauth_pure_403_marked_tier_denied_not_relogin(monkeypatch):
+    """403 from xAI's token endpoint is tier/entitlement, not stale tokens.
+
+    Regression test for #26847 — xAI's backend has been seen to 403
+    standard SuperGrok subscribers despite the in-app subscription
+    being active. Re-running ``hermes model`` won't help in that
+    case, so the AuthError must NOT set ``relogin_required=True``,
+    and must carry the dedicated ``xai_oauth_tier_denied`` code so
+    ``format_auth_error`` doesn't append the misleading re-auth hint.
+    """
+    response = _StubHTTPResponse(403, {"error": "permission_denied"})
+    _patch_httpx_client(monkeypatch, response)
+    with pytest.raises(AuthError) as exc:
+        refresh_xai_oauth_pure(
+            "at", "rt", token_endpoint="https://auth.x.ai/oauth2/token"
+        )
+    assert exc.value.code == "xai_oauth_tier_denied"
+    assert exc.value.relogin_required is False
+    message = str(exc.value).lower()
+    assert "403" in message
+    assert "xai_api_key" in message
+    assert "tier" in message
+
+
+def test_format_auth_error_tier_denied_does_not_suggest_relogin():
+    """``xai_oauth_tier_denied`` must not append the re-authenticate hint.
+
+    Regression for #26847: telling a tier-gated user to ``hermes model``
+    is actively wrong — re-logging in won't change xAI's allowlist
+    decision. The full message (with ``XAI_API_KEY`` fallback) is built
+    into the error itself.
+    """
+    err = AuthError(
+        "xAI token refresh failed with HTTP 403. Response: forbidden. "
+        "This OAuth account is not authorized for xAI API access — "
+        "xAI may be restricting API/OAuth use to specific SuperGrok tiers. "
+        "Set ``XAI_API_KEY`` and switch to ``provider: xai``.",
+        provider="xai-oauth",
+        code="xai_oauth_tier_denied",
+        relogin_required=False,
+    )
+    rendered = format_auth_error(err)
+    assert "re-authenticate" not in rendered.lower()
+    assert "hermes model" not in rendered.lower()
+    assert "XAI_API_KEY" in rendered
 
 
 def test_refresh_xai_oauth_pure_returns_updated_tokens(monkeypatch):

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -493,6 +493,56 @@ def test_recover_with_credential_pool_skips_refresh_on_entitlement_403():
     assert refresh_calls["n"] == 0, "try_refresh_current must NOT be called on entitlement 403"
 
 
+def test_recover_with_credential_pool_skips_refresh_on_bare_403_for_xai_oauth():
+    """A bare HTTP 403 from ``xai-oauth`` (no keyword match) must NOT loop refresh.
+
+    Regression for #26847 — xAI's backend has been seen to 403 standard
+    SuperGrok subscribers with a terser body that doesn't contain any of
+    the existing entitlement keywords ("do not have an active Grok
+    subscription", etc.). Before the defense-in-depth guard, the recovery
+    path would happily mint a fresh token, get a fresh 403, and spin.
+    """
+    from run_agent import AIAgent
+    from agent.error_classifier import FailoverReason
+
+    agent = _make_codex_agent()
+    assert agent.provider == "xai-oauth"
+
+    refresh_calls = {"n": 0}
+
+    class _FakePool:
+        def try_refresh_current(self):
+            refresh_calls["n"] += 1
+            return MagicMock(id="should_not_be_called")
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            return None
+
+        def has_available(self):
+            return False
+
+    agent._credential_pool = _FakePool()
+
+    error_context = {
+        "reason": "forbidden",
+        "message": "Forbidden",
+    }
+    assert not AIAgent._is_entitlement_failure(error_context, 403), (
+        "Pre-condition: bare 'Forbidden' body must NOT match the keyword "
+        "heuristic — otherwise this test isn't covering the defense-in-depth path."
+    )
+
+    recovered, _retried_429 = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context=error_context,
+    )
+
+    assert recovered is False, "Bare 403 on xai-oauth must surface, not refresh-loop"
+    assert refresh_calls["n"] == 0, "try_refresh_current must NOT be called on xai-oauth 403"
+
+
 def test_recover_with_credential_pool_still_refreshes_genuine_auth_failure():
     """Regression guard: legitimate auth errors must still trigger refresh."""
     from run_agent import AIAgent

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -24,7 +24,7 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 | Endpoint | `https://api.x.ai/v1` |
 | Auth server | `https://accounts.x.ai` |
 | Requires env var | No (`XAI_API_KEY` is **not** used for this provider) |
-| Subscription | [SuperGrok](https://x.ai/grok) (any active tier) |
+| Subscription | [SuperGrok](https://x.ai/grok) — see note below |
 
 ## Prerequisites
 
@@ -32,6 +32,10 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 - Hermes Agent installed
 - An active SuperGrok subscription on your xAI account
 - A browser available on the local machine (or use `--no-browser` for remote sessions)
+
+:::warning xAI may restrict OAuth API access by tier
+xAI's backend enforces its own allowlist on the OAuth API surface and has been seen to reject standard SuperGrok subscribers with `HTTP 403` (see issue [#26847](https://github.com/NousResearch/hermes-agent/issues/26847)) even though the in-app subscription is active. If OAuth login succeeds in the browser but inference returns 403, set `XAI_API_KEY` and switch to the API-key path (`provider: xai`) — that surface is not subject to the same gating today.
+:::
 
 ## Quick Start
 
@@ -207,6 +211,21 @@ hermes auth add xai-oauth --no-browser
 ```
 
 Full walkthrough (jump boxes, mosh/tmux, port conflicts): [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md).
+
+### HTTP 403 after a successful login (tier / entitlement)
+
+OAuth completed in the browser, tokens are saved, but inference or token refresh returns `HTTP 403` with a message similar to *"The caller does not have permission to execute the specified operation"*.
+
+This is **not** a stale-token problem — re-running `hermes model` won't change it. xAI's backend has been seen to restrict OAuth API access to specific SuperGrok tiers despite the in-app subscription being active (issue [#26847](https://github.com/NousResearch/hermes-agent/issues/26847)).
+
+**Fix:** set `XAI_API_KEY` and switch to the API-key path:
+
+```bash
+export XAI_API_KEY=xai-...
+hermes config set model.provider xai
+```
+
+Or upgrade your subscription at [x.ai/grok](https://x.ai/grok) if the OAuth route is required.
 
 ### "No xAI credentials found" error at runtime
 


### PR DESCRIPTION
## What does this PR do?

Makes the `xai-oauth` provider fail gracefully — and accurately — when xAI's backend returns `HTTP 403` to a standard SuperGrok subscriber.

Issue [#26847](https://github.com/NousResearch/hermes-agent/issues/26847) reported that the `xai-oauth` flow appears to gate API access on a Heavy-tier allowlist even though Hermes docs claim "any active SuperGrok tier" works. Subscribers who successfully complete the browser OAuth flow then hit `HTTP 403` at the very first inference call (or during refresh), and the error UX makes the situation worse in three ways:

1. `refresh_xai_oauth_pure` flagged the 403 as `relogin_required=True`, so the CLI told users to run `hermes model` to re-authenticate — but re-logging in cannot change xAI's tier verdict.
2. `_is_entitlement_failure` only matched a specific keyword set ("do not have an active Grok subscription" / "out of available resources" / "does not have permission" + "grok"). A terser 403 body would slip past that gate, and the credential-pool recovery would mint a fresh token, get a fresh 403, and spin forever until the user hit Ctrl+C.
3. The xAI Grok OAuth guide advertised "(any active tier)" with no fallback path documented.

This PR addresses all three:

- `refresh_xai_oauth_pure` and the loopback token-exchange now split 403 off from 400/401: they raise a dedicated `xai_oauth_tier_denied` `AuthError` with `relogin_required=False` and a message body that explains the entitlement gate and points at `XAI_API_KEY` + `provider: xai` as the documented fallback. `format_auth_error` then no longer appends the misleading "Run `hermes model` to re-authenticate." line.
- `_recover_with_credential_pool` adds a defense-in-depth check: any `HTTP 403` on `provider == "xai-oauth"` short-circuits `try_refresh_current` even when the body fails the existing keyword heuristic, so the friendly hint from `_summarize_api_error` lands instead of an infinite refresh loop.
- The xAI Grok OAuth guide drops the "(any active tier)" claim, adds a top-of-page warning callout referencing #26847, and gains a "HTTP 403 after a successful login (tier / entitlement)" Troubleshooting section with the `XAI_API_KEY` fallback recipe.

## Related Issue

Fixes #26847

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py` — In `refresh_xai_oauth_pure` and the loopback token-exchange path: detect `response.status_code == 403` before the generic non-200 branch and raise `AuthError(code="xai_oauth_tier_denied", relogin_required=False)` with a self-contained message that mentions tier gating and the `XAI_API_KEY` fallback. 400/401/5xx behavior is unchanged.
- `run_agent.py` — In `_recover_with_credential_pool`'s `FailoverReason.auth` branch, treat any 403 on `xai-oauth` as entitlement (in addition to the existing keyword heuristic). Stops `try_refresh_current` from spinning on bare/terser 403 bodies. The keyword path for all other providers is untouched.
- `tests/hermes_cli/test_auth_xai_oauth_provider.py` — **2 new tests**: `test_refresh_xai_oauth_pure_403_marked_tier_denied_not_relogin` (verifies code/flag/message), and `test_format_auth_error_tier_denied_does_not_suggest_relogin` (verifies the renderer drops the misleading hint and keeps the API-key reference).
- `tests/run_agent/test_codex_xai_oauth_recovery.py` — **1 new test**: `test_recover_with_credential_pool_skips_refresh_on_bare_403_for_xai_oauth` (asserts the keyword heuristic returns False for `{"reason":"forbidden","message":"Forbidden"}`, then asserts the recovery path still short-circuits `try_refresh_current` because the provider is `xai-oauth`).
- `website/docs/guides/xai-grok-oauth.md` — Drop the "(any active tier)" claim, add a top-of-page `:::warning` callout, and add a Troubleshooting subsection "HTTP 403 after a successful login (tier / entitlement)" that shows the `XAI_API_KEY` + `provider: xai` fallback.

## How to Test

```bash
# 1. New + existing xAI OAuth provider tests pass
python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py -q
# expected: 65 passed

# 2. New + existing xAI OAuth recovery tests pass
python -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py -q
# expected: 25 passed

# 3. Reproduce the misleading re-auth UX from #26847 without the fix would print
#    "Run `hermes model` to re-authenticate."  With the fix:
python -c "
from hermes_cli.auth import AuthError, format_auth_error
err = AuthError(
    'xAI token refresh failed with HTTP 403. Response: forbidden. '
    'This OAuth account is not authorized for xAI API access — '
    'xAI may be restricting API/OAuth use to specific SuperGrok tiers. '
    'Set XAI_API_KEY and switch to provider: xai.',
    provider='xai-oauth',
    code='xai_oauth_tier_denied',
    relogin_required=False,
)
print(format_auth_error(err))
"
# expected: a single paragraph mentioning HTTP 403 and XAI_API_KEY,
#           and crucially NO "Run `hermes model` to re-authenticate." suffix.
```

For end-to-end verification, a real reproduction requires an xAI account currently in the affected tier (the 403 is upstream-driven). With the fix, that user will see the new tier-aware error message and the docs Troubleshooting section will guide them to `XAI_API_KEY` + `provider: xai` without burning through refresh attempts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py tests/run_agent/test_codex_xai_oauth_recovery.py -q` and all 90 tests pass (3 new)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/guides/xai-grok-oauth.md` — accuracy + new Troubleshooting subsection)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python + docs change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix (issue #26847 reproduction):

```
$ hermes
Error: xAI token refresh failed. Response: {"error":"forbidden"} Run `hermes model` to re-authenticate.
$ hermes model    # ← user follows the suggestion
# OAuth login succeeds, fresh tokens stored
$ hermes
Error: xAI token refresh failed. Response: {"error":"forbidden"} Run `hermes model` to re-authenticate.
# ← infinite loop; re-login can never fix the tier-side 403
```

After the fix:

```
$ hermes
Error: xAI token refresh failed with HTTP 403. Response: {"error":"forbidden"} This OAuth account is not authorized for xAI API access — xAI may be restricting API/OAuth use to specific SuperGrok tiers despite the in-app subscription being active. Re-logging in won't change that; set `XAI_API_KEY` and switch to `provider: xai` (API-key path) if available, or upgrade your subscription at https://x.ai/grok.

# Follow the documented fallback:
$ export XAI_API_KEY=xai-...
$ hermes config set model.provider xai
$ hermes
# inference proceeds against the API-key surface
```
