### PR TITLE
docs: add gstack Coding Tasks section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1100,3 +1100,17 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+---
+
+## Coding Tasks
+
+When spawning Claude Code sessions for coding work, tell the session to use gstack skills.
+
+Examples:
+
+- **Security audit:** "Load gstack. Run /cso"
+- **Code review:** "Load gstack. Run /review"
+- **QA test a URL:** "Load gstack. Run /qa https://..."
+- **Build a feature end-to-end:** "Load gstack. Run /autoplan, implement the plan, then run /ship"
+- **Plan before building:** "Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement."


### PR DESCRIPTION
## Summary

- Adds a **Coding Tasks** section to `AGENTS.md` with guidance for spawning Claude Code sessions
- Documents gstack skill invocations for common workflows: security audit, code review, QA, end-to-end feature builds, and planning

## Test plan

- [ ] Verify the new section renders correctly in GitHub's markdown preview
- [ ] Confirm examples are accurate against gstack skill documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)