### PR TITLE
feat(acp): add session edit auto-approval modes

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -1,0 +1,228 @@
+"""Pre-execution ACP edit approval helpers.
+
+This module is intentionally isolated from the generic tool registry.  ACP binds
+an edit approval requester in a ContextVar for the duration of one ACP agent run;
+CLI, gateway, and other sessions leave it unset and therefore bypass this guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from concurrent.futures import TimeoutError as FutureTimeout
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from itertools import count
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EditProposal:
+    """A proposed single-file edit that can be shown to an ACP client."""
+
+    tool_name: str
+    path: str
+    old_text: str | None
+    new_text: str
+    arguments: dict[str, Any]
+
+
+EditApprovalRequester = Callable[[EditProposal], bool]
+
+_EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
+    "ACP_EDIT_APPROVAL_REQUESTER",
+    default=None,
+)
+_PERMISSION_REQUEST_IDS = count(1)
+
+
+def set_edit_approval_requester(requester: EditApprovalRequester | None) -> Token:
+    """Bind an ACP edit approval requester for the current context."""
+
+    return _EDIT_APPROVAL_REQUESTER.set(requester)
+
+
+def reset_edit_approval_requester(token: Token) -> None:
+    """Restore a previous edit approval requester binding."""
+
+    _EDIT_APPROVAL_REQUESTER.reset(token)
+
+
+def clear_edit_approval_requester() -> None:
+    """Clear the current requester; primarily used by tests."""
+
+    _EDIT_APPROVAL_REQUESTER.set(None)
+
+
+def get_edit_approval_requester() -> EditApprovalRequester | None:
+    return _EDIT_APPROVAL_REQUESTER.get()
+
+
+def _read_text_if_exists(path: str) -> str | None:
+    p = Path(path).expanduser()
+    if not p.exists():
+        return None
+    if not p.is_file():
+        raise OSError(f"Cannot edit non-file path: {path}")
+    return p.read_text(encoding="utf-8", errors="replace")
+
+
+def _proposal_for_write_file(arguments: dict[str, Any]) -> EditProposal:
+    path = str(arguments.get("path") or "")
+    if not path:
+        raise ValueError("path required")
+    content = arguments.get("content")
+    if content is None:
+        raise ValueError("content required")
+    return EditProposal(
+        tool_name="write_file",
+        path=path,
+        old_text=_read_text_if_exists(path),
+        new_text=str(content),
+        arguments=dict(arguments),
+    )
+
+
+def _proposal_for_patch_replace(arguments: dict[str, Any]) -> EditProposal:
+    path = str(arguments.get("path") or "")
+    if not path:
+        raise ValueError("path required")
+    old_string = arguments.get("old_string")
+    new_string = arguments.get("new_string")
+    if old_string is None or new_string is None:
+        raise ValueError("old_string and new_string required")
+
+    old_text = _read_text_if_exists(path)
+    if old_text is None:
+        raise ValueError(f"Failed to read file: {path}")
+
+    from tools.fuzzy_match import fuzzy_find_and_replace
+
+    new_text, match_count, _strategy, error = fuzzy_find_and_replace(
+        old_text,
+        str(old_string),
+        str(new_string),
+        bool(arguments.get("replace_all", False)),
+    )
+    if error or match_count == 0:
+        raise ValueError(error or f"Could not find match for old_string in {path}")
+
+    return EditProposal(
+        tool_name="patch",
+        path=path,
+        old_text=old_text,
+        new_text=new_text,
+        arguments=dict(arguments),
+    )
+
+
+def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditProposal | None:
+    """Return an edit proposal for supported file mutation calls."""
+
+    if tool_name == "write_file":
+        return _proposal_for_write_file(arguments)
+    if tool_name == "patch" and arguments.get("mode", "replace") == "replace":
+        return _proposal_for_patch_replace(arguments)
+    return None
+
+
+def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Run ACP edit approval if bound.
+
+    Returns a JSON tool-error string when the edit must be blocked, otherwise
+    ``None`` so dispatch can continue.  Requester exceptions deny by default.
+    """
+
+    requester = get_edit_approval_requester()
+    if requester is None:
+        return None
+
+    try:
+        proposal = build_edit_proposal(tool_name, arguments)
+    except Exception as exc:
+        logger.warning("Could not build ACP edit approval proposal for %s: %s", tool_name, exc)
+        return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)
+
+    if proposal is None:
+        return None
+
+    try:
+        approved = bool(requester(proposal))
+    except Exception as exc:
+        logger.warning("ACP edit approval requester failed: %s", exc)
+        approved = False
+
+    if approved:
+        return None
+    return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
+
+
+def build_acp_edit_tool_call(proposal: EditProposal):
+    """Build the ToolCallUpdate payload for ACP request_permission."""
+
+    import acp
+
+    tool_call_id = f"edit-approval-{next(_PERMISSION_REQUEST_IDS)}"
+    return acp.update_tool_call(
+        tool_call_id,
+        title=f"Approve edit: {proposal.path}",
+        kind="edit",
+        status="pending",
+        content=[
+            acp.tool_diff_content(
+                path=proposal.path,
+                old_text=proposal.old_text,
+                new_text=proposal.new_text,
+            )
+        ],
+        raw_input={"tool": proposal.tool_name, "arguments": proposal.arguments},
+    )
+
+
+def make_acp_edit_approval_requester(
+    request_permission_fn: Callable,
+    loop: asyncio.AbstractEventLoop,
+    session_id: str,
+    timeout: float = 60.0,
+) -> EditApprovalRequester:
+    """Return a sync requester that bridges edit proposals to ACP permissions."""
+
+    def _requester(proposal: EditProposal) -> bool:
+        from acp.schema import PermissionOption
+        from agent.async_utils import safe_schedule_threadsafe
+
+        options = [
+            PermissionOption(option_id="allow_once", kind="allow_once", name="Allow edit"),
+            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
+        ]
+        tool_call = build_acp_edit_tool_call(proposal)
+        coro = request_permission_fn(
+            session_id=session_id,
+            tool_call=tool_call,
+            options=options,
+        )
+        future = safe_schedule_threadsafe(
+            coro,
+            loop,
+            logger=logger,
+            log_message="Edit approval request: failed to schedule on loop",
+        )
+        if future is None:
+            return False
+        try:
+            response = future.result(timeout=timeout)
+        except (FutureTimeout, Exception) as exc:
+            future.cancel()
+            logger.warning("Edit approval request timed out or failed: %s", exc)
+            return False
+        outcome = getattr(response, "outcome", None)
+        return (
+            getattr(outcome, "outcome", None) == "selected"
+            and getattr(outcome, "option_id", None) == "allow_once"
+        )
+
+    return _requester

