### PR TITLE
fix(providers): add deepseek to _API_KEY_PROVIDER_AUX_MODELS_FALLBACK (#26924)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -275,6 +275,7 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "deepseek": "deepseek-chat",
 }
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -84,6 +84,18 @@ class TestMinimaxAuxModel:
         assert "highspeed" not in _get_aux_model_for_provider("minimax-cn")
 
 
+class TestDeepseekAuxModel:
+    """Verify DeepSeek (direct API-key provider) has an aux model fallback (#26924)."""
+
+    def test_deepseek_aux_is_chat(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-chat"
+
+    def test_deepseek_aux_not_empty(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+        assert _get_aux_model_for_provider("deepseek") != ""
+
+
 class TestMinimaxBetaHeaders:
     """MiniMax Anthropic-compat endpoints reject fine-grained-tool-streaming beta.
 


### PR DESCRIPTION
## Summary

Fixes #26924 — adds `deepseek` to `_API_KEY_PROVIDER_AUX_MODELS_FALLBACK` so DeepSeek users no longer get the misleading "No auxiliary LLM provider configured" warning.

## Problem

When `provider = "deepseek"`, every Hermes startup and cron job emits:

```
WARNING: No auxiliary LLM provider configured — falling back to main provider for compression
```

Root cause: DeepSeek is a direct API-key provider (no `ProviderProfile` plugin with `default_aux_model`), so `_get_aux_model_for_provider()` falls through to the legacy `_API_KEY_PROVIDER_AUX_MODELS_FALLBACK` dict — which didn't include `deepseek`.

## Fix

One-line addition to the fallback dict:

```python
"deepseek": "deepseek-chat",
```

Consistent with how `minimax`, `stepfun`, `kimi-coding`, and other direct API-key providers are handled.

## Tests

Two new regression tests in `test_minimax_provider.py` (`TestDeepseekAuxModel`):

- `test_deepseek_aux_is_chat` — asserts `_get_aux_model_for_provider("deepseek") == "deepseek-chat"`
- `test_deepseek_aux_not_empty` — asserts the return value is non-empty

## Verification

```bash
venv/bin/python -m pytest tests/agent/test_minimax_provider.py::TestDeepseekAuxModel -v
# 2 passed in 2.00s
```

## Type

🐛 Bug fix (non-breaking)