### PR TITLE
feat(skills): add global skills.auto_load config (#26800)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -509,3 +509,48 @@ def is_valid_namespace(candidate: Optional[str]) -> bool:
     if not candidate:
         return False
     return bool(_NAMESPACE_RE.match(candidate))
+
+
+# ── Global auto-load skills (#26800) ─────────────────────────────────────
+
+
+def get_auto_load_skills() -> List[str]:
+    """Read ``skills.auto_load`` from config.yaml.
+
+    Returns an ordered, deduplicated list of skill identifiers that should
+    be pre-loaded at the start of every new session (CLI, TUI, gateway).
+
+    Per-channel ``auto_skill`` bindings in the gateway still apply on top
+    of this list — see ``gateway/platforms/base.py::resolve_channel_skills``.
+
+    Returns an empty list when the key is missing, the config can't be
+    parsed, or the value is the wrong type — callers should treat the
+    feature as opt-in.
+    """
+    config_path = get_config_path()
+    if not config_path.exists():
+        return []
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return []
+    raw = skills_cfg.get("auto_load")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    seen: Set[str] = set()
+    out: List[str] = []
+    for item in raw:
+        name = str(item).strip()
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -538,6 +538,17 @@ skills:
   # Set to 0 to disable.
   creation_nudge_interval: 15
 
+  # Auto-load these skills at the start of every NEW session (#26800).
+  # Applies to CLI (`hermes chat`), TUI gateway, and chat gateways
+  # (Telegram/Discord/...).  Order is preserved; duplicates are dropped.
+  #
+  # CLI:     prepended to `-s/--skills`; suppressed by `--ignore-rules`.
+  # Gateway: merged BEFORE per-channel `channel_skill_bindings`.
+  # Resumed sessions are NOT re-injected (the skill is already in history).
+  # auto_load:
+  #   - using-superpowers
+  #   - my-house-style
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/cli.py
+++ b/cli.py
@@ -13976,6 +13976,14 @@ def main(
     
     parsed_skills = _parse_skills_argument(skills)
 
+    # Prepend config-driven auto-load skills (#26800).  Suppressed by
+    # --ignore-rules (HERMES_IGNORE_RULES=1), which the docs describe as
+    # skipping auto-injection of "preloaded skills".  Explicit -s/--skills
+    # still wins via build_preloaded_skills_prompt's internal dedup.
+    if not (ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"):
+        from agent.skill_utils import get_auto_load_skills
+        parsed_skills = list(get_auto_load_skills()) + parsed_skills
+
     # Create CLI instance
     cli = HermesCLI(
         model=model,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7267,13 +7267,31 @@ class GatewayRunner:
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
 
-        # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
-        # Discord channel_skill_bindings).  Supports a single name or ordered list.
+        # Auto-load skill(s) on NEW sessions, from two sources (in order):
+        #   1. Global ``skills.auto_load`` from config.yaml (#26800)
+        #   2. Per-channel ``auto_skill`` (Telegram DM Topics, Discord
+        #      channel_skill_bindings) — supports a single name or ordered list.
         # Only inject on NEW sessions — ongoing conversations already have the
         # skill content in their conversation history from the first message.
+        _global_auto: list[str] = []
+        try:
+            from agent.skill_utils import get_auto_load_skills
+            _global_auto = get_auto_load_skills()
+        except Exception as _e:
+            logger.debug("[Gateway] skills.auto_load read failed: %s", _e)
+
         _auto = getattr(event, "auto_skill", None)
-        if _is_new_session and _auto:
-            _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
+        _per_channel = (
+            [_auto] if isinstance(_auto, str) else (list(_auto) if _auto else [])
+        )
+        _skill_names: list[str] = []
+        _seen_names: set[str] = set()
+        for _n in list(_global_auto) + _per_channel:
+            if _n and _n not in _seen_names:
+                _seen_names.add(_n)
+                _skill_names.append(_n)
+
+        if _is_new_session and _skill_names:
             try:
                 from agent.skill_commands import _load_skill_payload, _build_skill_message
                 _combined_parts: list[str] = []

--- a/tests/agent/test_auto_load_skills.py
+++ b/tests/agent/test_auto_load_skills.py
@@ -1,0 +1,76 @@
+"""Tests for skills.auto_load config (#26800)."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    return home
+
+
+def _read(home):
+    from agent.skill_utils import get_auto_load_skills
+    with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
+        return get_auto_load_skills()
+
+
+class TestGetAutoLoadSkills:
+    def test_no_config_file(self, tmp_path):
+        home = tmp_path / "missing"
+        assert _read(home) == []
+
+    def test_missing_skills_block(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("agent:\n  max_turns: 10\n")
+        assert _read(hermes_home) == []
+
+    def test_missing_auto_load_key(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  creation_nudge_interval: 15\n"
+        )
+        assert _read(hermes_home) == []
+
+    def test_empty_list(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("skills:\n  auto_load: []\n")
+        assert _read(hermes_home) == []
+
+    def test_single_string_value(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  auto_load: using-superpowers\n"
+        )
+        assert _read(hermes_home) == ["using-superpowers"]
+
+    def test_list_value_order_preserved(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  auto_load:\n    - alpha\n    - beta\n    - gamma\n"
+        )
+        assert _read(hermes_home) == ["alpha", "beta", "gamma"]
+
+    def test_duplicates_deduplicated(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  auto_load:\n    - alpha\n    - beta\n    - alpha\n"
+        )
+        assert _read(hermes_home) == ["alpha", "beta"]
+
+    def test_whitespace_stripped_and_empties_dropped(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  auto_load:\n    - '  alpha  '\n    - ''\n    - beta\n"
+        )
+        assert _read(hermes_home) == ["alpha", "beta"]
+
+    def test_invalid_type_returns_empty(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("skills:\n  auto_load: 42\n")
+        assert _read(hermes_home) == []
+
+    def test_skills_block_not_mapping(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("skills: not-a-mapping\n")
+        assert _read(hermes_home) == []
+
+    def test_malformed_yaml_swallowed(self, hermes_home):
+        (hermes_home / "config.yaml").write_text("skills: [unterminated\n")
+        assert _read(hermes_home) == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1866,6 +1866,10 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
     agent_cfg = cfg.get("agent") or {}
     system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     startup_skills = _parse_tui_skills_env()
+    # Prepend config-driven auto-load skills (#26800).  build_preloaded_skills_prompt
+    # deduplicates internally so env-supplied skills still win when both list the same name.
+    from agent.skill_utils import get_auto_load_skills
+    startup_skills = list(get_auto_load_skills()) + list(startup_skills)
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
 


### PR DESCRIPTION
Adds a `skills.auto_load` list under the existing `skills:` config block so listed skills are pre-loaded at the start of every NEW session across all three real entry points — CLI (`hermes chat`), TUI gateway, and chat gateways (Telegram/Discord/IRC/...). Closes #26800.

## Changes

- **agent/skill_utils.py** (+45): new `get_auto_load_skills()` — direct YAML read with defensive type checks, returns `[]` on any failure. Sibling to existing `get_disabled_skill_names` / `get_external_skills_dirs`.
- **cli.py** (+8): prepended to `-s/--skills`; suppressed by `--ignore-rules` / `HERMES_IGNORE_RULES=1` (matches existing "auto-injection" semantics).
- **gateway/run.py** (+22/-4): merged with per-channel `event.auto_skill`, guarded by existing `_is_new_session` check so resumed sessions aren't re-injected.
- **tui_gateway/server.py** (+4): prepended to env-driven `_parse_tui_skills_env()`.
- **cli-config.yaml.example** (+11): commented example with order/dedup/suppression notes.
- **tests/agent/test_auto_load_skills.py** (new, 76 lines): 11 cases covering missing config, missing key, scalar vs list, dedup, whitespace strip, malformed YAML, wrong type, non-mapping `skills:`.

## Design

All three call sites already share `build_preloaded_skills_prompt()` for payload assembly; this change only feeds it an additional list source. `build_preloaded_skills_prompt()` deduplicates internally (first-seen wins), so explicit per-session selectors and per-channel `channel_skill_bindings` still compose correctly with the global list.

## Validation

|  | Before | After (`auto_load: [using-superpowers]`) |
|---|---|---|
| `hermes chat -q \"...\"` | system_prompt has no skill body | system_prompt contains using-superpowers body |
| `hermes chat --ignore-rules -q \"...\"` | (unchanged) | auto_load skipped — matches `--ignore-rules` contract |
| Gateway new session | only per-channel `auto_skill` injected | global `auto_load` + per-channel `auto_skill`, deduplicated |
| Gateway resumed session | no injection (existing behavior) | no injection (guard preserved) |

- `scripts/run_tests.sh` on touched suites: 61 passing (`tests/agent/test_auto_load_skills.py`, `test_skill_commands.py`, `test_external_skills.py`, `tests/cli/test_cli_preloaded_skills.py`).
- `scripts/check-windows-footguns.py` on touched files: clean.
- `ruff check` on touched files: clean.
- Manual E2E with isolated `HERMES_HOME`: skill body verified in `cli.system_prompt`.

## Platforms tested

darwin (macOS 14).

Closes #26800.