### PR TITLE
fix(tui): probe loopback CDP discovery endpoints

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3935,6 +3935,45 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
     assert urls[0] == "http://127.0.0.1:9222/json/version"
 
 
+def test_browser_manage_connect_default_local_uses_ipv6_when_ipv4_is_not_cdp(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    urls: list[str] = []
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def _opener(url, timeout=2.0):  # noqa: ARG001 - match urllib signature
+        urls.append(url)
+        if "[::1]:9222" in url:
+            return _Resp()
+        raise OSError("not a Chrome CDP discovery endpoint")
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _opener)
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        resp = server.handle_request(
+            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
+        )
+
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://[::1]:9222"
+    assert resp["result"]["messages"] == ["Chrome is already listening on port 9222"]
+    assert os.environ["BROWSER_CDP_URL"] == "http://[::1]:9222"
+    assert "http://127.0.0.1:9222/json/version" in urls
+    assert "http://[::1]:9222/json/version" in urls
+
+
 def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
     emitted: list[tuple[str, dict]] = []
@@ -3971,13 +4010,13 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
             )
 
     assert resp["result"]["connected"] is False
-    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+    assert resp["result"]["url"] == "http://localhost:9222"
     assert (
         resp["result"]["messages"][0]
         == "Chrome isn't running with remote debugging — attempting to launch..."
     )
     assert any(
-        "No Chrome/Chromium executable was found" in line
+        "Start Chrome with remote debugging" in line
         for line in resp["result"]["messages"]
     )
     assert any(
@@ -4086,7 +4125,7 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
 
     def _opener(_url, timeout=2.0):  # noqa: ARG001 — match urllib signature
         attempts["n"] += 1
-        if attempts["n"] < 3:
+        if attempts["n"] < 7:
             raise OSError("not ready")
         return _Resp()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6029,7 +6029,7 @@ def _is_default_local_cdp(parsed) -> bool:
     discovery_path = parsed.path in {"", "/", "/json", "/json/version"}
     return (
         parsed.scheme in {"http", "ws"}
-        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.hostname in {"127.0.0.1", "localhost", "::1"}
         and port == 9222
         and discovery_path
     )
@@ -6049,6 +6049,46 @@ def _probe_urls(parsed) -> list[str]:
     scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme)
     root = f"{scheme}://{parsed.netloc}".rstrip("/")
     return [f"{root}/json/version", f"{root}/json"]
+
+
+def _loopback_probe_candidates(parsed) -> list:
+    """Return local CDP discovery candidates, preserving the user's first choice.
+
+    macOS can end up with two Chrome listeners on the same port: one bound to
+    IPv4 ``127.0.0.1`` that is not a DevTools endpoint, and the real debug
+    Chrome bound to IPv6 ``::1``.  A plain TCP check or a hard normalization to
+    ``127.0.0.1`` then misses the connectable browser.  For the default local
+    CDP endpoint, probe all loopback spellings and keep the first one that
+    actually serves Chrome's discovery API.
+    """
+    try:
+        port = parsed.port or (443 if parsed.scheme in {"https", "wss"} else 80)
+    except ValueError:
+        return [parsed]
+
+    hosts = [parsed.hostname or ""]
+    if _is_default_local_cdp(parsed):
+        hosts.extend(["127.0.0.1", "::1", "localhost"])
+
+    candidates = []
+    seen: set[str] = set()
+    for host in hosts:
+        if not host:
+            continue
+        netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+        candidate = parsed._replace(
+            netloc=netloc,
+            path="",
+            params="",
+            query="",
+            fragment="",
+        )
+        key = candidate.geturl()
+        if key not in seen:
+            candidates.append(candidate)
+            seen.add(key)
+
+    return candidates or [parsed]
 
 
 def _normalize_cdp_url(parsed) -> str:
@@ -6133,11 +6173,10 @@ def _browser_connect(rid, params: dict) -> dict:
     except ValueError:
         return _err(rid, 4015, f"invalid port in browser url: {url}")
 
-    # Always normalize default-local to 127.0.0.1:9222 so downstream
-    # comparisons + messaging match what we'll actually persist.
-    if _is_default_local_cdp(parsed):
-        url = DEFAULT_BROWSER_CDP_URL
-        parsed = urlparse(url)
+    default_local_cdp = _is_default_local_cdp(parsed)
+    if default_local_cdp:
+        parsed = _normalize_cdp_url(parsed)
+        parsed = urlparse(parsed)
         port = parsed.port or 9222
 
     try:
@@ -6155,10 +6194,21 @@ def _browser_connect(rid, params: dict) -> dict:
             except OSError as e:
                 return _err(rid, 5031, f"could not reach browser CDP at {url}: {e}")
         else:
