### PR TITLE
feat(web): configurable HTTP 429 retry policy for web providers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -308,6 +308,24 @@ browser:
   inactivity_timeout: 120
 
 # =============================================================================
+# Web Tool Configuration
+# =============================================================================
+# Controls backend selection and HTTP 429 retry behavior for web providers
+# (Brave Search, SearXNG, Tavily).
+web:
+  # Shared fallback backend used when per-capability backend keys are empty.
+  # Valid values include: "firecrawl", "parallel", "tavily", "exa",
+  # "searxng", "brave-free", "ddgs"
+  backend: ""
+  # Optional per-capability backend overrides.
+  search_backend: ""
+  extract_backend: ""
+  # HTTP 429 retry policy (applies to providers that return 429).
+  retry_on_429: true
+  retry_count: 3
+  retry_interval: 60
+
+# =============================================================================
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -641,6 +641,9 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "retry_on_429": True,    # retry HTTP 429 responses from web providers
+        "retry_count": 3,        # retries after the first 429 response
+        "retry_interval": 60.0,  # fallback wait seconds between 429 retries
     },
 
     "browser": {

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -24,6 +24,7 @@ import os
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web.retry_policy import call_with_429_retry
 
 logger = logging.getLogger(__name__)
 
@@ -73,16 +74,18 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
         count = max(1, min(int(limit), 20))
 
         try:
-            resp = httpx.get(
-                _BRAVE_ENDPOINT,
-                params={"q": query, "count": count},
-                headers={
-                    "X-Subscription-Token": api_key,
-                    "Accept": "application/json",
-                },
-                timeout=15,
+            resp = call_with_429_retry(
+                lambda: httpx.get(
+                    _BRAVE_ENDPOINT,
+                    params={"q": query, "count": count},
+                    headers={
+                        "X-Subscription-Token": api_key,
+                        "Accept": "application/json",
+                    },
+                    timeout=15,
+                ),
+                provider_name="Brave Search",
             )
-            resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("Brave Search HTTP error: %s", exc)
             return {

--- a/plugins/web/retry_policy.py
+++ b/plugins/web/retry_policy.py
@@ -1,0 +1,141 @@
+"""Shared HTTP 429 retry policy for web providers.
+
+Config source: ``web`` section in ``~/.hermes/config.yaml``.
+Supported keys:
+- ``retry_on_429``: bool (default: true)
+- ``retry_count``: int, number of retries after the first attempt (default: 3)
+- ``retry_interval``: float seconds (default: 60)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RETRY_ON_429 = True
+_DEFAULT_RETRY_COUNT = 3
+_DEFAULT_RETRY_INTERVAL = 60.0
+_MAX_RETRY_COUNT = 20
+_MAX_RETRY_INTERVAL = 3600.0
+
+
+@dataclass(frozen=True)
+class WebRateLimitRetryPolicy:
+    retry_on_429: bool
+    retry_count: int
+    retry_interval: float
+
+
+def _load_web_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("web", {}) or {}
+    except Exception:
+        return {}
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _coerce_float(value: Any, default: float, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def get_web_rate_limit_retry_policy() -> WebRateLimitRetryPolicy:
+    cfg = _load_web_config()
+    retry_on_429 = _coerce_bool(cfg.get("retry_on_429"), _DEFAULT_RETRY_ON_429)
+    retry_count = _coerce_int(
+        cfg.get("retry_count"),
+        _DEFAULT_RETRY_COUNT,
+        minimum=0,
+        maximum=_MAX_RETRY_COUNT,
+    )
+    retry_interval = _coerce_float(
+        cfg.get("retry_interval"),
+        _DEFAULT_RETRY_INTERVAL,
+        minimum=0.0,
+        maximum=_MAX_RETRY_INTERVAL,
+    )
+    return WebRateLimitRetryPolicy(
+        retry_on_429=retry_on_429,
+        retry_count=retry_count,
+        retry_interval=retry_interval,
+    )
+
+
+def _retry_after_seconds(response: httpx.Response | None) -> float | None:
+    if response is None:
+        return None
+    retry_after = response.headers.get("Retry-After")
+    if not retry_after:
+        return None
+    try:
+        parsed = float(retry_after.strip())
+    except ValueError:
+        return None
+    if parsed < 0:
+        return 0.0
+    return min(parsed, _MAX_RETRY_INTERVAL)
+
+
+def call_with_429_retry(
+    request_fn: Callable[[], httpx.Response],
+    *,
+    provider_name: str,
+) -> httpx.Response:
+    """Execute ``request_fn`` with configurable HTTP 429 retries."""
+    policy = get_web_rate_limit_retry_policy()
+    max_retries = policy.retry_count if policy.retry_on_429 else 0
+
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            response = request_fn()
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code != 429 or attempt > max_retries:
+                raise
+            wait_seconds = _retry_after_seconds(exc.response)
+            if wait_seconds is None:
+                wait_seconds = policy.retry_interval
+            logger.warning(
+                "%s returned HTTP 429; retrying in %.1fs (retry %d/%d)",
+                provider_name,
+                wait_seconds,
+                attempt,
+                max_retries,
+            )
+            time.sleep(wait_seconds)

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -27,6 +27,7 @@ import os
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web.retry_policy import call_with_429_retry
 
 logger = logging.getLogger(__name__)
 
@@ -67,13 +68,15 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         }
 
         try:
-            resp = httpx.get(
-                f"{base_url}/search",
-                params=params,
-                timeout=15,
-                headers={"Accept": "application/json"},
+            resp = call_with_429_retry(
+                lambda: httpx.get(
+                    f"{base_url}/search",
+                    params=params,
+                    timeout=15,
+                    headers={"Accept": "application/json"},
+                ),
+                provider_name="SearXNG",
             )
-            resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("SearXNG HTTP error: %s", exc)
             return {

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -37,6 +37,7 @@ import os
 from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
+from plugins.web.retry_policy import call_with_429_retry
 
 logger = logging.getLogger(__name__)
 
@@ -67,8 +68,10 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     # /search and /extract are body-only.
     headers = {"Authorization": f"Bearer {api_key}"} if endpoint.strip("/") == "crawl" else {}
 
-    response = httpx.post(url, json=payload, headers=headers, timeout=60)
-    response.raise_for_status()
+    response = call_with_429_retry(
+        lambda: httpx.post(url, json=payload, headers=headers, timeout=60),
+        provider_name="Tavily",
+    )
     return response.json()
 
 

--- a/tests/tools/test_web_retry_policy.py
+++ b/tests/tools/test_web_retry_policy.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from plugins.web.retry_policy import call_with_429_retry
+
+
+def _http_429_error(retry_after: str | None = None) -> httpx.HTTPStatusError:
+    response = MagicMock()
+    response.status_code = 429
+    response.headers = {}
+    if retry_after is not None:
+        response.headers["Retry-After"] = retry_after
+    return httpx.HTTPStatusError("429", request=MagicMock(), response=response)
+
+
+def test_call_with_429_retry_uses_retry_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "plugins.web.retry_policy.get_web_rate_limit_retry_policy",
+        lambda: type(
+            "Policy",
+            (),
+            {"retry_on_429": True, "retry_count": 2, "retry_interval": 0.25},
+        )(),
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr("plugins.web.retry_policy.time.sleep", lambda s: sleeps.append(s))
+
+    attempts = {"count": 0}
+
+    def _request() -> MagicMock:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise _http_429_error()
+        ok = MagicMock()
+        ok.raise_for_status.return_value = None
+        return ok
+
+    result = call_with_429_retry(_request, provider_name="test")
+    assert attempts["count"] == 3
+    assert sleeps == [0.25, 0.25]
+    assert result is not None
+
+
+def test_call_with_429_retry_honors_retry_after_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "plugins.web.retry_policy.get_web_rate_limit_retry_policy",
+        lambda: type(
+            "Policy",
+            (),
+            {"retry_on_429": True, "retry_count": 1, "retry_interval": 99.0},
+        )(),
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr("plugins.web.retry_policy.time.sleep", lambda s: sleeps.append(s))
+
+    attempts = {"count": 0}
+
+    def _request() -> MagicMock:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise _http_429_error(retry_after="1.5")
+        ok = MagicMock()
+        ok.raise_for_status.return_value = None
+        return ok
+
+    call_with_429_retry(_request, provider_name="test")
+    assert sleeps == [1.5]
+
+
+def test_call_with_429_retry_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "plugins.web.retry_policy.get_web_rate_limit_retry_policy",
+        lambda: type(
+            "Policy",
+            (),
+            {"retry_on_429": False, "retry_count": 5, "retry_interval": 1.0},
+        )(),
+    )
+    monkeypatch.setattr("plugins.web.retry_policy.time.sleep", lambda _: None)
+
+    attempts = {"count": 0}
+
+    def _request() -> MagicMock:
+        attempts["count"] += 1
+        raise _http_429_error()
+
+    with pytest.raises(httpx.HTTPStatusError):
+        call_with_429_retry(_request, provider_name="test")
+    assert attempts["count"] == 1


### PR DESCRIPTION
## What does this PR do?

Adds configurable HTTP 429 retry behavior for web providers so operators can tune retry count and wait interval from `config.yaml` instead of relying on fixed behavior.

This implements `web.retry_on_429`, `web.retry_count`, and `web.retry_interval`, then wires the policy into Tavily, SearXNG, and Brave Search provider requests.

## Related Issue

Fixes #26887

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added shared retry policy helper at `plugins/web/retry_policy.py`.
- Added new web config defaults in `hermes_cli/config.py`:
  - `web.retry_on_429` (default `true`)
  - `web.retry_count` (default `3` retries)
  - `web.retry_interval` (default `60s`)
- Updated providers to use configurable 429 retry policy:
  - `plugins/web/tavily/provider.py`
  - `plugins/web/searxng/provider.py`
  - `plugins/web/brave_free/provider.py`
- Documented keys in `cli-config.yaml.example`.
- Added targeted tests in `tests/tools/test_web_retry_policy.py`.

## How to Test

1. Run targeted tests:
   `pytest -q -o addopts='' tests/tools/test_web_retry_policy.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py`
2. Configure `web.retry_count` / `web.retry_interval` in `config.yaml` and point a web backend to a 429-returning endpoint.
3. Confirm retries happen according to config and stop after the configured retry budget.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted verification:

- `pytest -q -o addopts='' tests/tools/test_web_retry_policy.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py`
- Result: `65 passed`
