### PR TITLE
fix(achievements): count only memory writes in memory_write_events (#26927)

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -263,10 +263,25 @@ def _scan_status_payload(now: Optional[int] = None) -> Dict[str, Any]:
     }
 
 
+def _call_function_field(call: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``call["function"]`` when it is a dict, else ``{}``.
+
+    Some legacy session rows store the field as a bare string (the tool
+    name) instead of the OpenAI ``{"name": ..., "arguments": ...}``
+    object.  ``call.get("function") or {}`` only filters out falsy values,
+    so a truthy non-dict like ``"memory"`` would slip through and cause
+    ``fn.get(...)`` to raise — aborting the whole scan instead of just
+    under-counting this one call.  This helper makes the guard
+    consistent across every reader.
+    """
+    fn = call.get("function")
+    return fn if isinstance(fn, dict) else {}
+
+
 def _tool_name_from_call(call: Any) -> Optional[str]:
     if not isinstance(call, dict):
         return None
-    fn = call.get("function") or {}
+    fn = _call_function_field(call)
     return call.get("name") or fn.get("name")
 
 
@@ -287,7 +302,7 @@ def _tool_arguments_from_call(call: Any) -> Dict[str, Any]:
     """
     if not isinstance(call, dict):
         return {}
-    fn = call.get("function") or {}
+    fn = _call_function_field(call)
     raw = call.get("arguments")
     if raw is None:
         raw = fn.get("arguments")

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -199,21 +199,40 @@ def save_snapshot(data: Dict[str, Any]) -> None:
     path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
 
 
+# Checkpoint schema version. Bump this every time ``analyze_messages``
+# changes the *meaning* of a stat that `scan_sessions` caches — otherwise
+# existing histories keep serving the old (pre-fix) numbers indefinitely
+# because ``session_fingerprint`` is only derived from session metadata
+# (started_at / last_active / model / title), not the analyzer output.
+#
+# v2 (#26927): ``memory_write_events`` no longer substring-matches
+#     ``"memory"`` against every tool name. Older caches over-count and
+#     must be discarded so the Memory Palace progress finally drops to
+#     the genuine write count instead of mirroring ``memory_events``.
+_CHECKPOINT_SCHEMA_VERSION = 2
+
+
 def load_checkpoint() -> Dict[str, Any]:
     path = checkpoint_path()
     if not path.exists():
-        return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+        return {"schema_version": _CHECKPOINT_SCHEMA_VERSION, "generated_at": 0, "sessions": {}}
     try:
         data = json.loads(path.read_text())
         if isinstance(data, dict):
             data.setdefault("schema_version", 1)
             data.setdefault("generated_at", 0)
             data.setdefault("sessions", {})
+            # Drop the per-session cache when the analyzer semantics moved
+            # forward. The file itself is left in place — ``save_checkpoint``
+            # rewrites it with the new version on the next scan.
+            if int(data.get("schema_version") or 0) < _CHECKPOINT_SCHEMA_VERSION:
+                data["sessions"] = {}
+                data["schema_version"] = _CHECKPOINT_SCHEMA_VERSION
             if isinstance(data.get("sessions"), dict):
                 return data
     except Exception:
         pass
-    return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+    return {"schema_version": _CHECKPOINT_SCHEMA_VERSION, "generated_at": 0, "sessions": {}}
 
 
 def save_checkpoint(data: Dict[str, Any]) -> None:
@@ -728,7 +747,7 @@ def scan_sessions(
                     pass
 
         save_checkpoint({
-            "schema_version": 1,
+            "schema_version": _CHECKPOINT_SCHEMA_VERSION,
             "generated_at": int(time.time()),
             "sessions": checkpoint_sessions,
         })

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -270,6 +270,51 @@ def _tool_name_from_call(call: Any) -> Optional[str]:
     return call.get("name") or fn.get("name")
 
 
+def _tool_arguments_from_call(call: Any) -> Dict[str, Any]:
+    """Return the parsed tool-call arguments dict (or ``{}`` on failure).
+
+    Tool-call ``arguments`` come in three shapes across model adapters:
+
+    * Already a ``dict`` (some streaming providers parse on the way in).
+    * A JSON-encoded ``str`` (the OpenAI Chat Completions wire format).
+    * Missing / ``None``.
+
+    Used by ``analyze_messages`` to distinguish ``memory`` writes from
+    reads/removes for the Memory Palace achievement — see #26927, where
+    ``memory_write_events`` had degenerated into an exact copy of
+    ``memory_events`` because the previous heuristic only looked at
+    tool names, not arguments.
+    """
+    if not isinstance(call, dict):
+        return {}
+    fn = call.get("function") or {}
+    raw = call.get("arguments")
+    if raw is None:
+        raw = fn.get("arguments")
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return {}
+        try:
+            parsed = json.loads(s)
+        except Exception:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+# Built-in memory tool actions that produce a net write to durable storage.
+# ``remove`` is excluded — it deletes content rather than persisting new
+# content, so counting it as a "write" would over-credit the Memory Palace
+# achievement.  ``mnemosyne_remember`` is a separate write-only tool name
+# from the external Mnemosyne plugin and is matched by name (no args
+# inspection needed).  See #26927.
+_MEMORY_WRITE_ACTIONS = frozenset({"add", "replace"})
+_MEMORY_TOOL_NAMES = frozenset({"memory"})
+
+
 def _content(msg: Dict[str, Any]) -> str:
     content = msg.get("content")
     if content is None:
@@ -313,6 +358,11 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     files_touched: Set[str] = set()
     full_text_parts: List[str] = []
     error_count = 0
+    # Per-action write count for the built-in ``memory`` tool.  Populated
+    # by inspecting tool-call arguments below; consumed by
+    # ``memory_write_events`` so the Memory Palace achievement counts
+    # genuine writes instead of every memory engagement (#26927).
+    memory_write_call_count = 0
 
     for msg in messages:
         text = _content(msg)
@@ -329,6 +379,11 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
             if name:
                 tool_names.add(name)
                 tool_sequence.append(name)
+                if name.lower() in _MEMORY_TOOL_NAMES:
+                    args = _tool_arguments_from_call(call)
+                    action = str(args.get("action") or "").strip().lower()
+                    if action in _MEMORY_WRITE_ACTIONS:
+                        memory_write_call_count += 1
         if ERROR_RE.search(text):
             error_count += 1
         blob = text
@@ -354,7 +409,16 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     skill_events = _count_tool(tool_sequence, "skill") + len(re.findall(r"\bskill", lower))
     skill_manage_events = _count_tool(tool_sequence, "skill_manage")
     memory_events = _count_tool(tool_sequence, "memory", "mnemosyne")
-    memory_write_events = _count_tool(tool_sequence, "mnemosyne_remember", "memory")
+    # ``memory_write_events`` was previously ``_count_tool(..., "mnemosyne_remember", "memory")``,
+    # which substring-matched every ``memory`` call (read / search / remove)
+    # and made it an exact copy of ``memory_events`` — see #26927.  The
+    # fix: count ``mnemosyne_remember`` by name (it's a write-only tool
+    # from the external Mnemosyne plugin) and gate the built-in ``memory``
+    # tool on its parsed ``action`` argument (``add`` or ``replace`` only).
+    memory_write_events = (
+        _count_tool(tool_sequence, "mnemosyne_remember")
+        + memory_write_call_count
+    )
 
     return {
         "session_id": session_id,

--- a/tests/plugins/test_achievements_memory_write_events.py
+++ b/tests/plugins/test_achievements_memory_write_events.py
@@ -250,3 +250,50 @@ def test_tool_arguments_helper_handles_all_shapes(plugin_api):
     assert h({}) == {}
     assert h(None) == {}
     assert h("not a dict") == {}
+
+
+# ---------------------------------------------------------------------------
+# Defensive parsing: non-dict ``function`` field must not abort the scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_function_field", [
+    "memory",                       # legacy string-only shape
+    42,                             # accidentally an int (model adapter bug)
+    ["memory", {"action": "add"}],  # list — saw this in one corrupted DB
+    True,                           # truthy but not a dict
+])
+def test_helpers_tolerate_non_dict_function_field(plugin_api, bad_function_field):
+    """Both helpers must short-circuit when ``call["function"]`` isn't a dict.
+
+    Regression for the Copilot review on PR #26936: ``call.get("function")
+    or {}`` only filters out *falsy* values, so a truthy non-dict (string,
+    int, list, bool) used to crash ``fn.get(...)`` and abort the entire
+    session scan instead of just under-counting the malformed call.
+    """
+    call = {"name": "memory", "function": bad_function_field, "arguments": {"action": "add"}}
+    # Neither helper may raise — both must degrade gracefully.
+    assert plugin_api._tool_name_from_call(call) == "memory"
+    # Top-level ``arguments`` is still honoured even though ``function`` is junk.
+    assert plugin_api._tool_arguments_from_call(call) == {"action": "add"}
+
+
+def test_analyze_messages_does_not_abort_on_corrupt_function_field(plugin_api):
+    """A single malformed call must not zero out the whole session's stats."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"name": "memory", "function": "memory", "arguments": {"action": "add"}},
+                _memory_call("add"),
+            ],
+        },
+    ]
+    # Pre-fix this raised AttributeError on ``"memory".get("arguments")``;
+    # post-fix the malformed call is parsed via the top-level ``arguments``
+    # and counted, and the well-formed call counts too.
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 2
+    assert snap["memory_write_events"] == 2
+
+

--- a/tests/plugins/test_achievements_memory_write_events.py
+++ b/tests/plugins/test_achievements_memory_write_events.py
@@ -1,0 +1,252 @@
+"""Regression coverage for ``memory_write_events`` (issue #26927).
+
+Before the fix, ``memory_write_events`` was computed with
+``_count_tool(tool_sequence, "mnemosyne_remember", "memory")`` —
+where ``_count_tool`` substring-matches needles against tool names.
+The ``"memory"`` needle therefore matched every call to the built-in
+``memory`` tool, regardless of whether the model passed
+``action=add``, ``action=replace``, or ``action=remove``.  The metric
+degenerated into an exact copy of ``memory_events``, and the Memory
+Palace achievement always showed the same progress as Memory Keeper.
+
+The fix:
+
+* Count ``mnemosyne_remember`` by name (it's a write-only tool from
+  the external Mnemosyne plugin — no args inspection needed).
+* For the built-in ``memory`` tool, inspect each tool call's
+  ``arguments`` and only count ``action in {"add", "replace"}`` as
+  a write.  ``remove`` deletes content rather than persisting new
+  content, so it is excluded.
+* Drop the broken ``"memory"`` substring needle.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+PLUGIN_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "hermes-achievements"
+    / "dashboard"
+    / "plugin_api.py"
+)
+
+
+@pytest.fixture
+def plugin_api():
+    spec = importlib.util.spec_from_file_location(
+        "plugin_api_memory_write_events", PLUGIN_MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _memory_call(action: str, *, target: str = "memory", content: str = "x"):
+    """Build an OpenAI-style tool call with JSON-encoded arguments."""
+    import json
+
+    return {
+        "function": {
+            "name": "memory",
+            "arguments": json.dumps(
+                {"action": action, "target": target, "content": content}
+            ),
+        },
+    }
+
+
+def _memory_call_with_dict_args(action: str):
+    """Some adapters parse ``arguments`` before storage — handle both."""
+    return {
+        "function": {"name": "memory"},
+        "name": "memory",
+        "arguments": {"action": action, "target": "memory", "content": "x"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core bug: write metric must NOT equal the engagement metric
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_memory_calls_dont_count_as_writes(plugin_api):
+    """A session with only ``action=remove`` must produce write=0, events>=1.
+
+    Direct reproduction of #26927: pre-fix, this returned write == events.
+    """
+    msgs = [
+        {"role": "user", "content": "clean up"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                _memory_call("remove"),
+                _memory_call("remove"),
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 2, (
+        "Every memory call must still count toward Memory Keeper "
+        "engagement (memory_events is unchanged by the fix)."
+    )
+    assert snap["memory_write_events"] == 0, (
+        "Pure ``remove`` calls produce no writes — this is the core "
+        "regression for #26927."
+    )
+
+
+def test_add_and_replace_count_as_writes(plugin_api):
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                _memory_call("add"),
+                _memory_call("replace"),
+                _memory_call("remove"),
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 3
+    assert snap["memory_write_events"] == 2, (
+        "``add`` and ``replace`` are the only write actions; ``remove`` "
+        "is a deletion."
+    )
+
+
+def test_dict_shaped_arguments_are_supported(plugin_api):
+    """Some adapters parse ``arguments`` into a dict before persistence."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                _memory_call_with_dict_args("add"),
+                _memory_call_with_dict_args("remove"),
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 2
+    assert snap["memory_write_events"] == 1
+
+
+def test_case_insensitive_action_value(plugin_api):
+    """Models occasionally upper-case the action; tolerate that."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                _memory_call("ADD"),
+                _memory_call("Replace"),
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_write_events"] == 2
+
+
+def test_missing_or_malformed_arguments_dont_count_as_writes(plugin_api):
+    """When we can't tell what the action was, default to non-write.
+
+    Better to under-count than to repeat the #26927 over-count bug.
+    """
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                # No arguments at all
+                {"function": {"name": "memory"}},
+                # Bad JSON
+                {"function": {"name": "memory", "arguments": "{not valid"}},
+                # Non-object JSON
+                {"function": {"name": "memory", "arguments": "42"}},
+                # Empty string
+                {"function": {"name": "memory", "arguments": ""}},
+                # Action missing from otherwise-valid args
+                {
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"target": "memory"}',
+                    }
+                },
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 5
+    assert snap["memory_write_events"] == 0
+
+
+def test_mnemosyne_remember_is_still_a_write(plugin_api):
+    """The external Mnemosyne plugin uses ``mnemosyne_remember`` as a
+    write-only tool name; that part of the heuristic still works."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "mnemosyne_remember"}},
+                {"function": {"name": "mnemosyne_recall"}},
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    # ``memory_events`` substring-matches "mnemosyne" — both should count.
+    assert snap["memory_events"] == 2
+    # Only the write-specific name counts as a write.
+    assert snap["memory_write_events"] == 1
+
+
+def test_mixed_memory_and_mnemosyne_writes_are_summed(plugin_api):
+    """The two write-tool sources are summed, not max'd or duplicated."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                _memory_call("add"),
+                _memory_call("add"),
+                {"function": {"name": "mnemosyne_remember"}},
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_write_events"] == 3
+
+
+def test_non_memory_tools_never_count_as_memory_writes(plugin_api):
+    """Defense in depth: a ``terminal`` call with ``action=add`` in its
+    args (unusual but possible) must NOT count as a memory write."""
+    msgs = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"action": "add", "command": "ls"}',
+                    }
+                },
+            ],
+        },
+    ]
+    snap = plugin_api.analyze_messages("s", "t", msgs)
+    assert snap["memory_events"] == 0
+    assert snap["memory_write_events"] == 0
+
+
+def test_tool_arguments_helper_handles_all_shapes(plugin_api):
+    """Lock the helper's contract so future edits don't reintroduce the bug."""
+    h = plugin_api._tool_arguments_from_call
+    assert h({"arguments": {"action": "add"}}) == {"action": "add"}
+    assert h({"function": {"arguments": '{"action": "add"}'}}) == {"action": "add"}
+    assert h({"function": {"arguments": "{bad json"}}) == {}
+    assert h({"function": {"arguments": "42"}}) == {}
+    assert h({"function": {}}) == {}
+    assert h({}) == {}
+    assert h(None) == {}
+    assert h("not a dict") == {}

