### PR TITLE
fix(hindsight): preserve embedded profile env

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,40 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+### Reactivating the Kanban dashboard
+
+Kanban dispatch runs inside the gateway by default, while the browser board lives
+in the dashboard. If `http://100.84.162.95:9119/kanban` or another dashboard
+Kanban URL stops responding after an update/restart, first verify the gateway
+and board, then restart the dashboard on the private-network address:
+
+```bash
+hermes gateway status
+hermes kanban stats
+hermes kanban dispatch --dry-run --max 3
+hermes dashboard --status
+
+systemd-run --user \
+  --unit hermes-dashboard-kanban \
+  --property WorkingDirectory=/home/hermes/.hermes/hermes-agent \
+  /home/hermes/.hermes/hermes-agent/venv/bin/python \
+  -m hermes_cli.main \
+  --tui dashboard \
+  --host 100.84.162.95 \
+  --port 9119 \
+  --no-open \
+  --insecure \
+  --skip-build
+
+curl http://100.84.162.95:9119/kanban
+systemctl --user status hermes-dashboard-kanban.service --no-pager
+```
+
+Only use `--insecure` on a trusted private network such as your own Tailscale
+tailnet; it exposes the dashboard management UI to that network. Do not start
+the deprecated `hermes-kanban-dispatcher.service` unless gateway-embedded
+dispatch has been deliberately disabled.
+
 ---
 
 ## Skip the API-key collection — Nous Portal

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1546,7 +1546,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
+            _mark_provider_unhealthy("openrouter", ttl=60, reason="missing credentials")
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
@@ -1555,7 +1555,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy("openrouter", ttl=60, reason="missing credentials")
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1587,7 +1587,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
                 "Auxiliary: skipping Nous Portal (rate-limited, resets in %.0fs)",
                 _remaining,
             )
-            _mark_provider_unhealthy("nous", ttl=_remaining)
+            _mark_provider_unhealthy("nous", ttl=_remaining, reason="rate limit")
             return None, None
     except Exception:
         pass
@@ -1599,7 +1599,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
             "Auxiliary Nous client unavailable: no Nous authentication found "
             "(run: hermes auth)."
         )
