### PR TITLE
fix(agent): preserve thinking blocks in latest assistant message verbatim

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1794,28 +1794,11 @@ def convert_messages_to_anthropic(
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
         else:
-            # Latest assistant on direct Anthropic: keep signed thinking
-            # blocks for reasoning continuity; downgrade unsigned ones to
-            # plain text.
-            new_content = []
-            for b in m["content"]:
-                if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
-                    new_content.append(b)
-                    continue
-                if b.get("type") == "redacted_thinking":
-                    # Redacted blocks use 'data' for the signature payload
-                    if b.get("data"):
-                        new_content.append(b)
-                    # else: drop — no data means it can't be validated
-                elif b.get("signature"):
-                    # Signed thinking block — keep it
-                    new_content.append(b)
-                else:
-                    # Unsigned thinking — downgrade to text so it's not lost
-                    thinking_text = b.get("thinking", "")
-                    if thinking_text:
-                        new_content.append({"type": "text", "text": thinking_text})
-            m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+            # Latest assistant on direct Anthropic: pass thinking/redacted_thinking
+            # blocks through completely unchanged. The API validates block
+            # integrity and rejects any modification — including drops, text
+            # rewrites, or replacing the list with a placeholder.
+            pass
 
         # Strip cache_control from any remaining thinking/redacted_thinking
         # blocks — cache markers interfere with signature validation.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1574,26 +1574,29 @@ class TestThinkingBlockSignatureManagement:
         assert len(thinking) == 1
         assert thinking[0]["signature"] == "sig_valid"
 
-    def test_unsigned_thinking_downgraded_to_text_on_last_turn(self):
-        """Unsigned thinking blocks on the last turn become text blocks."""
+    def test_unsigned_thinking_preserved_on_last_turn(self):
+        """Unsigned thinking blocks on the last turn pass through unchanged.
+
+        The Anthropic API requires that thinking/redacted_thinking blocks in the
+        latest assistant message are returned exactly as received — any
+        modification (including converting to text) triggers HTTP 400.
+        """
         messages = [
             {
                 "role": "assistant",
                 "content": "Response text.",
                 "reasoning_details": [
                     {"type": "thinking", "thinking": "Unsigned reasoning."},
-                    # No 'signature' field
                 ],
             },
         ]
         _, result = convert_messages_to_anthropic(messages)
         blocks = result[0]["content"]
 
-        # No thinking blocks should remain
-        assert not any(b.get("type") == "thinking" for b in blocks)
-        # The reasoning text should be preserved as a text block
-        text_contents = [b.get("text", "") for b in blocks if b.get("type") == "text"]
-        assert "Unsigned reasoning." in text_contents
+        # Thinking block must pass through as-is; must not be converted to text
+        thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0]["thinking"] == "Unsigned reasoning."
 
     def test_redacted_thinking_with_data_preserved(self):
         """Redacted thinking with 'data' field is kept on last turn."""
@@ -1612,21 +1615,25 @@ class TestThinkingBlockSignatureManagement:
         assert len(redacted) == 1
         assert redacted[0]["data"] == "opaque_signature_data"
 
-    def test_redacted_thinking_without_data_dropped(self):
-        """Redacted thinking without 'data' is dropped — can't be validated."""
+    def test_redacted_thinking_without_data_preserved_on_last_turn(self):
+        """Redacted thinking without 'data' passes through unchanged on last turn.
+
+        The API requires the latest assistant message's thinking blocks to be
+        returned verbatim — dropping a block (even one without data) triggers
+        HTTP 400.
+        """
         messages = [
             {
                 "role": "assistant",
                 "content": "Response.",
                 "reasoning_details": [
                     {"type": "redacted_thinking"},
-                    # No 'data' field
                 ],
             },
         ]
         _, result = convert_messages_to_anthropic(messages)
         blocks = result[0]["content"]
-        assert not any(b.get("type") == "redacted_thinking" for b in blocks)
+        assert any(b.get("type") == "redacted_thinking" for b in blocks)
 
     def test_cache_control_stripped_from_thinking_blocks(self):
         """cache_control markers are removed from thinking/redacted_thinking blocks."""
@@ -1753,6 +1760,79 @@ class TestThinkingBlockSignatureManagement:
         ]
         assert len(last_thinking) == 1
         assert last_thinking[0]["signature"] == "sig_3"
