### PR TITLE
fix(discord): single-shot send_typing to kill stuck typing indicator race (closes #26854)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -577,8 +577,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
-        # Persistent typing indicator loops per channel (DMs don't reliably
-        # show the standard typing gateway event for bots)
+        # Typing-indicator state is intentionally empty: ``send_typing``
+        # now issues a single non-blocking POST per call and lets
+        # ``_keep_typing`` (base.py) drive the cadence.  The dict is
+        # kept (deprecated) so legacy tests / introspection that probe
+        # this attribute don't ``AttributeError`` — see #26854.
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
@@ -2701,50 +2704,49 @@ class DiscordAdapter(BasePlatformAdapter):
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """Start a persistent typing indicator for a channel.
+        """Send a single typing indicator pulse for a channel.
 
-        Discord's TYPING_START gateway event is unreliable in DMs for bots.
-        Instead, start a background loop that hits the typing endpoint every
-        8 seconds (typing indicator lasts ~10s).  The loop is cancelled when
-        stop_typing() is called (after the response is sent).
+        Discord's ``POST /channels/{id}/typing`` endpoint already grants
+        ~10 s of "is typing" status server-side, and ``_keep_typing``
+        (gateway/platforms/base.py) refreshes every 2 s — there's no
+        need for an adapter-side persistent loop on top of that.
+
+        The previous implementation spun a separate 8 s ``_typing_loop``
+        task and tracked it in ``self._typing_tasks``.  When the agent
+        finished, ``stop_typing()`` would cancel that task — but
+        ``_keep_typing`` could call ``send_typing()`` a few millis later,
+        recreating the loop *after* cleanup had already inspected the
+        task dict.  Combined with the 0.5 s cap in ``_stop_typing_task``
+        (base.py), a Discord connection-timeout was enough to leave the
+        recreated loop running indefinitely — see #26854.
+
+        Collapsing this to a single non-blocking request removes the
+        second loop entirely.  When ``_keep_typing`` stops ticking,
+        Discord's native 10 s TTL retires the indicator on its own.
         """
         if not self._client:
             return
-        # Don't start a duplicate loop
-        if chat_id in self._typing_tasks:
-            return
-
-        async def _typing_loop() -> None:
-            try:
-                while True:
-                    try:
-                        route = discord.http.Route(
-                            "POST", "/channels/{channel_id}/typing",
-                            channel_id=chat_id,
-                        )
-                        await self._client.http.request(route)
-                    except asyncio.CancelledError:
-                        return
-                    except Exception as e:
-                        logger.debug("Discord typing indicator failed for %s: %s", chat_id, e)
-                        return
-                    await asyncio.sleep(8)
-            except asyncio.CancelledError:
-                pass
-            finally:
-                self._typing_tasks.pop(chat_id, None)
-
-        self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
+        try:
+            route = discord.http.Route(
+                "POST", "/channels/{channel_id}/typing",
+                channel_id=chat_id,
+            )
+            await self._client.http.request(route)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("Discord typing indicator failed for %s: %s", chat_id, e)
 
     async def stop_typing(self, chat_id: str) -> None:
-        """Stop the persistent typing indicator for a channel."""
-        task = self._typing_tasks.pop(chat_id, None)
-        if task:
-            task.cancel()
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):
-                pass
+        """No-op — typing is refreshed per-tick by ``_keep_typing``.
+
+        Kept for adapter-API symmetry (base.py's ``_keep_typing``
+        ``finally`` block and ``_process_message_background`` cleanup
+        both call ``stop_typing`` when present).  Discord's native
+        ~10 s typing TTL retires the indicator once ``_keep_typing``
+        stops pumping refreshes, so there's nothing to cancel here.
+        """
+        return
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Discord channel."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -390,58 +390,131 @@ async def test_forum_post_file_creation_failure():
 
 
 # ---------------------------------------------------------------------------
-# Typing indicator task lifecycle
+# Typing indicator — single-shot semantics (regression for #26854)
+#
+# Before #26854: ``send_typing`` spawned an adapter-side 8-second
+# ``_typing_loop`` task tracked in ``_typing_tasks``.  ``_keep_typing``
+# (base.py) refreshed every 2 s on top of that — and could re-create
+# the inner loop *after* ``stop_typing`` had cancelled it, leaving the
+# typing indicator stuck for hours.  The fix collapses ``send_typing``
+# to a single non-blocking POST and lets ``_keep_typing`` drive the
+# cadence; Discord's native ~10 s TTL retires the indicator naturally.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_typing_task_removed_after_api_error():
-    """When typing API call fails, stale task must be removed so typing can restart."""
+async def test_send_typing_issues_single_request_per_call():
+    """``send_typing`` must POST exactly once and never spawn a background loop."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
+
+    await adapter.send_typing("12345")
+
+    assert adapter._client.http.request.await_count == 1, \
+        "send_typing must issue exactly one POST per call (no background loop)"
+    assert adapter._typing_tasks == {}, \
+        "send_typing must not spawn or track any persistent typing tasks"
+
+
+@pytest.mark.asyncio
+async def test_send_typing_swallows_api_errors_without_raising():
+    """A network/rate-limit error during typing must not crash the caller."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter._client = MagicMock()
     adapter._client.http = MagicMock()
     adapter._client.http.request = AsyncMock(side_effect=Exception("rate limited"))
-    adapter._typing_tasks = {}
 
+    # Must not raise — _keep_typing relies on this to keep the refresh
+    # cadence intact even when individual ticks fail.
     await adapter.send_typing("12345")
-    await asyncio.sleep(0.1)
 
-    assert "12345" not in adapter._typing_tasks, \
-        "Stale task should be removed after API error"
+    assert adapter._typing_tasks == {}, \
+        "Failed typing call must not leave any task state behind"
 
 
 @pytest.mark.asyncio
-async def test_typing_restartable_after_error():
-    """After a typing error, send_typing should start a new task (not blocked by stale entry)."""
-    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-    adapter._client = MagicMock()
-    adapter._client.http = MagicMock()
-    adapter._typing_tasks = {}
-
-    # First call fails
-    adapter._client.http.request = AsyncMock(side_effect=Exception("503"))
-    await adapter.send_typing("12345")
-    await asyncio.sleep(0.1)
-
-    # Second call should work
-    adapter._client.http.request = AsyncMock()
-    await adapter.send_typing("12345")
-
-    assert "12345" in adapter._typing_tasks, \
-        "Should restart typing after previous failure"
-
-
-@pytest.mark.asyncio
-async def test_typing_stop_cleans_up():
-    """stop_typing should remove the task from _typing_tasks."""
+async def test_send_typing_repeated_calls_each_issue_one_request():
+    """Each ``_keep_typing`` tick must result in exactly one POST."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter._client = MagicMock()
     adapter._client.http = MagicMock()
     adapter._client.http.request = AsyncMock()
-    adapter._typing_tasks = {}
 
-    await adapter.send_typing("12345")
-    assert "12345" in adapter._typing_tasks
+    for _ in range(3):
+        await adapter.send_typing("12345")
+
+    assert adapter._client.http.request.await_count == 3, \
+        "Three send_typing calls must produce three POSTs (no coalescing, no loop)"
+    assert adapter._typing_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_is_idempotent_noop():
+    """``stop_typing`` is a no-op now — there is no loop to cancel.
+
+    Regression for #26854: the previous implementation had a cancel
+    path that could race with ``_keep_typing``'s next refresh, leaving
+    the indicator stuck.  ``stop_typing`` must succeed regardless of
+    whether ``send_typing`` was ever called, and must not raise.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
 
     await adapter.stop_typing("12345")
-    assert "12345" not in adapter._typing_tasks
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await adapter.stop_typing("12345")
+
+    assert adapter._typing_tasks == {}, \
+        "stop_typing must remain a no-op and never touch task state"
+    assert adapter._client.http.request.await_count == 1, \
+        "stop_typing must not issue any HTTP requests of its own"
+
+
+@pytest.mark.asyncio
+async def test_send_typing_no_client_is_silent():
+    """Pre-connect / post-disconnect: ``send_typing`` returns silently."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = None
+
+    await adapter.send_typing("12345")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_no_orphan_loop_after_stop_typing_send_typing_race():
+    """``send_typing`` after ``stop_typing`` must not leave an orphan task.
+
+    Direct regression for the race condition in #26854.  The original
+    code spawned a persistent ``_typing_loop`` task inside
+    ``send_typing``; if ``_keep_typing`` happened to call
+    ``send_typing`` right after the agent's ``stop_typing`` cancelled
+    the previous loop, a brand-new task would be created — and the
+    0.5 s cap in base.py's ``_stop_typing_task`` cleanup wasn't long
+    enough to catch it.  Result: typing indicator stuck for hours.
+
+    With the fix, ``send_typing`` is a single-shot POST and creates
+    no task, so the race window simply doesn't exist.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
+
+    # Reproduce the race: stop -> immediate send -> stop again.
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await asyncio.sleep(0.1)
+
+    assert adapter._typing_tasks == {}, (
+        "send_typing must never leave a background task behind, "
+        "even when interleaved with stop_typing"
+    )
+    assert adapter._client.http.request.await_count == 2, (
+        "Each send_typing call must produce exactly one POST"
+    )


### PR DESCRIPTION
## What does this PR do?

Eliminates the race condition that left the Discord "is typing..." indicator stuck for hours after the agent finished responding.

Issue [#26854](https://github.com/NousResearch/hermes-agent/issues/26854) traced the bug to two refresh loops fighting for ownership of the typing indicator on every active Discord session:

1. **`_keep_typing`** in `gateway/platforms/base.py` — calls `send_typing()` every 2 s while a handler is running.
2. **`_typing_loop`** in `gateway/platforms/discord.py` — a *second* loop spawned inside `send_typing()` that hits `POST /channels/{id}/typing` every 8 s and parks itself in `self._typing_tasks`.

The race: when the agent finished, `run.py` called `stop_typing()` which cancelled the inner loop. But `_keep_typing` could call `send_typing()` again a few milliseconds later, recreating `_typing_loop` *after* the cleanup path had already inspected `_typing_tasks`. The 0.5 s `asyncio.wait_for` cap in base.py's `_stop_typing_task` (line 3046) wasn't long enough to catch the recreated loop — especially when a Discord `Connection timeout` was already in flight, as the user's `gateway.error.log` showed. The orphan loop then happily refreshed the typing indicator every 8 s for hours until the gateway was restarted.

Fix: collapse `send_typing()` to a single non-blocking POST and let `_keep_typing` drive the cadence. Discord's native ~10 s typing TTL retires the indicator naturally as soon as `_keep_typing` stops pumping — no second loop, no `_typing_tasks` task state, no race window.

`stop_typing()` becomes a no-op (kept for the base.py adapter-API contract; both `_keep_typing`'s `finally` block and `_process_message_background`'s cleanup call `self.stop_typing` when present). `_typing_tasks` is preserved as an empty dict so legacy tests / introspection that probe the attribute don't `AttributeError`.

## Related Issue

Fixes #26854

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` — `send_typing()` issues exactly one `POST /channels/{id}/typing` per call (no background task, no nested loop). `stop_typing()` becomes a no-op. `_typing_tasks` is intentionally left as an empty dict (never populated) for backwards-compat with anything probing the attribute. Net `-41 / +43` lines.
- `tests/gateway/test_discord_send.py` — Replace the three legacy `_typing_tasks`-based lifecycle tests with **6 focused regression tests** for the new contract:
  - `test_send_typing_issues_single_request_per_call` — one POST per call, no task spawned.
  - `test_send_typing_swallows_api_errors_without_raising` — rate-limit / 5xx must not crash `_keep_typing`.
  - `test_send_typing_repeated_calls_each_issue_one_request` — three calls = three POSTs (no coalescing).
  - `test_stop_typing_is_idempotent_noop` — `stop_typing` is safe to call before/after/multiple times.
  - `test_send_typing_no_client_is_silent` — pre-connect / post-disconnect path.
  - `test_no_orphan_loop_after_stop_typing_send_typing_race` — direct reproduction of the #26854 race (interleaved `stop_typing` / `send_typing`) proving no task is ever left behind.

## How to Test

```bash
# 1. New typing-lifecycle tests pass
python -m pytest tests/gateway/test_discord_send.py -q
# expected: 20 passed (the 6 typing tests above + 14 pre-existing send/forum tests)

# 2. Base-adapter _keep_typing timeout suite still passes
python -m pytest tests/gateway/test_keep_typing_timeout.py -q
# expected: 5 passed

# 3. Broader Discord regression sweep
python -m pytest tests/gateway/test_discord_send.py \
                tests/gateway/test_discord_race_polish.py \
                tests/gateway/test_discord_connect.py \
                tests/gateway/test_discord_thread_persistence.py \
                tests/gateway/test_discord_reply_mode.py \
                tests/gateway/test_discord_imports.py \
                tests/gateway/test_keep_typing_timeout.py -q
# expected: 84 passed

# 4. Manual: stop/send race reproduction
python -c "
import asyncio
from unittest.mock import AsyncMock, MagicMock
import sys
sys.path.insert(0, 'tests/gateway')
from test_discord_send import _ensure_discord_mock
_ensure_discord_mock()
from gateway.config import PlatformConfig
from gateway.platforms.discord import DiscordAdapter

async def main():
    a = DiscordAdapter(PlatformConfig(enabled=True, token='***'))
    a._client = MagicMock()
    a._client.http = MagicMock()
    a._client.http.request = AsyncMock()
    # Same interleaving that caused the stuck indicator pre-fix:
    await a.send_typing('c')
    await a.stop_typing('c')
    await a.send_typing('c')
    await a.stop_typing('c')
    print('typing_tasks:', a._typing_tasks)
    print('posts:', a._client.http.request.await_count)
asyncio.run(main())
"
# expected: typing_tasks: {}   posts: 2
```

End-to-end against a real Discord workspace: send a long-running prompt (2+ minutes of tool calls) in a thread, wait for the response, and confirm the "is typing..." indicator disappears within Discord's native ~10 s TTL after the final chunk is delivered (previously: stuck until gateway restart).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `test(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `python -m pytest tests/gateway/test_discord_send.py tests/gateway/test_keep_typing_timeout.py -q` and all 25 tests pass
- [x] I've added tests for my changes (6 new regression tests, including a direct race-condition reproduction)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config / behavior change beyond bug fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python adapter change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix (issue #26854 timeline):

```
14:02:11 [_keep_typing tick]   send_typing(c1)   -> spawns _typing_loop A in _typing_tasks[c1]
14:02:13 [_keep_typing tick]   send_typing(c1)   -> already in _typing_tasks[c1], skipped
...
14:04:30 [agent finishes]      stop_typing(c1)   -> cancels _typing_loop A
14:04:30 [_keep_typing tick]   send_typing(c1)   -> spawns _typing_loop B   <-- race
14:04:30 [_stop_typing_task]   wait_for(typing_task, 0.5s) -> times out
14:04:31 [_keep_typing exits]  cancellation, finally: stop_typing -> pops, but B is still alive
14:04:38 [_typing_loop B]      POST /channels/c1/typing                 <-- orphan refresh
14:04:46 [_typing_loop B]      POST /channels/c1/typing
...                                                                     (forever, until restart)
```

After the fix (same sequence):

```
14:02:11 [_keep_typing tick]   send_typing(c1)   -> 1 POST, no task
14:02:13 [_keep_typing tick]   send_typing(c1)   -> 1 POST, no task
...
14:04:30 [agent finishes]      stop_typing(c1)   -> no-op (nothing to cancel)
14:04:30 [_keep_typing tick]   send_typing(c1)   -> 1 POST, no task
14:04:30 [_keep_typing exits]  cancellation, finally: stop_typing -> no-op
14:04:40 [Discord backend]     ~10 s typing TTL elapsed, indicator clears
```
