### PR TITLE
feat(image-gen): add provider edit contract

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -142,6 +142,44 @@ class ImageGenProvider(abc.ABC):
         should ignore unknown keys.
         """
 
+    def supports_edit(self) -> bool:
+        """Return True when this backend supports prompt-guided image editing."""
+        return False
+
+    def edit(
+        self,
+        prompt: str,
+        images: List[str] | None = None,
+        *,
+        image: str | None = None,
+        mask: str | None = None,
+        aspect_ratio: str | None = DEFAULT_ASPECT_RATIO,
+        size: str | None = None,
+        model: str | None = None,
+        quality_tier: str | None = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Edit one or more existing images.
+
+        Providers that support image-to-image should override this and return
+        the same uniform response shape as :meth:`generate`. ``images`` is the
+        canonical ordered list of reference inputs; ``image`` is a legacy
+        single-reference alias kept for call-site compatibility. Providers that
+        support both should merge ``image`` ahead of/into ``images`` according to
+        their API's ordering semantics. The default is a structured unsupported
+        response so existing generate-only providers do not need to implement an
+        edit method and unknown future keyword arguments are safely ignored.
+        """
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        return error_response(
+            error=f"Image provider '{self.name}' does not support image editing",
+            error_type="unsupported",
+            provider=self.name,
+            model=model or "",
+            prompt=str(prompt or ""),
+            aspect_ratio=aspect,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/agent/test_image_gen_provider_edit_contract.py
+++ b/tests/agent/test_image_gen_provider_edit_contract.py
@@ -1,0 +1,90 @@
+"""Tests for the base image generation provider edit contract."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agent.image_gen_provider import ImageGenProvider
+
+
+class GenerateOnlyProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "generate_only"
+
+    def generate(self, prompt: str, aspect_ratio: str = "landscape", **kwargs: Any) -> Dict[str, Any]:
+        return {"success": True, "prompt": prompt, "aspect_ratio": aspect_ratio}
+
+
+def test_generate_only_provider_can_instantiate_without_edit_override():
+    provider = GenerateOnlyProvider()
+
+    assert provider.name == "generate_only"
+    assert provider.supports_edit() is False
+
+
+def test_default_edit_returns_structured_unsupported_response():
+    provider = GenerateOnlyProvider()
+
+    result = provider.edit(
+        "make it brighter",
+        images=["https://example.test/source.png"],
+        image="https://example.test/alias.png",
+        mask="https://example.test/mask.png",
+        aspect_ratio="square",
+        model="future-model",
+        quality_tier="high",
+        ignored_future_kwarg=True,
+    )
+
+    assert result["success"] is False
+    assert result["image"] is None
+    assert result["error_type"] == "unsupported"
+    assert "does not support image editing" in result["error"]
+    assert result["provider"] == "generate_only"
+    assert result["prompt"] == "make it brighter"
+    assert result["aspect_ratio"] == "square"
+    assert result["model"] == "future-model"
+
+
+def test_default_edit_clamps_invalid_aspect_ratio():
+    result = GenerateOnlyProvider().edit("prompt", image="source", aspect_ratio="wide")
+
+    assert result["aspect_ratio"] == "landscape"
+
+
+def test_default_edit_accepts_no_reference_images():
+    result = GenerateOnlyProvider().edit("prompt")
+
+    assert result["success"] is False
+    assert result["error_type"] == "unsupported"
+    assert result["model"] == ""
+
+
+def test_default_edit_accepts_none_and_empty_edge_values():
+    result = GenerateOnlyProvider().edit(
+        "prompt",
+        images=None,
+        image=None,
+        mask=None,
+        aspect_ratio="",
+        model=None,
+        quality_tier=None,
+        ignored_future_kwarg=None,
+    )
+
+    assert result["success"] is False
+    assert result["aspect_ratio"] == "landscape"
+    assert result["model"] == ""
+
+
+def test_default_edit_accepts_empty_images_and_extra_kwargs():
+    result = GenerateOnlyProvider().edit(
+        "prompt",
+        images=[],
+        aspect_ratio=None,
+        nested_future_kwarg={"x": object()},
+    )
+
+    assert result["success"] is False
+    assert result["aspect_ratio"] == "landscape"


### PR DESCRIPTION
## Summary
- Adds an explicit image-edit capability contract to `ImageGenProvider`.
- Default providers remain generate-only: `supports_edit()` returns `False` and `edit()` returns a structured unsupported response.
- Provider implementations can opt in by overriding `supports_edit()` / `edit()` without changing image generation behavior.

## Relationship
- Layer 1 of the image-edit split: shared provider edit contract only.
- Logical review order: #26967 → #26968 → #40491 → #40498.
- These PRs are intentionally related but not GitHub-stacked; each targets `main` so CI remains independent.
- Validation, concrete providers, and tool registration are kept in later PRs to reduce review scope.

## Testing
- `venv/bin/python -m py_compile agent/image_gen_provider.py tests/agent/test_image_gen_provider_edit_contract.py`
- `venv/bin/python -m pytest tests/agent/test_image_gen_provider_edit_contract.py -q -o 'addopts='`
- `git diff --check`
