### PR TITLE
fix(run_agent): surface rate-limit reset time in status messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5203,6 +5203,13 @@ class AIAgent:
                 if value not in {None, ""}:
                     context["reset_at"] = value
                     break
+            if "reset_at" not in context:
+                resets_in_seconds = payload.get("resets_in_seconds")
+                if resets_in_seconds not in {None, ""}:
+                    try:
+                        context["reset_at"] = time.time() + float(resets_in_seconds)
+                    except (TypeError, ValueError):
+                        pass
             retry_after = payload.get("retry_after")
             if retry_after not in {None, ""} and "reset_at" not in context:
                 try:
@@ -5246,6 +5253,41 @@ class AIAgent:
                         context["reset_at"] = time.time() + float(sec_match.group(1))
 
         return context
+
+    @staticmethod
+    def _format_reset_in_hint(reset_at: Any) -> str:
+        """Render ``reset_at`` as a relative ``Xm Ys`` duration, or ``""``.
+
+        Accepts epoch seconds, epoch milliseconds, and ISO-8601 strings —
+        the same value shapes ``_extract_api_error_context`` may emit. Returns
+        an empty string when the value can't be parsed or has already elapsed,
+        so callers can safely concatenate without a None check.
+        """
+        if reset_at is None or reset_at == "":
+            return ""
+        target: Optional[float] = None
+        if isinstance(reset_at, (int, float)):
+            target = float(reset_at)
+        elif isinstance(reset_at, str):
+            raw = reset_at.strip()
+            if not raw:
+                return ""
+            try:
+                target = float(raw)
+            except ValueError:
+                try:
+                    target = datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+                except ValueError:
+                    return ""
+        if target is None or target <= 0:
+            return ""
+        if target > 1_000_000_000_000:
+            target = target / 1000.0
+        delta = target - time.time()
+        if delta <= 0:
+            return ""
+        from agent.nous_rate_guard import format_remaining
+        return format_remaining(delta)
 
     def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
@@ -14787,7 +14829,11 @@ class AIAgent:
                                     pass
                     wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                     if is_rate_limited:
-                        self._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
+                        _reset_hint = self._format_reset_in_hint(
+                            error_context.get("reset_at") if isinstance(error_context, dict) else None
+                        )
+                        _reset_suffix = f" Resets in ~{_reset_hint}." if _reset_hint else ""
+                        self._emit_status(f"⏱️ Rate limited.{_reset_suffix} Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                     else:
                         self._emit_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
                     logger.warning(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3832,6 +3832,86 @@ class TestCredentialPoolRecovery:
         assert context["message"] == "Weekly credits exhausted."
         assert context["reset_at"] == "2026-04-12T10:30:00Z"
 
+    def test_extract_api_error_context_parses_resets_in_seconds(self, agent):
+        """Codex 429 bodies expose ``resets_in_seconds`` instead of an
+        absolute ``resets_at`` — convert to an absolute epoch so downstream
+        consumers (credential pool, status formatter) get a consistent type.
+        """
+        import time as _time
+
+        response = SimpleNamespace(headers={})
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "resets_in_seconds": 756,
+                }
+            },
+            response=response,
+        )
+
+        before = _time.time()
+        context = agent._extract_api_error_context(error)
+        after = _time.time()
+
+        assert "reset_at" in context
+        assert before + 756 - 1 <= context["reset_at"] <= after + 756 + 1
+
+    def test_extract_api_error_context_resets_at_wins_over_resets_in_seconds(self, agent):
+        """When both keys are present, the absolute ``resets_at`` value is
+        authoritative — the agent must not silently convert it via the
+        relative path.
+        """
+        response = SimpleNamespace(headers={})
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "resets_at": "2026-04-12T10:30:00Z",
+                    "resets_in_seconds": 756,
+                }
+            },
+            response=response,
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reset_at"] == "2026-04-12T10:30:00Z"
+
+    def test_format_reset_in_hint_renders_numeric_epoch(self, agent):
+        import time as _time
+
+        reset_at = _time.time() + 780  # 13 minutes out
+        hint = agent._format_reset_in_hint(reset_at)
+        # Allow 12m..13m tolerance — `time.time()` ticks between the set and
+        # the format call, so the boundary may round down by a second.
+        assert hint in {"13m", "12m 59s", "12m 58s"}
+
+    def test_format_reset_in_hint_renders_iso_string(self, agent):
+        from datetime import datetime, timedelta, timezone
+
+        target = datetime.now(timezone.utc) + timedelta(seconds=180)
+        hint = agent._format_reset_in_hint(target.isoformat().replace("+00:00", "Z"))
+        # 3 minutes out — accept 2m 5xs through 3m
+        assert hint.startswith(("2m", "3m"))
+
+    def test_format_reset_in_hint_renders_milliseconds_epoch(self, agent):
+        import time as _time
+
+        reset_at_ms = (_time.time() + 600) * 1000.0
+        hint = agent._format_reset_in_hint(reset_at_ms)
+        assert hint in {"10m", "9m 59s", "9m 58s"}
+
+    def test_format_reset_in_hint_returns_empty_for_unparseable(self, agent):
+        assert agent._format_reset_in_hint(None) == ""
+        assert agent._format_reset_in_hint("") == ""
+        assert agent._format_reset_in_hint("not a date") == ""
+
+    def test_format_reset_in_hint_returns_empty_when_already_elapsed(self, agent):
+        import time as _time
+
+        assert agent._format_reset_in_hint(_time.time() - 60) == ""
+
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")
         captured = {}


