### PR TITLE
Align desktop installer with GUI bootstrap flow

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -12,7 +12,7 @@ npm install
 
 For Python, you have two options:
 
-**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11+ on `PATH`.
+**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11-3.13 on Windows.
 
 **Option B — share an existing CLI install:** if you already ran `scripts/install.ps1` / `scripts/install.sh`, that's the same layout the desktop uses. The desktop reuses your existing venv and editable install — no extra steps. See [Runtime Bootstrap](#runtime-bootstrap) below for details.
 
@@ -24,20 +24,20 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 
 ### Runtime prerequisites
 
-Hermes Desktop needs:
+Hermes Desktop's baseline installer dependencies are:
 
-- **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution. (required)
-- **Git for Windows** (Windows only) — provides Git Bash, which Hermes' terminal tool calls directly. Linux and macOS already ship a system bash. (required)
-- **ripgrep** — used by Hermes' `search_files` tool for fast `.gitignore`-aware file/content search. Recommended on all platforms; Hermes falls back to `grep`/`find` if missing (works but slower and noisier).
+- **Python 3.11-3.13** — for the agent runtime, dashboard backend, and tool execution.
+- **Node.js 20+ LTS** — for browser tools and Node-backed capabilities.
+- **Git for Windows** — for Git Bash, which powers Hermes terminal commands on Windows.
 
-The packaged Windows installer (`Hermes-*.exe`) detects all three at install time. Required items missing are auto-installed via `winget install -e --id Python.Python.3.11 --scope user` and `winget install -e --id Git.Git`. The recommended ripgrep is offered as `winget install -e --id BurntSushi.ripgrep.MSVC --scope user`. If `winget` isn't available the installer shows manual download URLs and lets you continue. The MSI installer (`Hermes-*.msi`) doesn't run the prereq page — enterprise deploys are expected to handle prereqs out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js 20+, and Git for Windows via `winget` when possible. Python 3.14 is not accepted yet because several Hermes dependencies do not publish compatible wheels. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
 
-For dev (`npm run dev`) the Python and Git Bash checks happen at first launch via the Electron bootstrapper, which throws a clear error if either prereq is missing. Manual install commands you can run yourself:
+For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 
 ```powershell
 winget install -e --id Python.Python.3.11 --scope user
+winget install -e --id OpenJS.NodeJS.LTS
 winget install -e --id Git.Git
-winget install -e --id BurntSushi.ripgrep.MSVC --scope user
 ```
 
 ## Development
@@ -218,11 +218,11 @@ The desktop resolves a Hermes backend in this order:
 ### First-launch flow on a packaged install
 
 1. Sync factory image → `HERMES_HOME/hermes-agent`. Skipped if a `.git` directory exists at the destination (developer install) — never overwrites a user's local repo.
-2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no Python 3.11+ is found).
+2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no supported Python is found).
 3. `pip install -e HERMES_HOME/hermes-agent` — `pyproject.toml` is the single source of truth for dependencies.
 4. Stamp `.hermes-desktop-runtime.json` with the schema version + pyproject hash + factory version.
 
-Subsequent launches compare the marker against the active `pyproject.toml` and skip steps 2-4 when nothing has changed.
+Subsequent launches compare the marker against the active `pyproject.toml` and skip venv/dependency work when nothing has changed.
 
 ### Upgrades
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -24,21 +24,21 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 
 ### Runtime prerequisites
 
-Hermes Desktop needs:
+Hermes Desktop's baseline installer prerequisites are:
 
 - **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution. (required)
-- **Git for Windows** (Windows only) — provides Git Bash, which Hermes' terminal tool calls directly. Linux and macOS already ship a system bash. (required)
-- **ripgrep** — used by Hermes' `search_files` tool for fast `.gitignore`-aware file/content search. Recommended on all platforms; Hermes falls back to `grep`/`find` if missing (works but slower and noisier).
+- **Node.js LTS** — for browser/UI tooling and Node-backed capabilities. (required)
 
-The packaged Windows installer (`Hermes-*.exe`) detects all three at install time. Required items missing are auto-installed via `winget install -e --id Python.Python.3.11 --scope user` and `winget install -e --id Git.Git`. The recommended ripgrep is offered as `winget install -e --id BurntSushi.ripgrep.MSVC --scope user`. If `winget` isn't available the installer shows manual download URLs and lets you continue. The MSI installer (`Hermes-*.msi`) doesn't run the prereq page — enterprise deploys are expected to handle prereqs out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and ensures Python 3.11 + Node.js are present via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall Python and Node.js out-of-band.
 
-For dev (`npm run dev`) the Python and Git Bash checks happen at first launch via the Electron bootstrapper, which throws a clear error if either prereq is missing. Manual install commands you can run yourself:
+For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 
 ```powershell
 winget install -e --id Python.Python.3.11 --scope user
-winget install -e --id Git.Git
-winget install -e --id BurntSushi.ripgrep.MSVC --scope user
+winget install -e --id OpenJS.NodeJS.LTS
 ```
+
+Git for Windows is still needed for Hermes' terminal tool on Windows, but it is no longer part of the baseline GUI installer path.
 
 ## Development
 
@@ -222,7 +222,7 @@ The desktop resolves a Hermes backend in this order:
 3. `pip install -e HERMES_HOME/hermes-agent` — `pyproject.toml` is the single source of truth for dependencies.
 4. Stamp `.hermes-desktop-runtime.json` with the schema version + pyproject hash + factory version.
 
-Subsequent launches compare the marker against the active `pyproject.toml` and skip steps 2-4 when nothing has changed.
+Subsequent launches compare the marker against the active `pyproject.toml` and skip venv/dependency work when nothing has changed.
 
 ### Upgrades
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -24,12 +24,12 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 
 ### Runtime prerequisites
 
-Hermes Desktop's baseline installer prerequisites are:
+Hermes Desktop's baseline installer dependencies are:
 
-- **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution. (required)
-- **Node.js LTS** — for browser tools and Node-backed capabilities. (required)
+- **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution.
+- **Node.js LTS** — for browser tools and Node-backed capabilities.
 
-The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and ensures Python 3.11 + Node.js are present via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall Python and Node.js out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11 + Node.js via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall Python and Node.js out-of-band.
 
 For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,7 +27,7 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 Hermes Desktop's baseline installer prerequisites are:
 
 - **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution. (required)
-- **Node.js LTS** — for browser/UI tooling and Node-backed capabilities. (required)
+- **Node.js LTS** — for browser tools and Node-backed capabilities. (required)
 
 The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and ensures Python 3.11 + Node.js are present via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall Python and Node.js out-of-band.
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -12,7 +12,7 @@ npm install
 
 For Python, you have two options:
 
-**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11-3.13 on Windows.
+**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11+ on `PATH`.
 
 **Option B — share an existing CLI install:** if you already ran `scripts/install.ps1` / `scripts/install.sh`, that's the same layout the desktop uses. The desktop reuses your existing venv and editable install — no extra steps. See [Runtime Bootstrap](#runtime-bootstrap) below for details.
 
@@ -24,20 +24,20 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 
 ### Runtime prerequisites
 
-Hermes Desktop's baseline installer dependencies are:
+Hermes Desktop needs:
 
-- **Python 3.11-3.13** — for the agent runtime, dashboard backend, and tool execution.
-- **Node.js 20+ LTS** — for browser tools and Node-backed capabilities.
-- **Git for Windows** — for Git Bash, which powers Hermes terminal commands on Windows.
+- **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution. (required)
+- **Git for Windows** (Windows only) — provides Git Bash, which Hermes' terminal tool calls directly. Linux and macOS already ship a system bash. (required)
+- **ripgrep** — used by Hermes' `search_files` tool for fast `.gitignore`-aware file/content search. Recommended on all platforms; Hermes falls back to `grep`/`find` if missing (works but slower and noisier).
 
-The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js 20+, and Git for Windows via `winget` when possible. Python 3.14 is not accepted yet because several Hermes dependencies do not publish compatible wheels. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) detects all three at install time. Required items missing are auto-installed via `winget install -e --id Python.Python.3.11 --scope user` and `winget install -e --id Git.Git`. The recommended ripgrep is offered as `winget install -e --id BurntSushi.ripgrep.MSVC --scope user`. If `winget` isn't available the installer shows manual download URLs and lets you continue. The MSI installer (`Hermes-*.msi`) doesn't run the prereq page — enterprise deploys are expected to handle prereqs out-of-band.
 
-For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
+For dev (`npm run dev`) the Python and Git Bash checks happen at first launch via the Electron bootstrapper, which throws a clear error if either prereq is missing. Manual install commands you can run yourself:
 
 ```powershell
 winget install -e --id Python.Python.3.11 --scope user
-winget install -e --id OpenJS.NodeJS.LTS
 winget install -e --id Git.Git
+winget install -e --id BurntSushi.ripgrep.MSVC --scope user
 ```
 
 ## Development
@@ -218,11 +218,11 @@ The desktop resolves a Hermes backend in this order:
 ### First-launch flow on a packaged install
 
 1. Sync factory image → `HERMES_HOME/hermes-agent`. Skipped if a `.git` directory exists at the destination (developer install) — never overwrites a user's local repo.
-2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no supported Python is found).
+2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no Python 3.11+ is found).
 3. `pip install -e HERMES_HOME/hermes-agent` — `pyproject.toml` is the single source of truth for dependencies.
 4. Stamp `.hermes-desktop-runtime.json` with the schema version + pyproject hash + factory version.
 
-Subsequent launches compare the marker against the active `pyproject.toml` and skip venv/dependency work when nothing has changed.
+Subsequent launches compare the marker against the active `pyproject.toml` and skip steps 2-4 when nothing has changed.
 
 ### Upgrades
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -28,17 +28,17 @@ Hermes Desktop's baseline installer dependencies are:
 
 - **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution.
 - **Node.js LTS** — for browser tools and Node-backed capabilities.
+- **Git for Windows** — for Git Bash, which powers Hermes terminal commands on Windows.
 
-The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11 + Node.js via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall Python and Node.js out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js, and Git for Windows via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
 
 For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 
 ```powershell
 winget install -e --id Python.Python.3.11 --scope user
 winget install -e --id OpenJS.NodeJS.LTS
+winget install -e --id Git.Git
 ```
-
-Git for Windows is still needed for Hermes' terminal tool on Windows, but it is no longer part of the baseline GUI installer path.
 
 ## Development
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,10 +27,10 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 Hermes Desktop's baseline installer dependencies are:
 
 - **Python 3.11-3.13** — for the agent runtime, dashboard backend, and tool execution.
-- **Node.js LTS** — for browser tools and Node-backed capabilities.
+- **Node.js 20+ LTS** — for browser tools and Node-backed capabilities.
 - **Git for Windows** — for Git Bash, which powers Hermes terminal commands on Windows.
 
-The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js, and Git for Windows via `winget` when possible. Python 3.14 is not accepted yet because several Hermes dependencies do not publish compatible wheels. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js 20+, and Git for Windows via `winget` when possible. Python 3.14 is not accepted yet because several Hermes dependencies do not publish compatible wheels. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
 
 For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -12,7 +12,7 @@ npm install
 
 For Python, you have two options:
 
-**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11+ on `PATH`.
+**Option A — let the desktop provision it for you (recommended for first-time setup):** just run `npm run dev`. On first launch the desktop creates a venv at `HERMES_HOME/hermes-agent/venv` and runs `pip install -e .` against the resolved Hermes source automatically. Requires Python 3.11-3.13 on Windows.
 
 **Option B — share an existing CLI install:** if you already ran `scripts/install.ps1` / `scripts/install.sh`, that's the same layout the desktop uses. The desktop reuses your existing venv and editable install — no extra steps. See [Runtime Bootstrap](#runtime-bootstrap) below for details.
 
@@ -26,11 +26,11 @@ HERMES_DESKTOP_HERMES_ROOT=/path/to/your/clone npm run dev
 
 Hermes Desktop's baseline installer dependencies are:
 
-- **Python 3.11+** — for the agent runtime, dashboard backend, and tool execution.
+- **Python 3.11-3.13** — for the agent runtime, dashboard backend, and tool execution.
 - **Node.js LTS** — for browser tools and Node-backed capabilities.
 - **Git for Windows** — for Git Bash, which powers Hermes terminal commands on Windows.
 
-The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js, and Git for Windows via `winget` when possible. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
+The packaged Windows installer (`Hermes-*.exe`) is intentionally barebones: it installs the GUI and offers to install Python 3.11, Node.js, and Git for Windows via `winget` when possible. Python 3.14 is not accepted yet because several Hermes dependencies do not publish compatible wheels. On first launch, the GUI handles the Hermes-specific work: syncing the bundled agent payload, creating the virtualenv, installing Python dependencies, and showing progress in the onboarding UI. The MSI installer does not run the prerequisite page, so enterprise deploys should preinstall these dependencies out-of-band.
 
 For dev (`npm run dev`) the Python check happens at first launch via the Electron bootstrapper. Manual install commands you can run yourself:
 
@@ -218,7 +218,7 @@ The desktop resolves a Hermes backend in this order:
 ### First-launch flow on a packaged install
 
 1. Sync factory image → `HERMES_HOME/hermes-agent`. Skipped if a `.git` directory exists at the destination (developer install) — never overwrites a user's local repo.
-2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no Python 3.11+ is found).
+2. Create venv at `HERMES_HOME/hermes-agent/venv` using system Python (errors out with a Python-install hint if no supported Python is found).
 3. `pip install -e HERMES_HOME/hermes-agent` — `pyproject.toml` is the single source of truth for dependencies.
 4. Stamp `.hermes-desktop-runtime.json` with the schema version + pyproject hash + factory version.
 

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -630,44 +630,12 @@ function findSystemPython() {
   return null
 }
 
