### PR TITLE
docs: add Hermes context bridge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Instructions for AI coding assistants and developers working on the hermes-agent codebase.
 
+## Hermes Context Bridge
+
+- For local Codex/Claude context inheritance, recovery, and source-boundary rules, read `/Users/songying/.hermes/BRIDGE.md` first.
+- Prefer Hermes canonical paths under `/Users/songying/.hermes/` over legacy `/Users/songying/.openclaw/` compatibility paths.
+- Treat knowledge/wiki/output/memory as reference or durable memory unless live workspace/runtime evidence confirms execution truth.
+
 ## Development Environment
 
 ```bash


### PR DESCRIPTION
## Summary
- add a short Hermes Context Bridge section to `AGENTS.md`
- point local Codex/Claude recovery workflows at `/Users/songying/.hermes/BRIDGE.md`
- document source-boundary expectations: canonical Hermes paths, legacy OpenClaw compatibility paths, and live evidence over knowledge/memory

## Verification
- `git diff --check -- AGENTS.md`
- UTF-8/read sanity for `AGENTS.md`

## Notes
- Docs-only change.
- This PR intentionally does not sync or vendor any Hermes skills; it only adds a bridge pointer to avoid context drift.
