### PR TITLE
feat(harness): add safe undersea workflow runner

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,148 @@
+# Agent Harness Workflow
+
+This repository includes a lightweight phase/step harness adapted from `jha0313/harness_framework`.
+
+## Purpose
+
+Use the harness when a feature is large enough to split into ordered implementation steps and you want an external coding agent to execute each step with guardrails, status tracking, retry context, and commits.
+
+## Directory layout
+
+```text
+phases/
+├── index.json
+└── 0-mvp/
+    ├── index.json
+    ├── step1.md
+    └── step1-output.json   # generated after execution
+```
+
+Top-level `phases/index.json`:
+
+```json
+{
+  "phases": [
+    {"dir": "0-mvp", "status": "pending"}
+  ]
+}
+```
+
+Phase `phases/0-mvp/index.json`:
+
+```json
+{
+  "project": "Hermes Agent",
+  "phase": "mvp",
+  "allowed_paths": [
+    "phases/0-mvp/",
+    "scripts/harness_execute.py",
+    "tests/scripts/test_harness_execute.py"
+  ],
+  "steps": [
+    {"step": 1, "name": "first-task", "status": "pending"}
+  ]
+}
+```
+
+Each `stepN.md` should contain:
+
+```markdown
+# Step N: short title
+
+## Objective
+What this step changes.
+
+## Scope
+- Files or components that may be touched.
+- Explicit non-goals.
+
+## Acceptance Criteria
+- Exact commands/tests that must pass.
+- Expected observable behavior.
+```
+
+## Running
+
+Default agent command is Claude Code style:
+
+```bash
+python scripts/harness_execute.py 0-mvp
+```
+
+To use another agent, pass a safe command prefix. The harness appends the generated prompt as the final argument:
+
+```bash
+python scripts/harness_execute.py 0-mvp \
+  --agent-command "codex exec"
+```
+
+Dangerous/full-auto flags such as `--full-auto`, `--yolo`, and `--dangerously-skip-permissions` are refused by default. Use `--allow-unsafe-agent` only inside an isolated worktree after explicit approval.
+
+Or set it once:
+
+```bash
+export HARNESS_AGENT_COMMAND="codex exec"
+python scripts/harness_execute.py 0-mvp
+```
+
+Optional push after all steps complete requires a second explicit confirmation after reviewing the diff and secret scan:
+
+```bash
+python scripts/harness_execute.py 0-mvp --push --yes-push
+```
+
+### Commands harness
+
+Automation target: while a harness phase is running, update the current status snapshot every 1 minute so operators can see which phase/step is active, when it started, and whether it is pending, running, blocked, completed, or errored. The interval is configurable with `--status-interval` and must be greater than 0.
+
+## Step status contract
+
+The agent must update `phases/<phase>/index.json` for the current step:
+
+- success: `"status": "completed"` and `"summary": "one-line result"`
+- needs human input: `"status": "blocked"` and `"blocked_reason": "..."`
+- cannot complete: `"status": "error"` and `"error_message": "..."`
+
+The harness records timestamps, writes a redacted/bounded `stepN-output.json` artifact, refreshes `status.json` while a step runs, updates top-level phase status, and commits only phase-allowlisted paths. `allowed_paths` are frozen when the run starts; if an agent mutates them or changes out-of-scope files, the run fails closed. Output artifacts are excluded from staging by default.
+
+## Guardrails loaded into every step
+
+The prompt includes:
+
+- `AGENTS.md`
+- `CLAUDE.md` when present
+- top-level Markdown docs under `docs/*.md`
+- summaries from completed previous steps
+
+## Undersea Friends operating model
+
+Use harness phases for material changes to the Undersea Friends structure: automation, file/config edits, gateway/provider/process work, cross-profile handoffs, and long-running refactors. Casual conversation can still happen directly with any friend; not every message needs ticketing.
+
+Role ownership:
+
+- `nemo` (`니모`): execution and verification gate for harness phases, Hermes settings, file edits, tests, and gateway-safe runbooks.
+- `manta` (`만타`): front-door planner for AX/research/automation framing, options, and decision criteria.
+- `whale` (`고래`): canonicalization, LLM_WIKI/data quality, schema/index/log hygiene, and long-term structure checks.
+- `shark` (`상어`): security, permissions, secret exposure, public/private boundary, and risky-operation review.
+- `octopus` (`문어`): multi-tool automation/prototype helper across Slack, Notion, docs, mail, browser, and files.
+
+For cross-profile work, the handoff packet must include: `goal / why / current state / paths / risks / execution steps / verification / report format`. Risky live operations must begin with read-only diagnosis and require explicit user approval before changing gateways, processes, providers, or credentials-adjacent files.
+
+Current structure-change phase:
+
+```bash
+python scripts/harness_execute.py 0-undersea-friends-harness-structure \
+  --agent-command "codex exec"
+```
+
+This phase declares `allowed_paths` in its phase index so the harness can stage only the intended harness/docs/test files.
+
+## Safety notes
+
+- Run only from a clean worktree or a dedicated isolated worktree; the harness refuses dirty worktrees by default.
+- The harness never uses blanket `git add -A`; it stages only `allowed_paths` from the phase index plus the phase directory, excluding `stepN-output.json` artifacts.
+- `allowed_paths` are captured at startup. If an agent edits the allowlist or leaves out-of-scope files dirty, the harness refuses to commit.
+- Keep step scopes small; do not put multiple unrelated features in one step.
+- Avoid secrets in phase files or step outputs. Captured output is redacted and truncated, but agents should still avoid printing secrets.
+- Do not restart/stop gateways or kill processes inside a harness step unless the step explicitly states approval and rollback conditions.
+- Use `--push --yes-push` only after reviewing the staged diff and confirming no secret/config/gateway-adjacent changes are included.