-// findGitBash — locate bash.exe on Windows. Hermes' terminal tool requires
-// bash (POSIX shell), and on Windows that's almost always Git for Windows'
-// bundled Git Bash. We check the same set of locations tools/environments/
-// local.py:_find_bash() checks at runtime, so a positive result here means
-// the agent will be able to start a terminal too.
-//
-// On non-Windows hosts bash is part of the OS and this just returns the
-// first bash on PATH.
-function findGitBash() {
-  if (!IS_WINDOWS) {
-    return findOnPath('bash')
+function pythonInstallHint() {
+  if (IS_WINDOWS) {
+    return 'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, then relaunch Hermes.'
   }
 
-  // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
-  // first so users who installed via install.ps1 are detected before we
-  // start probing system-wide locations.
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
-  }
-
-  // Standard Git for Windows install locations.
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
-  }
-
-  for (const candidate of candidates) {
-    if (fileExists(candidate)) return candidate
-  }
-
-  // Last resort — bash on PATH (covers WSL bash, MSYS2, custom installs).
-  // On WSL hosts findOnPath itself filters out Windows-binary paths via
-  // isWindowsBinaryPathInWsl, so we won't hand back a wsl.exe shim either.
-  return findOnPath('bash')
+  return 'Install Python 3.11+ from https://www.python.org/downloads/ or your system package manager, then relaunch Hermes.'
 }
 
 function getVenvPython(venvRoot) {
@@ -1109,11 +1077,7 @@ function resolveHermesBackend(dashboardArgs) {
   const factoryPresent = isHermesSourceRoot(FACTORY_HERMES_ROOT)
   const activePresent = isHermesSourceRoot(ACTIVE_HERMES_ROOT)
   if (factoryPresent || activePresent) {
-    throw new Error(
-      'Hermes payload is present but no Python 3.11+ interpreter could be found. ' +
-        'Install Python 3.11+ from https://www.python.org/downloads/ or the Microsoft Store, ' +
-        'then relaunch Hermes.'
-    )
+    throw new Error(`Hermes payload is present but no supported Python interpreter could be found. ${pythonInstallHint()}`)
   }
   throw new Error(
     'Could not find Hermes. Install the Hermes CLI ' +
@@ -1174,29 +1138,10 @@ async function ensureRuntime(backend) {
   if (!fileExists(venvPython)) {
     const systemPython = findSystemPython()
     if (!systemPython) {
-      throw new Error(
-        'Python 3.11+ is required to bootstrap Hermes. Install Python from ' +
-          'https://www.python.org/downloads/ (or the Microsoft Store on Windows), then relaunch Hermes.'
-      )
+      throw new Error(`A supported Python interpreter is required to bootstrap Hermes. ${pythonInstallHint()}`)
     }
     await advanceBootProgress('runtime.venv', 'Creating Hermes virtual environment', 50)
     await runProcess(systemPython, ['-m', 'venv', VENV_ROOT])
-  }
-
-  // Step 2b: On Windows, preflight Git Bash. Hermes' terminal tool calls
-  // bash.exe directly (tools/environments/local.py); without it the agent
-  // can't run a terminal command. We surface this here as a clear, actionable
-  // error rather than letting the user discover it on their first chat
-  // ("hey, run `ls`" → opaque tool failure). The NSIS prereq page handles
-  // this for installer users; this check catches everyone else (.msi users,
-  // npm run dev with a fresh checkout, manual installs, etc.).
-  if (IS_WINDOWS && !findGitBash()) {
-    throw new Error(
-      'Git for Windows is required for Hermes on Windows (provides Git Bash, ' +
-        "which the agent's terminal tool uses). Install it from " +
-        'https://git-scm.com/download/win or run `winget install -e --id Git.Git`, ' +
-        'then relaunch Hermes.'
-    )
   }
 
   // Step 3: Ensure deps are installed. We compare a marker against the

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1183,20 +1183,11 @@ async function ensureRuntime(backend) {
     await runProcess(systemPython, ['-m', 'venv', VENV_ROOT])
   }
 
-  // Step 2b: On Windows, preflight Git Bash. Hermes' terminal tool calls
-  // bash.exe directly (tools/environments/local.py); without it the agent
-  // can't run a terminal command. We surface this here as a clear, actionable
-  // error rather than letting the user discover it on their first chat
-  // ("hey, run `ls`" → opaque tool failure). The NSIS prereq page handles
-  // this for installer users; this check catches everyone else (.msi users,
-  // npm run dev with a fresh checkout, manual installs, etc.).
+  // Step 2b: Git Bash powers the Windows terminal tool, but it is no longer
+  // part of the baseline GUI installer. Don't block the app from booting;
+  // terminal-only workflows can surface the missing dependency when needed.
   if (IS_WINDOWS && !findGitBash()) {
-    throw new Error(
-      'Git for Windows is required for Hermes on Windows (provides Git Bash, ' +
-        "which the agent's terminal tool uses). Install it from " +
-        'https://git-scm.com/download/win or run `winget install -e --id Git.Git`, ' +
-        'then relaunch Hermes.'
-    )
+    rememberLog('Git Bash not found; terminal commands will be unavailable until Git for Windows is installed.')
   }
 
   // Step 3: Ensure deps are installed. We compare a marker against the

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1070,8 +1070,8 @@ function resolveHermesBackend(dashboardArgs) {
   const activePresent = isHermesSourceRoot(ACTIVE_HERMES_ROOT)
   if (factoryPresent || activePresent) {
     throw new Error(
-      'Hermes payload is present but no Python 3.11+ interpreter could be found. ' +
-        'Install Python 3.11+ from https://www.python.org/downloads/ or the Microsoft Store, ' +
+      'Hermes payload is present but no supported Python interpreter could be found. ' +
+        'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, ' +
         'then relaunch Hermes.'
     )
   }
@@ -1135,8 +1135,8 @@ async function ensureRuntime(backend) {
     const systemPython = findSystemPython()
     if (!systemPython) {
       throw new Error(
-        'Python 3.11+ is required to bootstrap Hermes. Install Python from ' +
-          'https://www.python.org/downloads/ (or the Microsoft Store on Windows), then relaunch Hermes.'
+        'A supported Python interpreter is required to bootstrap Hermes. ' +
+          'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, then relaunch Hermes.'
       )
     }
     await advanceBootProgress('runtime.venv', 'Creating Hermes virtual environment', 50)

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -630,6 +630,14 @@ function findSystemPython() {
   return null
 }
 
+function pythonInstallHint() {
+  if (IS_WINDOWS) {
+    return 'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, then relaunch Hermes.'
+  }
+
+  return 'Install Python 3.11+ from https://www.python.org/downloads/ or your system package manager, then relaunch Hermes.'
+}
+
 function getVenvPython(venvRoot) {
   return path.join(venvRoot, IS_WINDOWS ? path.join('Scripts', 'python.exe') : path.join('bin', 'python'))
 }
@@ -1069,11 +1077,7 @@ function resolveHermesBackend(dashboardArgs) {
   const factoryPresent = isHermesSourceRoot(FACTORY_HERMES_ROOT)
   const activePresent = isHermesSourceRoot(ACTIVE_HERMES_ROOT)
   if (factoryPresent || activePresent) {
-    throw new Error(
-      'Hermes payload is present but no supported Python interpreter could be found. ' +
-        'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, ' +
-        'then relaunch Hermes.'
-    )
+    throw new Error(`Hermes payload is present but no supported Python interpreter could be found. ${pythonInstallHint()}`)
   }
   throw new Error(
     'Could not find Hermes. Install the Hermes CLI ' +
@@ -1134,10 +1138,7 @@ async function ensureRuntime(backend) {
   if (!fileExists(venvPython)) {
     const systemPython = findSystemPython()
     if (!systemPython) {
-      throw new Error(
-        'A supported Python interpreter is required to bootstrap Hermes. ' +
-          'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, then relaunch Hermes.'
-      )
+      throw new Error(`A supported Python interpreter is required to bootstrap Hermes. ${pythonInstallHint()}`)
     }
     await advanceBootProgress('runtime.venv', 'Creating Hermes virtual environment', 50)
     await runProcess(systemPython, ['-m', 'venv', VENV_ROOT])

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -630,12 +630,44 @@ function findSystemPython() {
   return null
 }
 
-function pythonInstallHint() {
-  if (IS_WINDOWS) {
-    return 'On Windows, install Python 3.11, 3.12, or 3.13 from https://www.python.org/downloads/, then relaunch Hermes.'
+// findGitBash — locate bash.exe on Windows. Hermes' terminal tool requires
+// bash (POSIX shell), and on Windows that's almost always Git for Windows'
+// bundled Git Bash. We check the same set of locations tools/environments/
+// local.py:_find_bash() checks at runtime, so a positive result here means
+// the agent will be able to start a terminal too.
+//
+// On non-Windows hosts bash is part of the OS and this just returns the
+// first bash on PATH.
+function findGitBash() {
+  if (!IS_WINDOWS) {
+    return findOnPath('bash')
   }
 
-  return 'Install Python 3.11+ from https://www.python.org/downloads/ or your system package manager, then relaunch Hermes.'
+  // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
+  // first so users who installed via install.ps1 are detected before we
+  // start probing system-wide locations.
+  const localAppData = process.env.LOCALAPPDATA || ''
+  const candidates = []
+  if (localAppData) {
+    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
+    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
+  }
+
+  // Standard Git for Windows install locations.
+  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
+  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
+  if (localAppData) {
+    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
+  }
+
+  for (const candidate of candidates) {
+    if (fileExists(candidate)) return candidate
+  }
+
+  // Last resort — bash on PATH (covers WSL bash, MSYS2, custom installs).
+  // On WSL hosts findOnPath itself filters out Windows-binary paths via
+  // isWindowsBinaryPathInWsl, so we won't hand back a wsl.exe shim either.
+  return findOnPath('bash')
 }
 
 function getVenvPython(venvRoot) {
@@ -1077,7 +1109,11 @@ function resolveHermesBackend(dashboardArgs) {
   const factoryPresent = isHermesSourceRoot(FACTORY_HERMES_ROOT)
   const activePresent = isHermesSourceRoot(ACTIVE_HERMES_ROOT)
   if (factoryPresent || activePresent) {
-    throw new Error(`Hermes payload is present but no supported Python interpreter could be found. ${pythonInstallHint()}`)
+    throw new Error(
+      'Hermes payload is present but no Python 3.11+ interpreter could be found. ' +
+        'Install Python 3.11+ from https://www.python.org/downloads/ or the Microsoft Store, ' +
+        'then relaunch Hermes.'
+    )
   }
   throw new Error(
     'Could not find Hermes. Install the Hermes CLI ' +
@@ -1138,10 +1174,29 @@ async function ensureRuntime(backend) {
   if (!fileExists(venvPython)) {
     const systemPython = findSystemPython()
     if (!systemPython) {
-      throw new Error(`A supported Python interpreter is required to bootstrap Hermes. ${pythonInstallHint()}`)
+      throw new Error(
+        'Python 3.11+ is required to bootstrap Hermes. Install Python from ' +
+          'https://www.python.org/downloads/ (or the Microsoft Store on Windows), then relaunch Hermes.'
+      )
     }
     await advanceBootProgress('runtime.venv', 'Creating Hermes virtual environment', 50)
     await runProcess(systemPython, ['-m', 'venv', VENV_ROOT])
+  }
+
+  // Step 2b: On Windows, preflight Git Bash. Hermes' terminal tool calls
+  // bash.exe directly (tools/environments/local.py); without it the agent
+  // can't run a terminal command. We surface this here as a clear, actionable
+  // error rather than letting the user discover it on their first chat
+  // ("hey, run `ls`" → opaque tool failure). The NSIS prereq page handles
+  // this for installer users; this check catches everyone else (.msi users,
+  // npm run dev with a fresh checkout, manual installs, etc.).
+  if (IS_WINDOWS && !findGitBash()) {
+    throw new Error(
+      'Git for Windows is required for Hermes on Windows (provides Git Bash, ' +
+        "which the agent's terminal tool uses). Install it from " +
+        'https://git-scm.com/download/win or run `winget install -e --id Git.Git`, ' +
+        'then relaunch Hermes.'
+    )
   }
 
   // Step 3: Ensure deps are installed. We compare a marker against the

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -630,46 +630,6 @@ function findSystemPython() {
   return null
 }
 
-// findGitBash — locate bash.exe on Windows. Hermes' terminal tool requires
-// bash (POSIX shell), and on Windows that's almost always Git for Windows'
-// bundled Git Bash. We check the same set of locations tools/environments/
-// local.py:_find_bash() checks at runtime, so a positive result here means
-// the agent will be able to start a terminal too.
-//
-// On non-Windows hosts bash is part of the OS and this just returns the
-// first bash on PATH.
-function findGitBash() {
-  if (!IS_WINDOWS) {
-    return findOnPath('bash')
-  }
-
-  // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
-  // first so users who installed via install.ps1 are detected before we
-  // start probing system-wide locations.
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'bash.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'usr', 'bin', 'bash.exe'))
-  }
-
-  // Standard Git for Windows install locations.
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'))
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
-  }
-
-  for (const candidate of candidates) {
-    if (fileExists(candidate)) return candidate
-  }
-
-  // Last resort — bash on PATH (covers WSL bash, MSYS2, custom installs).
-  // On WSL hosts findOnPath itself filters out Windows-binary paths via
-  // isWindowsBinaryPathInWsl, so we won't hand back a wsl.exe shim either.
-  return findOnPath('bash')
-}
-
 function getVenvPython(venvRoot) {
   return path.join(venvRoot, IS_WINDOWS ? path.join('Scripts', 'python.exe') : path.join('bin', 'python'))
 }
@@ -1181,13 +1141,6 @@ async function ensureRuntime(backend) {
     }
     await advanceBootProgress('runtime.venv', 'Creating Hermes virtual environment', 50)
     await runProcess(systemPython, ['-m', 'venv', VENV_ROOT])
-  }
-
-  // Step 2b: Git Bash powers the Windows terminal tool, but it is no longer
-  // part of the baseline GUI installer. Don't block the app from booting;
-  // terminal-only workflows can surface the missing dependency when needed.
-  if (IS_WINDOWS && !findGitBash()) {
-    rememberLog('Git Bash not found; terminal commands will be unavailable until Git for Windows is installed.')
   }
 
   // Step 3: Ensure deps are installed. We compare a marker against the

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -3,8 +3,9 @@
 ; ============================================================================
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
-; selection page and the install-files page. Detects Python 3.11+, Git for
-; Windows, and ripgrep; offers to install missing items via winget.
+; selection page and the install-files page. Detects the baseline runtime
+; prerequisites (Python 3.11-3.13, Node.js 20+, and Git for Windows); offers to
+; install missing items via winget.
 ;
 ; Page sequence:
 ;   Welcome → Directory → [PrereqPage] → InstFiles → Finish
@@ -19,10 +20,9 @@
 ; Diagnostics:
 ;   $TEMP\Hermes-Installer.log captures every detection probe (command,
 ;   exit code, captured output), the user's checkbox choices, and full
-;   winget stdout/stderr for Python and ripgrep installs. Git install
-;   goes via ExecShellWait (for UAC focus reasons) which cannot capture
-;   output, so for Git we log start/end + the post-install filesystem
-;   probe result only. Users hitting bugs should attach this file.
+;   winget stdout/stderr for Python installs. Node.js and Git installs go via
+;   ExecShellWait so UAC comes forward; for those we log start/end plus a
+;   post-install filesystem probe. Users hitting bugs should attach this file.
 ;
 ; The Function declarations live at top-level in this file so they're parsed
 ; at include time; the customPageAfterChangeDir macro references them via
@@ -30,29 +30,24 @@
 ;
 ; UAC behavior:
 ;   Python: --scope user, no UAC.
-;   ripgrep: --scope user, no UAC.
-;   Git for Windows: always per-machine, triggers UAC prompt.
-;   Footer warns the user about Git's UAC; ExecShellWait preserves the
-;   foreground focus chain so the prompt comes to front.
+;   Node.js: winget-managed install; installer package may request elevation.
+;   Git for Windows: winget-managed install; may request elevation.
 ;
 ; Detection:
-;   Python: try `py -3.11`/`-3.12`/`-3.13`/`-3.14`. The Python launcher
+;   Python: try `py -3.11`/`-3.12`/`-3.13`. The Python launcher
 ;     returns exit 0 only when that specific version is installed. The
 ;     Microsoft Store "Python stub" doesn't install py.exe, so users with
 ;     only the stub get correctly classified as not-installed.
-;   Git: `where git` returns exit 0 if git is on PATH.
-;   ripgrep: `where rg` returns exit 0 if rg is on PATH.
+;   Node.js: require a modern Node (major >= 20). Check PATH first, then the
+;     Hermes-managed %LOCALAPPDATA%\hermes\node\node.exe if present.
+;   Git: check known Git Bash locations for Git for Windows / Hermes-managed Git.
 ;   winget: `where winget` returns exit 0 on Win11 / Win10 1809+ with App
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
 ; Required vs. recommended:
-;   Python and Git are REQUIRED — without them the agent's runtime + terminal
-;   tool fail. The page emphasizes "required" wording and the bootstrapper
-;   throws if either is missing at first launch.
-;   ripgrep is RECOMMENDED — Hermes' search_files tool uses it for fast
-;   .gitignore-aware search, and falls back to grep/find from Git Bash when
-;   missing (works but slower, less filtering). Page wording is softer for
-;   ripgrep so users understand they CAN skip it.
+;   Python, Node.js, and Git Bash are baseline dependencies. The GUI handles the
+;   Hermes source payload, virtualenv, and Python dependency install on first
+;   launch.
 ;
 ; Skip behaviors:
 ;   - All three already detected → page is auto-skipped via Abort
@@ -68,18 +63,18 @@
 Var HermesDialog
 Var HermesPyStatusLabel
 Var HermesPyCheckbox
-Var HermesGitStatusLabel
-Var HermesGitCheckbox
-Var HermesRgStatusLabel
-Var HermesRgCheckbox
+Var HermesNodeStatusLabel
+Var HermesNodeCheckbox
+Var HermesGitBashStatusLabel
+Var HermesGitBashCheckbox
 Var HermesFooterLabel
 Var HermesHasWinget
 Var HermesHasPython
-Var HermesHasGit
-Var HermesHasRipgrep
+Var HermesHasNode
+Var HermesHasGitBash
 Var HermesInstallPython
-Var HermesInstallGit
-Var HermesInstallRipgrep
+Var HermesInstallNode
+Var HermesInstallGitBash
 Var HermesLogHandle
 Var HermesLogPath
 
@@ -95,9 +90,9 @@ Var HermesLogPath
 ;   - NSIS's built-in `LogSet on` / `LogText` requires the "advanced logging"
 ;     build of makensis (NSIS_CONFIG_LOG=1), which electron-builder's bundled
 ;     binary doesn't include. So we roll our own with FileWrite.
-;   - Every winget invocation streams its full stdout/stderr into the log via
-;     nsExec::ExecToStack — the same data the Details panel shows, but
-;     captured for post-mortem.
+;   - Python's winget invocation streams stdout/stderr into the log via
+;     nsExec::ExecToStack. Node.js and Git use ExecShellWait instead because
+;     their installers may elevate; this keeps UAC in front of the wizard.
 ;   - Detection probes also log exit codes + captured output, so when a user
 ;     reports "the page said Python isn't installed but I have it", we can
 ;     see exactly which probes ran and what they returned.
@@ -239,7 +234,7 @@ FunctionEnd
 ; install exists at one of the standard locations. FileExists never runs
 ; the binary so this is safe even if the user has the MS Store stub on
 ; their PATH. We probe both system-wide (Program Files) and per-user
-; (LocalAppData\Programs) install locations for versions 3.11–3.14.
+; (LocalAppData\Programs) install locations for versions 3.11–3.13.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPythonViaFilesystem
   ${HermesLog} "filesystem: probing standard Python install paths"
@@ -314,7 +309,7 @@ FunctionEnd
 
 ; ----------------------------------------------------------------------------
 ; HermesDetectPrereqs — populates $HermesHasWinget / $HermesHasPython /
-; $HermesHasGit / $HermesHasRipgrep with "0" or "1". Called from the
+; $HermesHasNode / $HermesHasGitBash with "0" or "1". Called from the
 ; page-create function. Every probe is logged via HermesProbe.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPrereqs
@@ -398,25 +393,40 @@ Function HermesDetectPrereqs
     ${HermesLogKV} "after filesystem probe, HermesHasPython" "$HermesHasPython"
   ${EndIf}
 
-  ; --- Git ---
-  Push 'cmd.exe /c where git'
+  ; --- Node.js 20+ ---
+  Push 'cmd.exe /c node -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
   Call HermesProbe
   ${If} $0 == 0
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasNode "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\node\node.exe"
+    Push '"$LOCALAPPDATA\hermes\node\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+    Call HermesProbe
+    ${If} $0 == 0
+      StrCpy $HermesHasNode "1"
+    ${Else}
+      StrCpy $HermesHasNode "0"
+    ${EndIf}
   ${Else}
-    StrCpy $HermesHasGit "0"
+    StrCpy $HermesHasNode "0"
   ${EndIf}
-  ${HermesLogKV} "HermesHasGit" "$HermesHasGit"
+  ${HermesLogKV} "HermesHasNode" "$HermesHasNode"
 
-  ; --- ripgrep ---
-  Push 'cmd.exe /c where rg'
-  Call HermesProbe
-  ${If} $0 == 0
-    StrCpy $HermesHasRipgrep "1"
-  ${Else}
-    StrCpy $HermesHasRipgrep "0"
+  ; --- Git Bash ---
+  StrCpy $HermesHasGitBash "0"
+  ${If} ${FileExists} "$LOCALAPPDATA\hermes\git\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\git\usr\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
+    StrCpy $HermesHasGitBash "1"
   ${EndIf}
-  ${HermesLogKV} "HermesHasRipgrep" "$HermesHasRipgrep"
+  ${HermesLogKV} "HermesHasGitBash" "$HermesHasGitBash"
 
   ${HermesLog} "=== HermesDetectPrereqs: end ==="
 FunctionEnd
@@ -464,7 +474,7 @@ Function HermesRunWinget
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
-; HermesPrereqPageCreate — builds the prereq page UI. If all three items are
+; HermesPrereqPageCreate — builds the prereq page UI. If all items are
 ; already installed we Abort, which causes NSIS to skip directly to the next
 ; page in the sequence (InstFiles).
 ; ----------------------------------------------------------------------------
@@ -472,13 +482,13 @@ Function HermesPrereqPageCreate
   Call HermesDetectPrereqs
 
   ${If} $HermesHasPython == "1"
-  ${AndIf} $HermesHasGit == "1"
-  ${AndIf} $HermesHasRipgrep == "1"
+  ${AndIf} $HermesHasNode == "1"
+  ${AndIf} $HermesHasGitBash == "1"
     ${HermesLog} "page: all prereqs detected, auto-skipping prereq page"
     Abort
   ${EndIf}
 
-  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython git=$HermesHasGit rg=$HermesHasRipgrep)"
+  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode git_bash=$HermesHasGitBash)"
 
   ; Set the wizard's standard header (top blue/gradient bar). 1037 is the
   ; title control, 1038 is the subtitle. Without this, the header still
@@ -486,7 +496,7 @@ Function HermesPrereqPageCreate
   GetDlgItem $0 $HWNDPARENT 1037
   SendMessage $0 ${WM_SETTEXT} 0 "STR:System Requirements"
   GetDlgItem $0 $HWNDPARENT 1038
-  SendMessage $0 ${WM_SETTEXT} 0 "STR:Hermes needs Python 3.11+ and Git for Windows. ripgrep is recommended."
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:Install baseline runtime dependencies before the GUI finishes Hermes setup."
 
   nsDialogs::Create 1018
   Pop $HermesDialog
@@ -495,17 +505,20 @@ Function HermesPrereqPageCreate
   ${EndIf}
 
   StrCpy $HermesInstallPython "0"
-  StrCpy $HermesInstallGit "0"
-  StrCpy $HermesInstallRipgrep "0"
+  StrCpy $HermesInstallNode "0"
+  StrCpy $HermesInstallGitBash "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
-  ; "System Requirements" and subtitle, so we don't repeat them here —
-  ; just one short explanatory line.
-  ${NSD_CreateLabel} 0u 0u 100% 16u "Items already installed are listed as detected. Missing items can be installed automatically via winget."
+  ; "System Requirements" and subtitle, so we don't repeat them here.
+  ${If} $HermesHasWinget == "1"
+    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Missing items can be installed automatically via winget."
+  ${Else}
+    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Continue setup, then install missing items manually."
+  ${EndIf}
   Pop $0
 
-  ; --- Python panel (REQUIRED) ---
-  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11+  (required)"
+  ; --- Python panel ---
+  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11-3.13"
   Pop $0
   ${If} $HermesHasPython == "1"
     ${NSD_CreateLabel} 8u 28u 95% 10u "Detected on your system."
@@ -518,53 +531,68 @@ Function HermesPrereqPageCreate
       Pop $HermesPyCheckbox
       ${NSD_Check} $HermesPyCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/ and re-run this installer."
+      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/, then relaunch Hermes."
       Pop $HermesPyStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- Git panel (REQUIRED) ---
-  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Git for Windows  (required, provides Git Bash)"
+  ; --- Node.js panel ---
+  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js 20+ LTS"
   Pop $0
-  ${If} $HermesHasGit == "1"
+  ${If} $HermesHasNode == "1"
     ${NSD_CreateLabel} 8u 60u 95% 10u "Detected on your system."
-    Pop $HermesGitStatusLabel
+    Pop $HermesNodeStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes' terminal tool."
-      Pop $HermesGitStatusLabel
-      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Git for Windows"
-      Pop $HermesGitCheckbox
-      ${NSD_Check} $HermesGitCheckbox
+      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Used by Hermes browser tools and Node-backed capabilities."
+      Pop $HermesNodeStatusLabel
+      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Node.js LTS"
+      Pop $HermesNodeCheckbox
+      ${NSD_Check} $HermesNodeCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win and re-run this installer."
-      Pop $HermesGitStatusLabel
+      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://nodejs.org/en/download/, then relaunch Hermes."
+      Pop $HermesNodeStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- ripgrep panel (RECOMMENDED) ---
-  ${NSD_CreateGroupBox} 0u 82u 100% 30u "ripgrep  (recommended for fast file search)"
+  ; --- Git panel ---
+  ${NSD_CreateGroupBox} 0u 82u 100% 30u "Git for Windows"
   Pop $0
-  ${If} $HermesHasRipgrep == "1"
+  ${If} $HermesHasGitBash == "1"
     ${NSD_CreateLabel} 8u 92u 95% 10u "Detected on your system."
-    Pop $HermesRgStatusLabel
+    Pop $HermesGitBashStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Hermes will fall back to slower grep/find."
-      Pop $HermesRgStatusLabel
-      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install ripgrep"
-      Pop $HermesRgCheckbox
-      ${NSD_Check} $HermesRgCheckbox
+      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Provides Git Bash for Hermes terminal commands."
+      Pop $HermesGitBashStatusLabel
+      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install Git for Windows"
+      Pop $HermesGitBashCheckbox
+      ${NSD_Check} $HermesGitBashCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://github.com/BurntSushi/ripgrep#installation if you want fast .gitignore-aware search."
-      Pop $HermesRgStatusLabel
+      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win for terminal commands."
+      Pop $HermesGitBashStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- Footer (UAC notice when Git install will run) ---
-  ${If} $HermesHasGit == "0"
-  ${AndIf} $HermesHasWinget == "1"
-    ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows requires administrator approval. The UAC prompt may appear behind this window — check your taskbar."
+  ${If} $HermesHasPython == "1"
+  ${AndIf} $HermesHasNode == "1"
+  ${AndIf} $HermesHasGitBash == "1"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
+    Pop $HermesFooterLabel
+  ${ElseIf} $HermesHasWinget == "0"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Continue setup, then install missing dependencies manually and relaunch Hermes."
+    Pop $HermesFooterLabel
+  ${ElseIf} $HermesHasWinget == "1"
+    ${If} $HermesHasNode == "0"
+    ${OrIf} $HermesHasGitBash == "0"
+      ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Node.js or Git for Windows may request administrator approval. Check your taskbar if hidden."
+      Pop $HermesFooterLabel
+    ${Else}
+      ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
+      Pop $HermesFooterLabel
+    ${EndIf}
+  ${Else}
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
     Pop $HermesFooterLabel
   ${EndIf}
 
@@ -581,15 +609,15 @@ Function HermesPrereqPageLeave
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_GetState} $HermesPyCheckbox $HermesInstallPython
   ${EndIf}
-  ${If} $HermesHasGit == "0"
+  ${If} $HermesHasNode == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesGitCheckbox $HermesInstallGit
+    ${NSD_GetState} $HermesNodeCheckbox $HermesInstallNode
   ${EndIf}
-  ${If} $HermesHasRipgrep == "0"
+  ${If} $HermesHasGitBash == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesRgCheckbox $HermesInstallRipgrep
+    ${NSD_GetState} $HermesGitBashCheckbox $HermesInstallGitBash
   ${EndIf}
-  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_git=$HermesInstallGit install_ripgrep=$HermesInstallRipgrep"
+  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode install_git_bash=$HermesInstallGitBash"
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
@@ -672,76 +700,94 @@ hermes_prereq_not_silent:
     ; Python with --scope user installs to %LOCALAPPDATA%\Programs\Python\
     ; — no UAC, no foreground chain to preserve. HermesRunWinget captures
     ; both the Details-panel output AND a copy to the installer log.
-    DetailPrint "Installing Python 3.11+ via winget (silent per-user install, no admin prompt)..."
+    DetailPrint "Installing Python 3.11 via winget (silent per-user install, no admin prompt)..."
     Push 'install -e --id Python.Python.3.11 --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
     Push 'Python 3.11'
     Call HermesRunWinget
     ${If} $0 != 0
       DetailPrint "Python install via winget exited with code $0."
       ${HermesLog} "Python install FAILED (exit $0). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Python 3.11+ manually from https://www.python.org/downloads/ after Hermes setup finishes. Hermes will not run until Python is installed."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nAfter this installer finishes, install Python 3.11, 3.12, or 3.13 manually from https://www.python.org/downloads/, then relaunch Hermes. Hermes will not run until Python is installed."
     ${Else}
-      DetailPrint "Python 3.11+ installed successfully."
+      DetailPrint "Python 3.11 installed successfully."
       ${HermesLog} "Python install succeeded"
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallRipgrep == "1"
-    ; ripgrep with --scope user — ~5MB, no UAC needed. Failure is non-fatal:
-    ; Hermes' search_files tool falls back to grep/find from Git Bash.
-    DetailPrint "Installing ripgrep via winget (silent per-user install, no admin prompt)..."
-    Push 'install -e --id BurntSushi.ripgrep.MSVC --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
-    Push 'ripgrep'
-    Call HermesRunWinget
-    ${If} $0 != 0
-      DetailPrint "ripgrep install via winget exited with code $0 (non-fatal — Hermes will fall back to grep/find)."
-      ${HermesLog} "ripgrep install failed (exit $0) — non-fatal"
+  ${If} $HermesInstallNode == "1"
+    DetailPrint "Installing Node.js LTS via winget..."
+    ${HermesLog} "Node.js: starting ExecShellWait — UAC may appear; no stdout capture possible"
+    ${HermesLog} "  command: winget install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
+    ExecShellWait "open" "winget" "install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
+    ${HermesLog} "Node.js: ExecShellWait returned"
+
+    StrCpy $0 "0"
+    ${If} ${FileExists} "$PROGRAMFILES64\nodejs\node.exe"
+      Push '"$PROGRAMFILES64\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$PROGRAMFILES\nodejs\node.exe"
+      Push '"$PROGRAMFILES\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$PROGRAMFILES32\nodejs\node.exe"
+      Push '"$PROGRAMFILES32\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$LOCALAPPDATA\Programs\nodejs\node.exe"
+      Push '"$LOCALAPPDATA\Programs\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+
+    ${If} $0 == "1"
+      DetailPrint "Node.js installed successfully."
+      ${HermesLog} "Node.js install succeeded (version probe positive)"
     ${Else}
-      DetailPrint "ripgrep installed successfully."
-      ${HermesLog} "ripgrep install succeeded"
+      DetailPrint "Node.js 20+ could not be validated after install."
+      ${HermesLog} "Node.js install failed, needs a restart, or installed an unsupported version (version probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js 20+ could not be validated after winget.$\r$\n$\r$\nA restart may be required. See log: $HermesLogPath$\r$\n$\r$\nInstall Node.js 20+ manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallGit == "1"
-    ; Git for Windows always installs per-machine and triggers UAC. We use
-    ; ExecShellWait (NSIS's wrapper around Windows ShellExecute) instead of
-    ; nsExec because ShellExecute preserves the foreground focus chain
-    ; across non-elevated → elevated process spawns. With nsExec the
-    ; intermediate hidden winget.exe breaks that chain and UAC ends up
-    ; behind the installer window.
-    ;
-    ; Trade-off: ExecShellWait doesn't capture output, so winget runs in
-    ; its own console window. The console flashes briefly while winget
-    ; downloads, then UAC fires for the elevated Git installer with
-    ; correct foreground promotion. We CANNOT log winget's stdout/stderr
-    ; for this case; we only log start time, end time, and the post-
-    ; install filesystem probe result.
-    DetailPrint "Installing Git for Windows via winget (UAC prompt will appear)..."
-    ${HermesLog} "Git: starting ExecShellWait — UAC will fire; no stdout capture possible"
+  ${If} $HermesInstallGitBash == "1"
+    DetailPrint "Installing Git for Windows via winget..."
+    ${HermesLog} "Git: starting ExecShellWait — UAC may appear; no stdout capture possible"
     ${HermesLog} "  command: winget install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
     ExecShellWait "open" "winget" "install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
-    ${HermesLog} "Git: ExecShellWait returned (no exit code available from ShellExecute)"
+    ${HermesLog} "Git: ExecShellWait returned"
 
-    ; ExecShellWait returns no exit code, so verify by checking the file
-    ; system directly. Don't use `where git` — that reads OUR process's
-    ; PATH, which was captured at NSIS startup before Git's installer ran
-    ; and modified the system PATH. Until we restart, the new PATH isn't
-    ; visible to us. Probe Git's standard install locations instead.
-    StrCpy $0 "0"  ; "git found" flag
+    StrCpy $0 "0"
     ${If} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES64\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES32\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $LOCALAPPDATA\Programs\Git\bin\bash.exe"
       StrCpy $0 "1"
-    ${Else}
-      ${HermesLog} "Git: bash.exe NOT found at any standard location"
     ${EndIf}
 
     ${If} $0 == "1"
@@ -749,8 +795,8 @@ hermes_prereq_not_silent:
       ${HermesLog} "Git install succeeded (filesystem probe positive)"
     ${Else}
       DetailPrint "Git for Windows install did not complete (bash.exe not found at standard install locations)."
-      ${HermesLog} "Git install FAILED (filesystem probe negative). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Git for Windows manually from https://git-scm.com/download/win after Hermes setup finishes. Hermes' terminal tool will not work until Git Bash is available."
+      ${HermesLog} "Git install failed or needs a restart (filesystem probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Git for Windows manually from https://git-scm.com/download/win if Hermes terminal commands fail."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -513,7 +513,7 @@ Function HermesPrereqPageCreate
   ${If} $HermesHasWinget == "1"
     ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Missing items can be installed automatically via winget."
   ${Else}
-    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Install missing items manually, then re-run this installer."
+    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Continue setup, then install missing items manually."
   ${EndIf}
   Pop $0
 
@@ -531,7 +531,7 @@ Function HermesPrereqPageCreate
       Pop $HermesPyCheckbox
       ${NSD_Check} $HermesPyCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/ and re-run this installer."
+      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/, then relaunch Hermes."
       Pop $HermesPyStatusLabel
     ${EndIf}
   ${EndIf}
@@ -550,7 +550,7 @@ Function HermesPrereqPageCreate
       Pop $HermesNodeCheckbox
       ${NSD_Check} $HermesNodeCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://nodejs.org/en/download/ and re-run this installer."
+      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://nodejs.org/en/download/, then relaunch Hermes."
       Pop $HermesNodeStatusLabel
     ${EndIf}
   ${EndIf}

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -42,7 +42,7 @@
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
 ; Required vs. recommended:
-;   Python and Node.js are REQUIRED baseline dependencies. The GUI handles the
+;   Python and Node.js are baseline dependencies. The GUI handles the
 ;   Hermes source payload, virtualenv, and Python dependency install on first
 ;   launch.
 ;
@@ -465,7 +465,7 @@ Function HermesPrereqPageCreate
   GetDlgItem $0 $HWNDPARENT 1037
   SendMessage $0 ${WM_SETTEXT} 0 "STR:System Requirements"
   GetDlgItem $0 $HWNDPARENT 1038
-  SendMessage $0 ${WM_SETTEXT} 0 "STR:Hermes needs Python 3.11+ and Node.js before the GUI finishes setup."
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:Install baseline runtime dependencies before the GUI finishes Hermes setup."
 
   nsDialogs::Create 1018
   Pop $HermesDialog
@@ -482,8 +482,8 @@ Function HermesPrereqPageCreate
   ${NSD_CreateLabel} 0u 0u 100% 16u "Items already installed are listed as detected. Missing items can be installed automatically via winget."
   Pop $0
 
-  ; --- Python panel (REQUIRED) ---
-  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11+  (required)"
+  ; --- Python panel ---
+  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11+"
   Pop $0
   ${If} $HermesHasPython == "1"
     ${NSD_CreateLabel} 8u 28u 95% 10u "Detected on your system."
@@ -501,15 +501,15 @@ Function HermesPrereqPageCreate
     ${EndIf}
   ${EndIf}
 
-  ; --- Node.js panel (REQUIRED) ---
-  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js LTS  (required)"
+  ; --- Node.js panel ---
+  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js LTS"
   Pop $0
   ${If} $HermesHasNode == "1"
     ${NSD_CreateLabel} 8u 60u 95% 10u "Detected on your system."
     Pop $HermesNodeStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes browser tools and Node-backed capabilities."
+      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Used by Hermes browser tools and Node-backed capabilities."
       Pop $HermesNodeStatusLabel
       ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Node.js LTS"
       Pop $HermesNodeCheckbox

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -32,7 +32,7 @@
 ;   Node.js: winget-managed install; installer package may request elevation.
 ;
 ; Detection:
-;   Python: try `py -3.11`/`-3.12`/`-3.13`/`-3.14`. The Python launcher
+;   Python: try `py -3.11`/`-3.12`/`-3.13`. The Python launcher
 ;     returns exit 0 only when that specific version is installed. The
 ;     Microsoft Store "Python stub" doesn't install py.exe, so users with
 ;     only the stub get correctly classified as not-installed.
@@ -227,7 +227,7 @@ FunctionEnd
 ; install exists at one of the standard locations. FileExists never runs
 ; the binary so this is safe even if the user has the MS Store stub on
 ; their PATH. We probe both system-wide (Program Files) and per-user
-; (LocalAppData\Programs) install locations for versions 3.11–3.14.
+; (LocalAppData\Programs) install locations for versions 3.11–3.13.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPythonViaFilesystem
   ${HermesLog} "filesystem: probing standard Python install paths"
@@ -509,7 +509,7 @@ Function HermesPrereqPageCreate
     Pop $HermesNodeStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes browser and UI tooling."
+      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes browser tools and Node-backed capabilities."
       Pop $HermesNodeStatusLabel
       ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Node.js LTS"
       Pop $HermesNodeCheckbox

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -3,8 +3,9 @@
 ; ============================================================================
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
-; selection page and the install-files page. Detects Python 3.11+, Git for
-; Windows, and ripgrep; offers to install missing items via winget.
+; selection page and the install-files page. Detects the baseline runtime
+; prerequisites (Python 3.11+ and Node.js); offers to install missing items
+; via winget.
 ;
 ; Page sequence:
 ;   Welcome → Directory → [PrereqPage] → InstFiles → Finish
@@ -19,10 +20,8 @@
 ; Diagnostics:
 ;   $TEMP\Hermes-Installer.log captures every detection probe (command,
 ;   exit code, captured output), the user's checkbox choices, and full
-;   winget stdout/stderr for Python and ripgrep installs. Git install
-;   goes via ExecShellWait (for UAC focus reasons) which cannot capture
-;   output, so for Git we log start/end + the post-install filesystem
-;   probe result only. Users hitting bugs should attach this file.
+;   winget stdout/stderr for Python and Node.js installs. Users hitting bugs
+;   should attach this file.
 ;
 ; The Function declarations live at top-level in this file so they're parsed
 ; at include time; the customPageAfterChangeDir macro references them via
@@ -30,32 +29,25 @@
 ;
 ; UAC behavior:
 ;   Python: --scope user, no UAC.
-;   ripgrep: --scope user, no UAC.
-;   Git for Windows: always per-machine, triggers UAC prompt.
-;   Footer warns the user about Git's UAC; ExecShellWait preserves the
-;   foreground focus chain so the prompt comes to front.
+;   Node.js: winget-managed install; installer package may request elevation.
 ;
 ; Detection:
 ;   Python: try `py -3.11`/`-3.12`/`-3.13`/`-3.14`. The Python launcher
 ;     returns exit 0 only when that specific version is installed. The
 ;     Microsoft Store "Python stub" doesn't install py.exe, so users with
 ;     only the stub get correctly classified as not-installed.
-;   Git: `where git` returns exit 0 if git is on PATH.
-;   ripgrep: `where rg` returns exit 0 if rg is on PATH.
+;   Node.js: `where node` returns exit 0 if node is on PATH. We also check
+;     %LOCALAPPDATA%\hermes\node\node.exe for Hermes-managed installs.
 ;   winget: `where winget` returns exit 0 on Win11 / Win10 1809+ with App
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
 ; Required vs. recommended:
-;   Python and Git are REQUIRED — without them the agent's runtime + terminal
-;   tool fail. The page emphasizes "required" wording and the bootstrapper
-;   throws if either is missing at first launch.
-;   ripgrep is RECOMMENDED — Hermes' search_files tool uses it for fast
-;   .gitignore-aware search, and falls back to grep/find from Git Bash when
-;   missing (works but slower, less filtering). Page wording is softer for
-;   ripgrep so users understand they CAN skip it.
+;   Python and Node.js are REQUIRED baseline dependencies. The GUI handles the
+;   Hermes source payload, virtualenv, and Python dependency install on first
+;   launch.
 ;
 ; Skip behaviors:
-;   - All three already detected → page is auto-skipped via Abort
+;   - Both already detected → page is auto-skipped via Abort
 ;   - Silent install (/S) → customInstall winget block skips
 ;   - User unchecks all checkboxes → page advances without running winget
 ; ============================================================================
@@ -68,18 +60,14 @@
 Var HermesDialog
 Var HermesPyStatusLabel
 Var HermesPyCheckbox
-Var HermesGitStatusLabel
-Var HermesGitCheckbox
-Var HermesRgStatusLabel
-Var HermesRgCheckbox
+Var HermesNodeStatusLabel
+Var HermesNodeCheckbox
 Var HermesFooterLabel
 Var HermesHasWinget
 Var HermesHasPython
-Var HermesHasGit
-Var HermesHasRipgrep
+Var HermesHasNode
 Var HermesInstallPython
-Var HermesInstallGit
-Var HermesInstallRipgrep
+Var HermesInstallNode
 Var HermesLogHandle
 Var HermesLogPath
 
@@ -314,7 +302,7 @@ FunctionEnd
 
 ; ----------------------------------------------------------------------------
 ; HermesDetectPrereqs — populates $HermesHasWinget / $HermesHasPython /
-; $HermesHasGit / $HermesHasRipgrep with "0" or "1". Called from the
+; $HermesHasNode with "0" or "1". Called from the
 ; page-create function. Every probe is logged via HermesProbe.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPrereqs
@@ -398,25 +386,17 @@ Function HermesDetectPrereqs
     ${HermesLogKV} "after filesystem probe, HermesHasPython" "$HermesHasPython"
   ${EndIf}
 
-  ; --- Git ---
-  Push 'cmd.exe /c where git'
+  ; --- Node.js ---
+  Push 'cmd.exe /c where node'
   Call HermesProbe
   ${If} $0 == 0
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasNode "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\node\node.exe"
+    StrCpy $HermesHasNode "1"
   ${Else}
-    StrCpy $HermesHasGit "0"
+    StrCpy $HermesHasNode "0"
   ${EndIf}
-  ${HermesLogKV} "HermesHasGit" "$HermesHasGit"
-
-  ; --- ripgrep ---
-  Push 'cmd.exe /c where rg'
-  Call HermesProbe
-  ${If} $0 == 0
-    StrCpy $HermesHasRipgrep "1"
-  ${Else}
-    StrCpy $HermesHasRipgrep "0"
-  ${EndIf}
-  ${HermesLogKV} "HermesHasRipgrep" "$HermesHasRipgrep"
+  ${HermesLogKV} "HermesHasNode" "$HermesHasNode"
 
   ${HermesLog} "=== HermesDetectPrereqs: end ==="
 FunctionEnd
@@ -464,7 +444,7 @@ Function HermesRunWinget
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
-; HermesPrereqPageCreate — builds the prereq page UI. If all three items are
+; HermesPrereqPageCreate — builds the prereq page UI. If both items are
 ; already installed we Abort, which causes NSIS to skip directly to the next
 ; page in the sequence (InstFiles).
 ; ----------------------------------------------------------------------------
@@ -472,13 +452,12 @@ Function HermesPrereqPageCreate
   Call HermesDetectPrereqs
 
   ${If} $HermesHasPython == "1"
-  ${AndIf} $HermesHasGit == "1"
-  ${AndIf} $HermesHasRipgrep == "1"
+  ${AndIf} $HermesHasNode == "1"
     ${HermesLog} "page: all prereqs detected, auto-skipping prereq page"
     Abort
   ${EndIf}
 
-  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython git=$HermesHasGit rg=$HermesHasRipgrep)"
+  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode)"
 
   ; Set the wizard's standard header (top blue/gradient bar). 1037 is the
   ; title control, 1038 is the subtitle. Without this, the header still
@@ -486,7 +465,7 @@ Function HermesPrereqPageCreate
   GetDlgItem $0 $HWNDPARENT 1037
   SendMessage $0 ${WM_SETTEXT} 0 "STR:System Requirements"
   GetDlgItem $0 $HWNDPARENT 1038
-  SendMessage $0 ${WM_SETTEXT} 0 "STR:Hermes needs Python 3.11+ and Git for Windows. ripgrep is recommended."
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:Hermes needs Python 3.11+ and Node.js before the GUI finishes setup."
 
   nsDialogs::Create 1018
   Pop $HermesDialog
@@ -495,8 +474,7 @@ Function HermesPrereqPageCreate
   ${EndIf}
 
   StrCpy $HermesInstallPython "0"
-  StrCpy $HermesInstallGit "0"
-  StrCpy $HermesInstallRipgrep "0"
+  StrCpy $HermesInstallNode "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
   ; "System Requirements" and subtitle, so we don't repeat them here —
@@ -523,50 +501,27 @@ Function HermesPrereqPageCreate
     ${EndIf}
   ${EndIf}
 
-  ; --- Git panel (REQUIRED) ---
-  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Git for Windows  (required, provides Git Bash)"
+  ; --- Node.js panel (REQUIRED) ---
+  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js LTS  (required)"
   Pop $0
-  ${If} $HermesHasGit == "1"
+  ${If} $HermesHasNode == "1"
     ${NSD_CreateLabel} 8u 60u 95% 10u "Detected on your system."
-    Pop $HermesGitStatusLabel
+    Pop $HermesNodeStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes' terminal tool."
-      Pop $HermesGitStatusLabel
-      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Git for Windows"
-      Pop $HermesGitCheckbox
-      ${NSD_Check} $HermesGitCheckbox
+      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes browser and UI tooling."
+      Pop $HermesNodeStatusLabel
+      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Node.js LTS"
+      Pop $HermesNodeCheckbox
+      ${NSD_Check} $HermesNodeCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win and re-run this installer."
-      Pop $HermesGitStatusLabel
+      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://nodejs.org/en/download/ and re-run this installer."
+      Pop $HermesNodeStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- ripgrep panel (RECOMMENDED) ---
-  ${NSD_CreateGroupBox} 0u 82u 100% 30u "ripgrep  (recommended for fast file search)"
-  Pop $0
-  ${If} $HermesHasRipgrep == "1"
-    ${NSD_CreateLabel} 8u 92u 95% 10u "Detected on your system."
-    Pop $HermesRgStatusLabel
-  ${Else}
-    ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Hermes will fall back to slower grep/find."
-      Pop $HermesRgStatusLabel
-      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install ripgrep"
-      Pop $HermesRgCheckbox
-      ${NSD_Check} $HermesRgCheckbox
-    ${Else}
-      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://github.com/BurntSushi/ripgrep#installation if you want fast .gitignore-aware search."
-      Pop $HermesRgStatusLabel
-    ${EndIf}
-  ${EndIf}
-
-  ; --- Footer (UAC notice when Git install will run) ---
-  ${If} $HermesHasGit == "0"
-  ${AndIf} $HermesHasWinget == "1"
-    ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows requires administrator approval. The UAC prompt may appear behind this window — check your taskbar."
-    Pop $HermesFooterLabel
-  ${EndIf}
+  ${NSD_CreateLabel} 0u 86u 100% 20u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
+  Pop $HermesFooterLabel
 
   nsDialogs::Show
 FunctionEnd
@@ -581,15 +536,11 @@ Function HermesPrereqPageLeave
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_GetState} $HermesPyCheckbox $HermesInstallPython
   ${EndIf}
-  ${If} $HermesHasGit == "0"
+  ${If} $HermesHasNode == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesGitCheckbox $HermesInstallGit
+    ${NSD_GetState} $HermesNodeCheckbox $HermesInstallNode
   ${EndIf}
-  ${If} $HermesHasRipgrep == "0"
-  ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesRgCheckbox $HermesInstallRipgrep
-  ${EndIf}
-  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_git=$HermesInstallGit install_ripgrep=$HermesInstallRipgrep"
+  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode"
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
@@ -686,71 +637,18 @@ hermes_prereq_not_silent:
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallRipgrep == "1"
-    ; ripgrep with --scope user — ~5MB, no UAC needed. Failure is non-fatal:
-    ; Hermes' search_files tool falls back to grep/find from Git Bash.
-    DetailPrint "Installing ripgrep via winget (silent per-user install, no admin prompt)..."
-    Push 'install -e --id BurntSushi.ripgrep.MSVC --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
-    Push 'ripgrep'
+  ${If} $HermesInstallNode == "1"
+    DetailPrint "Installing Node.js LTS via winget..."
+    Push 'install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
+    Push 'Node.js LTS'
     Call HermesRunWinget
     ${If} $0 != 0
-      DetailPrint "ripgrep install via winget exited with code $0 (non-fatal — Hermes will fall back to grep/find)."
-      ${HermesLog} "ripgrep install failed (exit $0) — non-fatal"
+      DetailPrint "Node.js install via winget exited with code $0."
+      ${HermesLog} "Node.js install FAILED (exit $0). User notified via MessageBox."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Node.js manually from https://nodejs.org/en/download/ after Hermes setup finishes. Some Hermes tools will not work until Node.js is installed."
     ${Else}
-      DetailPrint "ripgrep installed successfully."
-      ${HermesLog} "ripgrep install succeeded"
-    ${EndIf}
-  ${EndIf}
-
-  ${If} $HermesInstallGit == "1"
-    ; Git for Windows always installs per-machine and triggers UAC. We use
-    ; ExecShellWait (NSIS's wrapper around Windows ShellExecute) instead of
-    ; nsExec because ShellExecute preserves the foreground focus chain
-    ; across non-elevated → elevated process spawns. With nsExec the
-    ; intermediate hidden winget.exe breaks that chain and UAC ends up
-    ; behind the installer window.
-    ;
-    ; Trade-off: ExecShellWait doesn't capture output, so winget runs in
-    ; its own console window. The console flashes briefly while winget
-    ; downloads, then UAC fires for the elevated Git installer with
-    ; correct foreground promotion. We CANNOT log winget's stdout/stderr
-    ; for this case; we only log start time, end time, and the post-
-    ; install filesystem probe result.
-    DetailPrint "Installing Git for Windows via winget (UAC prompt will appear)..."
-    ${HermesLog} "Git: starting ExecShellWait — UAC will fire; no stdout capture possible"
-    ${HermesLog} "  command: winget install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
-    ExecShellWait "open" "winget" "install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
-    ${HermesLog} "Git: ExecShellWait returned (no exit code available from ShellExecute)"
-
-    ; ExecShellWait returns no exit code, so verify by checking the file
-    ; system directly. Don't use `where git` — that reads OUR process's
-    ; PATH, which was captured at NSIS startup before Git's installer ran
-    ; and modified the system PATH. Until we restart, the new PATH isn't
-    ; visible to us. Probe Git's standard install locations instead.
-    StrCpy $0 "0"  ; "git found" flag
-    ${If} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES64\Git\bin\bash.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES\Git\bin\bash.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES32\Git\bin\bash.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
-      ${HermesLog} "Git: found bash.exe at $LOCALAPPDATA\Programs\Git\bin\bash.exe"
-      StrCpy $0 "1"
-    ${Else}
-      ${HermesLog} "Git: bash.exe NOT found at any standard location"
-    ${EndIf}
-
-    ${If} $0 == "1"
-      DetailPrint "Git for Windows installed successfully."
-      ${HermesLog} "Git install succeeded (filesystem probe positive)"
-    ${Else}
-      DetailPrint "Git for Windows install did not complete (bash.exe not found at standard install locations)."
-      ${HermesLog} "Git install FAILED (filesystem probe negative). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Git for Windows manually from https://git-scm.com/download/win after Hermes setup finishes. Hermes' terminal tool will not work until Git Bash is available."
+      DetailPrint "Node.js installed successfully."
+      ${HermesLog} "Node.js install succeeded"
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -707,7 +707,7 @@ hermes_prereq_not_silent:
     ${If} $0 != 0
       DetailPrint "Python install via winget exited with code $0."
       ${HermesLog} "Python install FAILED (exit $0). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Python 3.11, 3.12, or 3.13 manually from https://www.python.org/downloads/ after Hermes setup finishes. Hermes will not run until Python is installed."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nAfter this installer finishes, install Python 3.11, 3.12, or 3.13 manually from https://www.python.org/downloads/, then relaunch Hermes. Hermes will not run until Python is installed."
     ${Else}
       DetailPrint "Python 3.11 installed successfully."
       ${HermesLog} "Python install succeeded"

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -723,22 +723,52 @@ hermes_prereq_not_silent:
 
     StrCpy $0 "0"
     ${If} ${FileExists} "$PROGRAMFILES64\nodejs\node.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$PROGRAMFILES\nodejs\node.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$PROGRAMFILES32\nodejs\node.exe"
-      StrCpy $0 "1"
-    ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\nodejs\node.exe"
-      StrCpy $0 "1"
+      Push '"$PROGRAMFILES64\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$PROGRAMFILES\nodejs\node.exe"
+      Push '"$PROGRAMFILES\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$PROGRAMFILES32\nodejs\node.exe"
+      Push '"$PROGRAMFILES32\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
+    ${EndIf}
+    ${If} $0 == "0"
+    ${AndIf} ${FileExists} "$LOCALAPPDATA\Programs\nodejs\node.exe"
+      Push '"$LOCALAPPDATA\Programs\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+      Call HermesProbe
+      ${If} $0 == 0
+        StrCpy $0 "1"
+      ${Else}
+        StrCpy $0 "0"
+      ${EndIf}
     ${EndIf}
 
     ${If} $0 == "1"
       DetailPrint "Node.js installed successfully."
-      ${HermesLog} "Node.js install succeeded (filesystem probe positive)"
+      ${HermesLog} "Node.js install succeeded (version probe positive)"
     ${Else}
-      DetailPrint "Node.js install did not complete (node.exe not found at standard install locations)."
-      ${HermesLog} "Node.js install failed or needs a restart (filesystem probe negative)."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Node.js manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
+      DetailPrint "Node.js install did not complete (Node 20+ not found at standard install locations)."
+      ${HermesLog} "Node.js install failed or needs a restart (version probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Node.js 20+ manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -766,9 +766,9 @@ hermes_prereq_not_silent:
       DetailPrint "Node.js installed successfully."
       ${HermesLog} "Node.js install succeeded (version probe positive)"
     ${Else}
-      DetailPrint "Node.js install did not complete (Node 20+ not found at standard install locations)."
-      ${HermesLog} "Node.js install failed or needs a restart (version probe negative)."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Node.js 20+ manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
+      DetailPrint "Node.js 20+ could not be validated after install."
+      ${HermesLog} "Node.js install failed, needs a restart, or installed an unsupported version (version probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js 20+ could not be validated after winget.$\r$\n$\r$\nA restart may be required. See log: $HermesLogPath$\r$\n$\r$\nInstall Node.js 20+ manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -4,8 +4,8 @@
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
 ; selection page and the install-files page. Detects the baseline runtime
-; prerequisites (Python 3.11+ and Node.js); offers to install missing items
-; via winget.
+; prerequisites (Python 3.11+, Node.js, and Git for Windows); offers to
+; install missing items via winget.
 ;
 ; Page sequence:
 ;   Welcome → Directory → [PrereqPage] → InstFiles → Finish
@@ -20,8 +20,9 @@
 ; Diagnostics:
 ;   $TEMP\Hermes-Installer.log captures every detection probe (command,
 ;   exit code, captured output), the user's checkbox choices, and full
-;   winget stdout/stderr for Python and Node.js installs. Users hitting bugs
-;   should attach this file.
+;   winget stdout/stderr for Python and Node.js installs. Git install goes via
+;   ExecShellWait so UAC comes forward; for Git we log start/end and a
+;   post-install bash.exe probe. Users hitting bugs should attach this file.
 ;
 ; The Function declarations live at top-level in this file so they're parsed
 ; at include time; the customPageAfterChangeDir macro references them via
@@ -30,6 +31,7 @@
 ; UAC behavior:
 ;   Python: --scope user, no UAC.
 ;   Node.js: winget-managed install; installer package may request elevation.
+;   Git for Windows: winget-managed install; may request elevation.
 ;
 ; Detection:
 ;   Python: try `py -3.11`/`-3.12`/`-3.13`. The Python launcher
@@ -38,16 +40,17 @@
 ;     only the stub get correctly classified as not-installed.
 ;   Node.js: `where node` returns exit 0 if node is on PATH. We also check
 ;     %LOCALAPPDATA%\hermes\node\node.exe for Hermes-managed installs.
+;   Git: check known Git Bash locations, then `where bash`.
 ;   winget: `where winget` returns exit 0 on Win11 / Win10 1809+ with App
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
 ; Required vs. recommended:
-;   Python and Node.js are baseline dependencies. The GUI handles the
+;   Python, Node.js, and Git Bash are baseline dependencies. The GUI handles the
 ;   Hermes source payload, virtualenv, and Python dependency install on first
 ;   launch.
 ;
 ; Skip behaviors:
-;   - Both already detected → page is auto-skipped via Abort
+;   - All three already detected → page is auto-skipped via Abort
 ;   - Silent install (/S) → customInstall winget block skips
 ;   - User unchecks all checkboxes → page advances without running winget
 ; ============================================================================
@@ -62,12 +65,16 @@ Var HermesPyStatusLabel
 Var HermesPyCheckbox
 Var HermesNodeStatusLabel
 Var HermesNodeCheckbox
+Var HermesGitStatusLabel
+Var HermesGitCheckbox
 Var HermesFooterLabel
 Var HermesHasWinget
 Var HermesHasPython
 Var HermesHasNode
+Var HermesHasGit
 Var HermesInstallPython
 Var HermesInstallNode
+Var HermesInstallGit
 Var HermesLogHandle
 Var HermesLogPath
 
@@ -302,7 +309,7 @@ FunctionEnd
 
 ; ----------------------------------------------------------------------------
 ; HermesDetectPrereqs — populates $HermesHasWinget / $HermesHasPython /
-; $HermesHasNode with "0" or "1". Called from the
+; $HermesHasNode / $HermesHasGit with "0" or "1". Called from the
 ; page-create function. Every probe is logged via HermesProbe.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPrereqs
@@ -398,6 +405,29 @@ Function HermesDetectPrereqs
   ${EndIf}
   ${HermesLogKV} "HermesHasNode" "$HermesHasNode"
 
+  ; --- Git Bash ---
+  StrCpy $HermesHasGit "0"
+  ${If} ${FileExists} "$LOCALAPPDATA\hermes\git\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\git\usr\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
+    StrCpy $HermesHasGit "1"
+  ${Else}
+    Push 'cmd.exe /c where bash'
+    Call HermesProbe
+    ${If} $0 == 0
+      StrCpy $HermesHasGit "1"
+    ${EndIf}
+  ${EndIf}
+  ${HermesLogKV} "HermesHasGit" "$HermesHasGit"
+
   ${HermesLog} "=== HermesDetectPrereqs: end ==="
 FunctionEnd
 
@@ -444,7 +474,7 @@ Function HermesRunWinget
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
-; HermesPrereqPageCreate — builds the prereq page UI. If both items are
+; HermesPrereqPageCreate — builds the prereq page UI. If all items are
 ; already installed we Abort, which causes NSIS to skip directly to the next
 ; page in the sequence (InstFiles).
 ; ----------------------------------------------------------------------------
@@ -453,11 +483,12 @@ Function HermesPrereqPageCreate
 
   ${If} $HermesHasPython == "1"
   ${AndIf} $HermesHasNode == "1"
+  ${AndIf} $HermesHasGit == "1"
     ${HermesLog} "page: all prereqs detected, auto-skipping prereq page"
     Abort
   ${EndIf}
 
-  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode)"
+  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode git=$HermesHasGit)"
 
   ; Set the wizard's standard header (top blue/gradient bar). 1037 is the
   ; title control, 1038 is the subtitle. Without this, the header still
@@ -475,6 +506,7 @@ Function HermesPrereqPageCreate
 
   StrCpy $HermesInstallPython "0"
   StrCpy $HermesInstallNode "0"
+  StrCpy $HermesInstallGit "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
   ; "System Requirements" and subtitle, so we don't repeat them here —
@@ -520,8 +552,33 @@ Function HermesPrereqPageCreate
     ${EndIf}
   ${EndIf}
 
-  ${NSD_CreateLabel} 0u 86u 100% 20u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
-  Pop $HermesFooterLabel
+  ; --- Git panel ---
+  ${NSD_CreateGroupBox} 0u 82u 100% 30u "Git for Windows"
+  Pop $0
+  ${If} $HermesHasGit == "1"
+    ${NSD_CreateLabel} 8u 92u 95% 10u "Detected on your system."
+    Pop $HermesGitStatusLabel
+  ${Else}
+    ${If} $HermesHasWinget == "1"
+      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Provides Git Bash for Hermes terminal commands."
+      Pop $HermesGitStatusLabel
+      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install Git for Windows"
+      Pop $HermesGitCheckbox
+      ${NSD_Check} $HermesGitCheckbox
+    ${Else}
+      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win for terminal commands."
+      Pop $HermesGitStatusLabel
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $HermesHasGit == "0"
+  ${AndIf} $HermesHasWinget == "1"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows may request administrator approval. Check your taskbar if the prompt is hidden."
+    Pop $HermesFooterLabel
+  ${Else}
+    ${NSD_CreateLabel} 0u 116u 100% 18u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
+    Pop $HermesFooterLabel
+  ${EndIf}
 
   nsDialogs::Show
 FunctionEnd
@@ -540,7 +597,11 @@ Function HermesPrereqPageLeave
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_GetState} $HermesNodeCheckbox $HermesInstallNode
   ${EndIf}
-  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode"
+  ${If} $HermesHasGit == "0"
+  ${AndIf} $HermesHasWinget == "1"
+    ${NSD_GetState} $HermesGitCheckbox $HermesInstallGit
+  ${EndIf}
+  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode install_git=$HermesInstallGit"
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
@@ -649,6 +710,34 @@ hermes_prereq_not_silent:
     ${Else}
       DetailPrint "Node.js installed successfully."
       ${HermesLog} "Node.js install succeeded"
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $HermesInstallGit == "1"
+    DetailPrint "Installing Git for Windows via winget..."
+    ${HermesLog} "Git: starting ExecShellWait — UAC may appear; no stdout capture possible"
+    ${HermesLog} "  command: winget install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
+    ExecShellWait "open" "winget" "install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
+    ${HermesLog} "Git: ExecShellWait returned"
+
+    StrCpy $0 "0"
+    ${If} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
+      StrCpy $0 "1"
+    ${EndIf}
+
+    ${If} $0 == "1"
+      DetailPrint "Git for Windows installed successfully."
+      ${HermesLog} "Git install succeeded (filesystem probe positive)"
+    ${Else}
+      DetailPrint "Git for Windows install did not complete (bash.exe not found at standard install locations)."
+      ${HermesLog} "Git install failed or needs a restart (filesystem probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Git for Windows manually from https://git-scm.com/download/win if Hermes terminal commands fail."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -3,9 +3,8 @@
 ; ============================================================================
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
-; selection page and the install-files page. Detects the baseline runtime
-; prerequisites (Python 3.11-3.13, Node.js 20+, and Git for Windows); offers to
-; install missing items via winget.
+; selection page and the install-files page. Detects Python 3.11+, Git for
+; Windows, and ripgrep; offers to install missing items via winget.
 ;
 ; Page sequence:
 ;   Welcome → Directory → [PrereqPage] → InstFiles → Finish
@@ -20,9 +19,10 @@
 ; Diagnostics:
 ;   $TEMP\Hermes-Installer.log captures every detection probe (command,
 ;   exit code, captured output), the user's checkbox choices, and full
-;   winget stdout/stderr for Python installs. Node.js and Git installs go via
-;   ExecShellWait so UAC comes forward; for those we log start/end plus a
-;   post-install filesystem probe. Users hitting bugs should attach this file.
+;   winget stdout/stderr for Python and ripgrep installs. Git install
+;   goes via ExecShellWait (for UAC focus reasons) which cannot capture
+;   output, so for Git we log start/end + the post-install filesystem
+;   probe result only. Users hitting bugs should attach this file.
 ;
 ; The Function declarations live at top-level in this file so they're parsed
 ; at include time; the customPageAfterChangeDir macro references them via
@@ -30,24 +30,29 @@
 ;
 ; UAC behavior:
 ;   Python: --scope user, no UAC.
-;   Node.js: winget-managed install; installer package may request elevation.
-;   Git for Windows: winget-managed install; may request elevation.
+;   ripgrep: --scope user, no UAC.
+;   Git for Windows: always per-machine, triggers UAC prompt.
+;   Footer warns the user about Git's UAC; ExecShellWait preserves the
+;   foreground focus chain so the prompt comes to front.
 ;
 ; Detection:
-;   Python: try `py -3.11`/`-3.12`/`-3.13`. The Python launcher
+;   Python: try `py -3.11`/`-3.12`/`-3.13`/`-3.14`. The Python launcher
 ;     returns exit 0 only when that specific version is installed. The
 ;     Microsoft Store "Python stub" doesn't install py.exe, so users with
 ;     only the stub get correctly classified as not-installed.
-;   Node.js: require a modern Node (major >= 20). Check PATH first, then the
-;     Hermes-managed %LOCALAPPDATA%\hermes\node\node.exe if present.
-;   Git: check known Git Bash locations for Git for Windows / Hermes-managed Git.
+;   Git: `where git` returns exit 0 if git is on PATH.
+;   ripgrep: `where rg` returns exit 0 if rg is on PATH.
 ;   winget: `where winget` returns exit 0 on Win11 / Win10 1809+ with App
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
 ; Required vs. recommended:
-;   Python, Node.js, and Git Bash are baseline dependencies. The GUI handles the
-;   Hermes source payload, virtualenv, and Python dependency install on first
-;   launch.
+;   Python and Git are REQUIRED — without them the agent's runtime + terminal
+;   tool fail. The page emphasizes "required" wording and the bootstrapper
+;   throws if either is missing at first launch.
+;   ripgrep is RECOMMENDED — Hermes' search_files tool uses it for fast
+;   .gitignore-aware search, and falls back to grep/find from Git Bash when
+;   missing (works but slower, less filtering). Page wording is softer for
+;   ripgrep so users understand they CAN skip it.
 ;
 ; Skip behaviors:
 ;   - All three already detected → page is auto-skipped via Abort
@@ -63,18 +68,18 @@
 Var HermesDialog
 Var HermesPyStatusLabel
 Var HermesPyCheckbox
-Var HermesNodeStatusLabel
-Var HermesNodeCheckbox
-Var HermesGitBashStatusLabel
-Var HermesGitBashCheckbox
+Var HermesGitStatusLabel
+Var HermesGitCheckbox
+Var HermesRgStatusLabel
+Var HermesRgCheckbox
 Var HermesFooterLabel
 Var HermesHasWinget
 Var HermesHasPython
-Var HermesHasNode
-Var HermesHasGitBash
+Var HermesHasGit
+Var HermesHasRipgrep
 Var HermesInstallPython
-Var HermesInstallNode
-Var HermesInstallGitBash
+Var HermesInstallGit
+Var HermesInstallRipgrep
 Var HermesLogHandle
 Var HermesLogPath
 
@@ -90,9 +95,9 @@ Var HermesLogPath
 ;   - NSIS's built-in `LogSet on` / `LogText` requires the "advanced logging"
 ;     build of makensis (NSIS_CONFIG_LOG=1), which electron-builder's bundled
 ;     binary doesn't include. So we roll our own with FileWrite.
-;   - Python's winget invocation streams stdout/stderr into the log via
-;     nsExec::ExecToStack. Node.js and Git use ExecShellWait instead because
-;     their installers may elevate; this keeps UAC in front of the wizard.
+;   - Every winget invocation streams its full stdout/stderr into the log via
+;     nsExec::ExecToStack — the same data the Details panel shows, but
+;     captured for post-mortem.
 ;   - Detection probes also log exit codes + captured output, so when a user
 ;     reports "the page said Python isn't installed but I have it", we can
 ;     see exactly which probes ran and what they returned.
@@ -234,7 +239,7 @@ FunctionEnd
 ; install exists at one of the standard locations. FileExists never runs
 ; the binary so this is safe even if the user has the MS Store stub on
 ; their PATH. We probe both system-wide (Program Files) and per-user
-; (LocalAppData\Programs) install locations for versions 3.11–3.13.
+; (LocalAppData\Programs) install locations for versions 3.11–3.14.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPythonViaFilesystem
   ${HermesLog} "filesystem: probing standard Python install paths"
@@ -309,7 +314,7 @@ FunctionEnd
 
 ; ----------------------------------------------------------------------------
 ; HermesDetectPrereqs — populates $HermesHasWinget / $HermesHasPython /
-; $HermesHasNode / $HermesHasGitBash with "0" or "1". Called from the
+; $HermesHasGit / $HermesHasRipgrep with "0" or "1". Called from the
 ; page-create function. Every probe is logged via HermesProbe.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPrereqs
@@ -393,40 +398,25 @@ Function HermesDetectPrereqs
     ${HermesLogKV} "after filesystem probe, HermesHasPython" "$HermesHasPython"
   ${EndIf}
 
-  ; --- Node.js 20+ ---
-  Push 'cmd.exe /c node -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+  ; --- Git ---
+  Push 'cmd.exe /c where git'
   Call HermesProbe
   ${If} $0 == 0
-    StrCpy $HermesHasNode "1"
-  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\node\node.exe"
-    Push '"$LOCALAPPDATA\hermes\node\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
-    Call HermesProbe
-    ${If} $0 == 0
-      StrCpy $HermesHasNode "1"
-    ${Else}
-      StrCpy $HermesHasNode "0"
-    ${EndIf}
+    StrCpy $HermesHasGit "1"
   ${Else}
-    StrCpy $HermesHasNode "0"
+    StrCpy $HermesHasGit "0"
   ${EndIf}
-  ${HermesLogKV} "HermesHasNode" "$HermesHasNode"
+  ${HermesLogKV} "HermesHasGit" "$HermesHasGit"
 
-  ; --- Git Bash ---
-  StrCpy $HermesHasGitBash "0"
-  ${If} ${FileExists} "$LOCALAPPDATA\hermes\git\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
-  ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\git\usr\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
-  ${ElseIf} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
-  ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
-  ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
-  ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
-    StrCpy $HermesHasGitBash "1"
+  ; --- ripgrep ---
+  Push 'cmd.exe /c where rg'
+  Call HermesProbe
+  ${If} $0 == 0
+    StrCpy $HermesHasRipgrep "1"
+  ${Else}
+    StrCpy $HermesHasRipgrep "0"
   ${EndIf}
-  ${HermesLogKV} "HermesHasGitBash" "$HermesHasGitBash"
+  ${HermesLogKV} "HermesHasRipgrep" "$HermesHasRipgrep"
 
   ${HermesLog} "=== HermesDetectPrereqs: end ==="
 FunctionEnd
@@ -474,7 +464,7 @@ Function HermesRunWinget
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
-; HermesPrereqPageCreate — builds the prereq page UI. If all items are
+; HermesPrereqPageCreate — builds the prereq page UI. If all three items are
 ; already installed we Abort, which causes NSIS to skip directly to the next
 ; page in the sequence (InstFiles).
 ; ----------------------------------------------------------------------------
@@ -482,13 +472,13 @@ Function HermesPrereqPageCreate
   Call HermesDetectPrereqs
 
   ${If} $HermesHasPython == "1"
-  ${AndIf} $HermesHasNode == "1"
-  ${AndIf} $HermesHasGitBash == "1"
+  ${AndIf} $HermesHasGit == "1"
+  ${AndIf} $HermesHasRipgrep == "1"
     ${HermesLog} "page: all prereqs detected, auto-skipping prereq page"
     Abort
   ${EndIf}
 
-  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode git_bash=$HermesHasGitBash)"
+  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython git=$HermesHasGit rg=$HermesHasRipgrep)"
 
   ; Set the wizard's standard header (top blue/gradient bar). 1037 is the
   ; title control, 1038 is the subtitle. Without this, the header still
@@ -496,7 +486,7 @@ Function HermesPrereqPageCreate
   GetDlgItem $0 $HWNDPARENT 1037
   SendMessage $0 ${WM_SETTEXT} 0 "STR:System Requirements"
   GetDlgItem $0 $HWNDPARENT 1038
-  SendMessage $0 ${WM_SETTEXT} 0 "STR:Install baseline runtime dependencies before the GUI finishes Hermes setup."
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:Hermes needs Python 3.11+ and Git for Windows. ripgrep is recommended."
 
   nsDialogs::Create 1018
   Pop $HermesDialog
@@ -505,20 +495,17 @@ Function HermesPrereqPageCreate
   ${EndIf}
 
   StrCpy $HermesInstallPython "0"
-  StrCpy $HermesInstallNode "0"
-  StrCpy $HermesInstallGitBash "0"
+  StrCpy $HermesInstallGit "0"
+  StrCpy $HermesInstallRipgrep "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
-  ; "System Requirements" and subtitle, so we don't repeat them here.
-  ${If} $HermesHasWinget == "1"
-    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Missing items can be installed automatically via winget."
-  ${Else}
-    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Continue setup, then install missing items manually."
-  ${EndIf}
+  ; "System Requirements" and subtitle, so we don't repeat them here —
+  ; just one short explanatory line.
+  ${NSD_CreateLabel} 0u 0u 100% 16u "Items already installed are listed as detected. Missing items can be installed automatically via winget."
   Pop $0
 
-  ; --- Python panel ---
-  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11-3.13"
+  ; --- Python panel (REQUIRED) ---
+  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11+  (required)"
   Pop $0
   ${If} $HermesHasPython == "1"
     ${NSD_CreateLabel} 8u 28u 95% 10u "Detected on your system."
@@ -531,68 +518,53 @@ Function HermesPrereqPageCreate
       Pop $HermesPyCheckbox
       ${NSD_Check} $HermesPyCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/, then relaunch Hermes."
+      ${NSD_CreateLabel} 8u 27u 95% 14u "Not detected. Install manually from https://www.python.org/downloads/ and re-run this installer."
       Pop $HermesPyStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- Node.js panel ---
-  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js 20+ LTS"
+  ; --- Git panel (REQUIRED) ---
+  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Git for Windows  (required, provides Git Bash)"
   Pop $0
-  ${If} $HermesHasNode == "1"
+  ${If} $HermesHasGit == "1"
     ${NSD_CreateLabel} 8u 60u 95% 10u "Detected on your system."
-    Pop $HermesNodeStatusLabel
+    Pop $HermesGitStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Used by Hermes browser tools and Node-backed capabilities."
-      Pop $HermesNodeStatusLabel
-      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Node.js LTS"
-      Pop $HermesNodeCheckbox
-      ${NSD_Check} $HermesNodeCheckbox
+      ${NSD_CreateLabel} 8u 59u 95% 9u "Not detected. Required by Hermes' terminal tool."
+      Pop $HermesGitStatusLabel
+      ${NSD_CreateCheckbox} 8u 69u 95% 9u "Install Git for Windows"
+      Pop $HermesGitCheckbox
+      ${NSD_Check} $HermesGitCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://nodejs.org/en/download/, then relaunch Hermes."
-      Pop $HermesNodeStatusLabel
+      ${NSD_CreateLabel} 8u 59u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win and re-run this installer."
+      Pop $HermesGitStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ; --- Git panel ---
-  ${NSD_CreateGroupBox} 0u 82u 100% 30u "Git for Windows"
+  ; --- ripgrep panel (RECOMMENDED) ---
+  ${NSD_CreateGroupBox} 0u 82u 100% 30u "ripgrep  (recommended for fast file search)"
   Pop $0
-  ${If} $HermesHasGitBash == "1"
+  ${If} $HermesHasRipgrep == "1"
     ${NSD_CreateLabel} 8u 92u 95% 10u "Detected on your system."
-    Pop $HermesGitBashStatusLabel
+    Pop $HermesRgStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
-      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Provides Git Bash for Hermes terminal commands."
-      Pop $HermesGitBashStatusLabel
-      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install Git for Windows"
-      Pop $HermesGitBashCheckbox
-      ${NSD_Check} $HermesGitBashCheckbox
+      ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Hermes will fall back to slower grep/find."
+      Pop $HermesRgStatusLabel
+      ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install ripgrep"
+      Pop $HermesRgCheckbox
+      ${NSD_Check} $HermesRgCheckbox
     ${Else}
-      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win for terminal commands."
-      Pop $HermesGitBashStatusLabel
+      ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://github.com/BurntSushi/ripgrep#installation if you want fast .gitignore-aware search."
+      Pop $HermesRgStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesHasPython == "1"
-  ${AndIf} $HermesHasNode == "1"
-  ${AndIf} $HermesHasGitBash == "1"
-    ${NSD_CreateLabel} 0u 116u 100% 18u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
-    Pop $HermesFooterLabel
-  ${ElseIf} $HermesHasWinget == "0"
-    ${NSD_CreateLabel} 0u 116u 100% 18u "Continue setup, then install missing dependencies manually and relaunch Hermes."
-    Pop $HermesFooterLabel
-  ${ElseIf} $HermesHasWinget == "1"
-    ${If} $HermesHasNode == "0"
-    ${OrIf} $HermesHasGitBash == "0"
-      ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Node.js or Git for Windows may request administrator approval. Check your taskbar if hidden."
-      Pop $HermesFooterLabel
-    ${Else}
-      ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
-      Pop $HermesFooterLabel
-    ${EndIf}
-  ${Else}
-    ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
+  ; --- Footer (UAC notice when Git install will run) ---
+  ${If} $HermesHasGit == "0"
+  ${AndIf} $HermesHasWinget == "1"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows requires administrator approval. The UAC prompt may appear behind this window — check your taskbar."
     Pop $HermesFooterLabel
   ${EndIf}
 
@@ -609,15 +581,15 @@ Function HermesPrereqPageLeave
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_GetState} $HermesPyCheckbox $HermesInstallPython
   ${EndIf}
-  ${If} $HermesHasNode == "0"
+  ${If} $HermesHasGit == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesNodeCheckbox $HermesInstallNode
+    ${NSD_GetState} $HermesGitCheckbox $HermesInstallGit
   ${EndIf}
-  ${If} $HermesHasGitBash == "0"
+  ${If} $HermesHasRipgrep == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesGitBashCheckbox $HermesInstallGitBash
+    ${NSD_GetState} $HermesRgCheckbox $HermesInstallRipgrep
   ${EndIf}
-  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode install_git_bash=$HermesInstallGitBash"
+  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_git=$HermesInstallGit install_ripgrep=$HermesInstallRipgrep"
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
@@ -700,94 +672,76 @@ hermes_prereq_not_silent:
     ; Python with --scope user installs to %LOCALAPPDATA%\Programs\Python\
     ; — no UAC, no foreground chain to preserve. HermesRunWinget captures
     ; both the Details-panel output AND a copy to the installer log.
-    DetailPrint "Installing Python 3.11 via winget (silent per-user install, no admin prompt)..."
+    DetailPrint "Installing Python 3.11+ via winget (silent per-user install, no admin prompt)..."
     Push 'install -e --id Python.Python.3.11 --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
     Push 'Python 3.11'
     Call HermesRunWinget
     ${If} $0 != 0
       DetailPrint "Python install via winget exited with code $0."
       ${HermesLog} "Python install FAILED (exit $0). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nAfter this installer finishes, install Python 3.11, 3.12, or 3.13 manually from https://www.python.org/downloads/, then relaunch Hermes. Hermes will not run until Python is installed."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Python 3.11+ manually from https://www.python.org/downloads/ after Hermes setup finishes. Hermes will not run until Python is installed."
     ${Else}
-      DetailPrint "Python 3.11 installed successfully."
+      DetailPrint "Python 3.11+ installed successfully."
       ${HermesLog} "Python install succeeded"
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallNode == "1"
-    DetailPrint "Installing Node.js LTS via winget..."
-    ${HermesLog} "Node.js: starting ExecShellWait — UAC may appear; no stdout capture possible"
-    ${HermesLog} "  command: winget install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
-    ExecShellWait "open" "winget" "install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
-    ${HermesLog} "Node.js: ExecShellWait returned"
-
-    StrCpy $0 "0"
-    ${If} ${FileExists} "$PROGRAMFILES64\nodejs\node.exe"
-      Push '"$PROGRAMFILES64\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
-      Call HermesProbe
-      ${If} $0 == 0
-        StrCpy $0 "1"
-      ${Else}
-        StrCpy $0 "0"
-      ${EndIf}
-    ${EndIf}
-    ${If} $0 == "0"
-    ${AndIf} ${FileExists} "$PROGRAMFILES\nodejs\node.exe"
-      Push '"$PROGRAMFILES\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
-      Call HermesProbe
-      ${If} $0 == 0
-        StrCpy $0 "1"
-      ${Else}
-        StrCpy $0 "0"
-      ${EndIf}
-    ${EndIf}
-    ${If} $0 == "0"
-    ${AndIf} ${FileExists} "$PROGRAMFILES32\nodejs\node.exe"
-      Push '"$PROGRAMFILES32\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
-      Call HermesProbe
-      ${If} $0 == 0
-        StrCpy $0 "1"
-      ${Else}
-        StrCpy $0 "0"
-      ${EndIf}
-    ${EndIf}
-    ${If} $0 == "0"
-    ${AndIf} ${FileExists} "$LOCALAPPDATA\Programs\nodejs\node.exe"
-      Push '"$LOCALAPPDATA\Programs\nodejs\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
-      Call HermesProbe
-      ${If} $0 == 0
-        StrCpy $0 "1"
-      ${Else}
-        StrCpy $0 "0"
-      ${EndIf}
-    ${EndIf}
-
-    ${If} $0 == "1"
-      DetailPrint "Node.js installed successfully."
-      ${HermesLog} "Node.js install succeeded (version probe positive)"
+  ${If} $HermesInstallRipgrep == "1"
+    ; ripgrep with --scope user — ~5MB, no UAC needed. Failure is non-fatal:
+    ; Hermes' search_files tool falls back to grep/find from Git Bash.
+    DetailPrint "Installing ripgrep via winget (silent per-user install, no admin prompt)..."
+    Push 'install -e --id BurntSushi.ripgrep.MSVC --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
+    Push 'ripgrep'
+    Call HermesRunWinget
+    ${If} $0 != 0
+      DetailPrint "ripgrep install via winget exited with code $0 (non-fatal — Hermes will fall back to grep/find)."
+      ${HermesLog} "ripgrep install failed (exit $0) — non-fatal"
     ${Else}
-      DetailPrint "Node.js 20+ could not be validated after install."
-      ${HermesLog} "Node.js install failed, needs a restart, or installed an unsupported version (version probe negative)."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js 20+ could not be validated after winget.$\r$\n$\r$\nA restart may be required. See log: $HermesLogPath$\r$\n$\r$\nInstall Node.js 20+ manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
+      DetailPrint "ripgrep installed successfully."
+      ${HermesLog} "ripgrep install succeeded"
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallGitBash == "1"
-    DetailPrint "Installing Git for Windows via winget..."
-    ${HermesLog} "Git: starting ExecShellWait — UAC may appear; no stdout capture possible"
+  ${If} $HermesInstallGit == "1"
+    ; Git for Windows always installs per-machine and triggers UAC. We use
+    ; ExecShellWait (NSIS's wrapper around Windows ShellExecute) instead of
+    ; nsExec because ShellExecute preserves the foreground focus chain
+    ; across non-elevated → elevated process spawns. With nsExec the
+    ; intermediate hidden winget.exe breaks that chain and UAC ends up
+    ; behind the installer window.
+    ;
+    ; Trade-off: ExecShellWait doesn't capture output, so winget runs in
+    ; its own console window. The console flashes briefly while winget
+    ; downloads, then UAC fires for the elevated Git installer with
+    ; correct foreground promotion. We CANNOT log winget's stdout/stderr
+    ; for this case; we only log start time, end time, and the post-
+    ; install filesystem probe result.
+    DetailPrint "Installing Git for Windows via winget (UAC prompt will appear)..."
+    ${HermesLog} "Git: starting ExecShellWait — UAC will fire; no stdout capture possible"
     ${HermesLog} "  command: winget install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
     ExecShellWait "open" "winget" "install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
-    ${HermesLog} "Git: ExecShellWait returned"
+    ${HermesLog} "Git: ExecShellWait returned (no exit code available from ShellExecute)"
 
-    StrCpy $0 "0"
+    ; ExecShellWait returns no exit code, so verify by checking the file
+    ; system directly. Don't use `where git` — that reads OUR process's
+    ; PATH, which was captured at NSIS startup before Git's installer ran
+    ; and modified the system PATH. Until we restart, the new PATH isn't
+    ; visible to us. Probe Git's standard install locations instead.
+    StrCpy $0 "0"  ; "git found" flag
     ${If} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
+      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES64\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
+      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
+      ${HermesLog} "Git: found bash.exe at $PROGRAMFILES32\Git\bin\bash.exe"
       StrCpy $0 "1"
     ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
+      ${HermesLog} "Git: found bash.exe at $LOCALAPPDATA\Programs\Git\bin\bash.exe"
       StrCpy $0 "1"
+    ${Else}
+      ${HermesLog} "Git: bash.exe NOT found at any standard location"
     ${EndIf}
 
     ${If} $0 == "1"
@@ -795,8 +749,8 @@ hermes_prereq_not_silent:
       ${HermesLog} "Git install succeeded (filesystem probe positive)"
     ${Else}
       DetailPrint "Git for Windows install did not complete (bash.exe not found at standard install locations)."
-      ${HermesLog} "Git install failed or needs a restart (filesystem probe negative)."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Git for Windows manually from https://git-scm.com/download/win if Hermes terminal commands fail."
+      ${HermesLog} "Git install FAILED (filesystem probe negative). User notified via MessageBox."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Git for Windows install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Git for Windows manually from https://git-scm.com/download/win after Hermes setup finishes. Hermes' terminal tool will not work until Git Bash is available."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -4,7 +4,7 @@
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
 ; selection page and the install-files page. Detects the baseline runtime
-; prerequisites (Python 3.11-3.13, Node.js, and Git for Windows); offers to
+; prerequisites (Python 3.11-3.13, Node.js 20+, and Git for Windows); offers to
 ; install missing items via winget.
 ;
 ; Page sequence:
@@ -38,9 +38,9 @@
 ;     returns exit 0 only when that specific version is installed. The
 ;     Microsoft Store "Python stub" doesn't install py.exe, so users with
 ;     only the stub get correctly classified as not-installed.
-;   Node.js: `where node` returns exit 0 if node is on PATH. We also check
-;     %LOCALAPPDATA%\hermes\node\node.exe for Hermes-managed installs.
-;   Git: check known Git Bash locations, then `where bash`.
+;   Node.js: require a modern Node (major >= 20). Check PATH first, then the
+;     Hermes-managed %LOCALAPPDATA%\hermes\node\node.exe if present.
+;   Git: check known Git Bash locations for Git for Windows / Hermes-managed Git.
 ;   winget: `where winget` returns exit 0 on Win11 / Win10 1809+ with App
 ;     Installer. If unavailable, the page shows manual download URLs.
 ;
@@ -393,13 +393,19 @@ Function HermesDetectPrereqs
     ${HermesLogKV} "after filesystem probe, HermesHasPython" "$HermesHasPython"
   ${EndIf}
 
-  ; --- Node.js ---
-  Push 'cmd.exe /c where node'
+  ; --- Node.js 20+ ---
+  Push 'cmd.exe /c node -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
   Call HermesProbe
   ${If} $0 == 0
     StrCpy $HermesHasNode "1"
   ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\node\node.exe"
-    StrCpy $HermesHasNode "1"
+    Push '"$LOCALAPPDATA\hermes\node\node.exe" -e "process.exit(Number(process.versions.node.split(String.fromCharCode(46))[0]) >= 20 ? 0 : 1)"'
+    Call HermesProbe
+    ${If} $0 == 0
+      StrCpy $HermesHasNode "1"
+    ${Else}
+      StrCpy $HermesHasNode "0"
+    ${EndIf}
   ${Else}
     StrCpy $HermesHasNode "0"
   ${EndIf}
@@ -419,12 +425,6 @@ Function HermesDetectPrereqs
     StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
     StrCpy $HermesHasGitBash "1"
-  ${Else}
-    Push 'cmd.exe /c where bash'
-    Call HermesProbe
-    ${If} $0 == 0
-      StrCpy $HermesHasGitBash "1"
-    ${EndIf}
   ${EndIf}
   ${HermesLogKV} "HermesHasGitBash" "$HermesHasGitBash"
 
@@ -537,7 +537,7 @@ Function HermesPrereqPageCreate
   ${EndIf}
 
   ; --- Node.js panel ---
-  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js LTS"
+  ${NSD_CreateGroupBox} 0u 50u 100% 30u "Node.js 20+ LTS"
   Pop $0
   ${If} $HermesHasNode == "1"
     ${NSD_CreateLabel} 8u 60u 95% 10u "Detected on your system."

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -20,9 +20,9 @@
 ; Diagnostics:
 ;   $TEMP\Hermes-Installer.log captures every detection probe (command,
 ;   exit code, captured output), the user's checkbox choices, and full
-;   winget stdout/stderr for Python and Node.js installs. Git install goes via
-;   ExecShellWait so UAC comes forward; for Git we log start/end and a
-;   post-install bash.exe probe. Users hitting bugs should attach this file.
+;   winget stdout/stderr for Python installs. Node.js and Git installs go via
+;   ExecShellWait so UAC comes forward; for those we log start/end plus a
+;   post-install filesystem probe. Users hitting bugs should attach this file.
 ;
 ; The Function declarations live at top-level in this file so they're parsed
 ; at include time; the customPageAfterChangeDir macro references them via
@@ -90,9 +90,9 @@ Var HermesLogPath
 ;   - NSIS's built-in `LogSet on` / `LogText` requires the "advanced logging"
 ;     build of makensis (NSIS_CONFIG_LOG=1), which electron-builder's bundled
 ;     binary doesn't include. So we roll our own with FileWrite.
-;   - Every winget invocation streams its full stdout/stderr into the log via
-;     nsExec::ExecToStack — the same data the Details panel shows, but
-;     captured for post-mortem.
+;   - Python's winget invocation streams stdout/stderr into the log via
+;     nsExec::ExecToStack. Node.js and Git use ExecShellWait instead because
+;     their installers may elevate; this keeps UAC in front of the wizard.
 ;   - Detection probes also log exit codes + captured output, so when a user
 ;     reports "the page said Python isn't installed but I have it", we can
 ;     see exactly which probes ran and what they returned.
@@ -582,10 +582,15 @@ Function HermesPrereqPageCreate
   ${ElseIf} $HermesHasWinget == "0"
     ${NSD_CreateLabel} 0u 116u 100% 18u "Continue setup, then install missing dependencies manually and relaunch Hermes."
     Pop $HermesFooterLabel
-  ${ElseIf} $HermesHasGitBash == "0"
-  ${AndIf} $HermesHasWinget == "1"
-    ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows may request administrator approval. Check your taskbar if the prompt is hidden."
-    Pop $HermesFooterLabel
+  ${ElseIf} $HermesHasWinget == "1"
+    ${If} $HermesHasNode == "0"
+    ${OrIf} $HermesHasGitBash == "0"
+      ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Node.js or Git for Windows may request administrator approval. Check your taskbar if hidden."
+      Pop $HermesFooterLabel
+    ${Else}
+      ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
+      Pop $HermesFooterLabel
+    ${EndIf}
   ${Else}
     ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
     Pop $HermesFooterLabel
@@ -711,16 +716,29 @@ hermes_prereq_not_silent:
 
   ${If} $HermesInstallNode == "1"
     DetailPrint "Installing Node.js LTS via winget..."
-    Push 'install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
-    Push 'Node.js LTS'
-    Call HermesRunWinget
-    ${If} $0 != 0
-      DetailPrint "Node.js install via winget exited with code $0."
-      ${HermesLog} "Node.js install FAILED (exit $0). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Node.js manually from https://nodejs.org/en/download/ after Hermes setup finishes. Some Hermes tools will not work until Node.js is installed."
-    ${Else}
+    ${HermesLog} "Node.js: starting ExecShellWait — UAC may appear; no stdout capture possible"
+    ${HermesLog} "  command: winget install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"
+    ExecShellWait "open" "winget" "install -e --id OpenJS.NodeJS.LTS --silent --disable-interactivity --accept-package-agreements --accept-source-agreements" SW_SHOWNORMAL
+    ${HermesLog} "Node.js: ExecShellWait returned"
+
+    StrCpy $0 "0"
+    ${If} ${FileExists} "$PROGRAMFILES64\nodejs\node.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$PROGRAMFILES\nodejs\node.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$PROGRAMFILES32\nodejs\node.exe"
+      StrCpy $0 "1"
+    ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\nodejs\node.exe"
+      StrCpy $0 "1"
+    ${EndIf}
+
+    ${If} $0 == "1"
       DetailPrint "Node.js installed successfully."
-      ${HermesLog} "Node.js install succeeded"
+      ${HermesLog} "Node.js install succeeded (filesystem probe positive)"
+    ${Else}
+      DetailPrint "Node.js install did not complete (node.exe not found at standard install locations)."
+      ${HermesLog} "Node.js install failed or needs a restart (filesystem probe negative)."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Node.js install via winget did not complete successfully.$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Node.js manually from https://nodejs.org/en/download/ if Hermes browser tools or Node-backed capabilities fail."
     ${EndIf}
   ${EndIf}
 

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -4,7 +4,7 @@
 ;
 ; A native NSIS Wizard page (using nsDialogs) inserted between the directory
 ; selection page and the install-files page. Detects the baseline runtime
-; prerequisites (Python 3.11+, Node.js, and Git for Windows); offers to
+; prerequisites (Python 3.11-3.13, Node.js, and Git for Windows); offers to
 ; install missing items via winget.
 ;
 ; Page sequence:
@@ -509,13 +509,16 @@ Function HermesPrereqPageCreate
   StrCpy $HermesInstallGit "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
-  ; "System Requirements" and subtitle, so we don't repeat them here —
-  ; just one short explanatory line.
-  ${NSD_CreateLabel} 0u 0u 100% 16u "Items already installed are listed as detected. Missing items can be installed automatically via winget."
+  ; "System Requirements" and subtitle, so we don't repeat them here.
+  ${If} $HermesHasWinget == "1"
+    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Missing items can be installed automatically via winget."
+  ${Else}
+    ${NSD_CreateLabel} 0u 0u 100% 16u "Detected items are listed below. Install missing items manually, then re-run this installer."
+  ${EndIf}
   Pop $0
 
   ; --- Python panel ---
-  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11+"
+  ${NSD_CreateGroupBox} 0u 18u 100% 30u "Python 3.11-3.13"
   Pop $0
   ${If} $HermesHasPython == "1"
     ${NSD_CreateLabel} 8u 28u 95% 10u "Detected on your system."
@@ -684,16 +687,16 @@ hermes_prereq_not_silent:
     ; Python with --scope user installs to %LOCALAPPDATA%\Programs\Python\
     ; — no UAC, no foreground chain to preserve. HermesRunWinget captures
     ; both the Details-panel output AND a copy to the installer log.
-    DetailPrint "Installing Python 3.11+ via winget (silent per-user install, no admin prompt)..."
+    DetailPrint "Installing Python 3.11 via winget (silent per-user install, no admin prompt)..."
     Push 'install -e --id Python.Python.3.11 --scope user --silent --disable-interactivity --accept-package-agreements --accept-source-agreements'
     Push 'Python 3.11'
     Call HermesRunWinget
     ${If} $0 != 0
       DetailPrint "Python install via winget exited with code $0."
       ${HermesLog} "Python install FAILED (exit $0). User notified via MessageBox."
-      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nYou can install Python 3.11+ manually from https://www.python.org/downloads/ after Hermes setup finishes. Hermes will not run until Python is installed."
+      MessageBox MB_OK|MB_ICONEXCLAMATION|MB_TOPMOST "Python install via winget did not complete successfully (exit code $0).$\r$\n$\r$\nSee log: $HermesLogPath$\r$\n$\r$\nInstall Python 3.11, 3.12, or 3.13 manually from https://www.python.org/downloads/ after Hermes setup finishes. Hermes will not run until Python is installed."
     ${Else}
-      DetailPrint "Python 3.11+ installed successfully."
+      DetailPrint "Python 3.11 installed successfully."
       ${HermesLog} "Python install succeeded"
     ${EndIf}
   ${EndIf}

--- a/apps/desktop/installer/prereq-check.nsh
+++ b/apps/desktop/installer/prereq-check.nsh
@@ -65,16 +65,16 @@ Var HermesPyStatusLabel
 Var HermesPyCheckbox
 Var HermesNodeStatusLabel
 Var HermesNodeCheckbox
-Var HermesGitStatusLabel
-Var HermesGitCheckbox
+Var HermesGitBashStatusLabel
+Var HermesGitBashCheckbox
 Var HermesFooterLabel
 Var HermesHasWinget
 Var HermesHasPython
 Var HermesHasNode
-Var HermesHasGit
+Var HermesHasGitBash
 Var HermesInstallPython
 Var HermesInstallNode
-Var HermesInstallGit
+Var HermesInstallGitBash
 Var HermesLogHandle
 Var HermesLogPath
 
@@ -309,7 +309,7 @@ FunctionEnd
 
 ; ----------------------------------------------------------------------------
 ; HermesDetectPrereqs — populates $HermesHasWinget / $HermesHasPython /
-; $HermesHasNode / $HermesHasGit with "0" or "1". Called from the
+; $HermesHasNode / $HermesHasGitBash with "0" or "1". Called from the
 ; page-create function. Every probe is logged via HermesProbe.
 ; ----------------------------------------------------------------------------
 Function HermesDetectPrereqs
@@ -406,27 +406,27 @@ Function HermesDetectPrereqs
   ${HermesLogKV} "HermesHasNode" "$HermesHasNode"
 
   ; --- Git Bash ---
-  StrCpy $HermesHasGit "0"
+  StrCpy $HermesHasGitBash "0"
   ${If} ${FileExists} "$LOCALAPPDATA\hermes\git\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$LOCALAPPDATA\hermes\git\usr\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$PROGRAMFILES64\Git\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$PROGRAMFILES\Git\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$PROGRAMFILES32\Git\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${ElseIf} ${FileExists} "$LOCALAPPDATA\Programs\Git\bin\bash.exe"
-    StrCpy $HermesHasGit "1"
+    StrCpy $HermesHasGitBash "1"
   ${Else}
     Push 'cmd.exe /c where bash'
     Call HermesProbe
     ${If} $0 == 0
-      StrCpy $HermesHasGit "1"
+      StrCpy $HermesHasGitBash "1"
     ${EndIf}
   ${EndIf}
-  ${HermesLogKV} "HermesHasGit" "$HermesHasGit"
+  ${HermesLogKV} "HermesHasGitBash" "$HermesHasGitBash"
 
   ${HermesLog} "=== HermesDetectPrereqs: end ==="
 FunctionEnd
@@ -483,12 +483,12 @@ Function HermesPrereqPageCreate
 
   ${If} $HermesHasPython == "1"
   ${AndIf} $HermesHasNode == "1"
-  ${AndIf} $HermesHasGit == "1"
+  ${AndIf} $HermesHasGitBash == "1"
     ${HermesLog} "page: all prereqs detected, auto-skipping prereq page"
     Abort
   ${EndIf}
 
-  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode git=$HermesHasGit)"
+  ${HermesLog} "page: rendering prereq page (winget=$HermesHasWinget python=$HermesHasPython node=$HermesHasNode git_bash=$HermesHasGitBash)"
 
   ; Set the wizard's standard header (top blue/gradient bar). 1037 is the
   ; title control, 1038 is the subtitle. Without this, the header still
@@ -506,7 +506,7 @@ Function HermesPrereqPageCreate
 
   StrCpy $HermesInstallPython "0"
   StrCpy $HermesInstallNode "0"
-  StrCpy $HermesInstallGit "0"
+  StrCpy $HermesInstallGitBash "0"
 
   ; Page body intro. The wizard's header (set above) shows the title
   ; "System Requirements" and subtitle, so we don't repeat them here.
@@ -558,28 +558,36 @@ Function HermesPrereqPageCreate
   ; --- Git panel ---
   ${NSD_CreateGroupBox} 0u 82u 100% 30u "Git for Windows"
   Pop $0
-  ${If} $HermesHasGit == "1"
+  ${If} $HermesHasGitBash == "1"
     ${NSD_CreateLabel} 8u 92u 95% 10u "Detected on your system."
-    Pop $HermesGitStatusLabel
+    Pop $HermesGitBashStatusLabel
   ${Else}
     ${If} $HermesHasWinget == "1"
       ${NSD_CreateLabel} 8u 91u 95% 9u "Not detected. Provides Git Bash for Hermes terminal commands."
-      Pop $HermesGitStatusLabel
+      Pop $HermesGitBashStatusLabel
       ${NSD_CreateCheckbox} 8u 101u 95% 9u "Install Git for Windows"
-      Pop $HermesGitCheckbox
-      ${NSD_Check} $HermesGitCheckbox
+      Pop $HermesGitBashCheckbox
+      ${NSD_Check} $HermesGitBashCheckbox
     ${Else}
       ${NSD_CreateLabel} 8u 91u 95% 14u "Not detected. Install manually from https://git-scm.com/download/win for terminal commands."
-      Pop $HermesGitStatusLabel
+      Pop $HermesGitBashStatusLabel
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesHasGit == "0"
+  ${If} $HermesHasPython == "1"
+  ${AndIf} $HermesHasNode == "1"
+  ${AndIf} $HermesHasGitBash == "1"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
+    Pop $HermesFooterLabel
+  ${ElseIf} $HermesHasWinget == "0"
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Continue setup, then install missing dependencies manually and relaunch Hermes."
+    Pop $HermesFooterLabel
+  ${ElseIf} $HermesHasGitBash == "0"
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_CreateLabel} 0u 116u 100% 18u "Note: Git for Windows may request administrator approval. Check your taskbar if the prompt is hidden."
     Pop $HermesFooterLabel
   ${Else}
-    ${NSD_CreateLabel} 0u 116u 100% 18u "After launch, Hermes will finish installing the bundled agent files and Python dependencies in the GUI."
+    ${NSD_CreateLabel} 0u 116u 100% 18u "Selected missing items will install before launch; Hermes finishes setup in the GUI."
     Pop $HermesFooterLabel
   ${EndIf}
 
@@ -600,11 +608,11 @@ Function HermesPrereqPageLeave
   ${AndIf} $HermesHasWinget == "1"
     ${NSD_GetState} $HermesNodeCheckbox $HermesInstallNode
   ${EndIf}
-  ${If} $HermesHasGit == "0"
+  ${If} $HermesHasGitBash == "0"
   ${AndIf} $HermesHasWinget == "1"
-    ${NSD_GetState} $HermesGitCheckbox $HermesInstallGit
+    ${NSD_GetState} $HermesGitBashCheckbox $HermesInstallGitBash
   ${EndIf}
-  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode install_git=$HermesInstallGit"
+  ${HermesLog} "page: user choices — install_python=$HermesInstallPython install_node=$HermesInstallNode install_git_bash=$HermesInstallGitBash"
 FunctionEnd
 
 ; ----------------------------------------------------------------------------
@@ -716,7 +724,7 @@ hermes_prereq_not_silent:
     ${EndIf}
   ${EndIf}
 
-  ${If} $HermesInstallGit == "1"
+  ${If} $HermesInstallGitBash == "1"
     DetailPrint "Installing Git for Windows via winget..."
     ${HermesLog} "Git: starting ExecShellWait — UAC may appear; no stdout capture possible"
     ${HermesLog} "  command: winget install -e --id Git.Git --silent --disable-interactivity --accept-package-agreements --accept-source-agreements"

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -177,7 +177,7 @@ function Preparing({ boot }: { boot: DesktopBootState }) {
     <div className="grid gap-3" role="status">
       <p className="text-sm text-muted-foreground">
         {installing
-          ? 'Hermes is finishing install. This usually takes under a minute on first run.'
+          ? 'Hermes is setting up the local agent runtime. First launch can take a few minutes.'
           : 'Starting Hermes…'}
       </p>
       <div className="h-2 overflow-hidden rounded-full bg-muted">

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -177,7 +177,7 @@ function Preparing({ boot }: { boot: DesktopBootState }) {
     <div className="grid gap-3" role="status">
       <p className="text-sm text-muted-foreground">
         {installing
-          ? 'Hermes is setting up the local agent runtime. First launch can take a few minutes.'
+          ? 'Hermes is finishing install. This usually takes under a minute on first run.'
           : 'Starting Hermes…'}
       </p>
       <div className="h-2 overflow-hidden rounded-full bg-muted">

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -112,7 +112,7 @@
     --radius-scalar: 0.2;
 
     /* Space under last message vs overlay composer — driven by the measured composer height (see composer/index.tsx). */
-    --thread-last-message-clearance: calc(var(--composer-measured-height) + 1.25rem);
+    --thread-last-message-clearance: calc(var(--composer-measured-height) + 3rem);
 
     --composer-shell-pad-block-end: 2.5rem;
     --message-text-indent: 1.5rem;
@@ -413,20 +413,20 @@ canvas {
   }
 }
 
-/* Last thread row with a message root — avoids composer overlap (Chromium/Electron). */
-[data-slot='aui_thread-content']
-  > :nth-last-child(
-    1
-      of
-      :is(
+/* Keep the floating composer from covering the final thread row. */
+[data-slot='aui_thread-content']:has(
+    > :is(
         [data-slot='aui_assistant-message-root'],
         [data-slot='aui_user-message-root'],
         [data-slot='aui_system-message-root'],
         [data-slot='aui_edit-composer-root'],
         [data-slot='aui_response-loading']
       )
-  ) {
-  margin-bottom: var(--thread-last-message-clearance);
+  )::after {
+  content: '';
+  display: block;
+  flex: 0 0 var(--thread-last-message-clearance);
+  width: 100%;
 }
 
 [data-slot='aui_assistant-message-content'] {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -112,7 +112,7 @@
     --radius-scalar: 0.2;
 
     /* Space under last message vs overlay composer — driven by the measured composer height (see composer/index.tsx). */
-    --thread-last-message-clearance: calc(var(--composer-measured-height) + 3rem);
+    --thread-last-message-clearance: calc(var(--composer-measured-height) + 1.25rem);
 
     --composer-shell-pad-block-end: 2.5rem;
     --message-text-indent: 1.5rem;
@@ -413,20 +413,20 @@ canvas {
   }
 }
 
-/* Keep the floating composer from covering the final thread row. */
-[data-slot='aui_thread-content']:has(
-    > :is(
+/* Last thread row with a message root — avoids composer overlap (Chromium/Electron). */
+[data-slot='aui_thread-content']
+  > :nth-last-child(
+    1
+      of
+      :is(
         [data-slot='aui_assistant-message-root'],
         [data-slot='aui_user-message-root'],
         [data-slot='aui_system-message-root'],
         [data-slot='aui_edit-composer-root'],
         [data-slot='aui_response-loading']
       )
-  )::after {
-  content: '';
-  display: block;
-  flex: 0 0 var(--thread-last-message-clearance);
-  width: 100%;
+  ) {
+  margin-bottom: var(--thread-last-message-clearance);
 }
 
 [data-slot='aui_assistant-message-content'] {


### PR DESCRIPTION
## Summary
- Scope the Windows desktop prereq page to baseline installer dependencies: Python 3.11-3.13, Node.js LTS, and Git for Windows/Git Bash.
- Keep Hermes Agent setup in the GUI first-launch path: sync bundled payload, create the venv, install Python deps, validate imports, and show onboarding progress.
- Match the copy to the installer behavior: prereqs are offered via winget when available, with manual install guidance when winget is missing or an install fails.
- Drop the desktop startup Git Bash warning; terminal flows still surface that dependency only when a Windows terminal command needs it.
- Reserve more bottom space in the chat thread so the floating composer does not cover the final row.

## Test plan
- npm run type-check
- npx eslint electron/main.cjs src/components/desktop-onboarding-overlay.tsx
- npx eslint src/components/assistant-ui/thread.tsx electron/main.cjs src/components/desktop-onboarding-overlay.tsx