### PR TITLE
[verified] fix: harden reliability edge cases

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -67,6 +67,19 @@ _EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
 _ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z(-\d{2})?$")
 
 
+def _snapshot_tar_filter(member: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+    """Skip link entries so snapshots remain safe to restore.
+
+    Rollback rejects symlink and hardlink members because their targets can
+    escape the extraction directory. Avoid producing those members ourselves
+    when a user has symlinks under ``skills/``.
+    """
+    if member.issym() or member.islnk():
+        logger.warning("Skipping link in curator snapshot: %s", member.name)
+        return None
+    return member
+
+
 def _backups_dir() -> Path:
     return get_hermes_home() / "skills" / ".curator_backups"
 
@@ -256,7 +269,12 @@ def snapshot_skills(reason: str = "manual") -> Optional[Path]:
                     continue
                 # arcname: store paths relative to skills/ so extraction
                 # drops cleanly back into the skills dir.
-                tf.add(str(entry), arcname=entry.name, recursive=True)
+                tf.add(
+                    str(entry),
+                    arcname=entry.name,
+                    recursive=True,
+                    filter=_snapshot_tar_filter,
+                )
         # Capture cron/jobs.json alongside the tarball. Never fails the
         # snapshot — the skills side is the core guarantee; cron is
         # additive. We still record in the manifest whether it was
@@ -602,12 +620,18 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
         with tarfile.open(archive, "r:gz") as tf:
             # Python 3.12+ supports filter='data' for safer extraction.
             # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
+            # still reject absolute paths, .. components, and symlinks
+            # defensively. Symlinks/hard-links in the archive can otherwise
+            # follow out of the extract dir and clobber arbitrary files.
             for member in tf.getmembers():
                 name = member.name
                 if name.startswith("/") or ".." in Path(name).parts:
                     raise tarfile.TarError(
                         f"refusing to extract unsafe path: {name!r}"
+                    )
+                if member.issym() or member.islnk():
+                    raise tarfile.TarError(
+                        f"refusing to extract symlink/hardlink member: {name!r}"
                     )
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -176,9 +176,17 @@ def parse_duration(s: str) -> int:
     
     value = int(match.group(1))
     unit = match.group(2)[0]  # First char: m, h, or d
-    
+
     multipliers = {'m': 1, 'h': 60, 'd': 1440}
-    return value * multipliers[unit]
+    total_minutes = value * multipliers[unit]
+    # Reject zero-length intervals: an "every 0m" schedule would set
+    # next_run_at = now on every tick, producing an unbounded spin loop
+    # in the scheduler. Treat it as malformed at parse time.
+    if total_minutes <= 0:
+        raise ValueError(
+            f"Duration must be at least 1 minute (got '{s}', resolves to {total_minutes}m)"
+        )
+    return total_minutes
 
 
 def parse_schedule(schedule: str) -> Dict[str, Any]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13668,36 +13668,39 @@ class GatewayRunner:
                         "user_name": user_name,
                     })
                     if not source:
+                        # Source resolution failed (missing routing metadata).
+                        # Fall through to the text-only notification path below
+                        # so the user at least gets a plain completion message
+                        # instead of losing the event entirely.
                         logger.warning(
-                            "Dropping completion notification with no routing metadata for process %s",
+                            "No routing metadata for process %s — falling back to text notification",
                             session_id,
                         )
+                    else:
+                        adapter = None
+                        for p, a in self.adapters.items():
+                            if p == source.platform:
+                                adapter = a
+                                break
+                        if adapter and source.chat_id:
+                            try:
+                                synth_event = MessageEvent(
+                                    text=synth_text,
+                                    message_type=MessageType.TEXT,
+                                    source=source,
+                                    internal=True,
+                                )
+                                logger.info(
+                                    "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                                    session_id,
+                                    session_key,
+                                    source.chat_id,
+                                    source.thread_id,
+                                )
+                                await adapter.handle_message(synth_event)
+                            except Exception as e:
+                                logger.error("Agent notify injection error: %s", e)
                         break
