### PR TITLE
feat(feishu): inject chat_id and chat_type into session context prompt

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -366,14 +366,20 @@ def build_session_context_prompt(
             "and offer to elaborate."
         )
     elif context.source.platform == Platform.FEISHU:
-        # Inject chat_id so the agent can determine which persona to use
-        # (e.g., OPC multi-agent setup with different Feishu groups)
-        src = context.source
-        if src.chat_id:
-            lines.append("")
-            lines.append(f"**Feishu Chat ID:** `{src.chat_id}`")
-            if src.chat_type:
-                lines.append(f"**Chat Type:** {src.chat_type}")
+        # Inject chat_id and chat_type so the agent can determine which
+        # persona to use (e.g., multi-agent setup with different Feishu groups).
+        # Fields are independent — chat_type is useful even without chat_id.
+        _chat_id = getattr(context.source, "chat_id", None)
+        _chat_type = getattr(context.source, "chat_type", None)
+        if _chat_id:
+            _safe_id = _chat_id.replace("`", "").strip()
+            if _safe_id:
+                lines.append("")
+                lines.append(f"**Feishu Chat ID:** `{_safe_id}`")
+        if _chat_type:
+            _safe_type = _chat_type.replace("`", "").strip()
+            if _safe_type:
+                lines.append(f"**Chat Type:** {_safe_type}")
     elif context.source.platform == Platform.YUANBAO:
         lines.append("")
         lines.append(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -365,6 +365,15 @@ def build_session_context_prompt(
             "If the user needs a detailed answer, give the short version first "
             "and offer to elaborate."
         )
+    elif context.source.platform == Platform.FEISHU:
+        # Inject chat_id so the agent can determine which persona to use
+        # (e.g., OPC multi-agent setup with different Feishu groups)
+        src = context.source
+        if src.chat_id:
+            lines.append("")
+            lines.append(f"**Feishu Chat ID:** `{src.chat_id}`")
+            if src.chat_type:
+                lines.append(f"**Chat Type:** {src.chat_type}")
     elif context.source.platform == Platform.YUANBAO:
         lines.append("")
         lines.append(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -369,15 +369,17 @@ def build_session_context_prompt(
         # Inject chat_id and chat_type so the agent can determine which
         # persona to use (e.g., multi-agent setup with different Feishu groups).
         # Fields are independent — chat_type is useful even without chat_id.
+        # Sanitize: strip backticks and newlines to prevent prompt injection
+        # via crafted IDs or chat type values.
         _chat_id = getattr(context.source, "chat_id", None)
         _chat_type = getattr(context.source, "chat_type", None)
         if _chat_id:
-            _safe_id = _chat_id.replace("`", "").strip()
+            _safe_id = _chat_id.replace("`", "").replace("\n", " ").replace("\r", "").strip()
             if _safe_id:
                 lines.append("")
                 lines.append(f"**Feishu Chat ID:** `{_safe_id}`")
         if _chat_type:
-            _safe_type = _chat_type.replace("`", "").strip()
+            _safe_type = _chat_type.replace("`", "").replace("\n", " ").replace("\r", "").strip()
             if _safe_type:
                 lines.append(f"**Chat Type:** {_safe_type}")
     elif context.source.platform == Platform.YUANBAO:

--- a/tests/gateway/test_feishu_session_context.py
+++ b/tests/gateway/test_feishu_session_context.py
@@ -1,0 +1,84 @@
+"""Tests for Feishu chat_id and chat_type injection in session context prompts."""
+
+from gateway.session import (
+    SessionContext,
+    SessionSource,
+    build_session_context_prompt,
+)
+from gateway.config import Platform
+
+
+def _make_feishu_context(chat_id="oc_abc123", chat_type="group", **kwargs):
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=kwargs.pop("user_id", "user-1"),
+        user_name=kwargs.pop("user_name", None),
+    )
+    return SessionContext(
+        source=source,
+        connected_platforms=[Platform.FEISHU],
+        home_channels=kwargs.pop("home_channels", {}),
+    )
+
+
+class TestFeishuChatIdInjection:
+    def test_chat_id_in_prompt(self):
+        ctx = _make_feishu_context(chat_id="oc_abc123")
+        prompt = build_session_context_prompt(ctx)
+        assert "Feishu Chat ID" in prompt
+        assert "oc_abc123" in prompt
+
+    def test_chat_type_in_prompt(self):
+        ctx = _make_feishu_context(chat_type="group")
+        prompt = build_session_context_prompt(ctx)
+        assert "Chat Type" in prompt
+        assert "group" in prompt
+
+    def test_chat_type_present_without_chat_id(self):
+        """chat_type should appear even when chat_id is empty."""
+        ctx = _make_feishu_context(chat_id="", chat_type="dm")
+        prompt = build_session_context_prompt(ctx)
+        assert "Chat Type" in prompt
+        assert "dm" in prompt
+
+    def test_chat_id_present_without_chat_type(self):
+        ctx = _make_feishu_context(chat_id="oc_xyz", chat_type="")
+        prompt = build_session_context_prompt(ctx)
+        assert "Feishu Chat ID" in prompt
+        assert "oc_xyz" in prompt
+        assert "Chat Type" not in prompt
+
+    def test_both_empty(self):
+        ctx = _make_feishu_context(chat_id="", chat_type="")
+        prompt = build_session_context_prompt(ctx)
+        assert "Feishu Chat ID" not in prompt
+        assert "Chat Type" not in prompt
+
+
+class TestFeishuPromptInjectionSafety:
+    def test_backticks_stripped_from_chat_id(self):
+        ctx = _make_feishu_context(chat_id="oc_`injected`_abc")
+        prompt = build_session_context_prompt(ctx)
+        # Backticks should be stripped from the value
+        assert "injected" in prompt
+        # The value inside the backtick-wrapped code span should not contain backticks
+        assert "`oc_injected_abc`" in prompt
+
+    def test_backticks_stripped_from_chat_type(self):
+        ctx = _make_feishu_context(chat_type="group`malicious`")
+        prompt = build_session_context_prompt(ctx)
+        assert "groupmalicious" in prompt
+
+    def test_only_backticks_results_in_skip(self):
+        """If value is only backticks, it should be skipped entirely."""
+        ctx = _make_feishu_context(chat_id="```")
+        prompt = build_session_context_prompt(ctx)
+        assert "Feishu Chat ID" not in prompt
+
+    def test_control_chars_preserved_in_id(self):
+        """Newlines/tabs are stripped by strip(), but normal text is kept."""
+        ctx = _make_feishu_context(chat_id="  oc_abc  ")
+        prompt = build_session_context_prompt(ctx)
+        assert "oc_abc" in prompt


### PR DESCRIPTION
## What

Injects the Feishu `chat_id` and `chat_type` into the session context system prompt, following the same pattern as Discord, BlueBubbles, Slack, and Yuanbao.

## Why

Without knowing which group/chat the agent is responding in, it's impossible to implement per-chat persona switching on Feishu. This is useful for multi-agent setups where different Feishu groups represent different roles (e.g., product, design, engineering teams), each with their own identity defined in SOUL.md.

## How

Adds a `Platform.FEISHU` branch in `build_session_context_prompt()` that appends:

- **Feishu Chat ID:** oc_xxx
- **Chat Type:** group / dm

This allows SOUL.md (or any system prompt logic) to match on chat_id and switch personas accordingly.

## Example SOUL.md usage

Check the Feishu Chat ID in the system prompt, then switch persona:

| Chat ID | Role |
|---|---|
| oc_abc123 | Product Manager, mature and steady |
| oc_def456 | Designer, gentle and detail-oriented |

## Testing

Verified working on a live Feishu instance with 3 group chats, each responding with the correct persona based on chat_id matching in SOUL.md.