--- a/phases/0-undersea-friends-harness-structure/index.json
+++ b/phases/0-undersea-friends-harness-structure/index.json
@@ -1,0 +1,39 @@
+{
+  "project": "Hermes Agent / Undersea Friends",
+  "phase": "undersea-friends-harness-structure",
+  "objective": "Shift Undersea Friends operations from ad-hoc profile requests to a harness-driven phase/step operating structure with explicit status, role boundaries, and verification gates.",
+  "status_snapshot": "phases/0-undersea-friends-harness-structure/status.json",
+  "allowed_paths": [
+    "docs/HARNESS.md",
+    "scripts/harness_execute.py",
+    "tests/scripts/test_harness_execute.py",
+    "phases/0-undersea-friends-harness-structure/"
+  ],
+  "steps": [
+    {
+      "step": 1,
+      "name": "codify-undersea-harness-operating-model",
+      "status": "pending"
+    },
+    {
+      "step": 2,
+      "name": "implement-one-minute-status-snapshot",
+      "status": "pending"
+    },
+    {
+      "step": 3,
+      "name": "standardize-handoff-packets",
+      "status": "pending"
+    },
+    {
+      "step": 4,
+      "name": "add-undersea-profile-health-inventory",
+      "status": "pending"
+    },
+    {
+      "step": 5,
+      "name": "document-and-verify-harness-workflow",
+      "status": "pending"
+    }
+  ]
+}

--- a/phases/0-undersea-friends-harness-structure/status.json
+++ b/phases/0-undersea-friends-harness-structure/status.json
@@ -1,0 +1,11 @@
+{
+  "phase": "undersea-friends-harness-structure",
+  "current_step": null,
+  "current_step_name": null,
+  "status": "pending",
+  "started_at": null,
+  "updated_at": null,
+  "completed_steps": 0,
+  "total_steps": 5,
+  "note": "Initial snapshot; Step 2 will implement automatic 60-second updates while the harness is running."
+}

--- a/phases/0-undersea-friends-harness-structure/step1.md
+++ b/phases/0-undersea-friends-harness-structure/step1.md
@@ -1,0 +1,26 @@
+# Step 1: codify-undersea-harness-operating-model
+
+## Objective
+Update the Undersea Friends operating model so automation and structural changes are planned and executed through harness phases/steps instead of ad-hoc profile instructions.
+
+## Scope
+- Modify existing docs only where appropriate:
+  - `docs/HARNESS.md`
+  - `~/.hermes/shared-memory/undersea-friends/README.md`
+  - `~/.hermes/shared-memory/undersea-friends/FRIENDS_INDEX.md` if role routing needs clarification.
+- Do not print, move, or copy secrets.
+- Do not restart gateways or modify live process state.
+
+## Required content
+- Define Nemo as the execution/verification gate for harness phases.
+- Define Manta as the front-door planner for AX/research/automation framing.
+- Define Whale as canonicalization, data quality, and long-term structure guardian.
+- Define Shark as security/permissions/secret-risk reviewer.
+- Define Octopus as multi-tool automation/prototype helper.
+- Keep direct user-to-profile conversation allowed; harness is for automation/change work, not every casual message.
+
+## Acceptance Criteria
+- Existing documentation states that material automation, file/config changes, gateway/provider/process work, and cross-profile handoffs should use a harness phase or a handoff packet.
+- Documentation includes the minimum handoff packet fields: `goal / why / current state / paths / risks / execution steps / verification / report format`.
+- No secret values are added to any document.
+- Run: `python -m json.tool phases/index.json >/dev/null` and `python -m json.tool phases/0-undersea-friends-harness-structure/index.json >/dev/null`.

--- a/phases/0-undersea-friends-harness-structure/step2.md
+++ b/phases/0-undersea-friends-harness-structure/step2.md
@@ -1,0 +1,22 @@
+# Step 2: implement-one-minute-status-snapshot
+
+## Objective
+Implement the harness status snapshot automation so a running phase updates its current status at least every 60 seconds.
+
+## Scope
+- Modify: `scripts/harness_execute.py`
+- Modify or add tests under: `tests/scripts/test_harness_execute.py`
+- Do not add external dependencies.
+- Do not change the phase/step JSON contract except by adding backward-compatible fields.
+
+## Desired behavior
+- When a phase starts, write `phases/<phase>/status.json` with phase, current step, step name, status `running`, started_at, updated_at, completed_steps, total_steps.
+- While an agent subprocess is running, refresh `updated_at` every 60 seconds.
+- On `completed`, `blocked`, or `error`, write the terminal state immediately.
+- The updater must stop cleanly when the agent subprocess exits.
+
+## Acceptance Criteria
+- Tests prove a status snapshot is written at step start.
+- Tests prove terminal status is written on completed/error/blocked paths.
+- Tests cover the ticker without waiting 60 real seconds by injecting or mocking the interval/ticker.
+- Run: `./venv/bin/python -m pytest tests/scripts/test_harness_execute.py -q`.

