### PR TITLE
perf(run_agent): cache-stable mode — trim verification + reduce tool-result budgets for recurring single-wake spawns

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -334,6 +334,45 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "</missing_context>"
 )
 
+# Cache-stable variant of the OpenAI execution guidance (RC4).
+#
+# For recurring single-wake spawns (Paperclip disposition issues) the strong
+# "verify every requirement / re-check after every mutation" <verification>
+# block drives gpt-5.x to ~30-40 model turns vs OpenClaw's ~10-15 on the same
+# work (measured: AOS-10 H-IN_REVIEW 225s / 1.43M input tok). Paperclip only
+# strictly requires the end-of-run disposition PATCH; the per-step re-reads
+# are pure latency. This variant keeps every other discipline (tool
+# persistence, mandatory tool use, prerequisite checks, anti-hallucination)
+# and replaces ONLY the <verification> block with a single end-of-run
+# disposition-confirm line. Derived from the canonical constant via
+# string replacement so the two can never drift apart; the assertion makes
+# a drifted/removed block a hard import-time failure rather than a silent
+# no-op. Selected at the call site only when _cache_stable_mode is on.
+_OPENAI_VERIFICATION_BLOCK_STRONG = (
+    "<verification>\n"
+    "Before finalizing your response:\n"
+    "- Correctness: does the output satisfy every stated requirement?\n"
+    "- Grounding: are factual claims backed by tool outputs or provided context?\n"
+    "- Formatting: does the output match the requested format or schema?\n"
+    "- Safety: if the next step has side effects (file writes, commands, API calls), "
+    "confirm scope before executing.\n"
+    "</verification>\n"
+)
+_OPENAI_VERIFICATION_BLOCK_CACHE_STABLE = (
+    "<verification>\n"
+    "Before exiting, confirm the disposition PATCH to the issue returned a 2xx "
+    "status. No other per-step re-reads are required.\n"
+    "</verification>\n"
+)
+assert _OPENAI_VERIFICATION_BLOCK_STRONG in OPENAI_MODEL_EXECUTION_GUIDANCE, (
+    "OPENAI_MODEL_EXECUTION_GUIDANCE <verification> block drifted; update "
+    "_OPENAI_VERIFICATION_BLOCK_STRONG in prompt_builder.py to match (RC4)."
+)
+OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE = OPENAI_MODEL_EXECUTION_GUIDANCE.replace(
+    _OPENAI_VERIFICATION_BLOCK_STRONG,
+    _OPENAI_VERIFICATION_BLOCK_CACHE_STABLE,
+)
+
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
 # Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.
 GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (

--- a/run_agent.py
+++ b/run_agent.py
@@ -133,6 +133,7 @@ from tools.terminal_tool import (
     _get_sudo_password_callback,
 )
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
+from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, DEFAULT_PREVIEW_SIZE_CHARS
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
 
@@ -160,7 +161,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -2114,6 +2115,28 @@ class AIAgent:
         if not isinstance(_agent_section, dict):
             _agent_section = {}
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+
+        # Cache-stable mode (RC4/RC5): for recurring single-wake spawns
+        # (Paperclip disposition issues) we trim per-step verification
+        # pressure and shrink in-context tool-result budgets so high-turn
+        # flows (IN_REVIEW / CONTINUATION) don't blow past OpenClaw-equivalent
+        # turn counts. Default OFF — interactive CLI/Telegram/Discord/cron
+        # are byte-for-byte unaffected. Activated by platform, env var, or
+        # the agent.cache_stable config key (operator-owned for Paperclip).
+        self._cache_stable_mode = (
+            (self.platform or "").lower().strip() == "paperclip"
+            or os.environ.get("HERMES_CACHE_STABLE", "").lower() in {"1", "true", "yes"}
+            or bool(_agent_section.get("cache_stable", False))
+        )
+        # Reduced tool-result budgets used only in cache-stable mode. Built
+        # once. PINNED_THRESHOLDS (read_file=inf) and 3-layer persistence
+        # are preserved by BudgetConfig.resolve_threshold regardless of these
+        # numbers — only the in-context footprint shrinks.
+        self._cache_stable_budget = BudgetConfig(
+            default_result_size=20_000,
+            turn_budget=60_000,
+            preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
+        )
 
         # App-level API retry count (wraps each model API call).  Default 3,
         # overridable via agent.api_max_retries in config.yaml.  See #11616.
@@ -6147,8 +6170,18 @@ class AIAgent:
                     stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
                 # OpenAI GPT/Codex execution discipline (tool persistence,
                 # prerequisite checks, verification, anti-hallucination).
+                # RC4: in cache-stable mode, use the variant whose
+                # <verification> block is reduced to a single end-of-run
+                # disposition-PATCH confirm — drops the per-step re-read
+                # turns that blow up high-turn Paperclip flows. The variant
+                # is itself a fixed constant, so RC2's byte-stable prefix
+                # invariant still holds.
                 if "gpt" in _model_lower or "codex" in _model_lower:
-                    stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                    stable_parts.append(
+                        OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+                        if self._cache_stable_mode
+                        else OPENAI_MODEL_EXECUTION_GUIDANCE
+                    )
 
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
@@ -11388,6 +11421,7 @@ class AIAgent:
                 tool_name=name,
                 tool_use_id=tc.id,
                 env=get_active_env(effective_task_id),
+                config=(self._cache_stable_budget if self._cache_stable_mode else DEFAULT_BUDGET),
             ) if not _is_multimodal_tool_result(function_result) else function_result
 
             subdir_hints = self._subdirectory_hints.check_tool_call(name, args)
