### PR TITLE
fix: honor OpenAI Codex provider proxy config

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -242,8 +242,20 @@ def _get_proxy_from_env() -> Optional[str]:
 
 
 def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
-    """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
+    """Return a configured proxy unless NO_PROXY excludes this base URL."""
     proxy = _get_proxy_from_env()
+    if not proxy and base_url:
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config()
+            provider = cfg_get(cfg, "model", "provider", default="")
+            if str(provider or "").strip().lower() == "openai-codex":
+                proxy = cfg_get(cfg, "providers", "openai-codex", "proxy_url", default=None)
+        except Exception:
+            proxy = None
+        if proxy:
+            proxy = normalize_proxy_url(str(proxy))
     if not proxy or not base_url:
         return proxy
 

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -188,6 +188,86 @@ def test_get_proxy_for_base_url_returns_none_when_proxy_unset(monkeypatch):
     assert _get_proxy_for_base_url("https://api.openai.com/v1") is None
 
 
+def test_get_proxy_for_base_url_uses_openai_codex_provider_proxy_url(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {
+            "model": {"provider": "openai-codex"},
+            "providers": {
+                "openai-codex": {"proxy_url": "socks://127.0.0.1:6152"},
+            },
+        },
+    )
+
+    assert (
+        _get_proxy_for_base_url("https://chatgpt.com/backend-api/codex")
+        == "socks5://127.0.0.1:6152"
+    )
+
+
+def test_get_proxy_for_base_url_env_proxy_takes_precedence_over_codex_config(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://env-proxy:8080")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {
+            "model": {"provider": "openai-codex"},
+            "providers": {
+                "openai-codex": {"proxy_url": "http://config-proxy:6152"},
+            },
+        },
+    )
+
+    assert (
+        _get_proxy_for_base_url("https://chatgpt.com/backend-api/codex")
+        == "http://env-proxy:8080"
+    )
+
+
+def test_get_proxy_for_base_url_no_proxy_suppresses_codex_config_proxy(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("NO_PROXY", "chatgpt.com")
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {
+            "model": {"provider": "openai-codex"},
+            "providers": {
+                "openai-codex": {"proxy_url": "http://127.0.0.1:6152"},
+            },
+        },
+    )
+
+    assert _get_proxy_for_base_url("https://chatgpt.com/backend-api/codex") is None
+
+
+def test_get_proxy_for_base_url_ignores_codex_proxy_for_other_provider(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy",
+                "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {
+            "model": {"provider": "openrouter"},
+            "providers": {
+                "openai-codex": {"proxy_url": "http://127.0.0.1:6152"},
+            },
+        },
+    )
+
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") is None
+
+
 @patch("run_agent.OpenAI")
 def test_create_openai_client_bypasses_proxy_for_no_proxy_host(mock_openai, monkeypatch):
     """E2E: with HTTPS_PROXY + NO_PROXY=localhost, a local base_url gets a


### PR DESCRIPTION
## Summary
- honor `providers.openai-codex.proxy_url` when no proxy environment variable is configured
- keep existing env proxy precedence and `NO_PROXY` bypass behavior
- add regression coverage for Codex config proxy, env precedence, `NO_PROXY`, and non-Codex providers

## Test Plan
- `venv/bin/python -m pytest tests/run_agent/test_create_openai_client_proxy_env.py -o 'addopts=' -q`
- `git diff --check -- run_agent.py tests/run_agent/test_create_openai_client_proxy_env.py`
- `venv/bin/python -m py_compile run_agent.py`

## Context
Users may have a provider-specific proxy configured for OpenAI Codex in `config.yaml`, but the primary OpenAI client previously only read proxy environment variables. In environments where direct access to `https://chatgpt.com/backend-api/codex` times out, this made Codex API calls fail even though authorization was valid and the provider config contained a working proxy.
