### PR TITLE
feat(slack): render markdown tables as column-padded monospace blocks (#26947)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -98,6 +98,203 @@ def check_slack_requirements() -> bool:
     return ensure_and_bind("platform.slack", _import, globals(), prompt=False)
 
 
+# --- Markdown table detection / rendering -------------------------------
+#
+# Slack's mrkdwn does not render GitHub-flavored markdown tables — the
+# pipe characters survive as literal text and the columns smear into
+# unreadable lines.  Block Kit has no public ``table`` block either, so
+# the practical fix (used by every other agent that handles this) is to
+# convert detected tables into a monospace-aligned preformatted block
+# (triple-backticks).  Slack renders that as a code block where columns
+# line up, which is the closest thing to a "real table" available on
+# the platform today.  See #26947.
+
+# Header / body row: at least one ``|`` separator after optional leading
+# whitespace, content on the line.  We deliberately accept lines that
+# don't START with ``|`` (some authors omit the leading pipe) but the
+# separator row check below is strict enough to reject false positives.
+_MD_TABLE_ROW_RE = re.compile(r"^\s*\|?.*\|.*\|?\s*$")
+
+# Separator row: every cell is either ``---``, ``:---``, ``---:``, or
+# ``:---:`` (alignment hints), with at least three dashes, optional
+# surrounding whitespace, and at least one ``|`` separator.  This is
+# what disambiguates a table from arbitrary text that happens to
+# contain pipes (e.g. a logical-OR snippet).
+_MD_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$"
+)
+
+
+def _split_md_table_row(line: str) -> list:
+    """Split a markdown table row into trimmed cell strings.
+
+    Handles both leading-pipe (``| a | b |``) and headerless (``a | b``)
+    forms.  Backslash-escaped pipes (``\\|``) are preserved as literal
+    pipes inside the cell.
+    """
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    # Split on ``|`` but keep escaped ``\|`` intact.
+    parts = re.split(r"(?<!\\)\|", stripped)
+    return [p.replace("\\|", "|").strip() for p in parts]
+
+
+def _parse_md_alignments(separator_cells: list) -> list:
+    """Map separator cells (``:---``, ``---:``, ``:---:``, ``---``) to
+    ``"left"``, ``"right"``, ``"center"``, or ``"left"`` (default)."""
+    alignments = []
+    for cell in separator_cells:
+        c = cell.strip()
+        has_left = c.startswith(":")
+        has_right = c.endswith(":")
+        if has_left and has_right:
+            alignments.append("center")
+        elif has_right:
+            alignments.append("right")
+        else:
+            alignments.append("left")
+    return alignments
+
+
+def _pad_cell(text: str, width: int, alignment: str) -> str:
+    if alignment == "right":
+        return text.rjust(width)
+    if alignment == "center":
+        return text.center(width)
+    return text.ljust(width)
+
+
+def _render_md_table_as_monospace(header: list, body_rows: list,
+                                  alignments: list) -> str:
+    """Format a parsed table as a column-padded monospace block.
+
+    Returns a string wrapped in triple backticks so Slack renders it
+    as preformatted text.  No language tag is emitted: a language hint
+    would survive the round-trip and confuse syntax-highlighting code.
+    """
+    # Equalise column count across all rows (pad short rows with "").
+    col_count = max(
+        [len(header)] + [len(r) for r in body_rows] + [len(alignments)]
+    )
+    header = header + [""] * (col_count - len(header))
+    alignments = alignments + ["left"] * (col_count - len(alignments))
+    padded_body = [r + [""] * (col_count - len(r)) for r in body_rows]
+
+    # Column widths use visual width of each cell.  We don't compute
+    # East-Asian wide-char width — Slack renders the monospace block in
+    # a fixed-width font where each character still occupies one cell,
+    # so ``len`` is the right metric.
+    widths = [
+        max(len(header[i]), *(len(r[i]) for r in padded_body))
+        if padded_body
+        else len(header[i])
+        for i in range(col_count)
+    ]
+
+    def _fmt_row(cells: list) -> str:
+        return "| " + " | ".join(
+            _pad_cell(cells[i], widths[i], alignments[i])
+            for i in range(col_count)
+        ) + " |"
+
+    separator = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
+
+    lines = [_fmt_row(header), separator]
+    lines.extend(_fmt_row(r) for r in padded_body)
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def _convert_markdown_tables_to_monospace(text: str) -> str:
+    """Replace GFM markdown tables in ``text`` with monospace code blocks.
+
+    A "table" is a header row, followed by a separator row of dashes
+    (with optional alignment colons), followed by zero or more body
+    rows.  Anything that doesn't satisfy the separator-row regex is
+    left untouched, so prose containing literal pipes is preserved.
+
+    Tables that fall inside a fenced code block ought to remain as
+    literal markdown — we don't want to "fix" a code sample showing
+    a markdown table.  ``format_message`` calls this helper BEFORE its
+    own code-block protection pass, so we handle the fenced-region
+    exclusion ourselves here.
+    """
+    if not text or "|" not in text:
+        return text
+
+    # Mask fenced code regions so we don't reformat tables inside them.
+    fenced_spans: list = []
+
+    def _mask_fence(m):
+        fenced_spans.append(m.group(0))
+        return f"\x00MDFENCE{len(fenced_spans) - 1}\x00"
+
+    masked = re.sub(
+        r"```(?:[^\n]*\n)?[\s\S]*?```", _mask_fence, text,
+    )
+
+    lines = masked.split("\n")
+    out: list = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # A table needs at least header + separator on the next line.
+        if (
+            i + 1 < len(lines)
+            and _MD_TABLE_ROW_RE.match(line)
+            and "|" in line
+            and _MD_TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            header_cells = _split_md_table_row(line)
+            alignments = _parse_md_alignments(
+                _split_md_table_row(lines[i + 1])
+            )
+            body: list = []
+            j = i + 2
+            while (
+                j < len(lines)
+                and _MD_TABLE_ROW_RE.match(lines[j])
+                and "|" in lines[j]
+                and lines[j].strip()
+            ):
+                body.append(_split_md_table_row(lines[j]))
+                j += 1
+            # Require at least 2 columns — a single-column "table" is
+            # almost certainly a false positive (a bulleted list of
+            # piped items, log lines, etc.).
+            if len(header_cells) >= 2:
+                out.append(
+                    _render_md_table_as_monospace(header_cells, body, alignments)
+                )
+                i = j
+                continue
+        out.append(line)
+        i += 1
+
+    rebuilt = "\n".join(out)
+
+    # Restore the fenced regions we masked above.
+    def _unmask(m):
+        idx = int(m.group(1))
+        return fenced_spans[idx] if 0 <= idx < len(fenced_spans) else m.group(0)
+
+    return re.sub(r"\x00MDFENCE(\d+)\x00", _unmask, rebuilt)
+
+
+def _markdown_tables_enabled() -> bool:
+    """Whether to auto-convert markdown tables to monospace blocks.
+
+    Defaults to ``True``.  Operators who already post-process their
+    agent output for Slack can opt out via
+    ``SLACK_RENDER_MARKDOWN_TABLES=false`` without redeploying code.
+    """
+    return os.getenv("SLACK_RENDER_MARKDOWN_TABLES", "true").lower() not in {
+        "false", "0", "no", "off",
+    }
+
+
 def _extract_text_from_slack_blocks(blocks: list) -> str:
     """Extract readable text from Slack Block Kit blocks, including quoted/forwarded content.
 
@@ -1195,6 +1392,15 @@ class SlackAdapter(BasePlatformAdapter):
             return key
 
         text = content
+
+        # 0) Convert GFM markdown tables into monospace code blocks.
+        #    Slack's mrkdwn has no native table rendering and the public
+        #    Block Kit API has no ``table`` block, so the universally-
+        #    compatible fix is a column-padded triple-backtick block.
+        #    We do this BEFORE step 1 so the generated code fences are
+        #    then protected like any other fenced block.  See #26947.
+        if _markdown_tables_enabled():
+            text = _convert_markdown_tables_to_monospace(text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         text = re.sub(

--- a/tests/gateway/test_slack_markdown_tables.py
+++ b/tests/gateway/test_slack_markdown_tables.py
@@ -1,0 +1,309 @@
+"""Regression coverage for Slack markdown-table rendering (issue #26947).
+
+Slack's mrkdwn does not natively render GitHub-flavored markdown
+tables — pipe characters survive as literal text and the columns
+smear together.  Block Kit has no public ``table`` block either, so
+the practical fix (used by every other agent that handles this) is
+to detect tables and convert them into a column-padded monospace
+code block before the message reaches ``chat.postMessage``.
+
+These tests pin both the converter helper and its integration into
+``format_message`` so neither half can silently regress.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from gateway.platforms.base import PlatformConfig
+from gateway.platforms.slack import (
+    SlackAdapter,
+    _convert_markdown_tables_to_monospace as convert,
+)
+
+
+@pytest.fixture()
+def adapter():
+    a = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Converter: basic shapes
+# ---------------------------------------------------------------------------
+
+
+def test_basic_table_is_wrapped_in_triple_backticks():
+    """The minimal repro from #26947 must render as a monospace block."""
+    md = (
+        "| Header 1 | Header 2 |\n"
+        "| -------- | -------- |\n"
+        "| Cell 1   | Cell 2   |\n"
+        "| Cell 3   | Cell 4   |"
+    )
+    out = convert(md)
+    assert out.startswith("```\n"), (
+        "Tables must be wrapped in a fence so Slack renders them as "
+        "preformatted monospace text."
+    )
+    assert out.endswith("\n```")
+    # Header row preserved.
+    assert "| Header 1 | Header 2 |" in out
+    # Separator row regenerated with dashes matching column width.
+    assert "|----------|----------|" in out
+    # Body rows preserved.
+    assert "| Cell 1   | Cell 2   |" in out
+    assert "| Cell 3   | Cell 4   |" in out
+
+
+def test_columns_are_padded_to_widest_cell():
+    """The whole point — columns must line up in fixed-width font."""
+    md = (
+        "| a | bbb |\n"
+        "|---|-----|\n"
+        "| longer cell | x |"
+    )
+    out = convert(md)
+    # Header cells get padded to widest cell width.
+    assert "| a           | bbb |" in out
+    assert "| longer cell | x   |" in out
+
+
+def test_alignment_hints_are_honoured():
+    """``:---:`` → centered, ``---:`` → right-aligned."""
+    md = (
+        "| L | C | R |\n"
+        "|:---|:---:|---:|\n"
+        "| 1 | 2 | 3 |\n"
+        "| longer | x | yz |"
+    )
+    out = convert(md)
+    # Right column ``R``: ``3`` and ``yz`` should be right-padded.
+    assert "|  3 |" in out
+    assert "| yz |" in out
+    # Center column ``C``: single-char cells stay roughly centered.
+    # ``len("C") == 1``, max width == 1, so centering is a no-op here —
+    # widen the column to make the assertion meaningful.
+    md2 = (
+        "| L | Center | R |\n"
+        "|:---|:---:|---:|\n"
+        "| 1 | 2 | 3 |"
+    )
+    out2 = convert(md2)
+    # Centered ``2`` in a 6-wide column must have whitespace on both sides.
+    assert "|   2    |" in out2 or "|  2     |" in out2
+
+
+def test_headerless_form_with_no_leading_pipe_is_supported():
+    """Some authors omit the leading ``|`` — still a valid GFM table."""
+    md = (
+        "a | b\n"
+        "---|---\n"
+        "1 | 2"
+    )
+    out = convert(md)
+    assert out.startswith("```\n")
+    assert "| a | b |" in out
+    assert "| 1 | 2 |" in out
+
+
+def test_escaped_pipe_inside_cell_is_preserved():
+    """``\\|`` inside a cell must survive as a literal pipe."""
+    md = "| a | b |\n|---|---|\n| x \\| y | z |"
+    out = convert(md)
+    assert "x | y" in out
+
+
+def test_ragged_rows_get_padded_to_column_count():
+    """A row with fewer cells than the header must not corrupt alignment."""
+    md = (
+        "| a | b | c |\n"
+        "|---|---|---|\n"
+        "| 1 | 2 |\n"        # short row
+        "| x | y | z |"
+    )
+    out = convert(md)
+    # Short row got a synthetic empty third cell.
+    assert "| 1 | 2 |   |" in out
+    assert "| x | y | z |" in out
+
+
+def test_empty_body_table_still_renders():
+    """Header + separator with no rows is still a valid (if useless) table."""
+    md = "| a | b |\n|---|---|"
+    out = convert(md)
+    assert out.startswith("```\n")
+    assert "| a | b |" in out
+    assert "|---|---|" in out
+
+
+# ---------------------------------------------------------------------------
+# Converter: rejection of non-table input
+# ---------------------------------------------------------------------------
+
+
+def test_prose_with_pipes_is_left_alone():
+    """We must NOT convert arbitrary prose just because it has pipes."""
+    text = "Use `foo | bar` to chain commands; bash uses | as a pipe."
+    assert convert(text) == text
+
+
+def test_single_column_pseudo_table_is_rejected():
+    """One-column ``tables`` are almost always false positives
+    (bulleted lists, log lines etc.).  Leave them alone."""
+    text = "| only |\n|---|\n| one |"
+    assert convert(text) == text
+
+
+def test_text_without_any_pipe_short_circuits():
+    """Performance / correctness: no pipes → no work."""
+    text = "Hello world\nNo tables here.\nJust prose."
+    assert convert(text) == text
+
+
+def test_empty_and_none_inputs_pass_through():
+    assert convert("") == ""
+    assert convert(None) is None
+
+
+def test_table_inside_fenced_code_block_is_left_alone():
+    """If the user is *showing* a markdown table inside a code sample,
+    we must not reformat it — that would corrupt their example."""
+    text = (
+        "Here's a markdown table:\n"
+        "```\n"
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "```\n"
+        "End."
+    )
+    out = convert(text)
+    # The whole fenced region must come back byte-identical.
+    assert "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```" in out
+
+
+def test_separator_row_must_be_proper_dashes():
+    """A line of ``|`` separators alone is not a separator row.
+    Without a valid separator, we have no table."""
+    text = "| a | b |\n| c | d |\n| 1 | 2 |"
+    assert convert(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Converter: surrounding context
+# ---------------------------------------------------------------------------
+
+
+def test_table_is_converted_in_place_inside_a_larger_message():
+    md = (
+        "Status update:\n"
+        "\n"
+        "| service | state |\n"
+        "|---------|-------|\n"
+        "| api     | up    |\n"
+        "\n"
+        "See dashboard for details."
+    )
+    out = convert(md)
+    assert out.startswith("Status update:")
+    assert out.endswith("See dashboard for details.")
+    assert "```\n| service | state |" in out
+
+
+def test_two_consecutive_tables_are_each_converted():
+    md = (
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "\n"
+        "| c | d |\n"
+        "|---|---|\n"
+        "| 3 | 4 |"
+    )
+    out = convert(md)
+    # Two distinct fenced blocks, one per table.
+    assert out.count("```") == 4
+
+
+# ---------------------------------------------------------------------------
+# Integration: format_message + send pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_format_message_renders_tables_as_monospace(adapter):
+    """``format_message`` must invoke the converter and leave the
+    generated code fence un-mangled by later mrkdwn passes."""
+    md = (
+        "**Status**\n"
+        "\n"
+        "| Service | State |\n"
+        "|---------|-------|\n"
+        "| api     | **up** |\n"
+    )
+    out = adapter.format_message(md)
+    # Surrounding bold still converted to mrkdwn bold.
+    assert out.startswith("*Status*")
+    # Table fenced; ``**up**`` inside the cell stays literal because
+    # the code fence protects it from the bold-conversion pass.
+    assert "```\n| Service | State  |" in out
+    assert "| api     | **up** |" in out
+
+
+def test_format_message_preserves_existing_code_block_with_table_inside(adapter):
+    """A pre-existing code block must not be touched.  This is the
+    critical contract — users who paste markdown tutorials must see
+    their code samples come through verbatim."""
+    md = (
+        "Example:\n"
+        "```\n"
+        "| h1 | h2 |\n"
+        "|----|----|\n"
+        "| a  | b  |\n"
+        "```\n"
+    )
+    out = adapter.format_message(md)
+    assert "```\n| h1 | h2 |\n|----|----|\n| a  | b  |\n```" in out
+
+
+def test_format_message_no_table_no_change(adapter):
+    """Non-table content must be byte-identical to the pre-fix path —
+    no perf regression, no whitespace drift."""
+    md = "**hello** _world_"
+    assert adapter.format_message(md) == "*hello* _world_"
+
+
+# ---------------------------------------------------------------------------
+# Off-switch: SLACK_RENDER_MARKDOWN_TABLES=false
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE", "Off"])
+def test_off_switch_disables_table_rendering(monkeypatch, adapter, value):
+    monkeypatch.setenv("SLACK_RENDER_MARKDOWN_TABLES", value)
+    md = "| a | b |\n|---|---|\n| 1 | 2 |"
+    out = adapter.format_message(md)
+    # No code fence emitted — original pipes survive (mangled but
+    # un-mangled by us, exactly the pre-fix behavior the operator
+    # explicitly opted into).
+    assert "```" not in out
+    assert "| a | b |" in out
+
+
+def test_off_switch_default_is_on(monkeypatch, adapter):
+    """Empty / unset env defaults to ON — most users want tables fixed."""
+    monkeypatch.delenv("SLACK_RENDER_MARKDOWN_TABLES", raising=False)
+    md = "| a | b |\n|---|---|\n| 1 | 2 |"
+    out = adapter.format_message(md)
+    assert "```" in out
+
+
+def test_off_switch_garbage_value_falls_back_to_on(monkeypatch, adapter):
+    """A typo'd value (``yes``, ``true``, ``maybe``) must not silently
+    disable the feature."""
+    monkeypatch.setenv("SLACK_RENDER_MARKDOWN_TABLES", "maybe")
+    md = "| a | b |\n|---|---|\n| 1 | 2 |"
+    out = adapter.format_message(md)
+    assert "```" in out

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -271,6 +271,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |
+| `SLACK_RENDER_MARKDOWN_TABLES` | Convert GFM markdown tables in outbound messages into column-padded monospace code blocks so Slack renders them as aligned tables instead of leaving raw pipes as text (default: `true`). Set to `false` / `0` / `no` / `off` to send tables unmodified. |
 | `GOOGLE_CHAT_PROJECT_ID` | GCP project hosting the Pub/Sub topic (falls back to `GOOGLE_CLOUD_PROJECT`) |
 | `GOOGLE_CHAT_SUBSCRIPTION_NAME` | Full Pub/Sub subscription path, `projects/{proj}/subscriptions/{sub}` (legacy alias: `GOOGLE_CHAT_SUBSCRIPTION`) |
 | `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` | Path to Service Account JSON, or the JSON inline (falls back to `GOOGLE_APPLICATION_CREDENTIALS`) |


### PR DESCRIPTION
## What does this PR do?

Teaches the Slack adapter to render markdown tables as actual aligned tables instead of leaving raw pipe characters as plain text.

Issue [#26947](https://github.com/NousResearch/hermes-agent/issues/26947) reported that when Hermes sends a markdown table to Slack (e.g. ``| col1 | col2 |``), the pipes and dashed separator survive as literal characters and the columns smear together. The root cause is that:

1. Slack's ``mrkdwn`` has no native renderer for GitHub-flavored markdown tables.
2. Slack's public Block Kit API has **no ``table`` block** either (the issue's "Block Kit table" is a misnomer — even Slack's own docs only suggest preformatted text as the workaround).

The universally-compatible fix used by every other agent that handles this is to detect markdown tables on the way out and convert them to a column-padded triple-backtick block. Triple-backtick text is rendered as fixed-width preformatted code by Slack, so the columns line up the way the user intended.

This PR implements that, inline in ``format_message``:

```
| Header 1 | Header 2 |        ```
| -------- | -------- |        | Header 1 | Header 2 |
| Cell 1   | Cell 2   |   →    |----------|----------|
| Cell 3   | Cell 4   |        | Cell 1   | Cell 2   |
                              | Cell 3   | Cell 4   |
                              ```
```

The conversion runs as ``step 0`` of ``format_message`` — **before** the existing fenced-code-block protection pass — so the generated code fence is then treated like any other code block and survives later mrkdwn rewrites (bold, italics, link conversion, header conversion, etc.) intact.

## Related Issue

Closes #26947

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``gateway/platforms/slack.py`` — add module-level ``_convert_markdown_tables_to_monospace`` (plus helpers ``_split_md_table_row``, ``_parse_md_alignments``, ``_pad_cell``, ``_render_md_table_as_monospace``) and an env-driven toggle ``_markdown_tables_enabled``. Wire the converter into ``format_message`` as step 0 so the generated code fences are then protected by the existing fenced-block placeholder pass. No existing send path is touched; tables that don't match the strict separator-row regex are passed through byte-identical.
- ``tests/gateway/test_slack_markdown_tables.py`` — **26 new regression tests** covering basic shape, column padding, alignment hints (``:---:`` / ``---:``), headerless/no-leading-pipe form, escaped pipes, ragged rows, empty-body tables, prose with pipes, single-column rejection, no-pipe short-circuit, empty/``None`` inputs, fenced-block exclusion (we never reformat a user's code sample), pipe rows without a valid separator, two consecutive tables, in-place conversion inside a larger message, integration with the rest of ``format_message`` (bold/italics outside the table still convert, fence inside the table protects literals), no-table content byte-identity, and the off-switch (case-insensitive ``false`` / ``0`` / ``no`` / ``off``; default / empty / garbage value → on).
- ``website/docs/reference/environment-variables.md`` — document ``SLACK_RENDER_MARKDOWN_TABLES`` alongside the other Slack toggles.

## Detection rules (deliberately strict)

To avoid false positives on prose that happens to contain pipes:

* A "table" needs at least two rows.
* The second row must be a separator row of dashes (with optional ``:`` alignment markers) and ``>=3`` dashes per cell.
* The header must have ``>=2`` columns (single-column "tables" are almost always bulleted lists with piped items, not real tables).
* Tables inside an existing fenced code block are left byte-identical — we never reformat a user's code sample.

Alignment hints (``:---``, ``---:``, ``:---:``) are honoured by left-/right-/center-padding the generated cells. Ragged rows are padded to the column count. Backslash-escaped pipes inside cells survive as literal pipes.

## Opt-out

Operators who already post-process agent output for Slack can disable the feature with ``SLACK_RENDER_MARKDOWN_TABLES=false`` (also accepts ``0`` / ``no`` / ``off``, case-insensitive). Default is on — most users want their tables to actually render.

## How to Test

```bash
# 1. New regression suite passes
python -m pytest tests/gateway/test_slack_markdown_tables.py -q
# expected: 26 passed

# 2. Existing Slack tests still pass (no regression)
python -m pytest tests/gateway/test_slack.py -q
# expected: 186 passed

# 3. Manual smoke — eyeball the before/after for the issue's repro
python - <<'PY'
from gateway.platforms.slack import SlackAdapter
from gateway.platforms.base import PlatformConfig
a = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
md = (
    "**Status**\n\n"
    "| Service | State | Notes |\n"
    "|---------|-------|-------|\n"
    "| api     | up    | stable |\n"
    "| db      | down  | restart needed |\n"
)
print(a.format_message(md))
PY
```

Expected output of step 3:

````
*Status*

```
| Service | State | Notes          |
|---------|-------|----------------|
| api     | up    | stable         |
| db      | down  | restart needed |
```
````

Posted into Slack with ``mrkdwn=True`` (the existing send path), the bold heading renders as bold and the code block renders as an aligned monospace table — exactly the "real Slack table" the issue asked for.