-            probes = _probe_urls(parsed)
-            ok = any(_http_ok(p, timeout=2.0) for p in probes)
+            candidates = _loopback_probe_candidates(parsed) if default_local_cdp else [parsed]
 
-            if not ok and _is_default_local_cdp(parsed):
+            def _pick_reachable_candidate(timeout: float):
+                for candidate in candidates:
+                    if any(_http_ok(p, timeout=timeout) for p in _probe_urls(candidate)):
+                        return candidate
+                return None
+
+            reachable = _pick_reachable_candidate(timeout=2.0)
+            ok = reachable is not None
+            if reachable is not None:
+                parsed = reachable
+                port = parsed.port or port
+
+            if not ok and default_local_cdp:
                 from hermes_cli.browser_connect import try_launch_chrome_debug
 
                 announce(
@@ -6168,7 +6218,10 @@ def _browser_connect(rid, params: dict) -> dict:
                 if try_launch_chrome_debug(port, system):
                     for _ in range(20):
                         time.sleep(0.5)
-                        if any(_http_ok(p, timeout=1.0) for p in probes):
+                        reachable = _pick_reachable_candidate(timeout=1.0)
+                        if reachable is not None:
+                            parsed = reachable
+                            port = parsed.port or port
                             ok = True
                             break
 
@@ -6182,7 +6235,7 @@ def _browser_connect(rid, params: dict) -> dict:
                     )
             elif not ok:
                 return _err(rid, 5031, f"could not reach browser CDP at {url}")
-            elif _is_default_local_cdp(parsed):
+            elif default_local_cdp:
                 announce(f"Chrome is already listening on port {port}")
 
         normalized = _normalize_cdp_url(parsed)


### PR DESCRIPTION
## What does this PR do?

Fixes #26864.

This fixes default-local TUI `/browser connect` when the valid Chrome CDP endpoint is bound on IPv6 loopback (`[::1]:9222`) while IPv4 loopback (`127.0.0.1:9222`) has a listener that is not a usable CDP discovery endpoint.

The change makes the TUI gateway validate default-local loopback candidates by probing Chrome's CDP discovery endpoints and persisting the first candidate that actually serves `/json/version` or `/json`.

## Related Issue

Fixes #26864

Related but non-duplicative upstream work checked before opening this PR:

- #10231: switched default from `localhost` to `127.0.0.1` for IPv6-first localhost failures. This PR handles the inverse case.
- #12912 / #12968: broader local Chrome CDP validation work.
- #17238: TUI `/browser connect` local CDP handling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Treat `::1` as a default local CDP host.
  - Add default-local loopback candidate probing for `127.0.0.1`, `::1`, and `localhost`, preserving the requested host first.
  - Select and persist the first loopback candidate whose `/json/version` or `/json` endpoint responds successfully.
- `tests/test_tui_gateway_server.py`
  - Add regression coverage for the macOS split-listener case where `127.0.0.1:9222` is not CDP but `[::1]:9222` is the valid CDP endpoint.
  - Adjust affected expectations so failed explicit `localhost` connects preserve the requested URL and launch-retry tests still exercise the intended retry path.

## How to Test

Reproduction observed before the fix:

1. Start or observe Chrome debugging on port `9222` on macOS.
2. Confirm IPv4 loopback is not the usable CDP endpoint:
   ```bash
   curl -i http://127.0.0.1:9222/json/version
   # HTTP/1.1 404 Not Found
   ```
3. Confirm IPv6 loopback is the usable CDP endpoint:
   ```bash
   curl -i 'http://[::1]:9222/json/version'
   # HTTP/1.1 200 OK, includes webSocketDebuggerUrl
   ```
4. Run `/browser connect` through the TUI browser manage path.
5. With this PR, Hermes probes loopback candidates and persists `http://[::1]:9222` when that is the working endpoint.

Local validation run:

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k 'browser_manage_connect'
# 17 passed

scripts/run_tests.sh tests/test_tui_gateway_server.py -q
# 178 passed

git diff --check
# ok
```

I also ran `graphify update .` per local repo guidance, but graph visualization generation failed because the graph is too large for HTML output. It did not affect the code/test changes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

Note: I ran the targeted TUI gateway suite (`178 passed`), not the full repository test suite.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed before fix:

```bash
curl -i http://127.0.0.1:9222/json/version
# HTTP/1.1 404 Not Found

curl -i 'http://[::1]:9222/json/version'
# HTTP/1.1 200 OK
# Browser: Chrome/148.0.7778.168
# webSocketDebuggerUrl: ws://[::1]:9222/devtools/browser/...
```
