### PR TITLE
fix: close leaked CLI and TUI sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4514,6 +4514,26 @@ class HermesCLI:
             ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
     
+    def _finalize_session_row(self, end_reason: str = "cli_close") -> None:
+        """Mark the active CLI session ended in state.db, best-effort.
+
+        Single-query mode does not enter ``run()``, so it must call this
+        explicitly before returning/exiting.  Use ``agent.session_id`` rather
+        than ``self.session_id`` so auto-compression continuation sessions are
+        closed instead of the already-ended parent row.
+        """
+        agent = getattr(self, "agent", None)
+        db = getattr(self, "_session_db", None)
+        session_id = getattr(agent, "session_id", None) or getattr(self, "session_id", None)
+        if not db or not session_id:
+            return
+        try:
+            if getattr(agent, "session_id", None) and agent.session_id != self.session_id:
+                self.session_id = agent.session_id
+            db.end_session(session_id, end_reason)
+        except Exception:
+            pass
+
     def _show_security_advisories(self):
         """Show a startup banner if any unacked security advisories match.
 
@@ -14099,10 +14119,13 @@ def main(
                     # status lines).  The response is printed once below.
                     cli.agent.stream_delta_callback = None
                     cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
+                    try:
+                        result = cli.agent.run_conversation(
+                            user_message=effective_query,
+                            conversation_history=cli.conversation_history,
+                        )
+                    finally:
+                        cli._finalize_session_row("cli_close")
                     # Sync session_id if mid-run compression created a
                     # continuation session. The exit line below reports
                     # session_id to stderr for automation wrappers; without
@@ -14128,6 +14151,7 @@ def main(
                         print(response)
                     # Session ID goes to stderr so piped stdout is clean.
                     print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                    cli._finalize_session_row("cli_close")
                     
                     # Ensure proper exit code for automation wrappers
                     sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
@@ -14154,8 +14178,11 @@ def main(
             # Surface security advisories before the agent runs — short
             # banner, doesn't depend on the welcome banner being shown.
             cli._show_security_advisories()
-            cli.chat(query, images=single_query_images or None)
-            cli._print_exit_summary()
+            try:
+                cli.chat(query, images=single_query_images or None)
+            finally:
+                cli._finalize_session_row("cli_close")
+                cli._print_exit_summary()
         return
     
     # Run interactive mode

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -732,6 +732,65 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def repair_stale_open_sessions(
+        self,
+        *,
+        older_than_seconds: float = 12 * 60 * 60,
+        end_reason: str = "stale_closeout_repair",
+    ) -> int:
+        """Close old open session rows that have reached a terminal idle state.
+
+        Crashy/dashboard-disconnect paths from older versions could leave
+        ``sessions.ended_at`` NULL long after the last turn was done.  This
+        repair is conservative: it only touches rows whose latest activity is
+        older than ``older_than_seconds`` and whose latest message is terminal
+        enough to prove no model/tool turn is currently mid-flight (assistant
+        with ``finish_reason='stop'``, a completed tool result, or no messages
+        at all).  It returns the number of rows updated.
+        """
+        now = time.time()
+        cutoff = now - max(0.0, float(older_than_seconds))
+
+        def _do(conn):
+            conn.execute(
+                """
+                WITH latest AS (
+                    SELECT
+                        s.id,
+                        s.started_at,
+                        m.role AS latest_role,
+                        m.finish_reason AS latest_finish_reason,
+                        m.timestamp AS latest_timestamp,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY s.id
+                            ORDER BY m.timestamp DESC, m.id DESC
+                        ) AS rn
+                    FROM sessions s
+                    LEFT JOIN messages m ON m.session_id = s.id
+                    WHERE s.ended_at IS NULL
+                ), candidates AS (
+                    SELECT id
+                    FROM latest
+                    WHERE rn = 1
+                      AND COALESCE(latest_timestamp, started_at) < ?
+                      AND (
+                            latest_role IS NULL
+                         OR (latest_role = 'assistant' AND latest_finish_reason = 'stop')
+                         OR latest_role = 'tool'
+                      )
+                )
+                UPDATE sessions
+                   SET ended_at = ?, end_reason = ?
+                 WHERE ended_at IS NULL
+                   AND id IN (SELECT id FROM candidates)
+                """,
+                (cutoff, now, end_reason),
+            )
+            row = conn.execute("SELECT changes()").fetchone()
+            return int(row[0]) if row else 0
+
+        return self._execute_write(_do) or 0
+
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
         def _do(conn):

--- a/tests/cli/test_single_query_closeout.py
+++ b/tests/cli/test_single_query_closeout.py
@@ -1,0 +1,32 @@
+import types
+
+
+def test_finalize_session_row_marks_agent_session_ended_and_syncs_id():
+    from cli import HermesCLI
+
+    calls = []
+
+    class _DB:
+        def end_session(self, session_id, end_reason):
+            calls.append((session_id, end_reason))
+
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "parent-session"
+    cli.agent = types.SimpleNamespace(session_id="continuation-session")
+    cli._session_db = _DB()
+
+    cli._finalize_session_row("cli_close")
+
+    assert calls == [("continuation-session", "cli_close")]
+    assert cli.session_id == "continuation-session"
+
+
+def test_finalize_session_row_noops_without_session_db():
+    from cli import HermesCLI
+
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "session-key"
+    cli.agent = types.SimpleNamespace(session_id="session-key")
+    cli._session_db = None
+
+    cli._finalize_session_row("cli_close")

--- a/tests/hermes_state/test_repair_stale_open_sessions.py
+++ b/tests/hermes_state/test_repair_stale_open_sessions.py
@@ -1,0 +1,89 @@
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _age_session(db: SessionDB, session_id: str, timestamp: float) -> None:
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (timestamp, session_id),
+    )
+    db._conn.execute(
+        "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+        (timestamp, session_id),
+    )
+    db._conn.commit()
+
+
+def _end_reason(db: SessionDB, session_id: str):
+    row = db._conn.execute(
+        "SELECT end_reason FROM sessions WHERE id = ?",
+        (session_id,),
+    ).fetchone()
+    return row[0]
+
+
+def test_repair_stale_open_sessions_closes_terminal_rows_only(db):
+    old = time.time() - 10_000
+
+    db.create_session("assistant-stop", source="tui")
+    db.append_message(
+        "assistant-stop",
+        role="assistant",
+        content="done",
+        finish_reason="stop",
+    )
+
+    db.create_session("tool-result", source="tui")
+    db.append_message("tool-result", role="tool", content="ok")
+
+    db.create_session("empty-old", source="tui")
+
+    db.create_session("user-waiting", source="tui")
+    db.append_message("user-waiting", role="user", content="still waiting")
+
+    db.create_session("assistant-tool-call", source="tui")
+    db.append_message(
+        "assistant-tool-call",
+        role="assistant",
+        content="calling tool",
+        finish_reason="tool_calls",
+    )
+
+    for session_id in (
+        "assistant-stop",
+        "tool-result",
+        "empty-old",
+        "user-waiting",
+        "assistant-tool-call",
+    ):
+        _age_session(db, session_id, old)
+
+    repaired = db.repair_stale_open_sessions(
+        older_than_seconds=60,
+        end_reason="test_repair",
+    )
+
+    assert repaired == 3
+    assert _end_reason(db, "assistant-stop") == "test_repair"
+    assert _end_reason(db, "tool-result") == "test_repair"
+    assert _end_reason(db, "empty-old") == "test_repair"
+    assert _end_reason(db, "user-waiting") is None
+    assert _end_reason(db, "assistant-tool-call") is None
+
+
+def test_repair_stale_open_sessions_leaves_recent_terminal_rows_open(db):
+    db.create_session("recent", source="tui")
+    db.append_message("recent", role="assistant", content="done", finish_reason="stop")
+
+    repaired = db.repair_stale_open_sessions(older_than_seconds=60)
+
+    assert repaired == 0
+    assert _end_reason(db, "recent") is None

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -839,7 +839,7 @@ def test_ws_transport_disconnect_respects_idle_reap_grace(monkeypatch):
         server._sessions.pop("sid", None)
 
 
-def test_ws_transport_disconnect_detaches_running_session(monkeypatch):
+def test_ws_transport_disconnect_detaches_running_session_for_deferred_close(monkeypatch):
     transport = object()
     worker = types.SimpleNamespace(
         close=lambda: (_ for _ in ()).throw(AssertionError("closed running worker"))
@@ -856,6 +856,42 @@ def test_ws_transport_disconnect_detaches_running_session(monkeypatch):
         assert closed == 0
         assert "sid" in server._sessions
         assert server._sessions["sid"]["transport"] is server._stdio_transport
+        assert server._sessions["sid"]["_close_when_idle"] == "tui_disconnect"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_orphaned_running_session_closes_after_turn_clears_running(monkeypatch):
+    calls = {"ended": [], "worker_closed": 0, "agent_closed": 0}
+
+    class _DB:
+        def end_session(self, session_id, end_reason):
+            calls["ended"].append((session_id, end_reason))
+
+    class _Worker:
+        def close(self):
+            calls["worker_closed"] += 1
+
+    agent = types.SimpleNamespace(session_id="session-key")
+    agent.close = lambda: calls.__setitem__("agent_closed", calls["agent_closed"] + 1)
+    agent.commit_memory_session = lambda _history: None
+    session = _session(
+        agent=agent,
+        slash_worker=_Worker(),
+        running=False,
+        _close_when_idle="tui_disconnect",
+    )
+    server._sessions["sid"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *args: None)
+
+    try:
+        assert server._close_session_if_marked_idle("sid", session) is True
+
+        assert "sid" not in server._sessions
+        assert calls["ended"] == [("session-key", "tui_disconnect")]
+        assert calls["worker_closed"] == 1
+        assert calls["agent_closed"] == 1
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -756,7 +756,7 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
 
 
 def test_ws_transport_disconnect_closes_idle_session_resources(monkeypatch):
-    transport = object()
+    transport = types.SimpleNamespace(is_closed=True)
     calls = {"ended": [], "worker_closed": 0, "agent_closed": 0}
 
     class _DB:
@@ -782,6 +782,53 @@ def test_ws_transport_disconnect_closes_idle_session_resources(monkeypatch):
 
     try:
         closed = server._close_sessions_for_transport(transport, "tui_disconnect")
+
+        assert closed == 1
+        assert "sid" not in server._sessions
+        assert calls["ended"] == [("session-key", "tui_disconnect")]
+        assert calls["worker_closed"] == 1
+        assert calls["agent_closed"] == 1
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_ws_transport_disconnect_respects_idle_reap_grace(monkeypatch):
+    now = time.time()
+    transport = types.SimpleNamespace(is_closed=True)
+    calls = {"ended": [], "worker_closed": 0, "agent_closed": 0}
+
+    class _DB:
+        def end_session(self, session_id, end_reason):
+            calls["ended"].append((session_id, end_reason))
+
+    class _Worker:
+        def close(self):
+            calls["worker_closed"] += 1
+
+    agent = types.SimpleNamespace(session_id="session-key")
+    agent.close = lambda: calls.__setitem__("agent_closed", calls["agent_closed"] + 1)
+    agent.commit_memory_session = lambda _history: None
+
+    server._sessions["sid"] = _session(
+        agent=agent,
+        transport=transport,
+        slash_worker=_Worker(),
+        last_seen_at=now,
+        created_at=now,
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *args: None)
+
+    try:
+        assert server._close_sessions_for_transport(transport, "tui_disconnect") == 0
+        assert "sid" in server._sessions
+        assert calls == {"ended": [], "worker_closed": 0, "agent_closed": 0}
+
+        closed = server._reap_confirmed_idle_sessions(
+            grace_seconds=30.0,
+            now=now + 31.0,
+            end_reason="tui_disconnect",
+        )
 
         assert closed == 1
         assert "sid" not in server._sessions

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -755,6 +755,64 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_ws_transport_disconnect_closes_idle_session_resources(monkeypatch):
+    transport = object()
+    calls = {"ended": [], "worker_closed": 0, "agent_closed": 0}
+
+    class _DB:
+        def end_session(self, session_id, end_reason):
+            calls["ended"].append((session_id, end_reason))
+
+    class _Worker:
+        def close(self):
+            calls["worker_closed"] += 1
+
+    agent = types.SimpleNamespace(session_id="session-key")
+    agent.close = lambda: calls.__setitem__("agent_closed", calls["agent_closed"] + 1)
+    agent.commit_memory_session = lambda _history: None
+
+    server._sessions["sid"] = _session(
+        agent=agent,
+        transport=transport,
+        slash_worker=_Worker(),
+        history=[{"role": "assistant", "content": "done", "finish_reason": "stop"}],
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *args: None)
+
+    try:
+        closed = server._close_sessions_for_transport(transport, "tui_disconnect")
+
+        assert closed == 1
+        assert "sid" not in server._sessions
+        assert calls["ended"] == [("session-key", "tui_disconnect")]
+        assert calls["worker_closed"] == 1
+        assert calls["agent_closed"] == 1
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_ws_transport_disconnect_detaches_running_session(monkeypatch):
+    transport = object()
+    worker = types.SimpleNamespace(
+        close=lambda: (_ for _ in ()).throw(AssertionError("closed running worker"))
+    )
+    server._sessions["sid"] = _session(
+        transport=transport,
+        slash_worker=worker,
+        running=True,
+    )
+
+    try:
+        closed = server._close_sessions_for_transport(transport, "tui_disconnect")
+
+        assert closed == 0
+        assert "sid" in server._sessions
+        assert server._sessions["sid"]["transport"] is server._stdio_transport
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -121,6 +121,7 @@ _pending: dict[str, tuple[str, threading.Event]] = {}
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
+_stale_session_repair_ran = False
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
@@ -131,6 +132,11 @@ try:
 except (ValueError, TypeError):
     _slash_timeout = 45.0
 _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
+try:
+    _idle_reap_grace = float(os.environ.get("HERMES_TUI_IDLE_REAP_GRACE_S") or "30")
+except (ValueError, TypeError):
+    _idle_reap_grace = 30.0
+_IDLE_REAP_GRACE_S = max(0.0, _idle_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
@@ -361,21 +367,85 @@ def _close_session_resources(session: dict | None, end_reason: str) -> None:
         pass
 
 
-def _close_sessions_for_transport(transport: object, end_reason: str = "tui_disconnect") -> int:
+def _close_sessions_for_transport(
+    transport: object,
+    end_reason: str = "tui_disconnect",
+    *,
+    grace_seconds: float | None = None,
+) -> int:
     """Close idle sessions owned by a disconnected transport.
 
     Dashboard/WebSocket TUI clients can disappear without issuing
     ``session.close``.  Leaving their sessions attached to a dead transport
