### PR TITLE
fix(gateway): bridge gateway_restart_notification from YAML platform sections to PlatformConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -322,15 +322,21 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        # gateway_restart_notification may be bridged into extra via the
+        # shared-key loop in load_gateway_config(); check both top-level
+        # and extra so YAML ``discord: gateway_restart_notification: false``
+        # works without needing a separate platforms: block.
+        _grn = data.get("gateway_restart_notification")
+        if _grn is None:
+            _grn = data.get("extra", {}).get("gateway_restart_notification")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(
-                data.get("gateway_restart_notification"), True
-            ),
+            gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
         )
 
@@ -849,6 +855,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,23 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_gateway_restart_notification_reads_from_extra_fallback(self):
+        """When gateway_restart_notification is absent at top-level but present
+        in extra (as happens after the shared-key bridging loop in
+        load_gateway_config), from_dict must still pick it up."""
+        restored = PlatformConfig.from_dict({
+            "extra": {"gateway_restart_notification": False},
+        })
+        assert restored.gateway_restart_notification is False
+
+    def test_gateway_restart_notification_top_level_takes_precedence_over_extra(self):
+        """Top-level value wins when both top-level and extra provide the key."""
+        restored = PlatformConfig.from_dict({
+            "gateway_restart_notification": True,
+            "extra": {"gateway_restart_notification": False},
+        })
+        assert restored.gateway_restart_notification is True
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -679,3 +696,66 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestGatewayRestartNotificationBridging:
+    """Regression tests for the gateway_restart_notification config bridge bug.
+
+    Setting ``discord: gateway_restart_notification: false`` in config.yaml
+    was silently ignored because:
+
+    1. The shared-key bridging loop in load_gateway_config() did not include
+       ``gateway_restart_notification`` in its bridge list, so the value never
+       reached ``platforms_data["discord"]``.
+    2. PlatformConfig.from_dict() only read the key from the top-level dict,
+       not from ``extra`` where bridged values land.
+
+    Both issues are fixed. These tests verify the end-to-end path.
+    """
+
+    def test_discord_yaml_section_bridged_to_platform_config(self, tmp_path, monkeypatch):
+        """``discord: gateway_restart_notification: false`` in config.yaml
+        must propagate to PlatformConfig.gateway_restart_notification."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        discord_cfg = config.platforms.get(Platform.DISCORD)
+        assert discord_cfg is not None
+        assert discord_cfg.gateway_restart_notification is False
+
+    def test_telegram_yaml_section_bridged_to_platform_config(self, tmp_path, monkeypatch):
+        """``telegram: gateway_restart_notification: false`` in config.yaml
+        must propagate to PlatformConfig.gateway_restart_notification."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        telegram_cfg = config.platforms.get(Platform.TELEGRAM)
+        assert telegram_cfg is not None
+        assert telegram_cfg.gateway_restart_notification is False
+
+    def test_default_true_when_not_set(self, tmp_path, monkeypatch):
+        """When gateway_restart_notification is absent, the default must be True."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n  require_mention: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+        discord_cfg = config.platforms.get(Platform.DISCORD)
+        assert discord_cfg is not None
+        assert discord_cfg.gateway_restart_notification is True


### PR DESCRIPTION
## Bug Description

Setting `gateway_restart_notification: false` in config.yaml platform sections (e.g. `discord:`, `telegram:`) was silently ignored — restart/shutdown notifications were always sent to the platform regardless of the user's preference.

## Root Cause

Two-part breakage in the config loading pipeline:

1. **Missing bridge key**: The shared-key bridging loop in `load_gateway_config()` (lines ~806-853) omitted `gateway_restart_notification` from its bridge list. Other comparable keys like `require_mention`, `reply_to_mode`, `dm_policy` etc. were all bridged — this one was simply missed when the feature was added.

2. **No `extra` fallback in `from_dict()`**: Bridged values land in `platforms_data["<plat>"]["extra"]`, but `PlatformConfig.from_dict()` only read `gateway_restart_notification` from the top-level dict. Since the bridging loop put it in `extra`, `from_dict()` never saw it and always fell through to the default (`True`).

The net effect: `discord: gateway_restart_notification: false` in config.yaml was a no-op.

## Fix

- **`gateway/config.py` bridging loop**: Add `gateway_restart_notification` to the set of bridged keys so it propagates from YAML `discord:` / `telegram:` sections into `platforms_data`.
- **`PlatformConfig.from_dict()`**: Fall back to `data["extra"]["gateway_restart_notification"]` when the top-level key is absent. Top-level takes precedence when both are present.

## How to Verify

1. Add `gateway_restart_notification: false` under a `discord:` section in `~/.hermes/config.yaml`
2. Restart the gateway
3. Confirm the "⚠️ Gateway shutting down" notification is **not** sent to Discord
4. Remove the setting → confirm notifications resume (default `True`)

## Test Plan

- [x] Added regression test: `PlatformConfig.from_dict()` reads from `extra` fallback
- [x] Added regression test: top-level takes precedence over `extra`
- [x] Added regression test: end-to-end `load_gateway_config()` bridges `discord: gateway_restart_notification: false`
- [x] Added regression test: end-to-end `load_gateway_config()` bridges `telegram: gateway_restart_notification: false`
- [x] Added regression test: default `True` when not set
- [x] All 158 existing tests in related test files still pass

## Risk Assessment

Low — The fix only affects the config loading path for `gateway_restart_notification`. Other config keys use the same bridging pattern and are unaffected. The `extra` fallback in `from_dict()` only activates when the top-level key is absent, preserving existing behavior for configs that set the key through `gateway.json` (which writes to the top level).