### PR TITLE
docs(simplex): remove broken Docker install command (#26974)

### DIFF
--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -17,7 +17,7 @@ curl -L https://github.com/simplex-chat/simplex-chat/releases/latest/download/si
 chmod +x simplex-chat
 ```
 
-The SimpleX Chat project does not publish a prebuilt Docker image for the chat client; to run it under Docker, build from source using the [Dockerfile in the upstream repo](https://github.com/simplex-chat/simplex-chat).
+The SimpleX Chat project does not publish a prebuilt Docker image for the chat client; to run it under Docker, build from source from the [simplex-chat repository](https://github.com/simplex-chat/simplex-chat).
 
 ## Start the daemon
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -9,16 +9,15 @@
 
 ## Install simplex-chat
 
-Download the latest release from the [simplex-chat GitHub releases](https://github.com/simplex-chat/simplex-chat/releases) page, or via Docker:
+Download the latest release from the [simplex-chat GitHub releases](https://github.com/simplex-chat/simplex-chat/releases) page:
 
 ```bash
 # Linux / macOS binary
 curl -L https://github.com/simplex-chat/simplex-chat/releases/latest/download/simplex-chat-ubuntu-22_04-x86-64 -o simplex-chat
 chmod +x simplex-chat
-
-# Or Docker
-docker run -p 5225:5225 simplexchat/simplex-chat -p 5225
 ```
+
+The SimpleX Chat project does not publish a prebuilt Docker image for the chat client; to run it under Docker, build from source using the [Dockerfile in the upstream repo](https://github.com/simplex-chat/simplex-chat).
 
 ## Start the daemon
 


### PR DESCRIPTION
## Summary

`website/docs/user-guide/messaging/simplex.md` advised installing the
simplex-chat CLI via `docker run -p 5225:5225 simplexchat/simplex-chat -p 5225`,
but `simplexchat/simplex-chat` is not a published Docker Hub image.

## The bug

Reproducing the docs command (#26974):

```
> docker run -p 5225:5225 simplexchat/simplex-chat -p 5225
Unable to find image 'simplexchat/simplex-chat:latest' locally
docker: Error response from daemon: pull access denied for
simplexchat/simplex-chat, repository does not exist or may require
'docker login'.
```

The SimpleX Chat project publishes Docker images for its server-side
components (e.g. `simplexchat/smp-server`, `simplexchat/xftp-server`), but
the chat CLI itself ships only as a binary release via GitHub Releases.

## The fix

Two-line docs change in `website/docs/user-guide/messaging/simplex.md`:

- Drop the `docker run -p 5225:5225 simplexchat/simplex-chat -p 5225` line
  from the install snippet so users do not copy a command that 404s.
- Replace it with a short note pointing readers at the upstream Dockerfile
  for users who want to roll their own container — building from source
  remains a valid path.

The verified binary-download path on lines 16–17 (the `curl ... releases/latest/download/simplex-chat-ubuntu-22_04-x86-64` snippet) is preserved.

## Test plan

- [x] Docs-only change — no code paths touched.
- [x] Verified rendered markdown locally renders cleanly (single bash block, paragraph that follows).
- [x] Reproduction guard: the broken `docker run` command from the issue is no longer in the docs.

## Related

- Fixes #26974

## Infographic

![simplex-docs-fix](https://v3b.fal.media/files/b/0a9b6c1d/bjeW7S0fSxP7LNqA96HKf_bfdZyxpe.png)
