### PR TITLE
fix(mcp): ignore empty stdio args placeholder

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -128,6 +128,17 @@ def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
     return parsed
 
 
+def _normalize_cli_args(raw_args: Optional[List[Any]]) -> List[str]:
+    """Normalize CLI-provided stdio args, dropping empty placeholders."""
+    normalized: List[str] = []
+    for item in raw_args or []:
+        text = str(item or "")
+        if not text.strip():
+            continue
+        normalized.append(text)
+    return normalized
+
+
 def _apply_mcp_preset(
     name: str,
     *,
@@ -231,7 +242,7 @@ def cmd_mcp_add(args):
     # mcp_add_p.add_argument("--command", dest="mcp_command", ...) in
     # hermes_cli/main.py for why the dest is renamed.
     command = getattr(args, "mcp_command", None)
-    cmd_args = getattr(args, "args", None) or []
+    cmd_args = _normalize_cli_args(getattr(args, "args", None))
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -246,6 +246,37 @@ class TestMcpAdd:
         assert srv["command"] == "npx"
         assert srv["args"] == ["@mcp/github"]
 
+    def test_add_stdio_server_ignores_empty_args_placeholder(self, tmp_path, capsys, monkeypatch):
+        """Regression for #26886: empty CLI arg placeholders must not persist as ['']."""
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["command"] == "npx"
+            assert "args" not in config
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            mcp_command="npx",
+            args=[""],
+        ))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        srv = config["mcp_servers"]["github"]
+        assert srv["command"] == "npx"
+        assert "args" not in srv
+
     def test_add_connection_failure_save_disabled(
         self, tmp_path, capsys, monkeypatch
     ):
@@ -599,4 +630,3 @@ class TestMcpLogin:
         cmd_mcp_login(_make_args(name="srv"))
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
-


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI argument normalization bug in `hermes mcp add` where an empty placeholder arg from shell/UI invocation can be persisted as `args: [""]`. The PR drops empty/whitespace-only placeholders before writing MCP server config, so stdio servers without real args are stored cleanly.

## Related Issue

Fixes #26886

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_normalize_cli_args()` in `hermes_cli/mcp_config.py` to remove empty/whitespace-only values from CLI-provided `args`.
- Updated `cmd_mcp_add` to use normalized args before applying preset/transport logic.
- Added regression test `test_add_stdio_server_ignores_empty_args_placeholder` in `tests/hermes_cli/test_mcp_config.py` to verify `args=[""]` is not persisted.

## How to Test

1. Run:
   `python3 -m pytest -o addopts='' tests/hermes_cli/test_mcp_config.py -k 'ignores_empty_args_placeholder or add_stdio_server or add_preset_fills_transport or preset_does_not_override_explicit_command'`
2. Confirm all selected tests pass (including the new regression).
3. Optionally run a manual repro with `hermes mcp add ... --args ""` and verify saved config does not contain `args: [""]`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`pytest` result:

`6 passed, 27 deselected in 1.27s`