-        _mark_provider_unhealthy("nous", ttl=60)
+        _mark_provider_unhealthy("nous", ttl=60, reason="missing credentials")
         return None, None
     if runtime is None and nous:
         logger.debug(
@@ -2291,10 +2291,17 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
+def _mark_provider_unhealthy(
+    provider: str,
+    ttl: Optional[float] = None,
+    *,
+    reason: str = "payment / credit error",
+) -> None:
     """Mark ``provider`` as recently-402'd, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
-    ``call_llm`` and ``acall_llm`` after a confirmed payment error.
+    ``call_llm`` and ``acall_llm`` after a confirmed payment error. Some
+    resolver paths also use the same short-lived skip cache for missing
+    credentials or rate-limit guards; ``reason`` keeps the operator log honest.
     """
     label = _normalize_chain_label(provider)
     if not label:
@@ -2302,10 +2309,11 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at
     logger.warning(
-        "Auxiliary: marking %s unhealthy for %ds (payment / credit error). "
+        "Auxiliary: marking %s unhealthy for %ds (%s). "
         "Subsequent auxiliary calls will skip it until %s.",
         label,
         int(ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS),
+        reason,
         time.strftime("%H:%M:%S", time.localtime(expires_at)),
     )
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -751,6 +751,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
         """Custom setup wizard — installs only the deps needed for the selected mode."""
+        import getpass
         import subprocess
         import shutil
         import sys

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -70,6 +70,16 @@ _PROVIDER_DEFAULT_MODELS = {
     "lmstudio": "local-model",
     "openai_compatible": "your-model-name",
 }
+_EMBEDDINGS_PROVIDER_DEFAULT_MODELS = {
+    "local": "BAAI/bge-small-en-v1.5",
+    "tei": "requires HINDSIGHT_API_EMBEDDINGS_TEI_URL",
+    "openai": "text-embedding-3-small",
+    "cohere": "embed-english-v3.0",
+    "google": "gemini-embedding-001",
+    "openrouter": "perplexity/pplx-embed-v1-0.6b",
+    "litellm": "text-embedding-3-small",
+    "litellm-sdk": "cohere/embed-english-v3.0",
+}
 
 
 def _parse_int_setting(value: Any, default: int) -> int:
@@ -427,6 +437,16 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
 
+    # Hindsight's embedded daemon reads embedding settings directly from the
+    # profile env file. Keep these in sync with Hermes's profile-scoped config
+    # without storing embedding API keys in config.json.
+    embeddings_provider = config.get("embeddings_provider")
+    if embeddings_provider:
+        env_values["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] = str(embeddings_provider)
+    embeddings_openai_model = config.get("embeddings_openai_model")
+    if embeddings_provider == "openai" and embeddings_openai_model:
+        env_values["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] = str(embeddings_openai_model)
+
     idle_timeout = (
         config.get("idle_timeout")
         if config.get("idle_timeout") is not None
@@ -446,15 +466,104 @@ def _embedded_profile_env_path(config: dict[str, Any]):
 
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):
-    """Write the profile-scoped env file that standalone hindsight-embed uses."""
+    """Write the profile-scoped env file that standalone hindsight-embed uses.
+
+    Preserve keys not managed by Hermes (notably embedding API keys) so daemon
+    startup/reconfiguration cannot erase user-provided secrets.
+    """
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    existing_values = _load_simple_env(profile_env)
+
+    # If no new LLM key was provided, do not erase an existing profile-scoped
+    # daemon key. This is especially important for openai-codex: extraction uses
+    # OAuth, while OpenAI embeddings can still require a daemon-visible API key.
+    if (
+        env_values.get("HINDSIGHT_API_LLM_API_KEY") == ""
+        and existing_values.get("HINDSIGHT_API_LLM_API_KEY")
+    ):
+        env_values.pop("HINDSIGHT_API_LLM_API_KEY", None)
+
+    merged_values = {**existing_values, **env_values}
     profile_env.write_text(
-        "".join(f"{key}={value}\n" for key, value in env_values.items()),
+        "".join(f"{key}={value}\n" for key, value in merged_values.items()),
         encoding="utf-8",
     )
     return profile_env
+
+
+def _effective_embedded_profile_env(config: dict[str, Any]) -> dict[str, str]:
+    """Return the daemon env values Hermes can see for an embedded profile."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith("HINDSIGHT_") or key == "OPENAI_API_KEY"
+    }
+    env.update(_load_simple_env(_embedded_profile_env_path(config)))
+    expected = _build_embedded_profile_env(config)
+    if (
+        expected.get("HINDSIGHT_API_LLM_API_KEY") == ""
+        and env.get("HINDSIGHT_API_LLM_API_KEY")
+    ):
+        expected.pop("HINDSIGHT_API_LLM_API_KEY", None)
+    env.update(expected)
+    return env
+
+
+def _validate_embedded_profile_env(config: dict[str, Any]) -> None:
+    """Validate required embedded-daemon env before starting Hindsight."""
+    env = _effective_embedded_profile_env(config)
+    profile_env = _embedded_profile_env_path(config)
+    profile = _embedded_profile_name(config)
+    provider = str(env.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") or "local").strip().lower()
+    model = env.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL") or ""
+
+    missing: list[str] = []
+    if provider == "openai":
+        if not (
+            env.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY")
+            or env.get("HINDSIGHT_API_LLM_API_KEY")
+        ):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY")
+    elif provider == "tei":
+        if not env.get("HINDSIGHT_API_EMBEDDINGS_TEI_URL"):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_TEI_URL")
+    elif provider == "cohere":
+        if not (
+            env.get("HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY")
+            or env.get("HINDSIGHT_API_COHERE_API_KEY")
+        ):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_COHERE_API_KEY")
+    elif provider == "google":
+        if not (
+            env.get("HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY")
+            or env.get("HINDSIGHT_API_LLM_API_KEY")
+            or env.get("HINDSIGHT_API_EMBEDDINGS_VERTEXAI_PROJECT_ID")
+        ):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_GEMINI_API_KEY")
+    elif provider == "openrouter":
+        if not (
+            env.get("HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY")
+            or env.get("HINDSIGHT_API_OPENROUTER_API_KEY")
+            or env.get("HINDSIGHT_API_LLM_API_KEY")
+        ):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_OPENROUTER_API_KEY")
+    elif provider == "litellm-sdk":
+        if not env.get("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY"):
+            missing.append("HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY")
+
+    if not missing:
+        return
+
+    model_text = f", model={model}" if model else ""
+    raise RuntimeError(
+        "Hindsight local_embedded profile is missing required embedding "
+        f"configuration: {', '.join(missing)}. "
+        f"profile={profile}, env_file={profile_env}, "
+        f"embeddings_provider={provider}{model_text}. "
+        f"Add the missing setting to {profile_env} or rerun `hermes memory setup`."
+    )
 
 def _sanitize_bank_segment(value: str) -> str:
     """Sanitize a bank_id_template placeholder value.
@@ -673,6 +782,7 @@ class HindsightMemoryProvider(MemoryProvider):
         provider_config: dict = dict(existing_config)
         provider_config["mode"] = mode
         env_writes: dict = {}
+        profile_env_writes: dict[str, str] = {}
 
         # Step 2: Install/upgrade deps for selected mode
         _MIN_CLIENT_VERSION = "0.4.22"
@@ -777,6 +887,68 @@ class HindsightMemoryProvider(MemoryProvider):
                             break
                 env_writes["HINDSIGHT_LLM_API_KEY"] = existing_llm_key
 
+            embeddings_values = list(_EMBEDDINGS_PROVIDER_DEFAULT_MODELS.keys())
+            embeddings_items = [
+                (p, f"default model: {_EMBEDDINGS_PROVIDER_DEFAULT_MODELS[p]}")
+                for p in embeddings_values
+            ]
+            existing_embeddings_provider = provider_config.get("embeddings_provider")
+            embeddings_default_idx = (
+                embeddings_values.index(existing_embeddings_provider)
+                if existing_embeddings_provider in embeddings_values
+                else 0
+            )
+            embeddings_idx = _curses_select(
+                "  Select embeddings provider",
+                embeddings_items,
+                default=embeddings_default_idx,
+            )
+            embeddings_provider = embeddings_values[embeddings_idx]
+            provider_config["embeddings_provider"] = embeddings_provider
+
+            if embeddings_provider == "openai":
+                current_embeddings_model = (
+                    provider_config.get("embeddings_openai_model")
+                    or _EMBEDDINGS_PROVIDER_DEFAULT_MODELS["openai"]
+                )
+                val = input(f"  OpenAI embeddings model [{current_embeddings_model}]: ").strip()
+                provider_config["embeddings_openai_model"] = val or current_embeddings_model
+
+                existing_profile_env = _load_simple_env(_embedded_profile_env_path(provider_config))
+                existing_embeddings_key = (
+                    existing_profile_env.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY")
+                    or os.environ.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY", "")
+                )
+                if existing_embeddings_key:
+                    masked = (
+                        f"...{existing_embeddings_key[-4:]}"
+                        if len(existing_embeddings_key) > 4
+                        else "set"
+                    )
+                    sys.stdout.write(
+                        f"  OpenAI embeddings API key (current: {masked}, blank to keep): "
+                    )
+                else:
+                    sys.stdout.write("  OpenAI embeddings API key (blank to reuse LLM key when possible): ")
+                sys.stdout.flush()
+                embeddings_key = (
+                    getpass.getpass(prompt="")
+                    if sys.stdin.isatty()
+                    else sys.stdin.readline().strip()
+                )
+                if embeddings_key:
+                    profile_env_writes["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] = embeddings_key
+                elif not existing_embeddings_key and llm_provider == "openai":
+                    reusable_llm_key = env_writes.get("HINDSIGHT_LLM_API_KEY", "")
+                    if reusable_llm_key:
+                        profile_env_writes["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] = reusable_llm_key
+                elif not existing_embeddings_key:
+                    profile_env_path = _embedded_profile_env_path(provider_config)
+                    print(
+                        "  ⚠ OpenAI embeddings need "
+                        f"HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY in {profile_env_path}"
+                    )
+
         # Step 4: Save everything
         provider_config.setdefault("bank_id", "hermes")
         provider_config.setdefault("recall_budget", "mid")
@@ -837,6 +1009,18 @@ class HindsightMemoryProvider(MemoryProvider):
                 materialized_config,
                 llm_api_key=llm_api_key or None,
             )
+            if profile_env_writes:
+                profile_env = _embedded_profile_env_path(materialized_config)
+                merged_profile_env = _load_simple_env(profile_env)
+                merged_profile_env.update(profile_env_writes)
+                profile_env.write_text(
+                    "".join(f"{key}={value}\n" for key, value in merged_profile_env.items()),
+                    encoding="utf-8",
+                )
+            try:
+                _validate_embedded_profile_env(materialized_config)
+            except RuntimeError as exc:
+                print(f"  ⚠ {exc}")
 
         print(f"\n  ✓ Hindsight memory configured ({mode} mode)")
         if env_writes:
@@ -1254,7 +1438,6 @@ class HindsightMemoryProvider(MemoryProvider):
                     from rich.console import Console
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
                     profile = self._config.get("profile", "hermes")
 
                     # Update the profile .env to match our current config so
@@ -1263,14 +1446,28 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    config_changed = any(
+                        saved.get(key) != value
+                        for key, value in expected_env.items()
+                        if not (
+                            key == "HINDSIGHT_API_LLM_API_KEY"
+                            and value == ""
+                            and saved.get(key)
+                        )
+                    )
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                    else:
+                        _materialize_embedded_profile_env(self._config)
+
+                    _validate_embedded_profile_env(self._config)
+
+                    client = self._get_client()
+                    if config_changed and client._manager.is_running(profile):
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Config changed, restarting daemon ===\n")
+                        client._manager.stop(profile)
 
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:

--- a/scripts/update-current-branch.sh
+++ b/scripts/update-current-branch.sh
@@ -5,19 +5,24 @@
 # replayed on top of the latest official main. It never switches to main and
 # never hard-resets your branch. If Git hits conflicts, the rebase stops with
 # your backup branch and any autostash left intact for manual recovery.
+# Before updating, it also takes a Hermes backup so config/state can be
+# restored outside Git if needed.
 
 set -euo pipefail
 
 OFFICIAL_REPO_SLUG="NousResearch/hermes-agent"
 OFFICIAL_REPO_URL="https://github.com/NousResearch/hermes-agent.git"
 DEFAULT_EXPECTED_BRANCH="local/hindsight-embedded-profile-env"
+DEFAULT_BACKUP_WRAPPER="/home/hermes/hermes-backups/backup-hermes.sh"
+BACKUP_WRAPPER="${HERMES_UPDATE_BACKUP_SCRIPT:-$DEFAULT_BACKUP_WRAPPER}"
 
 usage() {
     cat <<'EOF'
 Usage: scripts/update-current-branch.sh [options]
 
 Rebase the current branch onto the latest official Hermes main while preserving
-local commits and uncommitted work.
+local commits and uncommitted work. Before fetching/rebasing, the script takes
+an initial Hermes backup by calling the configured backup wrapper script.
 
 Options:
   --no-push                Do not update the branch's upstream remote after
@@ -33,6 +38,7 @@ Options:
   --any-branch             Disable the expected-branch guard for one run.
   --upstream REF           Rebase onto this ref instead of auto-detected
                            official main (for example origin/main).
+  --no-backup              Skip the initial Hermes backup step.
   --dry-run                Show what would be updated without changing refs.
   -h, --help               Show this help.
 
@@ -42,6 +48,7 @@ Examples:
   scripts/update-current-branch.sh --no-restart
   scripts/update-current-branch.sh --expected-branch my/local-branch
   scripts/update-current-branch.sh --upstream origin/main
+  scripts/update-current-branch.sh --no-backup
 EOF
 }
 
@@ -165,12 +172,23 @@ restore_stash_if_needed() {
     exit 1
 }
 
+run_initial_backup() {
+    [ "$RUN_INITIAL_BACKUP" = "1" ] || return 0
+
+    [ -x "$BACKUP_WRAPPER" ] || die "backup wrapper is missing or not executable: $BACKUP_WRAPPER"
+
+    info "Creating Hermes backup via $BACKUP_WRAPPER"
+    run "$BACKUP_WRAPPER"
+    ok "Hermes backup completed"
+}
+
 DRY_RUN=0
 PUSH_FORK=1
 RESTART_SERVICES=1
 UPSTREAM_REF=""
 EXPECTED_BRANCH="${HERMES_UPDATE_BRANCH:-$DEFAULT_EXPECTED_BRANCH}"
 ALLOW_ANY_BRANCH=0
+RUN_INITIAL_BACKUP=1
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -201,6 +219,10 @@ while [ "$#" -gt 0 ]; do
             UPSTREAM_REF="$2"
             shift 2
             ;;
+        --no-backup)
+            RUN_INITIAL_BACKUP=0
+            shift
+            ;;
         --dry-run)
             DRY_RUN=1
             shift
@@ -229,6 +251,8 @@ if [ "$ALLOW_ANY_BRANCH" != "1" ]; then
         die "refusing to update branch '$current_branch'; expected '$EXPECTED_BRANCH'. Use --expected-branch NAME for a planned branch rename, or --any-branch to override once."
     fi
 fi
+
+run_initial_backup
 
 if [ -z "$UPSTREAM_REF" ]; then
     if official="$(official_remote)"; then

--- a/scripts/update-current-branch.sh
+++ b/scripts/update-current-branch.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# Update the current Hermes checkout while preserving the current branch.
+#
+# This is intended for fork/patch workflows where local commits should be
+# replayed on top of the latest official main. It never switches to main and
+# never hard-resets your branch. If Git hits conflicts, the rebase stops with
+# your backup branch and any autostash left intact for manual recovery.
+
+set -euo pipefail
+
+OFFICIAL_REPO_SLUG="NousResearch/hermes-agent"
+OFFICIAL_REPO_URL="https://github.com/NousResearch/hermes-agent.git"
+DEFAULT_EXPECTED_BRANCH="local/hindsight-embedded-profile-env"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/update-current-branch.sh [options]
+
+Rebase the current branch onto the latest official Hermes main while preserving
+local commits and uncommitted work.
+
+Options:
+  --no-push                Do not update the branch's upstream remote after
+                           a successful rebase. By default, the script pushes
+                           with --force-with-lease so local and fork stay in sync.
+  --push-fork              Deprecated alias for the default push behavior.
+  --expected-branch NAME   Require this local branch before updating. Defaults
+                           to local/hindsight-embedded-profile-env, or the
+                           HERMES_UPDATE_BRANCH env var when set.
+  --any-branch             Disable the expected-branch guard for one run.
+  --upstream REF           Rebase onto this ref instead of auto-detected
+                           official main (for example origin/main).
+  --dry-run                Show what would be updated without changing refs.
+  -h, --help               Show this help.
+
+Examples:
+  scripts/update-current-branch.sh
+  scripts/update-current-branch.sh --no-push
+  scripts/update-current-branch.sh --expected-branch my/local-branch
+  scripts/update-current-branch.sh --upstream origin/main
+EOF
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '→ %s\n' "$*"
+}
+
+ok() {
+    printf '✓ %s\n' "$*"
+}
+
+warn() {
+    printf '⚠ %s\n' "$*" >&2
+}
+
+run() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+'
+        printf ' %q' "$@"
+        printf '\n'
+    else
+        "$@"
+    fi
+}
+
+remote_url() {
+    git remote get-url "$1" 2>/dev/null || true
+}
+
+remote_is_official() {
+    local url normalized
+    url="$(remote_url "$1")"
+    [ -n "$url" ] || return 1
+    normalized="${url%.git}"
+    case "$normalized" in
+        *github.com[:/]$OFFICIAL_REPO_SLUG) return 0 ;;
+        https://github.com/$OFFICIAL_REPO_SLUG) return 0 ;;
+        git@github.com:$OFFICIAL_REPO_SLUG) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+sanitize_ref_component() {
+    printf '%s' "$1" | tr '/:~^?*[\\ ' '----------'
+}
+
+official_remote() {
+    local remote
+    for remote in upstream origin fork; do
+        if git remote get-url "$remote" >/dev/null 2>&1 && remote_is_official "$remote"; then
+            printf '%s\n' "$remote"
+            return 0
+        fi
+    done
+    return 1
+}
+
+ensure_no_git_operation_in_progress() {
+    local git_dir
+    git_dir="$(git rev-parse --git-dir)"
+    for marker in \
+        "$git_dir/rebase-merge" \
+        "$git_dir/rebase-apply" \
+        "$git_dir/MERGE_HEAD" \
+        "$git_dir/CHERRY_PICK_HEAD" \
+        "$git_dir/REVERT_HEAD"
+    do
+        if [ -e "$marker" ]; then
+            die "another Git operation is in progress. Resolve or abort it before updating."
+        fi
+    done
+}
+
+stash_worktree_if_needed() {
+    local stash_name stash_ref
+    if [ -z "$(git status --porcelain)" ]; then
+        return 0
+    fi
+
+    stash_name="hermes-current-branch-update-$(date -u +%Y%m%d-%H%M%S)"
+    info "Uncommitted changes detected; stashing as $stash_name"
+    run git stash push --include-untracked -m "$stash_name"
+
+    if [ "$DRY_RUN" = "1" ]; then
+        STASH_REF="dry-run-stash"
+        return 0
+    fi
+
+    stash_ref="$(git rev-parse --verify refs/stash)"
+    STASH_REF="$stash_ref"
+}
+
+restore_stash_if_needed() {
+    [ -n "${STASH_REF:-}" ] || return 0
+    if [ "$DRY_RUN" = "1" ]; then
+        info "Would restore stashed uncommitted changes"
+        return 0
+    fi
+
+    info "Restoring stashed uncommitted changes"
+    if git stash apply "$STASH_REF"; then
+        local selector
+        selector="$(git stash list --format='%gd %H' | awk -v ref="$STASH_REF" '$2 == ref { print $1; exit }')"
+        if [ -n "$selector" ]; then
+            git stash drop "$selector" >/dev/null
+        else
+            warn "restored changes, but could not find the stash entry to drop"
+            warn "stash commit: $STASH_REF"
+        fi
+        return 0
+    fi
+
+    warn "stashed changes conflicted while restoring"
+    warn "your stash is preserved at commit: $STASH_REF"
+    warn "resolve conflicts, or recover with: git stash apply $STASH_REF"
+    exit 1
+}
+
+DRY_RUN=0
+PUSH_FORK=1
+UPSTREAM_REF=""
+EXPECTED_BRANCH="${HERMES_UPDATE_BRANCH:-$DEFAULT_EXPECTED_BRANCH}"
+ALLOW_ANY_BRANCH=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --push-fork)
+            PUSH_FORK=1
+            shift
+            ;;
+        --no-push)
+            PUSH_FORK=0
+            shift
+            ;;
+        --expected-branch)
+            [ "$#" -ge 2 ] || die "--expected-branch requires a branch name"
+            EXPECTED_BRANCH="$2"
+            ALLOW_ANY_BRANCH=0
+            shift 2
+            ;;
+        --any-branch)
+            ALLOW_ANY_BRANCH=1
+            shift
+            ;;
+        --upstream)
+            [ "$#" -ge 2 ] || die "--upstream requires a ref"
+            UPSTREAM_REF="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "not inside a Git repository"
+cd "$repo_root"
+
+ensure_no_git_operation_in_progress
+
+current_branch="$(git branch --show-current)"
+[ -n "$current_branch" ] || die "detached HEAD is not supported; check out a branch first"
+
+if [ "$ALLOW_ANY_BRANCH" != "1" ]; then
+    [ -n "$EXPECTED_BRANCH" ] || die "expected branch guard is empty; use --any-branch to override"
+    if [ "$current_branch" != "$EXPECTED_BRANCH" ]; then
+        die "refusing to update branch '$current_branch'; expected '$EXPECTED_BRANCH'. Use --expected-branch NAME for a planned branch rename, or --any-branch to override once."
+    fi
+fi
+
+if [ -z "$UPSTREAM_REF" ]; then
+    if official="$(official_remote)"; then
+        info "Official upstream remote: $official ($(remote_url "$official"))"
+    else
+        if git remote get-url upstream >/dev/null 2>&1; then
+            official="upstream"
+        else
+            info "Adding official upstream remote"
+            run git remote add upstream "$OFFICIAL_REPO_URL"
+            official="upstream"
+        fi
+    fi
+
+    info "Fetching latest official main"
+    run git fetch "$official" main
+    UPSTREAM_REF="$official/main"
+else
+    info "Using requested upstream ref: $UPSTREAM_REF"
+    remote_name="${UPSTREAM_REF%%/*}"
+    if [ "$remote_name" != "$UPSTREAM_REF" ] && git remote get-url "$remote_name" >/dev/null 2>&1; then
+        info "Fetching $remote_name"
+        run git fetch "$remote_name"
+    fi
+fi
+
+git rev-parse --verify "$UPSTREAM_REF" >/dev/null 2>&1 || die "cannot resolve upstream ref: $UPSTREAM_REF"
+
+upstream_branch="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+info "Current branch: $current_branch"
+if [ -n "$upstream_branch" ]; then
+    info "Branch upstream: $upstream_branch"
+else
+    warn "current branch has no configured upstream remote"
+fi
+
+backup_branch="backup/$(sanitize_ref_component "$current_branch")-before-update-$(date -u +%Y%m%d-%H%M%S)"
+info "Creating backup branch: $backup_branch"
+run git branch "$backup_branch" HEAD
+
+ahead="$(git rev-list --count "$UPSTREAM_REF..HEAD")"
+behind="$(git rev-list --count "HEAD..$UPSTREAM_REF")"
+info "Branch is $ahead commit(s) ahead and $behind commit(s) behind $UPSTREAM_REF"
+
+STASH_REF=""
+stash_worktree_if_needed
+
+info "Rebasing $current_branch onto $UPSTREAM_REF"
+if ! run git rebase "$UPSTREAM_REF"; then
+    warn "rebase stopped because of conflicts"
+    warn "backup branch: $backup_branch"
+    if [ -n "${STASH_REF:-}" ]; then
+        warn "uncommitted changes are preserved in stash commit: $STASH_REF"
+    fi
+    warn "after resolving conflicts, run: git rebase --continue"
+    warn "to go back, run: git rebase --abort && git switch $backup_branch"
+    exit 1
+fi
+
+restore_stash_if_needed
+
+ok "Updated $current_branch onto $UPSTREAM_REF"
+ok "Backup branch kept at $backup_branch"
+
+
+print_post_update_upstream_guidance() {
+    local tracking ahead_remote behind_remote remote_name remote_branch
+    tracking="$1"
+    [ -n "$tracking" ] || return 0
+
+    ahead_remote="$(git rev-list --count "$tracking..HEAD" 2>/dev/null || printf '0')"
+    behind_remote="$(git rev-list --count "HEAD..$tracking" 2>/dev/null || printf '0')"
+    if [ "$ahead_remote" = "0" ] && [ "$behind_remote" = "0" ]; then
+        ok "Branch upstream is in sync: $tracking"
+        return 0
+    fi
+
+    remote_name="${tracking%%/*}"
+    remote_branch="${tracking#*/}"
+    warn "local branch and $tracking are not in sync after the rebase"
+    warn "status: ahead $ahead_remote, behind $behind_remote"
+    warn "this is expected after rebasing until the fork branch is updated"
+    warn "push safely with: git push --force-with-lease $remote_name HEAD:$remote_branch"
+}
+
+if [ "$PUSH_FORK" = "1" ]; then
+    [ -n "$upstream_branch" ] || die "--push-fork requested, but current branch has no upstream"
+    push_remote="${upstream_branch%%/*}"
+    push_branch="${upstream_branch#*/}"
+    info "Pushing $current_branch to $push_remote/$push_branch with --force-with-lease"
+    run git push --force-with-lease "$push_remote" "HEAD:$push_branch"
+    ok "Pushed $push_remote/$push_branch"
+else
+    print_post_update_upstream_guidance "$upstream_branch"
+fi
+
+git status --short --branch

