### PR TITLE
fix(achievements): count only memory writes

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -270,6 +270,34 @@ def _tool_name_from_call(call: Any) -> Optional[str]:
     return call.get("name") or fn.get("name")
 
 
+def _tool_args_from_call(call: Any) -> Dict[str, Any]:
+    if not isinstance(call, dict):
+        return {}
+    fn = call.get("function") or {}
+    args = call.get("arguments", fn.get("arguments"))
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        try:
+            parsed = json.loads(args)
+        except Exception:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _is_memory_write_call(call: Any) -> bool:
+    name = (_tool_name_from_call(call) or "").strip().lower()
+    if not name:
+        return False
+    if name == "mnemosyne_remember":
+        return True
+    if name != "memory":
+        return False
+    action = str(_tool_args_from_call(call).get("action", "")).strip().lower()
+    return action in {"add", "replace"}
+
+
 def _content(msg: Dict[str, Any]) -> str:
     content = msg.get("content")
     if content is None:
@@ -313,6 +341,7 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     files_touched: Set[str] = set()
     full_text_parts: List[str] = []
     error_count = 0
+    memory_write_events = 0
 
     for msg in messages:
         text = _content(msg)
@@ -329,6 +358,8 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
             if name:
                 tool_names.add(name)
                 tool_sequence.append(name)
+                if _is_memory_write_call(call):
+                    memory_write_events += 1
         if ERROR_RE.search(text):
             error_count += 1
         blob = text
@@ -354,7 +385,6 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     skill_events = _count_tool(tool_sequence, "skill") + len(re.findall(r"\bskill", lower))
     skill_manage_events = _count_tool(tool_sequence, "skill_manage")
     memory_events = _count_tool(tool_sequence, "memory", "mnemosyne")
-    memory_write_events = _count_tool(tool_sequence, "mnemosyne_remember", "memory")
 
     return {
         "session_id": session_id,

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -375,3 +375,42 @@ def test_partial_snapshots_do_not_persist_unlock_timestamps(plugin_api):
         "partial scans must not record unlock timestamps — a later session "
         "could change whether the badge deserves to be unlocked yet"
     )
+
+
+def test_analyze_messages_counts_only_memory_writes(plugin_api):
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"search","target":"memory","query":"alpha"}',
+                    }
+                },
+                {
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"add","target":"memory","content":"beta"}',
+                    }
+                },
+                {
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"replace","target":"memory","old_text":"beta","content":"gamma"}',
+                    }
+                },
+                {
+                    "function": {
+                        "name": "mnemosyne_remember",
+                        "arguments": '{"content":"delta"}',
+                    }
+                },
+            ],
+        }
+    ]
+
+    stats = plugin_api.analyze_messages("sess-1", "Memory writes", messages)
+
+    assert stats["memory_events"] == 4
+    assert stats["memory_write_events"] == 3


### PR DESCRIPTION
## What does this PR do?

Fixes `memory_write_events` in the bundled `hermes-achievements` plugin so it only counts real durable-memory writes instead of every `memory` tool call.

## Related Issue

Fixes #26927

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `plugins/hermes-achievements/dashboard/plugin_api.py`:
  - parse tool-call arguments for `memory`
  - count `memory_write_events` only for `memory` actions `add` / `replace`
  - continue counting `mnemosyne_remember` as a write
- Added regression test in `tests/plugins/test_achievements_plugin.py` proving read/search calls no longer inflate write-only achievements.

## How to Test

1. `python3 -m pytest -q tests/plugins/test_achievements_plugin.py -o addopts=''`
2. `python3 -m ruff check plugins/hermes-achievements/dashboard/plugin_api.py tests/plugins/test_achievements_plugin.py`
3. `python3 -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py tests/plugins/test_achievements_plugin.py`
4. `git diff --check`

## Screenshots / Logs

- Targeted pytest: `10 passed in 0.76s`
- `ruff`: passed
- `py_compile`: passed
- `git diff --check`: clean
