### PR TITLE
Harden Slack and Mattermost mass mention handling

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -44,10 +44,22 @@ _CHANNEL_TYPE_MAP = {
     "O": "channel",
 }
 
+_MATTERMOST_DISABLE_MENTIONS_PROPS = {"disable_mentions": True}
+
 # Reconnect parameters (exponential backoff).
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+
+def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a post payload that prevents Mattermost from firing mentions."""
+    props = payload.get("props")
+    if isinstance(props, dict):
+        payload["props"] = {**props, **_MATTERMOST_DISABLE_MENTIONS_PROPS}
+    else:
+        payload["props"] = dict(_MATTERMOST_DISABLE_MENTIONS_PROPS)
+    return payload
 
 
 def check_mattermost_requirements() -> bool:
@@ -265,10 +277,10 @@ class MattermostAdapter(BasePlatformAdapter):
 
         last_id = None
         for chunk in chunks:
-            payload: Dict[str, Any] = {
+            payload: Dict[str, Any] = _with_mentions_disabled({
                 "channel_id": chat_id,
                 "message": chunk,
-            }
+            })
             # Thread support: reply_to is the root post ID.
             if reply_to and self._reply_mode == "thread":
                 payload["root_id"] = reply_to
@@ -310,7 +322,7 @@ class MattermostAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         data = await self._api_put(
             f"posts/{message_id}/patch",
-            {"message": formatted},
+            _with_mentions_disabled({"message": formatted}),
         )
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to edit post")
@@ -445,11 +457,11 @@ class MattermostAdapter(BasePlatformAdapter):
         if not file_id:
             return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
 
-        payload: Dict[str, Any] = {
+        payload: Dict[str, Any] = _with_mentions_disabled({
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
-        }
+        })
         if reply_to and self._reply_mode == "thread":
             payload["root_id"] = reply_to
 
@@ -483,11 +495,11 @@ class MattermostAdapter(BasePlatformAdapter):
         if not file_id:
             return SendResult(success=False, error="File upload failed")
 
-        payload: Dict[str, Any] = {
+        payload: Dict[str, Any] = _with_mentions_disabled({
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
-        }
+        })
         if reply_to and self._reply_mode == "thread":
             payload["root_id"] = reply_to
 
@@ -570,11 +582,11 @@ class MattermostAdapter(BasePlatformAdapter):
                 if not file_ids:
                     continue
 
-                payload: Dict[str, Any] = {
+                payload: Dict[str, Any] = _with_mentions_disabled({
                     "channel_id": chat_id,
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
-                }
+                })
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,8 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+_SLACK_SPECIAL_MENTION_RE = re.compile(r"<!(?:everyone|channel|here)(?:\|[^>\n]*)?>", re.IGNORECASE)
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -1180,6 +1182,8 @@ class SlackAdapter(BasePlatformAdapter):
         Protected regions (code blocks, inline code) are extracted first so
         their contents are never modified.  Standard markdown constructs
         (headers, bold, italic, links) are translated to mrkdwn syntax.
+        Broadcast mentions are escaped before entity protection so model output
+        cannot trigger workspace- or channel-wide notifications by default.
         """
         if not content:
             return content
@@ -1195,6 +1199,12 @@ class SlackAdapter(BasePlatformAdapter):
             return key
 
         text = content
+
+        # Slack treats <!everyone>, <!channel>, and <!here> as executable
+        # broadcast mentions even when sent by a bot.  Escape only the leading
+        # angle bracket so the token is displayed literally while preserving the
+        # rest of the text for later formatting passes.
+        text = _SLACK_SPECIAL_MENTION_RE.sub(lambda m: m.group(0).replace("<", "&lt;", 1), text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         text = re.sub(

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -180,6 +180,25 @@ class TestMattermostSend:
         assert payload["message"] == "Hello!"
 
     @pytest.mark.asyncio
+    async def test_send_disables_mentions(self):
+        """Bot-authored posts should not trigger @all/@channel notifications."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post123"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send("channel_1", "LLM says: @all restart")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["message"] == "LLM says: @all restart"
+        assert payload["props"]["disable_mentions"] is True
+
+    @pytest.mark.asyncio
     async def test_send_empty_content_succeeds(self):
         """Empty content should return success without calling the API."""
         result = await self.adapter.send("channel_1", "")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1426,8 +1426,16 @@ class TestFormatMessage:
         assert result == "AT&amp;T &lt; 5 &gt; 3"
 
     def test_preserves_existing_slack_entities(self, adapter):
-        text = "Hey <@U123>, see <https://example.com|example> and <!here>"
+        text = "Hey <@U123>, see <https://example.com|example> and <!subteam^S123|team>"
         assert adapter.format_message(text) == text
+
+    def test_escapes_special_broadcast_mentions(self, adapter):
+        text = "Broadcast <!everyone> <!channel> <!here|here>"
+        result = adapter.format_message(text)
+        assert result == "Broadcast &lt;!everyone&gt; &lt;!channel&gt; &lt;!here|here&gt;"
+        assert "<!everyone>" not in result
+        assert "<!channel>" not in result
+        assert "<!here" not in result
 
     def test_strikethrough(self, adapter):
         assert adapter.format_message("~~deleted~~") == "~deleted~"
@@ -1556,13 +1564,13 @@ class TestFormatMessage:
 
     # --- Entity preservation (spec-compliance) ---
 
-    def test_channel_mention_preserved(self, adapter):
-        """<!channel> special mention passes through unchanged."""
-        assert adapter.format_message("Attention <!channel>") == "Attention <!channel>"
+    def test_channel_mention_escaped(self, adapter):
+        """<!channel> broadcast mention is displayed literally."""
+        assert adapter.format_message("Attention <!channel>") == "Attention &lt;!channel&gt;"
 
-    def test_everyone_mention_preserved(self, adapter):
-        """<!everyone> special mention passes through unchanged."""
-        assert adapter.format_message("Hey <!everyone>") == "Hey <!everyone>"
+    def test_everyone_mention_escaped(self, adapter):
+        """<!everyone> broadcast mention is displayed literally."""
+        assert adapter.format_message("Hey <!everyone>") == "Hey &lt;!everyone&gt;"
 
     def test_subteam_mention_preserved(self, adapter):
         """<!subteam^ID> user group mention passes through unchanged."""


### PR DESCRIPTION
## Summary

Fixes #26869.

This hardens Slack and Mattermost gateway delivery against accidental or prompt-induced broadcast mentions in bot-authored output.

Changes:

- Escape Slack broadcast mentions (`<!everyone>`, `<!channel>`, `<!here>`) before the existing Slack entity-preservation pass.
- Keep normal Slack entities such as user mentions, user-group mentions, date tokens, links, and channel links preserved.
- Add Mattermost `props.disable_mentions=true` to bot-authored post and patch payloads, including file/image caption posts.
- Add regression tests for Slack formatting and Mattermost send payloads.

## Testing

- `scripts/run_tests.sh tests/gateway/test_slack.py::TestFormatMessage tests/gateway/test_mattermost.py::TestMattermostSend -q`
