### PR TITLE
fix(aux): use OpenAI completion token cap for auto endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4153,14 +4153,13 @@ def _build_call_kwargs(
             provider == "zai"
             and ("4v" in _model_lower or "5v" in _model_lower or "-v" in _model_lower)
         )
+        endpoint_base = base_url
+        if not endpoint_base and provider == "custom":
+            endpoint_base = _current_custom_base_url()
         if _skip_max_tokens:
             pass  # ZAI vision models do not accept max_tokens
-        elif provider == "custom":
-            custom_base = base_url or _current_custom_base_url()
-            if base_url_hostname(custom_base) == "api.openai.com":
-                kwargs["max_completion_tokens"] = max_tokens
-            else:
-                kwargs["max_tokens"] = max_tokens
+        elif base_url_hostname(endpoint_base or "") == "api.openai.com":
+            kwargs["max_completion_tokens"] = max_tokens
         else:
             kwargs["max_tokens"] = max_tokens
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -72,6 +72,42 @@ class TestAuxiliaryMaxTokensParam:
              patch("agent.auxiliary_client._read_nous_auth", return_value=None):
             assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
 
+    def test_build_kwargs_uses_openai_completion_tokens_for_auto_endpoint(self):
+        kwargs = _build_call_kwargs(
+            provider="auto",
+            model="gpt-5-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=512,
+            base_url="https://api.openai.com/v1/",
+        )
+
+        assert kwargs["max_completion_tokens"] == 512
+        assert "max_tokens" not in kwargs
+
+    def test_build_kwargs_keeps_max_tokens_for_auto_non_openai_endpoint(self):
+        kwargs = _build_call_kwargs(
+            provider="auto",
+            model="gpt-5-nano",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=512,
+            base_url="https://example.test/v1/",
+        )
+
+        assert kwargs["max_tokens"] == 512
+        assert "max_completion_tokens" not in kwargs
+
+    def test_build_kwargs_preserves_custom_runtime_base_fallback(self):
+        with patch("agent.auxiliary_client._current_custom_base_url", return_value="https://api.openai.com/v1"):
+            kwargs = _build_call_kwargs(
+                provider="custom",
+                model="gpt-5-nano",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=512,
+            )
+
+        assert kwargs["max_completion_tokens"] == 512
+        assert "max_tokens" not in kwargs
+
 
 class TestNormalizeAuxProvider:
     def test_maps_github_copilot_aliases(self):


### PR DESCRIPTION
## Summary
- Use `max_completion_tokens` whenever the auxiliary call targets the real OpenAI API endpoint, even when the configured provider is `auto`.
- Preserve `max_tokens` for non-OpenAI endpoints.
- Preserve the existing `custom` provider fallback through `_current_custom_base_url()`.

## Why
A WebUI title-generation failure reported in `nesquena/hermes-webui#2235` points to an auxiliary call configured as `provider=auto`, `model=gpt-5-nano`, and `base_url=https://api.openai.com/v1`. In that path, Hermes Agent was still sending `max_tokens`, which GPT-5/OpenAI-compatible chat completions rejects. The existing OpenAI endpoint compatibility was only applied to `provider=custom`; this extends the endpoint-based check to `auto` while keeping non-OpenAI endpoints unchanged.

## Verification
- `python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryMaxTokensParam -o 'addopts=' -q` → `5 passed`
- Smoke test confirmed:
  - `auto + https://api.openai.com/v1/` → `max_completion_tokens`
  - `auto + https://example.test/v1/` → `max_tokens`
  - `custom + https://api.openai.com/v1/` → `max_completion_tokens`
- WebUI regression test in separate clean worktree: `tests/test_2235_initial_aux_title.py` → `10 passed`

## Note
`tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_codex_timeout_evicts_cached_wrapper` fails locally on clean `origin/main` as well, so it is treated as a pre-existing baseline issue unrelated to this PR.

Related: nesquena/hermes-webui#2235
