### PR TITLE
fix(gateway): /stop and /interrupt bypass steer/queue to always interrupt agent (#26813)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2615,13 +2615,43 @@ class GatewayRunner:
 
         running_agent = self._running_agents.get(session_key)
 
+        # --- Control command bypass (#26813) ---
+        # /stop and /interrupt are control commands, not user input. When
+        # busy_input_mode is "steer" or "queue" they must still interrupt the
+        # running agent immediately — otherwise the user has no way to stop a
+        # long-running turn from gateway platforms (Slack, Feishu, Discord, etc.)
+        raw_text = (event.text or "").strip()
+        first_token = raw_text.split(maxsplit=1)[0] if raw_text else ""
+        # Normalize: /stop, stop, /interrupt, interrupt, /cancel, cancel
+        # Also strip @mention suffix (e.g. /stop@hermes_bot → stop)
+        _cmd_name = first_token.lstrip("/").split("@", 1)[0].lower() if first_token else ""
+        # Platforms like Feishu send /stop as plain text (no native slash).
+        _control_interrupted = False
+        if _cmd_name in {"stop", "interrupt", "cancel"}:
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                try:
+                    running_agent.interrupt(raw_text)
+                except Exception:
+                    pass
+            logger.info(
+                "Control command %r in session %s — forced interrupt regardless of busy_input_mode=%s",
+                first_token, session_key, self._busy_input_mode,
+            )
+            _control_interrupted = True
+
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
         # (sentinel) or lacks steer(), or the payload is empty, fall back
         # to queue semantics so nothing is lost.
         effective_mode = self._busy_input_mode
         steered = False
-        if effective_mode == "steer":
+        if _control_interrupted:
+            # Control commands must not be steered, queued, or merged
+            # into pending messages.  The interrupt above is sufficient;
+            # fall through to the busy ack so the user sees confirmation.
+            effective_mode = "interrupt"
+            steered = True  # prevents merge_pending below
+        elif effective_mode == "steer":
             steer_text = (event.text or "").strip()
             can_steer = (
                 steer_text
@@ -2651,8 +2681,9 @@ class GatewayRunner:
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
-        # at the next check point.
-        if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+        # at the next check point.  Skip if a control-command interrupt was
+        # already performed above (#26813).
+        if effective_mode == "interrupt" and not _control_interrupted and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 running_agent.interrupt(event.text)
             except Exception:

--- a/tests/gateway/test_control_command_bypass.py
+++ b/tests/gateway/test_control_command_bypass.py
@@ -1,0 +1,300 @@
+"""Tests for control-command bypass in _handle_active_session_busy_message (#26813).
+
+Verifies that /stop, /interrupt, /cancel (and their plain-text equivalents)
+always interrupt a running agent, even when busy_input_mode is "steer" or "queue".
+"""
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so we can import gateway code without heavy deps
+# ---------------------------------------------------------------------------
+import sys, types
+
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(text="/stop", chat_id="123", platform_val="telegram"):
+    source = SessionSource(
+        platform=MagicMock(value=platform_val),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg1",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+def _make_adapter(platform_val="telegram"):
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value=platform_val)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestControlCommandBypass:
+    """Control commands must bypass steer/queue and force an interrupt."""
+
+    @pytest.mark.asyncio
+    async def test_stop_in_steer_mode_interrupts(self):
+        """/stop in steer mode → agent.interrupt() called, steer() NOT called."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/stop")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("/stop")
+        agent.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_in_steer_mode_interrupts(self):
+        """/interrupt in steer mode → forced interrupt."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/interrupt")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("/interrupt")
+        agent.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_in_queue_mode_interrupts(self):
+        """/cancel in queue mode → forced interrupt (not queued)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/cancel")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("/cancel")
+        # The control command must NOT be queued for next turn
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plain_stop_in_steer_mode_interrupts(self):
+        """Plain 'stop' (no slash) in steer mode → also forced interrupt (Feishu case)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="stop")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("stop")
+        agent.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plain_interrupt_in_queue_mode_interrupts(self):
+        """Plain 'interrupt' in queue mode → forced interrupt."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="interrupt")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("interrupt")
+
+    @pytest.mark.asyncio
+    async def test_non_control_text_still_stears(self):
+        """Normal text in steer mode → still steered (not intercepted)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="also check the tests")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_called_once_with("also check the tests")
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_control_text_in_queue_still_queues(self):
+        """Normal text in queue mode → still queued (not interrupted)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="add this later")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_mention_suffix(self):
+        """/stop@botname in steer mode → forced interrupt (mention stripped)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/stop@hermes_bot")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once()
+        agent.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_pending_sentinel_no_crash(self):
+        """/stop when agent is still pending (sentinel) → no crash, no interrupt call."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/stop")
+        sk = build_session_key(event.source)
+
+        runner._running_agents[sk] = sentinel
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        # Should not raise; interrupt is skipped because agent is sentinel
+        await runner._handle_active_session_busy_message(event, sk)
+
+    @pytest.mark.asyncio
+    async def test_control_command_ack_sent(self):
+        """Control command interrupt should still send busy ack."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/stop")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 60,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "thinking",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        # Busy ack should have been sent
+        adapter._send_with_retry.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Fixes #26813

## Problem

When `busy_input_mode` is `"steer"` (the recommended default for active-conversation platforms) or `"queue"`, sending `/stop` or `/interrupt` to a running agent does **not** interrupt it. Instead the command text is fed to `running_agent.steer("/stop")` or queued for the next turn — the agent treats it as regular context text and keeps running.

This means users on gateway platforms (Slack, Feishu, Discord, Telegram) have **no way** to stop a long-running agent turn. On Slack specifically, the `!stop` rewrite path correctly converts to `/stop`, but the bug still prevents it from working. The only workaround is restarting the entire gateway process.

## Root Cause

`_handle_active_session_busy_message` sets `effective_mode = self._busy_input_mode` and branches into steer/queue/interrupt **without first checking** whether `event.text` is a known gateway control command.

## Fix

Before the steer/queue branching block, parse the first token of `event.text`:
- Strip leading `/` and `@mention` suffix
- If the normalized token is `stop`, `interrupt`, or `cancel` → force an immediate `interrupt()` and skip steer/queue/pending-message logic

Supports:
- `/stop`, `/interrupt`, `/cancel` (slash-prefixed)
- `stop`, `interrupt`, `cancel` (plain text — Feishu has no native slash commands)
- `/stop@botname` (group-chat @mention suffix)

### Changed files
- `gateway/run.py` — control-command bypass in `_handle_active_session_busy_message` (~line 2618)
- `tests/gateway/test_control_command_bypass.py` — 10 new tests

## Verification

```bash
# New tests
uv run pytest tests/gateway/test_control_command_bypass.py -v -o "addopts="
# → 10 passed

# Existing busy-session tests (no regression)
uv run pytest tests/gateway/test_busy_session_ack.py -v -o "addopts="
# → 15 passed

# Lint
uv run ruff check gateway/run.py tests/gateway/test_control_command_bypass.py
# → All checks passed!
```

## Risks / Follow-ups

- The bypass only applies to the exact first token; text like "please stop" is NOT intercepted — it follows normal steer/queue semantics. This is intentional to avoid false positives on conversational text.
- Future: consider making the control-command set configurable per deployment.
