### PR TITLE
fix(achievements): track fallback router routes

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -23,11 +23,27 @@ except ImportError:
 try:
     from fastapi import APIRouter
 except Exception:  # Allows local unit tests without dashboard dependencies.
+    class _FallbackRoute:
+        def __init__(self, path: str, methods: Set[str], endpoint: Any):
+            self.path = path
+            self.methods = methods
+            self.endpoint = endpoint
+
     class APIRouter:  # type: ignore
-        def get(self, *_args, **_kwargs):
-            return lambda fn: fn
-        def post(self, *_args, **_kwargs):
-            return lambda fn: fn
+        def __init__(self):
+            self.routes: List[_FallbackRoute] = []
+
+        def _route(self, method: str, path: str):
+            def decorator(fn):
+                self.routes.append(_FallbackRoute(path, {method}, fn))
+                return fn
+            return decorator
+
+        def get(self, path: str, *_args, **_kwargs):
+            return self._route("GET", path)
+
+        def post(self, path: str, *_args, **_kwargs):
+            return self._route("POST", path)
 
 router = APIRouter()
 

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -1,3 +1,4 @@
+import builtins
 import importlib.util
 import unittest
 from pathlib import Path
@@ -150,6 +151,29 @@ class AchievementEngineTests(unittest.TestCase):
         self.assertEqual(stats["config_events"], 0)
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
+
+    def test_fallback_router_tracks_route_surface_without_fastapi(self):
+        original_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "fastapi":
+                raise ImportError("fastapi intentionally unavailable")
+            return original_import(name, *args, **kwargs)
+
+        spec = importlib.util.spec_from_file_location("plugin_api_no_fastapi", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+
+        try:
+            builtins.__import__ = blocked_import
+            spec.loader.exec_module(module)
+        finally:
+            builtins.__import__ = original_import
+
+        routes_by_path = {route.path: route.methods for route in module.router.routes}
+        self.assertIn("/achievements", routes_by_path)
+        self.assertEqual(routes_by_path["/achievements"], {"GET"})
+        self.assertEqual(routes_by_path["/rescan"], {"POST"})
+        self.assertNotIn("/overview", routes_by_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Mirrors minimal FastAPI `APIRouter` route metadata in the Hermes achievements fallback router when optional dashboard deps are unavailable.
- Adds a regression test that imports the achievement plugin with `fastapi` intentionally unavailable and verifies route metadata for GET/POST endpoints.
- Keeps the fallback useful for route-surface assertions instead of exposing an always-empty `routes` list.

## Hermes Review
- Static scan of added lines: no secrets, shell injection, eval/exec, pickle, SQL string formatting, merge conflict markers, or debug leftovers.
- Independent Hermes reviewer approved with only non-blocking suggestions.
- PR branch was isolated from `origin/main` so Vega's divergent local `main` commits are not included.

## Test Plan
- `git diff --check`
- `/Users/kanjiz-vega/.hermes/hermes-agent/.venv/bin/python -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py plugins/hermes-achievements/tests/test_achievement_engine.py`
- `/Users/kanjiz-vega/.hermes/hermes-agent/.venv/bin/python -m unittest discover -s plugins/hermes-achievements/tests -p 'test_achievement_engine.py' -v`
- `scripts/run_tests.sh tests/plugins/test_achievements_plugin.py -q`
- `scripts/run_tests.sh plugins/hermes-achievements/tests/ tests/plugins/test_achievements_plugin.py -q`
