### PR TITLE
fix: make compression status messages configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1801,6 +1801,9 @@ def init_agent(
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
+    compression_status_messages = is_truthy_value(
+        _compression_cfg.get("status_messages"), default=True
+    )
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # Cap on compression retry rounds before a turn gives up with "max
@@ -2313,6 +2316,7 @@ def init_agent(
         except Exception:
             pass
     agent.compression_enabled = compression_enabled
+    agent.compression_status_messages = compression_status_messages
     agent.compression_in_place = compression_in_place
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.max_compression_attempts = compression_max_attempts

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -215,9 +215,12 @@ def _record_codex_app_server_compaction(
     )
     if not force:
         try:
-            from agent.conversation_compression import COMPACTION_STATUS
+            from agent.conversation_compression import (
+                COMPACTION_STATUS,
+                emit_compression_status,
+            )
 
-            agent._emit_status(COMPACTION_STATUS)
+            emit_compression_status(agent, COMPACTION_STATUS)
         except Exception:
             pass
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -60,8 +60,27 @@ COMPACTION_STATUS = (
 COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
 
 
+def emit_compression_status(agent: Any, message: str) -> None:
+    """Use the configurable emitter, with the legacy duck-typed fallback."""
+    emit = getattr(agent, "_emit_compression_status", None)
+    (emit if callable(emit) else agent._emit_status)(message)
+
+
+def buffer_compression_status(agent: Any, message: str) -> None:
+    """Use the configurable buffer, with the legacy duck-typed fallback."""
+    buffer = getattr(agent, "_buffer_compression_status", None)
+    (buffer if callable(buffer) else agent._buffer_status)(message)
+
+
 def _emit_compaction_done(agent: Any) -> None:
-    """Emit the structured terminal edge for a started compaction."""
+    """Emit the terminal edge when visible, or when a visual client needs it."""
+    platform = getattr(agent, "platform", "")
+    platform = getattr(platform, "value", platform)
+    if (
+        not getattr(agent, "compression_status_messages", True)
+        and platform not in {"desktop", "tui"}
+    ):
+        return
     status_callback = getattr(agent, "status_callback", None)
     if not status_callback:
         return
@@ -524,7 +543,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     "Run `hermes setup` or set OPENROUTER_API_KEY."
                 )
             agent._compression_warning = msg
-            agent._emit_status(msg)
+            emit_compression_status(agent, msg)
             logger.warning(
                 "No auxiliary LLM provider for compression — "
                 "summaries will be unavailable."
@@ -691,7 +710,7 @@ def check_compression_model_feasibility(agent: Any) -> None:
                     f"compression model's {aux_context:,}.)"
                 )
             agent._compression_warning = msg
-            agent._emit_status(msg)
+            emit_compression_status(agent, msg)
             logger.warning(
                 "Auxiliary compression model %s has %d token context, "
                 "below the main model's compression threshold of %d "
@@ -1089,7 +1108,7 @@ def compress_context(
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    agent._emit_status(COMPACTION_STATUS)
+    emit_compression_status(agent, COMPACTION_STATUS)
     _compaction_done_emitted = False
 
     def _complete_compaction_lifecycle() -> None:
@@ -1801,7 +1820,7 @@ def compress_context(
                 f"accuracy may degrade. Consider /new to start fresh."
             )
             agent._compression_warning = _cc_msg
-            agent._emit_status(_cc_msg)
+            emit_compression_status(agent, _cc_msg)
 
         # Emit session:compress event so hooks (e.g. MemPalace sync) can ingest
         # the completed old session before its details are lost. In in-place mode
@@ -1947,7 +1966,7 @@ def _compress_context_via_codex_app_server(
         f"{approx_tokens:,}" if approx_tokens else "unknown",
     )
     try:
-        agent._emit_status(COMPACTION_STATUS)
+        emit_compression_status(agent, COMPACTION_STATUS)
     except Exception:
         pass
 
@@ -2295,7 +2314,9 @@ __all__ = [
     "COMPACTION_STATUS",
     "COMPACTION_DONE_STATUS",
     "COMPACTION_STATUS_MARKER",
+    "buffer_compression_status",
     "check_compression_model_feasibility",
+    "emit_compression_status",
     "replay_compression_warning",
     "compress_context",
     "try_shrink_image_parts_in_messages",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,7 +34,9 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    buffer_compression_status,
     conversation_history_after_compression,
+    emit_compression_status,
 )
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -1310,7 +1312,8 @@ def run_conversation(
                 compression_attempts,
                 max_compression_attempts,
             )
-            agent._emit_status(
+            emit_compression_status(
+                agent,
                 PRE_API_COMPRESSION_STATUS_TEMPLATE.format(
                     tokens=request_pressure_tokens
                 )
@@ -3526,7 +3529,8 @@ def run_conversation(
                             agent, messages
                         )
                         if len(messages) < original_len or old_ctx > _reduced_ctx:
-                            agent._buffer_status(
+                            buffer_compression_status(
+                                agent,
                                 COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE.format(
                                     new_ctx=_reduced_ctx, old_ctx=old_ctx
                                 )
@@ -3769,7 +3773,7 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                    buffer_compression_status(agent, f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -3790,9 +3794,9 @@ def run_conversation(
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
                         if len(messages) < original_len:
-                            agent._buffer_status(COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
+                            buffer_compression_status(agent, COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
                         else:
-                            agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
+                            buffer_compression_status(agent, COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
@@ -4010,7 +4014,7 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE.format(tokens=approx_tokens, attempt=compression_attempts, cap=max_compression_attempts))
+                    buffer_compression_status(agent, COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE.format(tokens=approx_tokens, attempt=compression_attempts, cap=max_compression_attempts))
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -4031,9 +4035,9 @@ def run_conversation(
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
-                            agent._buffer_status(COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
+                            buffer_compression_status(agent, COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE.format(before=original_len, after=len(messages)))
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
-                            agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
+                            buffer_compression_status(agent, COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -35,6 +35,7 @@ from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
     conversation_history_after_compression,
+    emit_compression_status,
 )
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
@@ -662,7 +663,8 @@ def build_turn_context(
                     f"{_idle_floor:,}",
                     agent.session_id or "none",
                 )
-                agent._emit_status(
+                emit_compression_status(
+                    agent,
                     IDLE_COMPACTION_STATUS_TEMPLATE.format(
                         idle_seconds=int(_idle_gap), tokens=_idle_tokens
                     )
@@ -771,7 +773,8 @@ def build_turn_context(
                 agent.model,
                 f"{_compressor.context_length:,}",
             )
-            agent._emit_status(
+            emit_compression_status(
+                agent,
                 PREFLIGHT_COMPRESSION_STATUS_TEMPLATE.format(
                     tokens=_preflight_tokens,
                     threshold=_compressor.threshold_tokens,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -407,6 +407,10 @@ compression:
   # Enable automatic context compression (default: true)
   # Set to false if you prefer to manage context manually or want errors on overflow
   enabled: true
+
+  # Show compression lifecycle/retry messages (default: true). Set false to
+  # hide them; desktop/TUI may still show a non-transcript Summarizing indicator.
+  status_messages: true
   
   # Trigger compression at this % of model's context limit (default: 0.50 = 50%)
   # Lower values = more aggressive compression, higher values = compress later

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17748,6 +17748,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "model_thresholds"),
         ("compression", "threshold_tokens"),
         ("compression", "codex_gpt55_autoraise"),
+        ("compression", "status_messages"),
         ("compression", "codex_app_server_auto"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -912,6 +912,32 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
 
+    def _emit_compression_status(self, message: str) -> None:
+        """Emit compression chatter unless disabled in config.
+
+        Desktop/TUI clients still receive the stable compaction marker so their
+        non-transcript ``Summarizing…`` indicator can track the real lifecycle.
+        """
+        if getattr(self, "compression_status_messages", True):
+            self._emit_status(message)
+            return
+
+        platform = getattr(self, "platform", "")
+        platform = getattr(platform, "value", platform)
+        callback = getattr(self, "status_callback", None)
+        if platform not in {"desktop", "tui"} or not callback:
+            return
+        try:
+            from agent.conversation_compression import COMPACTION_STATUS_MARKER
+
+            if COMPACTION_STATUS_MARKER in message:
+                callback("lifecycle", message)
+        except Exception:
+            logger.debug(
+                "status_callback error in _emit_compression_status",
+                exc_info=True,
+            )
+
     def _emit_warning(self, message: str) -> None:
         """Emit a user-visible warning through the same status plumbing.
 
@@ -1004,6 +1030,11 @@ class AIAgent:
         except Exception:
             # Never break the retry loop on a buffer hiccup.
             pass
+
+    def _buffer_compression_status(self, message: str) -> None:
+        """Buffer compression retry chatter unless disabled in config."""
+        if getattr(self, "compression_status_messages", True):
+            self._buffer_status(message)
 
     def _buffer_vprint(self, message: str) -> None:
         """Buffer a vprint(force=True) retry/fallback line."""

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -229,6 +229,7 @@ class TestExtractCacheBustingConfig:
                     "enabled": False,
                     "threshold": 0.6,
                     "codex_gpt55_autoraise": False,
+                    "status_messages": False,
                     "target_ratio": 0.3,
                     "protect_last_n": 25,
                     "codex_app_server_auto": "hermes",
@@ -239,6 +240,7 @@ class TestExtractCacheBustingConfig:
         assert out["compression.enabled"] is False
         assert out["compression.threshold"] == 0.6
         assert out["compression.codex_gpt55_autoraise"] is False
+        assert out["compression.status_messages"] is False
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
         assert out["compression.codex_app_server_auto"] == "hermes"

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -826,6 +826,44 @@ class TestPreflightCompression:
             for ev, msg in status_messages
         )
 
+    def test_preflight_status_honors_disabled_config(self, agent):
+        agent.compression_enabled = True
+        agent.compression_status_messages = False
+        agent.platform = "discord"
+        agent.context_compressor.context_length = 2000
+        agent.context_compressor.threshold_tokens = 200
+        big_history = [
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"Message {i} with enough padding to trigger preflight compression",
+            }
+            for i in range(40)
+        ]
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="After silent preflight"
+        )
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        with (
+            patch.object(
+                agent,
+                "_compress_context",
+                return_value=(
+                    [{"role": "user", "content": "compressed"}],
+                    "new system prompt",
+                ),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        mock_compress.assert_called()
+        assert result["completed"] is True
+        assert not any("Preflight compression" in msg for _, msg in status_messages)
+
     def test_preflight_defers_when_recent_real_usage_fit(self, agent):
         """A noisy rough estimate should not re-compact a recently fitting request."""
         agent.compression_enabled = True

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -78,6 +78,9 @@ class DummyAgent:
         self.statuses.append(message)
         self.status_callback("lifecycle", message)
 
+    def _emit_compression_status(self, message):
+        self._emit_status(message)
+
     def _emit_warning(self, message):
         self.warnings.append(message)
         self.status_callback("warn", message)

--- a/tests/run_agent/test_compression_status_messages.py
+++ b/tests/run_agent/test_compression_status_messages.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from agent.conversation_compression import (
+    COMPACTION_DONE_STATUS,
+    COMPACTION_STATUS,
+    ROUTINE_COMPRESSION_STATUS_SAMPLES,
+    _emit_compaction_done,
+    buffer_compression_status,
+    emit_compression_status,
+)
+from run_agent import AIAgent
+
+
+def _make_agent(config):
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, True),
+        ({"compression": {"status_messages": False}}, False),
+        ({"compression": {"status_messages": "no"}}, False),
+    ],
+)
+def test_compression_status_messages_config(config, expected):
+    assert _make_agent(config).compression_status_messages is expected
+
+
+def test_disabled_compression_status_is_silent_on_chat_platforms():
+    agent = _make_agent({"compression": {"status_messages": False}})
+    agent.platform = "discord"
+    agent._vprint = MagicMock()
+    agent.status_callback = MagicMock()
+
+    for message in ROUTINE_COMPRESSION_STATUS_SAMPLES:
+        agent._emit_compression_status(message)
+        agent._buffer_compression_status(message)
+
+    _emit_compaction_done(agent)
+
+    agent._vprint.assert_not_called()
+    agent.status_callback.assert_not_called()
+    assert getattr(agent, "_retry_status_buffer", []) == []
+
+
+def test_disabled_compression_status_preserves_desktop_indicator():
+    agent = _make_agent({"compression": {"status_messages": False}})
+    agent.platform = "desktop"
+    agent._vprint = MagicMock()
+    agent.status_callback = MagicMock()
+
+    agent._emit_compression_status(COMPACTION_STATUS)
+    _emit_compaction_done(agent)
+
+    agent._vprint.assert_not_called()
+    assert agent.status_callback.call_args_list == [
+        call("lifecycle", COMPACTION_STATUS),
+        call("compacted", COMPACTION_DONE_STATUS),
+    ]
+
+
+def test_compression_status_helpers_support_legacy_duck_typed_agents():
+    agent = SimpleNamespace(_emit_status=MagicMock(), _buffer_status=MagicMock())
+
+    emit_compression_status(agent, "emit")
+    buffer_compression_status(agent, "buffer")
+
+    agent._emit_status.assert_called_once_with("emit")
+    agent._buffer_status.assert_called_once_with("buffer")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -806,6 +806,7 @@ Context compression is configured exclusively through `config.yaml` — there ar
 ```yaml
 compression:
   enabled: true
+  status_messages: true      # false hides lifecycle/retry messages; desktop/TUI may still show Summarizing…
   threshold: 0.50
   target_ratio: 0.20         # fraction of threshold to preserve as recent tail
   protect_last_n: 20         # minimum recent messages to keep uncompressed

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -743,6 +743,7 @@ All compression settings live in `config.yaml` (no environment variables).
 ```yaml
 compression:
   enabled: true                                     # Toggle compression on/off
+  status_messages: true                              # Show compression lifecycle/retry messages
   threshold: 0.50                                   # Compress at this % of context limit
   threshold_tokens: null                            # Absolute token cap (optional) — takes lower of ratio vs absolute
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
@@ -762,6 +763,8 @@ auxiliary:
 :::info Legacy config migration
 Older configs with `compression.summary_model`, `compression.summary_provider`, and `compression.summary_base_url` are automatically migrated to `auxiliary.compression.*` on first load (config version 17). No manual action needed.
 :::
+
+`status_messages` defaults to `true`. Set it to `false` to hide compression lifecycle and retry messages. Desktop and TUI clients may still show a non-transcript **Summarizing…** indicator while compaction runs.
 
 `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. It exists to break a death spiral: when API calls keep disconnecting on an oversized session, the gateway never receives token-usage data, so the token-based threshold can't fire, so the transcript keeps growing and disconnects get worse. This count-based floor fires on message count alone (always known, regardless of API failures) to force compression and recover the session. Default `5000` — far above any normal session, including large-context (1M+) models doing thousands of short turns, which compress on the token threshold long before this. Raise it further for unusual platforms, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
 


### PR DESCRIPTION
## Summary
- add `compression.status_messages` (default `true`) and include it in gateway agent-cache invalidation
- gate all current-main compression lifecycle paths, including preflight, pre-API, idle, retry/reduction, repeated-compaction, and native Codex status emitters
- preserve the desktop/TUI non-transcript `Summarizing…` lifecycle when messages are disabled, including its terminal `compacted` event
- document the setting in the example config and compression reference

## Behavior
With `compression.status_messages: false`, compression still runs but CLI/chat lifecycle and retry messages are hidden. Desktop and TUI clients still receive the structured `compacting`/`compacted` lifecycle needed to show and clear their non-transcript `Summarizing…` indicator.

Related: #25115

## Test plan
- `python -m pytest -q tests/run_agent/test_compression_status_messages.py tests/run_agent/test_413_compression.py tests/run_agent/test_codex_app_server_compaction.py tests/gateway/test_agent_cache.py::TestExtractCacheBustingConfig::test_reads_compression_subkeys tests/tui_gateway/test_compaction_status.py tests/gateway/test_telegram_noise_filter.py tests/agent/test_compression_attempt_telemetry.py tests/agent/test_api_content_sidecar.py tests/agent/test_turn_context.py` — 666 passed
- `ruff check` on all changed Python files — passed
- `python -m py_compile` on all changed Python files — passed
- `git diff --check` — passed
