### PR TITLE
[codex] add xAI web search tool

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1624,6 +1624,22 @@ DEFAULT_CONFIG = {
         "retries": 2,
     },
 
+    # Web Search via xAI's built-in web_search Responses tool.
+    # The tool registers when xAI credentials are available (SuperGrok
+    # OAuth or XAI_API_KEY) AND the xai_web_search toolset is enabled in
+    # `hermes tools`. These settings tune the backing Responses API call.
+    "xai_web_search": {
+        # xAI model used for the Responses call. Any Grok model with
+        # web_search tool access works.
+        "model": "grok-4.3",
+        # Request timeout in seconds (minimum 30). Agentic server-side
+        # web search can take longer than simple search APIs.
+        "timeout_seconds": 180,
+        # Number of automatic retries on 5xx / ReadTimeout / ConnectionError.
+        # Each retry backs off (1.5x attempt seconds, capped at 5s).
+        "retries": 2,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 23,
 }

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def is_accessible_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if is_accessible_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if is_accessible_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if is_accessible_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if is_accessible_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -62,6 +62,7 @@ CONFIGURABLE_TOOLSETS = [
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
+    ("xai_web_search",  "🌐 xAI Web Search",            "xai_web_search (requires xAI OAuth or XAI_API_KEY)"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -92,7 +93,7 @@ CONFIGURABLE_TOOLSETS = [
 # or XAI_API_KEY). Users opt in via `hermes tools` → X (Twitter) Search,
 # which walks them through credential setup. The tool's check_fn means
 # the schema won't appear to the model even if enabled without credentials.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "xai_web_search"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset
@@ -325,6 +326,39 @@ TOOL_CATEGORIES = {
             "(uses your subscription quota instead of API spend)."
         ),
         "icon": "🐦",
+        "providers": [
+            {
+                "name": "xAI Grok OAuth (SuperGrok Subscription)",
+                "badge": "subscription",
+                "tag": "Browser login at accounts.x.ai — no API key required",
+                "env_vars": [],
+                "post_setup": "xai_grok",
+            },
+            {
+                "name": "xAI API key",
+                "badge": "paid",
+                "tag": "Direct xAI API billing via XAI_API_KEY",
+                "env_vars": [
+                    {
+                        "key": "XAI_API_KEY",
+                        "prompt": "xAI API key",
+                        "url": "https://console.x.ai/",
+                    },
+                ],
+            },
+        ],
+    },
+    "xai_web_search": {
+        "name": "xAI Web Search",
+        "setup_title": "Select xAI Credential Source",
+        "setup_note": (
+            "Hermes routes xAI web searches through xAI's built-in "
+            "web_search Responses tool. Both credential sources hit the "
+            "same https://api.x.ai/v1/responses endpoint — pick whichever "
+            "you already have. SuperGrok OAuth is preferred when both are "
+            "set (uses your subscription quota instead of API spend)."
+        ),
+        "icon": "🌐",
         "providers": [
             {
                 "name": "xAI Grok OAuth (SuperGrok Subscription)",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -77,6 +77,10 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+def test_configurable_toolsets_include_xai_web_search_default_off():
+    assert any(ts_key == "xai_web_search" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+    assert "xai_web_search" in _DEFAULT_OFF_TOOLSETS
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 

--- a/tests/tools/test_xai_web_search_tool.py
+++ b/tests/tools/test_xai_web_search_tool.py
@@ -1,0 +1,308 @@
+"""Tests for the xAI Web Search tool backed by Responses API."""
+
+import json
+
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Client Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def _no_xai_env(monkeypatch):
+    for var in ("XAI_API_KEY", "XAI_BASE_URL", "HERMES_XAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_xai_web_search_posts_responses_request(monkeypatch):
+    from hermes_cli import __version__
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "xAI Web Search found current documentation.",
+                "citations": [{"url": "https://docs.x.ai/", "title": "xAI Docs"}],
+                "server_side_tool_usage": {"SERVER_SIDE_TOOL_WEB_SEARCH": 1},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_web_search_tool(
+            query="What does xAI Web Search support?",
+            allowed_domains=["https://docs.x.ai/developers/tools/web-search"],
+            enable_image_understanding=True,
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.3"
+    assert captured["json"]["store"] is False
+    assert tool_def["type"] == "web_search"
+    assert tool_def["filters"]["allowed_domains"] == ["docs.x.ai"]
+    assert tool_def["enable_image_understanding"] is True
+    assert result["success"] is True
+    assert result["tool"] == "xai_web_search"
+    assert result["xai_tool"] == "web_search"
+    assert result["answer"] == "xAI Web Search found current documentation."
+    assert result["server_side_tool_usage"] == {"SERVER_SIDE_TOOL_WEB_SEARCH": 1}
+
+
+def test_xai_web_search_rejects_conflicting_domain_filters(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        xai_web_search_tool(
+            query="latest xAI docs",
+            allowed_domains=["docs.x.ai"],
+            excluded_domains=["x.com"],
+        )
+    )
+
+    assert result["error"] == "allowed_domains and excluded_domains cannot be used together"
+
+
+def test_xai_web_search_extracts_inline_url_citations(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "The docs describe Web Search.",
+                                "annotations": [
+                                    {
+                                        "type": "url_citation",
+                                        "url": "https://docs.x.ai/developers/tools/web-search",
+                                        "title": "Web Search",
+                                        "start_index": 4,
+                                        "end_index": 8,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_web_search_tool(query="xAI web search docs"))
+
+    assert result["success"] is True
+    assert result["answer"] == "The docs describe Web Search."
+    assert result["inline_citations"] == [
+        {
+            "url": "https://docs.x.ai/developers/tools/web-search",
+            "title": "Web Search",
+            "start_index": 4,
+            "end_index": 8,
+        }
+    ]
+
+
+def test_xai_web_search_returns_structured_http_error(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"web_search is not enabled for this model"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "web_search is not enabled for this model",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(xai_web_search_tool(query="latest xAI docs"))
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "xai_web_search"
+    assert result["xai_tool"] == "web_search"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: web_search is not enabled for this model"
+
+
+def test_xai_web_search_retries_read_timeout_then_succeeds(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse({"output_text": "Recovered after retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_web_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_web_search_tool(query="grok web search"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_xai_web_search_retries_5xx_then_succeeds(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "Internal error", "error": "Service temporarily unavailable."},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_web_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_web_search_tool(query="grok web search"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."
+
+
+def test_xai_web_search_uses_xai_oauth_when_available(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_web_search_tool import check_xai_web_search_requirements, xai_web_search_tool
+
+    _no_xai_env(monkeypatch)
+
+    def _fake_resolve():
+        return {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.xai_web_search_tool.resolve_xai_http_credentials", _fake_resolve
+    )
+    invalidate_check_fn_cache()
+
+    assert check_xai_web_search_requirements() is True
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        return _FakeResponse({"output_text": "Found via OAuth."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_web_search_tool(query="anything about xai"))
+
+    assert result["success"] is True
+    assert result["credential_source"] == "xai-oauth"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
+
+def test_xai_web_search_returns_tool_error_when_no_credentials(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_web_search_tool import check_xai_web_search_requirements, xai_web_search_tool
+
+    _no_xai_env(monkeypatch)
+
+    def _fake_resolve():
+        return {
+            "provider": "xai",
+            "api_key": "",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.xai_web_search_tool.resolve_xai_http_credentials", _fake_resolve
+    )
+    invalidate_check_fn_cache()
+
+    assert check_xai_web_search_requirements() is False
+
+    result = xai_web_search_tool(query="anything")
+    assert "No xAI credentials available" in result
+    assert "hermes auth add xai-oauth" in result
+
+
+def test_xai_web_search_honors_config_model_and_timeout(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr(
+        "tools.xai_web_search_tool._load_xai_web_search_config",
+        lambda: {"model": "grok-custom-test", "timeout_seconds": 45, "retries": 0},
+    )
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["model"] = json["model"]
+        captured["timeout"] = timeout
+        return _FakeResponse({"output_text": "Custom model OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_web_search_tool(query="anything"))
+
+    assert result["success"] is True
+    assert captured["model"] == "grok-custom-test"
+    assert captured["timeout"] == 45
+
+
+def test_xai_web_search_registered_in_registry_with_check_fn():
+    import tools.xai_web_search_tool  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry.get_entry("xai_web_search")
+    assert entry is not None
+    assert entry.toolset == "xai_web_search"
+    assert entry.check_fn is not None
+    assert entry.check_fn.__name__ == "check_xai_web_search_requirements"
+    assert "XAI_API_KEY" in entry.requires_env

--- a/tests/tools/test_xai_web_search_tool.py
+++ b/tests/tools/test_xai_web_search_tool.py
@@ -87,6 +87,65 @@ def test_xai_web_search_rejects_conflicting_domain_filters(monkeypatch):
     assert result["error"] == "allowed_domains and excluded_domains cannot be used together"
 
 
+def test_xai_web_search_empty_query_returns_tool_error(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(xai_web_search_tool(query="  "))
+
+    assert result["error"] == "query is required for xai_web_search"
+
+
+def test_xai_web_search_rejects_too_many_domains(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        xai_web_search_tool(
+            query="latest docs",
+            allowed_domains=[
+                "a.example",
+                "b.example",
+                "c.example",
+                "d.example",
+                "e.example",
+                "f.example",
+            ],
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "allowed_domains supports at most 5 domains"
+    assert result["error_type"] == "ValueError"
+
+
+def test_xai_web_search_excluded_domains_payload_and_default_image_flag(monkeypatch):
+    from tools.xai_web_search_tool import xai_web_search_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse({"output_text": "Excluded domain search OK."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_web_search_tool(
+            query="latest xAI docs",
+            excluded_domains=["https://docs.x.ai:443/path", ".example.com"],
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert result["success"] is True
+    assert tool_def["filters"]["excluded_domains"] == ["docs.x.ai", "example.com"]
+    assert "enable_image_understanding" not in tool_def
+
+
 def test_xai_web_search_extracts_inline_url_citations(monkeypatch):
     from tools.xai_web_search_tool import xai_web_search_tool
 

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -2,24 +2,24 @@
 
 from __future__ import annotations
 
-import os
 from typing import Dict
-
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
+import os
 
 
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
-    Wraps :func:`hermes_cli.config.get_env_value` so tests can patch
-    ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
-    xAI credential resolver.
+    Import the Hermes helper at call time so tests that temporarily patch or
+    reload ``hermes_cli.config`` cannot leave this module holding a stale
+    patched function.
     """
-    if _hermes_get_env_value is not None:
-        value = _hermes_get_env_value(name)
+    try:
+        from hermes_cli.config import get_env_value as hermes_get_env_value
+    except Exception:
+        hermes_get_env_value = None
+
+    if hermes_get_env_value is not None:
+        value = hermes_get_env_value(name)
         if value is not None:
             return value
     return os.environ.get(name, default)

--- a/tools/xai_web_search_tool.py
+++ b/tools/xai_web_search_tool.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Web Search tool backed by xAI's built-in ``web_search`` Responses API tool.
+
+This is intentionally separate from Hermes' provider-agnostic ``web_search``
+tool. It exposes xAI's server-side Responses tool directly for users who want
+Grok to search and browse the web through xAI, while leaving existing web
+search backends unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_WEB_SEARCH_MODEL = "grok-4.3"
+DEFAULT_XAI_WEB_SEARCH_TIMEOUT_SECONDS = 180
+DEFAULT_XAI_WEB_SEARCH_RETRIES = 2
+MAX_DOMAINS = 5
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_xai_web_search_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("xai_web_search", {}) or {}
+    except Exception:
+        return {}
+
+
+def _get_xai_web_search_model() -> str:
+    cfg = _load_xai_web_search_config()
+    return (str(cfg.get("model") or "").strip() or DEFAULT_XAI_WEB_SEARCH_MODEL)
+
+
+def _get_xai_web_search_timeout_seconds() -> int:
+    cfg = _load_xai_web_search_config()
+    raw_value = cfg.get("timeout_seconds", DEFAULT_XAI_WEB_SEARCH_TIMEOUT_SECONDS)
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_WEB_SEARCH_TIMEOUT_SECONDS
+
+
+def _get_xai_web_search_retries() -> int:
+    cfg = _load_xai_web_search_config()
+    raw_value = cfg.get("retries", DEFAULT_XAI_WEB_SEARCH_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_WEB_SEARCH_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_xai_bearer() -> Tuple[str, str, str]:
+    """Return ``(api_key, base_url, source)`` or raise on missing credentials."""
+    creds = resolve_xai_http_credentials()
+    api_key = str(creds.get("api_key") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "No xAI credentials available. Run `hermes auth add xai-oauth` "
+            "to sign in with your SuperGrok subscription, or set XAI_API_KEY."
+        )
+    base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    source = str(creds.get("provider") or "xai")
+    return api_key, base_url, source
+
+
+def check_xai_web_search_requirements() -> bool:
+    """Return True when xAI credentials are available and non-empty."""
+    try:
+        creds = resolve_xai_http_credentials()
+        return bool(str(creds.get("api_key") or "").strip())
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_domains(domains: Optional[List[str]], field_name: str) -> List[str]:
+    cleaned: List[str] = []
+    for domain in domains or []:
+        raw = str(domain or "").strip()
+        if not raw:
+            continue
+        parsed = urlparse(raw if "://" in raw else f"//{raw}")
+        host = (parsed.netloc or parsed.path).split("/")[0].strip().lower()
+        host = host.lstrip(".")
+        if host:
+            cleaned.append(host)
+    if len(cleaned) > MAX_DOMAINS:
+        raise ValueError(f"{field_name} supports at most {MAX_DOMAINS} domains")
+    return cleaned
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    citations: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            for annotation in content.get("annotations", []) or []:
+                if annotation.get("type") != "url_citation":
+                    continue
+                citations.append(
+                    {
+                        "url": annotation.get("url", ""),
+                        "title": annotation.get("title", ""),
+                        "start_index": annotation.get("start_index"),
+                        "end_index": annotation.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error = str(payload.get("error") or "").strip()
+        if not error and isinstance(payload.get("error"), dict):
+            error = str(payload["error"].get("message") or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+
+def xai_web_search_tool(
+    query: str,
+    allowed_domains: Optional[List[str]] = None,
+    excluded_domains: Optional[List[str]] = None,
+    enable_image_understanding: bool = False,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required for xai_web_search")
+
+    try:
+        api_key, base_url, source = _resolve_xai_bearer()
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+
+    try:
+        allowed = _normalize_domains(allowed_domains, "allowed_domains")
+        excluded = _normalize_domains(excluded_domains, "excluded_domains")
+        if allowed and excluded:
+            return tool_error("allowed_domains and excluded_domains cannot be used together")
+
+        tool_def: Dict[str, Any] = {"type": "web_search"}
+        filters: Dict[str, Any] = {}
+        if allowed:
+            filters["allowed_domains"] = allowed
+        if excluded:
+            filters["excluded_domains"] = excluded
+        if filters:
+            tool_def["filters"] = filters
+        if enable_image_understanding:
+            tool_def["enable_image_understanding"] = True
+
+        payload = {
+            "model": _get_xai_web_search_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": query.strip(),
+                }
+            ],
+            "tools": [tool_def],
+            "store": False,
+        }
+
+        timeout_seconds = _get_xai_web_search_timeout_seconds()
+        max_retries = _get_xai_web_search_retries()
+        response: Optional[requests.Response] = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{base_url}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_web_search upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.ReadTimeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_web_search transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("xai_web_search request did not return a response")
+
+        data = response.json()
+        answer = _extract_response_text(data)
+        citations = list(data.get("citations") or [])
+        inline_citations = _extract_inline_citations(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "credential_source": source,
+                "tool": "xai_web_search",
+                "xai_tool": "web_search",
+                "model": payload["model"],
+                "query": query.strip(),
+                "answer": answer,
+                "citations": citations,
+                "inline_citations": inline_citations,
+                "server_side_tool_usage": data.get("server_side_tool_usage") or {},
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("xai_web_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_web_search",
+                "xai_tool": "web_search",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.ReadTimeout as e:
+        logger.error("xai_web_search timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_web_search",
+                "xai_tool": "web_search",
+                "error": (
+                    "xAI web_search timed out after "
+                    f"{_get_xai_web_search_timeout_seconds()} seconds"
+                ),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("xai_web_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_web_search",
+                "xai_tool": "web_search",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+XAI_WEB_SEARCH_SCHEMA = {
+    "name": "xai_web_search",
+    "description": (
+        "Search and browse the live web using xAI's built-in web_search "
+        "Responses API tool. Use this when the user specifically wants Grok/xAI "
+        "web search or when xAI server-side citations are useful."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look up on the web.",
+            },
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional domains to search exclusively (max 5).",
+            },
+            "excluded_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional domains to exclude from search (max 5).",
+            },
+            "enable_image_understanding": {
+                "type": "boolean",
+                "description": "Whether xAI should analyze images encountered while browsing.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def _handle_xai_web_search(args, **kw):
+    return xai_web_search_tool(
+        query=args.get("query", ""),
+        allowed_domains=args.get("allowed_domains"),
+        excluded_domains=args.get("excluded_domains"),
+        enable_image_understanding=bool(args.get("enable_image_understanding", False)),
+    )
+
+
+registry.register(
+    name="xai_web_search",
+    toolset="xai_web_search",
+    schema=XAI_WEB_SEARCH_SCHEMA,
+    handler=_handle_xai_web_search,
+    check_fn=check_xai_web_search_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🌐",
+    max_result_size_chars=100_000,
+)

--- a/tools/xai_web_search_tool.py
+++ b/tools/xai_web_search_tool.py
@@ -106,7 +106,7 @@ def _normalize_domains(domains: Optional[List[str]], field_name: str) -> List[st
         if not raw:
             continue
         parsed = urlparse(raw if "://" in raw else f"//{raw}")
-        host = (parsed.netloc or parsed.path).split("/")[0].strip().lower()
+        host = (parsed.hostname or parsed.netloc or parsed.path).split("/")[0].strip().lower()
         host = host.lstrip(".")
         if host:
             cleaned.append(host)


### PR DESCRIPTION
## Summary

Adds a dedicated `xai_web_search` Hermes tool backed by xAI's built-in `web_search` Responses API server-side tool.

This keeps Hermes' existing provider-agnostic `web_search` behavior unchanged while exposing the xAI-native search path for users who want Grok/xAI web search, domain filters, image understanding, and server-side citations.

## What changed

- Added `tools/xai_web_search_tool.py`.
- Added default `xai_web_search` config with model, timeout, and retry settings.
- Added `xai_web_search` to `hermes tools` as a default-off xAI credential-gated toolset.
- Added unit coverage for request shape, domain filters, inline citations, error handling, retries, credential gating, config overrides, and registry registration.

## Validation

- `uv run --extra dev pytest tests/tools/test_xai_web_search_tool.py tests/tools/test_x_search_tool.py tests/hermes_cli/test_tools_config.py tests/test_toolsets.py`
- `uv run --extra dev ruff check tools/xai_web_search_tool.py tests/tools/test_xai_web_search_tool.py hermes_cli/config.py hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py`
- Real smoke test against xAI `/responses` with `web_search` and `allowed_domains=["docs.x.ai"]`: succeeded in 10.6s with inline citations.
