### PR TITLE
fix(web): update sanitize-html lockfile entry

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3635,6 +3635,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4543,6 +4549,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/leva": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
@@ -5369,15 +5384,16 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }


### PR DESCRIPTION
Summary
- Update the web lockfile's transitive sanitize-html entry from 2.17.3 to 2.17.4.
- Add the new transitive launder/dayjs lockfile entries required by sanitize-html 2.17.4.

Why
- npm audit reports GHSA-rpr9-rxv7-x643 against sanitize-html <=2.17.3 in the web package lock.
- The direct dependency range from @nous-research/ui already allows the patched release, so this is a lockfile-only security hardening change.

Verification
- npm audit --omit=dev --package-lock-only --audit-level=critical (repo root): found 0 vulnerabilities
- npm audit --omit=dev --package-lock-only --audit-level=critical (web): found 0 vulnerabilities
- npm audit --omit=dev --package-lock-only --audit-level=critical (ui-tui): found 0 vulnerabilities
- npm audit --omit=dev --package-lock-only --audit-level=critical (scripts/whatsapp-bridge): found 0 vulnerabilities
