### PR TITLE
fix(mcp): filter empty strings from --args to prevent corrupted args: [""]

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -221,7 +221,7 @@ def cmd_mcp_add(args):
     name = args.name
     url = getattr(args, "url", None)
     command = getattr(args, "command", None)
-    cmd_args = getattr(args, "args", None) or []
+    cmd_args = [a for a in (getattr(args, "args", None) or []) if a]
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)


### PR DESCRIPTION
## Summary
- Fixes `hermes mcp add` corrupting an empty `--args` array to `args: [""]` in config.yaml
- Filters out empty strings from the parsed args list so `[""]` → `[]`, which is then correctly omitted from config

## Root Cause
With argparse `nargs="*"`, passing `--args ""` stores `[""]` (list with one empty string). This passes the `if cmd_args:` truthiness check and gets written to the config, causing the MCP server to receive a malformed empty-string argument.

## Test plan
- [ ] `hermes mcp add test --command echo --args ""` → verify config has no `args` key
- [ ] `hermes mcp add test --command npx --args @modelcontextprotocol/server-github` → verify args saved correctly
- [ ] `hermes mcp add test --command echo` (no --args) → verify no args in config

Closes #26886

🤖 Generated with [Claude Code](https://claude.com/claude-code)