### PR TITLE
fix(auth): only suppress on remove when no user-managed siblings remain (#24390)

### DIFF
--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -278,19 +278,18 @@ def _remove_codex_device_code(provider: str, removed) -> RemovalResult:
     ``"device_code"`` (no prefix).  Entries may show up in the pool as
     either ``"device_code"`` (seeded) or ``"manual:device_code"`` (added
     via ``hermes auth add openai-codex``), but in both cases the re-seed
-    gate lives at the ``"device_code"`` suppression key.  We suppress
-    that canonical key here; the central dispatcher also suppresses
-    ``removed.source`` which is fine — belt-and-suspenders, idempotent.
-    """
-    from hermes_cli.auth import suppress_credential_source
+    gate lives at the ``"device_code"`` suppression key.
 
+    Suppression is centralized in ``auth_remove_command`` — it consults
+    the remaining pool via ``step.matches()`` and suppresses BOTH the
+    literal removed source (``manual:device_code``) AND the step's
+    canonical ``source_id`` (``device_code``) only when no sibling
+    entries remain. This avoids gagging other manual codex credentials
+    when the user removes just one. See upstream issue #24390.
+    """
     result = RemovalResult()
     if _clear_auth_store_provider(provider):
         result.cleaned.append(f"Cleared {provider} OAuth tokens from auth store")
-    # Suppress the canonical re-seed source, not just whatever source the
-    # removed entry had.  Otherwise `manual:device_code` removals wouldn't
-    # block the `device_code` re-seed path.
-    suppress_credential_source(provider, "device_code")
     result.hints.extend([
         "Suppressed openai-codex device_code source — it will not be re-seeded.",
         "Note: Codex CLI credentials still live in ~/.codex/auth.json",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -461,7 +461,37 @@ def auth_remove_command(args) -> None:
     for line in result.cleaned:
         print(line)
     if result.suppress:
-        suppress_credential_source(provider, removed.source)
+        # Only skip suppression when a user-managed sibling (manual:* source)
+        # remains under the same removal step. Multiple manual OAuth
+        # credentials commonly share ownership — e.g. every
+        # `hermes auth add openai-codex --type oauth` adds an entry with
+        # source="manual:device_code". Suppressing because the user removed
+        # one of them would silently gag the survivors at the next fresh
+        # pool load. See upstream issue #24390.
+        #
+        # Singleton-seeded entries (e.g. source="device_code" auto-imported
+        # from ~/.codex/auth.json) are NOT counted as siblings to preserve —
+        # those are exactly what the remove command is meant to suppress.
+        #
+        # Use the in-memory `pool` (already mutated by remove_index above),
+        # NOT a fresh load_pool() call — a fresh load triggers
+        # _seed_from_singletons which can re-import the very entry
+        # suppression is meant to block.
+        from agent.credential_pool import _is_manual_source
+        user_managed_siblings = [
+            e for e in pool.entries()
+            if step.matches(provider, e.source) and _is_manual_source(e.source)
+        ]
+        if user_managed_siblings:
+            # Skip suppression; drop the now-misleading "re-seeded" hint.
+            result.hints = [h for h in result.hints if "re-seeded" not in h]
+        else:
+            # No user-managed siblings — suppress both the literal removed
+            # source AND the step's canonical source_id (these may differ:
+            # codex pool entries have "manual:device_code" but the re-seed
+            # gate in _seed_from_singletons keys on "device_code").
+            for src in {removed.source, step.source_id}:
+                suppress_credential_source(provider, src)
     for line in result.hints:
         print(line)
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1126,6 +1126,145 @@ def test_auth_remove_codex_manual_source_suppresses_reseed(tmp_path, monkeypatch
     assert "openai-codex" not in updated.get("providers", {})
 
 
+def test_auth_remove_codex_keeps_source_when_siblings_remain(tmp_path, monkeypatch):
+    """Regression: removing one of N pool entries that share a source must NOT
+    suppress the source — that would silently gag the survivors at next fresh
+    pool load. See upstream issue #24390.
+
+    Reproduction: 3 manual:device_code entries (kthurman, james, afton). Remove
+    one. The other two share the same source. Before the fix, suppression fired
+    and killed both survivors via is_source_suppressed() gates in
+    _seed_from_singletons. After the fix, suppression is skipped while siblings
+    remain; the last-removal-triggers-suppression behavior (covered by
+    test_auth_remove_codex_manual_source_suppresses_reseed) still works.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    auth_store = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "acc-survivor-a",
+                    "refresh_token": "ref-survivor-a",
+                },
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "cx1",
+                    "label": "kthurman-ltinc",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "acc-survivor-a",
+                    "refresh_token": "ref-survivor-a",
+                },
+                {
+                    "id": "cx2",
+                    "label": "account-to-remove",
+                    "auth_type": "oauth",
+                    "priority": 1,
+                    "source": "manual:device_code",
+                    "access_token": "acc-doomed",
+                    "refresh_token": "ref-doomed",
+                },
+                {
+                    "id": "cx3",
+                    "label": "afton-codex",
+                    "auth_type": "oauth",
+                    "priority": 2,
+                    "source": "manual:device_code",
+                    "access_token": "acc-survivor-b",
+                    "refresh_token": "ref-survivor-b",
+                },
+            ]
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_remove_command
+
+    auth_remove_command(SimpleNamespace(provider="openai-codex", target="account-to-remove"))
+
+    updated = json.loads((hermes_home / "auth.json").read_text())
+    suppressed = updated.get("suppressed_sources", {}).get("openai-codex", [])
+
+    # Critical assertion — the bug was that these got added even with siblings remaining.
+    assert "manual:device_code" not in suppressed, (
+        "manual:device_code was suppressed while 2 sibling entries still share that source"
+    )
+    assert "device_code" not in suppressed, (
+        "device_code canonical key was suppressed while 2 sibling entries still share the manual variant"
+    )
+
+    # Sanity: survivors are still in the pool.
+    remaining_labels = {e["label"] for e in updated["credential_pool"]["openai-codex"]}
+    assert remaining_labels == {"kthurman-ltinc", "afton-codex"}
+
+
+def test_auth_remove_codex_suppresses_when_last_sibling_removed(tmp_path, monkeypatch):
+    """Symmetric to the regression test: when the LAST entry with a given source
+    is removed, suppression DOES fire (this preserves the protection from
+    upstream PR #13427).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    auth_store = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "acc-lonely",
+                    "refresh_token": "ref-lonely",
+                },
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "cx-solo",
+                    "label": "only-codex",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "acc-lonely",
+                    "refresh_token": "ref-lonely",
+                },
+            ]
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_remove_command
+
+    auth_remove_command(SimpleNamespace(provider="openai-codex", target="only-codex"))
+
+    updated = json.loads((hermes_home / "auth.json").read_text())
+    suppressed = updated.get("suppressed_sources", {}).get("openai-codex", [])
+
+    # Last entry removed — suppression SHOULD fire to prevent re-seeding.
+    assert "device_code" in suppressed, (
+        "Last codex entry removed but device_code canonical source not suppressed; "
+        "re-seeding will resurrect it on next pool load (regresses upstream PR #13427)"
+    )
+
+
 def test_auth_add_codex_clears_suppression_marker(tmp_path, monkeypatch):
     """Re-linking codex via `hermes auth add openai-codex` must clear any suppression marker."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
Fixes #24390. `hermes auth remove` was over-suppressing provider credential sources, blocking subsequent auth refresh attempts. Fix: only suppress the (provider, source_id) pair when no other user-managed sibling sources remain for that provider.

Test plan: repro case (Codex OAuth refresh after `hermes auth remove`) succeeds end-to-end; existing auth tests pass.