### PR TITLE
fix: add DeepSeek to aux model fallback map

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -144,6 +144,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
+    "deepseek": "deepseek-chat",
 }
 
 # Vision-specific model overrides for direct providers.


### PR DESCRIPTION
## Summary

Adds `"deepseek": "deepseek-chat"` to `_API_KEY_PROVIDER_AUX_MODELS` so the auxiliary model resolver can find a cheap fallback model for DeepSeek users.

Without this entry, any feature that needs an auxiliary model (vision auto-detect, web extraction, session search) silently fails to resolve when the user's provider is DeepSeek.

## Test plan

- [ ] Verify `_resolve_api_key_provider()` now returns `deepseek-chat` when the active provider is `deepseek`
- [ ] Confirm existing providers are unaffected

Closes #26924

🤖 Generated with [Claude Code](https://claude.com/claude-code)