### PR TITLE
fix(auxiliary): handle custom glm vision parameter mismatch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4149,14 +4149,21 @@ def _build_call_kwargs(
         # ZAI vision models (glm-4v-flash, glm-4v-plus, etc.) reject max_tokens with
         # error code 1210 ("API 调用参数有误") on multimodal requests — skip it.
         _model_lower = (model or "").lower()
+        custom_base = base_url or _current_custom_base_url()
+        _is_zai_custom_endpoint = (
+            provider == "custom"
+            and (
+                base_url_host_matches(custom_base, "bigmodel.cn")
+                or base_url_host_matches(custom_base, "z.ai")
+            )
+        )
         _skip_max_tokens = (
-            provider == "zai"
+            (provider == "zai" or _is_zai_custom_endpoint)
             and ("4v" in _model_lower or "5v" in _model_lower or "-v" in _model_lower)
         )
         if _skip_max_tokens:
             pass  # ZAI vision models do not accept max_tokens
         elif provider == "custom":
-            custom_base = base_url or _current_custom_base_url()
             if base_url_hostname(custom_base) == "api.openai.com":
                 kwargs["max_completion_tokens"] = max_tokens
             else:
@@ -4403,6 +4410,8 @@ def call_llm(
         ):
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
+            if _is_zai_param_error:
+                kwargs.pop("temperature", None)
             try:
                 return _validate_llm_response(
                     client.chat.completions.create(**kwargs), task)
@@ -4754,6 +4763,8 @@ async def async_call_llm(
         ):
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
+            if _is_zai_param_error:
+                kwargs.pop("temperature", None)
             try:
                 return _validate_llm_response(
                     await client.chat.completions.create(**kwargs), task)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2482,6 +2482,38 @@ class TestBuildCallKwargsToolDedup:
         assert "tools" not in kwargs
 
 
+class TestBuildCallKwargsZaiVision:
+    """ZAI vision endpoints must not receive max_tokens."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://open.bigmodel.cn/api/paas/v4",
+            "https://api.z.ai/api/paas/v4",
+        ],
+    )
+    def test_custom_zai_vision_skips_max_tokens(self, base_url):
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="glm-4v-flash",
+            messages=[{"role": "user", "content": "analyze image"}],
+            max_tokens=2000,
+            base_url=base_url,
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_custom_non_zai_endpoint_keeps_max_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="glm-4v-flash",
+            messages=[{"role": "user", "content": "analyze image"}],
+            max_tokens=2000,
+            base_url="https://example.internal/v1",
+        )
+        assert kwargs.get("max_tokens") == 2000
+
+
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Strip provider env vars so each test starts clean."""


### PR DESCRIPTION
## What does this PR do?

Fixes GLM/ZAI vision request compatibility when `auxiliary.vision` is configured via a custom endpoint (`provider: glm` + `base_url` + `api_key`).

The bug path was:
- provider resolves to `custom`
- `_build_call_kwargs` only skipped `max_tokens` for `provider == "zai"`
- GLM vision endpoints (bigmodel/z.ai) reject this with 1210 parameter errors

This change extends the same guard to custom endpoints that resolve to `bigmodel.cn` or `z.ai` for vision model names, and hardens 1210 retry handling by also dropping `temperature` on the ZAI-specific retry path.

## Related Issue

Fixes #26827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [`agent/auxiliary_client.py`](agent/auxiliary_client.py):
  - `_build_call_kwargs` now skips `max_tokens` for vision models when `provider == "custom"` and base URL host matches `bigmodel.cn` or `z.ai`.
  - Sync/async `call_llm` retry path now strips `temperature` as well when handling ZAI 1210 parameter errors.
- Added tests in [`tests/agent/test_auxiliary_client.py`](tests/agent/test_auxiliary_client.py):
  - custom bigmodel/z.ai vision endpoints do not emit `max_tokens`
  - non-ZAI custom endpoints keep `max_tokens`

## How to Test

1. Run targeted tests:
   - `uv run --with pytest==9.0.2 --with pytest-xdist==3.8.0 --with pytest-asyncio==1.3.0 python -m pytest -q tests/agent/test_auxiliary_client.py -k "TestBuildCallKwargsZaiVision"`
2. Run touched-file lint:
   - `uv run --with ruff==0.15.10 ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
3. Reproduce with a GLM vision custom endpoint (`open.bigmodel.cn`/`api.z.ai`) and verify requests no longer include `max_tokens` and no longer fail with 1210 due to this parameter.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted test output: `3 passed in 3.78s`
- `git diff --check`: clean
