### PR TITLE
feat: support per-task kanban model overrides

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1247,6 +1247,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
           (f" @ {task.workspace_path}" if task.workspace_path else ""))
     if task.skills:
         print(f"  skills:    {', '.join(task.skills)}")
+    if task.model:
+        print(f"  model:     {task.model}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -71,6 +71,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "model": t.model,
     }
 
 
@@ -285,6 +286,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--model", default=None,
+                          help="Per-task worker model override. Omit to use the "
+                               "assignee profile's configured default model.")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1115,6 +1119,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            model=getattr(args, "model", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -607,6 +607,9 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Per-task main-model override for the spawned worker. ``None`` means
+    # use the assignee profile's configured default model.
+    model: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -671,6 +674,7 @@ class Task:
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
+            model=row["model"] if "model" in keys else None,
         )
 
 
@@ -797,7 +801,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
-    max_retries          INTEGER
+    max_retries          INTEGER,
+    -- Per-task main-model override for the worker. NULL = use the
+    -- assignee profile's configured default model.
+    model                TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1076,6 +1083,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+    if "model" not in cols:
+        _add_column_if_missing(conn, "tasks", "model", "model TEXT")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1245,6 +1254,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    model: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1273,6 +1283,9 @@ def create_task(
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
+    model = str(model).strip() if model is not None else None
+    if model == "":
+        model = None
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
@@ -1378,8 +1391,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         tenant, idempotency_key, max_runtime_seconds, skills,
-                        max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        max_retries, model
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1397,6 +1410,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        model,
                     ),
                 )
                 for pid in parents:
@@ -1414,6 +1428,7 @@ def create_task(
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
+                        "model": model,
                     },
                 )
             return task_id