--- a/scripts/update-current-branch.sh
+++ b/scripts/update-current-branch.sh
@@ -23,6 +23,9 @@ Options:
   --no-push                Do not update the branch's upstream remote after
                            a successful rebase. By default, the script pushes
                            with --force-with-lease so local and fork stay in sync.
+  --no-restart             Do not restart running gateway/dashboard processes
+                           after a successful update. By default, running
+                           services are restarted so the UI loads new code.
   --push-fork              Deprecated alias for the default push behavior.
   --expected-branch NAME   Require this local branch before updating. Defaults
                            to local/hindsight-embedded-profile-env, or the
@@ -36,6 +39,7 @@ Options:
 Examples:
   scripts/update-current-branch.sh
   scripts/update-current-branch.sh --no-push
+  scripts/update-current-branch.sh --no-restart
   scripts/update-current-branch.sh --expected-branch my/local-branch
   scripts/update-current-branch.sh --upstream origin/main
 EOF
@@ -163,6 +167,7 @@ restore_stash_if_needed() {
 
 DRY_RUN=0
 PUSH_FORK=1
+RESTART_SERVICES=1
 UPSTREAM_REF=""
 EXPECTED_BRANCH="${HERMES_UPDATE_BRANCH:-$DEFAULT_EXPECTED_BRANCH}"
 ALLOW_ANY_BRANCH=0
@@ -175,6 +180,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         --no-push)
             PUSH_FORK=0
