### PR TITLE
fix(feishu): handle generic card form actions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2560,7 +2560,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if isinstance(action_value, dict) else None
         )
 
-        if hermes_action:
+        if hermes_action in _APPROVAL_CHOICE_MAP:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
@@ -2605,6 +2605,38 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+    @staticmethod
+    def _card_action_payload(action: Any, action_value: Any) -> Dict[str, Any]:
+        """Return the useful payload from a Feishu card action callback."""
+        payload: Dict[str, Any] = {}
+        if isinstance(action_value, dict):
+            payload.update(action_value)
+        elif action_value:
+            payload["value"] = action_value
+
+        form_value = getattr(action, "form_value", None) or {}
+        if form_value:
+            payload["form_value"] = form_value
+        input_value = getattr(action, "input_value", None)
+        if input_value:
+            payload["input_value"] = input_value
+        option = getattr(action, "option", None)
+        if option:
+            payload["option"] = option
+        options = getattr(action, "options", None)
+        if options:
+            payload["options"] = options
+        name = getattr(action, "name", None)
+        if name:
+            payload["name"] = name
+        checked = getattr(action, "checked", None)
+        if checked is not None:
+            payload["checked"] = checked
+        timezone = getattr(action, "timezone", None)
+        if timezone:
+            payload["timezone"] = timezone
+        return payload
+
     def _logical_card_action_key(self, event: Any, action_value: Any) -> str:
         context = getattr(event, "context", None)
         operator = getattr(event, "operator", None)
@@ -2613,10 +2645,11 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = str(getattr(context, "open_chat_id", "") or "")
         open_id = str(getattr(operator, "open_id", "") or "")
         action_tag = str(getattr(action, "tag", "") or "button")
+        payload = self._card_action_payload(action, action_value)
         try:
-            value_json = json.dumps(action_value or {}, ensure_ascii=False, sort_keys=True, default=str)
+            value_json = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
         except Exception:
-            value_json = str(action_value)
+            value_json = str(payload)
         return "|".join([open_message_id or chat_id, open_id, action_tag, value_json])
 
     def _is_logical_card_action_duplicate(self, event: Any, action_value: Any) -> bool:
@@ -2842,11 +2875,12 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
+        action_payload = self._card_action_payload(action, action_value)
 
         synthetic_text = f"card_action:{action_tag}"
-        if action_value:
+        if action_payload:
             try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
+                synthetic_text += f" {json.dumps(action_payload, ensure_ascii=False)}"
             except Exception:
                 pass
         open_message_id = str(getattr(context, "open_message_id", "") or "")

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1465,6 +1465,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
+        # Logical card-action guard for non-approval cards. Feishu creates a new
+        # callback token for each click, so token dedup alone does not stop users
+        # from double-clicking the same button and triggering multiple agent runs.
+        self._card_action_logical_keys: "OrderedDict[str, float]" = OrderedDict()
+        self._card_action_logical_lock = threading.Lock()
         # Inbound events that arrived before the adapter loop was ready
         # (e.g. during startup/restart or network-flap reconnect). A single
         # drainer thread replays them as soon as the loop becomes available.
@@ -2564,10 +2569,67 @@ class FeishuAdapter(BasePlatformAdapter):
                 loop=loop,
             )
 
+        if self._is_logical_card_action_duplicate(event, action_value):
+            logger.info("[Feishu] Dropping repeated card action click for the same message/operator/action")
+            return self._build_card_action_callback_response(
+                self._build_generic_card_action_received_card(duplicate=True)
+            )
+
         self._submit_on_loop(loop, self._handle_card_action_event(data))
+        return self._build_card_action_callback_response(
+            self._build_generic_card_action_received_card(duplicate=False)
+        )
+
+    @staticmethod
+    def _build_generic_card_action_received_card(*, duplicate: bool = False) -> Dict[str, Any]:
+        title = "已处理过" if duplicate else "已收到"
+        content = "这个按钮已经点过了，不会重复触发。" if duplicate else "按钮点击已收到，正在处理。"
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"✅ {title}", "tag": "plain_text"},
+                "template": "green" if not duplicate else "grey",
+            },
+            "elements": [{"tag": "markdown", "content": content}],
+        }
+
+    @staticmethod
+    def _build_card_action_callback_response(card_data: Dict[str, Any]) -> Any:
         if P2CardActionTriggerResponse is None:
             return None
