### PR TITLE
fix: restore baseline CI blockers

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2110,22 +2110,28 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
 
     candidates = []
 
+    def _is_dir_accessible(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if _is_dir_accessible(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if _is_dir_accessible(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if _is_dir_accessible(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if _is_dir_accessible(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from typing import Dict
-
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
 
 
 def get_env_value(name: str, default=None):
@@ -18,10 +14,13 @@ def get_env_value(name: str, default=None):
     ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
     xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
-        value = _hermes_get_env_value(name)
+    try:
+        config_mod = importlib.import_module("hermes_cli.config")
+        value = config_mod.get_env_value(name)
         if value is not None:
             return value
+    except Exception:
+        pass
     return os.environ.get(name, default)
 
 


### PR DESCRIPTION
## Summary
- Sync ACP registry metadata to the current pyproject version (`0.14.0`).
- Make systemd PATH discovery tolerate inaccessible Hermes home subdirectories instead of crashing with `PermissionError`.
- Resolve xAI HTTP credentials through `hermes_cli.config` dynamically so tests that patch dotenv loading do not leave a stale imported helper behind.

## Why
The current open image-generation PR stack is blocked by baseline CI failures unrelated to those PR diffs:
- `tests/acp/test_registry_manifest.py` version mismatch
- `tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome` inaccessible `/root/.hermes/...` path probes
- `tests/tools/test_transcription_dotenv_fallback.py` xAI dotenv regression cases

## Test Plan
- [x] `scripts/run_tests.sh tests/acp/test_registry_manifest.py tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome tests/tools/test_transcription_dotenv_fallback.py -q`

## Notes
This is intentionally a narrow unblocker for the piled-up PRs. No image-generation code is changed here.