--- a/tests/plugins/test_achievements_memory_write_events.py
+++ b/tests/plugins/test_achievements_memory_write_events.py
@@ -297,3 +297,59 @@ def test_analyze_messages_does_not_abort_on_corrupt_function_field(plugin_api):
     assert snap["memory_write_events"] == 2
 
 
+# ---------------------------------------------------------------------------
+# Checkpoint schema version: stale caches must be invalidated on load
+# ---------------------------------------------------------------------------
+
+
+def test_load_checkpoint_drops_sessions_when_schema_version_is_stale(plugin_api, tmp_path, monkeypatch):
+    """A pre-v2 checkpoint must hand back an empty ``sessions`` dict.
+
+    Without this, sessions cached before the #26927 fix would keep the
+    old over-counted ``memory_write_events`` indefinitely — the
+    fingerprint is per-session and unaware of analyzer semantics, so the
+    cache-reuse branch in ``scan_sessions`` would never re-analyze them.
+    """
+    monkeypatch.setattr(plugin_api, "checkpoint_path", lambda: tmp_path / "checkpoint.json")
+    (tmp_path / "checkpoint.json").write_text(
+        '{"schema_version": 1, "generated_at": 123, "sessions": '
+        '{"s1": {"fingerprint": {}, "stats": {"memory_write_events": 999}}}}'
+    )
+
+    data = plugin_api.load_checkpoint()
+    assert data["sessions"] == {}
+    assert data["schema_version"] == plugin_api._CHECKPOINT_SCHEMA_VERSION
+
+
+def test_load_checkpoint_keeps_sessions_when_schema_version_is_current(plugin_api, tmp_path, monkeypatch):
+    """Same-version caches survive load — only the analyzer-bump case wipes."""
+    monkeypatch.setattr(plugin_api, "checkpoint_path", lambda: tmp_path / "checkpoint.json")
+    current = plugin_api._CHECKPOINT_SCHEMA_VERSION
+    payload = (
+        '{"schema_version": ' + str(current) + ', "generated_at": 123, '
+        '"sessions": {"s1": {"fingerprint": {}, "stats": {"memory_write_events": 3}}}}'
+    )
+    (tmp_path / "checkpoint.json").write_text(payload)
+
+    data = plugin_api.load_checkpoint()
+    assert "s1" in data["sessions"]
+    assert data["sessions"]["s1"]["stats"]["memory_write_events"] == 3
+    assert data["schema_version"] == current
+
+
+def test_load_checkpoint_missing_version_is_treated_as_stale(plugin_api, tmp_path, monkeypatch):
+    """Pre-versioned files (which defaulted to v1) must be invalidated too."""
+    monkeypatch.setattr(plugin_api, "checkpoint_path", lambda: tmp_path / "checkpoint.json")
+    # Note: no ``schema_version`` key — older builds wrote files in this
+    # shape. ``load_checkpoint`` should default the missing field to 1
+    # and then trip the stale-cache branch.
+    (tmp_path / "checkpoint.json").write_text(
+        '{"generated_at": 123, "sessions": '
+        '{"s1": {"fingerprint": {}, "stats": {"memory_write_events": 999}}}}'
+    )
+
+    data = plugin_api.load_checkpoint()
+    assert data["sessions"] == {}
+    assert data["schema_version"] == plugin_api._CHECKPOINT_SCHEMA_VERSION
+
+


