### PR TITLE
fix(auth): send Bearer auth for Azure Foundry `anthropic_messages` endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -471,14 +471,18 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
-    require Authorization: Bearer *** of Anthropic's native x-api-key header.
-    MiniMax's global and China Anthropic-compatible endpoints follow this pattern.
+    require Authorization: Bearer instead of Anthropic's native x-api-key header.
+    MiniMax's global and China Anthropic-compatible endpoints, and Azure AI
+    Foundry's Anthropic-style endpoint follow this pattern.
     """
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False
     normalized = normalized.rstrip("/").lower()
-    return normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+    return (
+        normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+        or "azure.com" in normalized
+    )
 
 
 def _base_url_needs_context_1m_beta(base_url: str | None) -> bool:


### PR DESCRIPTION
## Summary

- Add `azure.com` to `_requires_bearer_auth()` so Azure AI Foundry's Anthropic-style endpoint gets `Authorization: Bearer` instead of `x-api-key`
- The `_requires_bearer_auth()` check fires before the generic `_is_third_party_anthropic_endpoint()` branch, so Azure endpoints now take the Bearer path

## Root cause

`build_anthropic_client()` checks `_requires_bearer_auth()` first (line 586), then falls through to `_is_third_party_anthropic_endpoint()` (line 596) which sets `kwargs["api_key"]` (x-api-key header). Azure endpoints matched the latter but not the former, resulting in HTTP 401.

Fixes #26970