### PR TITLE
fix: detect launchd service via print fallback

### DIFF
--- a/.omc/plans/hermes-monolith-split-2026-05-20.md
+++ b/.omc/plans/hermes-monolith-split-2026-05-20.md
@@ -1,0 +1,307 @@
+# Hermes Monolith Split — Plan v2 (post upstream-sync)
+
+**Date**: 2026-05-20
+**Author**: minsu (jbn7660-hash)
+**Versions**:
+- v0 = initial draft (superseded; 3 monolith focus, false 5K LOC promise)
+- v1 = post plan-gate Critic + Codex review (superseded; same monolith set)
+- **v2 = THIS revision** — `run_agent.py` phase **dropped** after discovering upstream already split it on 2026-05-16 (HEAD `5e743559e`). Sibling work: fork sync completed on `minsu/launchd-status-fallback` (HEAD now `25c09ec0c`), uncommitted work preserved in stash `stash@{0}` + diff `/tmp/uncommitted-2026-05-20-snapshot-tracked.diff` + branch ref `backup/minsu-launchd-status-fallback-2026-05-20-pre-sync`. PR #1 (`chore/docs-context-guard`) updated with `4c73eb4a1` reflecting new upstream layout.
+
+**Trigger**: GPT-5.5 (256k) compact loops on hermes-agent fork builds, caused by ~14-18k LOC single files.
+
+---
+
+## What upstream already did (May 2026, do NOT redo)
+
+Upstream NousResearch extracted run_agent.py from ~16,500 → 4,137 LOC across these commits between fork merge-base `f3a4af9cf` and origin HEAD `5e743559e`:
+
+```
+9f408989c refactor(run_agent): extract __init__ (1,381 LOC) to agent/agent_init.py
+94c3e0ab8 refactor(run_agent): extract 10 more helpers to agent/agent_runtime_helpers.py
+053025238 refactor(run_agent): extract run_conversation to agent/conversation_loop.py
+47823790b refactor(run_agent): review fixes — keyword-forward __init__, drop dead code, tighten guards
+b07524e53 feat(xai-oauth): port to extracted modules
+27df24956 feat(nvidia): port to extracted modules
+fe4c87eb2 fix(agent): port to extracted modules
+…
+```
+
+New `agent/*` modules in origin/main:
+
+| Module | LOC | Role |
+|---|---|---|
+| `run_agent.py` | 4,137 | `AIAgent` class shell + `main()` |
+| `agent/agent_init.py` | 1,510 | constructor body |
+| `agent/conversation_loop.py` | 4,099 | `run_conversation` |
+| `agent/agent_runtime_helpers.py` | 2,158 | 10 helpers |
+| `agent/chat_completion_helpers.py` | 2,078 | per-provider chat call helpers |
+| `agent/conversation_compression.py` | 605 | summarize-and-trim |
+| `agent/codex_runtime.py` | 448 | Codex Responses adapter |
+| `agent/iteration_budget.py` | 62 | `IterationBudget` (exactly what v1's plan called `agent/_helpers/budget.py`) |
+
+**Phase 2 of plan v0/v1 (run_agent.py split) is fully discharged by upstream.** Removed from this plan.
+
+## Remaining monolith targets (still need our work)
+
+origin/main HEAD `5e743559e`:
+
+| File | LOC | 256k % | Notes |
+|---|---|---|---|
+| `gateway/run.py` | 18,205 | 89% | grew slightly from v1 era; still single `GatewayRunner` god class |
+| `cli.py` | 14,518 | 71% | unchanged in structure |
+| `hermes_cli/main.py` | 13,233 | 65% | grew; argparse + CLI bootstrap |
+
+These three remain in scope. Upstream has NOT split them.
+
+## Honest framing — what each phase actually achieves
+
+| Phase | Target | LOC delta (realistic) | Note |
+|---|---|---|---|
+| Phase 0 | Prereq scaffolding | n/a | audit + parity tests, no monolith edit |
+| Phase 1 | `gateway/run.py` | ~700-900 LOC extracted | preparation for eventual god-class mixin split |
+| Phase 2 | `cli.py` | ~1,500-1,800 LOC extracted | cli.py is mostly function-level; largest single-phase delta |
+| Phase 3 | `hermes_cli/main.py` | ~600-1,000 LOC extracted | argparse + setup wizard mostly modular already |
+| Phase 4 | God-class mixin split (3 classes) | deferred to separate plan | only after Phases 1-3 stable for 14+ days |
+
+**Phase 1-3 reduce each monolith by ~5-12%.** That is NOT the compact-loop solution by itself — the compact-loop fix already landed via PR #1 docs split + the "NEVER full-read" guards in AGENTS.md. Phases 1-3 are prep for Phase 4.
+
+If you accept that framing, continue. If you want a 70%+ LOC reduction now, only Phase 4 delivers it and Phase 4 is high-risk on god-class extraction.
+
+---
+
+## Goal
+
+Reduce each remaining monolith by extracting module-level helper functions into focused `_helpers/` sub-packages, without behavioral change, without prompt-cache invalidation, and with mandatory re-export shims so external consumers (tests, plugins, tui_gateway, cron, tools) keep working.
+
+## Non-goals
+
+- No behavior change. No new features.
+- No prompt-cache key change.
+- No directory restructure outside the 3 monolith files' own packages.
+- `run_agent.py` / `agent/*` — already handled by upstream, out of scope.
+- Plugin / skill / website modification.
+
+## Mandatory prerequisites (BLOCKING — Phase 1 cannot start until done)
+
+Same five from v1 (P0 module-global audit, P1 re-export shim, P2 cross-monolith import audit, P3 prompt-cache parity test, P4 module-init snapshot test, P5 phantom doc references), refocused on the 3 remaining monoliths:
+
+| Item | Status | Notes |
+|---|---|---|
+| `scripts/audit_module_globals.py` | DONE (Phase 0 partial) | check works on `gateway/run.py`, `cli.py`, `hermes_cli/main.py` |
+| `scripts/audit_external_imports.py` | DONE (Phase 0 partial) | re-run against new origin/main consumer base |
+| `scripts/lint_monolith_growth.py` | DONE (Phase 0 partial) | baseline `.monolith_baseline.json` needs regeneration against origin/main (the existing baseline has `run_agent.py: 4 functions` from outdated worktree — correct for upstream main but confirm) |
+| `tests/agent/test_prompt_cache_stability.py` | DONE (Phase 0 partial) | verify it runs against the new agent/* layout (may need import path updates) |
+| `tests/refactor/test_module_init_snapshot.py` | **MISSING** — executor dropped this | finish in this session |
+
+## Phase 0 — finish prerequisite scaffolding
+
+| Deliverable | Status |
+|---|---|
+| `scripts/audit_module_globals.py` | ✓ |
+| `scripts/audit_external_imports.py` | ✓ |
+| `scripts/lint_monolith_growth.py` + baseline.json | ✓ (baseline matches origin/main) |
+| `tests/agent/test_prompt_cache_stability.py` | ✓ (needs verification against new agent/* layout) |
+| `tests/refactor/test_module_init_snapshot.py` | ✗ MISSING |
+| `tests/refactor/__init__.py` | ✓ |
+| `tests/refactor/fixtures/.gitkeep` | ✓ |
+| Commit & push | not yet |
+
+**Action**: write `test_module_init_snapshot.py` per the spec in this plan's Phase 0 section, run both parity tests with `--update-fixtures`, then re-run them clean. Commit. Push to fork. Open PR #2.
+
+## Phase 1 — `gateway/run.py` (~18,200 LOC)
+
+Same shape as v1 Phase 1, plus re-audit because origin/main is at HEAD `5e743559e`, ~1,100 LOC larger than v1's reference snapshot:
+
+1. Re-run `scripts/audit_module_globals.py gateway/run.py` to enumerate every cross-boundary module global.
+2. Re-run `scripts/audit_external_imports.py gateway.run` to enumerate every consumer importing from `gateway.run` directly. Mandatory re-export list.
+3. Build candidate file list (`gateway/_helpers/<topic>.py` per topic — text / time / replay / ssl / env / skills / session / cfg, exact mapping per audit output).
+4. Two-commit PR (copy + delete+wire).
+
+## Phase 2 — `cli.py` (~14,500 LOC)
+
+Same audit-then-extract pattern. cli.py is mostly module-level functions already, so it has the largest extraction potential. Already known sub-targets (subject to audit):
+
+- text/strip helpers (`_strip_reasoning_tags`, etc.)
+- `load_cli_config` (~425 LOC; imported by `tui_gateway/server.py`)
+- worktree helpers
+- color/skin helpers
+- output history
+- `_run_cleanup` — **stays in cli.py** (per v1 C2: entangled with `_cleanup_done` + `_active_agent_ref`).
+
+## Phase 3 — `hermes_cli/main.py` (~13,200 LOC)
+
+This was Non-goals in v1; promoted to Phase 3 in v2 because (a) the 3 remaining monoliths are now the entire workload, (b) Phase 4 god-class split needs main.py reduced too.
+
+Largest extraction candidates (per a quick scan of v1's analysis):
+- subcommand handler functions (argparse-tree entries)
+- profile resolution helpers
+- setup wizard sub-routines
+
+Audit-then-extract, same as Phases 1 and 2.
+
+## Phase 4 — God-class mixin split (DEFERRED)
+
+`GatewayRunner` / `HermesCLI` (and the now-empty-ish `AIAgent` shell on origin/main) → mixin split. Plan separately after Phases 1-3 stable for 14+ days.
+
+---
+
+## Per-PR mechanics (unchanged from v1)
+
+- Two commits per PR: (1) copy moved code into new file, monolith untouched; (2) delete from monolith + import + re-export shim.
+- Re-export shims are mandatory and live for the lifetime of at least one minor version.
+- Each PR description links the `audit_module_globals.py` + `audit_external_imports.py` output captured before extraction.
+
+## Acceptance (per phase)
+
+Unchanged from v1. The `<= 5,000 LOC` per-file target is reserved for Phase 4 — Phases 1-3 acceptance is "audit + parity tests green, helpers extracted with re-export shims intact, two-commit reviewability proven."
+
+## Risks (unchanged from v1, plus one new entry)
+
+| Risk | Mitigation |
+|---|---|
+| (v1's 9 risks — module globals, re-exports, prompt cache, init order, circular imports, squash hazards, plugin monkey-patches, naming bikeshed, growth lint) | (v1's mitigations) |
+| **NEW: fork divergence from upstream** | Pin upstream sync as a precondition at the start of each phase. Run `git fetch origin main && git merge-base --is-ancestor HEAD origin/main` — if false, abort the phase, do the sync first, regenerate baselines. |
+| **NEW: stashed user work `stash@{0}` may conflict with phase changes** | User to drain `stash@{0}` (apply + resolve conflicts against new run_agent.py / gateway/run.py / etc.) BEFORE Phase 1 PR opens. If stash is irrelevant to phase scope, can defer indefinitely. Diff captured at `/tmp/uncommitted-2026-05-20-snapshot-tracked.diff`. |
+
+## Orchestration
+
+- Worktree per phase, branched off latest origin/main, rebased onto origin/main before opening PR.
+- One PR per phase, two commits per PR, sequential merging with ≥ one full CI cycle + 48h dogfood between phases.
+- Rollback procedure: revert merge, do NOT cherry-pick fixups.
+
+## Codex 5.5 external gate
+
+- Plan-gate: this v2 should be re-fired through `codex-consult` because v1 was reviewed against a different target set (run_agent.py included; that's now removed). Cost is small; v2 is mostly a delta over v1.
+- Diff-gate: each phase PR before merge.
+
+## Timeline (revised honest)
+
+| Phase | Effort | Wall time |
+|---|---|---|
+| Phase 0 finish (`test_module_init_snapshot.py` + commits + PR) | 1-2h | same day |
+| Plan-gate Codex revisit on v2 (optional) | 1h | same day |
+| Phase 1 (gateway helpers) | 5-7h | 2-3 days |
+| Phase 2 (cli helpers) | 7-10h | 3-4 days |
+| Phase 3 (hermes_cli/main.py helpers) | 5-8h | 2-3 days |
+| Phase 4 (god-class mixin split) | 15-25h | separate sprint, plan again |
+
+**Phases 0-3 total**: ~20-27h focused work, ~10-15 calendar days incl. review + 48h dogfood per phase.
+
+---
+
+## User work parking (stash)
+
+Before fork upstream sync, the following was preserved:
+
+- `stash@{0}` "pre-upstream-sync-2026-05-20: 8 modified + 4 new tool/test files + img/dir artifacts"
+  - 8 modified: `agent/context_compressor.py`, `gateway/run.py` (26 LOC), `hermes_cli/config.py`, `run_agent.py` (130 LOC), `tests/agent/test_context_compressor.py`, `tests/run_agent/test_run_agent.py`, `toolsets.py`, `website/docs/user-guide/configuration.md`
+  - 4 new: `agent/context_rollover.py`, `tests/agent/test_context_rollover.py`, `tools/external_llm_tools.py`, `tests/tools/test_external_llm_tools.py`
+  - Plus dir artifacts: `.omc/`, `.playwright-mcp/`, `memory/`, `stitch_mcid/`, several `mcid_*.png`
+- Branch ref backup: `backup/minsu-launchd-status-fallback-2026-05-20-pre-sync`
+- Diff snapshot file: `/tmp/uncommitted-2026-05-20-snapshot-tracked.diff` (518 lines)
+- Status snapshot file: `/tmp/uncommitted-2026-05-20-status.txt`
+
+**Resolution path** (user discretion):
+- The `run_agent.py` 130-LOC stashed change is now against a file that is ~12k LOC smaller. The stashed diff almost certainly references hunks that no longer exist or have moved into `agent/*`. Likely outcomes: (a) the work was already done upstream — drop the stash, (b) the work was unique — recreate on top of the new layout, (c) hybrid — partial cherry-pick.
+- Recommended: `git stash show -p stash@{0} > /tmp/stash-2026-05-20-snapshot.diff`, then for each modified file, eyeball the hunks against current origin/main to decide. Don't attempt `git stash pop` blindly — conflicts on `run_agent.py` will be severe.
+
+---
+
+## Status
+
+- [x] v0 → v1 (Critic + Codex plan-gate revisions)
+- [x] v1 → v2 (post upstream-sync discovery; run_agent.py phase dropped; user fork synced to origin/main; PR #1 docs commit `4c73eb4a1` reflects new layout)
+- [ ] Phase 0 — finish `test_module_init_snapshot.py`
+- [ ] Phase 0 — commit + push + PR #2
+- [ ] Plan-gate Codex revisit on v2 (optional)
+- [ ] User: drain or accept `stash@{0}` 
+- [ ] Phase 1 PR opened (gateway/run.py)
+- [ ] Phase 1 merged + 48h dogfood
+- [ ] Phase 2 PR opened (cli.py)
+- [ ] Phase 2 merged + 48h dogfood
+- [ ] Phase 3 PR opened (hermes_cli/main.py)
+- [ ] Phase 3 merged + 48h dogfood
+- [ ] Phase 4 plan v0 written
+
+## v1 → v2 change ledger
+
+| Change | Reason |
+|---|---|
+| Dropped Phase 2 (run_agent.py extraction) | Upstream did it 2026-05-16; we'd be duplicating ~12k LOC of refactoring |
+| Promoted `hermes_cli/main.py` from Non-goals to Phase 3 | Remaining monolith set shrank from 4 to 3; main.py is the natural third target |
+| Phase numbering | v1 Phase 1 (gateway) stays Phase 1; v1 Phase 3 (cli) becomes Phase 2; new Phase 3 (main.py) |
+| New prerequisite: fork must be synced to upstream before each phase starts | Fork was 589 commits behind on 2026-05-20; this is now a real failure mode |
+| Added stash management section | User uncommitted work needs explicit resolution path before phase work begins |
+| LOC table updated to origin/main HEAD `5e743559e` snapshot | v1 numbers were against the user's old HEAD |
+| Phase 0 partial completion acknowledged | Executor dropped `test_module_init_snapshot.py`; track it explicitly |
+| Codex/Critic plan-gate findings preserved | All v1 P0/P1/M1-M5 remain valid for the 3 remaining monoliths |
+
+---
+
+## v2 → v3 addendum (Codex 5.5 v2 plan-gate revisit, GO with conditions)
+
+Plan-gate Codex 5.5 ran a second time against v2 (`/tmp/codex-plan-hermes-monolith-split-v2-2026-05-20.md`). **Verdict: GO** — v1 → v2 delta is sound, dropping `run_agent.py` phase is justified. **One P0 blocker + five P1 + one P2** to fold in before Phase 1 PR opens.
+
+### CDX-V2-P0 — Stash hunks intersect Phase 1 target (`gateway/run.py`)
+
+The preserved user uncommitted work touches `gateway/run.py` (Phase 1's target). Auditing each hunk is **mandatory** before Phase 1.
+
+**Status: AUDITED 2026-05-20.** Pure stash hunks isolated against the wip-branch base:
+
+- `gateway/run.py` (50 diff lines, two distinct intents):
+  1. **launchd service detection** at `GatewayRunner` ~L8956 — extends `_under_service` from systemd-only (`INVOCATION_ID`) to also recognize launchd (`LAUNCH_JOBKEY_LABEL`, `XPC_SERVICE_NAME`). User's macOS gateway fix.
+  2. **`last_prompt_tokens` hydration** at `GatewayRunner` ~L15689 — pre-loop seeding of `context_compressor.last_prompt_tokens` from persisted `SessionEntry` on fresh agent construction. User's rollover-preflight correctness fix.
+- `run_agent.py` (164 diff lines, two distinct intents):
+  1. **`ContextRolloverConfig` load** at `AIAgent.__init__` ~L2368 — wires the new `agent/context_rollover.py` module's config object into the agent. **After upstream split, this hunk belongs in `agent/agent_init.py`, not `run_agent.py`.** Replay needs manual placement.
+  2. **Compression-summary warning text** at ~L10713 — `"Inserted a fallback context marker."` → `"Inserted a deterministic extractive fallback summary."`. **After upstream split, this hunk belongs in `agent/conversation_loop.py` or `agent/conversation_compression.py`** (which one — check during replay).
+
+Plus net-new files (untracked, no replay conflict): `agent/context_rollover.py`, `tests/agent/test_context_rollover.py`, `tools/external_llm_tools.py`, `tests/tools/test_external_llm_tools.py`.
+
+Plus modified files that replay clean against new origin/main (no upstream split): `agent/context_compressor.py`, `hermes_cli/config.py`, `tests/agent/test_context_compressor.py`, `tests/run_agent/test_run_agent.py`, `toolsets.py`, `website/docs/user-guide/configuration.md`.
+
+**Phase 1 unblock condition**: user must replay the `gateway/run.py` launchd-detect + hydration hunks onto current origin/main (line numbers will shift; intent transfers cleanly), commit them on `minsu/launchd-status-fallback` or a successor branch. Replay is **user-driven** — automation would risk dropping intent.
+
+Snapshots preserved at:
+- `/tmp/wip-stash-gateway-run-pure-2026-05-20.diff` (50 lines, gateway hunks only)
+- `/tmp/wip-stash-run-agent-pure-2026-05-20.diff` (164 lines, run_agent hunks only)
+- `/tmp/uncommitted-2026-05-20-snapshot-tracked.diff` (518 lines, all 8 modified files)
+- Branch `wip/stash-2026-05-20-uncommitted` (working tree carries the full applied stash)
+
+### CDX-V2-P1-1 — Retire stale `run_agent.py` gates
+
+Plan v2 still references `run_agent.py` in Risk + Acceptance + Per-PR mechanics. Sweep the body so no audit step blocks on a file that's already split upstream.
+
+**Status**: tracked; plan body sweep deferred (informational drift, not execution drift).
+
+### CDX-V2-P1-2 — Expand init-snapshot to new `agent/*` modules
+
+After the upstream split, the behaviorally-loaded imports moved to `agent/agent_init.py`, `agent/conversation_loop.py`, `agent/agent_runtime_helpers.py`. Snapshot those too.
+
+**Status: DONE** — `MONOLITHS` list in `tests/refactor/test_module_init_snapshot.py` extended; baseline regenerated and verified.
+
+### CDX-V2-P1-3 — Pre-Phase-3 mini-audit for `hermes_cli/main.py`
+
+Phase 3 acceptance must require the `audit_module_globals.py` + `audit_external_imports.py` output for `hermes_cli/main.py` to be attached to the Phase 3 PR description.
+
+### CDX-V2-P1-4 — Regenerate baselines post-sync
+
+**Status: DONE** — fixtures captured against post-sync layout (HEAD `5e743559e`), `5/5 passed` on no-flag re-run.
+
+### CDX-V2-P1-5 — Replace calendar-based Phase 4 readiness gate
+
+Plan v2 says "tests stay green for 2 weeks on main." Replace with concrete evidence: zero revert-tagged commits on `gateway/` / `agent/` / `hermes_cli/` paths since the prior phase merge, OR ≥ N consecutive green CI runs touching the extracted helpers.
+
+### CDX-V2-P2 — Move durable recovery state from `/tmp` into repo
+
+Move `/tmp/uncommitted-2026-05-20-*.diff` and recovery snapshots into `.omc/recovery/<topic>/<date>.diff` (or repo-relative equivalent) so they survive reboot. Non-blocking for Phase 1; do before Phase 3 ships.
+
+---
+
+## Action queue (post v3 addendum)
+
+1. **User**: replay `gateway/run.py` launchd-detect + hydration hunks onto current `origin/main`, commit on `minsu/launchd-status-fallback`. Unblocks Phase 1 audit.
+2. **User**: replay `run_agent.py` `ContextRolloverConfig` hunk onto `agent/agent_init.py`. Replay compression-summary warning hunk onto upstream's relocated emit site (likely `agent/conversation_loop.py` per upstream commit `053025238` — verify).
+3. **User**: replay 6 non-conflicting modified files (`context_compressor.py`, `hermes_cli/config.py`, `tests/agent/test_context_compressor.py`, `tests/run_agent/test_run_agent.py`, `toolsets.py`, `website/docs/user-guide/configuration.md`). Add 4 untracked new files (`agent/context_rollover.py`, `tests/agent/test_context_rollover.py`, `tools/external_llm_tools.py`, `tests/tools/test_external_llm_tools.py`). Commit.
+4. **Automation**: re-run `scripts/lint_monolith_growth.py` after user replay to confirm no new top-level funcs slipped into the monoliths.
+5. **Automation**: open Phase 1 PR (`gateway/run.py`).
+6. **Plan body cleanup** (CDX-V2-P1-1): sweep stale `run_agent.py` mentions into the "already-split" sub-block.

--- a/.omc/recovery/uncommitted-2026-05-20-snapshot-tracked.diff
+++ b/.omc/recovery/uncommitted-2026-05-20-snapshot-tracked.diff
@@ -1,0 +1,518 @@
+diff --git a/agent/context_compressor.py b/agent/context_compressor.py
+index e7a14faf5..a808c7626 100644
+--- a/agent/context_compressor.py
++++ b/agent/context_compressor.py
+@@ -763,6 +763,104 @@ class ContextCompressor(ContextEngine):
+ 
+         return "\n\n".join(parts)
+ 
++    def _build_extractive_fallback_summary(
++        self,
++        turns_to_summarize: List[Dict[str, Any]],
++        *,
++        dropped_count: int,
++        error_text: str,
++    ) -> str:
++        """Build a deterministic summary when the LLM summarizer is unavailable.
++
++        This is deliberately extractive rather than clever: preserve the most
++        recent user requests, assistant/tool actions, file paths, and command
++        snippets so compression failure degrades to a usable checkpoint instead
++        of a bare "context was lost" marker.  It never calls an LLM, so it works
++        during provider timeouts and keeps gateway turns moving.
++        """
++        serialized = self._serialize_for_summary(turns_to_summarize)
++        lines = [line.strip() for line in serialized.splitlines() if line.strip()]
++
++        latest_user = "None."
++        completed: list[str] = []
++        relevant_files: list[str] = []
++        critical: list[str] = []
++        file_pattern = re.compile(r"(?:(?:/|\./|~/)[\w.\-()/]+|[\w.\-()/]+\.(?:py|ts|tsx|js|jsx|json|ya?ml|md|toml|sh|txt))")
++        command_pattern = re.compile(r"`([^`]{3,160})`")
++
++        for line in lines:
++            if line.startswith("[USER]:"):
++                latest_user = line[len("[USER]:"):].strip() or latest_user
++            if line.startswith(("[ASSISTANT]:", "[TOOL RESULT")):
++                text = line
++                if len(text) > 280:
++                    text = text[:277].rstrip() + "..."
++                if text not in completed:
++                    completed.append(text)
++            for match in file_pattern.findall(line):
++                if match not in relevant_files:
++                    relevant_files.append(match)
++            for match in command_pattern.findall(line):
++                item = f"Command seen: `{match}`"
++                if item not in critical:
++                    critical.append(item)
++
++        recent_lines = lines[-12:]
++        recent = []
++        for line in recent_lines:
++            if len(line) > 320:
++                line = line[:317].rstrip() + "..."
++            recent.append(f"- {line}")
++
++        completed_block = "\n".join(
++            f"{idx}. {item}" for idx, item in enumerate(completed[-12:], start=1)
++        ) or "None captured."
++        files_block = "\n".join(f"- {item}" for item in relevant_files[:30]) or "None captured."
++        critical_block = "\n".join(f"- {item}" for item in critical[:20]) or "None captured."
++        recent_block = "\n".join(recent) or "- No recoverable text captured."
++
++        return self._with_summary_prefix(redact_sensitive_text(f"""## Active Task
++{latest_user}
++
++## Goal
++Continue the latest user request using the remaining live transcript and current filesystem/state. This checkpoint was generated locally because the LLM compression summarizer failed.
++
++## Constraints & Preferences
++Preserve user preferences from the system prompt and persistent memory. Treat this extractive summary as incomplete but authoritative for the dropped turns it quotes.
++
++## Completed Actions
++{completed_block}
++
++## Active State
++Compression fallback used after dropping {dropped_count} message(s). Summarizer error: {error_text or 'unknown'}.
++
++## In Progress
++Resume from the latest user request and the recent live tail after this summary.
++
++## Blocked
++LLM context summary generation failed; Hermes used deterministic extractive fallback instead of a bare context-loss marker.
++
++## Key Decisions
++None inferred by fallback summarizer.
++
++## Resolved Questions
++Unknown — fallback summarizer preserves excerpts only.
++
++## Pending User Asks
++{latest_user}
++
++## Relevant Files
++{files_block}
++
++## Remaining Work
++Inspect current repository/session state as needed, then continue without relying on dropped raw turns.
++
++## Critical Context
++{critical_block}
++
++## Recent Dropped-Turn Excerpts
++{recent_block}"""))
++
+     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
+         """Switch from a separate ``summary_model`` back to the main model.
+ 
+@@ -1494,12 +1592,11 @@ The user has requested that this compaction PRIORITISE preserving all informatio
+             n_dropped = compress_end - compress_start
+             self._last_summary_dropped_count = n_dropped
+             self._last_summary_fallback_used = True
+-            summary = (
+-                f"{SUMMARY_PREFIX}\n"
+-                f"Summary generation was unavailable. {n_dropped} message(s) were "
+-                f"removed to free context space but could not be summarized. The removed "
+-                f"messages contained earlier work in this session. Continue based on the "
+-                f"recent messages below and the current state of any files or resources."
++            err_text = getattr(self, "_last_summary_error", None) or "unknown error"
++            summary = self._build_extractive_fallback_summary(
++                turns_to_summarize,
++                dropped_count=n_dropped,
++                error_text=err_text,
+             )
+ 
+         _merge_summary_into_tail = False
+diff --git a/gateway/run.py b/gateway/run.py
+index f9a282a41..c6472961a 100644
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -8956,9 +8956,14 @@ class GatewayRunner:
+         # When running under a service manager (systemd/launchd), use the
+         # service restart path: exit with code 75 so the service manager
+         # restarts us.  The detached subprocess approach (setsid + bash)
+-        # doesn't work under systemd because KillMode=mixed kills all
+-        # processes in the cgroup, including the detached helper.
+-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
++        # is fragile under service managers: systemd may kill the whole
++        # cgroup, while launchd may leave the job unloaded if shutdown and
++        # bootstrap race each other.  Detect both managers explicitly.
++        _under_service = bool(
++            os.environ.get("INVOCATION_ID")  # systemd
++            or os.environ.get("LAUNCH_JOBKEY_LABEL")  # launchd
++            or os.environ.get("XPC_SERVICE_NAME")  # launchd
++        )
+         if _under_service:
+             self.request_restart(detached=False, via_service=True)
+         else:
+@@ -15684,6 +15689,27 @@ class GatewayRunner:
+             _approval_session_token = set_current_session_key(_approval_session_key)
+             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+             try:
++                # Hydrate last prompt-token usage from the gateway session entry
++                # before run_conversation() performs context-rollover preflight.
++                # Gateway agents can be freshly constructed on cache miss,
++                # config-signature change, or gateway restart; in those cases the
++                # in-memory ContextCompressor starts at last_prompt_tokens=0 even
++                # though SessionEntry persisted the previous API-reported prompt
++                # size.  Without this, fresh_subagent rollover silently falls
++                # back to a rough estimate and can miss high-context Slack
++                # thread turns that should be delegated.
++                try:
++                    _stored_entry = self.session_store._entries.get(session_key) if session_key else None
++                    _stored_prompt_tokens = int(getattr(_stored_entry, "last_prompt_tokens", 0) or 0)
++                    if _stored_prompt_tokens > 0 and hasattr(agent, "context_compressor"):
++                        _current_prompt_tokens = int(
++                            getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0
++                        )
++                        if _current_prompt_tokens <= 0:
++                            agent.context_compressor.last_prompt_tokens = _stored_prompt_tokens
++                except Exception as _hydrate_err:
++                    logger.debug("last_prompt_tokens hydration skipped: %s", _hydrate_err)
++
+                 # If _prepare_inbound_message_text buffered image paths for native
+                 # attachment, wrap the user turn as an OpenAI-style multimodal
+                 # content list. Consume-and-clear so subsequent turns on the same
+diff --git a/hermes_cli/config.py b/hermes_cli/config.py
+index 574f2397d..fb6d89c28 100644
+--- a/hermes_cli/config.py
++++ b/hermes_cli/config.py
+@@ -773,6 +773,15 @@ DEFAULT_CONFIG = {
+                                       # system prompt + rolling summary + recent tail.
+     },
+ 
++    "context_rollover": {
++        "enabled": False,             # when true, nudge large sessions to delegate long work to a fresh child
++        "warn_threshold": 0.30,       # reserved for status/UI warnings
++        "rollover_threshold": 0.40,   # inject fresh-session handoff at this context usage ratio
++        "hard_threshold": 0.60,       # reserved for future force-rollover policies
++        "mode": "fresh_subagent",    # fresh_subagent | compress_only
++        "max_handoff_messages": 12,   # recent transcript tail included in handoff prompt
++    },
++
+     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
+     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+     "prompt_caching": {
+diff --git a/run_agent.py b/run_agent.py
+index 1dd4219b2..68a53441a 100644
+--- a/run_agent.py
++++ b/run_agent.py
+@@ -2368,6 +2368,24 @@ class AIAgent:
+             )
+         self.compression_enabled = compression_enabled
+ 
++        try:
++            from agent.context_rollover import ContextRolloverConfig
++            _rollover_cfg_raw = {}
++            if isinstance(_agent_cfg, dict):
++                # ``context_rollover`` is a top-level config section.  Older
++                # experimental builds briefly looked under ``agent``; keep that
++                # as a fallback so profile-local configs from that window still
++                # work, but prefer the documented location.
++                _rollover_cfg_raw = _agent_cfg.get("context_rollover")
++                if not isinstance(_rollover_cfg_raw, dict):
++                    _rollover_cfg_raw = (_agent_cfg.get("agent", {}) or {}).get("context_rollover", {})
++            self.context_rollover_config = ContextRolloverConfig.from_mapping(
++                _rollover_cfg_raw if isinstance(_rollover_cfg_raw, dict) else {}
++            )
++        except Exception as _rollover_cfg_err:
++            logger.warning("Context rollover config ignored: %s", _rollover_cfg_err)
++            self.context_rollover_config = None
++
+         # Reject models whose context window is below the minimum required
+         # for reliable tool-calling workflows (64K tokens).
+         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+@@ -10695,7 +10713,7 @@ class AIAgent:
+                 self._last_compression_summary_warning = summary_error
+                 self._emit_warning(
+                     f"⚠ Compression summary failed: {summary_error}. "
+-                    "Inserted a fallback context marker."
++                    "Inserted a deterministic extractive fallback summary."
+                 )
+         else:
+             # No hard failure — but did the configured aux model error out
+@@ -10914,6 +10932,35 @@ class AIAgent:
+             parent_agent=self,
+         )
+ 
++    @staticmethod
++    def _format_forced_rollover_result(delegate_result: str) -> str:
++        """Turn a forced rollover delegate_task result into user-facing text.
++
++        Normal delegate_task calls feed JSON back to the parent model for
++        synthesis.  Forced rollover intentionally skips another parent-model
++        turn, so extract the child summary directly and fall back to the raw
++        result if the shape is unexpected.
++        """
++        try:
++            payload = json.loads(delegate_result or "{}")
++            if isinstance(payload, dict):
++                results = payload.get("results")
++                if isinstance(results, list) and results:
++                    first = results[0]
++                    if isinstance(first, dict):
++                        summary = first.get("summary") or first.get("final_response")
++                        if summary:
++                            return str(summary)
++                        error = first.get("error")
++                        if error:
++                            return f"Fresh-session delegation failed: {error}"
++                error = payload.get("error")
++                if error:
++                    return f"Fresh-session delegation failed: {error}"
++        except Exception:
++            pass
++        return str(delegate_result or "Fresh-session delegation completed without a summary.")
++
+     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
+                      tool_call_id: Optional[str] = None, messages: list = None,
+                      pre_tool_block_checked: bool = False) -> str:
+@@ -12305,6 +12352,89 @@ class AIAgent:
+         messages.append(user_msg)
+         current_turn_user_idx = len(messages) - 1
+         self._persist_user_message_idx = current_turn_user_idx
++
++        # Proactive context rollover: when the parent session is already large,
++        # force substantial continued work into a fresh delegate_task child
++        # instead of dragging the full parent transcript through more tool
++        # iterations.  The parent thread keeps continuity; the heavy work gets
++        # a clean child context.
++        _rollover_dispatch_started = False
++        try:
++            from agent.context_rollover import build_usage_snapshot, maybe_build_rollover_handoff
++
++            _rollover_cfg = getattr(self, "context_rollover_config", None)
++            _ctx_len = int(getattr(self.context_compressor, "context_length", 0) or 0)
++            _last_prompt = int(getattr(self.context_compressor, "last_prompt_tokens", 0) or 0)
++            if _last_prompt > 0:
++                _rollover_tokens = _last_prompt
++                _rollover_source = "actual"
++            else:
++                _rollover_tokens = estimate_request_tokens_rough(messages, tools=self.tools or None)
++                _rollover_source = "estimated"
++            _rollover_snapshot = build_usage_snapshot(
++                prompt_tokens=_rollover_tokens,
++                context_length=_ctx_len,
++                source=_rollover_source,
++            )
++            _rollover_handoff = maybe_build_rollover_handoff(
++                config=_rollover_cfg,
++                snapshot=_rollover_snapshot,
++                messages=messages,
++                user_message=user_message,
++                cwd=os.getcwd(),
++                valid_tool_names=getattr(self, "valid_tool_names", set()),
++            ) if _rollover_cfg else None
++            if _rollover_handoff:
++                # Rollover is a control-plane decision, not a suggestion to the
++                # model.  Older behavior appended a handoff prompt to the user
++                # message and hoped the model would call delegate_task; in busy
++                # gateway threads that often kept heavy work in the bloated
++                # parent session.  Force the fresh child session here before the
++                # next model call so thread continuity is preserved while tool
++                # work happens with a clean context.
++                if persist_user_message is None:
++                    self._persist_user_message_override = original_user_message
++                self._emit_status(
++                    f"↪ Context {(_rollover_snapshot.percent * 100):.0f}% — delegating to fresh session"
++                )
++                _rollover_dispatch_started = True
++                _delegate_result = self._dispatch_delegate_task({
++                    "goal": user_message,
++                    "context": _rollover_handoff,
++                })
++                final_response = self._format_forced_rollover_result(_delegate_result)
++                messages.append({"role": "assistant", "content": final_response})
++                self._persist_session(messages, conversation_history)
++                self._cleanup_task_resources(effective_task_id)
++                return {
++                    "final_response": final_response,
++                    "last_reasoning": None,
++                    "messages": messages,
++                    "api_calls": 0,
++                    "completed": True,
++                    "turn_exit_reason": "context_rollover_delegate",
++                    "partial": False,
++                    "interrupted": False,
++                    "model": self.model,
++                    "provider": self.provider,
++                    "base_url": self.base_url,
++                    "input_tokens": self.session_input_tokens,
++                    "output_tokens": self.session_output_tokens,
++                    "cache_read_tokens": self.session_cache_read_tokens,
++                    "cache_write_tokens": self.session_cache_write_tokens,
++                    "reasoning_tokens": self.session_reasoning_tokens,
++                    "prompt_tokens": self.session_prompt_tokens,
++                    "completion_tokens": self.session_completion_tokens,
++                    "total_tokens": self.session_total_tokens,
++                    "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
++                    "estimated_cost_usd": self.session_estimated_cost_usd,
++                    "cost_status": self.session_cost_status,
++                    "cost_source": self.session_cost_source,
++                }
++        except Exception as _rollover_err:
++            if _rollover_dispatch_started:
++                raise
++            logger.debug("Context rollover preflight skipped: %s", _rollover_err, exc_info=True)
+         
+         if not self.quiet_mode:
+             _print_preview = _summarize_user_message_for_log(user_message)
+diff --git a/tests/agent/test_context_compressor.py b/tests/agent/test_context_compressor.py
+index 559cf2237..e0e5b74d1 100644
+--- a/tests/agent/test_context_compressor.py
++++ b/tests/agent/test_context_compressor.py
+@@ -727,9 +727,9 @@ class TestSummaryFailureTrackingForGatewayWarning:
+         msgs = [
+             {"role": "system", "content": "sys"},
+             {"role": "user", "content": "msg 1"},
+-            {"role": "assistant", "content": "msg 2"},
+-            {"role": "user", "content": "msg 3"},
+-            {"role": "assistant", "content": "msg 4"},
++            {"role": "assistant", "content": "read `pytest tests/agent/test_context_compressor.py -q`"},
++            {"role": "tool", "content": "edited agent/context_compressor.py successfully"},
++            {"role": "user", "content": "please inspect agent/context_compressor.py and run `pytest tests/agent/test_context_compressor.py -q`"},
+             {"role": "user", "content": "msg 5"},
+             {"role": "assistant", "content": "msg 6"},
+             {"role": "user", "content": "msg 7"},
+@@ -743,11 +743,14 @@ class TestSummaryFailureTrackingForGatewayWarning:
+         assert c._last_summary_fallback_used is True
+         assert c._last_summary_dropped_count > 0
+         assert c._last_summary_error is not None
+-        # Result must still be well-formed (fallback summary present).
+-        assert any(
+-            isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
+-            for m in result
+-        )
++        # Result must still be well-formed (extractive fallback summary present).
++        summaries = [
++            m.get("content", "") for m in result
++            if isinstance(m.get("content"), str) and "Compression fallback used" in m["content"]
++        ]
++        assert summaries
++        assert "agent/context_compressor.py" in summaries[0]
++        assert "pytest tests/agent/test_context_compressor.py -q" in summaries[0]
+ 
+     def test_compress_clears_fallback_flag_on_subsequent_success(self):
+         mock_response = MagicMock()
+diff --git a/tests/run_agent/test_run_agent.py b/tests/run_agent/test_run_agent.py
+index cd62cd41d..4a39de456 100644
+--- a/tests/run_agent/test_run_agent.py
++++ b/tests/run_agent/test_run_agent.py
+@@ -2530,6 +2530,57 @@ class TestRunConversation:
+         assert result["final_response"] == "Final answer"
+         assert result["completed"] is True
+ 
++    def test_context_rollover_forces_fresh_subagent_for_large_long_task(self, agent):
++        from agent.context_rollover import ContextRolloverConfig
++
++        self._setup_agent(agent)
++        agent.valid_tool_names.add("delegate_task")
++        agent.context_rollover_config = ContextRolloverConfig.from_mapping({"enabled": True})
++        agent.context_compressor.context_length = 100_000
++        agent.context_compressor.last_prompt_tokens = 45_000
++        delegate_payload = '{"results":[{"status":"success","summary":"Delegated result"}]}'
++
++        with (
++            patch.object(agent, "_dispatch_delegate_task", return_value=delegate_payload) as mock_delegate,
++            patch.object(agent, "_persist_session") as mock_persist,
++            patch.object(agent, "_save_trajectory"),
++            patch.object(agent, "_cleanup_task_resources"),
++        ):
++            result = agent.run_conversation("fix the build and run tests")
++
++        assert result["final_response"] == "Delegated result"
++        assert result["turn_exit_reason"] == "context_rollover_delegate"
++        assert result["api_calls"] == 0
++        agent.client.chat.completions.create.assert_not_called()
++        delegate_args = mock_delegate.call_args.args[0]
++        assert delegate_args["goal"] == "fix the build and run tests"
++        assert "CONTEXT ROLLOVER HANDOFF" in delegate_args["context"]
++        assert "delegate_task" in delegate_args["context"]
++        persisted_messages = mock_persist.call_args.args[0]
++        assert persisted_messages[-1] == {"role": "assistant", "content": "Delegated result"}
++
++    def test_context_rollover_skips_short_reply_even_when_large(self, agent):
++        from agent.context_rollover import ContextRolloverConfig
++
++        self._setup_agent(agent)
++        agent.valid_tool_names.add("delegate_task")
++        agent.context_rollover_config = ContextRolloverConfig.from_mapping({"enabled": True})
++        agent.context_compressor.context_length = 100_000
++        agent.context_compressor.last_prompt_tokens = 45_000
++        resp = _mock_response(content="You're welcome", finish_reason="stop")
++        agent.client.chat.completions.create.return_value = resp
++
++        with (
++            patch.object(agent, "_persist_session"),
++            patch.object(agent, "_save_trajectory"),
++            patch.object(agent, "_cleanup_task_resources"),
++        ):
++            result = agent.run_conversation("thanks")
++
++        assert result["final_response"] == "You're welcome"
++        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
++        assert all("CONTEXT ROLLOVER HANDOFF" not in (m.get("content") or "") for m in sent_messages)
++
+     def test_tool_calls_then_stop(self, agent):
+         self._setup_agent(agent)
+         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+diff --git a/toolsets.py b/toolsets.py
+index 5de07e4c7..7038b15d0 100644
+--- a/toolsets.py
++++ b/toolsets.py
+@@ -54,6 +54,9 @@ _HERMES_CORE_TOOLS = [
+     "clarify",
+     # Code execution + delegation
+     "execute_code", "delegate_task",
++    # External LLM wrappers (Claude Code/Opus/Review, Codex web/consult, Gemini scan)
++    "claude_code_task", "claude_plan_task", "claude_opus_task", "claude_review_task",
++    "codex_web_research", "codex_consult_task", "gemini_scan_task",
+     # Cronjob management
+     "cronjob",
+     # Cross-platform messaging (gated on gateway running via check_fn)
+@@ -150,6 +153,15 @@ TOOLSETS = {
+         "tools": ["mixture_of_agents"],
+         "includes": []
+     },
++
++    "external_llm": {
++        "description": "Route heavy work to local Claude Code, Claude Opus/Review, Codex web/consult, and Gemini CLI wrappers",
++        "tools": [
++            "claude_code_task", "claude_plan_task", "claude_opus_task", "claude_review_task",
++            "codex_web_research", "codex_consult_task", "gemini_scan_task",
++        ],
++        "includes": []
++    },
+     
+     "skills": {
+         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
+diff --git a/website/docs/user-guide/configuration.md b/website/docs/user-guide/configuration.md
+index 77e5d74ad..a06acc90c 100644
+--- a/website/docs/user-guide/configuration.md
++++ b/website/docs/user-guide/configuration.md
+@@ -607,6 +607,14 @@ compression:
+   protect_last_n: 20                                # Min recent messages to keep uncompressed
+   hygiene_hard_message_limit: 400                   # Gateway safety valve — see below
+ 
++context_rollover:
++  enabled: false                                    # Nudge large sessions to delegate long work to a fresh child
++  warn_threshold: 0.30                              # Reserved for status/UI warnings
++  rollover_threshold: 0.40                          # Build fresh-session handoff at this context usage ratio
++  hard_threshold: 0.60                              # Reserved for future force-rollover policies
++  mode: fresh_subagent                              # fresh_subagent | compress_only
++  max_handoff_messages: 12                          # Recent transcript tail included in handoff prompt
++
+ # The summarization model/provider is configured under auxiliary:
+ auxiliary:
+   compression:
+@@ -621,6 +629,8 @@ Older configs with `compression.summary_model`, `compression.summary_provider`,
+ 
+ `hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+ 
++`context_rollover` is a proactive quality-preservation layer for large sessions. When enabled and a substantial request arrives after `rollover_threshold`, Hermes injects a temporary handoff nudge telling the parent agent to use `delegate_task` for fresh-context work. Short conversational replies are skipped, the synthetic handoff is not persisted into session history, and upstream defaults keep the feature disabled unless explicitly configured.
++
+ :::tip Gateway hot-reload of compression and context length
+ As of recent releases, editing `model.context_length` or any `compression.*` key in `config.yaml` on a running gateway takes effect on the next message — no gateway restart, no `/reset`, no session rotation required. The cached-agent signature includes these keys, so the gateway transparently rebuilds the agent when it sees a change. API keys and tool/skill config still require the usual reload paths.
+ :::

--- a/.omc/recovery/uncommitted-2026-05-20-status.txt
+++ b/.omc/recovery/uncommitted-2026-05-20-status.txt
@@ -1,0 +1,23 @@
+ M agent/context_compressor.py
+ M gateway/run.py
+ M hermes_cli/config.py
+ M run_agent.py
+ M tests/agent/test_context_compressor.py
+ M tests/run_agent/test_run_agent.py
+ M toolsets.py
+ M website/docs/user-guide/configuration.md
+?? .omc/
+?? .playwright-mcp/
+?? agent/context_rollover.py
+?? mcid_original_overlays/
+?? mcid_premium_original_overlays/
+?? mcid_revised_ad_1.png
+?? mcid_revised_ad_2.png
+?? mcid_revised_ad_3.png
+?? mcid_revised_ad_4.png
+?? mcid_revised_designs_board.png
+?? memory/
+?? stitch_mcid/
+?? tests/agent/test_context_rollover.py
+?? tests/tools/test_external_llm_tools.py
+?? tools/external_llm_tools.py

--- a/.omc/recovery/wip-stash-gateway-run-pure-2026-05-20.diff
+++ b/.omc/recovery/wip-stash-gateway-run-pure-2026-05-20.diff
@@ -1,0 +1,50 @@
+diff --git a/gateway/run.py b/gateway/run.py
+index f9a282a41..c6472961a 100644
+--- a/gateway/run.py
++++ b/gateway/run.py
+@@ -8956,9 +8956,14 @@ class GatewayRunner:
+         # When running under a service manager (systemd/launchd), use the
+         # service restart path: exit with code 75 so the service manager
+         # restarts us.  The detached subprocess approach (setsid + bash)
+-        # doesn't work under systemd because KillMode=mixed kills all
+-        # processes in the cgroup, including the detached helper.
+-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
++        # is fragile under service managers: systemd may kill the whole
++        # cgroup, while launchd may leave the job unloaded if shutdown and
++        # bootstrap race each other.  Detect both managers explicitly.
++        _under_service = bool(
++            os.environ.get("INVOCATION_ID")  # systemd
++            or os.environ.get("LAUNCH_JOBKEY_LABEL")  # launchd
++            or os.environ.get("XPC_SERVICE_NAME")  # launchd
++        )
+         if _under_service:
+             self.request_restart(detached=False, via_service=True)
+         else:
+@@ -15684,6 +15689,27 @@ class GatewayRunner:
+             _approval_session_token = set_current_session_key(_approval_session_key)
+             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+             try:
++                # Hydrate last prompt-token usage from the gateway session entry
++                # before run_conversation() performs context-rollover preflight.
++                # Gateway agents can be freshly constructed on cache miss,
++                # config-signature change, or gateway restart; in those cases the
++                # in-memory ContextCompressor starts at last_prompt_tokens=0 even
++                # though SessionEntry persisted the previous API-reported prompt
++                # size.  Without this, fresh_subagent rollover silently falls
++                # back to a rough estimate and can miss high-context Slack
++                # thread turns that should be delegated.
++                try:
++                    _stored_entry = self.session_store._entries.get(session_key) if session_key else None
++                    _stored_prompt_tokens = int(getattr(_stored_entry, "last_prompt_tokens", 0) or 0)
++                    if _stored_prompt_tokens > 0 and hasattr(agent, "context_compressor"):
++                        _current_prompt_tokens = int(
++                            getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0
++                        )
++                        if _current_prompt_tokens <= 0:
++                            agent.context_compressor.last_prompt_tokens = _stored_prompt_tokens
++                except Exception as _hydrate_err:
++                    logger.debug("last_prompt_tokens hydration skipped: %s", _hydrate_err)
++
+                 # If _prepare_inbound_message_text buffered image paths for native
+                 # attachment, wrap the user turn as an OpenAI-style multimodal
+                 # content list. Consume-and-clear so subsequent turns on the same

--- a/.omc/recovery/wip-stash-run-agent-pure-2026-05-20.diff
+++ b/.omc/recovery/wip-stash-run-agent-pure-2026-05-20.diff
@@ -1,0 +1,164 @@
+diff --git a/run_agent.py b/run_agent.py
+index 1dd4219b2..68a53441a 100644
+--- a/run_agent.py
++++ b/run_agent.py
+@@ -2368,6 +2368,24 @@ class AIAgent:
+             )
+         self.compression_enabled = compression_enabled
+ 
++        try:
++            from agent.context_rollover import ContextRolloverConfig
++            _rollover_cfg_raw = {}
++            if isinstance(_agent_cfg, dict):
++                # ``context_rollover`` is a top-level config section.  Older
++                # experimental builds briefly looked under ``agent``; keep that
++                # as a fallback so profile-local configs from that window still
++                # work, but prefer the documented location.
++                _rollover_cfg_raw = _agent_cfg.get("context_rollover")
++                if not isinstance(_rollover_cfg_raw, dict):
++                    _rollover_cfg_raw = (_agent_cfg.get("agent", {}) or {}).get("context_rollover", {})
++            self.context_rollover_config = ContextRolloverConfig.from_mapping(
++                _rollover_cfg_raw if isinstance(_rollover_cfg_raw, dict) else {}
++            )
++        except Exception as _rollover_cfg_err:
++            logger.warning("Context rollover config ignored: %s", _rollover_cfg_err)
++            self.context_rollover_config = None
++
+         # Reject models whose context window is below the minimum required
+         # for reliable tool-calling workflows (64K tokens).
+         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+@@ -10695,7 +10713,7 @@ class AIAgent:
+                 self._last_compression_summary_warning = summary_error
+                 self._emit_warning(
+                     f"⚠ Compression summary failed: {summary_error}. "
+-                    "Inserted a fallback context marker."
++                    "Inserted a deterministic extractive fallback summary."
+                 )
+         else:
+             # No hard failure — but did the configured aux model error out
+@@ -10914,6 +10932,35 @@ class AIAgent:
+             parent_agent=self,
+         )
+ 
++    @staticmethod
++    def _format_forced_rollover_result(delegate_result: str) -> str:
++        """Turn a forced rollover delegate_task result into user-facing text.
++
++        Normal delegate_task calls feed JSON back to the parent model for
++        synthesis.  Forced rollover intentionally skips another parent-model
++        turn, so extract the child summary directly and fall back to the raw
++        result if the shape is unexpected.
++        """
++        try:
++            payload = json.loads(delegate_result or "{}")
++            if isinstance(payload, dict):
++                results = payload.get("results")
++                if isinstance(results, list) and results:
++                    first = results[0]
++                    if isinstance(first, dict):
++                        summary = first.get("summary") or first.get("final_response")
++                        if summary:
++                            return str(summary)
++                        error = first.get("error")
++                        if error:
++                            return f"Fresh-session delegation failed: {error}"
++                error = payload.get("error")
++                if error:
++                    return f"Fresh-session delegation failed: {error}"
++        except Exception:
++            pass
++        return str(delegate_result or "Fresh-session delegation completed without a summary.")
++
+     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
+                      tool_call_id: Optional[str] = None, messages: list = None,
+                      pre_tool_block_checked: bool = False) -> str:
+@@ -12305,6 +12352,89 @@ class AIAgent:
+         messages.append(user_msg)
+         current_turn_user_idx = len(messages) - 1
+         self._persist_user_message_idx = current_turn_user_idx
++
++        # Proactive context rollover: when the parent session is already large,
++        # force substantial continued work into a fresh delegate_task child
++        # instead of dragging the full parent transcript through more tool
++        # iterations.  The parent thread keeps continuity; the heavy work gets
++        # a clean child context.
++        _rollover_dispatch_started = False
++        try:
++            from agent.context_rollover import build_usage_snapshot, maybe_build_rollover_handoff
++
++            _rollover_cfg = getattr(self, "context_rollover_config", None)
++            _ctx_len = int(getattr(self.context_compressor, "context_length", 0) or 0)
++            _last_prompt = int(getattr(self.context_compressor, "last_prompt_tokens", 0) or 0)
++            if _last_prompt > 0:
++                _rollover_tokens = _last_prompt
++                _rollover_source = "actual"
++            else:
++                _rollover_tokens = estimate_request_tokens_rough(messages, tools=self.tools or None)
++                _rollover_source = "estimated"
++            _rollover_snapshot = build_usage_snapshot(
++                prompt_tokens=_rollover_tokens,
++                context_length=_ctx_len,
++                source=_rollover_source,
++            )
++            _rollover_handoff = maybe_build_rollover_handoff(
++                config=_rollover_cfg,
++                snapshot=_rollover_snapshot,
++                messages=messages,
++                user_message=user_message,
++                cwd=os.getcwd(),
++                valid_tool_names=getattr(self, "valid_tool_names", set()),
++            ) if _rollover_cfg else None
++            if _rollover_handoff:
++                # Rollover is a control-plane decision, not a suggestion to the
++                # model.  Older behavior appended a handoff prompt to the user
++                # message and hoped the model would call delegate_task; in busy
++                # gateway threads that often kept heavy work in the bloated
++                # parent session.  Force the fresh child session here before the
++                # next model call so thread continuity is preserved while tool
++                # work happens with a clean context.
++                if persist_user_message is None:
++                    self._persist_user_message_override = original_user_message
++                self._emit_status(
++                    f"↪ Context {(_rollover_snapshot.percent * 100):.0f}% — delegating to fresh session"
++                )
++                _rollover_dispatch_started = True
++                _delegate_result = self._dispatch_delegate_task({
++                    "goal": user_message,
++                    "context": _rollover_handoff,
++                })
++                final_response = self._format_forced_rollover_result(_delegate_result)
++                messages.append({"role": "assistant", "content": final_response})
++                self._persist_session(messages, conversation_history)
++                self._cleanup_task_resources(effective_task_id)
++                return {
++                    "final_response": final_response,
++                    "last_reasoning": None,
++                    "messages": messages,
++                    "api_calls": 0,
++                    "completed": True,
++                    "turn_exit_reason": "context_rollover_delegate",
++                    "partial": False,
++                    "interrupted": False,
++                    "model": self.model,
++                    "provider": self.provider,
++                    "base_url": self.base_url,
++                    "input_tokens": self.session_input_tokens,
++                    "output_tokens": self.session_output_tokens,
++                    "cache_read_tokens": self.session_cache_read_tokens,
++                    "cache_write_tokens": self.session_cache_write_tokens,
++                    "reasoning_tokens": self.session_reasoning_tokens,
++                    "prompt_tokens": self.session_prompt_tokens,
++                    "completion_tokens": self.session_completion_tokens,
++                    "total_tokens": self.session_total_tokens,
++                    "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
++                    "estimated_cost_usd": self.session_estimated_cost_usd,
++                    "cost_status": self.session_cost_status,
++                    "cost_source": self.session_cost_source,
++                }
++        except Exception as _rollover_err:
++            if _rollover_dispatch_started:
++                raise
++            logger.debug("Context rollover preflight skipped: %s", _rollover_err, exc_info=True)
+         
+         if not self.quiet_mode:
+             _print_preview = _summarize_user_message_for_log(user_message)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1220,7 +1220,7 @@ def resolve_channel_prompt(
     if not isinstance(prompts, dict):
         return None
 
-    for key in (channel_id, parent_id):
+    for key in (channel_id, parent_id, "*", "default"):
         if not key:
             continue
         prompt = prompts.get(key)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -966,6 +966,18 @@ def _probe_launchd_service_running() -> bool:
         )
     except subprocess.TimeoutExpired:
         return False
+    if result.returncode == 0:
+        return True
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{_launchd_domain()}/{get_launchd_label()}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return result.returncode == 0
 
 
@@ -3061,6 +3073,7 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
     try:
         result = subprocess.run(
             ["launchctl", "list", label],
@@ -3073,6 +3086,20 @@ def launchd_status(deep: bool = False):
     except subprocess.TimeoutExpired:
         loaded = False
         loaded_output = ""
+
+    if not loaded:
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", target],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                loaded = True
+                loaded_output = f"{target} is loaded (verified via launchctl print)\n"
+        except subprocess.TimeoutExpired:
+            pass
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -140,6 +140,36 @@ class TestResolveChannelPrompts:
         }
         assert adapter._resolve_channel_prompt("999", parent_id="200") == "Thread override"
 
+    def test_wildcard_prompt_applies_to_any_channel(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"*": "Global channel prompt"}}
+        assert adapter._resolve_channel_prompt("unknown") == "Global channel prompt"
+
+    def test_exact_prompt_overrides_wildcard_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {
+                "*": "Global channel prompt",
+                "123": "Specific channel prompt",
+            }
+        }
+        assert adapter._resolve_channel_prompt("123") == "Specific channel prompt"
+
+    def test_default_prompt_fallback_applies_after_wildcard(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"default": "Default prompt"}}
+        assert adapter._resolve_channel_prompt("unknown") == "Default prompt"
+
+    def test_wildcard_prompt_overrides_default_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {
+                "*": "Wildcard prompt",
+                "default": "Default prompt",
+            }
+        }
+        assert adapter._resolve_channel_prompt("unknown") == "Wildcard prompt"
+
     def test_build_message_event_sets_channel_prompt(self):
         adapter = _make_adapter()
         adapter.config.extra = {"channel_prompts": {"321": "Command prompt"}}

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -678,6 +682,46 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_falls_back_to_print_when_list_misses_loaded_job(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(returncode=0, stdout="state = running\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "matches the current Hermes install" in output
+        assert "Gateway service is loaded" in output
+        assert "verified via launchctl print" in output
+        assert "not loaded" not in output
+
+    def test_probe_launchd_service_running_falls_back_to_print(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(returncode=0, stdout="state = running\n", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -737,6 +781,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
## Summary
- fall back to `launchctl print gui/<uid>/<label>` when `launchctl list <label>` misses a loaded launchd job
- keep `hermes gateway status` and running-service probing accurate on macOS launchd
- add regression coverage for the fallback path

## Tests
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts='`

## Local verification
- `hermes gateway restart`
- `hermes gateway status`
