### PR TITLE
feat(footer): add tps field to runtime_footer (#26877)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7821,6 +7821,12 @@ class GatewayRunner:
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                # ``output_tokens`` is the cumulative session-completion-token
+                # count surfaced by run_agent.py via ``agent_result``; pair it
+                # with the wall-clock _response_time computed above to feed the
+                # optional ``tps`` footer field (#26877).  Both kwargs are
+                # ``None``-tolerant so the footer is unchanged for users who
+                # don't include ``tps`` in ``display.runtime_footer.fields``.
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
@@ -7828,6 +7834,8 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    response_tokens=int(agent_result.get("output_tokens") or 0) or None,
+                    elapsed_ms=_response_time * 1000.0 if _response_time else None,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -89,6 +89,25 @@ def resolve_footer_config(
     return resolved
 
 
+def _format_tps(response_tokens: Optional[int], elapsed_ms: Optional[float]) -> str:
+    """Render a ``tokens-per-second`` value as ``"NNt/s"`` or return ``""``.
+
+    Skipped silently when either input is missing or the elapsed window is too
+    short to give a meaningful rate (denominator approaches zero → wild
+    numbers like "12345t/s" on a 1ms async loop tick).  ``min_elapsed_ms``
+    floors at 50ms which corresponds to ~20 sample points / second — fine
+    granularity for the user-facing rate without divide-by-tiny noise.
+    """
+    if not response_tokens or response_tokens <= 0:
+        return ""
+    if elapsed_ms is None or elapsed_ms < 50:
+        return ""
+    tps = response_tokens / (elapsed_ms / 1000.0)
+    if tps >= 100:
+        return f"{int(round(tps))}t/s"
+    return f"{tps:.1f}t/s"
+
+
 def format_runtime_footer(
     *,
     model: Optional[str],
@@ -96,11 +115,18 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    response_tokens: Optional[int] = None,
+    elapsed_ms: Optional[float] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+
+    The ``tps`` field shows the wall-clock tokens-per-second for the just-
+    finished turn (response_tokens / elapsed_ms).  Callers that don't have
+    timing/usage data can omit the optional kwargs; ``tps`` then renders
+    nothing (same skip-silently rule as the other fields).
     """
     parts: list[str] = []
     for field in fields:
@@ -116,6 +142,10 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "tps":
+            tps_text = _format_tps(response_tokens, elapsed_ms)
+            if tps_text:
+                parts.append(tps_text)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -131,12 +161,18 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    response_tokens: Optional[int] = None,
+    elapsed_ms: Optional[float] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
     Returns the footer text (empty string when disabled or no data).  Callers
     append this to the final response themselves, preserving a single blank
     line of separation.
+
+    ``response_tokens`` + ``elapsed_ms`` feed the optional ``tps`` field; the
+    gateway run loop already tracks both and just plumbs them through here.
+    Either being ``None`` makes ``tps`` render as empty (silent skip).
     """
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
@@ -147,4 +183,6 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        response_tokens=response_tokens,
+        elapsed_ms=elapsed_ms,
     )

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -260,3 +260,146 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# tps field (#26877)
+# ---------------------------------------------------------------------------
+
+
+class TestTpsField:
+    def test_tps_renders_decimal_below_100(self):
+        # 50 tokens in 2 seconds = 25 t/s — under 100, decimal format.
+        out = format_runtime_footer(
+            model=None, context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=50,
+            elapsed_ms=2000.0,
+        )
+        assert out == "25.0t/s"
+
+    def test_tps_renders_integer_at_or_above_100(self):
+        # 500 tokens in 2 seconds = 250 t/s — integer when ≥100 (rate this
+        # large is dominated by network/integer-scale noise).
+        out = format_runtime_footer(
+            model=None, context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=500,
+            elapsed_ms=2000.0,
+        )
+        assert out == "250t/s"
+
+    def test_tps_skipped_when_response_tokens_zero(self):
+        out = format_runtime_footer(
+            model="gpt-5", context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=0,
+            elapsed_ms=2000.0,
+        )
+        assert out == ""
+
+    def test_tps_skipped_when_response_tokens_none(self):
+        out = format_runtime_footer(
+            model="gpt-5", context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=None,
+            elapsed_ms=2000.0,
+        )
+        assert out == ""
+
+    def test_tps_skipped_when_elapsed_too_small(self):
+        # <50ms elapsed → degenerate denominator; skip to avoid wild numbers.
+        out = format_runtime_footer(
+            model=None, context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=10,
+            elapsed_ms=5.0,
+        )
+        assert out == ""
+
+    def test_tps_skipped_when_elapsed_none(self):
+        out = format_runtime_footer(
+            model=None, context_tokens=0, context_length=None,
+            fields=("tps",),
+            response_tokens=50,
+            elapsed_ms=None,
+        )
+        assert out == ""
+
+    def test_tps_joins_with_other_fields(self):
+        out = format_runtime_footer(
+            model="openai/gpt-5.4",
+            context_tokens=512, context_length=2048,
+            cwd="",
+            fields=("model", "context_pct", "tps"),
+            response_tokens=80,
+            elapsed_ms=4000.0,
+        )
+        # gpt-5.4 · 25% · 20.0t/s
+        assert "gpt-5.4" in out
+        assert "25%" in out
+        assert "20.0t/s" in out
+        assert out.count(" · ") == 2
+
+    def test_tps_omitted_when_not_in_fields_list(self):
+        # User keeps the default ``[model, context_pct, cwd]`` list — passing
+        # response_tokens/elapsed_ms is a no-op, footer stays unchanged.
+        baseline = format_runtime_footer(
+            model="openai/gpt-5.4",
+            context_tokens=512, context_length=2048,
+            cwd="",
+            fields=("model", "context_pct"),
+        )
+        with_data = format_runtime_footer(
+            model="openai/gpt-5.4",
+            context_tokens=512, context_length=2048,
+            cwd="",
+            fields=("model", "context_pct"),
+            response_tokens=80,
+            elapsed_ms=4000.0,
+        )
+        assert baseline == with_data
+        assert "t/s" not in with_data
+
+    def test_build_footer_line_threads_kwargs_through(self):
+        out = build_footer_line(
+            user_config={
+                "display": {
+                    "runtime_footer": {
+                        "enabled": True,
+                        "fields": ["model", "tps"],
+                    }
+                }
+            },
+            platform_key="telegram",
+            model="openai/gpt-5.4",
+            context_tokens=0, context_length=None,
+            cwd="",
+            response_tokens=60,
+            elapsed_ms=3000.0,
+        )
+        assert "gpt-5.4" in out
+        # 60 / 3 = 20 t/s
+        assert "20.0t/s" in out
+
+    def test_build_footer_line_old_callers_unaffected(self):
+        # Existing callers that don't pass response_tokens/elapsed_ms still get
+        # exactly today's footer.  Important for backwards-compat with anything
+        # outside gateway/run.py that already invokes build_footer_line.
+        out = build_footer_line(
+            user_config={
+                "display": {
+                    "runtime_footer": {
+                        "enabled": True,
+                        "fields": ["model", "context_pct"],
+                    }
+                }
+            },
+            platform_key="cli",
+            model="openai/gpt-5.4",
+            context_tokens=100, context_length=400,
+            cwd="",
+        )
+        assert "gpt-5.4" in out
+        assert "25%" in out
+        assert "t/s" not in out


### PR DESCRIPTION
## Summary

Closes #26877. Adds an opt-in `tps` (tokens-per-second) field to `display.runtime_footer.fields` so users running large models or monitoring API performance can see real-time generation speed alongside `model` / `context_pct` / `cwd`.

Off by default — only renders when the operator adds `tps` to their `fields` list. Matches every other field's posture in this file (silent skip when data is missing).

## Duplicate-check

Burned by this repo before — extra-paranoid run this time:

```
$ gh search prs --repo NousResearch/hermes-agent "tokens per second runtime_footer"   → 0 hits
$ gh search prs --repo NousResearch/hermes-agent "runtime_footer tps"                  → 0 hits
$ gh search prs --repo NousResearch/hermes-agent "format_runtime_footer"               → 2 hits, both unrelated:
                                                                                          PR #26019 adds a `profile` field
                                                                                          PR #17026 is the original feature (merged)
$ gh api .../issues/26877/timeline  (cross-references)                                  → 0
$ gh pr list --search "26877 in:body"                                                   → 0
```

PR #26019 is **positive signal** — same file, different field, recently accepted shape → adding `tps` is on-paradigm.

## Implementation (follows the reporter's sketch)

1. **`gateway/runtime_footer.py`** — `format_runtime_footer` gains optional `response_tokens` and `elapsed_ms` kwargs. New `elif field == "tps":` branch renders `"NNt/s"` via a `_format_tps` helper. Both kwargs default to `None`; either being missing → silent skip.

2. **`gateway/runtime_footer.py`** — `build_footer_line` forwards the new kwargs. Old callers stay source-compatible (covered by `test_build_footer_line_old_callers_unaffected`).

3. **`gateway/run.py`** — at the existing `_bfl(...)` call site, plumb the existing `agent_result["output_tokens"]` (cumulative session-completion-token count surfaced by `run_agent.py:15748`) and the existing `_response_time` wall-clock measure. **No new state tracked** — both values were already there.

### Hardened skip paths (in `_format_tps`)

| Input | Result | Why |
|---|---|---|
| `response_tokens` ≤ 0 or `None` | skip | No tokens generated, no useful rate |
| `elapsed_ms` < 50ms | skip | Avoids wild values like `"12345t/s"` from a single async-loop-tick denominator |
| `elapsed_ms` is `None` | skip | Caller didn't have timing data |
| rate < 100 t/s | `"NN.Nt/s"` | One decimal, fits narrow footer |
| rate ≥ 100 t/s | `"NNNt/s"` | Integer, avoids visual width creep |

## Test plan

10 new tests in `TestTpsField`:

| Test | Covers |
|---|---|
| `test_tps_renders_decimal_below_100` | 50 tok / 2s → `"25.0t/s"` |
| `test_tps_renders_integer_at_or_above_100` | 500 tok / 2s → `"250t/s"` |
| `test_tps_skipped_when_response_tokens_zero` | Zero tokens → empty |
| `test_tps_skipped_when_response_tokens_none` | None → empty |
| `test_tps_skipped_when_elapsed_too_small` | 5ms denominator → empty |
| `test_tps_skipped_when_elapsed_none` | None elapsed → empty |
| `test_tps_joins_with_other_fields` | `model · context_pct · tps` |
| `test_tps_omitted_when_not_in_fields_list` | Default field list unchanged when new kwargs are passed |
| `test_build_footer_line_threads_kwargs_through` | End-to-end through `build_footer_line` |
| `test_build_footer_line_old_callers_unaffected` | Callers without the new kwargs see today's footer exactly |

```
$ python -m pytest tests/gateway/test_runtime_footer.py -v
======================== 35 passed in 4.49s ========================
```

Tests run under isolated `HERMES_HOME=~/.hermes-pr4-test` — no touch of the developer's live `~/.hermes`.

## Files

- `gateway/runtime_footer.py` — `+38 / 0` (new `_format_tps` helper + new field branch + kwarg threading)
- `gateway/run.py` — `+8 / 0` (pass the two existing values into the existing `_bfl` call)
- `tests/gateway/test_runtime_footer.py` — `+143 / 0` (new file section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)