### PR DESCRIPTION
## What does this PR do?

`memory_write_events` — the metric that drives the **Memory Palace** achievement — was computed with `_count_tool(tool_sequence, "mnemosyne_remember", "memory")`. The `"memory"` needle substring-matches *every* call to the built-in `memory` tool (`add` / `replace` / **`remove`** / search / list), so the write metric had collapsed into a perfect duplicate of `memory_events` (which drives Memory Keeper). Result: Memory Palace progress was identical to Memory Keeper, and nothing the user did could move them apart.

The fix counts a memory write only when the call's parsed `arguments.action` is `add` or `replace`. `remove` is a deletion (not a write) and is excluded. `mnemosyne_remember` (write-only tool from the external Mnemosyne plugin) is still matched by name. The new `_tool_arguments_from_call()` helper handles the three on-disk shapes for OpenAI-style tool calls: pre-parsed `dict`, JSON-encoded `str`, and missing/`None`.

Two follow-up commits address Copilot's code review:

- **Defensive parsing.** `_tool_name_from_call` and `_tool_arguments_from_call` both used `call.get("function") or {}`, which only filters *falsy* values. A truthy non-dict (a bare string tool name, an int, a list from a corrupted session row) used to crash `fn.get(...)` and abort the whole scan instead of just under-counting the one bad call. Extracted into `_call_function_field` with an `isinstance(..., dict)` guard.
- **Stale checkpoint invalidation.** `scan_sessions` re-uses cached per-session stats via `session_fingerprint(meta)`, which is built only from `last_active` / `started_at` / `model` / `title` and is unaware of analyzer semantics. Without bumping the schema version, every session scanned before this fix would keep the old over-counted number indefinitely. Introduced `_CHECKPOINT_SCHEMA_VERSION = 2`; `load_checkpoint` discards the sessions map when the on-disk version is lower so the next scan re-analyzes everything exactly once.