-
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p == source.platform:
-                            adapter = a
-                            break
-                    if adapter and source.chat_id:
-                        try:
-                            synth_event = MessageEvent(
-                                text=synth_text,
-                                message_type=MessageType.TEXT,
-                                source=source,
-                                internal=True,
-                            )
-                            logger.info(
-                                "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
-                                session_id,
-                                session_key,
-                                source.chat_id,
-                                source.thread_id,
-                            )
-                            await adapter.handle_message(synth_event)
-                        except Exception as e:
-                            logger.error("Agent notify injection error: %s", e)
-                    break
 
                 # --- Normal text-only notification ---
                 # Decide whether to notify based on mode

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -633,7 +633,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if self._write_thread and self._write_thread.is_alive():
             self._write_thread.join(timeout=2.0)
         self._write_thread = None
-        self._write_thread = threading.Thread(target=_run, daemon=False, name="supermemory-memory-write")
+        self._write_thread = threading.Thread(target=_run, daemon=True, name="supermemory-memory-write")
         self._write_thread.start()
 
     def shutdown(self) -> None:

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -69,9 +69,28 @@ def test_snapshot_excludes_backups_dir_itself(backup_env):
     assert snap2 is not None
     with tarfile.open(snap2 / "skills.tar.gz") as tf:
         names = tf.getnames()
-    assert not any(n.startswith(".curator_backups") for n in names), (
-        "second snapshot must not contain the first snapshot recursively"
-    )
+    assert not any(n.startswith(".curator_backups") for n in names)
+
+
+def test_snapshot_skips_symlink_members(backup_env):
+    """Snapshots should not create link members that rollback refuses to extract."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    real_skill = _write_skill(skills, "real")
+    linked_skill = skills / "linked-skill"
+    try:
+        linked_skill.symlink_to(real_skill, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable on this platform: {exc}")
+
+    snap = cb.snapshot_skills(reason="symlink-test")
+    assert snap is not None
+    with tarfile.open(snap / "skills.tar.gz") as tf:
+        members = tf.getmembers()
+
+    assert all(not (m.issym() or m.islnk()) for m in members)
+    names = [m.name for m in members]
+    assert not any(n == "linked-skill" or n.startswith("linked-skill/") for n in names)
 
 
 def test_snapshot_excludes_hub_dir(backup_env):
@@ -257,6 +276,28 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     ok, msg, _ = cb.rollback()
     assert not ok
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
+
+
+def test_rollback_rejects_tarball_link_member(backup_env):
+    """Tarballs with symlink/hardlink members can target paths outside skills."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        link = tarfile.TarInfo("alpha/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        tf.addfile(link)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok
+    assert "symlink" in msg.lower() or "hardlink" in msg.lower() or "refus" in msg.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -65,6 +65,11 @@ class TestParseDuration:
         with pytest.raises(ValueError):
             parse_duration("m30")
 
+    def test_zero_duration_raises(self):
+        for value in ("0m", "0h", "0d", "000minutes"):
+            with pytest.raises(ValueError, match="at least 1 minute"):
+                parse_duration(value)
+
 
 # =========================================================================
 # parse_schedule

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -32,6 +32,9 @@ class _FakeRegistry:
             return self._sessions.pop(0)
         return None
 
+    def is_completion_consumed(self, session_id):
+        return False
+
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     """Create a GatewayRunner with a fake config for the given mode."""
@@ -243,6 +246,42 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_notify_missing_source_falls_back_to_text_notification(
+    monkeypatch, tmp_path
+):
+    """notify_on_complete should still send text if synthetic routing is unavailable."""
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="python task.py",
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_build_process_event_source", lambda _evt: None)
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = _watcher_dict()
+    watcher["notify_on_complete"] = True
+    await runner._run_process_watcher(watcher)
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+    sent_message = adapter.send.await_args.args[1]
+    assert "finished with exit code 0" in sent_message
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -639,6 +639,23 @@ class TestCheckpoint:
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "missing.json"):
             assert registry.recover_from_checkpoint() == 0
 
