### PR TITLE
fix(acp-registry): bump agent.json version to match v0.14.0 release

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }


### PR DESCRIPTION
## Summary

The v0.14.0 release commit ([a91a57fa5](https://github.com/NousResearch/hermes-agent/commit/a91a57fa5)) bumped `pyproject.toml` to `0.14.0` but did not update `acp_registry/agent.json`, leaving it pinned at `0.13.0`.

## The bug

`tests/acp/test_registry_manifest.py` ships two regression guards that catch exactly this drift:

- `test_agent_json_version_matches_pyproject` — asserts `manifest["version"] == pyproject["project"]["version"]`
- `test_agent_json_pins_uvx_package_to_pyproject_version` — asserts the uvx package pin matches the pyproject version exactly (the registry rejects `@latest` and floating pins, so a stale pin would publish a non-installable manifest)

Both have been failing on every PR's CI run since the v0.14.0 release commit landed — visible as 2 of the baseline failures in the `test` job on current `main`.

## The fix

Two-byte JSON edit to `acp_registry/agent.json`:

- `"version": "0.13.0"` → `"version": "0.14.0"`
- `"package": "hermes-agent[acp]==0.13.0"` → `"package": "hermes-agent[acp]==0.14.0"`

The release script (`scripts/release.py:_update_acp_registry_versions`) already has the auto-bump logic for this file, so this is a one-off catch-up; future releases should bump it automatically as long as `release.py` is invoked.

## Test plan

- [x] `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/acp/test_registry_manifest.py -v` — all 6 tests pass after the bump (2 were failing before)
- [x] Regression guard: the two failing assertions are the regression guards themselves — the test file is purpose-built to catch this kind of drift on every PR

## Related

- v0.14.0 release: #26862 (commit a91a57fa5)