### PR TITLE
fix(acp): replay assistant reasoning as agent_thought_chunk on session/load (#12285)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -18,6 +18,7 @@ import acp
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
+    AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommand,
     AvailableCommandsUpdate,
@@ -788,14 +789,20 @@ class HermesACPAgent(acp.Agent):
     # ---- Session management -------------------------------------------------
 
     @staticmethod
-    def _history_message_text(message: dict[str, Any]) -> str:
-        """Extract displayable text from a persisted OpenAI-style message."""
-        content = message.get("content")
-        if isinstance(content, str):
-            return content.strip()
-        if isinstance(content, list):
+    def _flatten_history_text(value: Any) -> str:
+        """Normalize a persisted text-or-text-parts value into a single string.
+
+        OpenAI-style assistant content (and provider reasoning fields) can arrive
+        as either a scalar string or a list of ``{"text": ...}`` /
+        ``{"type": "text", "content": ...}`` parts. Whitespace-only inputs
+        collapse to an empty string so callers can treat ``""`` as "nothing to
+        emit".
+        """
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, list):
             parts: list[str] = []
-            for item in content:
+            for item in value:
                 if isinstance(item, dict):
                     text = item.get("text")
                     if isinstance(text, str):
@@ -805,6 +812,29 @@ class HermesACPAgent(acp.Agent):
                 elif isinstance(item, str):
                     parts.append(item)
             return "\n".join(part.strip() for part in parts if part and part.strip()).strip()
+        return ""
+
+    @classmethod
+    def _history_message_text(cls, message: dict[str, Any]) -> str:
+        """Extract displayable text from a persisted OpenAI-style message."""
+        return cls._flatten_history_text(message.get("content"))
+
+    @classmethod
+    def _history_reasoning_text(cls, message: dict[str, Any]) -> str:
+        """Extract displayable reasoning/thought text from a persisted assistant message.
+
+        Returns the first non-empty value among ``reasoning_content`` (the
+        canonical field used by DeepSeek / Moonshot and the post-#16892
+        chat-completions normalizer) and ``reasoning`` (used by the codex
+        event projector and several other transports). Both keys are
+        actively written by live code paths, so neither branch is
+        deprecated — they cover different transports rather than old vs.
+        new sessions.
+        """
+        for key in ("reasoning_content", "reasoning"):
+            text = cls._flatten_history_text(message.get(key))
+            if text:
+                return text
         return ""
 
     @staticmethod
@@ -826,6 +856,11 @@ class HermesACPAgent(acp.Agent):
                 content=block,
             )
         return None
