### PR TITLE
fix(doctor): use x-goog-api-key for Gemini connectivity probe (#26623)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,6 +10,7 @@ import subprocess
 import shutil
 import importlib.util
 from pathlib import Path
+from typing import Dict, Optional
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -223,6 +224,39 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 
 
 _APIKEY_PROVIDERS_CACHE: list | None = None
+
+
+def _build_apikey_probe_headers(
+    pname: str,
+    base: str,
+    default_url: Optional[str],
+    key: str,
+) -> Dict[str, str]:
+    """Return the request headers for an API-key provider connectivity probe.
+
+    Most OpenAI-compatible providers accept ``Authorization: Bearer <key>`` on
+    the ``/models`` endpoint.  Google AI Studio (Gemini) is the notable
+    exception — it rejects Bearer auth with HTTP 401 and requires
+    ``x-goog-api-key: <key>`` instead.  Without this branch the doctor
+    falsely reports a valid ``GOOGLE_API_KEY`` as invalid (#26623).
+
+    Kimi servers want a ``User-Agent`` override regardless of which auth
+    style is used; the caller layers that on after the dict returned here.
+    """
+    _is_gemini = (
+        base_url_host_matches(base, "generativelanguage.googleapis.com")
+        or base_url_host_matches(default_url or "", "generativelanguage.googleapis.com")
+        or (pname or "").strip().lower() in {"gemini", "google", "google / gemini"}
+    )
+    if _is_gemini:
+        return {
+            "x-goog-api-key": key,
+            "User-Agent": _HERMES_USER_AGENT,
+        }
+    return {
+        "Authorization": f"Bearer {key}",
+        "User-Agent": _HERMES_USER_AGENT,
+    }
 
 
 def _build_apikey_providers_list() -> list:
@@ -1468,10 +1502,7 @@ def run_doctor(args):
             if base_url_host_matches(base, "api.kimi.com") and base.rstrip("/").endswith("/coding"):
                 base = base.rstrip("/") + "/v1"
             url = (base.rstrip("/") + "/models") if base else default_url
-            headers = {
-                "Authorization": f"Bearer {key}",
-                "User-Agent": _HERMES_USER_AGENT,
-            }
+            headers = _build_apikey_probe_headers(pname, base, default_url, key)
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
             r = httpx.get(url, headers=headers, timeout=10)

--- a/tests/hermes_cli/test_doctor_apikey_probe_headers.py
+++ b/tests/hermes_cli/test_doctor_apikey_probe_headers.py
@@ -1,0 +1,128 @@
+"""Regression tests for ``_build_apikey_probe_headers`` in ``hermes_cli.doctor``.
+
+Covers #26623: the doctor connectivity probe used to send
+``Authorization: Bearer <key>`` to every API-key provider, but Google AI
+Studio (Gemini) requires ``x-goog-api-key`` and rejects Bearer with HTTP
+401 — causing ``hermes doctor`` to falsely report a valid
+``GOOGLE_API_KEY`` as invalid.
+"""
+
+import pytest
+
+from hermes_cli.doctor import _build_apikey_probe_headers
+
+
+GEMINI_DEFAULT_URL = (
+    "https://generativelanguage.googleapis.com/v1beta/models"
+)
+
+
+class TestApikeyProbeHeaders:
+    # ── Gemini detection paths ────────────────────────────────────────
+
+    def test_gemini_detected_by_default_url(self):
+        headers = _build_apikey_probe_headers(
+            pname="gemini",
+            base="",
+            default_url=GEMINI_DEFAULT_URL,
+            key="abc123",
+        )
+        assert headers["x-goog-api-key"] == "abc123"
+        assert "Authorization" not in headers
+
+    def test_gemini_detected_by_overridden_base_url(self):
+        # User points GEMINI_BASE_URL at their own Gemini-compat proxy.
+        headers = _build_apikey_probe_headers(
+            pname="gemini",
+            base="https://generativelanguage.googleapis.com/v1",
+            default_url=None,
+            key="abc123",
+        )
+        assert headers["x-goog-api-key"] == "abc123"
+        assert "Authorization" not in headers
+
+    @pytest.mark.parametrize(
+        "pname", ["gemini", "Gemini", "GEMINI", "google", "Google", "Google / Gemini"]
+    )
+    def test_gemini_detected_by_name(self, pname):
+        # Even when neither base nor default_url is set, the provider name
+        # tells us this is Gemini and Bearer would 401.
+        headers = _build_apikey_probe_headers(
+            pname=pname,
+            base="",
+            default_url=None,
+            key="abc123",
+        )
+        assert headers["x-goog-api-key"] == "abc123"
+        assert "Authorization" not in headers
+
+    # ── Non-Gemini providers keep Bearer ─────────────────────────────
+
+    def test_openrouter_uses_bearer(self):
+        headers = _build_apikey_probe_headers(
+            pname="OpenRouter",
+            base="",
+            default_url="https://openrouter.ai/api/v1/models",
+            key="sk-or-test",
+        )
+        assert headers["Authorization"] == "Bearer sk-or-test"
+        assert "x-goog-api-key" not in headers
+
+    def test_deepseek_uses_bearer(self):
+        headers = _build_apikey_probe_headers(
+            pname="DeepSeek",
+            base="",
+            default_url="https://api.deepseek.com/v1/models",
+            key="sk-deepseek-test",
+        )
+        assert headers["Authorization"] == "Bearer sk-deepseek-test"
+
+    def test_kimi_uses_bearer(self):
+        headers = _build_apikey_probe_headers(
+            pname="Kimi / Moonshot",
+            base="https://api.moonshot.ai/v1",
+            default_url="https://api.moonshot.ai/v1/models",
+            key="sk-kimi-test",
+        )
+        assert headers["Authorization"] == "Bearer sk-kimi-test"
+
+    # ── Defensive cases ──────────────────────────────────────────────
+
+    def test_substring_match_does_not_false_positive(self):
+        # ``google`` substring in a hostile host must not be classified as
+        # Gemini — base_url_host_matches uses real URL parsing for this.
+        headers = _build_apikey_probe_headers(
+            pname="not-gemini",
+            base="https://evil.com/generativelanguage.googleapis.com/v1",
+            default_url=None,
+            key="abc123",
+        )
+        assert headers["Authorization"] == "Bearer abc123"
+        assert "x-goog-api-key" not in headers
+
+    def test_empty_pname_and_no_urls_defaults_to_bearer(self):
+        headers = _build_apikey_probe_headers(
+            pname="",
+            base="",
+            default_url=None,
+            key="abc123",
+        )
+        assert headers["Authorization"] == "Bearer abc123"
+
+    def test_user_agent_always_set(self):
+        # Both auth styles must include a User-Agent so the request isn't
+        # served a generic Python-httpx UA on providers that gate on it.
+        gemini = _build_apikey_probe_headers(
+            pname="gemini",
+            base="",
+            default_url=GEMINI_DEFAULT_URL,
+            key="abc",
+        )
+        bearer = _build_apikey_probe_headers(
+            pname="DeepSeek",
+            base="",
+            default_url="https://api.deepseek.com/v1/models",
+            key="abc",
+        )
+        assert gemini.get("User-Agent")
+        assert bearer.get("User-Agent")


### PR DESCRIPTION
## Summary

Fixes #26623. `hermes doctor` reports a valid `GOOGLE_API_KEY` as `✗ gemini (invalid API key)` because the generic API-key connectivity probe sends `Authorization: Bearer <key>` to every provider — including Google AI Studio, which only accepts `x-goog-api-key` and answers Bearer with HTTP 401. The doctor then maps 401 to "invalid API key", even though the main agent works fine with the same key (it uses the native Gemini client, not the generic OpenAI-compat probe).

## Root cause

`_probe_apikey_provider` in `hermes_cli/doctor.py` builds one set of headers for every provider:

```python
headers = {
    "Authorization": f"Bearer {key}",
    "User-Agent": _HERMES_USER_AGENT,
}
```

Gemini (added to the probe list dynamically from `plugins/model-providers/gemini`) needs `x-goog-api-key` instead. Bearer auth → 401 → false negative.

## Approach

Extract the header decision into a small `_build_apikey_probe_headers(pname, base, default_url, key)` helper that:

- Returns `{"x-goog-api-key": key, ...}` when the request targets a Gemini-shaped endpoint
- Returns `{"Authorization": f"Bearer {key}", ...}` for everyone else

Gemini is recognised by three independent signals (any one suffices):
1. `base_url_host_matches(base, "generativelanguage.googleapis.com")` — user-overridden base URL
2. `base_url_host_matches(default_url, "generativelanguage.googleapis.com")` — static default for the canonical Gemini profile
3. `pname.lower() in {"gemini", "google", "google / gemini"}` — fallback when the URL signals are missing

The substring-attack defence already lives inside `base_url_host_matches` (`utils.py`), so `https://evil.com/generativelanguage.googleapis.com/v1` does **not** trip the Gemini branch.

## What this does NOT change

- Non-Gemini providers (OpenRouter, DeepSeek, Kimi, MiniMax, Z.AI/GLM, Hugging Face, etc.) keep `Authorization: Bearer` — behaviour-preserving.
- Bedrock, Anthropic-native, OAuth providers — unchanged (they have their own probe paths).
- The Kimi User-Agent override layer still runs after the helper, just like before.

## Test plan

14 new tests in `tests/hermes_cli/test_doctor_apikey_probe_headers.py`:

| Test | Asserts |
|---|---|
| `test_gemini_detected_by_default_url` | Static default URL routes to `x-goog-api-key` |
| `test_gemini_detected_by_overridden_base_url` | `GEMINI_BASE_URL` override routes to `x-goog-api-key` |
| `test_gemini_detected_by_name[6 forms]` | Name-based detection: `gemini`, `Gemini`, `GEMINI`, `google`, `Google`, `Google / Gemini` |
| `test_openrouter/deepseek/kimi_uses_bearer` | Non-Gemini providers unaffected |
| `test_substring_match_does_not_false_positive` | Hostile host containing `generativelanguage.googleapis.com` in the path does NOT route to `x-goog-api-key` |
| `test_empty_pname_and_no_urls_defaults_to_bearer` | Defensive default |
| `test_user_agent_always_set` | Both branches keep `User-Agent` |

```
$ python -m pytest tests/hermes_cli/test_doctor_apikey_probe_headers.py -v
======================== 14 passed in 5.00s ========================

$ python -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py -q
=========================== 52 passed in 6.78s ===========================
```

Tests run under an isolated `HERMES_HOME=~/.hermes-pr3-test` — no touch of the developer's live `~/.hermes`.

## Files

- `hermes_cli/doctor.py` — `+35 / -4` (new helper + inline replacement + typing import)
- `tests/hermes_cli/test_doctor_apikey_probe_headers.py` — `+128` (new file, 14 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)