@@ -11425,7 +11459,11 @@ class AIAgent:
         num_tools = len(parsed_calls)
         if num_tools > 0:
             turn_tool_msgs = messages[-num_tools:]
-            enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
+            enforce_turn_budget(
+                turn_tool_msgs,
+                env=get_active_env(effective_task_id),
+                config=(self._cache_stable_budget if self._cache_stable_mode else DEFAULT_BUDGET),
+            )
 
         # ── /steer injection ──────────────────────────────────────────────
         # Append any pending user steer text to the last tool result so the
@@ -11810,6 +11848,7 @@ class AIAgent:
                 tool_name=function_name,
                 tool_use_id=tool_call.id,
                 env=get_active_env(effective_task_id),
+                config=(self._cache_stable_budget if self._cache_stable_mode else DEFAULT_BUDGET),
             ) if not _is_multimodal_tool_result(function_result) else function_result
 
             # Discover subdirectory context files from tool arguments
@@ -11866,7 +11905,11 @@ class AIAgent:
         # ── Per-turn aggregate budget enforcement ─────────────────────────
         num_tools_seq = len(assistant_message.tool_calls)
         if num_tools_seq > 0:
-            enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id))
+            enforce_turn_budget(
+                messages[-num_tools_seq:],
+                env=get_active_env(effective_task_id),
+                config=(self._cache_stable_budget if self._cache_stable_mode else DEFAULT_BUDGET),
+            )
 
         # ── /steer injection ──────────────────────────────────────────────
         # See _execute_tool_calls_parallel for the rationale. Same hook,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -1181,6 +1182,61 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_is_string(self):
         assert isinstance(OPENAI_MODEL_EXECUTION_GUIDANCE, str)
         assert len(OPENAI_MODEL_EXECUTION_GUIDANCE) > 100
+
+
+class TestOpenAIModelExecutionGuidanceCacheStable:
+    """RC4: the cache-stable variant trims only the <verification> block."""
+
+    def test_is_derived_and_identical_except_verification(self):
+        # Everything outside <verification> must be byte-identical to the
+        # canonical constant (it's built via .replace on that single block).
+        canon = OPENAI_MODEL_EXECUTION_GUIDANCE
+        cs = OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+        # Split each on the verification block boundaries and compare the
+        # surrounding text.
+        pre_canon = canon.split("<verification>")[0]
+        post_canon = canon.split("</verification>")[1]
+        pre_cs = cs.split("<verification>")[0]
+        post_cs = cs.split("</verification>")[1]
+        assert pre_canon == pre_cs
+        assert post_canon == post_cs
+
+    def test_strong_reread_block_removed(self):
+        cs = OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE.lower()
+        # The strong per-step verification bullets are gone.
+        assert "before finalizing your response" not in cs
+        assert "- correctness:" not in cs
+        assert "- grounding:" not in cs
+
+    def test_single_disposition_confirm_line_present(self):
+        cs = OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+        assert "<verification>" in cs and "</verification>" in cs
+        assert "disposition PATCH" in cs
+        assert "2xx" in cs
+        assert "No other per-step re-reads are required." in cs
+
+    def test_other_disciplines_retained(self):
+        # Tool persistence / prerequisite / missing-context blocks must survive.
+        cs = OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+        assert "<tool_persistence>" in cs
+        assert "<prerequisite_checks>" in cs
+        assert "<missing_context>" in cs
+
+    def test_variant_is_byte_stable(self):
+        # Two reads of the module constant are identical — it's a fixed
+        # string, so RC2's byte-stable-prefix invariant holds when this is
+        # selected.
+        import agent.prompt_builder as pb
+        assert (
+            pb.OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+            == OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE
+        )
+
+    def test_canonical_constant_untouched(self):
+        # The original must still carry the strong block (other code/tests
+        # depend on it; only the call-site swap changes behavior).
+        assert "Before finalizing your response:" in OPENAI_MODEL_EXECUTION_GUIDANCE
+        assert "- Correctness:" in OPENAI_MODEL_EXECUTION_GUIDANCE
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1028,6 +1028,81 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
 