--- a/phases/0-undersea-friends-harness-structure/step3.md
+++ b/phases/0-undersea-friends-harness-structure/step3.md
@@ -1,0 +1,29 @@
+# Step 3: standardize-handoff-packets
+
+## Objective
+Create a reusable handoff packet standard for Undersea Friends so profiles can transfer work without making the user act as a messenger.
+
+## Scope
+- Prefer updating existing docs first:
+  - `docs/HARNESS.md`
+  - `~/.hermes/shared-memory/team-rules.md`
+  - `~/.hermes/shared-memory/undersea-friends/README.md`
+- If a template file is necessary, add it under an existing documentation/templates location only after checking existing structure.
+- Do not include live Slack IDs, tokens, OAuth values, or secrets.
+
+## Required handoff fields
+- Goal
+- Why it matters
+- Current state
+- Target paths/systems
+- Role owner and recipient profile
+- Risks and safety boundaries
+- Execution steps
+- Verification criteria
+- Report format
+
+## Acceptance Criteria
+- The handoff packet standard is documented in one canonical place and referenced from the Undersea Friends operating model.
+- The standard explicitly says casual conversation does not need ticketization.
+- The standard explicitly says risky live operations require read-only diagnosis first and user approval before change.
+- Run JSON validation for phase files and a grep/search check confirming the canonical field names are present.

--- a/phases/0-undersea-friends-harness-structure/step4.md
+++ b/phases/0-undersea-friends-harness-structure/step4.md
@@ -1,0 +1,33 @@
+# Step 4: add-undersea-profile-health-inventory
+
+## Objective
+Add a read-only profile health inventory step so Undersea Friends can see profile readiness without touching gateways or secrets.
+
+## Scope
+- Modify or add scripts only if necessary; prefer extending harness status/reporting code.
+- Read-only checks only:
+  - profile directory exists
+  - `config.yaml` exists
+  - `SOUL.md` exists
+  - `AGENTS.md` exists
+  - required memories/handoff files exist when applicable
+  - provider/model names are present without exposing API keys
+- Do not read or print `.env` values.
+- Do not run gateway restart/stop/start.
+
+## Desired output
+A profile inventory report that can be embedded into `status.json` or written as a separate generated status artifact, for example:
+
+```json
+{
+  "profiles": [
+    {"profile": "nemo", "alias": "니모", "role": "execution", "config": "present", "soul": "present", "gateway_check": "not-run"}
+  ]
+}
+```
+
+## Acceptance Criteria
+- Inventory is read-only and never outputs secret values.
+- Missing profile docs are reported as warnings, not auto-created.
+- Tests or a dry-run command prove inventory works on a temporary fake profiles root.
+- Documentation says live gateway/process checks remain explicit opt-in diagnostics.

--- a/phases/0-undersea-friends-harness-structure/step5.md
+++ b/phases/0-undersea-friends-harness-structure/step5.md
@@ -1,0 +1,25 @@
+# Step 5: document-and-verify-harness-workflow
+
+## Objective
+Finalize the Undersea Friends harness workflow documentation and verify the phase can be executed safely.
+
+## Scope
+- Update `docs/HARNESS.md` with the Undersea Friends operating model and runbook.
+- Update shared-memory docs only if Step 1/3 did not already do so.
+- Do not run the full harness against live profiles unless the worktree is clean or intentionally prepared.
+- Do not push automatically.
+
+## Required runbook
+- How to create a new Undersea Friends phase.
+- How to choose the owner profile.
+- How status updates work every 1 minute.
+- How blocked/error states are reported.
+- How to resume after a blocked/error step.
+- Which operations require explicit user approval.
+
+## Acceptance Criteria
+- `docs/HARNESS.md` includes a concise Undersea Friends runbook.
+- Phase JSON validates with `python -m json.tool`.
+- Harness tests pass: `./venv/bin/python -m pytest tests/scripts/test_harness_execute.py -q`.
+- `python scripts/harness_execute.py --help` still works.
+- Final report lists changed files and confirms no gateway/process/secrets were touched.

--- a/phases/index.json
+++ b/phases/index.json
@@ -1,0 +1,9 @@
+{
+  "phases": [
+    {
+      "dir": "0-undersea-friends-harness-structure",
+      "status": "pending",
+      "summary": "Move Undersea Friends operations to a harness-driven phase/step structure with status visibility and role-safe handoffs."
+    }
+  ]
+}