+            shift
+            ;;
+        --no-restart)
+            RESTART_SERVICES=0
             shift
             ;;
         --expected-branch)
@@ -285,6 +294,50 @@ ok "Updated $current_branch onto $UPSTREAM_REF"
 ok "Backup branch kept at $backup_branch"
 
 
+
+clear_update_cache() {
+    local home
+    for home in "$HOME/.hermes" "$HOME/.hermes/profiles"/*; do
+        [ -e "$home/.update_check" ] || continue
+        rm -f "$home/.update_check"
+    done
+}
+
+restart_running_services() {
+    [ "$RESTART_SERVICES" = "1" ] || return 0
+    [ "$DRY_RUN" = "1" ] && return 0
+
+    local hermes_cmd gateway_was_running dashboard_cmds
+    hermes_cmd="$(command -v hermes || true)"
+    [ -n "$hermes_cmd" ] || return 0
+
+    gateway_was_running=0
+    if pgrep -f "hermes_cli.main gateway run" >/dev/null 2>&1; then
+        gateway_was_running=1
+    fi
+
+    dashboard_cmds="$(pgrep -af "hermes_cli.main dashboard" | sed 's/^[0-9][0-9]* //' || true)"
+
+    clear_update_cache
+
+    if [ "$gateway_was_running" = "1" ]; then
+        info "Restarting running gateway so it loads the updated code"
+        "$hermes_cmd" gateway restart || warn "gateway restart failed; run: hermes gateway restart"
+    fi
+
+    if [ -n "$dashboard_cmds" ]; then
+        info "Restarting running dashboard so the UI loads the updated code"
+        "$hermes_cmd" dashboard --stop || warn "dashboard stop failed; run: hermes dashboard --stop"
+        while IFS= read -r cmd; do
+            [ -n "$cmd" ] || continue
+            info "Starting dashboard: $cmd"
+            nohup bash -lc "$cmd" >/dev/null 2>&1 &
+        done <<EOF_DASHBOARD_CMDS
+$dashboard_cmds
+EOF_DASHBOARD_CMDS
+    fi
+}
+
 print_post_update_upstream_guidance() {
     local tracking ahead_remote behind_remote remote_name remote_branch
     tracking="$1"
@@ -315,5 +368,7 @@ if [ "$PUSH_FORK" = "1" ]; then
 else
     print_post_update_upstream_guidance "$upstream_branch"
 fi
+
+restart_running_services
 
 git status --short --branch

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -863,6 +863,19 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_missing_openrouter_credentials_logs_missing_credentials(self, monkeypatch, caplog):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            from agent.auxiliary_client import _try_openrouter
+
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = _try_openrouter()
+
+        assert client is None
+        assert model is None
+        assert any("missing credentials" in record.message for record in caplog.records)
+        assert not any("payment / credit error" in record.message for record in caplog.records)
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 
@@ -1033,6 +1046,22 @@ class TestAuxiliaryPoolAwareness:
 
         assert client is not None
         assert model == "google/gemini-3-flash-preview"
+
+    def test_try_nous_missing_auth_logs_missing_credentials(self, caplog):
+        with (
+            patch("agent.auxiliary_client._read_nous_auth", return_value=None),
+            patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=None),
+        ):
+            from agent.auxiliary_client import _try_nous
+
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = _try_nous()
+
+        assert client is None
+        assert model is None
+        assert any("no Nous authentication found" in record.message for record in caplog.records)
+        assert any("missing credentials" in record.message for record in caplog.records)
+        assert not any("payment / credit error" in record.message for record in caplog.records)
 
     def test_call_llm_retries_nous_after_401(self):
         class _Auth401(Exception):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -22,6 +22,8 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _materialize_embedded_profile_env,
+    _validate_embedded_profile_env,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
@@ -297,6 +299,74 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_materialize_embedded_profile_env_preserves_existing_daemon_api_key(self, tmp_path, monkeypatch):
+        user_home = tmp_path / "user-home"
+        profile_dir = user_home / ".hindsight" / "profiles"
+        profile_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(user_home))
+
+        profile_env = profile_dir / "hermes.env"
+        profile_env.write_text(
+            "HINDSIGHT_API_LLM_API_KEY=existing-secret\n"
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=embedding-secret\n"
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-large\n"
+        )
+
+        _materialize_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai-codex",
+            "llm_model": "gpt-5.4-mini",
+            "embeddings_provider": "openai",
+            "embeddings_openai_model": "text-embedding-3-small",
+        })
+
+        env_text = profile_env.read_text()
+        assert "HINDSIGHT_API_LLM_API_KEY=existing-secret\n" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=embedding-secret\n" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small\n" in env_text
+
+    def test_validate_embedded_profile_env_reports_missing_openai_embeddings_key(self, tmp_path, monkeypatch):
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.delenv("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("HINDSIGHT_API_LLM_API_KEY", raising=False)
+
+        config = {
+            "profile": "hermes",
+            "llm_provider": "openai-codex",
+            "llm_model": "gpt-5.4-mini",
+            "embeddings_provider": "openai",
+            "embeddings_openai_model": "text-embedding-3-small",
+        }
+
+        with pytest.raises(RuntimeError) as exc:
+            _validate_embedded_profile_env(config)
+
+        message = str(exc.value)
+        assert "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY" in message
+        assert str(user_home / ".hindsight" / "profiles" / "hermes.env") in message
+        assert "embeddings_provider=openai" in message
+
+    def test_validate_embedded_profile_env_accepts_existing_openai_embeddings_key(self, tmp_path, monkeypatch):
+        user_home = tmp_path / "user-home"
+        profile_dir = user_home / ".hindsight" / "profiles"
+        profile_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.delenv("HINDSIGHT_API_LLM_API_KEY", raising=False)
+
+        (profile_dir / "hermes.env").write_text(
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=embedding-secret\n",
+            encoding="utf-8",
+        )
+
+        _validate_embedded_profile_env({
+            "profile": "hermes",
+            "llm_provider": "openai-codex",
+            "llm_model": "gpt-5.4-mini",
+            "embeddings_provider": "openai",
+        })
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
@@ -331,7 +401,7 @@ class TestPostSetup:
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
-        selections = iter([1, 0])  # local_embedded, openai
+        selections = iter([1, 0, 0])  # local_embedded, openai LLM, local embeddings
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
@@ -356,6 +426,7 @@ class TestPostSetup:
             "HINDSIGHT_API_LLM_API_KEY=sk-local-test\n"
             "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
             "HINDSIGHT_API_LOG_LEVEL=info\n"
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER=local\n"
             "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
         )
 
@@ -365,7 +436,7 @@ class TestPostSetup:
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
-        selections = iter([1, 0])  # local_embedded, openai
+        selections = iter([1, 0, 0])  # local_embedded, openai LLM, local embeddings
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
@@ -388,7 +459,7 @@ class TestPostSetup:
         user_home.mkdir()
         monkeypatch.setenv("HOME", str(user_home))
 
-        selections = iter([1, 0])  # local_embedded, openai
+        selections = iter([1, 0, 0])  # local_embedded, openai LLM, local embeddings
         monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
@@ -406,6 +477,72 @@ class TestPostSetup:
         profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
         assert profile_env.exists()
         assert "HINDSIGHT_API_LLM_API_KEY=existing-key\n" in profile_env.read_text()
+
+    def test_local_embedded_setup_collects_openai_embeddings_key(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([1, 0, 2])  # local_embedded, openai LLM, openai embeddings
+        secrets = iter(["sk-llm-test", "sk-embeddings-test"])
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": next(secrets))
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        saved = json.loads((hermes_home / "hindsight" / "config.json").read_text())
+        assert saved["embeddings_provider"] == "openai"
+        assert saved["embeddings_openai_model"] == "text-embedding-3-small"
+
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        env_text = profile_env.read_text()
+        assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai\n" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL=text-embedding-3-small\n" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-embeddings-test\n" in env_text
+
+    def test_local_embedded_setup_blank_preserves_existing_tei_embeddings_provider(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: hermes_home)
+
+        provider = HindsightMemoryProvider()
+        provider.save_config({
+            "mode": "local_embedded",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embeddings_provider": "tei",
+        }, str(hermes_home))
+
+        profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
+        profile_env.parent.mkdir(parents=True)
+        profile_env.write_text(
+            "HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: kwargs.get("default", 0))
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        saved = json.loads((hermes_home / "hindsight" / "config.json").read_text())
+        assert saved["embeddings_provider"] == "tei"
+        env_text = profile_env.read_text()
+        assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER=tei\n" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_TEI_URL=http://localhost:8080\n" in env_text
 
 
     def test_local_embedded_setup_blank_inputs_preserve_existing_config(self, tmp_path, monkeypatch):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -236,6 +236,61 @@ the old standalone daemon alive for one release cycle, but running both
 a gateway-embedded dispatcher AND a standalone daemon against the same
 `kanban.db` causes claim races and is not supported.
 
+### Reactivating Kanban after a restart or update
+
+If the Kanban tab stops loading, reactivate the gateway and dashboard rather
+than the deprecated standalone kanban daemon. The gateway owns the dispatcher;
+the dashboard owns the `/kanban` page.
+
+```bash
+# 1. Make sure the gateway is running; this hosts the embedded dispatcher.
+hermes gateway status
+hermes gateway start        # or: hermes gateway restart
+
+# 2. Confirm the board is reachable and see whether work is waiting.
+hermes kanban stats
+hermes kanban dispatch --dry-run --max 3
+
+# 3. Check whether the dashboard is already running.
+hermes dashboard --status
+```
+
+For a local-only dashboard:
+
+```bash
+hermes dashboard --host 127.0.0.1 --port 9119 --no-open
+```
+
+For a private-network dashboard URL such as
+`http://100.84.162.95:9119/kanban`, bind to that interface explicitly. Only
+use `--insecure` on a trusted network such as your own Tailscale tailnet; it
+exposes the dashboard management UI to that network.
+
+```bash
+systemd-run --user \
+  --unit hermes-dashboard-kanban \
+  --property WorkingDirectory=/home/hermes/.hermes/hermes-agent \
+  /home/hermes/.hermes/hermes-agent/venv/bin/python \
+  -m hermes_cli.main \
+  --tui dashboard \
+  --host 100.84.162.95 \
+  --port 9119 \
+  --no-open \
+  --insecure \
+  --skip-build
+```
+
+Then verify the route and service state:
+
+```bash
+curl http://100.84.162.95:9119/kanban
+systemctl --user status hermes-dashboard-kanban.service --no-pager
+```
+
+Do not enable `hermes-kanban-dispatcher.service` unless you have deliberately
+disabled gateway-embedded dispatch with `kanban.dispatch_in_gateway: false`.
+Running both dispatchers against the same board is unsupported.
+
 ### Idempotent create (for automation / webhooks)
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the Hindsight `local_embedded` memory provider integration where Hermes rewrites the generated embedded daemon profile env file:

`~/.hindsight/profiles/<profile>.env`

Before this change, Hermes rebuilt that file from only the keys it explicitly managed. That could erase daemon-side settings required by Hindsight but intentionally not stored in Hermes config, especially embedding credentials such as:

`HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY`

This PR changes profile env materialization to merge Hermes-managed values into the existing env file instead of replacing it wholesale. It also makes the embedding provider/model settings explicit for `local_embedded` setup and adds preflight validation so missing embedding settings fail with a clear, actionable message before daemon startup.

This is related to #21830, but not identical. #21830 persists `HINDSIGHT_EMBED_API_DATABASE_URL`; this PR addresses the broader env ownership/materialization issue for user-managed daemon settings and embedding configuration.

## Related Issue

Related: #21830

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Preserve existing unmanaged keys in `~/.hindsight/profiles/<profile>.env` when materializing the embedded daemon env.
  - Keep Hermes-managed embedding provider/model settings in sync with the daemon env.
  - Avoid erasing an existing daemon-visible `HINDSIGHT_API_LLM_API_KEY` when no replacement LLM key is provided.
  - Compare only Hermes-managed env keys when deciding whether daemon configuration changed.
  - Extend `hermes memory setup` for Hindsight `local_embedded` mode to expose embeddings provider selection.
  - Collect or reuse OpenAI embeddings credentials when `openai` embeddings are selected, without storing embedding API keys in `config.json`.
  - Add embedded daemon env preflight validation for required provider settings such as `HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY` and `HINDSIGHT_API_EMBEDDINGS_TEI_URL`.
  - Improve startup failure clarity by including the profile name, profile env path, selected embeddings provider/model, and missing env var.

- `tests/plugins/memory/test_hindsight_provider.py`
  - Add regression coverage for preserving existing daemon API keys.
  - Add validation coverage for missing and present OpenAI embeddings keys.
  - Add setup coverage for local embeddings, OpenAI embeddings credential collection, and preserving an existing TEI embeddings provider.

## How to Test

1. Configure Hindsight `local_embedded` with an existing profile env containing a user-managed embedding key, for example:

   ```bash
   mkdir -p ~/.hindsight/profiles
   printf '%s\n' \
     'HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=sk-existing' \
     > ~/.hindsight/profiles/hermes.env
   ```

2. Run `hermes memory setup`, choose Hindsight `local_embedded`, and leave existing secrets blank when prompted. The generated profile env should preserve the embedding key instead of deleting it.

3. Run the focused regression tests:

   ```bash
   python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='
   python -m pytest tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_provider_init.py -q -o 'addopts='
   ```

Tested locally with:

```bash
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_provider_init.py -q -o 'addopts='
```

Results:

- `101 passed` for `tests/plugins/memory/test_hindsight_provider.py`
- `13 passed` for adjacent memory/session initialization tests

I also started the full contribution-guide command:

```bash
/home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -v -o 'addopts='
```

It collected `23655` tests and hit unrelated failures in `tests/acp/test_registry_manifest.py` before reaching this change area, so I stopped the long-running suite after confirming the focused and adjacent memory suites pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test output:

```text
tests/plugins/memory/test_hindsight_provider.py
101 passed

tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_provider_init.py
13 passed
```