@@ -4295,6 +4310,8 @@ def _default_spawn(
         for sk in task.skills:
             if sk and sk != "kanban-worker":
                 cmd.extend(["--skills", sk])
+    if task.model:
+        cmd.extend(["-m", task.model])
     cmd.extend([
         "chat",
         "-q", prompt,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -518,6 +518,7 @@ class CreateTaskBody(BaseModel):
     triage: bool = False
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
+    model: Optional[str] = None
     skills: Optional[list[str]] = None
 
 
@@ -540,6 +541,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             triage=payload.triage,
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
+            model=payload.model,
             skills=payload.skills,
         )
         task = kanban_db.get_task(conn, task_id)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -112,11 +112,12 @@ def test_run_slash_block_unblock_cycle(kanban_home):
 
 
 def test_run_slash_json_output(kanban_home):
-    out = kc.run_slash("create 'jsontask' --assignee alice --json")
+    out = kc.run_slash("create 'jsontask' --assignee alice --model gpt-5.5 --json")
     payload = json.loads(out)
     assert payload["title"] == "jsontask"
     assert payload["assignee"] == "alice"
     assert payload["status"] == "ready"
+    assert payload["model"] == "gpt-5.5"
 
 
 def test_run_slash_dispatch_dry_run_counts(kanban_home):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -61,6 +61,19 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_persists_model_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="hard one",
+            assignee="alice",
+            model="gpt-5.5",
+        )
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.model == "gpt-5.5"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")
@@ -1086,6 +1099,40 @@ class TestSharedBoardPaths:
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
 
 
+def test_default_spawn_includes_model_flag_when_task_sets_override(monkeypatch, tmp_path):
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.pid = 4242
+
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+    task = kb.Task(
+        id="t_model_override",
+        title="x",
+        body=None,
+        assignee="coder",
+        status="ready",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+        model="gpt-5.5",
+    )
+    kb._default_spawn(task, str(tmp_path / "ws"))
+    cmd = captured["cmd"]
+    assert "-m" in cmd
+    assert cmd[cmd.index("-m") + 1] == "gpt-5.5"
+
+
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs
 # ---------------------------------------------------------------------------
@@ -1310,7 +1357,8 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
             workflow_template_id TEXT,
             current_step_key TEXT,
             skills TEXT,
-            max_retries INTEGER
+            max_retries INTEGER,
+            model TEXT
         )
         """
     )
@@ -1329,6 +1377,40 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
 
     # Running migration on an already-migrated schema must not raise.
     kb._migrate_add_optional_columns(conn)
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "model" in cols
+    conn.close()
+
+
+def test_migrate_add_optional_columns_adds_model_column_for_legacy_tasks(kanban_home):
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY,
+            title TEXT NOT NULL,
+            max_retries INTEGER
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE task_events (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id    TEXT NOT NULL DEFAULT '',
+            kind       TEXT NOT NULL DEFAULT '',
+            payload    TEXT,
+            created_at INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+
+    kb._migrate_add_optional_columns(conn)
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "model" in cols
     conn.close()
 
 

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -1010,10 +1010,12 @@ def _(home, kb):
         "title": "📋 deploy 🚀 to 生产",
         "body": "日本語 body",
         "assignee": "deploy-bot",
+        "model": "gpt-5.5",
     })
     assert r.status_code == 200
     tid = r.json()["task"]["id"]
     assert r.json()["task"]["title"] == "📋 deploy 🚀 to 生产"
+    assert r.json()["task"]["model"] == "gpt-5.5"
 
     # Invalid JSON schema — unknown field, pydantic should either ignore or 422
     r = client.post("/api/plugins/kanban/tasks", json={

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -128,8 +128,6 @@ def worker_env(monkeypatch, tmp_path):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
-    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
-    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
     from pathlib import Path as _Path
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
@@ -171,13 +169,38 @@ def test_show_explicit_task_id(worker_env):
     assert d["task"]["id"] == other
 
 
+def test_show_includes_model_override(worker_env):
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(
+            conn,
+            title="strong model task",
+            assignee="peer",
+            model="gpt-5.5",
+        )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_show({"task_id": other})
+    d = json.loads(out)
+    assert d["task"]["model"] == "gpt-5.5"
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
-        a = kb.create_task(conn, title="alpha", assignee="factory", priority=5)
+        a = kb.create_task(
+            conn,
+            title="alpha",
+            assignee="factory",
+            priority=5,
+            model="gpt-5.5",
+        )
         b = kb.create_task(conn, title="beta", assignee="reviewer")
         c = kb.create_task(conn, title="gamma", assignee="factory", tenant="other")
     finally:
@@ -190,6 +213,7 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert ids == [a, c]
     assert d["count"] == 2
     assert d["tasks"][0]["title"] == "alpha"
+    assert d["tasks"][0]["model"] == "gpt-5.5"
     assert d["tasks"][0]["parent_count"] == 0
     assert b not in ids
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -128,6 +128,8 @@ def worker_env(monkeypatch, tmp_path):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
     from pathlib import Path as _Path
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
@@ -791,6 +793,22 @@ def test_create_accepts_skills_string(worker_env):
     with kb.connect() as conn:
         task = kb.get_task(conn, d["task_id"])
     assert task.skills == ["translation"]
+
+
+def test_create_accepts_model_override(worker_env):
+    """Tool writes the per-task model override through to the kernel."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    out = kt._handle_create({
+        "title": "hard task",
+        "assignee": "a",
+        "model": "gpt-5.5",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, d["task_id"])
+    assert task.model == "gpt-5.5"
 
 
 def test_create_rejects_non_list_skills(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -534,17 +534,29 @@ def _handle_heartbeat(args: dict, **kw) -> str:
         try:
             # Extend the claim TTL first. The dispatcher pins
             # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
-            # (see _default_spawn in kanban_db.py); falling back to the
-            # default _claimer_id() covers locally-driven workers that
-            # never went through the dispatcher path.
+            # (see _default_spawn in kanban_db.py). For locally-driven
+            # workers and tests that don't have that env, fall back to the
+            # task row's current claim_lock before finally trying the local
+            # process claimer id.
             claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+            task = None
+            expected_run_id = _worker_run_id(tid)
+            if not claim_lock:
+                task = kb.get_task(conn, tid)
+                claim_lock = task.claim_lock if task is not None else None
+                # In locally-driven / test contexts we may inherit an
+                # unrelated HERMES_KANBAN_RUN_ID from the parent Hermes
+                # worker. Without the dispatcher-pinned claim-lock env,
+                # prefer the task row's current run id instead of ambient
+                # process state.
+                expected_run_id = task.current_run_id if task is not None else None
             kb.heartbeat_claim(conn, tid, claimer=claim_lock)
 
             ok = kb.heartbeat_worker(
                 conn,
                 tid,
                 note=note,
-                expected_run_id=_worker_run_id(tid),
+                expected_run_id=expected_run_id,
             )
             if not ok:
                 return tool_error(
@@ -617,6 +629,7 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    model = args.get("model")
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -651,6 +664,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                model=(str(model).strip() if model is not None else None),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -1060,6 +1074,13 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional per-task worker model override. Omit to use "
+                    "the assignee profile's configured default model."
                 ),
             },
             "skills": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -215,6 +215,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "started_at": task.started_at,
         "completed_at": task.completed_at,
         "current_run_id": task.current_run_id,
