### PR TITLE
feat(auxiliary): add configurable fallback chains for auxiliary tasks (#26882)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2579,6 +2579,84 @@ def _try_payment_fallback(
     return None, None, ""
 
 
+def _try_configured_fallback_chain(
+    task: str,
+    failed_provider: str,
+    reason: str = "error",
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Try user-configured fallback_chain for a specific auxiliary task.
+
+    Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
+    entry in order.  Each entry must have at least ``provider``; ``model``,
+    ``base_url``, and ``api_key`` are optional.
+
+    Returns:
+        (client, model, provider_label) or (None, None, "") if no fallback.
+    """
+    if not task:
+        return None, None, ""
+
+    task_config = _get_auxiliary_task_config(task)
+    chain = task_config.get("fallback_chain")
+    if not chain or not isinstance(chain, list):
+        return None, None, ""
+
+    skip = failed_provider.lower().strip()
+    tried = []
+
+    for i, entry in enumerate(chain):
+        if not isinstance(entry, dict):
+            continue
+        fb_provider = str(entry.get("provider", "")).strip()
+        if not fb_provider or fb_provider.lower() == skip:
+            continue
+        fb_model = str(entry.get("model", "")).strip() or None
+        fb_base_url = str(entry.get("base_url", "")).strip() or None
+        fb_api_key = str(entry.get("api_key", "")).strip() or None
+
+        label = f"fallback_chain[{i}]({fb_provider})"
+
+        try:
+            fb_client = _resolve_single_provider(
+                fb_provider, fb_model, fb_base_url, fb_api_key)
+        except Exception:
+            fb_client = None
+
+        if fb_client is not None:
+            logger.info(
+                "Auxiliary %s: %s on %s — configured fallback to %s (%s)",
+                task, reason, failed_provider, label, fb_model or "default",
+            )
+            return fb_client, fb_model, label
+        tried.append(label)
+
+    if tried:
+        logger.debug(
+            "Auxiliary %s: configured fallback_chain exhausted (tried: %s)",
+            task, ", ".join(tried),
+        )
+    return None, None, ""
+
+
+def _resolve_single_provider(
+    provider: str,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[Any]:
+    """Resolve a single provider entry from fallback_chain to an OpenAI client.
+
+    Uses the existing provider resolution infrastructure where possible.
+    """
+    # Reuse resolve_provider_client which handles provider→client mapping
+    client, resolved_model = resolve_provider_client(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+    )
+    return client
+
 def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.
 
@@ -4523,7 +4601,7 @@ def call_llm(
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be
@@ -4539,8 +4617,18 @@ def call_llm(
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+
+            # Step 1: auto-detection chain fallback (existing behaviour)
+            fb_client = None
+            if is_auto:
+                fb_client, fb_model, fb_label = _try_payment_fallback(
+                    resolved_provider, task, reason=reason)
+
+            # Step 2: user-configured fallback_chain (new, #26882)
+            if fb_client is None:
+                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
+
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
@@ -4852,7 +4940,7 @@ async def async_call_llm(
             or _is_rate_limit_error(first_err)
         )
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 _mark_provider_unhealthy(
@@ -4864,8 +4952,17 @@ async def async_call_llm(
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+
+            # Step 1: auto-detection chain fallback (existing behaviour)
+            fb_client = None
+            if is_auto:
+                fb_client, fb_model, fb_label = _try_payment_fallback(
+                    resolved_provider, task, reason=reason)
+
+            # Step 2: user-configured fallback_chain (new, #26882)
+            if fb_client is None:
+                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,


### PR DESCRIPTION
## Summary

Add configurable `fallback_chain` for auxiliary tasks so that when a configured provider fails (quota, rate-limit, connection), the system automatically tries alternative providers instead of raising immediately.

Closes #26882

## Problem

Currently, auxiliary task fallback only works when `resolved_provider` is `"auto"` (no explicit provider configured). When a user explicitly configures an auxiliary task (e.g., `auxiliary.vision.provider: glm`), the `is_auto` gate at the fallback entry point prevents any fallback:

```python
is_auto = resolved_provider in {"auto", "", None}
if should_fallback and is_auto:  # ← blocks explicit-provider users
```

This means a user who configures `auxiliary.vision.provider: glm` gets zero recovery when glm fails — the error propagates directly.

## Solution

1. **New config key**: `auxiliary.<task>.fallback_chain` — a list of `{provider, model, base_url?, api_key?}` entries
2. **New function**: `_try_configured_fallback_chain()` — reads the chain from config, tries each entry via `resolve_provider_client()`
3. **Modified fallback gate**: Removed the `is_auto` requirement from the outer gate; auto-chain runs first (existing behaviour), then configured chain runs as fallback

### Config example

```yaml
auxiliary:
  vision:
    provider: glm
    model: glm-4v-flash
    fallback_chain:
      - provider: openrouter
        model: google/gemini-3-flash-preview
      - provider: nous
        model: claude-sonnet-4
  compression:
    provider: openrouter
    fallback_chain:
      - provider: openai
        model: gpt-4o-mini
```

### Behaviour

1. Try primary provider first (unchanged)
2. On fallback-worthy errors (429, 402, connection), try auto-detection chain (unchanged for `auto` users)
3. **New**: If auto-chain doesn't find a fallback (or user has explicit provider), try `fallback_chain` entries in order
4. If all entries fail, raise the last error

## Files Changed

| File | Change |
|------|--------|
| `agent/auxiliary_client.py` | +103/-6: added `_try_configured_fallback_chain()`, `_resolve_single_provider()`, modified `call_llm()` and `async_call_llm()` fallback gates |

## Test Results

```
295 passed, 1 skipped, 23362 deselected (all auxiliary tests)
```

## Design Decisions

- **Config over code**: Users define fallback chains in `config.yaml`, not in Python
- **Non-breaking**: Existing `auto` fallback behaviour is unchanged; `fallback_chain` is purely additive
- **Task-agnostic**: Works for ALL auxiliary tasks (vision, tts, compression, web_extract, etc.)
- **Reuses `resolve_provider_client()`**: No duplicate provider resolution logic
