### PR TITLE
feat(gateway): continue background tasks from replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,6 +644,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    SendResult,
     _reply_anchor_for_event,
     merge_pending_message_event,
 )
@@ -1386,6 +1387,8 @@ class GatewayRunner:
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._background_reply_continuations: "OrderedDict[tuple[str, str, str], Dict[str, Any]]" = OrderedDict()
+        self._background_reply_continuations_max = 256
 
 
     def _wire_teams_pipeline_runtime(self) -> None:
@@ -5877,6 +5880,15 @@ class GatewayRunner:
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        background_continuation = self._background_reply_continuation_for_event(event)
+        if background_continuation is not None:
+            response = await self._handle_background_reply_continuation(
+                event,
+                background_continuation,
+            )
+            if response is not None:
+                return response
         
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
@@ -7117,6 +7129,122 @@ class GatewayRunner:
             except Exception:
                 pass
         return source
+
+    @staticmethod
+    def _background_reply_key(source: SessionSource, message_id: Optional[str]) -> Optional[tuple[str, str, str]]:
+        """Return the in-memory key for a sent background result message."""
+        if not source or message_id is None:
+            return None
+        platform = getattr(getattr(source, "platform", None), "value", getattr(source, "platform", None))
+        chat_id = getattr(source, "chat_id", None)
+        if platform is None or chat_id is None:
+            return None
+        return (str(platform), str(chat_id), str(message_id))
+
+    def _background_reply_map(self) -> "OrderedDict[tuple[str, str, str], Dict[str, Any]]":
+        continuations = getattr(self, "_background_reply_continuations", None)
+        if not isinstance(continuations, OrderedDict):
+            continuations = OrderedDict(continuations or {})
+            self._background_reply_continuations = continuations
+        return continuations
+
+    def _remember_background_reply_message(
+        self,
+        source: SessionSource,
+        message_id: Optional[str],
+        task_id: str,
+    ) -> None:
+        """Map a delivered background result message to its background session."""
+        key = self._background_reply_key(source, message_id)
+        if key is None:
+            return
+        continuations = self._background_reply_map()
+        continuations[key] = {"task_id": task_id}
+        continuations.move_to_end(key)
+        max_size = getattr(self, "_background_reply_continuations_max", 256)
+        while len(continuations) > max_size:
+            continuations.popitem(last=False)
+
+    def _remember_background_reply_result(
+        self,
+        source: SessionSource,
+        task_id: str,
+        result: Optional[SendResult],
+    ) -> None:
+        """Index every message id produced by a background completion send."""
+        if not isinstance(result, SendResult) or not result.success:
+            return
+        message_ids: list[str] = []
+        if result.message_id:
+            message_ids.append(str(result.message_id))
+        raw_message_ids = None
+        if isinstance(result.raw_response, dict):
+            raw_message_ids = result.raw_response.get("message_ids")
+        if isinstance(raw_message_ids, (list, tuple)):
+            for message_id in raw_message_ids:
+                if message_id:
+                    message_ids.append(str(message_id))
+        for message_id in result.continuation_message_ids or ():
+            if message_id:
+                message_ids.append(str(message_id))
+        for message_id in dict.fromkeys(message_ids):
+            self._remember_background_reply_message(source, message_id, task_id)
+
+    def _background_reply_continuation_for_event(self, event: MessageEvent) -> Optional[Dict[str, Any]]:
+        """Return continuation metadata when an inbound message replies to a background result."""
+        if event.is_command():
+            return None
+        key = self._background_reply_key(event.source, getattr(event, "reply_to_message_id", None))
+        if key is None:
+            return None
+        continuations = getattr(self, "_background_reply_continuations", None)
+        if not continuations:
+            return None
+        continuation = continuations.get(key)
+        if continuation is not None and hasattr(continuations, "move_to_end"):
+            try:
+                continuations.move_to_end(key)
+            except Exception:
+                pass
+        return continuation if isinstance(continuation, dict) else None
+
+    async def _handle_background_reply_continuation(
+        self,
+        event: MessageEvent,
+        continuation: Dict[str, Any],
+    ) -> Optional[str]:
+        """Start a follow-up turn in the referenced background session."""
+        task_id = str(continuation.get("task_id") or "").strip()
+        if not task_id:
+            return None
+
+        prompt = (event.text or "").strip()
+        media_urls = list(event.media_urls) if event.media_urls else []
+        media_types = list(event.media_types) if event.media_types else []
+        if not prompt and not media_urls:
+            return None
+
+        _task = asyncio.create_task(
+            self._run_background_task(
+                prompt,
+                event.source,
+                task_id,
+                event_message_id=self._reply_anchor_for_event(event),
+                media_urls=media_urls,
+                media_types=media_types,
+            )
+        )
+        tasks = getattr(self, "_background_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._background_tasks = tasks
+        tasks.add(_task)
+        _task.add_done_callback(tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        if not preview:
+            preview = "(media follow-up)"
+        return t("gateway.background.started", preview=preview, task_id=task_id)
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
@@ -10693,17 +10821,19 @@ class GatewayRunner:
                 header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
 
                 if text_content:
-                    await adapter.send(
+                    send_result = await adapter.send(
                         chat_id=source.chat_id,
                         content=header + text_content,
                         metadata=_thread_metadata,
                     )
+                    self._remember_background_reply_result(source, task_id, send_result)
                 elif not images and not media_files:
-                    await adapter.send(
+                    send_result = await adapter.send(
                         chat_id=source.chat_id,
                         content=header + "(No response generated)",
                         metadata=_thread_metadata,
                     )
+                    self._remember_background_reply_result(source, task_id, send_result)
 
                 # Send extracted images
                 for image_url, alt_text in (images or []):

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -318,6 +318,94 @@ class TestRunBackgroundTask:
             "telegram_dm_topic_reply_fallback": True,
             "telegram_reply_to_message_id": "463",
         }
+
+    @pytest.mark.asyncio
+    async def test_completion_message_ids_allow_reply_continuation(self, monkeypatch):
+        """Successful background replies are indexed so user replies continue that task."""
+        from gateway import run as gateway_run
+
+        runner = _make_runner()
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("test-model", {"api_key": "test-key"})
+        )
+        runner._resolve_session_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(
+            return_value={
+                "model": "test-model",
+                "runtime": {"api_key": "test-key"},
+                "request_overrides": None,
+            }
+        )
+        runner._run_in_executor_with_context = AsyncMock(
+            return_value={"final_response": "done", "messages": []}
+        )
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=True,
+                message_id="900",
+                continuation_message_ids=("901",),
+                raw_response={"message_ids": ["900", "901", "902"]},
+            )
+        )
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        await runner._run_background_task("say hello", source, "bg_test")
+
+        continuations = getattr(runner, "_background_reply_continuations", {})
+        assert continuations[("telegram", "67890", "900")]["task_id"] == "bg_test"
+        assert continuations[("telegram", "67890", "901")]["task_id"] == "bg_test"
+        assert continuations[("telegram", "67890", "902")]["task_id"] == "bg_test"
+
+    @pytest.mark.asyncio
+    async def test_reply_to_background_completion_starts_followup_without_main_session(self):
+        """Replying to a background result starts a background follow-up, not the chat session."""
+        runner = _make_runner()
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._background_reply_continuations = {
+            ("telegram", "67890", "900"): {"task_id": "bg_test"},
+        }
+        runner._run_background_task = AsyncMock()
+        runner.session_store.get_or_create_session.side_effect = AssertionError(
+            "background reply should not enter the main session"
+        )
+
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        event = _make_event(text="now make it shorter")
+        event.reply_to_message_id = "900"
+        event.message_id = "902"
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            result = await runner._handle_message(event)
+
+        assert "Background task started" in result
+        assert "bg_test" in result
+        assert len(created_tasks) == 1
+        runner._run_background_task.assert_called_once()
+        call = runner._run_background_task.call_args
+        assert call.args[0] == "now make it shorter"
+        assert call.args[2] == "bg_test"
+        assert call.kwargs["event_message_id"] == "902"
+        runner.session_store.get_or_create_session.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_agent_cleanup_runs_when_background_agent_raises(self):


### PR DESCRIPTION
## Summary
- Route replies to known `/background` completion messages back into the matched background session/task.
- Index all completion message IDs returned by gateway sends, including split/chunked Telegram message IDs.
- Add focused gateway coverage for reply continuation routing and multi-ID completion results.

## Test Plan
- [x] `venv/bin/python -m pytest tests/gateway/test_background_command.py -q`
- [x] `venv/bin/python -m pytest tests/gateway/test_telegram_reply_quote.py tests/gateway/test_telegram_reply_mode.py -q`
- [x] `venv/bin/python -m ruff check gateway/run.py tests/gateway/test_background_command.py`

## Notes
- This is the minimal in-memory reply-anchor implementation. It does not persist reply mappings across gateway restarts.
