### PR TITLE
fix(gateway): avoid ghost session creation in read-only slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -43,12 +43,6 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List, Union
 
-# account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
-# /usage; we still import it at module top in the gateway because test
-# patches (tests/gateway/test_usage_command.py) target
-# `gateway.run.fetch_account_usage` as a module-level attribute. The
-# gateway is a long-running daemon, so its boot cost matters less than
-# preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
@@ -8605,17 +8599,47 @@ class GatewayRunner:
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
-        session_entry = self.session_store.get_or_create_session(source)
+        session_entry = self.session_store.get_session(source)
+        session_key = (
+            session_entry.session_key
+            if session_entry is not None
+            else self._session_key_for_source(source)
+        )
 
         connected_platforms = [p.value for p in self.adapters.keys()]
 
         # Check if there's an active agent
-        session_key = session_entry.session_key
         is_running = session_key in self._running_agents
 
         # Count pending /queue follow-ups (slot + overflow).
         adapter = self.adapters.get(source.platform) if source else None
         queue_depth = self._queue_depth(session_key, adapter=adapter)
+
+        if session_entry is None:
+            lines = [
+                t("gateway.status.header"),
+                "",
+                t("gateway.status.no_session"),
+                t("gateway.status.start_chat_hint"),
+                t(
+                    "gateway.status.agent_running",
+                    state=t("gateway.status.state_yes")
+                    if is_running
+                    else t("gateway.status.state_no"),
+                ),
+            ]
+            if queue_depth:
+                lines.append(t("gateway.status.queued", count=queue_depth))
+            lines.extend(
+                [
+                    "",
+                    t(
+                        "gateway.status.platforms",
+                        platforms=", ".join(connected_platforms),
+                    ),
+                ]
+            )
+            return "\n".join(lines)
 
         title = None
         # Pull token totals from the SQLite session DB rather than the