--- a/scripts/harness_execute.py
+++ b/scripts/harness_execute.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Phase harness executor for agent-driven implementation steps.
+
+This is a local, repo-agnostic adaptation of jha0313/harness_framework:
+- phase specs live under ``phases/<phase-dir>/``
+- ``index.json`` tracks step status
+- each pending step is delegated to an external coding agent command
+- the agent must update the phase index to completed/blocked/error
+
+Safety-first defaults for Hermes/Undersea Friends operations:
+- refuse dangerous full-auto agent flags unless explicitly opted in
+- refuse to run from a dirty worktree
+- stage only phase allowlisted paths, never blanket ``git add -A``
+- write redacted, bounded agent output artifacts
+- keep a ``status.json`` snapshot fresh while a step is running
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+KST = timezone(timedelta(hours=9))
+DEFAULT_AGENT_COMMAND = "claude -p --output-format json"
+DANGEROUS_AGENT_ARGS = {
+    "--dangerously-skip-permissions",
+    "--full-auto",
+    "--yolo",
+    "--force",
+}
+MAX_OUTPUT_CHARS = 20_000
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(api[_-]?key|token|secret|password|passwd)\s*[:=]\s*([^\s'\";,}]+)"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]+"),
+    re.compile(r"xapp-[A-Za-z0-9-]+"),
+]
+
+
+class HarnessExecutor:
+    """Execute pending phase steps with a coding agent command."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        phase_dir_name: str,
+        *,
+        agent_command: str | None = None,
+        auto_push: bool = False,
+        max_retries: int = 3,
+        allow_unsafe_agent: bool = False,
+        require_clean: bool = True,
+        status_interval: float = 60.0,
+        confirm_push: bool = False,
+    ):
+        self.root = Path(root).resolve()
+        self.phase_dir_name = phase_dir_name
+        self.phases_dir = self.root / "phases"
+        self.phase_dir = self.phases_dir / phase_dir_name
+        self.phase_index_path = self.phase_dir / "index.json"
+        self.top_index_path = self.phases_dir / "index.json"
+        self.agent_command = agent_command or os.environ.get("HARNESS_AGENT_COMMAND") or DEFAULT_AGENT_COMMAND
+        self.auto_push = auto_push
+        self.max_retries = max_retries
+        self.allow_unsafe_agent = allow_unsafe_agent
+        self.require_clean = require_clean
+        self.status_interval = status_interval
+        self.confirm_push = confirm_push
+
+        if self.status_interval <= 0:
+            print("ERROR: --status-interval must be greater than 0", file=sys.stderr)
+            raise SystemExit(2)
+
+        if not self.phase_dir.is_dir():
+            raise SystemExit(f"ERROR: {self.phase_dir} not found")
+        if not self.phase_index_path.exists():
+            raise SystemExit(f"ERROR: {self.phase_index_path} not found")
+        self.validate_agent_command()
+        self._allowed_paths = self.load_allowed_paths_from_index()
+
+    @staticmethod
+    def stamp() -> str:
+        return datetime.now(KST).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+    @staticmethod
+    def read_json(path: Path) -> dict[str, Any]:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def write_json(path: Path, data: dict[str, Any]) -> None:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+    @staticmethod
+    def redact_output(text: str) -> str:
+        redacted = text[:MAX_OUTPUT_CHARS]
+        for pattern in SECRET_PATTERNS:
+            redacted = pattern.sub(lambda m: f"{m.group(1)}=<redacted>" if m.lastindex and m.lastindex >= 1 else "<redacted>", redacted)
+        if len(text) > MAX_OUTPUT_CHARS:
+            redacted += f"\n... <truncated {len(text) - MAX_OUTPUT_CHARS} chars>"
+        return redacted
+
+    def read_phase_index(self) -> dict[str, Any]:
+        return self.read_json(self.phase_index_path)
+
+    def write_phase_index(self, index: dict[str, Any]) -> None:
+        self.write_json(self.phase_index_path, index)
+
+    def validate_agent_command(self) -> None:
+        if self.allow_unsafe_agent:
+            return
+        parts = shlex.split(self.agent_command)
+        dangerous = sorted(set(parts) & DANGEROUS_AGENT_ARGS)
+        if dangerous:
+            print(
+                "ERROR: unsafe harness agent flags are disabled by default: "
+                f"{', '.join(dangerous)}. Use --allow-unsafe-agent only in an isolated worktree.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+
+    def load_allowed_paths_from_index(self) -> list[str]:
+        index = self.read_phase_index()
+        paths = index.get("allowed_paths") or [f"phases/{self.phase_dir_name}/"]
+        normalized: list[str] = []
+        for item in paths:
+            path = str(item).strip()
+            if not path or path.startswith("/") or ".." in Path(path).parts:
+                raise SystemExit(f"ERROR: unsafe allowed path in phase index: {item!r}")
+            normalized.append(path.replace("\\", "/"))
+        phase_prefix = f"phases/{self.phase_dir_name}/"
+        if phase_prefix not in normalized:
+            normalized.append(phase_prefix)
+        return normalized
+
+
+    def allowed_paths(self) -> list[str]:
+        return list(self._allowed_paths)
+
+    def ensure_allowed_paths_unchanged(self) -> None:
+        current = self.load_allowed_paths_from_index()
+        if current != self._allowed_paths:
+            print(
+                "ERROR: phase allowed_paths changed during agent execution; refusing to stage changes.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    @staticmethod
+    def status_paths_from_porcelain_line(line: str) -> list[str]:
+        path = line[3:] if len(line) > 3 else ""
+        if " -> " in path:
+            return [part.strip().strip('"') for part in path.split(" -> ", 1)]
+        return [path.strip().strip('"')]
+
+    def is_allowed_worktree_path(self, path: str) -> bool:
+        if not path:
+            return True
+        phase_output_prefix = f"phases/{self.phase_dir_name}/step"
+        if path.startswith(phase_output_prefix) and path.endswith("-output.json"):
+            return True
+        for allowed in self._allowed_paths:
+            if allowed.endswith("/"):
+                if path.startswith(allowed):
+                    return True
+            elif path == allowed:
+                return True
+        return False
+
+    def ensure_no_out_of_scope_changes(self) -> None:
+        result = self.run_git("status", "--porcelain")
+        if result.returncode != 0:
+            raise SystemExit(f"ERROR: git status failed: {result.stderr.strip()}")
+        out_of_scope = [
+            path
+            for line in result.stdout.splitlines()
+            for path in self.status_paths_from_porcelain_line(line)
+            if not self.is_allowed_worktree_path(path)
+        ]
+        if out_of_scope:
+            preview = "\n".join(out_of_scope[:20])
+            print(
+                "ERROR: agent changed files outside phase allowed_paths; refusing to stage changes.\n"
+                f"Out-of-scope files:\n{preview}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    def load_guardrails(self) -> str:
+        """Load repo context files that should constrain every step."""
+        sections: list[str] = []
+        for name in ("AGENTS.md", "CLAUDE.md"):
+            path = self.root / name
+            if path.exists():
+                sections.append(f"## {name}\n\n{path.read_text(encoding='utf-8')}")
+
+        docs_dir = self.root / "docs"
+        if docs_dir.is_dir():
+            for doc in sorted(docs_dir.glob("*.md")):
+                rel = doc.relative_to(self.root)
+                sections.append(f"## {rel}\n\n{doc.read_text(encoding='utf-8')}")
+        return "\n\n---\n\n".join(sections)
+
+    @staticmethod
+    def completed_step_context(index: dict[str, Any]) -> str:
+        lines = []
+        for step in index.get("steps", []):
+            if step.get("status") == "completed" and step.get("summary"):
+                lines.append(f"- Step {step['step']} ({step['name']}): {step['summary']}")
+        if not lines:
+            return ""
+        return "## Previous step outputs\n\n" + "\n".join(lines) + "\n\n"
+
+    def build_prompt(self, step: dict[str, Any], index: dict[str, Any], previous_error: str | None = None) -> str:
+        step_num = step["step"]
+        step_file = self.phase_dir / f"step{step_num}.md"
+        if not step_file.exists():
+            raise SystemExit(f"ERROR: {step_file} not found")
+
+        project = index.get("project", "project")
+        phase = index.get("phase", self.phase_dir_name)
+        retry = ""
+        if previous_error:
+            retry = (
+                "\n## Previous attempt failed\n\n"
+                f"Use this failure as context and fix the cause:\n\n{previous_error}\n\n---\n\n"
+            )
+
+        return (
+            f"You are implementing a step for the {project} repository.\n\n"
+            f"## Phase\n\n{phase}\n\n---\n\n"
+            f"{self.load_guardrails()}\n\n---\n\n"
+            f"{self.completed_step_context(index)}"
+            f"{retry}"
+            "## Harness rules\n\n"
+            "1. Only perform the work requested by this step.\n"
+            "2. Preserve existing behavior and tests.\n"
+            "3. Verify the acceptance criteria directly.\n"
+            f"4. Update phases/{self.phase_dir_name}/index.json for this step:\n"
+            "   - success: set status to \"completed\" and add a one-line summary.\n"
+            "   - needs user input: set status to \"blocked\" and add blocked_reason.\n"
+            "   - cannot complete: set status to \"error\" and add error_message.\n"
+            "5. Do not commit, push, restart gateways, kill processes, or print secrets. "
+            "The harness will stage and commit allowlisted files after verification.\n\n"
+            "---\n\n"
+            f"## Step {step_num}: {step.get('name', '')}\n\n"
+            f"{step_file.read_text(encoding='utf-8')}"
+        )
+
+    def run_git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *args], cwd=self.root, capture_output=True, text=True)
+
+    def ensure_clean_worktree(self) -> None:
+        if not self.require_clean:
+            return
+        result = self.run_git("status", "--porcelain")
+        if result.returncode != 0:
+            raise SystemExit(f"ERROR: git status failed: {result.stderr.strip()}")
+        if result.stdout.strip():
+            preview = "\n".join(result.stdout.strip().splitlines()[:20])
+            print(
+                "ERROR: harness requires a clean worktree before agent execution. "
+                "Commit/stash unrelated changes or run in a dedicated worktree.\n"
+                f"Dirty files:\n{preview}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+
+    def checkout_branch(self, phase: str) -> None:
+        branch = f"feat-{self.safe_branch_slug(phase)}"
+        current = self.run_git("rev-parse", "--abbrev-ref", "HEAD")
+        if current.returncode != 0:
+            raise SystemExit(f"ERROR: git repo unavailable: {current.stderr.strip()}")
+        if current.stdout.strip() == branch:
+            return
+        exists = self.run_git("rev-parse", "--verify", branch)
+        result = self.run_git("checkout", branch) if exists.returncode == 0 else self.run_git("checkout", "-b", branch)
+        if result.returncode != 0:
+            raise SystemExit(f"ERROR: could not checkout {branch}: {result.stderr.strip()}")
+
+    @staticmethod
+    def safe_branch_slug(value: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9._/-]+", "-", value).strip("-/.")
+        if not slug or slug.startswith("-") or ".." in slug:
+            raise SystemExit(f"ERROR: unsafe phase branch name: {value!r}")
+        return slug[:120]
+
+    def invoke_agent(self, prompt: str) -> subprocess.CompletedProcess[str]:
+        cmd = [*shlex.split(self.agent_command), prompt]
+        return subprocess.run(cmd, cwd=self.root, capture_output=True, text=True, timeout=1800)
+
+    def commit_step(self, step_num: int, step_name: str, phase: str) -> None:
+        self.ensure_allowed_paths_unchanged()
+        self.ensure_no_out_of_scope_changes()
+        for path in self.allowed_paths():
+            add = self.run_git("add", "--", path)
+            if add.returncode != 0:
+                raise SystemExit(f"ERROR: git add failed for {path}: {add.stderr.strip()}")
+        for output_path in self.phase_dir.glob("step*-output.json"):
+            rel = output_path.relative_to(self.root).as_posix()
+            self.run_git("reset", "HEAD", "--", rel)
+        message = f"feat({phase}): step {step_num} — {step_name}"
+        commit = self.run_git("commit", "-m", message)
+        if commit.returncode != 0 and "nothing to commit" not in (commit.stdout + commit.stderr).lower():
+            raise SystemExit(f"ERROR: git commit failed: {commit.stderr.strip()}")
+
+    def update_top_index(self, status: str) -> None:
+        if not self.top_index_path.exists():
+            return
+        top = self.read_json(self.top_index_path)
+        timestamp_key = {"completed": "completed_at", "error": "failed_at", "blocked": "blocked_at"}.get(status)
+        for phase in top.get("phases", []):
+            if phase.get("dir") == self.phase_dir_name:
+                phase["status"] = status
+                if timestamp_key:
+                    phase[timestamp_key] = self.stamp()
+                break
+        self.write_json(self.top_index_path, top)
+
+    def write_status_snapshot(self, status: str, step: dict[str, Any] | None = None) -> None:
+        index = self.read_phase_index()
+        steps = index.get("steps", [])
+        completed = sum(1 for item in steps if item.get("status") == "completed")
+        existing: dict[str, Any] = {}
+        status_path = self.phase_dir / "status.json"
+        if status_path.exists():
+            try:
+                existing = self.read_json(status_path)
+            except json.JSONDecodeError:
+                existing = {}
+        current_step = step.get("step") if step else existing.get("current_step")
+        current_step_name = step.get("name") if step else existing.get("current_step_name")
+        now = self.stamp()
+        snapshot = {
+            "phase": index.get("phase", self.phase_dir_name),
+            "current_step": current_step,
+            "current_step_name": current_step_name,
+            "status": status,
+            "started_at": existing.get("started_at") or now,
+            "updated_at": now,
+            "completed_steps": completed,
+            "total_steps": len(steps),
+        }
+        self.write_json(status_path, snapshot)
+
+    def start_status_ticker(self, step: dict[str, Any]) -> tuple[threading.Event, threading.Thread]:
+        stop = threading.Event()
+
+        def tick() -> None:
+            while not stop.wait(self.status_interval):
+                self.write_status_snapshot("running", step)
+
+        thread = threading.Thread(target=tick, daemon=True)
+        thread.start()
+        return stop, thread
+
+    def mark_step_timestamp(self, step_num: int, key: str) -> None:
+        index = self.read_phase_index()
+        for step in index.get("steps", []):
+            if step.get("step") == step_num:
+                step[key] = self.stamp()
+                break
+        self.write_phase_index(index)
+
+    def run(self) -> None:
+        index = self.read_phase_index()
+        phase = index.get("phase", self.phase_dir_name)
+        self.ensure_clean_worktree()
+        self.checkout_branch(phase)
+        if "created_at" not in index:
+            index["created_at"] = self.stamp()
+            self.write_phase_index(index)
+
+        while True:
+            index = self.read_phase_index()
+            pending = next((s for s in index.get("steps", []) if s.get("status") == "pending"), None)
+            if pending is None:
+                index["completed_at"] = self.stamp()
+                self.write_phase_index(index)
+                self.write_status_snapshot("completed", None)
+                self.update_top_index("completed")
+                if self.auto_push:
+                    if not self.confirm_push:
+                        print("ERROR: --push requires --yes-push after reviewing staged history and secret scan", file=sys.stderr)
+                        raise SystemExit(2)
+                    branch = f"feat-{self.safe_branch_slug(phase)}"
+                    pushed = self.run_git("push", "-u", "origin", branch)
+                    if pushed.returncode != 0:
+                        raise SystemExit(f"ERROR: git push failed: {pushed.stderr.strip()}")
+                print(f"Phase '{phase}' completed")
+                return
+
+            self.execute_step(pending, phase)
+
+    def execute_step(self, step: dict[str, Any], phase: str) -> None:
+        step_num = step["step"]
+        step_name = step.get("name", f"step-{step_num}")
+        previous_error = None
+        self.mark_step_timestamp(step_num, "started_at")
+        self.write_status_snapshot("running", step)
+
+        for attempt in range(1, self.max_retries + 1):
+            index = self.read_phase_index()
+            prompt = self.build_prompt(step, index, previous_error)
+            stop, ticker = self.start_status_ticker(step)
+            try:
+                result = self.invoke_agent(prompt)
+            except subprocess.TimeoutExpired as exc:
+                result = subprocess.CompletedProcess(exc.cmd, 124, stdout=exc.stdout or "", stderr=str(exc))
+            finally:
+                stop.set()
+                ticker.join(timeout=1)
+
+            stdout_text = result.stdout.decode("utf-8", "replace") if isinstance(result.stdout, bytes) else (result.stdout or "")
+            stderr_text = result.stderr.decode("utf-8", "replace") if isinstance(result.stderr, bytes) else (result.stderr or "")
+            output = {
+                "step": step_num,
+                "name": step_name,
+                "attempt": attempt,
+                "exitCode": result.returncode,
+                "stdout_excerpt": self.redact_output(stdout_text),
+                "stderr_excerpt": self.redact_output(stderr_text),
+            }
+            self.write_json(self.phase_dir / f"step{step_num}-output.json", output)
+
+            updated = self.read_phase_index()
+            current = next((s for s in updated.get("steps", []) if s.get("step") == step_num), {})
+            status = current.get("status", "pending")
+            if status == "completed":
+                self.mark_step_timestamp(step_num, "completed_at")
+                self.write_status_snapshot("completed", step)
+                self.commit_step(step_num, step_name, phase)
+                print(f"✓ Step {step_num}: {step_name}")
+                return
+            if status == "blocked":
+                self.mark_step_timestamp(step_num, "blocked_at")
+                self.write_status_snapshot("blocked", step)
+                self.update_top_index("blocked")
+                raise SystemExit(2)
+
+            previous_error = current.get("error_message") or "Agent did not update step status to completed/blocked/error"
+            if attempt < self.max_retries:
+                updated = self.read_phase_index()
+                for item in updated.get("steps", []):
+                    if item.get("step") == step_num:
+                        item["status"] = "pending"
+                        item.pop("error_message", None)
+                self.write_phase_index(updated)
+                continue
+
+            updated = self.read_phase_index()
+            for item in updated.get("steps", []):
+                if item.get("step") == step_num:
+                    item["status"] = "error"
+                    item["error_message"] = f"[{self.max_retries} attempt(s)] {previous_error}"
+                    item["failed_at"] = self.stamp()
+            self.write_phase_index(updated)
+            self.write_status_snapshot("error", step)
+            self.update_top_index("error")
+            self.commit_step(step_num, step_name, phase)
+            raise SystemExit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Execute harness phase steps with a coding agent")
+    parser.add_argument("phase_dir", help="Phase directory name under ./phases, e.g. 0-mvp")
+    parser.add_argument("--root", default=".", help="Repository root, default: current directory")
+    parser.add_argument("--agent-command", help="Command prefix used to invoke the agent; prompt is appended")
+    parser.add_argument("--push", action="store_true", help="Push feat-<phase> branch after phase completion")
+    parser.add_argument("--yes-push", action="store_true", help="Second confirmation required with --push after manual diff/secret review")
+    parser.add_argument("--max-retries", type=int, default=3)
+    parser.add_argument("--allow-unsafe-agent", action="store_true", help="Allow dangerous/full-auto agent flags; use only in isolated worktrees")
+    parser.add_argument("--no-clean-check", action="store_true", help="Skip clean-worktree guard; not recommended")
+    parser.add_argument("--status-interval", type=float, default=60.0, help="Seconds between running status.json refreshes")
+    args = parser.parse_args(argv)
+
+    executor = HarnessExecutor(
+        args.root,
+        args.phase_dir,
+        agent_command=args.agent_command,
+        auto_push=args.push,
+        max_retries=args.max_retries,
+        allow_unsafe_agent=args.allow_unsafe_agent,
+        require_clean=not args.no_clean_check,
+        status_interval=args.status_interval,
+        confirm_push=args.yes_push,
+    )
+    executor.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_harness_execute.py
+++ b/tests/scripts/test_harness_execute.py
@@ -1,0 +1,323 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts import harness_execute as hx
+
+
+def write_json(path: Path, data: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+@pytest.fixture
+def harness_project(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# Agent Rules\n- keep changes small", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("# Claude Rules\n- run tests", encoding="utf-8")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "ARCHITECTURE.md").write_text("# Architecture\nCore loop", encoding="utf-8")
+    (docs / "ignore.txt").write_text("not markdown", encoding="utf-8")
+
+    write_json(tmp_path / "phases" / "index.json", {"phases": [{"dir": "0-mvp", "status": "pending"}]})
+    write_json(
+        tmp_path / "phases" / "0-mvp" / "index.json",
+        {
+            "project": "Hermes Agent",
+            "phase": "mvp",
+            "steps": [
+                {"step": 0, "name": "setup", "status": "completed", "summary": "scaffolded"},
+                {"step": 1, "name": "feature", "status": "pending"},
+            ],
+        },
+    )
+    (tmp_path / "phases" / "0-mvp" / "step1.md").write_text(
+        "# Step 1\n\nImplement the feature.\n\n## Acceptance Criteria\n- tests pass",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_load_guardrails_prefers_repo_context_and_markdown_docs(harness_project):
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+
+    guardrails = executor.load_guardrails()
+
+    assert "## AGENTS.md" in guardrails
+    assert "keep changes small" in guardrails
+    assert "## CLAUDE.md" in guardrails
+    assert "run tests" in guardrails
+    assert "## docs/ARCHITECTURE.md" in guardrails
+    assert "Core loop" in guardrails
+    assert "ignore.txt" not in guardrails
+
+
+def test_build_prompt_includes_previous_step_context_and_step_file(harness_project):
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    index = executor.read_phase_index()
+    step = index["steps"][1]
+
+    prompt = executor.build_prompt(step, index)
+
+    assert "Hermes Agent" in prompt
+    assert "Step 0 (setup): scaffolded" in prompt
+    assert "Implement the feature" in prompt
+    assert "phases/0-mvp/index.json" in prompt
+    assert 'status' in prompt and 'completed' in prompt
+
+
+def test_run_invokes_agent_and_marks_completed_step_with_commit(harness_project):
+    calls = []
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        calls.append(cmd)
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            if data["steps"][1]["status"] == "completed":
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=" M phases/0-mvp/index.json\n?? phases/0-mvp/step1-output.json\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "agent":
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            data["steps"][1]["status"] = "completed"
+            data["steps"][1]["summary"] = "feature implemented"
+            idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"ok": true}', stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run):
+        executor.run()
+
+    index = json.loads((harness_project / "phases" / "0-mvp" / "index.json").read_text(encoding="utf-8"))
+    top = json.loads((harness_project / "phases" / "index.json").read_text(encoding="utf-8"))
+    assert index["steps"][1]["status"] == "completed"
+    assert "completed_at" in index["steps"][1]
+    assert index["completed_at"]
+    assert top["phases"][0]["status"] == "completed"
+    assert any(cmd[0] == "agent" and "Acceptance Criteria" in cmd[-1] for cmd in calls)
+    assert any(cmd[:2] == ["git", "commit"] for cmd in calls)
+
+
+def test_run_records_error_after_agent_does_not_complete_step(harness_project):
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent", max_retries=1)
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 1
+    index = json.loads((harness_project / "phases" / "0-mvp" / "index.json").read_text(encoding="utf-8"))
+    top = json.loads((harness_project / "phases" / "index.json").read_text(encoding="utf-8"))
+    assert index["steps"][1]["status"] == "error"
+    assert "did not update" in index["steps"][1]["error_message"]
+    assert top["phases"][0]["status"] == "error"
+
+
+
+def test_rejects_dangerous_agent_command_by_default(harness_project):
+    with pytest.raises(SystemExit) as exc:
+        hx.HarnessExecutor(harness_project, "0-mvp", agent_command="codex exec --full-auto")
+
+    assert exc.value.code == 2
+
+
+def test_run_refuses_dirty_worktree_before_checkout(harness_project):
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=" M unrelated.py\n", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 2
+
+
+def test_commit_step_stages_only_allowed_paths(harness_project):
+    calls = []
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run):
+        executor.commit_step(1, "feature", "mvp")
+
+    assert ["git", "add", "-A"] not in calls
+    add_calls = [cmd for cmd in calls if cmd[:2] == ["git", "add"]]
+    assert add_calls
+    flattened = "\n".join(" ".join(cmd) for cmd in add_calls)
+    assert "phases/0-mvp" in flattened
+    assert "unrelated.py" not in flattened
+
+
+def test_rejects_non_positive_status_interval(harness_project):
+    with pytest.raises(SystemExit) as exc:
+        hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent", status_interval=0)
+
+    assert exc.value.code == 2
+
+
+def test_push_requires_second_confirmation(harness_project):
+    calls = []
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        calls.append(cmd)
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="feat-mvp\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+    data = json.loads(idx_path.read_text(encoding="utf-8"))
+    data["steps"][1]["status"] = "completed"
+    idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent", auto_push=True)
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 2
+    assert not any(cmd[:2] == ["git", "push"] for cmd in calls)
+
+
+def test_status_snapshot_updates_on_start_and_completion(harness_project):
+    calls = []
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        calls.append(cmd)
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "agent":
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            data["steps"][1]["status"] = "completed"
+            data["steps"][1]["summary"] = "feature implemented"
+            idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout='secret token=abc123456789', stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent", status_interval=0.01)
+    with patch.object(hx.subprocess, "run", side_effect=fake_run):
+        executor.run()
+
+    snapshot = json.loads((harness_project / "phases" / "0-mvp" / "status.json").read_text(encoding="utf-8"))
+    output = json.loads((harness_project / "phases" / "0-mvp" / "step1-output.json").read_text(encoding="utf-8"))
+    assert snapshot["status"] == "completed"
+    assert snapshot["current_step"] == 1
+    assert snapshot["completed_steps"] == 2
+    assert snapshot["total_steps"] == 2
+    assert "stdout" not in output
+    assert "abc123456789" not in json.dumps(output)
+
+
+
+def test_run_rejects_allowed_paths_mutation_by_agent(harness_project):
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "agent":
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            data["allowed_paths"] = ["phases/0-mvp/", "unrelated.py"]
+            data["steps"][1]["status"] = "completed"
+            data["steps"][1]["summary"] = "mutated allowlist"
+            idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 1
+
+
+
+def test_run_rejects_out_of_scope_agent_changes(harness_project):
+    status_calls = 0
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        nonlocal status_calls
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            status_calls += 1
+            stdout = "" if status_calls == 1 else " M unrelated.py\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "agent":
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            data["steps"][1]["status"] = "completed"
+            data["steps"][1]["summary"] = "changed unrelated file"
+            idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 1
+
+
+
+def test_run_rejects_rename_from_out_of_scope_into_allowed_path(harness_project):
+    status_calls = 0
+
+    def fake_run(cmd, cwd, capture_output=True, text=True, timeout=None):
+        nonlocal status_calls
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            status_calls += 1
+            stdout = "" if status_calls == 1 else "R  unrelated.py -> phases/0-mvp/new.py\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:2] == ["git", "checkout"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[0] == "agent":
+            idx_path = harness_project / "phases" / "0-mvp" / "index.json"
+            data = json.loads(idx_path.read_text(encoding="utf-8"))
+            data["steps"][1]["status"] = "completed"
+            data["steps"][1]["summary"] = "renamed file"
+            idx_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    executor = hx.HarnessExecutor(harness_project, "0-mvp", agent_command="agent")
+    with patch.object(hx.subprocess, "run", side_effect=fake_run), pytest.raises(SystemExit) as exc:
+        executor.run()
+
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- Add a safe harness executor for phase/step-based automation workflows.
- Add Undersea Friends harness scaffold with status snapshots and step specs.
- Document guardrails for allowed paths, status updates, and unsafe agent commands.

## Safety guardrails
- Reject dirty worktrees before running a harness phase.
- Block unsafe agent flags by default unless explicitly overridden.
- Freeze `allowed_paths` at run start and reject in-run mutation.
- Reject out-of-scope worktree changes, including staged renames from outside the allowlist.
- Store bounded/redacted stdout and stderr excerpts instead of raw full output.

## Test plan
- [x] `/Users/keonhui/.hermes/hermes-agent/venv/bin/python -m pytest tests/scripts/test_harness_execute.py -q`
- [x] JSON validation for `phases/index.json`, phase `index.json`, and `status.json`
- [x] Diff scan for common secret/token patterns