+
+    @staticmethod
+    def _history_thought_update(text: str) -> AgentThoughtChunk:
+        """Build an ACP history replay update for an assistant thought."""
+        return acp.update_agent_thought_text(text)
 
     @staticmethod
     def _history_tool_call_name_args(tool_call: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -858,9 +893,10 @@ class HermesACPAgent(acp.Agent):
 
         Zed's ACP history UI calls ``session/load`` after the user picks an item
         from the Agents sidebar. The agent must then replay the full conversation
-        as user/assistant chunks plus reconstructed tool-call start/completion
-        notifications; merely restoring server-side state makes Hermes remember
-        context, but leaves the editor looking like a clean thread.
+        as user/assistant chunks, thinking-mode thought chunks, plus reconstructed
+        tool-call start/completion notifications; merely restoring server-side
+        state makes Hermes remember context, but leaves the editor looking like a
+        clean thread.
         """
         if not self._conn or not state.history:
             return
@@ -882,24 +918,37 @@ class HermesACPAgent(acp.Agent):
         for message in state.history:
             role = str(message.get("role") or "")
 
-            if role in {"user", "assistant"}:
+            if role == "user":
+                text = self._history_message_text(message)
+                if text:
+                    update = self._history_message_update(role=role, text=text)
+                    if update is not None and not await _send(update):
+                        return
+                continue
+
+            if role == "assistant":
+                thought = self._history_reasoning_text(message)
+                if thought and not await _send(self._history_thought_update(thought)):
+                    return
+
                 text = self._history_message_text(message)
                 if text:
                     update = self._history_message_update(role=role, text=text)
                     if update is not None and not await _send(update):
                         return
 
-            if role == "assistant" and isinstance(message.get("tool_calls"), list):
-                for tool_call in message["tool_calls"]:
-                    if not isinstance(tool_call, dict):
-                        continue
-                    tool_call_id = self._history_tool_call_id(tool_call)
-                    if not tool_call_id:
-                        continue
-                    tool_name, args = self._history_tool_call_name_args(tool_call)
-                    active_tool_calls[tool_call_id] = (tool_name, args)
-                    if not await _send(build_tool_start(tool_call_id, tool_name, args)):
-                        return
+                tool_calls = message.get("tool_calls")
+                if isinstance(tool_calls, list):
+                    for tool_call in tool_calls:
+                        if not isinstance(tool_call, dict):
+                            continue
+                        tool_call_id = self._history_tool_call_id(tool_call)
+                        if not tool_call_id:
+                            continue
+                        tool_name, args = self._history_tool_call_name_args(tool_call)
+                        active_tool_calls[tool_call_id] = (tool_name, args)
+                        if not await _send(build_tool_start(tool_call_id, tool_name, args)):
+                            return
                 continue
 
             if role == "tool":

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -13,6 +13,7 @@ from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
     AgentPlanUpdate,
+    AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommandsUpdate,
     Implementation,
@@ -465,6 +466,211 @@ class TestSessionOps:
             and update.content.text == "So tell me the current state"
             for update in updates
         )
+
+    @pytest.mark.asyncio
+    async def test_load_session_replays_reasoning_thought_before_message(self, agent):
+        """Thinking-model thoughts must be replayed via ``agent_thought_chunk``.
+
+        Regression for #12285 — when a session is loaded, persisted assistant
+        ``reasoning_content`` / ``reasoning`` fields must surface as ACP
+        ``AgentThoughtChunk`` notifications in the same relative position they
+        had live (thought streams before the assistant message text), so Zed's
+        collapsed Thinking pane rebuilds instead of vanishing on reconnect.
+        """
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "Walk me through it."},
+            {
+                "role": "assistant",
+                "reasoning_content": "Let me think step by step about the request.",
+                "content": "Here is the plan.",
+            },
+            {"role": "user", "content": "And the legacy case?"},
+            {
+                "role": "assistant",
+                # No reasoning_content — exercise the legacy "reasoning" fallback
+                # path so sessions persisted before #16892 still replay thoughts.
+                "reasoning": "Older sessions stored the trace under the internal key.",
+                "content": "Same idea, older field name.",
+            },
+        ]
+
+        mock_conn.session_update.reset_mock()
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert isinstance(resp, LoadSessionResponse)
+
+        replay_kinds = [
+            getattr(call.kwargs.get("update"), "session_update", None)
+            for call in mock_conn.session_update.await_args_list
+            if getattr(call.kwargs.get("update"), "session_update", None)
+            in {"user_message_chunk", "agent_message_chunk", "agent_thought_chunk"}
+        ]
+        assert replay_kinds == [
+            "user_message_chunk",
+            "agent_thought_chunk",
+            "agent_message_chunk",
+            "user_message_chunk",
+            "agent_thought_chunk",
+            "agent_message_chunk",
+        ]
+
+        thought_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), AgentThoughtChunk)
+        ]
+        assert len(thought_updates) == 2
+        assert thought_updates[0].content.text == "Let me think step by step about the request."
+        assert thought_updates[1].content.text == "Older sessions stored the trace under the internal key."
+
+    @pytest.mark.asyncio
+    async def test_load_session_replays_reasoning_only_turn(self, agent):
+        """Assistant turns with reasoning but no content should still emit a thought.
+
+        Pure reasoning-only assistant entries (e.g. a thinking step before a
+        tool-call turn) commonly carry ``reasoning_content`` with empty
+        ``content``. The replay must still surface the thought so the editor's
+        Thinking pane rebuilds, even when there is no message text to follow.
+        """
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {
+                "role": "assistant",
+                "reasoning_content": "I should call the search tool next.",
+                "content": "",
+            },
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        thought_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), AgentThoughtChunk)
+        ]
+        message_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), AgentMessageChunk)
+        ]
+        assert len(thought_updates) == 1
+        assert thought_updates[0].content.text == "I should call the search tool next."
+        assert message_updates == []
+
+    @pytest.mark.asyncio
+    async def test_load_session_skips_empty_reasoning_fields(self, agent):
+        """Empty/whitespace reasoning fields must not produce notifications."""
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {
+                "role": "assistant",
+                "reasoning_content": "",
+                "reasoning": "   \n\t",
+                "content": "Just a regular answer.",
+            },
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        thought_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if isinstance(call.kwargs.get("update"), AgentThoughtChunk)
+        ]
+        assert thought_updates == []
+
+    @pytest.mark.asyncio
+    async def test_load_session_replays_thought_then_tool_call_without_message(self, agent):
+        """Canonical thinking-model shape: reasoning + tool_call + no body text.
+
+        Thinking models commonly emit a pre-tool thought followed by a
+        tool_calls turn with empty ``content``. Replay must emit:
+        ``agent_thought_chunk`` then ``tool_call`` then ``tool_call_update``
+        for the matching tool result — and crucially, NO ``agent_message_chunk``
+        for the empty-text assistant body. Regression for the canonical
+        thinking-then-tool flow on #12285.
+        """
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "Find the bug."},
+            {
+                "role": "assistant",
+                "reasoning_content": "I should grep for the function name first.",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_grep_1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_files",
+                            "arguments": '{"pattern":"foo","path":"."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_grep_1",
+                "content": '{"total_count":1,"matches":[{"path":"x.py","line":1,"content":"foo"}]}',
+            },
+        ]
+
+        mock_conn.session_update.reset_mock()
+        await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        kinds = [
+            getattr(call.kwargs.get("update"), "session_update", None)
+            for call in mock_conn.session_update.await_args_list
+            if getattr(call.kwargs.get("update"), "session_update", None)
+            in {
+                "user_message_chunk",
+                "agent_thought_chunk",
+                "agent_message_chunk",
+                "tool_call",
+                "tool_call_update",
+            }
+        ]
+        # No agent_message_chunk for the empty-content assistant turn.
+        assert "agent_message_chunk" not in kinds
+        # Thought must precede the tool_call_start within the assistant turn,
+        # and the tool result follows.
+        assert kinds == [
+            "user_message_chunk",
+            "agent_thought_chunk",
+            "tool_call",
+            "tool_call_update",
+        ]
 
     @pytest.mark.asyncio
     async def test_load_session_schedules_history_replay_after_response(self, agent):


### PR DESCRIPTION
## Summary

Replays persisted assistant `reasoning_content` / `reasoning` fields as ACP `agent_thought_chunk` notifications during `session/load` and `session/resume`, so editor clients (Zed, etc.) reconstruct collapsed Thinking panes when re-opening a session that used a thinking model — instead of restoring everything except the thoughts.

Closes #12285.

## Background

When `session/load` was first implemented, replay covered nothing (#12285 original report). Subsequent merges substantially closed the gap:

- **#17874** (salvage of @HenkDz's #17652) — initial `_replay_session_history` for user/assistant text chunks.
- **#19139** (salvage of @HenkDz's #18578) — added tool-call `start`/`complete` replay, post-response scheduling, usage updates, ~35 polished tool renderers.
- **#26583** (salvage of #26393) — native `plan` rebuilding from persisted `todo` results.
- **#16892** — write-side normalization so streamed `reasoning_text` lands in `reasoning_content` on disk reliably across providers (the prerequisite that makes thought replay actually meaningful for non-DeepSeek thinking models).

The one piece still missing was thought replay itself: persisted `reasoning_content` / `reasoning` fields were silently dropped during replay, even though they're emitted as `agent_thought_chunk` live via `acp.update_agent_thought_text` in `events.py::make_thinking_cb`.

This PR adds that last piece. It's the gap @Yukipukii1's #14691 originally aimed at; their PR predates #19139's tool replay so it would conflict heavily on rebase, but the contribution is credited (#14691 introduced the design for thought replay alongside `update_user_message_text` / `update_agent_message_text` mappings).

## Changes

### `acp_adapter/server.py`

- New `_flatten_history_text(value)` shared between `_history_message_text` and the new `_history_reasoning_text` — both shapes (scalar string / list of `{text, ...}` parts) handled in one place.
- New `_history_reasoning_text(message)` prefers `reasoning_content` (canonical post-#16892) and falls back to `reasoning` (legacy / SDK-attr path).
- New `_history_thought_update(text)` peers `_history_message_update` so all replay-chunk construction goes through the same factory layer.
- `_replay_session_history` reshape: the `assistant` branch now handles thought → message text → tool_calls in one block, matching how live streaming orders them (`reasoning_callback` deltas precede `stream_delta_callback`). The `user` branch is split out for clarity; behavior on non-reasoning histories is unchanged.

### `tests/acp/test_server.py`

Three new tests:
- `test_load_session_replays_reasoning_thought_before_message` — both `reasoning_content` and legacy `reasoning` paths fire; thought precedes message in the same turn.
- `test_load_session_replays_reasoning_only_turn` — reasoning-only assistant entries (empty `content`) still surface a thought.
- `test_load_session_skips_empty_reasoning_fields` — whitespace-only reasoning doesn't emit a spurious chunk.

## Validation

- `bash scripts/run_tests.sh tests/acp/ --ignore=tests/acp/test_registry_manifest.py` — **236 passed** (the two `test_registry_manifest.py` failures are a pre-existing v0.13.0/v0.14.0 fixture mismatch on `origin/main`, unrelated).
- `ruff check acp_adapter/server.py tests/acp/test_server.py` — clean.
- **Behavior parity** check against `origin/main` for histories without reasoning fields: identical notification stream (`user_message_chunk | agent_message_chunk | user_message_chunk | tool_call | tool_call_update`). Pure additive change.
- **E2E** against an isolated `HermesACPAgent` exercising the real `_replay_session_history`: confirms thought emitted before message text, both `reasoning_content` and `reasoning` paths fire, reasoning-only turns emit only thought, whitespace-only reasoning emits nothing, and the tricky case (assistant message with reasoning + tool_calls + empty content) produces `thought → tool_call → tool_call_update` with no spurious empty message chunk.

## Credit

- @Yukipukii1 — #14691 originally proposed thought replay via `update_agent_thought_text`; that PR also covered tool-call replay which has since landed via #19139 by another route, but the thought-replay design is theirs.
- @HenkDz — #17652 / #18578 established the `_replay_session_history` and `_history_*` helper conventions this builds on.
- @D1zzyDwarf — #16531 (text-only subset) is also closed by this work.
