### PR TITLE
fix: include Nous Portal free-tier models in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1370,6 +1370,29 @@ def list_authenticated_providers(
             # Merge with models.dev for preferred providers (same rationale as above).
             if hermes_slug in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+            # For Nous Portal: augment curated list with free-tier models from
+            # the Portal's /api/nous/recommended-models endpoint so free users
+            # see models like deepseek-v4-flash and stepfun/step-3.5-flash in
+            # the /model picker (mirrors hermes_cli/main.py Nous model picker).
+            if hermes_slug == "nous":
+                try:
+                    from hermes_cli.models import (
+                        check_nous_free_tier,
+                        union_with_portal_free_recommendations,
+                        union_with_portal_paid_recommendations,
+                        get_pricing_for_provider,
+                    )
+                    _pricing = get_pricing_for_provider("nous")
+                    if check_nous_free_tier():
+                        model_ids, _pricing = union_with_portal_free_recommendations(
+                            model_ids, _pricing,
+                        )
+                    else:
+                        model_ids, _pricing = union_with_portal_paid_recommendations(
+                            model_ids, _pricing,
+                        )
+                except Exception:
+                    pass
         total = len(model_ids)
         top = model_ids[:max_models]
 


### PR DESCRIPTION
## Problem

The gateway `/model` picker (used in TUI and messaging platforms) doesn't show Nous Portal free-tier models like `deepseek-v4-flash` and `stepfun/step-3.5-flash`. Only the curated paid models appear.

The CLI `hermes model` command shows them correctly at the bottom under "Available free models", but the gateway picker omits them entirely.

## Root Cause

`list_authenticated_providers()` in `hermes_cli/model_switch.py` loads the curated Nous model list from the remote catalog but never augments it with the Portal's `freeRecommendedModels` (or `paidRecommendations` for paid users).

The CLI `hermes model` (in `hermes_cli/main.py`) already handles this via:
- `check_nous_free_tier()` — detect user tier
- `union_with_portal_free_recommendations()` — add free models
- `union_with_portal_paid_recommendations()` — add paid models

But `list_authenticated_providers()` — which the gateway's `/model` command uses — doesn't call any of these.

## Fix

Augment the Nous model list in `list_authenticated_providers()` with the Portal's recommended models, mirroring the CLI logic:

- **Free-tier users**: prepend `freeRecommendedModels` (so newly-launched free models show up even if the curated list is stale)
- **Paid-tier users**: prepend `paidRecommendations`

The augmentation is wrapped in a try/except so network failures or auth issues degrade gracefully to the curated list.

## Testing

- All existing model_switch tests pass (71/71)
- 1 pre-existing failure (missing `prompt_toolkit` in test env, unrelated)