### PR TITLE
docs: add Hermes MemPalace to Community plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🧠 [Hermes MemPalace](https://github.com/kjames2001/hermes-mempalace) — Native MemPalace memory provider plugin: semantic search, knowledge graph, and diary journaling via ChromaDB.
 
 ---
 


### PR DESCRIPTION
Add [Hermes MemPalace](https://github.com/kjames2001/hermes-mempalace) — a standalone memory provider plugin that gives Hermes Agent native MemPalace integration (semantic search, knowledge graph, diary journaling via ChromaDB).

Per [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#memory-providers-ship-as-a-standalone-plugin), memory providers are closed to in-tree additions. This plugin was previously submitted as #24283 and has been extracted to a standalone repo as recommended by @kshitijk4poor.

- Repo: https://github.com/kjames2001/hermes-mempalace
- Installs via pip: `pip install hermes-mempalace`
- Implements full MemoryProvider ABC with 5 tools
- Setup wizard support via `post_setup()`