### PR TITLE
fix(teams_pipeline): tolerate malformed store JSON during startup

### DIFF
--- a/plugins/teams_pipeline/store.py
+++ b/plugins/teams_pipeline/store.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import threading
+import logging
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +17,7 @@ from hermes_constants import get_hermes_home
 
 
 DEFAULT_TEAMS_PIPELINE_STORE_FILENAME = "teams_pipeline_store.json"
+logger = logging.getLogger(__name__)
 
 
 def _utc_now_iso() -> str:
@@ -54,8 +56,20 @@ class TeamsPipelineStore:
         with self._lock:
             if not self.path.exists():
                 return
-            data = json.loads(self.path.read_text(encoding="utf-8") or "{}")
+            try:
+                data = json.loads(self.path.read_text(encoding="utf-8") or "{}")
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "Teams pipeline store %s is unreadable or malformed; starting with empty state: %s",
+                    self.path,
+                    exc,
+                )
+                return
             if not isinstance(data, dict):
+                logger.warning(
+                    "Teams pipeline store %s has non-object JSON root; starting with empty state",
+                    self.path,
+                )
                 return
             self._state["subscriptions"] = dict(data.get("subscriptions") or {})
             self._state["notification_receipts"] = dict(data.get("notification_receipts") or {})

--- a/tests/plugins/test_teams_pipeline_plugin.py
+++ b/tests/plugins/test_teams_pipeline_plugin.py
@@ -212,6 +212,23 @@ def test_store_persists_subscription_event_and_job_state(tmp_path):
     assert sink["page_id"] == "page-1"
 
 
+def test_store_corrupt_json_falls_back_to_empty_state(tmp_path, caplog):
+    store_path = tmp_path / "teams-store.json"
+    store_path.write_text("{bad json", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        store = TeamsPipelineStore(store_path)
+
+    assert store.stats() == {
+        "subscriptions": 0,
+        "notification_receipts": 0,
+        "event_timestamps": 0,
+        "jobs": 0,
+        "sink_records": 0,
+    }
+    assert "starting with empty state" in caplog.text
+
+
 def test_store_notification_receipts_are_idempotent(tmp_path):
     store = TeamsPipelineStore(tmp_path / "teams-store.json")
     notification = {


### PR DESCRIPTION
## Summary
Handle malformed or unreadable Teams pipeline store files without crashing the Teams pipeline runtime or CLI.

## Changes
- catch `JSONDecodeError`, `UnicodeDecodeError`, and `OSError` while loading `teams_pipeline_store.json`
- fall back to an empty in-memory state and log a warning instead of failing init
- add a regression test covering corrupt JSON store recovery

## Testing
- `pytest tests/plugins/test_teams_pipeline_plugin.py -q`
- `pytest tests/hermes_cli/test_teams_pipeline_plugin_cli.py -q`
- Result: `20 passed in 5.54s`

## Notes
- Windows `PermissionError: [WinError 5]` lines appeared during pytest temp-dir cleanup at process exit
- those cleanup warnings did not affect the actual test results