-    keeps slash workers alive and leaves state.db rows open.  Close idle
-    sessions on disconnect; keep actively-running sessions alive and detach
-    them to stdio so in-flight turns can finish without writing to a dead WS.
+    keeps slash workers alive and leaves state.db rows open.  Running sessions
+    are detached to stdio so in-flight turns can finish without writing to a
+    dead WS. Idle sessions are reaped only after the confirmed-idle grace
+    window; a quick reconnect can reattach them before closeout.
     """
+    for _sid, session in list(_sessions.items()):
+        if session.get("transport") is transport and session.get("running"):
+            session["transport"] = _stdio_transport
+    return _reap_confirmed_idle_sessions(
+        grace_seconds=grace_seconds,
+        end_reason=end_reason,
+    )
+
+
+def _schedule_idle_reap(
+    *,
+    grace_seconds: float | None = None,
+    end_reason: str = "tui_idle_reap",
+) -> None:
+    """Schedule one best-effort idle reap after the grace window elapses."""
+    delay = _IDLE_REAP_GRACE_S if grace_seconds is None else max(0.0, grace_seconds)
+
+    def _run() -> None:
+        try:
+            _reap_confirmed_idle_sessions(
+                grace_seconds=grace_seconds,
+                end_reason=end_reason,
+            )
+        except Exception:
+            logger.debug("idle session reap failed", exc_info=True)
+
+    timer = threading.Timer(delay, _run)
+    timer.daemon = True
+    timer.start()
+
+
+def _session_transport_is_closed(session: dict) -> bool:
+    transport = session.get("transport")
+    return bool(
+        transport is not None
+        and transport is not _stdio_transport
+        and getattr(transport, "is_closed", False)
+    )
+
+
+def _reap_confirmed_idle_sessions(
+    *,
+    grace_seconds: float | None = None,
+    now: float | None = None,
+    end_reason: str = "tui_idle_reap",
+) -> int:
+    """Close sessions whose owning dashboard transport is confirmed dead.
+
+    This is intentionally narrower than a time-only idle timeout: a session is
+    eligible only when (1) it is not running an agent turn, (2) it is attached
+    to a non-stdio transport that has observed a disconnect/write failure, and
+    (3) it has remained idle beyond the grace window. That lets us reap slash
+    workers that were born during a dashboard disconnect race without killing
+    active local Ink sessions or long-running turns.
+    """
+    cutoff = (now if now is not None else time.time()) - (
+        _IDLE_REAP_GRACE_S if grace_seconds is None else max(0.0, grace_seconds)
+    )
     closed = 0
     for sid, session in list(_sessions.items()):
-        if session.get("transport") is not transport:
+        if session.get("running") or not _session_transport_is_closed(session):
             continue
-        if session.get("running"):
-            session["transport"] = _stdio_transport
+        last_seen = float(session.get("last_seen_at") or session.get("created_at") or 0.0)
+        if last_seen > cutoff:
             continue
         popped = _sessions.pop(sid, None)
         if popped is None:
@@ -398,7 +468,7 @@ atexit.register(_shutdown_sessions)
 
 
 def _get_db():
-    global _db, _db_error
+    global _db, _db_error, _stale_session_repair_ran
     if _db is None:
         from hermes_state import SessionDB
 
@@ -412,6 +482,14 @@ def _get_db():
                 exc,
             )
             return None
+    if not _stale_session_repair_ran:
+        _stale_session_repair_ran = True
+        try:
+            repaired = _db.repair_stale_open_sessions()
+            if repaired:
+                logger.info("repaired %s stale open TUI session rows", repaired)
+        except Exception:
+            logger.debug("stale open session repair failed", exc_info=True)
     return _db
 
 
@@ -552,6 +630,15 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
+        params = _params if isinstance(_params, dict) else {}
+        sid = params.get("session_id") or ""
+        if sid and sid in _sessions:
+            _sessions[sid]["last_seen_at"] = time.time()
+            if transport is not None:
+                _sessions[sid]["transport"] = transport
+
+        _reap_confirmed_idle_sessions()
+
         if method not in _LONG_HANDLERS:
             return handle_request(req)
 
@@ -671,6 +758,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     except Exception:
                         pass
             ready.set()
+            _reap_confirmed_idle_sessions()
 
     threading.Thread(target=_build, daemon=True).start()
 
@@ -1986,6 +2074,8 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
         "tool_started_at": {},
+        "created_at": time.time(),
+        "last_seen_at": time.time(),
         # Pin async event emissions to whichever transport created the
         # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
         "transport": current_transport() or _stdio_transport,
@@ -2178,6 +2268,8 @@ def _(rid, params: dict) -> dict:
         "slash_worker": None,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
+        "created_at": time.time(),
+        "last_seen_at": time.time(),
         "transport": current_transport() or _stdio_transport,
     }
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -253,6 +253,13 @@ class _SlashWorker:
             )
 
     def close(self):
+        for pipe_name in ("stdin",):
+            pipe = getattr(self.proc, pipe_name, None)
+            try:
+                if pipe:
+                    pipe.close()
+            except Exception:
+                pass
         try:
             if self.proc.poll() is None:
                 self.proc.terminate()
@@ -260,6 +267,14 @@ class _SlashWorker:
         except Exception:
             try:
                 self.proc.kill()
+                self.proc.wait(timeout=1)
+            except Exception:
+                pass
+        for pipe_name in ("stdout", "stderr"):
+            pipe = getattr(self.proc, pipe_name, None)
+            try:
+                if pipe:
+                    pipe.close()
             except Exception:
                 pass
 
@@ -321,15 +336,59 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             pass
 
 
+def _close_session_resources(session: dict | None, end_reason: str) -> None:
+    """Best-effort closeout for one in-memory TUI session."""
+    if not session:
+        return
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        unregister_gateway_notify(session.get("session_key"))
+    except Exception:
+        pass
+    try:
+        agent = session.get("agent")
+        if hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+
+
+def _close_sessions_for_transport(transport: object, end_reason: str = "tui_disconnect") -> int:
+    """Close idle sessions owned by a disconnected transport.
+
+    Dashboard/WebSocket TUI clients can disappear without issuing
+    ``session.close``.  Leaving their sessions attached to a dead transport
+    keeps slash workers alive and leaves state.db rows open.  Close idle
+    sessions on disconnect; keep actively-running sessions alive and detach
+    them to stdio so in-flight turns can finish without writing to a dead WS.
+    """
+    closed = 0
+    for sid, session in list(_sessions.items()):
+        if session.get("transport") is not transport:
+            continue
+        if session.get("running"):
+            session["transport"] = _stdio_transport
+            continue
+        popped = _sessions.pop(sid, None)
+        if popped is None:
+            continue
+        _close_session_resources(popped, end_reason=end_reason)
+        closed += 1
+    return closed
+
+
 def _shutdown_sessions() -> None:
-    for session in list(_sessions.values()):
-        _finalize_session(session, end_reason="tui_shutdown")
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+    for sid, session in list(_sessions.items()):
+        popped = _sessions.pop(sid, None)
+        _close_session_resources(popped or session, end_reason="tui_shutdown")
 
 
 atexit.register(_shutdown_sessions)
@@ -2640,25 +2699,7 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
+    _close_session_resources(session, end_reason="tui_close")
     return _ok(rid, {"closed": True})
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -379,12 +379,14 @@ def _close_sessions_for_transport(
     ``session.close``.  Leaving their sessions attached to a dead transport
     keeps slash workers alive and leaves state.db rows open.  Running sessions
     are detached to stdio so in-flight turns can finish without writing to a
-    dead WS. Idle sessions are reaped only after the confirmed-idle grace
-    window; a quick reconnect can reattach them before closeout.
+    dead WS, then marked for closeout as soon as that turn clears ``running``.
+    Idle sessions are reaped only after the confirmed-idle grace window; a
+    quick reconnect can reattach them before closeout.
     """
     for _sid, session in list(_sessions.items()):
         if session.get("transport") is transport and session.get("running"):
             session["transport"] = _stdio_transport