+class TestCacheStableMode:
+    """RC4/RC5: _cache_stable_mode scoping + gating. Default OFF."""
+
+    def _make_agent(self, **kwargs):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                **kwargs,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_default_off_for_interactive(self, agent):
+        # No platform / env / config → flag OFF, interactive unaffected.
+        assert agent._cache_stable_mode is False
+
+    def test_reduced_budget_built_with_expected_caps(self, agent):
+        b = agent._cache_stable_budget
+        assert b.default_result_size == 20_000
+        assert b.turn_budget == 60_000
+        # read_file stays inf regardless of the reduced numbers (PINNED).
+        assert b.resolve_threshold("read_file") == float("inf")
+
+    def test_platform_paperclip_enables(self):
+        a = self._make_agent(platform="paperclip")
+        assert a._cache_stable_mode is True
+
+    def test_env_var_enables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CACHE_STABLE", "1")
+        a = self._make_agent()
+        assert a._cache_stable_mode is True
+
+    def test_non_paperclip_platform_stays_off(self):
+        a = self._make_agent(platform="telegram")
+        assert a._cache_stable_mode is False
+
+    def test_rc4_off_uses_strong_verification_for_gpt(self, agent):
+        agent.model = "gpt-5.5"
+        if hasattr(agent, "_invalidate_system_prompt"):
+            agent._invalidate_system_prompt()
+        prompt = agent._build_system_prompt()
+        assert "Before finalizing your response:" in prompt
+        assert "disposition PATCH" not in prompt
+
+    def test_rc4_on_uses_trimmed_verification_for_gpt(self):
+        a = self._make_agent(platform="paperclip")
+        a.model = "gpt-5.5"
+        if hasattr(a, "_invalidate_system_prompt"):
+            a._invalidate_system_prompt()
+        prompt = a._build_system_prompt()
+        assert "disposition PATCH" in prompt
+        assert "2xx" in prompt
+        assert "Before finalizing your response:" not in prompt
+
+    def test_rc4_byte_stable_across_sessions_when_on(self):
+        # RC2 invariant must still hold with the trimmed (fixed) constant.
+        a = self._make_agent(platform="paperclip")
+        a.model = "gpt-5.5"
+        a.session_id = "20260101_000000_aaaaaa"
+        first = a._build_system_prompt()
+        if hasattr(a, "_invalidate_system_prompt"):
+            a._invalidate_system_prompt()
+        a.session_id = "20260101_000001_bbbbbb"
+        second = a._build_system_prompt()
+        assert first == second
+
+
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -49,6 +49,22 @@ class TestPinnedThresholds:
     def test_pinned_is_not_empty(self):
         assert len(PINNED_THRESHOLDS) >= 1
 
+    def test_cache_stable_reduced_budget_still_pins_read_file(self):
+        # RC5: the cache-stable BudgetConfig (20k/60k) must NOT truncate
+        # read_file — PINNED wins over the reduced default, preserving the
+        # 3-layer persistence (full payload still retrievable via read_file).
+        from tools.budget_config import BudgetConfig, DEFAULT_PREVIEW_SIZE_CHARS
+        cs = BudgetConfig(
+            default_result_size=20_000,
+            turn_budget=60_000,
+            preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
+        )
+        assert cs.resolve_threshold("read_file") == float("inf")
+        assert cs.default_result_size == 20_000
+        assert cs.turn_budget == 60_000
+        # A non-pinned tool DOES get the reduced cap.
+        assert cs.resolve_threshold("some_other_tool") == 20_000
+
 
 # ---------------------------------------------------------------------------
 # BudgetConfig defaults


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **cache-stable mode** that cuts model turn count and in-context footprint for recurring **single-wake** spawns (cron cycles, queue/disposition workers that create a fresh session per item). Two gated behaviors:

- **Verification trim**: a cache-stable variant of `OPENAI_MODEL_EXECUTION_GUIDANCE` whose `<verification>` block is reduced to a single end-of-run confirmation, dropping the strong per-step "verify/re-read after every mutation" pressure. Every other discipline (tool persistence, prerequisite checks, mandatory tool use, anti-hallucination) is retained.
- **Reduced tool-result budgets**: lower per-result / per-turn char budgets (20k / 60k) so high-turn flows don't accumulate a giant uncached context.

Both are **default OFF**. With the flag off, the built system prompt and budget config are byte-identical to current behavior — zero impact on interactive CLI / Telegram / Discord.

## Why

On a recurring single-wake workload (each item = a fresh session) we measured the agent running ~30-40 model turns where an equivalent codex-app-server agent ran ~10-15 on identical work, with per-item input 0.7-1.4M tokens — driven almost entirely by the strong verification block forcing re-reads after every mutation, plus large tool results held in-context. The single end-of-run check preserves correctness for workflows that have one authoritative completion action (here: a status write the platform enforces) while removing the per-step re-read tax.

This is the turn-count companion to the prefix-stability work (keeping per-spawn runtime metadata out of the cached system prompt — see PR #23438, which we also carry). Standalone and independent of it.

## Type of Change

- [x] ✨ New feature (opt-in, non-breaking; default OFF)

## Changes Made

- \`run_agent.py\`: \`self._cache_stable_mode\` set in \`__init__\` after the validated agent config sub-dict — true when platform-string matches an opt-in platform, OR \`HERMES_CACHE_STABLE\` env is set, OR \`agent.cache_stable: true\` in config. \`self._cache_stable_budget\` (a reduced \`BudgetConfig\`) built once.
- \`agent/prompt_builder.py\`: \`OPENAI_MODEL_EXECUTION_GUIDANCE_CACHE_STABLE\`, derived from the canonical constant via \`.replace()\` on the \`<verification>\` block, guarded by an import-time \`assert\` so the two cannot silently drift.
- \`run_agent.py\` system-prompt builder: selects the cache-stable guidance constant only when \`_cache_stable_mode\` (the variant is a fixed string, so prompt-prefix byte-stability across spawns is preserved).
- \`run_agent.py\`: the four \`maybe_persist_tool_result\` / \`enforce_turn_budget\` call sites now pass \`config=(self._cache_stable_budget if _cache_stable_mode else DEFAULT_BUDGET)\` — mirroring how the RL agent loop already threads \`config=\`. Module defaults untouched; \`PINNED_THRESHOLDS\` (read_file=inf) preserved by \`BudgetConfig.resolve_threshold\`; the 3-layer persistence is intact (full payloads still written to the sandbox and retrievable via \`read_file\`; only the in-context footprint shrinks).

## How to Test

\`pytest tests/agent/test_prompt_builder.py tests/tools/test_budget_config.py tests/run_agent/test_run_agent.py -q\` — 484 passed.

New coverage:
- \`TestOpenAIModelExecutionGuidanceCacheStable\`: variant identical-except-verification; strong block removed; single confirm line present; other disciplines retained; canonical constant untouched.
- \`TestCacheStableMode\`: default OFF; each trigger flips it; non-opt-in platform stays off; strong vs trimmed guidance by flag; system prompt byte-stable across sessions when on; reduced budget caps with \`read_file\` still inf.
- \`test_budget_config.py\`: reduced \`BudgetConfig\` still pins \`read_file=inf\`; non-pinned tool gets the reduced cap.

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commits (\`perf(run_agent):\`)
- [x] Searched existing PRs
- [x] Only this change (no unrelated commits)
- [x] Tests added + 484 passing on Ubuntu 24.04 / WSL2 (aarch64)
- [x] No config-key docs needed beyond the self-describing \`agent.cache_stable\` boolean; \`HERMES_CACHE_STABLE\` env mirrors it
- [x] Cross-platform: pure prompt-string selection + dataclass; no platform-specific code paths
- [x] Default OFF — interactive behavior byte-identical when unset

## Notes

- The platform-string clause is a local convenience; the **portable activation surface is the `HERMES_CACHE_STABLE` env var and the `agent.cache_stable` config key** — reviewers can ignore the specific platform name.
- The verification trim's single end-of-run check is phrased around a status-write completion action; deployments with a different authoritative completion step can adjust that one line in the variant constant.