-        return P2CardActionTriggerResponse()
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = card_data
+            response.card = card
+        return response
+
+    def _logical_card_action_key(self, event: Any, action_value: Any) -> str:
+        context = getattr(event, "context", None)
+        operator = getattr(event, "operator", None)
+        action = getattr(event, "action", None)
+        open_message_id = str(getattr(context, "open_message_id", "") or "")
+        chat_id = str(getattr(context, "open_chat_id", "") or "")
+        open_id = str(getattr(operator, "open_id", "") or "")
+        action_tag = str(getattr(action, "tag", "") or "button")
+        try:
+            value_json = json.dumps(action_value or {}, ensure_ascii=False, sort_keys=True, default=str)
+        except Exception:
+            value_json = str(action_value)
+        return "|".join([open_message_id or chat_id, open_id, action_tag, value_json])
+
+    def _is_logical_card_action_duplicate(self, event: Any, action_value: Any) -> bool:
+        key = self._logical_card_action_key(event, action_value)
+        now = time.time()
+        with self._card_action_logical_lock:
+            if key in self._card_action_logical_keys:
+                return True
+            self._card_action_logical_keys[key] = now
+            self._card_action_logical_keys.move_to_end(key)
+            while len(self._card_action_logical_keys) > 1000:
+                self._card_action_logical_keys.popitem(last=False)
+        return False
 
     @staticmethod
     def _loop_accepts_callbacks(loop: Any) -> bool:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -11,7 +11,7 @@ Supports:
 - Processing status reactions: Typing while working, removed on success,
   swapped for CrossMark on failure
 - Reaction events routed as synthetic text events (matches openclaw)
-- Interactive card button-click events routed as synthetic COMMAND events
+- Interactive card button-click events routed as synthetic text events
 - Webhook anomaly tracking (matches openclaw createWebhookAnomalyTracker)
 - Verification token validation as second auth layer (matches openclaw)
 
@@ -1234,6 +1234,33 @@ def _build_mention_hint(mentions: Sequence[FeishuMentionRef]) -> str:
     return f"[Mentioned: {', '.join(parts)}]" if parts else ""
 
 
