### PR TITLE
fix(codex): suppress commentary phase leakage

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -937,7 +937,6 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     saw_final_answer_phase = True
             message_text = _extract_responses_message_text(item)
             if message_text:
-                content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",
@@ -950,6 +949,14 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                 if normalized_phase:
                     raw_message_item["phase"] = normalized_phase
                 message_items_raw.append(raw_message_item)
+
+                # Codex Responses phases are semantic, not cosmetic.
+                # `commentary` / `analysis` output_text can contain private
+                # execution planning. Preserve it for Responses replay via
+                # `codex_message_items`, but never expose it as user-visible
+                # assistant content.
+                if normalized_phase not in {"commentary", "analysis"}:
+                    content_parts.append(message_text)
         elif item_type == "reasoning":
             reasoning_text = _extract_responses_reasoning_text(item)
             if reasoning_text:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7113,20 +7113,15 @@ class AIAgent:
                         if self._interrupt_requested:
                             break
                         event_type = getattr(event, "type", "")
-                        # Fire callbacks on text content deltas (suppress during tool calls)
+                        # Collect text content deltas, but do not stream them
+                        # directly for Codex/Responses. Deltas may belong to
+                        # `commentary` / `analysis` phase message items, which
+                        # can contain private execution planning. Visibility is
+                        # decided after completed output items are normalized.
                         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
                             delta_text = getattr(event, "delta", "")
                             if delta_text:
                                 self._codex_streamed_text_parts.append(delta_text)
-                            if delta_text and not has_tool_calls:
-                                if not first_delta_fired:
-                                    first_delta_fired = True
-                                    if on_first_delta:
-                                        try:
-                                            on_first_delta()
-                                        except Exception:
-                                            pass
-                                self._fire_stream_delta(delta_text)
                         # Track tool calls to suppress text streaming
                         elif "function_call" in event_type:
                             has_tool_calls = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5142,6 +5142,72 @@ class TestNormalizeCodexDictArguments:
         assert tc.function.arguments == args_str
 
 
+class TestNormalizeCodexPhases:
+    """Codex commentary/analysis phase text must not reach user-visible content."""
+
+    def _message_item(self, text, phase=None):
+        item = SimpleNamespace(
+            type="message",
+            status="completed",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text=text)],
+        )
+        if phase is not None:
+            item.phase = phase
+        return item
+
+    def test_commentary_only_message_is_incomplete_and_hidden(self, agent):
+        response = SimpleNamespace(
+            output=[self._message_item("Need patch skill. Search old section.", phase="commentary")],
+            status="completed",
+        )
+
+        msg, finish_reason = _normalize_codex_response(response)
+
+        assert finish_reason == "incomplete"
+        assert msg.content == ""
+        assert msg.codex_message_items[0]["phase"] == "commentary"
+        assert "Need patch skill" in msg.codex_message_items[0]["content"][0]["text"]
+
+    def test_commentary_plus_final_surfaces_only_final_text(self, agent):
+        response = SimpleNamespace(
+            output=[
+                self._message_item("Need inspect config first.", phase="commentary"),
+                self._message_item("结论：配置正常。", phase="final_answer"),
+            ],
+            status="completed",
+        )
+
+        msg, finish_reason = _normalize_codex_response(response)
+
+        assert finish_reason == "stop"
+        assert msg.content == "结论：配置正常。"
+        assert len(msg.codex_message_items) == 2
+
+    def test_commentary_plus_tool_call_has_empty_visible_content(self, agent):
+        response = SimpleNamespace(
+            output=[
+                self._message_item("Need maybe memory add to memory?", phase="commentary"),
+                SimpleNamespace(
+                    type="function_call",
+                    status="completed",
+                    name="memory",
+                    arguments='{"action":"add"}',
+                    call_id="call_abc123",
+                    id="fc_abc123",
+                ),
+            ],
+            status="completed",
+        )
+
+        msg, finish_reason = _normalize_codex_response(response)
+
+        assert finish_reason == "tool_calls"
+        assert msg.content == ""
+        assert len(msg.tool_calls) == 1
+        assert msg.codex_message_items[0]["phase"] == "commentary"
+
+
 # ---------------------------------------------------------------------------
 # OAuth flag and nudge counter fixes (salvaged from PR #1797)
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1137,7 +1137,9 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
     )
 
     assert finish_reason == "incomplete"
-    assert "inspect the repository" in (assistant_message.content or "")
+    assert assistant_message.content == ""
+    assert assistant_message.codex_message_items[0]["phase"] == "commentary"
+    assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
 
 
 def test_normalize_codex_response_preserves_message_status_for_replay(monkeypatch):
@@ -1456,7 +1458,7 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, *_args, **_kwargs):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1472,11 +1474,15 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
 
     assert result["completed"] is True
     assert result["final_response"] == "Architecture summary complete."
-    assert any(
-        msg.get("role") == "assistant"
-        and msg.get("finish_reason") == "incomplete"
-        and "inspect the repo structure" in (msg.get("content") or "")
+    incomplete_messages = [
+        msg for msg in result["messages"]
+        if msg.get("role") == "assistant" and msg.get("finish_reason") == "incomplete"
+    ]
+    assert any(msg.get("content") == "" for msg in incomplete_messages)
+    assert not any(
+        "inspect the repo structure" in (msg.get("content") or "")
         for msg in result["messages"]
+        if msg.get("role") == "assistant"
     )
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -760,13 +760,13 @@ class TestHasStreamConsumers:
         assert agent._has_stream_consumers() is True
 
 
-# ── Test: Codex stream fires callbacks ────────────────────────────────
+# ── Test: Codex stream suppresses raw text callbacks ──────────────────
 
 
 class TestCodexStreamCallbacks:
-    """Verify _run_codex_stream fires delta callbacks."""
+    """Verify _run_codex_stream caches raw text deltas without leaking them."""
 
-    def test_codex_text_delta_fires_callback(self):
+    def test_codex_text_delta_is_cached_not_streamed(self):
         from run_agent import AIAgent
 
         deltas = []
@@ -809,7 +809,10 @@ class TestCodexStreamCallbacks:
         mock_client.responses.stream.return_value = mock_stream
 
         response = agent._run_codex_stream({}, client=mock_client)
-        assert "Hello from Codex!" in deltas
+        assert deltas == []
+        assert agent._codex_streamed_text_parts == ["Hello from Codex!"]
+        assert response is not None
+        assert response.output[0].content[0].text == "Hello from Codex!"
 
     def test_codex_stream_refreshes_activity_on_every_event(self):
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary
- Suppress Codex Responses `commentary` / `analysis` phase text from visible assistant content.
- Preserve Codex message items internally for replay/state continuity.
- Update streaming expectations so raw `output_text.delta` is cached, not emitted to platform callbacks before phase-aware normalization.

## Why
`commentary` and `analysis` can contain internal planning. They should not appear in Telegram/CLI/UI output unless a final-answer phase is present.

## Test Plan
- `venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_streaming.py::TestCodexStreamCallbacks -q`
- Result: `67 passed in 18.80s`

## Notes
Opened as draft because this is a visibility/privacy hardening change and maintainers may want to review provider replay semantics carefully.
