### PR TITLE
fix(image-gen): pre-cache provider URLs to image_cache before delivery (#26942)

### DIFF
--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -110,9 +110,10 @@ _PNG_1x1 = (
 
 
 class _FakeHTTPResponse:
-    def __init__(self, content: bytes, status: int = 200):
+    def __init__(self, content: bytes, status: int = 200, headers: dict | None = None):
         self.content = content
         self.status_code = status
+        self.headers = headers or {}
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -136,6 +137,27 @@ class _FakeHTTPClient:
     def get(self, url, headers=None):
         self._calls.append(url)
         return self._response
+
+
+class _SequenceHTTPClient:
+    """httpx.Client stand-in that returns successive responses for each
+    .get() call — used to simulate a redirect chain."""
+
+    def __init__(self, responses: list, calls: list):
+        self._responses = list(responses)
+        self._calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get(self, url, headers=None):
+        self._calls.append(url)
+        if not self._responses:
+            raise AssertionError(f"Unexpected extra GET to {url}")
+        return self._responses.pop(0)
 
 
 class TestImageGenerateEphemeralUrlCache:
@@ -350,3 +372,161 @@ class TestImageGenerateEphemeralUrlCache:
         assert calls == [url]
         assert result["image"] == url
         assert "media_tag" not in result
+
+    def test_handle_uses_content_type_when_url_lacks_extension(
+        self, monkeypatch, tmp_path
+    ):
+        """Provider URLs that omit a file extension or carry query-string
+        parameters (e.g. ``https://example.com/image?id=123``) must rely
+        on the HTTP Content-Type header to pick a correct extension —
+        defaulting to .jpg unconditionally would mislabel PNG/WebP
+        bytes."""
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        extensionless_url = "https://example.com/image?id=deadbeef"
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": extensionless_url,
+                "provider": "xai",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+        calls: list = []
+        response = _FakeHTTPResponse(_PNG_1x1, headers={"content-type": "image/png"})
+        monkeypatch.setattr(
+            httpx, "Client",
+            lambda *a, **kw: _FakeHTTPClient(response, calls),
+        )
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        assert calls == [extensionless_url]
+        assert result["success"] is True
+        # Content-Type sniff turns PNG bytes into .png even with no URL
+        # suffix; without this, cache_image_from_bytes would store as .jpg.
+        assert result["image"].endswith(".png"), result["image"]
+        assert result["media_tag"] == f"MEDIA:{result['image']}"
+        assert result["source_url"] == extensionless_url
+
+    def test_handle_rejects_redirect_to_ssrf_unsafe_target(
+        self, monkeypatch, tmp_path
+    ):
+        """A provider URL that 30x-redirects to a private/internal IP
+        must NOT be followed — ``is_safe_url`` runs on every hop, not
+        just the original URL, so the cached-image fetch can't be tricked
+        into fetching 127.0.0.1 or RFC1918 space behind a public
+        redirect. On rejection the original URL is preserved so the
+        adapter's legacy delivery chain still runs."""
+        from tools import image_generation_tool
+        from tools import url_safety
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        public_url = "https://imgen.x.ai/xai-tmp-imgen-redirect.jpeg"
+        unsafe_target = "http://127.0.0.1:8080/internal-image"
+
+        # Deterministic: the provider URL is safe, the redirect target is
+        # not. Avoids real DNS lookups in CI.
+        monkeypatch.setattr(
+            url_safety, "is_safe_url",
+            lambda u: u == public_url,
+        )
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": public_url,
+                "provider": "xai",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+        calls: list = []
+        redirect = _FakeHTTPResponse(
+            b"", status=302, headers={"location": unsafe_target}
+        )
+        monkeypatch.setattr(
+            httpx, "Client",
+            lambda *a, **kw: _SequenceHTTPClient([redirect], calls),
+        )
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        # The redirect target must NOT be fetched — only the original URL
+        # should appear in calls. The internal IP would be blocked by
+        # is_safe_url even if it were attempted.
+        assert calls == [public_url]
+        # Original URL preserved verbatim; no media tag emitted.
+        assert result["image"] == public_url
+        assert "source_url" not in result
+        assert "media_tag" not in result
+
+    def test_handle_follows_safe_redirect_to_public_target(
+        self, monkeypatch, tmp_path
+    ):
+        """A redirect to another public target (e.g. CDN-backed provider
+        URLs) is followed once is_safe_url passes — the manual redirect
+        loop must not break the common 302→CDN case."""
+        from tools import image_generation_tool
+        from tools import url_safety
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        public_url = "https://imgen.x.ai/xai-tmp-imgen-cdn.jpeg"
+        cdn_url = "https://cdn.example.com/cached/img.png"
+
+        # Both hops are public; bypass real DNS so the test is
+        # deterministic in offline CI.
+        monkeypatch.setattr(
+            url_safety, "is_safe_url",
+            lambda u: u in {public_url, cdn_url},
+        )
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": public_url,
+                "provider": "xai",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+        calls: list = []
+        redirect = _FakeHTTPResponse(
+            b"", status=302, headers={"location": cdn_url}
+        )
+        final = _FakeHTTPResponse(
+            _PNG_1x1, headers={"content-type": "image/png"}
+        )
+        monkeypatch.setattr(
+            httpx, "Client",
+            lambda *a, **kw: _SequenceHTTPClient([redirect, final], calls),
+        )
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        assert calls == [public_url, cdn_url]
+        assert result["success"] is True
+        assert result["image"].endswith(".png")
+        assert result["source_url"] == public_url
+        assert result["media_tag"] == f"MEDIA:{result['image']}"

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -97,3 +97,256 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+
+# A 1×1 PNG — smallest valid bytes that pass the magic-byte sniff in
+# gateway.platforms.base.cache_image_from_bytes.
+_PNG_1x1 = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8"
+    b"\xcf\xc0\x00\x00\x00\x03\x00\x01\xa9\x12\x9b\xb1\x00\x00\x00\x00"
+    b"IEND\xaeB`\x82"
+)
+
+
+class _FakeHTTPResponse:
+    def __init__(self, content: bytes, status: int = 200):
+        self.content = content
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeHTTPClient:
+    """Minimal sync httpx.Client stand-in supporting the context-manager
+    + .get() shape used by _cache_remote_image_url."""
+
+    def __init__(self, response: _FakeHTTPResponse, calls: list):
+        self._response = response
+        self._calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get(self, url, headers=None):
+        self._calls.append(url)
+        return self._response
+
+
+class TestImageGenerateEphemeralUrlCache:
+    """Regression guard for #26942 — image_generate URLs from providers like
+    xAI Grok (`imgen.x.ai/xai-tmp-imgen-*`) 404 by the time the messaging
+    adapter calls send_photo. Pre-caching at tool-completion time captures
+    the bytes before the URL expires and emits a MEDIA: tag so the
+    gateway's MEDIA-tag scanner delivers the local file."""
+
+    def test_handle_caches_ephemeral_remote_url_and_emits_media_tag(
+        self, monkeypatch, tmp_path
+    ):
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        ephemeral_url = "https://imgen.x.ai/xai-tmp-imgen-deadbeef-cafe-feed.jpeg"
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": ephemeral_url,
+                "provider": "xai",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+        calls: list = []
+        monkeypatch.setattr(
+            httpx, "Client",
+            lambda *a, **kw: _FakeHTTPClient(_FakeHTTPResponse(_PNG_1x1), calls),
+        )
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "a Frühlingsmorgen im Garten"}
+        ))
+
+        assert result["success"] is True
+        assert result["provider"] == "xai"
+        assert calls == [ephemeral_url], (
+            "Expected the ephemeral URL to be fetched exactly once at "
+            "tool-completion time"
+        )
+        assert result["source_url"] == ephemeral_url
+        # image field swapped to local path so extract_images() (which only
+        # matches https?:// markdown) no longer routes through the failing
+        # URL-based send_photo path.
+        assert result["image"] != ephemeral_url
+        # Extension is derived from the URL path (.jpeg → .jpeg, .png → .png)
+        # and cache_image_from_bytes keeps it verbatim.
+        assert result["image"].endswith(".jpeg")
+        assert "media_tag" in result
+        assert result["media_tag"] == f"MEDIA:{result['image']}"
+        # Belt-and-suspenders: the gateway's MEDIA scanner looks for the
+        # literal "MEDIA:" substring anywhere in the serialized tool
+        # result, so the augmented payload must serialize to contain it.
+        assert "MEDIA:" in json.dumps(result)
+
+    def test_handle_preserves_local_path_results_unchanged(self, monkeypatch, tmp_path):
+        """Plugin providers that already return a local path (the existing
+        _FakeCodexProvider contract) must not be re-processed — no HTTP
+        fetch, no field rewrite."""
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": "/tmp/codex-test.png",
+                "provider": "codex",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+
+        def _no_http(*a, **kw):
+            raise AssertionError("Local paths must not trigger an HTTP fetch")
+
+        monkeypatch.setattr(httpx, "Client", _no_http)
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "draw cat"}
+        ))
+
+        assert result["image"] == "/tmp/codex-test.png"
+        assert "source_url" not in result
+        assert "media_tag" not in result
+
+    def test_handle_preserves_error_results_unchanged(self, monkeypatch, tmp_path):
+        """A failed image_generate (success=False) has no URL to cache —
+        the payload must round-trip unchanged so the error reaches the
+        agent intact."""
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": False,
+                "image": None,
+                "error": "API quota exceeded",
+                "error_type": "RateLimitError",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+
+        def _no_http(*a, **kw):
+            raise AssertionError("Error results must not trigger an HTTP fetch")
+
+        monkeypatch.setattr(httpx, "Client", _no_http)
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        assert result["success"] is False
+        assert result["image"] is None
+        assert result["error_type"] == "RateLimitError"
+        assert "source_url" not in result
+        assert "media_tag" not in result
+
+    def test_handle_falls_back_to_url_when_cache_fetch_fails(
+        self, monkeypatch, tmp_path
+    ):
+        """When the URL is unreachable at tool-completion time (network
+        flake, partial outage), the result must round-trip with the
+        original URL intact — the messaging adapter's existing 3-tier
+        fallback (URL → download → text) can still take a swing."""
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        flaky_url = "https://imgen.x.ai/xai-tmp-imgen-broken.jpeg"
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({
+                "success": True,
+                "image": flaky_url,
+                "provider": "xai",
+            })
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+
+        class _BoomClient:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+            def get(self, url, headers=None):
+                raise RuntimeError("network refused")
+
+        monkeypatch.setattr(httpx, "Client", lambda *a, **kw: _BoomClient())
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        assert result["success"] is True
+        assert result["image"] == flaky_url, (
+            "URL must be preserved verbatim when caching fails so the "
+            "adapter can still attempt the legacy delivery chain"
+        )
+        assert "source_url" not in result
+        assert "media_tag" not in result
+
+    def test_handle_skips_non_image_response_bytes(self, monkeypatch, tmp_path):
+        """A URL that returns an HTML error page instead of image bytes
+        must be rejected by cache_image_from_bytes' magic-byte sniff;
+        the original URL must be preserved so the failure is observable."""
+        from tools import image_generation_tool
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        url = "https://imgen.x.ai/xai-tmp-imgen-html.jpeg"
+
+        def fake_dispatch(prompt, aspect_ratio):
+            return json.dumps({"success": True, "image": url})
+
+        monkeypatch.setattr(
+            image_generation_tool, "_dispatch_to_plugin_provider", fake_dispatch
+        )
+
+        import httpx
+        calls: list = []
+        html_bytes = b"<!doctype html><html><body>404 Not Found</body></html>"
+        monkeypatch.setattr(
+            httpx, "Client",
+            lambda *a, **kw: _FakeHTTPClient(_FakeHTTPResponse(html_bytes), calls),
+        )
+
+        result = json.loads(image_generation_tool._handle_image_generate(
+            {"prompt": "x"}
+        ))
+
+        assert calls == [url]
+        assert result["image"] == url
+        assert "media_tag" not in result

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -933,7 +933,10 @@ IMAGE_GENERATE_SCHEMA = {
         "backend (FAL, OpenAI, etc.) and model are user-configured and not "
         "selectable by the agent. Returns either a URL or an absolute file "
         "path in the `image` field; display it with markdown "
-        "![description](url-or-path) and the gateway will deliver it."
+        "![description](url-or-path) and the gateway will deliver it. "
+        "When the provider URL has been pre-cached locally to defeat fast "
+        "TTL expiry, `image` will be the local path and `source_url` will "
+        "carry the original URL for diagnostics."
     ),
     "parameters": {
         "type": "object",
@@ -1068,6 +1071,63 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     return json.dumps(result)
 
 
+_CONTENT_TYPE_TO_EXT = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+}
+
+
+def _extension_from_content_type(content_type: str) -> Optional[str]:
+    """Map a Content-Type header value to a known image extension, or
+    ``None`` when the type is missing/non-image so callers fall back to
+    URL-suffix parsing."""
+    if not isinstance(content_type, str):
+        return None
+    base = content_type.split(";", 1)[0].strip().lower()
+    return _CONTENT_TYPE_TO_EXT.get(base)
+
+
+def _safe_redirect_get(client, url: str, headers: dict, max_hops: int = 5):
+    """GET ``url`` and follow redirects manually, re-running ``is_safe_url``
+    on every hop's ``Location``. Returns the final non-redirect response.
+
+    httpx's ``follow_redirects=True`` would silently follow a 30x from a
+    public provider URL to an internal/SSRF-unsafe target. The initial
+    ``is_safe_url`` check in ``_cache_remote_image_url`` only validates the
+    original URL — without per-hop re-validation, a provider that
+    redirects to ``http://169.254.169.254/...`` would be fetched.
+
+    Raises ``RuntimeError`` on redirect loops, SSRF-unsafe targets, or
+    exceeded depth. Callers catch ``Exception`` and degrade to the
+    original URL.
+    """
+    from tools.url_safety import is_safe_url
+    from urllib.parse import urljoin
+
+    current = url
+    seen: set = set()
+    for _ in range(max_hops):
+        if current in seen:
+            raise RuntimeError(f"redirect loop at {current}")
+        seen.add(current)
+        resp = client.get(current, headers=headers)
+        if resp.status_code not in (301, 302, 303, 307, 308):
+            return resp
+        resp_headers = getattr(resp, "headers", None) or {}
+        location = resp_headers.get("location") or resp_headers.get("Location")
+        if not location:
+            return resp
+        next_url = urljoin(current, location)
+        if not is_safe_url(next_url):
+            raise RuntimeError(f"redirect to SSRF-unsafe URL: {next_url}")
+        current = next_url
+    raise RuntimeError(f"too many redirects (>{max_hops})")
+
+
 def _cache_remote_image_url(url: str) -> Optional[str]:
     """Download a remote image URL into the shared image cache and return its
     local path, or ``None`` on any failure so callers degrade to the URL.
@@ -1096,21 +1156,33 @@ def _cache_remote_image_url(url: str) -> Optional[str]:
 
     from pathlib import Path as _Path
     from urllib.parse import urlparse
-    ext = _Path(urlparse(url).path).suffix.lower()
-    if ext not in {".png", ".jpg", ".jpeg", ".gif", ".webp"}:
-        ext = ".jpg"
+    url_ext = _Path(urlparse(url).path).suffix.lower()
+    if url_ext not in _CONTENT_TYPE_TO_EXT.values() and url_ext != ".jpeg":
+        url_ext = ""
 
     try:
         import httpx
-        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
-            resp = client.get(
-                url,
+        # follow_redirects=False — see _safe_redirect_get; SSRF revalidation
+        # is run per-hop so a provider URL that 30x-redirects to a private
+        # IP is rejected, not silently fetched.
+        with httpx.Client(timeout=30.0, follow_redirects=False) as client:
+            resp = _safe_redirect_get(
+                client, url,
                 headers={
                     "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
                     "Accept": "image/*,*/*;q=0.8",
                 },
             )
             resp.raise_for_status()
+            # Prefer the server's Content-Type over the URL suffix:
+            # provider URLs frequently omit an extension or carry
+            # query-string parameters (e.g. ``?format=png``), so a
+            # URL-only sniff defaults to .jpg even when bytes are PNG.
+            resp_headers = getattr(resp, "headers", None) or {}
+            sniffed_ext = _extension_from_content_type(
+                resp_headers.get("content-type", "") or resp_headers.get("Content-Type", "")
+            )
+            ext = sniffed_ext or url_ext or ".jpg"
             return cache_image_from_bytes(resp.content, ext)
     except Exception as exc:
         logger.warning(

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1068,6 +1068,102 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     return json.dumps(result)
 
 
+def _cache_remote_image_url(url: str) -> Optional[str]:
+    """Download a remote image URL into the shared image cache and return its
+    local path, or ``None`` on any failure so callers degrade to the URL.
+
+    Mirrors ``_cache_mcp_image_block`` in ``tools/mcp_tool.py`` — same
+    ``cache_image_from_bytes`` helper, same magic-byte validation, same
+    "log and drop" failure mode — and exists so providers whose image links
+    expire fast (notably xAI ``imgen.x.ai/xai-tmp-imgen-*`` ephemeral URLs,
+    which 404 within seconds and lose every Telegram delivery fallback) get
+    captured at tool-completion time, before the messaging adapter races
+    the URL TTL.
+    """
+    if not isinstance(url, str) or not url.lower().startswith(("http://", "https://")):
+        return None
+
+    try:
+        from gateway.platforms.base import cache_image_from_bytes
+        from tools.url_safety import is_safe_url
+    except ImportError:
+        logger.debug("image_generate caching skipped — gateway helpers unavailable")
+        return None
+
+    if not is_safe_url(url):
+        logger.warning("image_generate: SSRF-unsafe image URL not cached: %s", url)
+        return None
+
+    from pathlib import Path as _Path
+    from urllib.parse import urlparse
+    ext = _Path(urlparse(url).path).suffix.lower()
+    if ext not in {".png", ".jpg", ".jpeg", ".gif", ".webp"}:
+        ext = ".jpg"
+
+    try:
+        import httpx
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            resp = client.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                    "Accept": "image/*,*/*;q=0.8",
+                },
+            )
+            resp.raise_for_status()
+            return cache_image_from_bytes(resp.content, ext)
+    except Exception as exc:
+        logger.warning(
+            "image_generate: pre-cache of %s failed (%s); keeping original URL",
+            url, exc,
+        )
+        return None
+
+
+def _augment_with_local_cache(result_json: str) -> str:
+    """Pre-cache the generated image and rewrite the tool result so platforms
+    deliver the local bytes instead of re-fetching a possibly-expired URL.
+
+    Leaves the payload untouched when:
+      - the result is not valid JSON or not a dict
+      - ``success`` is false (no image to cache)
+      - ``image`` is missing, not a string, or already a local path
+      - downloading or caching fails (preserves the URL so the adapter can
+        still attempt the legacy URL → fallback-download → text-fallback
+        chain)
+
+    On a successful cache:
+      - ``image`` → local file path (so the agent's markdown emits a path
+        that doesn't match ``extract_images()``'s ``https?://`` regex,
+        sidestepping the failing URL-based ``send_photo``)
+      - ``source_url`` → original URL (preserved for diagnostics)
+      - ``media_tag`` → ``MEDIA:<path>`` (mirrors the TTS tool so the
+        gateway's MEDIA-tag scanner — see ``gateway/run.py`` post-stream
+        media dispatch — delivers the file natively regardless of how the
+        agent renders the result in text)
+    """
+    try:
+        result = json.loads(result_json)
+    except (json.JSONDecodeError, TypeError):
+        return result_json
+
+    if not isinstance(result, dict) or not result.get("success"):
+        return result_json
+
+    url = result.get("image")
+    if not isinstance(url, str) or not url.lower().startswith(("http://", "https://")):
+        return result_json
+
+    local_path = _cache_remote_image_url(url)
+    if not local_path:
+        return result_json
+
+    result["source_url"] = url
+    result["image"] = local_path
+    result["media_tag"] = f"MEDIA:{local_path}"
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
     if not prompt:
@@ -1078,11 +1174,13 @@ def _handle_image_generate(args, **kw):
     # not the in-tree FAL path).
     dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
     if dispatched is not None:
-        return dispatched
+        return _augment_with_local_cache(dispatched)
 
-    return image_generate_tool(
-        prompt=prompt,
-        aspect_ratio=aspect_ratio,
+    return _augment_with_local_cache(
+        image_generate_tool(
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+        )
     )
 
 


### PR DESCRIPTION
## Summary

- Pre-cache `image_generate` provider URLs to `cache/images/` at tool-completion time so platforms deliver local bytes instead of racing TTLs on ephemeral provider URLs.
- Fixes xAI Grok `imgen.x.ai/xai-tmp-imgen-*` URLs that 404 within seconds, defeating Telegram's three-tier delivery fallback (media_group → URL send_photo → file-upload send_photo) and leaving the user with no image.

Fixes #26942.

## The bug

`image_generate` returns whatever URL the active provider hands back. For xAI's `imgen.x.ai/xai-tmp-imgen-*` URLs the TTL is measured in seconds, so by the time the messaging adapter walks its delivery chain the URL is already 404. Issue #26942 captures the full Telegram log: `send_media_group` → `webpage_curl_failed`, `URL-based send_photo` → `Wrong type of the web page content`, `File upload send_photo` (which re-downloads via httpx) → `404 Not Found`. The agent sees a successful tool result; the user sees nothing.

## The fix

Wrap both the plugin-dispatch and the in-tree FAL paths in `_augment_with_local_cache`, which:

1. Downloads the URL bytes synchronously at tool-completion time via `httpx.Client` (sync — `image_generate` is registered `is_async=False`).
2. Hands them to `gateway.platforms.base.cache_image_from_bytes`, which performs magic-byte validation (PNG / JPEG / GIF / WebP / BMP) and stores under the shared `cache/images/` dir — exactly the path used by `_cache_mcp_image_block` for MCP screenshots (#21328).
3. Rewrites the result payload:
   - `image` → local file path. `extract_images()` only matches `https?://` markdown URLs, so the swap quietly takes the failing URL-based `send_photo` path out of the picture.
   - `source_url` → the original URL, preserved for diagnostics.
   - `media_tag` → `MEDIA:<path>`. The gateway's `extract_media()` / post-stream media scanner picks this up out of tool result content, mirroring how the TTS tool's `media_tag` triggers native voice delivery.

Graceful degradation: any non-JSON result, `success: false` result, already-local path, SSRF-blocked URL, network failure, or magic-byte rejection round-trips the original payload unchanged. The adapter's existing 3-tier chain still gets its swing if anything in the cache step misbehaves.

## Test plan

- [x] Focused regression test: `tests/tools/test_image_generation_plugin_dispatch.py::TestImageGenerateEphemeralUrlCache` — 5 parametrized cases covering the ephemeral-URL happy path (literal `imgen.x.ai/xai-tmp-imgen-*` from the issue), already-local path no-op, error result no-op, network-failure URL preservation, and non-image-bytes magic-byte rejection.
- [x] Adjacent suite: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_image_generation.py tests/tools/test_image_generation_env.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_mcp_image_content.py -v` — 78 passed.
- [x] Regression guard: the new tests assert `result[\"image\"] != ephemeral_url`, `media_tag` present, and `httpx.Client.get` called exactly once with the ephemeral URL. Reverting `_augment_with_local_cache` fails all 5 new tests with the original URL leaking through verbatim.

## Contract protected

**Invariant**: when `image_generate` returns a successful result with a remote URL, the payload reaching the gateway must either (a) contain a `MEDIA:` tag pointing at locally-readable bytes, or (b) leave the URL fully intact so the adapter's legacy fallback chain remains available.

**Known-bad inputs covered**:
- Ephemeral `https://imgen.x.ai/xai-tmp-imgen-*.jpeg` URLs (the literal issue case)
- HTML error pages masquerading as image URLs (magic-byte sniff rejects, URL preserved)
- Network refusal mid-fetch (URL preserved)
- Plugin returns local path (existing `_FakeCodexProvider` contract, no-op)
- Plugin returns `success: false` (no URL to cache, no-op)

**Future-input coverage**: extension is derived from the URL path (`.jpeg`, `.png`, `.webp`, etc.) with a `.jpg` default; any future provider returning standard image extensions inherits the same caching automatically.

**Negative case**: `test_handle_falls_back_to_url_when_cache_fetch_fails` proves that a broken httpx fetch does not corrupt the result — the URL stays as-is and no spurious `media_tag` / `source_url` keys are added.

## Related

- #21328 (teknium1) — `fix(mcp): surface image tool results as MEDIA tags instead of dropping them`. Same `cache_image_from_bytes` + `MEDIA:` pattern; this PR extends it from MCP tool results to the `image_generate` tool path that's still passing raw URLs through.

> Sibling code paths that may need the same fix: `tools/video_generation_tool.py`. Issue #26942 notes the same markdown-emit problem for `vidgen.x.ai/xai-vidgen-bucket/` URLs, but the suggested shape is a bit different (explicit `media_type: \"video\"` + `send_video` glue). Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.