@@ -11936,10 +11960,14 @@ class GatewayRunner:
         provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         base_url = getattr(agent, "base_url", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
+        session_entry = self.session_store.get_session(source)
         if not provider and getattr(self, "_session_db", None) is not None:
             try:
-                _entry_for_billing = self.session_store.get_or_create_session(source)
-                persisted = self._session_db.get_session(_entry_for_billing.session_id) or {}
+                persisted = (
+                    self._session_db.get_session(session_entry.session_id) or {}
+                    if session_entry is not None
+                    else {}
+                )
             except Exception:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
@@ -12025,7 +12053,11 @@ class GatewayRunner:
             return "\n".join(lines)
 
         # No agent at all -- check session history for a rough count
-        session_entry = self.session_store.get_or_create_session(source)
+        if session_entry is None:
+            if account_lines:
+                return "\n".join(account_lines)
+            return t("gateway.usage.no_data")
+
         history = self.session_store.load_transcript(session_entry.session_id)
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -853,6 +853,20 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    def get_session(self, source: SessionSource) -> Optional[SessionEntry]:
+        """Return the existing session for *source* without creating one.
+
+        Read-only slash commands like ``/status`` and ``/usage`` should not
+        create a brand-new session row just because the user inspected the
+        gateway before sending any real message. This lookup mirrors the key
+        derivation of ``get_or_create_session()`` but deliberately avoids
+        mutating timestamps, ``sessions.json``, or SQLite.
+        """
+        session_key = self._generate_session_key(source)
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def get_or_create_session(
         self,
         source: SessionSource,

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes Gateway Status**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**Sessie-ID:** `{session_id}`"
     title:                 "**Titel:** {title}"
     created:               "**Geskep:** {timestamp}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes-Gateway-Status**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**Sitzungs-ID:** `{session_id}`"
     title:                 "**Titel:** {title}"
     created:               "**Erstellt:** {timestamp}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -262,6 +262,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes Gateway Status**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**Session ID:** `{session_id}`"
     title:                 "**Title:** {title}"
     created:               "**Created:** {timestamp}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Estado de Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID de sesión:** `{session_id}`"
     title:                 "**Título:** {title}"
     created:               "**Creado:** {timestamp}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **État de Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID de session :** `{session_id}`"
     title:                 "**Titre :** {title}"
     created:               "**Créé :** {timestamp}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -251,6 +251,8 @@ gateway:
 
   status:
     header:                "📊 **Stádas Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID Seisiúin:** `{session_id}`"
     title:                 "**Teideal:** {title}"
     created:               "**Cruthaithe:** {timestamp}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes Gateway állapot**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**Munkamenet-azonosító:** `{session_id}`"
     title:                 "**Cím:** {title}"
     created:               "**Létrehozva:** {timestamp}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Stato del Gateway Hermes**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID sessione:** `{session_id}`"
     title:                 "**Titolo:** {title}"
     created:               "**Creata:** {timestamp}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes ゲートウェイ状態**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**セッション ID:** `{session_id}`"
     title:                 "**タイトル:** {title}"
     created:               "**作成日時:** {timestamp}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes 게이트웨이 상태**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**세션 ID:** `{session_id}`"
     title:                 "**제목:** {title}"
     created:               "**생성됨:** {timestamp}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Estado do Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID da sessão:** `{session_id}`"
     title:                 "**Título:** {title}"
     created:               "**Criada:** {timestamp}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Состояние Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID сеанса:** `{session_id}`"
     title:                 "**Название:** {title}"
     created:               "**Создано:** {timestamp}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes Gateway Durumu**"
+    no_session:            "Henüz etkin bir oturum yok."
+    start_chat_hint:       "Bir tane oluşturmak için sohbete başlayın."
     session_id:            "**Oturum kimliği:** `{session_id}`"
     title:                 "**Başlık:** {title}"
     created:               "**Oluşturuldu:** {timestamp}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Стан Hermes Gateway**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**ID сесії:** `{session_id}`"
     title:                 "**Назва:** {title}"
     created:               "**Створено:** {timestamp}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes 閘道狀態**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**工作階段 ID：** `{session_id}`"
     title:                 "**標題：** {title}"
     created:               "**建立時間：** {timestamp}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -247,6 +247,8 @@ gateway:
 
   status:
     header:                "📊 **Hermes 网关状态**"
+    no_session:            "No active session yet."
+    start_chat_hint:       "Start chatting to create one."
     session_id:            "**会话 ID：** `{session_id}`"
     title:                 "**标题：** {title}"
     created:               "**创建时间：** {timestamp}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -183,6 +183,7 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
 
     runner.session_store = MagicMock()
+    runner.session_store.get_session.return_value = session_entry
     runner.session_store.get_or_create_session.return_value = session_entry
     runner.session_store.load_transcript.return_value = []
     runner.session_store.has_any_sessions.return_value = True

--- a/tests/gateway/test_readonly_session_creation.py
+++ b/tests/gateway/test_readonly_session_creation.py
@@ -1,0 +1,63 @@
+"""Regression tests for read-only gateway commands creating ghost sessions."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_runner(session_key: str):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._queue_depth = lambda _session_key, adapter=None: 0
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    runner.session_store = MagicMock()
+    runner.session_store.get_session.return_value = None
+    runner.session_store.get_or_create_session.side_effect = AssertionError(
+        "read-only command should not create a session"
+    )
+    runner._session_db = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_status_without_session_does_not_create_stub_session():
+    source = _make_source()
+    runner = _make_runner("agent:main:telegram:dm:c1")
+    event = SimpleNamespace(source=source)
+
+    result = await runner._handle_status_command(event)
+
+    assert "No active session yet." in result
+    runner.session_store.get_session.assert_called_once_with(source)
+
+
+@pytest.mark.asyncio
+async def test_usage_without_session_does_not_create_stub_session():
+    source = _make_source()
+    runner = _make_runner("agent:main:telegram:dm:c1")
+    event = SimpleNamespace(source=source)
+
+    result = await runner._handle_usage_command(event)
+
+    assert "No usage data available" in result
+    runner.session_store.get_session.assert_called_once_with(source)

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -30,7 +30,7 @@ def _make_event(text: str, *, platform: Platform = Platform.TELEGRAM) -> Message
     )
 
 
-def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.TELEGRAM):
+def _make_runner(session_entry: SessionEntry | None, *, platform: Platform = Platform.TELEGRAM):
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
@@ -43,6 +43,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
+    runner.session_store.get_session.return_value = session_entry
     runner.session_store.get_or_create_session.return_value = session_entry
     runner.session_store.load_transcript.return_value = []
     runner.session_store.has_any_sessions.return_value = True

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -52,6 +52,7 @@ def _make_runner(session_key, agent=None, cached_agent=None):
     runner._agent_cache = {}
     runner._agent_cache_lock = threading.Lock()
     runner.session_store = MagicMock()
+    runner.session_store.get_session.return_value = None
 
     if agent is not None:
         runner._running_agents[session_key] = agent
@@ -134,7 +135,7 @@ class TestUsageCachedAgent:
 
         session_entry = MagicMock()
         session_entry.session_id = "sess123"
-        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.get_session.return_value = session_entry
         runner.session_store.load_transcript.return_value = [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "hi there"},
@@ -219,7 +220,7 @@ class TestUsageAccountSection:
         }
         session_entry = MagicMock()
         session_entry.session_id = "sess-1"
-        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.get_session.return_value = session_entry
         runner.session_store.load_transcript.return_value = [
             {"role": "user", "content": "earlier"},
         ]


### PR DESCRIPTION
## Summary

This fixes a gateway state bug where read-only slash commands could create empty session state before the user had sent any real message.

### What changed

- add a read-only `SessionStore.get_session()` lookup
- switch `/status` and `/usage` to use the non-creating lookup
- return a no-session `/status` response instead of creating a stub session
- preserve the existing `/usage` no-data behavior when no session exists
- add regression coverage for both commands
- update gateway e2e fixtures to provide `get_session()` in the mocked session store
- add i18n keys for the no-session `/status` response

## Problem

`/status` and `/usage` previously called `get_or_create_session()` even when the user had not started a conversation yet. That could create ghost session rows / session metadata for pure inspection commands.

## Testing

```powershell
.\\.venv\\Scripts\\python.exe -m pytest -n0 -p no:cacheprovider --basetemp .tmp-pytest-2 tests/gateway/test_readonly_session_creation.py tests/gateway/test_status_command.py tests/gateway/test_usage_command.py tests/gateway/test_unknown_command.py tests/e2e/test_platform_commands.py tests/agent/test_i18n.py -q

Passed:

128 passed, 4 skipped