### PR TITLE
fix(mcp): recover redacted --env secrets in mcp add

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -30,6 +30,15 @@ from tools.mcp_tool import _ENV_VAR_PATTERN
 logger = logging.getLogger(__name__)
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_REDACTED_ENV_VALUE_RE = re.compile(
+    r"^(?:\*{3,}|\[REDACTED\]|<REDACTED>|\(REDACTED\)|REDACTED)$",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_redacted_env_value(value: str) -> bool:
+    """Return True when *value* is an obvious redaction placeholder."""
+    return bool(_REDACTED_ENV_VALUE_RE.fullmatch(str(value or "").strip()))
 
 
 _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
@@ -124,6 +133,19 @@ def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
             raise ValueError(f"Invalid --env value '{text}' (missing variable name)")
         if not _ENV_VAR_NAME_RE.match(key):
             raise ValueError(f"Invalid --env variable name '{key}'")
+        # Some entrypoints redact command text before it reaches argparse,
+        # turning secret values into "***" or "[REDACTED]". If we can recover
+        # from the caller environment, do so; otherwise fail fast so we don't
+        # persist an unusable placeholder into mcp_servers.<name>.env.
+        if _looks_like_redacted_env_value(value):
+            recovered = os.getenv(key, "").strip()
+            if recovered and not _looks_like_redacted_env_value(recovered):
+                value = recovered
+            else:
+                raise ValueError(
+                    f"--env {key}=... appears redacted. Export {key} in your shell "
+                    f"and retry, or pass --env {key}=${{{key}}}."
+                )
         parsed[key] = value
     return parsed
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -307,6 +307,55 @@ class TestMcpAdd:
             "DEBUG": "true",
         }
 
+    def test_add_stdio_server_recovers_redacted_env_from_shell(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """If --env value is redacted upstream, recover from os.environ."""
+        fake_tools = [FakeTool("search", "Search repos")]
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_live_token_1234567890")
+
+        def mock_probe(name, config, **kw):
+            assert config["env"] == {
+                "GITHUB_TOKEN": "ghp_live_token_1234567890",
+            }
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            mcp_command="npx",
+            args=["@mcp/github"],
+            env=["GITHUB_TOKEN=***"],
+        ))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        from hermes_cli.config import read_raw_config
+
+        srv = read_raw_config()["mcp_servers"]["github"]
+        assert srv["env"]["GITHUB_TOKEN"] == "ghp_live_token_1234567890"
+
+    def test_add_stdio_server_rejects_redacted_env_without_recovery(
+        self, capsys
+    ):
+        """Redacted placeholders must not be written when env recovery fails."""
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            mcp_command="npx",
+            args=["@mcp/github"],
+            env=["GITHUB_TOKEN=***"],
+        ))
+        out = capsys.readouterr().out
+        assert "appears redacted" in out
+
     def test_add_stdio_server_rejects_invalid_env_name(self, capsys):
         """Invalid environment variable names are rejected up front."""
         from hermes_cli.mcp_config import cmd_mcp_add
@@ -599,4 +648,3 @@ class TestMcpLogin:
         cmd_mcp_login(_make_args(name="srv"))
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
-


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where `hermes mcp add --env GITHUB_TOKEN=...` could persist a redaction placeholder (`***`, `[REDACTED]`, etc.) instead of a usable token value, which breaks stdio MCP server auth at runtime.

The fix treats obvious redaction placeholders as non-authoritative input: if the same key exists in the current shell environment, Hermes recovers the real value from `os.environ`; otherwise it fails fast with a clear actionable error instead of saving a broken config.

## Related Issue

Fixes #26885

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/mcp_config.py`:
- Added redaction-placeholder detection for `--env KEY=VALUE` parsing.
- Added safe recovery path from `os.environ[KEY]` when incoming value is clearly redacted.
- Added explicit validation error when placeholder cannot be recovered, preventing broken `mcp_servers.<name>.env` entries.
- Updated `tests/hermes_cli/test_mcp_config.py`:
- Added regression test for `GITHUB_TOKEN=***` recovering from shell env.
- Added regression test ensuring unrecoverable redacted placeholders are rejected with a clear error.

## How to Test

1. Run: `pytest -q -o addopts="" tests/hermes_cli/test_mcp_config.py`
2. Reproduce add flow with redacted placeholder and env fallback in test or manually:
   `export GITHUB_TOKEN=ghp_...`
   `hermes mcp add github --command npx --args @modelcontextprotocol/server-github --env GITHUB_TOKEN=***`
3. Confirm saved config stores a usable token value (or `${GITHUB_TOKEN}` form if supplied), not a redaction marker.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pytest -q -o addopts="" tests/hermes_cli/test_mcp_config.py` -> `34 passed`