+def _prefix_group_sender_context(
+    text: str,
+    *,
+    chat_type: str,
+    user_id: Optional[str],
+    user_name: Optional[str],
+) -> str:
+    """Add explicit sender attribution to Feishu group/forum message text.
+
+    MessageEvent.source carries sender metadata, but gateway sessions feed the
+    model primarily with message text. In small family/group chats, pronoun and
+    relationship resolution depends on knowing which human spoke, so keep a
+    compact text-level prefix for non-command group/forum messages.
+    """
+    if chat_type not in {"group", "forum"}:
+        return text
+    label = (user_name or user_id or "unknown").strip() or "unknown"
+    sender_id = (user_id or "unknown").strip() or "unknown"
+    prefix = f"[Feishu group message from {label} (user_id={sender_id})]"
+    if not text:
+        return prefix
+    if text.startswith("[Mentioned:"):
+        first_line, sep, rest = text.partition("\n")
+        return f"{first_line}\n{prefix}{sep}{rest}" if sep else f"{first_line}\n{prefix}"
+    return f"{prefix}\n{text}"
+
+
 def _strip_edge_self_mentions(
     text: str,
     mentions: Sequence[FeishuMentionRef],
@@ -1846,6 +1873,31 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    async def send_card(
+        self,
+        chat_id: str,
+        card: Dict[str, Any] | str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a generic Feishu/Lark interactive card message."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            payload = card if isinstance(card, str) else json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "card send failed")
+        except Exception as exc:
+            logger.warning("[Feishu] send_card failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -1895,16 +1947,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 ],
             }
 
-            payload = json.dumps(card, ensure_ascii=False)
-            response = await self._feishu_send_with_retry(
+            result = await self.send_card(
                 chat_id=chat_id,
-                msg_type="interactive",
-                payload=payload,
+                card=card,
                 reply_to=None,
                 metadata=metadata,
             )
-
-            result = self._finalize_send_result(response, "send_exec_approval failed")
             if result.success:
                 self._approval_state[approval_id] = {
                     "session_key": session_key,
@@ -1960,19 +2008,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             prompt_id = next(self._update_prompt_counter)
-            payload = json.dumps(
-                self._build_update_prompt_card(prompt=prompt, default=default, prompt_id=prompt_id),
-                ensure_ascii=False,
-            )
-            response = await self._feishu_send_with_retry(
+            result = await self.send_card(
                 chat_id=chat_id,
-                msg_type="interactive",
-                payload=payload,
+                card=self._build_update_prompt_card(prompt=prompt, default=default, prompt_id=prompt_id),
                 reply_to=None,
                 metadata=metadata,
             )
-
-            result = self._finalize_send_result(response, "send_update_prompt failed")
             if result.success:
                 self._update_prompt_state[prompt_id] = {
                     "session_key": session_key,
@@ -2721,7 +2762,7 @@ class FeishuAdapter(BasePlatformAdapter):
         return False
 
     async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
+        """Route Feishu interactive card button clicks as synthetic text events."""
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
         if token and self._is_card_action_duplicate(token):
@@ -2740,12 +2781,13 @@ class FeishuAdapter(BasePlatformAdapter):
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
+        synthetic_text = f"card_action:{action_tag}"
         if action_value:
             try:
                 synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
             except Exception:
                 pass
+        open_message_id = str(getattr(context, "open_message_id", "") or "")
 
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)
@@ -2761,13 +2803,13 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         synthetic_event = MessageEvent(
             text=synthetic_text,
-            message_type=MessageType.COMMAND,
+            message_type=MessageType.TEXT,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=open_message_id or token or str(uuid.uuid4()),
             timestamp=datetime.now(),
         )
-        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
+        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic text", action_tag, open_id, chat_id)
         await self._handle_message_with_guards(synthetic_event)
 
     # =========================================================================
@@ -3007,10 +3049,18 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
+        source_chat_type = self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type)
+        if inbound_type != MessageType.COMMAND:
+            text = _prefix_group_sender_context(
+                text,
+                chat_type=source_chat_type,
+                user_id=sender_profile["user_id"],
+                user_name=sender_profile["user_name"],
+            )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
+            chat_type=source_chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=thread_id,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4502,7 +4502,8 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             )
         )
         event = adapter._dispatch_inbound_event.call_args.args[0]
-        self.assertEqual(event.text, "stop pinging @Hermes please")
+        self.assertTrue(event.text.endswith("stop pinging @Hermes please"))
+        self.assertIn("[Feishu group message from Alice (user_id=u1)]", event.text)
 
     def test_pure_self_mention_message_is_ignored(self):
         """A message containing only '@Bot' (no body, no media) must not dispatch.
@@ -4720,7 +4721,8 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
             "who are you @_user_1",
             [{"key": "@_user_1", "open_id": "ou_bot", "name": "Hermes"}],
         )
-        self.assertEqual(event.text, "who are you")
+        self.assertTrue(event.text.endswith("who are you"))
+        self.assertIn("[Feishu group message from Alice (user_id=u1)]", event.text)
 
     def test_scenario_mid_text_self_mention_preserved(self):
         """Self mention in the middle of a sentence (followed by a non-terminal
@@ -4731,12 +4733,14 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
             "please don't @_user_1 anymore",
             [{"key": "@_user_1", "open_id": "ou_bot", "name": "Hermes"}],
         )
-        self.assertEqual(event.text, "please don't @Hermes anymore")
+        self.assertTrue(event.text.endswith("please don't @Hermes anymore"))
+        self.assertIn("[Feishu group message from Alice (user_id=u1)]", event.text)
 
     def test_scenario_no_mentions_zero_regression(self):
         adapter = self._build_adapter()
         event = self._run(adapter, "plain message", [])
-        self.assertEqual(event.text, "plain message")
+        self.assertTrue(event.text.endswith("plain message"))
+        self.assertIn("[Feishu group message from Alice (user_id=u1)]", event.text)
         self.assertNotIn("[Mentioned:", event.text)
 
     def test_scenario_post_at_alice_exposes_open_id(self):

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -487,6 +487,33 @@ def _patch_callback_card_types(monkeypatch):
 class TestCardActionCallbackResponse:
     """Test that _on_card_action_trigger returns updated card inline."""
 
+    def test_non_approval_card_click_is_one_shot(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        first = _make_card_action_data(
+            {"hermes_test": "post_restart_card"},
+            token="tok_first",
+            open_message_id="om_same_card",
+        )
+        second = _make_card_action_data(
+            {"hermes_test": "post_restart_card"},
+            token="tok_second",
+            open_message_id="om_same_card",
+        )
+
+        def _close_and_accept(_loop, coro):
+            coro.close()
+            return True
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=_close_and_accept) as mock_submit:
+            first_response = adapter._on_card_action_trigger(first)
+            second_response = adapter._on_card_action_trigger(second)
+
+        assert mock_submit.call_count == 1
+        assert first_response.card.data["header"]["title"]["content"] == "✅ 已收到"
+        assert second_response.card.data["header"]["title"]["content"] == "✅ 已处理过"
+
     def test_drops_action_when_loop_not_ready(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = None
@@ -549,7 +576,7 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
-    def test_no_card_for_non_approval_action(self, _patch_callback_card_types):
+    def test_non_approval_action_returns_received_card(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
@@ -559,7 +586,8 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         assert response is not None
-        assert response.card is None
+        assert response.card is not None
+        assert response.card.data["header"]["title"]["content"] == "✅ 已收到"
 
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -38,6 +38,7 @@ def _ensure_feishu_mocks():
 _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
 import gateway.platforms.feishu as feishu_module
 from gateway.platforms.feishu import FeishuAdapter
 
@@ -59,12 +60,13 @@ def _make_card_action_data(
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
     token: str = "tok_abc",
+    open_message_id: str = "om_card_message",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
     return SimpleNamespace(
         event=SimpleNamespace(
             token=token,
-            context=SimpleNamespace(open_chat_id=chat_id),
+            context=SimpleNamespace(open_chat_id=chat_id, open_message_id=open_message_id),
             operator=SimpleNamespace(open_id=open_id),
             action=SimpleNamespace(
                 tag="button",
@@ -78,6 +80,56 @@ def _close_submitted_coro(coro, _loop):
     """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
     coro.close()
     return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+# ===========================================================================
+# Generic interactive cards and group sender attribution
+# ===========================================================================
+
+class TestFeishuGenericCardsAndSenderContext:
+    """Regression tests for local Feishu extensions that must survive upgrades."""
+
+    @pytest.mark.asyncio
+    async def test_send_card_sends_interactive_payload(self):
+        adapter = _make_adapter()
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {"title": {"tag": "plain_text", "content": "Hermes 测试卡片"}},
+            "elements": [{"tag": "markdown", "content": "hello"}],
+        }
+        mock_response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_card"))
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_card(
+                chat_id="oc_chat",
+                card=card,
+                reply_to="om_parent",
+                metadata={"thread_id": "omt-thread"},
+            )
+
+        assert result.success is True
+        assert result.message_id == "om_card"
+        mock_send.assert_awaited_once()
+        kwargs = mock_send.call_args.kwargs
+        assert kwargs["chat_id"] == "oc_chat"
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["reply_to"] == "om_parent"
+        assert kwargs["metadata"] == {"thread_id": "omt-thread"}
+        assert json.loads(kwargs["payload"]) == card
+
+    def test_prefix_group_sender_context_preserves_mention_hint(self):
+        text = feishu_module._prefix_group_sender_context(
+            "[Mentioned: 臭宝机器人]\n\n今天怎么安排？",
+            chat_type="group",
+            user_id="921g931d",
+            user_name="大笨钟",
+        )
+
+        assert text.startswith("[Mentioned: 臭宝机器人]\n")
+        assert "[Feishu group message from 大笨钟 (user_id=921g931d)]" in text
+        assert text.endswith("今天怎么安排？")
 
 
 # ===========================================================================
@@ -381,10 +433,10 @@ class TestResolveApproval:
 # ===========================================================================
 
 class TestNonApprovalCardAction:
-    """Non-approval card actions should still route as synthetic commands."""
+    """Non-approval card actions should route as synthetic text."""
 
     @pytest.mark.asyncio
-    async def test_routes_as_synthetic_command(self):
+    async def test_routes_as_synthetic_text_with_open_message_id_reply_anchor(self):
         adapter = _make_adapter()
 
         data = _make_card_action_data(
@@ -404,7 +456,10 @@ class TestNonApprovalCardAction:
 
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
-        assert "/card button" in event.text
+        assert event.message_type == MessageType.TEXT
+        assert event.message_id == "om_card_message"
+        assert event.text.startswith("card_action:button")
+        assert '"custom_action": "something_else"' in event.text
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- restore Feishu group sender context prefixes and reusable generic interactive-card sending
- make generic Feishu card clicks one-shot using a logical click key
- route non-approval generic card actions into Hermes with form payloads preserved
- keep command approval actions on the approval-only path

## Why

Generic Feishu cards that collect form input need to submit `action.form_value` into Hermes without being mistaken for command-approval buttons. Repeated clicks on the same card action should also be acknowledged without triggering duplicate agent runs.

## Test Plan

```bash
pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_approval_buttons.py -q -o 'addopts='
```

Local result:

```text
170 passed, 62 skipped, 38 warnings
```

Note: skipped tests are async tests skipped by the local environment without pytest-asyncio; no new Feishu card test failures were observed.
