### PR TITLE
fix(agent): continue after Chinese local-file ack before tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3867,7 +3867,11 @@ class AIAgent:
             return False
 
         has_future_ack = bool(
-            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+            re.search(
+                r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b",
+                assistant_text,
+            )
+            or re.search(r"(我会|我将|我先|接下来|现在开始|开始|马上|准备)", assistant_text)
         )
         if not has_future_ack:
             return False
@@ -3892,6 +3896,13 @@ class AIAgent:
             "walkthrough",
             "report back",
             "summarize",
+            "write",
+            "draft",
+            "save",
+            "撰写",
+            "写",
+            "保存",
+            "写入",
         )
         workspace_markers = (
             "directory",
@@ -3908,6 +3919,22 @@ class AIAgent:
             "files",
             "path",
         )
+        persistent_output_markers = (
+            "save to local",
+            "save locally",
+            "save to file",
+            "write to file",
+            "write it to",
+            "persist to",
+            "local file",
+            "保存到本地",
+            "保存到文件",
+            "写入本地",
+            "写入文件",
+            "写到本地",
+            "写到文件",
+            "保存为",
+        )
 
         user_text = (user_message or "").strip().lower()
         user_targets_workspace = (
@@ -3915,11 +3942,25 @@ class AIAgent:
             or "~/" in user_text
             or "/" in user_text
         )
+        user_targets_persistent_output = any(
+            marker in user_text for marker in persistent_output_markers
+        )
         assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
         assistant_targets_workspace = any(
             marker in assistant_text for marker in workspace_markers
         )
-        return (user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action
+        assistant_targets_persistent_output = any(
+            marker in assistant_text for marker in persistent_output_markers
+        )
+        return (
+            (
+                user_targets_workspace
+                or assistant_targets_workspace
+                or user_targets_persistent_output
+                or assistant_targets_persistent_output
+            )
+            and assistant_mentions_action
+        )
 
 
     def _extract_reasoning(self, assistant_message) -> Optional[str]:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1563,6 +1563,45 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
+def test_run_conversation_codex_continues_after_chinese_ack_for_local_file_write(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_ack_message_response("信息收集完毕，现在开始撰写文档。"),
+        _codex_tool_call_response(),
+        _codex_message_response("文档已写入本地文件。"),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": '{"ok":true}',
+                }
+            )
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("请你写一个2w字的文档，并保存到本地")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "文档已写入本地文件。"
+    assert any(
+        msg.get("role") == "assistant"
+        and msg.get("finish_reason") == "incomplete"
+        and "开始撰写文档" in (msg.get("content") or "")
+        for msg in result["messages"]
+    )
+    assert any(
+        msg.get("role") == "user"
+        and "Continue now. Execute the required tool calls" in (msg.get("content") or "")
+        for msg in result["messages"]
+    )
+    assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
+
+
 def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
     """Debug dumps should show /responses URL when in codex_responses mode."""
     import json


### PR DESCRIPTION
## What does this PR do?

Fixes premature turn completion when the model emits a Chinese "starting now" acknowledgement for a tool-required local file-writing task, but has not called any tool yet.  
The agent now treats this as an intermediate acknowledgement and auto-continues so the next call can emit actual tool calls.

## Related Issue

Fixes #26892

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Expanded `AIAgent._looks_like_codex_intermediate_ack(...)` in `run_agent.py`:
  - Added Chinese future-action acknowledgement detection.
  - Added persistent local-file intent markers (`保存到本地`, `写入文件`, `save to file`, etc.).
  - Added write/save action markers to classify tool-required follow-up turns.
- Added regression test `test_run_conversation_codex_continues_after_chinese_ack_for_local_file_write` in `tests/run_agent/test_run_agent_codex_responses.py`.

## How to Test

1. `uv run --extra dev python -m pytest -q tests/run_agent/test_run_agent_codex_responses.py -k chinese_ack_for_local_file_write`
2. `uv run --extra dev python -m pytest -q tests/run_agent/test_run_agent_codex_responses.py -k continues_after_ack`
3. `python3 -m py_compile run_agent.py tests/run_agent/test_run_agent_codex_responses.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (reported issue platform) and local macOS runner

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- Targeted regression checks:
  - `1 passed` for `-k chinese_ack_for_local_file_write`
  - `2 passed` for `-k continues_after_ack`
