### PR TITLE
feat(plugins): add pre_goal_continuation hook for /goal veto

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8748,6 +8748,24 @@ class HermesCLI:
             _cprint(f"  {msg}")
 
         if decision.get("should_continue"):
+            # Plugin veto: pre_goal_continuation hook may pause the goal
+            # right before we'd enqueue the next tick (e.g. rate-limit guard).
+            try:
+                from hermes_cli.goals import apply_continuation_hooks
+                proceed = apply_continuation_hooks(
+                    session_id=getattr(mgr, "session_id", "") or "",
+                    goal_manager=mgr,
+                    decision=decision,
+                    last_response=last_response,
+                )
+            except Exception as exc:
+                logging.debug("goal continuation hook dispatch failed: %s", exc)
+                proceed = True
+            if not proceed:
+                _cprint(
+                    f"  {_DIM}⏸ Goal paused by plugin — use /goal resume to continue.{_RST}"
+                )
+                return
             prompt = decision.get("continuation_prompt")
             if prompt:
                 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9892,6 +9892,31 @@ class GatewayRunner:
         if not decision.get("should_continue"):
             return
 
+        # Plugin veto: pre_goal_continuation may pause the goal right
+        # before we'd enqueue the next gateway tick. Mirrors the CLI
+        # call site in ``HermesCLI._maybe_continue_goal_after_turn``.
+        try:
+            from hermes_cli.goals import apply_continuation_hooks
+            proceed = apply_continuation_hooks(
+                session_id=sid,
+                goal_manager=mgr,
+                decision=decision,
+                last_response=final_response or "",
+            )
+        except Exception as exc:
+            logger.debug("goal continuation hook dispatch failed: %s", exc)
+            proceed = True
+        if not proceed:
+            if source is not None:
+                try:
+                    await self._defer_goal_status_notice_after_delivery(
+                        source,
+                        "⏸ Goal paused by plugin — use /goal resume to continue.",
+                    )
+                except Exception as exc:
+                    logger.debug("goal continuation notice failed: %s", exc)
+            return
+
         prompt = decision.get("continuation_prompt") or ""
         if not prompt or source is None:
             return

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -741,9 +741,58 @@ class GoalManager:
         return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
 
 