### PR DESCRIPTION
## Summary

- Parse the `resets_in_seconds` field from provider 429 bodies (currently used by Codex/ChatGPT but silently ignored by `_extract_api_error_context`).
- Surface the parsed reset time in the user-facing retry status — `⏱️ Rate limited. Resets in ~12m 36s. Waiting 60.0s (attempt 2/3)...` — so Telegram/Slack/CLI users know whether to wait or move on.

Fixes #26889.

## The bug

When a provider returns 429, `_extract_api_error_context` in `run_agent.py` parses several reset hints from the body and headers into `error_context["reset_at"]`. That information is then used by the credential pool to decide whether to rotate, but it is **dropped before reaching the user** — the retry status just says `Rate limited. Waiting 60.0s` even when the body said the limit resets in 13 minutes.

Two specific gaps:

1. The Codex/ChatGPT 429 body shape includes `resets_in_seconds` (a relative seconds value) alongside `resets_at` (epoch). When only `resets_in_seconds` is set — or when it is the more accurate of the two — `_extract_api_error_context` ignores it because the function only checks the absolute keys (`resets_at`, `reset_at`) and `retry_after` / `Retry-After` headers.
2. Even when `reset_at` IS parsed correctly, the user-facing `_emit_status` message never references it.

Issue body:
> The Codex/ChatGPT 429 response body includes `resets_in_seconds` (e.g. `756`), but `_extract_api_error_context()` only checks for `resets_at`, `reset_at`, and `retry_after` keys. The `resets_in_seconds` field is silently ignored.

## The fix

**`_extract_api_error_context` learns `resets_in_seconds`.** Add a check between the existing `resets_at`/`reset_at` block and the `retry_after` fallback. Convert the relative value to an absolute epoch via `time.time() + float(value)` so downstream consumers (credential pool, the new formatter) see a single shape. The absolute `resets_at` keeps priority when both keys are present.

**New `_format_reset_in_hint` helper.** Renders epoch seconds, epoch milliseconds, or ISO-8601 strings — the three shapes `_extract_api_error_context` may emit — into a relative `Xm Ys` duration via the existing `format_remaining` helper from `agent.nous_rate_guard`. Returns `""` for unparseable values, past timestamps, or anything else the formatter can't make sense of, so callers can safely concatenate without a None check.

**Status message injection.** At the rate-limited retry point, build the suffix only when the hint parses cleanly:

```python
_reset_hint = self._format_reset_in_hint(
    error_context.get("reset_at") if isinstance(error_context, dict) else None
)
_reset_suffix = f" Resets in ~{_reset_hint}." if _reset_hint else ""
self._emit_status(f"⏱️ Rate limited.{_reset_suffix} Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
```

No behaviour change when `reset_at` is absent or already elapsed — the original message is unchanged. Non-rate-limit retries (`is_rate_limited == False`) are untouched.

## Test plan

- [x] Focused regression test: `tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery::test_extract_api_error_context_parses_resets_in_seconds` — without the production fix, this fails with `AssertionError: assert 'reset_at' in {'message': '...'}`; with the fix, it passes.
- [x] Priority guard: `test_extract_api_error_context_resets_at_wins_over_resets_in_seconds` — when both keys are present, the absolute timestamp wins; the relative-fallback path is not silently invoked.
- [x] Formatter coverage: 5 tests cover numeric epoch, ISO-8601 strings, epoch milliseconds, unparseable values, and already-elapsed timestamps.
- [x] Full file passes: `pytest tests/run_agent/test_run_agent.py` — 336 passed in 41.93s.
- [x] Existing test `test_extract_api_error_context_uses_reset_timestamp_and_reason` still passes — no regression to the priority rule for `resets_at` (absolute timestamp wins over relative).

## Related

- `gateway/run.py` was given a similar `resets_in_seconds` hint by commit `7ce374d3b` ("Improve gateway error handling for 429 usage limits and 500 context overflow") for the gateway plan-limit path. The agent's main retry loop (`run_agent.py`) is a separate code path that wasn't updated; this PR fills that gap.

> Sibling code paths that may need the same fix: `agent/account_usage.py` parses `resets_at` / `reset_at` from `windows[...]` for the `/usage` UI, but does not parse `resets_in_seconds` either. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.