### PR TITLE
fix(achievements): count memory writes by action not just tool name

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -287,6 +287,21 @@ def _count_tool(tool_names: List[str], *needles: str) -> int:
     return sum(1 for name in lowered if any(needle in name for needle in needles))
 
 
+def _is_memory_write_call(call: Any) -> bool:
+    """Check if a memory tool call is a write operation (add/replace action)."""
+    if not isinstance(call, dict):
+        return False
+    fn = call.get("function") or {}
+    args = fn.get("arguments") or call.get("arguments") or call.get("args") or {}
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            return False
+    action = args.get("action") if isinstance(args, dict) else None
+    return isinstance(action, str) and action in ("add", "replace")
+
+
 def model_provider(model_name: str) -> Optional[str]:
     name = (model_name or "").strip().lower()
     if not name or name == "none":
@@ -310,6 +325,7 @@ def is_local_model_name(model_name: str) -> bool:
 def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
     tool_names: Set[str] = set()
     tool_sequence: List[str] = []
+    tool_calls_list: List[Any] = []  # Track raw call objects for memory write detection
     files_touched: Set[str] = set()
     full_text_parts: List[str] = []
     error_count = 0
@@ -324,11 +340,13 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
             # Keep it for distinct-tool detection, but do not double-count it as a new call.
             if msg.get("role") != "tool":
                 tool_sequence.append(name)
+                tool_calls_list.append(None)  # No call object for tool_name entries
         for call in msg.get("tool_calls") or []:
             name = _tool_name_from_call(call)
             if name:
                 tool_names.add(name)
                 tool_sequence.append(name)
+                tool_calls_list.append(call)
         if ERROR_RE.search(text):
             error_count += 1
         blob = text
@@ -354,7 +372,14 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     skill_events = _count_tool(tool_sequence, "skill") + len(re.findall(r"\bskill", lower))
     skill_manage_events = _count_tool(tool_sequence, "skill_manage")
     memory_events = _count_tool(tool_sequence, "memory", "mnemosyne")
-    memory_write_events = _count_tool(tool_sequence, "mnemosyne_remember", "memory")
+    # Count memory write events: mnemosyne_remember always counts, memory tool only counts
+    # when the action parameter is "add" or "replace" (write operations).
+    # tool_calls_list[i] is None for tool_name-only entries, so we check both paths.
+    memory_write_events = _count_tool(tool_sequence, "mnemosyne_remember")
+    for i, name in enumerate(tool_sequence):
+        if name == "memory" and tool_calls_list[i] is not None:
+            if _is_memory_write_call(tool_calls_list[i]):
+                memory_write_events += 1
 
     return {
         "session_id": session_id,

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -377,7 +377,7 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     # tool_calls_list[i] is None for tool_name-only entries, so we check both paths.
     memory_write_events = _count_tool(tool_sequence, "mnemosyne_remember")
     for i, name in enumerate(tool_sequence):
-        if name == "memory" and tool_calls_list[i] is not None:
+        if str(name).lower() == "memory" and tool_calls_list[i] is not None:
             if _is_memory_write_call(tool_calls_list[i]):
                 memory_write_events += 1
 


### PR DESCRIPTION
The memory_write_events metric was counting every memory tool call regardless of action, making it identical to memory_events. Now it counts mnemosyne_remember calls directly, and for the generic memory tool only counts add/replace actions (actual writes), excluding list/search/remove. Fixes #26927.