### PR TITLE
fix(doctor): use x-goog-api-key for Google generativelanguage endpoint

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1474,6 +1474,15 @@ def run_doctor(args):
             }
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
+            # Google's Generative Language API (generativelanguage.googleapis.com)
+            # rejects ``Authorization: Bearer <api-key>`` with 401
+            # ``ACCESS_TOKEN_TYPE_UNSUPPORTED`` — that header is reserved for
+            # OAuth 2 access tokens, not plain API keys. Plain keys use
+            # ``x-goog-api-key`` (or ``?key=``). Without this, a perfectly valid
+            # GOOGLE_API_KEY/GEMINI_API_KEY always shows red in ``hermes doctor``.
+            if url and base_url_host_matches(url, "generativelanguage.googleapis.com"):
+                headers.pop("Authorization", None)
+                headers["x-goog-api-key"] = key
             r = httpx.get(url, headers=headers, timeout=10)
             if (
                 pname == "Alibaba/DashScope"


### PR DESCRIPTION
## Summary

`hermes doctor` reports a valid `GOOGLE_API_KEY` / `GEMINI_API_KEY` as **"invalid API key"** with the hint *"Check GOOGLE_API_KEY in .env"*, even when the key works perfectly at runtime. The generic API-key probe sends `Authorization: Bearer <key>`, but Google's Generative Language API doesn't accept that header for plain API keys — it's reserved for OAuth 2 access tokens. The runtime path uses the correct auth scheme, so only the doctor check is affected.

## Reproduction

1. Set a valid `GOOGLE_API_KEY` (e.g. from https://aistudio.google.com/app/apikey) on a project where the Gemini API is enabled.
2. Confirm runtime works: any Hermes call against Gemini succeeds.
3. Run `hermes doctor`.

**Expected:** ✓ Google / Gemini
**Actual:** ✗ Google / Gemini (invalid API key) → "Check GOOGLE_API_KEY in .env"

## Root cause

In `hermes_cli/doctor.py`, `_probe_apikey_provider` sends:

```python
headers = {
    "Authorization": f"Bearer {key}",
    ...
}
```

Google's response:

```
HTTP 401
"Request had invalid authentication credentials. Expected OAuth 2 access
token, login cookie or other valid authentication credential."
reason: ACCESS_TOKEN_TYPE_UNSUPPORTED
service: generativelanguage.googleapis.com
```

Plain API keys for `generativelanguage.googleapis.com` must be sent via `?key=<key>` or the `x-goog-api-key` header. The `Authorization: Bearer` header is reserved for OAuth 2 access tokens, and Google explicitly rejects API keys sent that way.

## Fix

Mirror the existing `api.kimi.com` special-case directly above: after computing `url`, detect when the host is `generativelanguage.googleapis.com` and swap `Authorization: Bearer` for `x-goog-api-key`. `base_url_host_matches` is already imported and used a few lines up.

Matches against the final `url` (not just `base`), so it works for both `*_BASE_URL`-overridden setups and the default URL from the Gemini provider profile.

## Test plan

- [x] Locally: `hermes doctor` with a working `GOOGLE_API_KEY` now reports ✓ Google / Gemini.
- [x] Verified the live `Authorization: Bearer <key>` request returns 401 `ACCESS_TOKEN_TYPE_UNSUPPORTED`, while the same key with `x-goog-api-key` returns 200 + model list.
- [ ] CI green.