## Related Issue

Fixes #26927

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/hermes-achievements/dashboard/plugin_api.py`
  - Add `_tool_arguments_from_call()` — parses OpenAI-style tool-call `arguments` (dict / JSON str / None) into a dict, returning `{}` on any failure.
  - Add `_call_function_field()` — guards `call["function"]` with `isinstance(..., dict)` so a corrupted (string / int / list / bool) field can no longer raise inside `fn.get(...)`. Both `_tool_arguments_from_call` and `_tool_name_from_call` use it.
  - Replace the broken `_count_tool(..., "mnemosyne_remember", "memory")` formula in `analyze_messages` with: per-tool-call inspection (`name == "memory"` + `action in {"add", "replace"}`) + `_count_tool(..., "mnemosyne_remember")` for the external plugin path.
  - Add `_CHECKPOINT_SCHEMA_VERSION = 2` and the stale-cache wipe in `load_checkpoint`; `save_checkpoint` (via `scan_sessions`) writes the current version.
- `tests/plugins/test_achievements_memory_write_events.py` — new regression suite (17 tests) covering action gating, all three argument shapes, parameterized non-dict `function` field, single-corrupt-call resilience, and checkpoint stale/current/missing-version behavior.

## How to Test

1. **Regression suite (this PR's coverage):**

   ```bash
   pytest tests/plugins/test_achievements_memory_write_events.py -q
   ```

   Expected: `17 passed`.

2. **Adjacent suite (no regression in existing Achievements tests):**

   ```bash
   pytest tests/plugins/test_achievements_memory_write_events.py tests/plugins/test_achievements_plugin.py -q
   ```

   Expected: `26 passed`.

3. **End-to-end reproduction of #26927.** With Hermes installed and at least one session that uses the built-in `memory` tool with mixed `add` / `remove` actions:

   ```bash
   # Force a clean rescan (the schema-version bump does this automatically;
   # this step just makes it explicit if you want to verify by hand).
   rm -f ~/.hermes/plugins/hermes-achievements/scan_checkpoint.json
   hermes plugin run hermes-achievements -- recompute
   ```

   Open the dashboard. Pre-fix: Memory Palace progress exactly equals Memory Keeper. Post-fix: Memory Palace ≤ Memory Keeper, and a session with only `remove` calls contributes 0 to Memory Palace while still contributing to Memory Keeper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (competing fix #26931 noted in the comments — maintainers to pick)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites locally and all pass
- [x] I've added tests for my changes (17 regression tests, including coverage for both Copilot review items)
- [x] I've tested on my platform: macOS 15 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — module-level docstrings on `_tool_arguments_from_call`, `_call_function_field`, and the `_CHECKPOINT_SCHEMA_VERSION` constant explain the *why*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure-Python stdlib JSON parsing and `pathlib`, no platform branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (analyzer-internal change, no tool-facing surface)

## Screenshots / Logs

```
$ pytest tests/plugins/test_achievements_memory_write_events.py -q
.................                                                        [100%]
17 passed in 1.35s
```

Copilot review items addressed by the two follow-up commits:

> Changing the `memory_write_events` formula does not invalidate the existing achievement checkpoint. […] sessions scanned before this fix will keep the old over-counted `memory_write_events` indefinitely until their metadata changes or users manually delete the checkpoint. Add an analyzer/schema version to the checkpoint/fingerprint or otherwise force a rescan so the bug is actually corrected for existing histories.

Resolved by commit `30873685` (`_CHECKPOINT_SCHEMA_VERSION = 2`; `load_checkpoint` drops stale `sessions` map).

> This helper is documented as returning `{}` on parse failure, but `fn` can be a non-dict truthy value and then `fn.get("arguments")` raises. […] guard `function` with an `isinstance(..., dict)` check before reading from it.

Resolved by commit `4f3741d6` (`_call_function_field` helper; both `_tool_name_from_call` and `_tool_arguments_from_call` updated; new tests cover the four non-dict shapes).
