### PR TITLE
fix(discord): add initiator to handoff threads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1583,6 +1583,8 @@ class BasePlatformAdapter(ABC):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        user_ids: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a fresh thread under ``parent_chat_id`` for a session handoff.
 
@@ -1590,6 +1592,11 @@ class BasePlatformAdapter(ABC):
         session to a thread-capable platform — the new thread isolates the
         handed-off conversation from any pre-existing chat in the home
         channel and gives users a clean per-handoff scrollback.
+
+        ``user_ids`` is optional platform-specific context: adapters that
+        support explicit thread membership (Discord) can add/follow the
+        operator immediately after creation. Platforms without membership
+        APIs ignore it.
 
         Returns the new thread/topic id (as a string) on success, or
         ``None`` if the platform doesn't support threading or the

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -11,6 +11,7 @@ Uses discord.py library for:
 
 import asyncio
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -3876,6 +3877,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        user_ids: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a Discord thread under a text channel for a handoff.
 
@@ -3915,6 +3918,48 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_name = (name or "handoff").strip()[:80] or "handoff"
         reason = "Hermes session handoff"
 
+        async def _add_thread_members(thread: Any) -> None:
+            """Best-effort: make handoff threads visible/followed for users.
+
+            Discord only auto-adds the bot that created a thread. For CLI
+            handoffs into a Discord home channel this means the operator may
+            not see the new thread in the channel's thread list. Adding the
+            initiating user (when known) fixes that without needing a visible
+            @mention in the seed message. We intentionally do not fall back to
+            every allowed user: that would make automated handoff/Kanban
+            threads noisy in multi-operator servers.
+            """
+            candidates = user_ids or []
+            seen: set[str] = set()
+            add_user = getattr(thread, "add_user", None)
+            if not callable(add_user):
+                return
+            for raw_user_id in candidates:
+                user_id = _clean_discord_id(str(raw_user_id or ""))
+                if not user_id or not user_id.isdigit() or user_id in seen:
+                    continue
+                seen.add(user_id)
+                try:
+                    user_int = int(user_id)
+                    guild = getattr(thread, "guild", None) or getattr(parent, "guild", None)
+                    user_obj = None
+                    if guild is not None and hasattr(guild, "get_member"):
+                        user_obj = guild.get_member(user_int)
+                    if user_obj is None and self._client is not None and hasattr(self._client, "get_user"):
+                        user_obj = self._client.get_user(user_int)
+                    if user_obj is None and discord is not None:
+                        user_obj = discord.Object(id=user_int)
+                    if user_obj is None:
+                        continue
+                    result = add_user(user_obj)
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] Handoff thread: failed to add user %s to thread %s: %s",
+                        self.name, user_id, getattr(thread, "id", "?"), exc,
+                    )
+
         # First try: create a thread directly on the channel.
         try:
             create = getattr(parent, "create_thread", None)
@@ -3924,6 +3969,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=1440,
                     reason=reason,
                 )
+                await _add_thread_members(thread)
                 return str(thread.id)
         except Exception as direct_error:
             logger.debug(
@@ -3942,6 +3988,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=1440,
                 reason=reason,
             )
+            await _add_thread_members(thread)
             return str(thread.id)
         except Exception as fallback_error:
             logger.warning(

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -704,6 +704,8 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        user_ids: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a Slack thread anchor for a session handoff.
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -987,6 +987,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
+        *,
+        user_ids: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a forum topic for a session handoff.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3923,9 +3923,21 @@ class GatewayRunner:
         # synthetic turn still lands; just without thread isolation.
         thread_name = f"Hermes — {cli_title}"
         try:
-            new_thread_id = await adapter.create_handoff_thread(
-                str(home.chat_id), thread_name,
-            )
+            create_handoff = adapter.create_handoff_thread
+            handoff_user_id = str(row.get("user_id") or "").strip()
+            create_kwargs: dict[str, Any] = {}
+            try:
+                if "user_ids" in inspect.signature(create_handoff).parameters and handoff_user_id:
+                    create_kwargs["user_ids"] = [handoff_user_id]
+            except (TypeError, ValueError):
+                if handoff_user_id:
+                    create_kwargs["user_ids"] = [handoff_user_id]
+            try:
+                new_thread_id = await create_handoff(str(home.chat_id), thread_name, **create_kwargs)
+            except TypeError:
+                if not create_kwargs:
+                    raise
+                new_thread_id = await create_handoff(str(home.chat_id), thread_name)
         except Exception as exc:
             logger.debug(
                 "Handoff: create_handoff_thread raised on %s: %s",

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -445,3 +445,43 @@ async def test_typing_stop_cleans_up():
 
     await adapter.stop_typing("12345")
     assert "12345" not in adapter._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_adds_requested_discord_members():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    member = SimpleNamespace(id=123)
+    guild = SimpleNamespace(get_member=lambda user_id: member if user_id == 123 else None)
+    thread = SimpleNamespace(id=555, guild=guild, add_user=AsyncMock())
+    parent = SimpleNamespace(id=999, guild=guild, create_thread=AsyncMock(return_value=thread))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: parent,
+        fetch_channel=AsyncMock(),
+        get_user=lambda _user_id: None,
+    )
+
+    thread_id = await adapter.create_handoff_thread("999", "queued handoff", user_ids=["123", "123", ""])
+
+    assert thread_id == "555"
+    parent.create_thread.assert_awaited_once()
+    thread.add_user.assert_awaited_once_with(member)
+
+
+@pytest.mark.asyncio
+async def test_create_handoff_thread_does_not_add_allowed_users_when_no_explicit_user():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._allowed_user_ids = {"123", "not-a-snowflake"}
+    member = SimpleNamespace(id=123)
+    guild = SimpleNamespace(get_member=lambda user_id: member if user_id == 123 else None)
+    thread = SimpleNamespace(id=555, guild=guild, add_user=AsyncMock())
+    parent = SimpleNamespace(id=999, guild=guild, create_thread=AsyncMock(return_value=thread))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: parent,
+        fetch_channel=AsyncMock(),
+        get_user=lambda _user_id: None,
+    )
+
+    thread_id = await adapter.create_handoff_thread("999", "queued handoff")
+
+    assert thread_id == "555"
+    thread.add_user.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Adds an optional `user_ids` argument to handoff-thread creation so platforms with explicit thread membership APIs can include the initiating operator.
- Implements best-effort Discord `thread.add_user(...)` for explicit handoff initiators.
- Avoids falling back to all allowed Discord users, so automated handoff threads do not become noisy in multi-operator servers.

## Testing
- `python -m pytest tests/gateway/test_discord_send.py -o 'addopts=' -q`
- Included in combined local convergence run: `272 passed`