+
+    def test_all_thinking_block_types_preserved_on_last_turn(self):
+        """All thinking block variants pass through verbatim on the last assistant turn.
+
+        Regression test for the HTTP 400 'thinking blocks cannot be modified'
+        error: the API rejects requests where any thinking/redacted_thinking
+        block in the latest assistant message differs from the original response.
+        """
+        messages = [
+            {"role": "user", "content": "Question"},
+            {
+                "role": "assistant",
+                "content": "Answer",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Signed thought.", "signature": "sig"},
+                    {"type": "thinking", "thinking": "Unsigned thought."},
+                    {"type": "redacted_thinking", "data": "opaque"},
+                    {"type": "redacted_thinking"},  # no data field
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in result if m["role"] == "assistant")
+        blocks = assistant["content"]
+
+        thinking = [b for b in blocks if b.get("type") == "thinking"]
+        redacted = [b for b in blocks if b.get("type") == "redacted_thinking"]
+
+        assert len(thinking) == 2
+        assert thinking[0]["thinking"] == "Signed thought."
+        assert thinking[0]["signature"] == "sig"
+        assert thinking[1]["thinking"] == "Unsigned thought."
+        assert len(redacted) == 2
+        assert redacted[0]["data"] == "opaque"
+
+    def test_thinking_stripped_from_non_latest_but_preserved_on_latest(self):
+        """Non-latest assistant messages lose thinking; latest keeps it intact."""
+        messages = [
+            {"role": "user", "content": "Q1"},
+            {
+                "role": "assistant",
+                "content": "A1",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Thought 1.", "signature": "s1"},
+                ],
+            },
+            {"role": "user", "content": "Q2"},
+            {
+                "role": "assistant",
+                "content": "A2",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Unsigned thought."},
+                    {"type": "redacted_thinking"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistants = [m for m in result if m["role"] == "assistant"]
+        assert len(assistants) == 2
+
+        # Non-latest: all thinking stripped
+        first_blocks = assistants[0]["content"]
+        assert not any(
+            b.get("type") in ("thinking", "redacted_thinking") for b in first_blocks
+        )
+
+        # Latest: both blocks pass through unchanged
+        last_blocks = assistants[1]["content"]
+        thinking = [b for b in last_blocks if b.get("type") == "thinking"]
+        redacted = [b for b in last_blocks if b.get("type") == "redacted_thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["thinking"] == "Unsigned thought."
+        assert len(redacted) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The Anthropic API requires that \`thinking\` and \`redacted_thinking\` blocks in the latest assistant message are passed back exactly as received. Any modification — dropping a block, converting unsigned thinking to text, or substituting an \`(empty)\` placeholder — triggers HTTP 400: *\"thinking or redacted_thinking blocks in the latest assistant message cannot be modified.\"*
- The previous \`else\` branch in \`convert_messages_to_anthropic()\` had three paths that all violated this contract: dropping \`redacted_thinking\` blocks without a \`data\` field, converting unsigned \`thinking\` blocks to \`{\"type\": \"text\"}\`, and replacing empty content with a placeholder.
- Fix: replace the entire branch body with \`pass\` — the latest assistant message's content passes through untouched. The existing \`cache_control\` stripping loop immediately after is preserved (that field is not part of the signed content and is safe to remove).

Partially addresses #17861 (the \"latest message modification\" case described there — the broader non-latest-turn reconstruction gap remains open). Related to #11096 Bug 2 (different symptom, same subsystem).

## Test plan

- Updated \`test_unsigned_thinking_downgraded_to_text_on_last_turn\` → now asserts the block passes through as \`thinking\` type (renamed \`test_unsigned_thinking_preserved_on_last_turn\`)
- Updated \`test_redacted_thinking_without_data_dropped\` → now asserts the block passes through unchanged (renamed \`test_redacted_thinking_without_data_preserved_on_last_turn\`)
- Added \`test_all_thinking_block_types_preserved_on_last_turn\`: regression test covering all four variants (signed thinking, unsigned thinking, redacted with data, redacted without data) on the latest assistant message
- Added \`test_thinking_stripped_from_non_latest_but_preserved_on_latest\`: confirms the non-latest strip path (elif branch) still works correctly alongside the new pass-through behavior
- \`pytest tests/agent/test_anthropic_adapter.py -k "thinking or reasoning_config"\` — 19/19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)