+def apply_continuation_hooks(
+    session_id: str,
+    goal_manager: "GoalManager",
+    decision: Dict[str, Any],
+    last_response: str,
+) -> bool:
+    """Invoke ``pre_goal_continuation`` plugin callbacks and react.
+
+    Returns ``True`` when the caller should PROCEED with the continuation
+    tick (no plugin vetoed). Returns ``False`` when a plugin returned
+    ``{"action": "pause", ...}`` — in that case this helper already
+    pauses the goal via ``goal_manager.pause()`` and the caller MUST
+    skip enqueueing the continuation prompt.
+
+    Failures (no plugin system loaded, callback raises, etc.) are
+    swallowed and treated as "proceed" — the hook must never wedge a
+    legitimate continuation.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook
+    except Exception:
+        return True
+    try:
+        results = invoke_hook(
+            "pre_goal_continuation",
+            session_id=session_id,
+            goal_manager=goal_manager,
+            decision=decision,
+            last_response=last_response,
+        )
+    except Exception:
+        return True
+
+    pause_reason: Optional[str] = None
+    for r in results or []:
+        if isinstance(r, dict) and r.get("action") == "pause":
+            pause_reason = str(r.get("reason") or "paused by plugin")
+            break
+    if pause_reason is None:
+        return True
+
+    try:
+        goal_manager.pause(reason=pause_reason)
+    except Exception:
+        pass
+    return False
+
+
 __all__ = [
     "GoalState",
     "GoalManager",
+    "apply_continuation_hooks",
     "CONTINUATION_PROMPT_TEMPLATE",
     "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
     "JUDGE_USER_PROMPT_TEMPLATE",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -165,6 +165,18 @@ VALID_HOOKS: Set[str] = {
     #   choice: "once" | "session" | "always" | "deny" | "timeout"
     "pre_approval_request",
     "post_approval_response",
+    # Goal continuation hook. Fired AFTER GoalManager.evaluate_after_turn
+    # has voted ``should_continue=True`` but BEFORE the continuation
+    # prompt is enqueued back into ``run_conversation``. Plugins may
+    # return a dict to influence flow:
+    #   {"action": "pause",  "reason": "..."} -> pause goal, skip tick
+    #   {"action": "allow"}  /  None           -> proceed normally
+    # First plugin returning ``{"action": "pause"}`` wins; remaining
+    # callbacks still run for their observer side-effects but their
+    # action verbs are ignored. Kwargs:
+    #   session_id: str, goal_manager: GoalManager, decision: dict,
+    #   last_response: str
+    "pre_goal_continuation",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -738,3 +738,123 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+
+# ──────────────────────────────────────────────────────────────────────
+# apply_continuation_hooks — pre_goal_continuation plugin veto
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestApplyContinuationHooks:
+    """Cover the ``pre_goal_continuation`` veto path. We patch
+    ``hermes_cli.plugins.invoke_hook`` directly so the test doesn't have
+    to spin up the full plugin manager."""
+
+    def _decision(self) -> dict:
+        return {
+            "status": "active",
+            "should_continue": True,
+            "continuation_prompt": "keep going",
+            "verdict": "continue",
+            "reason": "judge says continue",
+            "message": "",
+        }
+
+    def test_no_plugins_proceeds(self, hermes_home, monkeypatch):
+        from hermes_cli.goals import GoalManager, apply_continuation_hooks
+
+        mgr = GoalManager(session_id="ach-none")
+        mgr.set("ship it")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: []
+        )
+        proceed = apply_continuation_hooks(
+            session_id="ach-none",
+            goal_manager=mgr,
+            decision=self._decision(),
+            last_response="...",
+        )
+        assert proceed is True
+        assert mgr.state and mgr.state.status == "active"
+
+    def test_allow_proceeds(self, hermes_home, monkeypatch):
+        from hermes_cli.goals import GoalManager, apply_continuation_hooks
+
+        mgr = GoalManager(session_id="ach-allow")
+        mgr.set("ship it")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda *_a, **_kw: [{"action": "allow"}, None],
+        )
+        proceed = apply_continuation_hooks(
+            session_id="ach-allow",
+            goal_manager=mgr,
+            decision=self._decision(),
+            last_response="...",
+        )
+        assert proceed is True
+        assert mgr.state and mgr.state.status == "active"
+
+    def test_pause_action_pauses_goal_and_skips_continuation(self, hermes_home, monkeypatch):
+        from hermes_cli.goals import GoalManager, apply_continuation_hooks
+
+        mgr = GoalManager(session_id="ach-pause")
+        mgr.set("ship it")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda *_a, **_kw: [{"action": "pause", "reason": "rate limit"}],
+        )
+        proceed = apply_continuation_hooks(
+            session_id="ach-pause",
+            goal_manager=mgr,
+            decision=self._decision(),
+            last_response="...",
+        )
+        assert proceed is False
+        assert mgr.state is not None
+        assert mgr.state.status == "paused"
+        assert mgr.state.paused_reason == "rate limit"
+
+    def test_first_pause_wins(self, hermes_home, monkeypatch):
+        from hermes_cli.goals import GoalManager, apply_continuation_hooks
+
+        mgr = GoalManager(session_id="ach-firstwin")
+        mgr.set("ship it")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda *_a, **_kw: [
+                {"action": "pause", "reason": "first"},
+                {"action": "pause", "reason": "second"},
+            ],
+        )
+        proceed = apply_continuation_hooks(
+            session_id="ach-firstwin",
+            goal_manager=mgr,
+            decision=self._decision(),
+            last_response="...",
+        )
+        assert proceed is False
+        assert mgr.state.paused_reason == "first"
+
+    def test_hook_exception_is_fail_open(self, hermes_home, monkeypatch):
+        from hermes_cli.goals import GoalManager, apply_continuation_hooks
+
+        mgr = GoalManager(session_id="ach-raise")
+        mgr.set("ship it")
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("plugin manager exploded")
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _boom)
+        proceed = apply_continuation_hooks(
+            session_id="ach-raise",
+            goal_manager=mgr,
+            decision=self._decision(),
+            last_response="...",
+        )
+        assert proceed is True
+        assert mgr.state.status == "active"

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -514,8 +514,9 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 | [`on_session_end`](/docs/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/docs/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/docs/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`pre_goal_continuation`](/docs/user-guide/features/hooks#pre_goal_continuation) | After judge votes `continue` but before the next `/goal` tick fires | `session_id: str, goal_manager: GoalManager, decision: dict, last_response: str` | [veto](#pre_goal_continuation-veto) |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call` (context injection) and `pre_goal_continuation` (pause veto).
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
@@ -615,6 +616,35 @@ def register(ctx):
 #### Multiple plugins returning context
 
 When multiple plugins return context from `pre_llm_call`, their outputs are joined with double newlines and appended to the user message together. The order follows plugin discovery order (alphabetical by plugin directory name).
+
+### `pre_goal_continuation` veto
+
+`pre_goal_continuation` fires once per `/goal` continuation tick — after `GoalManager.evaluate_after_turn` has decided to continue but **before** the continuation prompt is enqueued back into the agent. Plugins can use it to pause the goal in response to external conditions (rate-limit windows, cost budgets, paged operator, …).
+
+#### Return format
+
+```python
+# Pause the goal — skip the upcoming tick.
+return {"action": "pause", "reason": "cc-rate-limit; resumes ~20:05"}
+
+# Proceed normally (either return is fine).
+return {"action": "allow"}
+return None
+```
+
+When any plugin returns `{"action": "pause"}`, Hermes calls `goal_manager.pause(reason=...)` for you and skips enqueueing the continuation prompt. The first paused vote wins; remaining plugins still run for side-effects but their action verbs are ignored. The goal can be resumed with `/goal resume` or by an external cron firing `/goal resume` back into the same session.
+
+#### Example: pause when an external budget is exhausted
+
+```python
+def gate(session_id, goal_manager, decision, last_response, **_):
+    if budget_exhausted():
+        return {"action": "pause", "reason": "budget exhausted; will retry tomorrow"}
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_goal_continuation", gate)
+```
 
 ### Register CLI commands
 


### PR DESCRIPTION
## Summary

Adds a new `pre_goal_continuation` plugin hook that fires after `GoalManager.evaluate_after_turn` votes `should_continue=True` but **before** the next continuation prompt is enqueued. Plugins can return `{"action": "pause", "reason": "..."}` to veto the upcoming tick — the helper pauses the goal so `/goal resume` is required to restart.

**Motivation:** today the only extension point near the `/goal` loop is `pre_llm_call`, which fires on every API call regardless of whether a continuation is about to happen. Plugins that want to gate continuations (rate-limit guards, cost budgets, paged-operator hooks) end up either piggybacking on `pre_llm_call` and racing the agent loop, or modifying core. Neither is acceptable.

The concrete use case driving this: an external rate-limit-guard plugin that pauses `/goal` when the Claude Code 5h-window budget is near exhaustion and schedules a one-shot cron to fire `/goal resume` after the window resets. With this hook the plugin needs ~30 lines and zero core touches.

## Changes

5 commits, one concern each:

1. **`feat(plugins): add pre_goal_continuation hook`** — adds the hook name + semantics comment to `VALID_HOOKS` in `hermes_cli/plugins.py`. No invocation yet, so the constant change is reviewable on its own and downstream test harnesses can register against the hook before the wiring lands.

2. **`feat(cli): invoke pre_goal_continuation before continuation tick`** — adds `apply_continuation_hooks(session_id, goal_manager, decision, last_response) -> bool` in `hermes_cli/goals.py` as the single source of truth, and wires the CLI call site in `_maybe_continue_goal_after_turn`. Helper pauses the goal itself on a pause verdict so the caller just respects the return value.

3. **`feat(gateway): mirror pre_goal_continuation invocation`** — mirrors the dispatch in `GatewayRunner` so `/goal` driven from Telegram/Discord/etc. honors the same veto. Without this the CLI and gateway would have inconsistent semantics for any plugin using the hook.

4. **`docs(plugins): document pre_goal_continuation`** — adds the hook to the reference table in `website/docs/guides/build-a-hermes-plugin.md`, calls out that it's one of two hooks whose return value matters (alongside `pre_llm_call`), and documents the `{"action": "pause", "reason": ...}` veto contract with a runnable example.

5. **`test(goals): cover pre_goal_continuation pause path`** — five tests covering the four veto branches plus the fail-open property:
   - no plugins → proceed
   - `{"action":"allow"}` / `None` → proceed
   - `{"action":"pause", "reason": ...}` → goal status flips to `paused`, helper returns `False`
   - first pause vote wins when multiple plugins pause
   - hook system raises → fail-open (broken plugin must never wedge a healthy goal)

## Semantics

The helper signature is:

```python
def apply_continuation_hooks(session_id, goal_manager, decision, last_response) -> bool: ...
```

- Returns `True` → caller proceeds with the continuation tick.
- Returns `False` → caller skips the enqueue; helper has already called `goal_manager.pause(reason)` so the goal state is consistent for `/goal status`.
- First plugin returning `{"action": "pause"}` wins; remaining callbacks still run for their observer side-effects but their action verbs are ignored.
- Any failure path (no plugin module, callback raises) is swallowed and treated as proceed.

## Testing

```
$ python -m pytest tests/hermes_cli/test_goals.py tests/hermes_cli/test_plugins.py \
                   tests/cli/test_cli_goal_interrupt.py tests/gateway/test_goal_status_notice.py
137 passed in 2.76s
```

The new `TestApplyContinuationHooks` class adds 5 of those 137. Existing `test_goals` / `test_plugins` / `test_cli_goal_interrupt` / `test_goal_status_notice` suites stay green — the new dispatch only runs when a plugin is registered against the hook, so no existing behavior changes for unconfigured users.

## Non-goals

- No changes to `GoalManager.evaluate_after_turn` semantics — the hook fires *after* the judge.
- No changes to the existing pause / resume paths — the helper reuses `GoalManager.pause(reason)`.
- No new config keys — opt-in is purely via plugin registration.
