### PR TITLE
fix(security): separate OAuth PKCE state from code_verifier (#10693)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1060,12 +1060,12 @@ def _generate_pkce() -> tuple:
 
 def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     """Run Hermes-native OAuth PKCE flow and return credential state."""
+    import secrets
     import time
     import webbrowser
 
     verifier, challenge = _generate_pkce()
-    import secrets as _secrets
-    oauth_state = _secrets.token_urlsafe(32)
+    oauth_state = secrets.token_urlsafe(32)
 
     params = {
         "code": "true",

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1064,6 +1064,8 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     import webbrowser
 
     verifier, challenge = _generate_pkce()
+    import secrets as _secrets
+    oauth_state = _secrets.token_urlsafe(32)
 
     params = {
         "code": "true",
@@ -1073,7 +1075,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         "scope": _OAUTH_SCOPES,
         "code_challenge": challenge,
         "code_challenge_method": "S256",
-        "state": verifier,
+        "state": oauth_state,
     }
     from urllib.parse import urlencode
 
@@ -1110,7 +1112,12 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
 
     splits = auth_code.split("#")
     code = splits[0]
-    state = splits[1] if len(splits) > 1 else ""
+    received_state = splits[1] if len(splits) > 1 else ""
+
+    # Validate state to prevent CSRF (RFC 6749 §10.12)
+    if received_state != oauth_state:
+        logger.warning("OAuth state mismatch — possible CSRF, aborting")
+        return None
 
     try:
         import urllib.request
@@ -1119,7 +1126,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "grant_type": "authorization_code",
             "client_id": _OAUTH_CLIENT_ID,
             "code": code,
-            "state": state,
+            "state": received_state,
             "redirect_uri": _OAUTH_REDIRECT_URI,
             "code_verifier": verifier,
         }).encode()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