+    def test_recover_ignores_non_list_checkpoint(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps({"session_id": "proc_not_a_list"}))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 0
+
+    def test_recover_skips_malformed_entries(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([
+            None,
+            "not-a-dict",
+            {"pid": os.getpid(), "command": "missing session id"},
+        ]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 0
+            assert registry.pending_watchers == []
+
     def test_recover_dead_pid(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -317,6 +317,38 @@ class CDPSupervisor:
         self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
         # Monotonic id generator for dialogs (human-readable in snapshots).
         self._dialog_seq = 0
+        # Tasks created with create_task() that need a strong reference so
+        # asyncio doesn't garbage-collect them before they finish. Examples:
+        # auto-dialog fulfillment and child-session domain enablement.
+        self._background_tasks: set[asyncio.Task] = set()
+
+    # ── Internal helpers ─────────────────────────────────────────────────────
+
+    def _spawn_background(self, coro) -> asyncio.Task:
+        """Create a background task with a strong reference and error logging.
+
+        Plain ``asyncio.create_task()`` only retains a weak reference, so a
+        fire-and-forget task can be garbage-collected mid-flight. We track it
+        in ``self._background_tasks`` until it finishes and surface any
+        exception via the supervisor logger instead of dropping it silently.
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+
+        def _on_done(t: asyncio.Task) -> None:
+            self._background_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:
+                logger.debug(
+                    "CDP supervisor %s: background task failed: %s",
+                    self.task_id,
+                    exc,
+                )
+
+        task.add_done_callback(_on_done)
+        return task
 
     # ── Public sync API ──────────────────────────────────────────────────────
 
@@ -862,13 +894,13 @@ class CDPSupervisor:
             # re-archive it as "remote".
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            self._spawn_background(
                 self._auto_handle_dialog(dialog, accept=False, prompt_text="")
             )
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            self._spawn_background(
                 self._auto_handle_dialog(
                     dialog, accept=True, prompt_text=dialog.default_prompt
                 )
@@ -880,7 +912,7 @@ class CDPSupervisor:
             loop = asyncio.get_running_loop()
             handle = loop.call_later(
                 self.dialog_timeout_s,
-                lambda: asyncio.create_task(self._dialog_timeout_expired(dialog.id)),
+                lambda: self._spawn_background(self._dialog_timeout_expired(dialog.id)),
             )
             self._dialog_watchdogs[dialog.id] = handle
 
@@ -1082,13 +1114,13 @@ class CDPSupervisor:
         if self.dialog_policy == DIALOG_POLICY_AUTO_DISMISS:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            self._spawn_background(
                 self._fulfill_bridge_request(dialog, accept=False, prompt_text="")
             )
         elif self.dialog_policy == DIALOG_POLICY_AUTO_ACCEPT:
             with self._state_lock:
                 self._archive_dialog_locked(dialog, "auto_policy")
-            asyncio.create_task(
+            self._spawn_background(
                 self._fulfill_bridge_request(
                     dialog, accept=True, prompt_text=default_prompt
                 )
@@ -1100,7 +1132,7 @@ class CDPSupervisor:
             loop = asyncio.get_running_loop()
             handle = loop.call_later(
                 self.dialog_timeout_s,
-                lambda: asyncio.create_task(self._dialog_timeout_expired(dialog.id)),
+                lambda: self._spawn_background(self._dialog_timeout_expired(dialog.id)),
             )
             self._dialog_watchdogs[dialog.id] = handle
 
@@ -1236,7 +1268,7 @@ class CDPSupervisor:
         # Enable domains on the child off-loop so the reader keeps pumping.
         # Awaiting the CDP replies here would deadlock because only the
         # reader can resolve those replies' Futures.
-        asyncio.create_task(self._enable_child_domains(sid))
+        self._spawn_background(self._enable_child_domains(sid))
 
     async def _enable_child_domains(self, sid: str) -> None:
         """Enable Page+Runtime (+nested setAutoAttach) on a child CDP session.

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -74,6 +74,7 @@ class _ProviderEntry:
     last_mtime_ns: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     pending_401: dict[str, "asyncio.Future[bool]"] = field(default_factory=dict)
+    pending_401_tasks: set["asyncio.Task[None]"] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -570,7 +571,15 @@ class MCPOAuthManager:
                     finally:
                         entry.pending_401.pop(key, None)
 
-                asyncio.create_task(_do_handle())
+                # Track the task to prevent garbage collection mid-flight and
+                # log any unexpected errors. The await on `pending` below keeps
+                # the caller blocked until _do_handle resolves it, but holding a
+                # strong reference is a belt-and-suspenders guard against asyncio
+                # cancelling a "fire-and-forget" task whose only reference is the
+                # event loop's internal weak set.
+                _task = asyncio.create_task(_do_handle())
+                entry.pending_401_tasks.add(_task)
+                _task.add_done_callback(entry.pending_401_tasks.discard)
 
         try:
             return await pending

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1337,9 +1337,23 @@ class ProcessRegistry:
             entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
         except Exception:
             return 0
+        if not isinstance(entries, list):
+            # Corrupted checkpoint (null, dict, scalar) — refuse to iterate so
+            # gateway startup is not derailed. The bad file will be rewritten
+            # the next time _write_checkpoint runs.
+            logger.warning(
+                "Checkpoint file is not a JSON list (type=%s); skipping recovery",
+                type(entries).__name__,
+            )
+            return 0
 
         recovered = 0
         for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            session_id = entry.get("session_id")
+            if not session_id:
+                continue
             pid = entry.get("pid")
             if not pid:
                 continue
@@ -1362,7 +1376,7 @@ class ProcessRegistry:
 
             if alive:
                 session = ProcessSession(
-                    id=entry["session_id"],
+                    id=session_id,
                     command=entry.get("command", "unknown"),
                     task_id=entry.get("task_id", ""),
                     session_key=entry.get("session_key", ""),


### PR DESCRIPTION
## Summary

- Harden curator backup/rollback by skipping link members during snapshot creation and rejecting symlink/hardlink members during restore.
- Reject zero-length cron durations so `every 0m`/`0h`/`0d` cannot spin the scheduler.
- Improve background process notification reliability by falling back to text delivery when synthetic agent routing metadata cannot be rebuilt.
- Retain short-lived fire-and-forget asyncio tasks in browser supervisor and MCP OAuth 401 handling to avoid weak-reference GC races.
- Make process checkpoint recovery tolerate malformed checkpoint shapes and entries.
- Align Supermemory async write worker with daemon-thread behavior used by its sibling sync worker.
- Add targeted regression coverage for the fixed cron, curator rollback/snapshot, gateway fallback, and checkpoint recovery paths.

## Review and verification

- Hermes reviewed Claude's original local diff and fixed one callback ordering issue before preparing this PR.
- Rebasing note: the local checkout had a divergent `main`, so this PR was created from a clean worktree based on `origin/main` to avoid carrying unrelated local commits.
- Independent Hermes review passed on the final PR worktree with no blocker-level security, correctness, performance, reliability, or test concerns.
- Static added-line scan: no hardcoded secrets, `shell=True`/`os.system`, `eval`/`exec`, `pickle.loads`, or obvious formatted-SQL patterns found.
- `git diff --check` passed.
- AST parse passed for all edited Python files.
- Atlas: `scripts/run_tests.sh tests/agent/test_curator_backup.py` — 27 passed.
- Atlas: `scripts/run_tests.sh tests/cron/test_jobs.py tests/agent/test_curator_backup.py tests/gateway/test_background_process_notifications.py tests/tools/test_process_registry.py::TestCheckpoint::test_recover_ignores_non_list_checkpoint tests/tools/test_process_registry.py::TestCheckpoint::test_recover_skips_malformed_entries tests/plugins/memory/test_supermemory_provider.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth.py` — 212 passed.
- Vega signoff: exact `fb00aa2f` archive, same 212-test command — 212 passed.
- Orion signoff: exact `fb00aa2f` archive, same 212-test command — 212 passed.

## Performance / Scalability / Security / Reliability

- Performance/scalability: task-retention sets add only a `set.add`/`discard` per short-lived background task; scheduler zero-duration rejection prevents the worst-case spin loop.
- Security: rollback now rejects tar link members and snapshot creation avoids producing link members itself, reducing archive extraction escape risk.
- Reliability: completion notifications degrade to plain text rather than being dropped, checkpoint recovery skips malformed state instead of crashing startup, and async background work is held strongly until completion.
- Deferred: broader tests for browser supervisor and MCP OAuth task-retention internals can be added separately, but the changed public behavior and regression-prone paths are covered here.