+        "model": task.model,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -258,6 +259,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "model": t.model,
                 }
 
             def _run_dict(r):
@@ -534,29 +536,17 @@ def _handle_heartbeat(args: dict, **kw) -> str:
         try:
             # Extend the claim TTL first. The dispatcher pins
             # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
-            # (see _default_spawn in kanban_db.py). For locally-driven
-            # workers and tests that don't have that env, fall back to the
-            # task row's current claim_lock before finally trying the local
-            # process claimer id.
+            # (see _default_spawn in kanban_db.py); falling back to the
+            # default _claimer_id() covers locally-driven workers that
+            # never went through the dispatcher path.
             claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
-            task = None
-            expected_run_id = _worker_run_id(tid)
-            if not claim_lock:
-                task = kb.get_task(conn, tid)
-                claim_lock = task.claim_lock if task is not None else None
-                # In locally-driven / test contexts we may inherit an
-                # unrelated HERMES_KANBAN_RUN_ID from the parent Hermes
-                # worker. Without the dispatcher-pinned claim-lock env,
-                # prefer the task row's current run id instead of ambient
-                # process state.
-                expected_run_id = task.current_run_id if task is not None else None
             kb.heartbeat_claim(conn, tid, claimer=claim_lock)
 
             ok = kb.heartbeat_worker(
                 conn,
                 tid,
                 note=note,
-                expected_run_id=expected_run_id,
+                expected_run_id=_worker_run_id(tid),
             )
             if not ok:
                 return tool_error(

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -59,7 +59,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation), and an optional per-task model override for worker routing.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
@@ -104,6 +104,11 @@ hermes kanban boards create atm10-server \
 # Operate on a specific board without switching.
 hermes kanban --board atm10-server list
 hermes kanban --board atm10-server create "Restart ATM server" --assignee ops
+
+# Route one hard task to a stronger model without creating a new profile.
+hermes kanban create "Investigate flaky prod crash" \
+    --assignee coder \
+    --model gpt-5.5
 
 # Change which board is "current" for subsequent calls.
 hermes kanban boards switch atm10-server


### PR DESCRIPTION
## Summary
- add nullable per-task `model` storage + migration in kanban DB
- thread `--model` through `hermes kanban create`, JSON/task serialization, and `kanban_create`
- spawn workers with `-m <model>` for overridden tasks and document/test the flow

## Context
Implements issue #24206 and completes the user-facing plumbing left partial in #23234.

## Testing
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py -q -o addopts=''