--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -40,6 +40,12 @@ _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
 _PERMISSION_REQUEST_IDS = count(1)
 
 
+SENSITIVE_AUTO_APPROVE_NAMES = {".env", ".env.local", ".env.production", "id_rsa", "id_ed25519"}
+AUTO_APPROVE_ASK = "ask"
+AUTO_APPROVE_WORKSPACE = "workspace_session"
+AUTO_APPROVE_SESSION = "session"
+
+
 def set_edit_approval_requester(requester: EditApprovalRequester | None) -> Token:
     """Bind an ACP edit approval requester for the current context."""
 
@@ -130,6 +136,40 @@ def build_edit_proposal(tool_name: str, arguments: dict[str, Any]) -> EditPropos
     return None
 
 
+def _is_sensitive_auto_approve_path(path: str) -> bool:
+    parts = Path(path).expanduser().parts
+    lowered = {part.lower() for part in parts}
+    if ".git" in lowered or ".ssh" in lowered:
+        return True
+    return Path(path).name.lower() in SENSITIVE_AUTO_APPROVE_NAMES
+
+
+def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | None = None) -> bool:
+    """Return whether an ACP edit proposal may bypass the prompt for this session.
+
+    This is intentionally session-scoped and conservative: sensitive paths still
+    ask even under autonomous policies.
+    """
+
+    policy = str(policy or AUTO_APPROVE_ASK).strip()
+    if policy == AUTO_APPROVE_ASK or _is_sensitive_auto_approve_path(proposal.path):
+        return False
+    path = Path(proposal.path).expanduser().resolve(strict=False)
+    if policy == AUTO_APPROVE_SESSION:
+        return True
+    if policy == AUTO_APPROVE_WORKSPACE:
+        if str(path).startswith("/tmp/"):
+            return True
+        if cwd:
+            root = Path(cwd).expanduser().resolve(strict=False)
+            try:
+                path.relative_to(root)
+                return True
+            except ValueError:
+                return False
+    return False
+
+
 def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> str | None:
     """Run ACP edit approval if bound.
 
@@ -188,12 +228,22 @@ def make_acp_edit_approval_requester(
     loop: asyncio.AbstractEventLoop,
     session_id: str,
     timeout: float = 60.0,
+    auto_approve_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> EditApprovalRequester:
     """Return a sync requester that bridges edit proposals to ACP permissions."""
 
     def _requester(proposal: EditProposal) -> bool:
         from acp.schema import PermissionOption
         from agent.async_utils import safe_schedule_threadsafe
+
+        if auto_approve_getter is not None:
+            try:
+                policy, cwd = auto_approve_getter()
+                if should_auto_approve_edit(proposal, policy, cwd):
+                    logger.info("Auto-approved ACP edit under policy %s: %s", policy, proposal.path)
+                    return True
+            except Exception:
+                logger.debug("ACP edit auto-approval policy check failed", exc_info=True)
 
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow edit"),

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -117,6 +117,7 @@ def make_tool_progress_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    edit_approval_policy_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
 
@@ -162,7 +163,20 @@ def make_tool_progress_cb(
                 logger.debug("Failed to capture ACP edit snapshot for %s", name, exc_info=True)
         tool_call_meta[tc_id] = {"args": args, "snapshot": snapshot}
 
-        update = build_tool_start(tc_id, name, args)
+        edit_diff = None
+        if name in {"write_file", "patch"} and edit_approval_policy_getter is not None:
+            try:
+                from acp_adapter.edit_approval import build_edit_proposal, should_auto_approve_edit
+
+                proposal = build_edit_proposal(name, args)
+                if proposal is not None:
+                    policy, cwd = edit_approval_policy_getter()
+                    if should_auto_approve_edit(proposal, policy, cwd):
+                        edit_diff = proposal
+            except Exception:
+                logger.debug("Failed to prepare auto-approved ACP edit diff for %s", name, exc_info=True)
+
+        update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)
         _send_update(conn, session_id, loop, update)
 
     return _tool_progress

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1169,6 +1169,7 @@ class HermesACPAgent(acp.Agent):
         tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
         previous_approval_cb = None
+        edit_approval_requester = None
 
         streamed_message = False
 
@@ -1185,6 +1186,16 @@ class HermesACPAgent(acp.Agent):
                 message_cb(text)
 
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
+            try:
+                from acp_adapter.edit_approval import make_acp_edit_approval_requester
+
+                edit_approval_requester = make_acp_edit_approval_requester(
+                    conn.request_permission,
+                    loop,
+                    session_id,
+                )
+            except Exception:
+                logger.debug("Could not create ACP edit approval requester", exc_info=True)
         else:
             tool_progress_cb = None
             reasoning_cb = None
@@ -1214,9 +1225,10 @@ class HermesACPAgent(acp.Agent):
         # which requires a notify_cb registered in _gateway_notify_cbs.
         previous_approval_cb = None
         previous_interactive = None
+        edit_approval_token = None
 
         def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive
+            nonlocal previous_approval_cb, previous_interactive, edit_approval_token
             # Bind HERMES_SESSION_KEY for this session so per-session caches
             # (e.g. the interactive sudo password cache in tools.terminal_tool)
             # scope to the ACP session rather than leaking across sessions
@@ -1240,6 +1252,13 @@ class HermesACPAgent(acp.Agent):
                     _terminal_tool.set_approval_callback(approval_cb)
                 except Exception:
                     logger.debug("Could not set ACP approval callback", exc_info=True)
+            if edit_approval_requester:
+                try:
+                    from acp_adapter.edit_approval import set_edit_approval_requester
+
+                    edit_approval_token = set_edit_approval_requester(edit_approval_requester)
+                except Exception:
+                    logger.debug("Could not set ACP edit approval requester", exc_info=True)
             # Signal to tools.approval that we have an interactive callback
             # and the non-interactive auto-approve path must not fire.
             previous_interactive = os.environ.get("HERMES_INTERACTIVE")
@@ -1267,6 +1286,13 @@ class HermesACPAgent(acp.Agent):
                         _terminal_tool.set_approval_callback(previous_approval_cb)
                     except Exception:
                         logger.debug("Could not restore approval callback", exc_info=True)
+                if edit_approval_token is not None:
+                    try:
+                        from acp_adapter.edit_approval import reset_edit_approval_requester
+
+                        reset_edit_approval_requester(edit_approval_token)
+                    except Exception:
+                        logger.debug("Could not restore ACP edit approval requester", exc_info=True)
                 if session_tokens is not None and clear_session_vars is not None:
                     try:
                         clear_session_vars(session_tokens)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -44,6 +44,8 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
     SessionForkCapabilities,
     SessionListCapabilities,
     SessionModelState,
@@ -494,6 +496,9 @@ class HermesACPAgent(acp.Agent):
         },
     )
 
+    _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
+    _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
+
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
@@ -505,6 +510,49 @@ class HermesACPAgent(acp.Agent):
         """Store the client connection for sending session updates."""
         self._conn = conn
         logger.info("ACP client connected")
+
+
+    def _session_config_options(self, state: SessionState) -> list[Any]:
+        values = getattr(state, "config_options", None)
+        if not isinstance(values, dict):
+            values = {}
+        current = str(values.get(self._EDIT_APPROVAL_POLICY_CONFIG_ID) or self._EDIT_APPROVAL_POLICY_DEFAULT)
+        allowed = {"ask", "workspace_session", "session"}
+        if current not in allowed:
+            current = self._EDIT_APPROVAL_POLICY_DEFAULT
+        return [
+            SessionConfigOptionSelect(
+                id=self._EDIT_APPROVAL_POLICY_CONFIG_ID,
+                name="Edit approvals",
+                description="Control ACP edit approvals for this session.",
+                category="permissions",
+                type="select",
+                current_value=current,
+                options=[
+                    SessionConfigSelectOption(
+                        value="ask",
+                        name="Ask before edits",
+                        description="Require approval for every file edit.",
+                    ),
+                    SessionConfigSelectOption(
+                        value="workspace_session",
+                        name="Auto-allow workspace edits",
+                        description="Allow workspace and /tmp edits for this session; still asks for sensitive paths.",
+                    ),
+                    SessionConfigSelectOption(
+                        value="session",
+                        name="Auto-allow all edits this session",
+                        description="Allow file edits for this session except sensitive paths.",
+                    ),
+                ],
+            )
+        ]
+
+    def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
+        values = getattr(state, "config_options", None)
+        if not isinstance(values, dict):
+            values = {}
+        return str(values.get(self._EDIT_APPROVAL_POLICY_CONFIG_ID) or self._EDIT_APPROVAL_POLICY_DEFAULT), state.cwd
 
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
@@ -940,6 +988,7 @@ class HermesACPAgent(acp.Agent):
         return NewSessionResponse(
             session_id=state.session_id,
             models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
         )
 
     def _schedule_history_replay(self, state: SessionState) -> None:
@@ -970,7 +1019,10 @@ class HermesACPAgent(acp.Agent):
         self._schedule_history_replay(state)
         self._schedule_available_commands_update(session_id)
         self._schedule_usage_update(state)
-        return LoadSessionResponse(models=self._build_model_state(state))
+        return LoadSessionResponse(
+            models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
+        )
 
     async def resume_session(
         self,
@@ -988,7 +1040,10 @@ class HermesACPAgent(acp.Agent):
         self._schedule_history_replay(state)
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
-        return ResumeSessionResponse(models=self._build_model_state(state))
+        return ResumeSessionResponse(
+            models=self._build_model_state(state),
+            config_options=self._session_config_options(state),
+        )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
         state = self.session_manager.get_session(session_id)
@@ -1018,7 +1073,11 @@ class HermesACPAgent(acp.Agent):
         logger.info("Forked session %s -> %s", session_id, new_id)
         if new_id:
             self._schedule_available_commands_update(new_id)
-        return ForkSessionResponse(session_id=new_id)
+        return ForkSessionResponse(
+            session_id=new_id,
+            models=self._build_model_state(state) if state is not None else None,
+            config_options=self._session_config_options(state) if state is not None else None,
+        )
 
     async def list_sessions(
         self,
@@ -1193,6 +1252,7 @@ class HermesACPAgent(acp.Agent):
                     conn.request_permission,
                     loop,
                     session_id,
+                    auto_approve_getter=lambda: self._edit_approval_policy_for_state(state),
                 )
             except Exception:
                 logger.debug("Could not create ACP edit approval requester", exc_info=True)
@@ -1736,4 +1796,4 @@ class HermesACPAgent(acp.Agent):
         setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(config_options=self._session_config_options(state))

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -44,10 +44,10 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
-    SessionConfigOptionSelect,
-    SessionConfigSelectOption,
     SessionForkCapabilities,
     SessionListCapabilities,
+    SessionMode,
+    SessionModeState,
     SessionModelState,
     SessionResumeCapabilities,
     SessionInfo,
@@ -498,6 +498,17 @@ class HermesACPAgent(acp.Agent):
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
+    _MODE_DEFAULT = "default"
+    _MODE_ACCEPT_EDITS = "accept_edits"
+    _MODE_DONT_ASK = "dont_ask"
+    _MODE_TO_EDIT_APPROVAL_POLICY = {
+        _MODE_DEFAULT: "ask",
+        _MODE_ACCEPT_EDITS: "workspace_session",
+        _MODE_DONT_ASK: "session",
+    }
+    _EDIT_APPROVAL_POLICY_TO_MODE = {
+        value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
+    }
 
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
@@ -512,47 +523,43 @@ class HermesACPAgent(acp.Agent):
         logger.info("ACP client connected")
 
 
-    def _session_config_options(self, state: SessionState) -> list[Any]:
-        values = getattr(state, "config_options", None)
-        if not isinstance(values, dict):
-            values = {}
-        current = str(values.get(self._EDIT_APPROVAL_POLICY_CONFIG_ID) or self._EDIT_APPROVAL_POLICY_DEFAULT)
-        allowed = {"ask", "workspace_session", "session"}
-        if current not in allowed:
-            current = self._EDIT_APPROVAL_POLICY_DEFAULT
-        return [
-            SessionConfigOptionSelect(
-                id=self._EDIT_APPROVAL_POLICY_CONFIG_ID,
-                name="Edit approvals",
-                description="Control ACP edit approvals for this session.",
-                category="permissions",
-                type="select",
-                current_value=current,
-                options=[
-                    SessionConfigSelectOption(
-                        value="ask",
-                        name="Ask before edits",
-                        description="Require approval for every file edit.",
-                    ),
-                    SessionConfigSelectOption(
-                        value="workspace_session",
-                        name="Auto-allow workspace edits",
-                        description="Allow workspace and /tmp edits for this session; still asks for sensitive paths.",
-                    ),
-                    SessionConfigSelectOption(
-                        value="session",
-                        name="Auto-allow all edits this session",
-                        description="Allow file edits for this session except sensitive paths.",
-                    ),
-                ],
-            )
-        ]
+    def _session_modes(self, state: SessionState) -> SessionModeState:
+        """Return ACP session modes while preserving Zed's separate model picker.
+
+        Zed renders ``config_options`` in the prominent selector slot where the
+        model picker was visible. Claude/Codex expose policy-like controls as ACP
+        modes, which coexist with the model picker, so Hermes maps edit approval
+        policy onto modes instead of advertising config options.
+        """
+
+        current = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
+        if current not in self._MODE_TO_EDIT_APPROVAL_POLICY:
+            current = self._MODE_DEFAULT
+        return SessionModeState(
+            current_mode_id=current,
+            available_modes=[
+                SessionMode(
+                    id=self._MODE_DEFAULT,
+                    name="Default",
+                    description="Ask before edits.",
+                ),
+                SessionMode(
+                    id=self._MODE_ACCEPT_EDITS,
+                    name="Accept Edits",
+                    description="Auto-allow workspace and /tmp edits; still asks for sensitive paths.",
+                ),
+                SessionMode(
+                    id=self._MODE_DONT_ASK,
+                    name="Don't Ask",
+                    description="Auto-allow file edits for this session except sensitive paths.",
+                ),
+            ],
+        )
 
     def _edit_approval_policy_for_state(self, state: SessionState) -> tuple[str, str | None]:
-        values = getattr(state, "config_options", None)
-        if not isinstance(values, dict):
-            values = {}
-        return str(values.get(self._EDIT_APPROVAL_POLICY_CONFIG_ID) or self._EDIT_APPROVAL_POLICY_DEFAULT), state.cwd
+        mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
+        policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
+        return policy, state.cwd
 
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
@@ -988,7 +995,7 @@ class HermesACPAgent(acp.Agent):
         return NewSessionResponse(
             session_id=state.session_id,
             models=self._build_model_state(state),
-            config_options=self._session_config_options(state),
+            modes=self._session_modes(state),
         )
 
     def _schedule_history_replay(self, state: SessionState) -> None:
@@ -1021,7 +1028,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return LoadSessionResponse(
             models=self._build_model_state(state),
-            config_options=self._session_config_options(state),
+            modes=self._session_modes(state),
         )
 
     async def resume_session(
@@ -1042,7 +1049,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return ResumeSessionResponse(
             models=self._build_model_state(state),
-            config_options=self._session_config_options(state),
+            modes=self._session_modes(state),
         )
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
@@ -1076,7 +1083,7 @@ class HermesACPAgent(acp.Agent):
         return ForkSessionResponse(
             session_id=new_id,
             models=self._build_model_state(state) if state is not None else None,
-            config_options=self._session_config_options(state) if state is not None else None,
+            modes=self._session_modes(state) if state is not None else None,
         )
 
     async def list_sessions(
@@ -1233,7 +1240,14 @@ class HermesACPAgent(acp.Agent):
         streamed_message = False
 
         if conn:
-            tool_progress_cb = make_tool_progress_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            tool_progress_cb = make_tool_progress_cb(
+                conn,
+                session_id,
+                loop,
+                tool_call_ids,
+                tool_call_meta,
+                edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
+            )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
             step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             message_cb = make_message_cb(conn, session_id, loop)
@@ -1775,9 +1789,12 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("Session %s: mode switch requested for missing session", session_id)
             return None
-        setattr(state, "mode", mode_id)
+        normalized_mode = str(mode_id or "").strip()
+        if normalized_mode not in self._MODE_TO_EDIT_APPROVAL_POLICY:
+            normalized_mode = self._MODE_DEFAULT
+        setattr(state, "mode", normalized_mode)
         self.session_manager.save_session(session_id)
-        logger.info("Session %s: mode switched to %s", session_id, mode_id)
+        logger.info("Session %s: mode switched to %s", session_id, normalized_mode)
         return SetSessionModeResponse()
 
     async def set_config_option(
@@ -1789,11 +1806,15 @@ class HermesACPAgent(acp.Agent):
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
 
-        options = getattr(state, "config_options", None)
-        if not isinstance(options, dict):
-            options = {}
-        options[str(config_id)] = value
-        setattr(state, "config_options", options)
+        if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
+            mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
+            setattr(state, "mode", mode)
+        else:
+            options = getattr(state, "config_options", None)
+            if not isinstance(options, dict):
+                options = {}
+            options[str(config_id)] = value
+            setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=self._session_config_options(state))
+        return SetSessionConfigOptionResponse(config_options=[])

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -895,7 +895,7 @@ def _build_tool_complete_content(
     if len(display_result) > 5000:
         display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
 
-    if tool_name in {"write_file", "patch", "skill_manage"}:
+    if tool_name == "skill_manage":
         try:
             from agent.display import extract_edit_diff
 
@@ -936,22 +936,15 @@ def build_tool_start(
 
     if tool_name == "patch":
         mode = arguments.get("mode", "replace")
-        if mode == "replace":
-            path = arguments.get("path", "")
-            old = arguments.get("old_string", "")
-            new = arguments.get("new_string", "")
-            content = [acp.tool_diff_content(path=path, new_text=new, old_text=old)]
-        else:
-            patch_text = arguments.get("patch", "")
-            content = _build_patch_mode_content(patch_text)
+        path = arguments.get("path") or "patch input"
+        content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "write_file":
         path = arguments.get("path", "")
-        file_content = arguments.get("content", "")
-        content = [acp.tool_diff_content(path=path, new_text=file_content)]
+        content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -928,6 +928,8 @@ def build_tool_start(
     tool_call_id: str,
     tool_name: str,
     arguments: Dict[str, Any],
+    *,
+    edit_diff: Any = None,
 ) -> ToolCallStart:
     """Create a ToolCallStart event for the given hermes tool invocation."""
     kind = get_tool_kind(tool_name)
@@ -935,16 +937,34 @@ def build_tool_start(
     locations = extract_locations(arguments)
 
     if tool_name == "patch":
-        mode = arguments.get("mode", "replace")
-        path = arguments.get("path") or "patch input"
-        content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
+        if edit_diff is not None:
+            content = [
+                acp.tool_diff_content(
+                    path=edit_diff.path,
+                    old_text=edit_diff.old_text,
+                    new_text=edit_diff.new_text,
+                )
+            ]
+        else:
+            mode = arguments.get("mode", "replace")
+            path = arguments.get("path") or "patch input"
+            content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "write_file":
-        path = arguments.get("path", "")
-        content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
+        if edit_diff is not None:
+            content = [
+                acp.tool_diff_content(
+                    path=edit_diff.path,
+                    old_text=edit_diff.old_text,
+                    new_text=edit_diff.new_text,
+                )
+            ]
+        else:
+            path = arguments.get("path", "")
+            content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )

--- a/docs/plans/2026-05-15-acp-zed-edit-approval-diffs.md
+++ b/docs/plans/2026-05-15-acp-zed-edit-approval-diffs.md
@@ -1,0 +1,152 @@
+# ACP Zed Pre-Edit Approval Diffs Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Gate file mutations in ACP/Zed behind explicit pre-edit approval with a structured diff, similar to Codex/Kimi edit review behavior.
+
+**Architecture:** Hermes already renders edit diffs after tools run. This PR adds a pre-mutation permission gate for file mutation tools. Intercept `write_file`, `patch`, and eventually `skill_manage` before they mutate disk; compute proposed old/new content; send ACP `session/request_permission` with `kind="edit"` and diff content; only execute the mutation after approval. Rejections return a clear tool result and leave files unchanged.
+
+**Tech Stack:** Python, ACP `request_permission`, `FileEditToolCallContent` / `acp.tool_diff_content`, Hermes file tools, pytest with temp files.
+
+---
+
+### Task 1: Confirm current ACP diff/permission schema
+
+Run:
+
+```bash
+/home/nour/.hermes/hermes-agent/venv/bin/python - <<'PY'
+from acp.schema import RequestPermissionRequest, ToolCallUpdate
+import acp, inspect
+print(RequestPermissionRequest.model_fields)
+print(ToolCallUpdate.model_fields)
+print(inspect.signature(acp.tool_diff_content))
+PY
+```
+
+Record actual field names. Do not rely on stale examples.
+
+### Task 2: Add denied-write test
+
+**Objective:** A rejected `write_file` must not mutate disk.
+
+**Files:**
+- Create/modify: `tests/acp/test_edit_approval.py`
+
+Test shape:
+
+```python
+def test_write_file_rejected_by_acp_permission_does_not_mutate(tmp_path):
+    path = tmp_path / "demo.txt"
+    path.write_text("old")
+
+    # Install fake ACP edit approval callback returning reject_once.
+    # Invoke the same interception function that the terminal/tool path will call.
+
+    result = maybe_gate_file_edit(
+        tool_name="write_file",
+        args={"path": str(path), "content": "new"},
+        approval_requester=fake_reject,
+    )
+
+    assert path.read_text() == "old"
+    assert "rejected" in result.lower()
+```
+
+The exact function name will be created in Task 4.
+
+### Task 3: Add approved-write test
+
+**Objective:** Approved writes proceed and include diff content in permission request.
+
+Assert:
+
+- fake requester received tool call `kind == "edit"`
+- content includes diff block for `demo.txt`
+- after approval, file content is changed
+
+### Task 4: Implement edit proposal computation
+
+**Files:**
+- Create: `acp_adapter/edit_approval.py`
+
+Add pure helpers first:
+
+```python
+@dataclass
+class EditProposal:
+    path: str
+    old_text: str | None
+    new_text: str
+    title: str
+
+
+def proposal_for_write_file(args: dict[str, Any]) -> EditProposal:
+    path = str(args["path"])
+    old_text = Path(path).read_text(encoding="utf-8") if Path(path).exists() else None
+    new_text = str(args.get("content", ""))
+    return EditProposal(path=path, old_text=old_text, new_text=new_text, title=f"Edit {path}")
+```
+
+For `patch`, start with replace-mode only. V4A/multi-file patches can be a second task or second PR if too risky.
+
+### Task 5: Implement ACP permission requester
+
+**Files:**
+- Modify: `acp_adapter/permissions.py` or new `acp_adapter/edit_approval.py`
+
+Build request with:
+
+```python
+acp.tool_diff_content(path=proposal.path, old_text=proposal.old_text, new_text=proposal.new_text)
+```
+
+Options:
+
+- allow once
+- reject once
+- optionally allow always/reject always only after policy storage exists
+
+Default deny on exception/cancel/timeout.
+
+### Task 6: Intercept file mutation tools before execution
+
+**Objective:** Ensure mutation cannot happen before approval.
+
+**Files:**
+- Likely modify: `model_tools.py` or `acp_adapter/server.py` session-context tool wrapper
+
+Do not bury this inside post-execution `acp_adapter/events.py`; that is too late.
+
+Preferred design:
+
+- set an ACP session contextvar around `agent.run_conversation(...)`
+- in the central tool execution path, before dispatching `write_file`/`patch`, call the ACP edit approval gate if contextvar exists
+- if rejected, return a normal tool result string like `{"success": false, "error": "Edit rejected by user"}`
+- if approved, continue to original tool implementation
+
+### Task 7: Expand patch coverage
+
+Add tests for:
+
+- `patch` replace mode approved/rejected
+- creating a new file via `write_file`
+- missing old string -> should fail before approval or return normal patch error, but must not mutate
+- permission requester exception -> deny and no mutation
+
+### Task 8: Verification
+
+Run:
+
+```bash
+scripts/run_tests.sh tests/acp/test_edit_approval.py tests/acp/test_events.py tests/acp/test_tools.py -q
+```
+
+Then run manual Zed verification:
+
+1. Ask Hermes ACP to edit a small file.
+2. Confirm Zed shows a diff before mutation.
+3. Reject and verify file unchanged.
+4. Approve and verify file changed.
+
+**Do not merge** without manual reject-path verification.

--- a/model_tools.py
+++ b/model_tools.py
@@ -745,6 +745,20 @@ def handle_function_call(
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
 
+        # ACP/Zed edit approval runs before any file mutation.  The requester
+        # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
+        # are unaffected when it is unset.
+        try:
+            from acp_adapter.edit_approval import maybe_require_edit_approval
+
+            edit_block_message = maybe_require_edit_approval(function_name, function_args)
+            if edit_block_message is not None:
+                return edit_block_message
+        except Exception as _edit_approval_err:
+            logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
+            if function_name in {"write_file", "patch"}:
+                return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
+
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).
         if function_name not in _READ_SEARCH_TOOLS:

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
     clear_edit_approval_requester,
     set_edit_approval_requester,
+    should_auto_approve_edit,
 )
 from model_tools import handle_function_call
 
@@ -177,3 +179,25 @@ def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
     assert proposals[0].tool_name == "patch"
     assert proposals[0].old_text == "alpha\nbeta\n"
     assert proposals[0].new_text == "alpha\ngamma\n"
+
+
+def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_path):
+    workspace_file = tmp_path / "src.py"
+    tmp_file = Path("/tmp/hermes-acp-auto-approve-test.txt")
+    env_file = tmp_path / ".env"
+
+    assert should_auto_approve_edit(
+        EditProposal("write_file", str(workspace_file), None, "x", {}),
+        "workspace_session",
+        str(tmp_path),
+    )
+    assert should_auto_approve_edit(
+        EditProposal("write_file", str(tmp_file), None, "x", {}),
+        "workspace_session",
+        str(tmp_path),
+    )
+    assert not should_auto_approve_edit(
+        EditProposal("write_file", str(env_file), None, "SECRET=x", {}),
+        "session",
+        str(tmp_path),
+    )

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -1,0 +1,179 @@
+"""Tests for ACP pre-edit approval gating."""
+
+from __future__ import annotations
+
+import json
+
+from acp_adapter.edit_approval import (
+    EditProposal,
+    build_acp_edit_tool_call,
+    clear_edit_approval_requester,
+    set_edit_approval_requester,
+)
+from model_tools import handle_function_call
+
+
+def teardown_function() -> None:
+    clear_edit_approval_requester()
+
+
+def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
+    proposal = EditProposal(
+        tool_name="write_file",
+        path="demo.txt",
+        old_text="old\n",
+        new_text="new\n",
+        arguments={"path": "demo.txt", "content": "new\n"},
+    )
+
+    tool_call = build_acp_edit_tool_call(proposal)
+
+    assert tool_call.kind == "edit"
+    assert tool_call.status == "pending"
+    assert tool_call.rawInput == {"tool": "write_file", "arguments": proposal.arguments}
+    assert len(tool_call.content) == 1
+    diff = tool_call.content[0]
+    assert diff.path == "demo.txt"
+    assert diff.oldText == "old\n"
+    assert diff.newText == "new\n"
+
+
+def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_write_file_approval_mutates_and_request_includes_diff(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    proposals = []
+
+    def approve(proposal):
+        proposals.append(proposal)
+        return True
+
+    set_edit_approval_requester(approve)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-approve",
+        )
+    )
+
+    assert result.get("bytes_written") == len("after\n")
+    assert target.read_text(encoding="utf-8") == "after\n"
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.tool_name == "write_file"
+    assert proposal.path == str(target)
+    assert proposal.old_text == "before\n"
+    assert proposal.new_text == "after\n"
+
+
+def test_write_file_new_file_request_has_empty_old_text(tmp_path):
+    target = tmp_path / "new.txt"
+    proposals = []
+
+    set_edit_approval_requester(lambda proposal: proposals.append(proposal) or True)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "created\n"},
+            task_id="acp-edit-new-file",
+        )
+    )
+
+    assert result.get("bytes_written") == len("created\n")
+    assert target.read_text(encoding="utf-8") == "created\n"
+    assert proposals[0].old_text is None
+    assert proposals[0].new_text == "created\n"
+
+
+def test_requester_exception_denies_and_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    def boom(_proposal):
+        raise RuntimeError("zed disconnected")
+
+    set_edit_approval_requester(boom)
+
+    result = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-exception",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_patch_replace_rejection_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "beta\n",
+                "new_string": "gamma\n",
+            },
+            task_id="acp-patch-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+
+def test_patch_replace_approval_request_includes_full_file_diff(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+    proposals = []
+
+    set_edit_approval_requester(lambda proposal: proposals.append(proposal) or True)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target),
+                "old_string": "beta\n",
+                "new_string": "gamma\n",
+            },
+            task_id="acp-patch-approve",
+        )
+    )
+
+    assert result.get("success") is True
+    assert target.read_text(encoding="utf-8") == "alpha\ngamma\n"
+    assert proposals[0].tool_name == "patch"
+    assert proposals[0].old_text == "alpha\nbeta\n"
+    assert proposals[0].new_text == "alpha\ngamma\n"

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -183,7 +183,7 @@ class TestMcpRegistrationE2E:
         assert "hello" in complete_event.content[0].content.text
         assert complete_event.raw_output is None
 
-    def test_patch_mode_tool_start_emits_diff_blocks_for_v4a_patch(self):
+    def test_patch_mode_tool_start_defers_diff_to_edit_approval_prompt(self):
         update = build_tool_start(
             "tc-1",
             "patch",
@@ -193,14 +193,9 @@ class TestMcpRegistrationE2E:
             },
         )
 
-        assert len(update.content) == 2
-        assert update.content[0].type == "diff"
-        assert update.content[0].path == "src/app.py"
-        assert update.content[0].old_text == "old line"
-        assert update.content[0].new_text == "new line"
-        assert update.content[1].type == "diff"
-        assert update.content[1].path == "src/new.py"
-        assert update.content[1].new_text == "hello"
+        assert len(update.content) == 1
+        assert update.content[0].type == "content"
+        assert "Approval prompt shows the diff" in update.content[0].content.text
 
     @pytest.mark.asyncio
     async def test_prompt_tool_results_paired_by_call_id(self, acp_agent, mock_manager):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -23,6 +23,7 @@ from acp.schema import (
     PromptResponse,
     ResumeSessionResponse,
     SessionModelState,
+    SessionModeState,
     SetSessionConfigOptionResponse,
     SetSessionModelResponse,
     SetSessionModeResponse,
@@ -51,31 +52,34 @@ def agent(mock_manager):
     """HermesACPAgent backed by a mock session manager."""
     return HermesACPAgent(session_manager=mock_manager)
 
-    @pytest.mark.asyncio
-    async def test_new_session_includes_edit_approval_config_option(self, agent):
-        resp = await agent.new_session(cwd="/tmp")
 
-        assert resp.config_options
-        option = resp.config_options[0]
-        assert option.id == "edit_approval_policy"
-        assert option.current_value == "ask"
-        assert {choice.value for choice in option.options} == {
-            "ask",
-            "workspace_session",
-            "session",
-        }
+@pytest.mark.asyncio
+async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
+    resp = await agent.new_session(cwd="/tmp")
 
-    @pytest.mark.asyncio
-    async def test_set_config_option_persists_edit_approval_policy(self, agent):
-        resp = await agent.new_session(cwd="/tmp")
-        update = await agent.set_config_option(
-            "edit_approval_policy",
-            resp.session_id,
-            "workspace_session",
-        )
+    assert resp.config_options is None
+    assert isinstance(resp.modes, SessionModeState)
+    assert resp.modes.current_mode_id == "default"
+    assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [
+        ("default", "Default"),
+        ("accept_edits", "Accept Edits"),
+        ("dont_ask", "Don't Ask"),
+    ]
 
-        assert isinstance(update, SetSessionConfigOptionResponse)
-        assert update.config_options[0].current_value == "workspace_session"
+
+@pytest.mark.asyncio
+async def test_set_config_option_persists_edit_approval_policy_without_advertising_config(agent):
+    resp = await agent.new_session(cwd="/tmp")
+    update = await agent.set_config_option(
+        "edit_approval_policy",
+        resp.session_id,
+        "workspace_session",
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert isinstance(update, SetSessionConfigOptionResponse)
+    assert update.config_options == []
+    assert getattr(state, "mode", None) == "accept_edits"
 
 
 # ---------------------------------------------------------------------------
@@ -619,11 +623,11 @@ class TestSessionConfiguration:
     @pytest.mark.asyncio
     async def test_set_session_mode_returns_response(self, agent):
         new_resp = await agent.new_session(cwd="/tmp")
-        resp = await agent.set_session_mode(mode_id="chat", session_id=new_resp.session_id)
+        resp = await agent.set_session_mode(mode_id="accept_edits", session_id=new_resp.session_id)
         state = agent.session_manager.get_session(new_resp.session_id)
 
         assert isinstance(resp, SetSessionModeResponse)
-        assert getattr(state, "mode", None) == "chat"
+        assert getattr(state, "mode", None) == "accept_edits"
 
     @pytest.mark.asyncio
     async def test_router_accepts_stable_session_config_methods(self, agent):
@@ -632,7 +636,7 @@ class TestSessionConfiguration:
 
         mode_result = await router(
             "session/set_mode",
-            {"modeId": "chat", "sessionId": new_resp.session_id},
+            {"modeId": "accept_edits", "sessionId": new_resp.session_id},
             False,
         )
         config_result = await router(
@@ -646,8 +650,7 @@ class TestSessionConfiguration:
         )
 
         assert mode_result == {}
-        assert config_result["configOptions"]
-        assert config_result["configOptions"][0]["id"] == "edit_approval_policy"
+        assert config_result["configOptions"] == []
 
     @pytest.mark.asyncio
     async def test_router_accepts_unstable_model_switch_when_enabled(self, agent):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -51,6 +51,32 @@ def agent(mock_manager):
     """HermesACPAgent backed by a mock session manager."""
     return HermesACPAgent(session_manager=mock_manager)
 
+    @pytest.mark.asyncio
+    async def test_new_session_includes_edit_approval_config_option(self, agent):
+        resp = await agent.new_session(cwd="/tmp")
+
+        assert resp.config_options
+        option = resp.config_options[0]
+        assert option.id == "edit_approval_policy"
+        assert option.current_value == "ask"
+        assert {choice.value for choice in option.options} == {
+            "ask",
+            "workspace_session",
+            "session",
+        }
+
+    @pytest.mark.asyncio
+    async def test_set_config_option_persists_edit_approval_policy(self, agent):
+        resp = await agent.new_session(cwd="/tmp")
+        update = await agent.set_config_option(
+            "edit_approval_policy",
+            resp.session_id,
+            "workspace_session",
+        )
+
+        assert isinstance(update, SetSessionConfigOptionResponse)
+        assert update.config_options[0].current_value == "workspace_session"
+
 
 # ---------------------------------------------------------------------------
 # initialize
@@ -620,7 +646,8 @@ class TestSessionConfiguration:
         )
 
         assert mode_result == {}
-        assert config_result == {"configOptions": []}
+        assert config_result["configOptions"]
+        assert config_result["configOptions"][0]["id"] == "edit_approval_policy"
 
     @pytest.mark.asyncio
     async def test_router_accepts_unstable_model_switch_when_enabled(self, agent):

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from acp_adapter.edit_approval import EditProposal
 from acp_adapter.tools import (
     TOOL_KIND_MAP,
     build_tool_complete,
@@ -173,6 +174,25 @@ class TestBuildToolStart:
         assert isinstance(item, ContentToolCallContent)
         assert "Approval prompt shows the diff" in item.content.text
         assert "new_file.py" in item.content.text
+
+    def test_auto_approved_edit_start_shows_diff_content(self):
+        """Auto-approved edit starts need the diff because no approval card exists."""
+        args = {"path": "/tmp/acp.txt", "old_string": "old", "new_string": "new"}
+        result = build_tool_start(
+            "tc-auto-edit",
+            "patch",
+            args,
+            edit_diff=EditProposal("patch", "/tmp/acp.txt", "old\n", "new\n", args),
+        )
+
+        assert isinstance(result, ToolCallStart)
+        assert result.kind == "edit"
+        assert len(result.content) == 1
+        item = result.content[0]
+        assert isinstance(item, FileEditToolCallContent)
+        assert item.path == "/tmp/acp.txt"
+        assert item.old_text == "old\n"
+        assert item.new_text == "new\n"
 
     def test_build_tool_start_for_terminal(self):
         """terminal should produce text content with the command."""

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -147,7 +147,7 @@ class TestBuildToolTitle:
 
 class TestBuildToolStart:
     def test_build_tool_start_for_patch(self):
-        """patch should produce a FileEditToolCallContent (diff)."""
+        """patch start should not duplicate the edit-approval diff."""
         args = {
             "path": "src/main.py",
             "old_string": "print('hello')",
@@ -156,24 +156,23 @@ class TestBuildToolStart:
         result = build_tool_start("tc-1", "patch", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "edit"
-        # The first content item should be a diff
         assert len(result.content) >= 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "src/main.py"
-        assert diff_item.new_text == "print('world')"
-        assert diff_item.old_text == "print('hello')"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "Approval prompt shows the diff" in item.content.text
+        assert "src/main.py" in item.content.text
 
     def test_build_tool_start_for_write_file(self):
-        """write_file should produce a FileEditToolCallContent (diff)."""
+        """write_file start should not duplicate the edit-approval diff."""
         args = {"path": "new_file.py", "content": "print('hello')"}
         result = build_tool_start("tc-w1", "write_file", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "edit"
         assert len(result.content) >= 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "new_file.py"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "Approval prompt shows the diff" in item.content.text
+        assert "new_file.py" in item.content.text
 
     def test_build_tool_start_for_terminal(self):
         """terminal should produce text content with the command."""
@@ -442,8 +441,8 @@ class TestBuildToolComplete:
         assert len(display_text) < 6000
         assert "truncated" in display_text
 
-    def test_build_tool_complete_for_patch_uses_diff_blocks(self):
-        """Completed patch calls should keep structured diff content for Zed."""
+    def test_build_tool_complete_for_patch_summarizes_without_repeating_diff(self):
+        """Completed patch calls should not duplicate the edit-approval diff."""
         patch_result = (
             '{"success": true, "diff": "--- a/README.md\\n+++ b/README.md\\n@@ -1 +1,2 @@\\n old line\\n+new line\\n", '
             '"files_modified": ["README.md"]}'
@@ -451,18 +450,17 @@ class TestBuildToolComplete:
         result = build_tool_complete("tc-p1", "patch", patch_result)
         assert isinstance(result, ToolCallProgress)
         assert len(result.content) == 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path == "README.md"
-        assert diff_item.old_text == "old line"
-        assert diff_item.new_text == "old line\nnew line"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "✅ patch completed" in item.content.text
+        assert "README.md" in item.content.text
 
     def test_build_tool_complete_for_patch_falls_back_to_text_when_no_diff(self):
         result = build_tool_complete("tc-p2", "patch", '{"success": true}')
         assert isinstance(result, ToolCallProgress)
         assert isinstance(result.content[0], ContentToolCallContent)
 
-    def test_build_tool_complete_for_write_file_uses_snapshot_diff(self, tmp_path):
+    def test_build_tool_complete_for_write_file_summarizes_without_repeating_diff(self, tmp_path):
         target = tmp_path / "diff-test.txt"
         snapshot = type("Snapshot", (), {"paths": [target], "before": {str(target): None}})()
         target.write_text("hello from hermes\n", encoding="utf-8")
@@ -476,11 +474,10 @@ class TestBuildToolComplete:
         )
         assert isinstance(result, ToolCallProgress)
         assert len(result.content) == 1
-        diff_item = result.content[0]
-        assert isinstance(diff_item, FileEditToolCallContent)
-        assert diff_item.path.endswith("diff-test.txt")
-        assert diff_item.old_text is None
-        assert diff_item.new_text == "hello from hermes"
+        item = result.content[0]
+        assert isinstance(item, ContentToolCallContent)
+        assert "✅ write_file completed" in item.content.text
+        assert "diff-test.txt" in item.content.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Moves Zed edit auto-approval controls from ACP config options to ACP modes so the model picker remains visible.
- Maps `Default`, `Accept Edits`, and `Don't Ask` modes onto the existing edit approval policy backend.
- Shows the structured edit diff on the tool-start card for auto-approved edits, where no approval card exists.
- Keeps manual approval mode compact so the approval card remains the canonical diff surface.

## Stack note
This is a follow-up in the ACP/Zed edit approval stack and is intended to sit after the edit approval diff PR.

## Test plan
- `scripts/run_tests.sh tests/acp/test_server.py tests/acp/test_tools.py tests/acp/test_edit_approval.py -q --tb=short`
