### PR TITLE
fix(weixin): route cross-process send_message through gateway API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2825,6 +2825,73 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    async def _handle_platform_send(self, request: "web.Request") -> "web.Response":
+        """POST /v1/platforms/{platform}/send — relay a send_message call through
+        the gateway's live adapter.  Used by CLI/cron agents that run in a separate
+        process and don't share the gateway's _LIVE_ADAPTERS state.
+
+        Body: {"token": "...", "chat_id": "...", "message": "...",
+               "media_files": [["/path", false], ...]}
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        platform = request.match_info.get("platform", "").strip().lower()
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+        token = str(body.get("token", "")).strip()
+        chat_id = str(body.get("chat_id", "")).strip()
+        message = str(body.get("message", "")).strip()
+        media_files = body.get("media_files") or []
+
+        if not token or not chat_id:
+            return web.json_response(
+                {"error": "token and chat_id are required"}, status=400
+            )
+
+        # Look up the live adapter for this platform
+        if platform == "weixin":
+            try:
+                from gateway.platforms.weixin import _LIVE_ADAPTERS as _WEIXIN_ADAPTERS
+                live_adapter = _WEIXIN_ADAPTERS.get(token)
+                if live_adapter is None:
+                    return web.json_response(
+                        {"error": "Weixin adapter not connected for this token. "
+                                  "Gateway must be running with an active Weixin connection."},
+                        status=503,
+                    )
+                send_session = getattr(live_adapter, "_send_session", None)
+                if send_session is None or send_session.closed:
+                    return web.json_response(
+                        {"error": "Weixin send session not available"}, status=503
+                    )
+
+                from gateway.platforms.weixin import send_weixin_direct
+                result = await send_weixin_direct(
+                    extra=getattr(live_adapter, "_extra_cache", {}) or {},
+                    token=token,
+                    chat_id=chat_id,
+                    message=message,
+                    media_files=media_files,
+                )
+                return web.json_response(result)
+
+            except ImportError:
+                return web.json_response(
+                    {"error": "Weixin adapter not available"}, status=503
+                )
+            except Exception as e:
+                logger.exception("Platform send relay failed for weixin")
+                return web.json_response({"error": str(e)}, status=500)
+
+        return web.json_response(
+            {"error": f"Unsupported platform: {platform}"}, status=400
+        )
+
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         auth_err = self._check_auth(request)
@@ -3367,6 +3434,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
+            self._app.router.add_post("/v1/platforms/{platform}/send", self._handle_platform_send)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
             # Cron jobs management API

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2097,7 +2097,7 @@ async def _relay_weixin_via_gateway(
             async with session.post(api_url, json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
                 result = await resp.json()
                 if resp.status != 200:
-                    return {"error": result.get("error", f"Gateway relay failed (HTTP {resp.status})")}
+                    return {"error": result.get("error", f"Gateway relay failed - HTTP {resp.status}")}
                 return result
     except aiohttp.ClientError as e:
         return {"error": f"Gateway relay connection failed: {e}"}

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2068,6 +2068,43 @@ class WeixinAdapter(BasePlatformAdapter):
         return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
 
 
+async def _relay_weixin_via_gateway(
+    *,
+    token: str,
+    chat_id: str,
+    message: str,
+    media_files: Optional[List[Tuple[str, bool]]] = None,
+) -> Dict[str, Any]:
+    """Relay a Weixin send through the gateway's API server.
+
+    Used when send_message is called from a CLI/cron process that doesn't
+    share the gateway's _LIVE_ADAPTERS state.  The gateway's API server
+    has access to the live adapter with a valid iLink session.
+    """
+    import aiohttp
+
+    api_port = int(os.getenv("HERMES_API_PORT", "8642"))
+    api_url = f"http://127.0.0.1:{api_port}/v1/platforms/weixin/send"
+
+    payload = {
+        "token": token,
+        "chat_id": chat_id,
+        "message": message,
+        "media_files": media_files or [],
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(api_url, json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                result = await resp.json()
+                if resp.status != 200:
+                    return {"error": result.get("error", f"Gateway relay failed (HTTP {resp.status})")}
+                return result
+    except aiohttp.ClientError as e:
+        return {"error": f"Gateway relay connection failed: {e}"}
+    except Exception as e:
+        return {"error": f"Gateway relay failed: {e}"}
+
+
 async def send_weixin_direct(
     *,
     extra: Dict[str, Any],
@@ -2123,6 +2160,21 @@ async def send_weixin_direct(
             "context_token_used": bool(context_token),
         }
 
+    # No live adapter — running outside the gateway process (CLI, cron, etc.).
+    # Relay through the gateway's API server which has access to the live adapter.
+    try:
+        from gateway.status import is_gateway_running
+        if is_gateway_running():
+            return await _relay_weixin_via_gateway(
+                token=resolved_token,
+                chat_id=chat_id,
+                message=message,
+                media_files=media_files,
+            )
+    except Exception:
+        pass
+
+    # Gateway not accessible — fall through to direct send
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(


### PR DESCRIPTION
## Problem

`send_message` from CLI/cron processes fails with WeChat (errcode=-14) because the CLI process does not share the gateway's `_LIVE_ADAPTERS` state. The fallback creates a new `WeixinAdapter` without an established iLink session context, which the iLink API rejects.

## Solution

When no live adapter is found (outside gateway process), relay the send through the gateway's API server which has access to the live adapter with a valid iLink session.

### New endpoint
`POST /v1/platforms/{platform}/send` on the API server:
- Looks up the live adapter by platform token
- Routes text + media sends through the live adapter
- Returns the send result or error

### Relay flow
```
CLI send_message(weixin)
  → _LIVE_ADAPTERS empty (separate process)
  → is_gateway_running() == True
  → POST http://127.0.0.1:8642/v1/platforms/weixin/send
  → gateway API server looks up live adapter
  → send through established iLink session
  → success!
```

If gateway is not running, falls through to the existing direct approach.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `gateway/platforms/api_server.py` | +68 | `POST /v1/platforms/{platform}/send` endpoint + `_handle_platform_send` handler |
| `gateway/platforms/weixin.py` | +52 | `_relay_weixin_via_gateway()` helper + routing in `send_weixin_direct()` |

Both files compile cleanly. No regressions in existing WeChat gateway functionality.

Closes #14452