### PR TITLE
fix(auxiliary): preserve named provider on custom endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3983,8 +3983,13 @@ def _resolve_task_provider_model(
     if task:
         # Config.yaml is the primary source for per-task overrides.
         if cfg_base_url and cfg_api_key:
-            # Both base_url and api_key explicitly set → custom endpoint.
-            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+            # Both base_url and api_key explicitly set. Preserve an explicit
+            # provider so downstream provider-specific logic still applies
+            # (e.g. transport quirks / parameter guards) on custom endpoints.
+            effective_provider = (
+                cfg_provider if cfg_provider and cfg_provider != "auto" else "custom"
+            )
+            return effective_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_base_url and cfg_provider and cfg_provider != "auto":
             # base_url set without api_key but with a known provider — use
             # the provider so it can resolve credentials from env vars

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -62,3 +62,48 @@ def test_vision_base_url_override_keeps_explicit_provider():
     assert model == "glm-4v"
     assert mock_resolve.call_args.args[0] == "zai"
     assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_resolve_task_provider_model_preserves_provider_with_custom_endpoint():
+    """auxiliary.<task>.provider must survive when base_url+api_key are both configured."""
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={
+            "provider": "zai",
+            "model": "glm-4v-flash",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4/",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+        },
+    ):
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task="vision")
+
+    assert provider == "zai"
+    assert model == "glm-4v-flash"
+    assert base_url == "https://open.bigmodel.cn/api/paas/v4/"
+    assert api_key == "sk-test"
+    assert api_mode == "chat_completions"
+
+
+def test_resolve_task_provider_model_uses_custom_when_provider_is_auto():
+    """When provider is auto, base_url+api_key should still resolve to custom."""
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={
+            "provider": "auto",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.com/v1",
+            "api_key": "sk-test",
+        },
+    ):
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task="vision")
+
+    assert provider == "custom"
+    assert model == "gpt-4o-mini"
+    assert base_url == "https://example.com/v1"
+    assert api_key == "sk-test"
+    assert api_mode is None


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary provider resolution so `auxiliary.<task>.provider` is preserved when `base_url` and `api_key` are both configured. Previously this path forced provider to `"custom"`, which skipped provider-specific handling in downstream call logic.

## Related Issue

Fixes #26879

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `_resolve_task_provider_model()` in `agent/auxiliary_client.py`:
  - when `cfg_base_url` + `cfg_api_key` are both set, preserve explicit non-`auto` `cfg_provider` instead of forcing `"custom"`.
- Added regression tests in `tests/agent/test_vision_resolved_args.py`:
  - verifies named provider is preserved for custom endpoint configs
  - verifies `provider: auto` still resolves to `"custom"` for this path

## How to Test

1. Run:
   `python3 -m pytest -o addopts='' tests/agent/test_vision_resolved_args.py`
2. Confirm all tests pass.
3. Verify behavior from config:
   set `auxiliary.vision.provider=zai` with `base_url` + `api_key` and confirm resolved provider remains `zai`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`4 passed in 0.63s`
