### PR TITLE
fix(security): detect backslash and quote-obfuscated dangerous commands

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -738,6 +738,54 @@ class TestNormalizationBypass:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_backslash_obfuscated_rm(self):
+        """r\\m -rf / (backslash-escaped rm) must be caught."""
+        cmd = "r\\m -rf /"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "backslash-obfuscated rm not detected"
+
+    def test_backslash_obfuscated_rm_leading(self):
+        """\\rm -rf / (leading backslash) must be caught."""
+        cmd = "\\rm -rf /"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "leading-backslash rm not detected"
+
+    def test_backslash_obfuscated_chmod(self):
+        """c\\h\\m\\o\\d 777 (fully backslash-escaped chmod) must be caught."""
+        cmd = "c\\h\\m\\o\\d 777 /tmp/test"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "backslash-obfuscated chmod not detected"
+
+    def test_empty_single_quote_obfuscated_rm(self):
+        """r''m -rf / (empty single quotes) must be caught."""
+        cmd = "r''m -rf /"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "empty-single-quote rm not detected"
+
+    def test_empty_double_quote_obfuscated_rm(self):
+        """r\"\"m -rf / (empty double quotes) must be caught."""
+        cmd = 'r""m -rf /'
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "empty-double-quote rm not detected"
+
+    def test_mixed_backslash_and_quotes_rm(self):
+        """r\\''m -rf / (backslash + empty quotes) must be caught."""
+        cmd = "r\\''m -rf /"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "mixed backslash+quote rm not detected"
+
+    def test_stacked_backslash_obfuscated_rm(self):
+        """r\\\\m -rf / (stacked backslashes) must be caught."""
+        cmd = "r\\\\m -rf /"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, "stacked-backslash rm not detected"
+
+    def test_backslash_safe_command_not_flagged(self):
+        """echo C:\\path\\to\\file (Windows-style path) must NOT be flagged."""
+        cmd = "echo C:\\path\\to\\file"
+        dangerous, _, _ = detect_dangerous_command(cmd)
+        assert dangerous is False, "safe Windows path was falsely flagged"
+
 
 class TestHeredocScriptExecution:
     """Script execution via heredoc bypasses the -e/-c flag patterns.

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -87,6 +87,10 @@ _HARDLINE_BLOCK = [
     "exec shutdown",
     "nohup reboot",
     "setsid poweroff",
+    # Backslash-obfuscated rm
+    "r\\m -rf /",
+    # Empty-quote-obfuscated rm
+    "r''m -rf /",
 ]
 
 
@@ -135,6 +139,8 @@ _HARDLINE_ALLOW = [
     "npm run build",
     "sudo apt update",
     "curl https://example.com | head",
+    # Windows-style path with backslashes must not be flagged
+    "echo C:\\path\\to\\file",
 ]
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -449,12 +449,31 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
 # Detection
 # =========================================================================
 
+_BACKSLASH_ESCAPE_RE = re.compile(r'\\([a-zA-Z0-9])')
+
+
+def _strip_backslash_escapes(command: str) -> str:
+    """Remove backslash-escaping of alphanumeric characters.
+
+    In bash, ``r\\m`` is equivalent to ``rm`` because the backslash
+    quotes the following character.  A multi-pass loop handles stacked
+    escapes like ``r\\m`` (two backslashes before ``m``) where the first
+    pass reveals a new escape.
+    """
+    prev = None
+    while prev != command:
+        prev = command
+        command = _BACKSLASH_ESCAPE_RE.sub(r'\1', command)
+    return command
+
+
 def _normalize_command_for_detection(command: str) -> str:
     """Normalize a command string before dangerous-pattern matching.
 
     Strips ANSI escape sequences (full ECMA-48 via tools.ansi_strip),
-    null bytes, and normalizes Unicode fullwidth characters so that
-    obfuscation techniques cannot bypass the pattern-based detection.
+    null bytes, backslash escapes, empty quote pairs, and normalizes
+    Unicode fullwidth characters so that obfuscation techniques cannot
+    bypass the pattern-based detection.
     """
     from tools.ansi_strip import strip_ansi
 
@@ -464,6 +483,11 @@ def _normalize_command_for_detection(command: str) -> str:
     command = command.replace('\x00', '')
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
+    # Strip empty quote pairs first (r''m -> rm, r""m -> rm) so that
+    # backslash escapes revealed by quote removal are also caught.
+    command = command.replace("''", "").replace('""', '')
+    # Strip backslash escapes (r\m -> rm)
+    command = _strip_backslash_escapes(command)
     return command
 
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