+    "70629228+shaun0927@users.noreply.github.com": "shaun0927",
     "98262967+Bihruze@users.noreply.github.com": "Bihruze",
     "nidhi2894@gmail.com": "nidhi-singh02",
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -1,0 +1,170 @@
+"""Regression tests for the Anthropic OAuth PKCE flow.
+
+Guards against re-introducing the bug where the PKCE ``code_verifier`` was
+reused as the OAuth ``state`` parameter, leaking the verifier via the
+authorization URL (browser history, Referer headers, auth-server logs) and
+removing CSRF protection on the callback path.
+
+History:
+  - PR #1775 first fixed this on ``run_hermes_oauth_login()``.
+  - PR #2647 (b17e5c10) added ``run_hermes_oauth_login_pure()`` and silently
+    copy-pasted the pre-#1775 vulnerable pattern.
+  - PR #3107 removed the old function, leaving only the regressed copy.
+  - PR #10699 (issue #10693) fixed the regression on the surviving function.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any, Dict
+from urllib.parse import parse_qs, urlparse
+
+
+def _patch_oauth_flow(
+    monkeypatch,
+    *,
+    callback_code: str,
+    token_response: Dict[str, Any] | None = None,
+    capture_token_request: Dict[str, Any] | None = None,
+    capture_auth_url: Dict[str, str] | None = None,
+) -> None:
+    """Wire up monkeypatches that let ``run_hermes_oauth_login_pure()`` run
+    end-to-end without touching a real browser, stdin, or HTTP endpoint.
+
+    ``callback_code`` is the literal string the user would paste back into the
+    terminal (``"<code>#<state>"`` format).
+    ``capture_token_request`` and ``capture_auth_url`` are out-dict captures
+    so the test can introspect what was sent to the auth URL and the token
+    endpoint, respectively.
+    """
+    import urllib.request
+
+    if token_response is None:
+        token_response = {
+            "access_token": "sk-ant-test-access",
+            "refresh_token": "sk-ant-test-refresh",
+            "expires_in": 3600,
+        }
+
+    def fake_open(url):
+        if capture_auth_url is not None:
+            capture_auth_url["url"] = url
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+    monkeypatch.setattr("builtins.input", lambda *_a, **_kw: callback_code)
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def fake_urlopen(req, *_a, **_kw):
+        if capture_token_request is not None:
+            capture_token_request["url"] = req.full_url
+            capture_token_request["data"] = json.loads(req.data.decode())
+            capture_token_request["headers"] = dict(req.headers)
+        return _FakeResponse(json.dumps(token_response).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+def test_authorization_url_state_is_not_pkce_verifier(monkeypatch, tmp_path):
+    """The ``state`` parameter in the authorization URL must NOT equal the
+    PKCE ``code_verifier``.
+
+    Reusing the verifier as state leaks the verifier into browser history,
+    Referer headers, and auth-server access logs — defeating RFC 7636.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    captured_token: Dict[str, Any] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        # state echoed back unchanged so the CSRF guard passes
+        callback_code="auth-code-from-anthropic#PLACEHOLDER",
+        capture_auth_url=captured_url,
+        capture_token_request=captured_token,
+    )
+
+    # Stub the callback parse: we need the state echoed back to match. To do
+    # that without hardcoding the state value, override input() AFTER seeing
+    # the auth URL.
+    import builtins
+
+    real_input_calls = {"count": 0}
+
+    def fake_input(*_a, **_kw):
+        real_input_calls["count"] += 1
+        # First (and only) call is the "Authorization code:" prompt.
+        url = captured_url.get("url", "")
+        qs = parse_qs(urlparse(url).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code-from-anthropic#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+    assert result is not None, "OAuth flow should succeed with matching state"
+
+    url = captured_url["url"]
+    qs = parse_qs(urlparse(url).query)
+
+    assert "state" in qs and qs["state"][0], "authorization URL must include state"
+    assert "code_challenge" in qs, "authorization URL must include code_challenge"
+
+    state_in_url = qs["state"][0]
+    verifier_sent = captured_token["data"]["code_verifier"]
+
+    # The whole point: state and verifier must be independent values.
+    assert state_in_url != verifier_sent, (
+        "PKCE code_verifier was reused as OAuth state — regression of #10693 / "
+        "#1775. The verifier is supposed to be a secret known only to the "
+        "client; placing it in the authorization URL leaks it via browser "
+        "history, Referer headers, and auth-server logs."
+    )
+
+    # And the verifier MUST NOT appear anywhere in the URL.
+    assert verifier_sent not in url, (
+        "PKCE verifier leaked into authorization URL — regression of #10693"
+    )
+
+
+def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
+    """If the state returned in the callback does not match the one we sent
+    in the authorization URL, the flow must abort before exchanging the code.
+
+    Without this check, an attacker who tricks the user into pasting a
+    crafted ``<code>#<state>`` string can complete the token exchange — the
+    CSRF protection that ``state`` is supposed to provide (RFC 6749 §10.12)
+    would be absent.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_token: Dict[str, Any] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="attacker-code#attacker-state-does-not-match",
+        capture_token_request=captured_token,
+    )
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is None, "mismatched state must abort the flow"
+    assert "url" not in captured_token, (
+        "token exchange must NOT happen when state mismatches"
+    )


### PR DESCRIPTION
Salvage of #10699 by @shaun0927 — cherry-picked clean onto current main with contributor authorship preserved.

## Summary
`run_hermes_oauth_login_pure()` reused the PKCE `code_verifier` as the OAuth `state` parameter, leaking the verifier into the authorization URL (browser history, Referer headers, auth-server logs) and removing CSRF protection on the callback. Now generates an independent `secrets.token_urlsafe(32)` for `state` and validates it before token exchange.

## Regression context
This exact bug was fixed in PR #1775 on the old `run_hermes_oauth_login()`. PR #2647 (commit b17e5c10, credential pools) added a new `run_hermes_oauth_login_pure()` and silently copy-pasted the pre-#1775 vulnerable pattern. PR #3107 then removed the old (fixed) function, leaving only the regressed copy.

## Changes
- `agent/anthropic_adapter.py` (+10/-3) — @shaun0927's fix, cherry-picked
- `tests/agent/test_anthropic_oauth_pkce.py` (+159) — two regression tests:
  - `test_authorization_url_state_is_not_pkce_verifier` — asserts state in the auth URL is independent from the verifier sent in the token exchange, and the verifier never appears in the URL
  - `test_callback_state_mismatch_aborts` — asserts the flow returns None (no token exchange) when callback state does not match
- `scripts/release.py` — AUTHOR_MAP entry for shaun0927

## Validation
- Targeted: 200/200 pass across `test_anthropic_oauth_pkce.py`, `test_anthropic_adapter.py`, `test_anthropic_oauth_flow.py`, `test_auth_commands.py`
- Negative control: reintroducing the b17e5c10 vulnerable pattern (state = verifier, no callback validation) makes both new tests fail

Closes #10693
Supersedes #10699