### PR TITLE
fix: clear stale global context length on model switch

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5141,6 +5141,11 @@ def _save_model_choice(model_id: str) -> None:
     # Always use dict format so provider/base_url can be stored alongside
     if isinstance(config.get("model"), dict):
         config["model"]["default"] = model_id
+        # ``model.context_length`` is a global override. Older custom-endpoint
+        # setup flows could leave a provider-specific value here, which then
+        # leaked to every later provider/model selection. Model-specific
+        # context belongs under provider/custom-provider metadata.
+        config["model"].pop("context_length", None)
     else:
         config["model"] = {"default": model_id}
     save_config(config)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3297,6 +3297,7 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
+        _clear_model_context_length_override(model)
         if effective_key:
             model["api_key"] = effective_key
         if api_mode:
@@ -3323,6 +3324,7 @@ def _model_flow_custom(config):
             _caller_model = {"default": _caller_model} if _caller_model else {}
         _caller_model["provider"] = "custom"
         _caller_model["base_url"] = effective_url
+        _clear_model_context_length_override(_caller_model)
         if effective_key:
             _caller_model["api_key"] = effective_key
         if api_mode:
@@ -3432,6 +3434,19 @@ def _auto_provider_name(base_url: str) -> str:
     else:
         name = name.capitalize()
     return name
+
+
+def _clear_model_context_length_override(model: dict) -> None:
+    """Remove stale global context-length override from ``model`` config.
+
+    ``model.context_length`` applies globally to the active runtime model. The
+    custom-provider wizard asks for a context length for the selected custom
+    model, but that value must be saved under provider metadata, not retained in
+    the global ``model`` block where it would affect OpenAI, Anthropic, Codex,
+    and every subsequent provider switch.
+    """
+    if isinstance(model, dict):
+        model.pop("context_length", None)
 
 
 def _custom_provider_api_key_config_value(provider_info, resolved_api_key=""):
@@ -3914,6 +3929,7 @@ def _model_flow_named_custom(config, provider_info):
         if config_api_key:
             model["api_key"] = config_api_key
     # Apply api_mode from custom_providers entry, or clear stale value
+    _clear_model_context_length_override(model)
     custom_api_mode = provider_info.get("api_mode", "")
     if custom_api_mode:
         model["api_mode"] = custom_api_mode
@@ -5220,6 +5236,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        _clear_model_context_length_override(model)
         if provider_id in {"opencode-zen", "opencode-go"}:
             model["api_mode"] = opencode_model_api_mode(provider_id, selected)
         else:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -546,6 +546,66 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     assert saved_env["MODEL"] == "llm"
 
 
+def test_model_flow_custom_clears_stale_global_context_length(monkeypatch):
+    saved_cfg = {
+        "model": {
+            "default": "old-model",
+            "provider": "openai-codex",
+            "base_url": "",
+            "context_length": 64000,
+        }
+    }
+    captured_provider = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda key: "" if key in {"OPENAI_BASE_URL", "OPENAI_API_KEY"} else "",
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": [],
+            "probed_url": f"{base_url.rstrip('/')}/models",
+            "resolved_base_url": None,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: saved_cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr(
+        "hermes_cli.main._save_custom_provider",
+        lambda base_url, api_key="", model="", context_length=None, name=None, api_mode=None: captured_provider.update(
+            {"model": model, "context_length": context_length, "name": name}
+        ),
+    )
+
+    answers = iter(
+        [
+            "https://deepsproxy.example.com/v1",
+            "",  # api mode: auto-detect
+            "deepseek-chat",
+            "64k",
+            "deepsproxy",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "test-key")
+
+    hermes_main._model_flow_custom({"model": dict(saved_cfg["model"])})
+
+    assert saved_cfg["model"]["provider"] == "custom"
+    assert saved_cfg["model"]["base_url"] == "https://deepsproxy.example.com/v1"
+    assert "context_length" not in saved_cfg["model"]
+    assert captured_provider == {
+        "model": "deepseek-chat",
+        "context_length": 64000,
+        "name": "deepsproxy",
+    }
+
+
 def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     saved_cfg = {"model": {"default": "", "provider": "custom", "base_url": ""}}
     captured_provider = {}


### PR DESCRIPTION
## Summary

- Clear stale `model.context_length` global overrides when switching models/providers.
- Prevent custom endpoint context lengths from leaking into later provider selections.
- Keep custom endpoint context lengths scoped to custom provider model metadata.
- Add regression coverage for the deepsproxy-style custom provider flow.

Credit: this fix was implemented with Hermes Agent.

## Why

`model.context_length` is a global runtime override. If a custom endpoint setup left `context_length: 64000` in the global `model:` block, every provider selected afterward could inherit that 64k limit, including Codex, OpenAI, Anthropic, and other non-custom providers.

The custom provider wizard should preserve context length only as provider/model metadata, not as a global model override.

## Testing

- `scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_user_providers_model_switch.py -q`
- Result: `79 passed`

Co-authored-by: Hermes Agent <hermes-agent@users.noreply.github.com>
