### PR TITLE
fix: require non-empty credential pool entries in provider listing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1233,7 +1233,12 @@ def list_authenticated_providers(
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
                 if store and hermes_id in store.get("credential_pool", {}):
-                    has_creds = True
+                    # Require non-empty credential pool entries — an empty
+                    # array (e.g. "kimi-coding-cn": []) means the provider
+                    # was once configured but credentials were removed.
+                    pool_creds = store["credential_pool"].get(hermes_id, [])
+                    if pool_creds:
+                        has_creds = True
             except Exception:
                 pass
         if not has_creds:


### PR DESCRIPTION
## Summary

The `list_authenticated_providers()` function in `model_switch.py` has a bug where empty credential pool entries (e.g. `\kimi-coding-cn\: []`) are treated as valid authentication, causing phantom providers to appear in the `/model` picker.

The credential check only verified that a provider ID existed as a key in the `credential_pool` dict — it did not check whether the entry had actual credentials.

## Reproduction

1. Configure a provider (e.g. Kimi CN) via `.env` → credential\_pool entry created in `auth.json`
2. Remove the API key from `.env` → credential\_pool still has `\kimi-coding-cn\: []`
3. Run `/model` in TUI → kimi still appears in the provider list even though no key exists

## Fix

Changed the credential pool check to require non-empty entries:

```python
pool_creds = store["credential_pool"].get(hermes_id, [])
if pool_creds:  # require non-empty
    has_creds = True
```

This is both corrective (the stale empty entry should be cleaned up) and defensive (prevents future empty entries from causing phantom providers).

## Test Plan

- [ ] Providers with actual credentials in credential\_pool still appear
- [ ] Empty `[]` or missing entries no longer appear as authenticated providers
- [ ] All existing tests pass

Closes #—