+            session["_close_when_idle"] = end_reason
     return _reap_confirmed_idle_sessions(
         grace_seconds=grace_seconds,
         end_reason=end_reason,
@@ -420,6 +422,24 @@ def _session_transport_is_closed(session: dict) -> bool:
         and transport is not _stdio_transport
         and getattr(transport, "is_closed", False)
     )
+
+
+def _close_session_if_marked_idle(sid: str, session: dict) -> bool:
+    """Close a running session that was orphaned by a transport disconnect.
+
+    Running dashboard sessions are detached from their dead WebSocket so their
+    in-flight turn can finish.  Once the turn clears ``running``, this helper
+    performs the deferred closeout so the DB row and slash worker do not leak.
+    """
+    close_when_idle = session.pop("_close_when_idle", None)
+    if not close_when_idle:
+        return False
+    popped = _sessions.pop(sid, None)
+    _close_session_resources(
+        popped or session,
+        end_reason=str(close_when_idle),
+    )
+    return True
 
 
 def _reap_confirmed_idle_sessions(
@@ -3596,6 +3616,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             _clear_session_context(session_tokens)
             with session["history_lock"]:
                 session["running"] = False
+            if _close_session_if_marked_idle(sid, session):
+                return
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -112,6 +112,11 @@ class WSTransport:
     def close(self) -> None:
         self._closed = True
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether this transport has observed a disconnect/write failure."""
+        return self._closed
+
 
 async def handle_ws(ws: Any) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
@@ -166,15 +171,7 @@ async def handle_ws(ws: Any) -> None:
     finally:
         transport.close()
         server._close_sessions_for_transport(transport, end_reason="tui_disconnect")
-
-        # Detach the transport from any running sessions it still owns so
-        # later emits fall back to stdio instead of crashing into a closed
-        # socket. Idle sessions were finalized above to avoid leaking slash
-        # workers and open state.db rows when WS clients disconnect without a
-        # session.close RPC.
-        for _, sess in list(server._sessions.items()):
-            if sess.get("transport") is transport:
-                sess["transport"] = server._stdio_transport
+        server._schedule_idle_reap(end_reason="tui_disconnect")
 
         try:
             await ws.close()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -165,9 +165,13 @@ async def handle_ws(ws: Any) -> None:
                 break
     finally:
         transport.close()
+        server._close_sessions_for_transport(transport, end_reason="tui_disconnect")
 
-        # Detach the transport from any sessions it owned so later emits
-        # fall back to stdio instead of crashing into a closed socket.
+        # Detach the transport from any running sessions it still owns so
+        # later emits fall back to stdio instead of crashing into a closed
+        # socket. Idle sessions were finalized above to avoid leaking slash
+        # workers and open state.db rows when WS clients disconnect without a
+        # session.close RPC.
         for _, sess in list(server._sessions.items()):
             if sess.get("transport") is transport:
                 sess["transport"] = server._stdio_transport


### PR DESCRIPTION
## Summary
- finalize CLI single-query sessions on exit/error using the agent's current session id
- close idle WebSocket-owned TUI sessions on disconnect to reap slash workers and state rows
- centralize TUI session closeout and harden slash worker pipe/process cleanup

## Tests
- python -m pytest tests/test_tui_gateway_server.py::test_session_close_commits_memory_and_fires_finalize_hook tests/test_tui_gateway_server.py::test_ws_transport_disconnect_closes_idle_session_resources tests/test_tui_gateway_server.py::test_ws_transport_disconnect_detaches_running_session tests/cli/test_single_query_closeout.py -q -o 'addopts='
- python -m pytest tests/test_tui_gateway_server.py tests/test_lazy_session_regressions.py tests/cli/test_single_query_closeout.py -q -o 'addopts='
- python -m pytest tests/cli/test_single_query_closeout.py tests/test_tui_gateway_server.py::test_ws_transport_disconnect_closes_idle_session_resources tests/test_tui_gateway_server.py::test_ws_transport_disconnect_detaches_running_session tests/test_tui_gateway_server.py::test_session_close_commits_memory_and_fires_finalize_hook tests/run_agent/test_exit_cleanup_interrupt.py tests/cron/test_scheduler.py -k 'closes_session or close or fd_leak' -q -o 'addopts='