### PR TITLE
feat(cli): emit OSC 9 input-needed alert on interactive prompts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -959,6 +959,19 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Emit an OSC 9 terminal notification whenever the agent blocks on an
+  # interactive prompt (clarify question, command approval, sudo password,
+  # secret capture). Notification-aware terminals — cmux, iTerm2, Ghostty,
+  # Kitty, WezTerm — flash the pane/tab and play a system notification.
+  # Terminals that don't recognise OSC 9 silently discard the sequence.
+  # Useful for long-running tasks where you've Cmd-Tab'd away — the moment
+  # Hermes needs you, the pane lights up. The sequence is written directly
+  # to /dev/tty so prompt_toolkit's renderer can't strip it. Off
+  # automatically when stdout is not a TTY.
+  #   true:  Notify on input prompts (default)
+  #   false: Silent
+  input_alert: true
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -1557,6 +1557,46 @@ def _accent_hex() -> str:
         return "#FFBF00"
 
 
+def _notify_input_needed(body: str = "Hermes needs your input") -> None:
+    """Emit OSC 9 to the terminal so notification-aware emulators ring.
+
+    Fires when Hermes blocks on an interactive prompt (clarify, command
+    approval, sudo, secret) so terminal multiplexers and emulators that
+    parse OSC 9 (cmux, iTerm2, Ghostty, Kitty, WezTerm, …) can flash the
+    pane/tab and play a system notification. Silently ignored by every
+    other terminal — OSC sequences that aren't recognised are simply
+    discarded by the terminal's parser.
+
+    Two implementation details that look surprising:
+
+    1. **Writes to /dev/tty, not sys.stdout.** While prompt_toolkit's
+       Application is active (which it always is when these callbacks
+       fire — the prompt panel is being rendered), sys.stdout is wrapped
+       by prompt_toolkit's renderer and raw escape sequences get
+       stripped/buffered by its diff-redraw loop. /dev/tty bypasses that
+       wrapping and lands the bytes on the underlying TTY where the
+       terminal's OSC parser can see them.
+
+    2. **BEL terminator (\\x07), not ST (\\x1b\\\\).** Both are valid per
+       the OSC spec; BEL is the iTerm-canonical form and is what every
+       terminal in the support matrix above accepts.
+
+    Disable via ``display.input_alert: false`` in config.yaml. Off
+    automatically when stdout is not a TTY (so redirected logs don't
+    accumulate stray escape sequences).
+    """
+    try:
+        cfg = CLI_CONFIG.get("display", {}) if isinstance(CLI_CONFIG, dict) else {}
+        if not cfg.get("input_alert", True):
+            return
+        if not sys.stdout.isatty():
+            return
+        with open("/dev/tty", "w", buffering=1, encoding="utf-8") as tty:
+            tty.write(f"\x1b]9;{body}\x07")
+    except Exception:
+        pass
+
+
 def _rich_text_from_ansi(text: str) -> _RichText:
     """Safely render assistant/tool output that may contain ANSI escapes.
 
@@ -10264,6 +10304,7 @@ class HermesCLI:
 
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
+        _notify_input_needed("Hermes: clarify question")
 
         # Poll for the user's response.  The countdown in the hint line
         # updates on each invalidate — but frequent repaints cause visible
@@ -10324,6 +10365,7 @@ class HermesCLI:
         self._sudo_deadline = _time.monotonic() + timeout
 
         self._invalidate()
+        _notify_input_needed("Hermes: sudo password")
 
         while True:
             try:
@@ -10381,6 +10423,7 @@ class HermesCLI:
             self._approval_deadline = _time.monotonic() + timeout
 
             self._invalidate()
+            _notify_input_needed("Hermes: command approval")
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -10624,6 +10667,7 @@ class HermesCLI:
         return lines
 
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
+        _notify_input_needed(f"Hermes: secret needed ({var_name})")
         return prompt_for_secret(self, var_name, prompt, metadata)
 
     def _capture_modal_input_snapshot(self) -> None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -952,6 +952,13 @@ DEFAULT_CONFIG = {
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
         "bell_on_complete": False,
+        # When true (default), the CLI emits an OSC 9 terminal notification
+        # whenever Hermes blocks on an interactive prompt (clarify, command
+        # approval, sudo password, secret capture). Notification-aware
+        # terminals — cmux, iTerm2, Ghostty, Kitty, WezTerm — flash the
+        # pane/tab and play a system notification. Other terminals discard
+        # the sequence silently. Set false to disable.
+        "input_alert": True,
         "show_reasoning": False,
         "streaming": False,
         "timestamps": False,      # Show [HH:MM] on user and assistant labels

--- a/tests/cli/test_cli_input_alert.py
+++ b/tests/cli/test_cli_input_alert.py
@@ -1,0 +1,99 @@
+"""Tests for ``cli._notify_input_needed`` — the OSC 9 input-prompt alert.
+
+Covers:
+
+* Sequence shape (ESC ] 9 ; <body> BEL).
+* Disable via ``display.input_alert: false``.
+* No-op when stdout is not a TTY (the redirected-log guard).
+* Failure path silently absorbs IO errors (no /dev/tty in the sandbox).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, mock_open, MagicMock
+
+import cli as cli_module
+
+
+def test_notify_writes_osc9_with_bel_terminator(monkeypatch):
+    """Helper writes ``ESC ] 9 ; <body> BEL`` to /dev/tty when enabled + TTY."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello world")
+
+    m.assert_called_once_with("/dev/tty", "w", buffering=1, encoding="utf-8")
+    fake_tty.write.assert_called_once_with("\x1b]9;hello world\x07")
+
+
+def test_notify_disabled_via_config(monkeypatch):
+    """Setting ``display.input_alert: false`` short-circuits before any IO."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": False})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_skipped_when_stdout_not_tty(monkeypatch):
+    """Redirected stdout (pipes, file logs) — no notification emitted."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    m = mock_open()
+    with patch("cli.sys.stdout.isatty", return_value=False), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hello")
+
+    m.assert_not_called()
+
+
+def test_notify_swallows_io_errors(monkeypatch):
+    """If /dev/tty can't be opened (sandbox, non-POSIX), the helper is silent."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {"input_alert": True})
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("no tty")
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", _boom):
+        # Must not raise. The whole point of the helper is best-effort.
+        cli_module._notify_input_needed("hello")
+
+
+def test_notify_default_on(monkeypatch):
+    """Default (no ``input_alert`` key in config) is enabled."""
+    monkeypatch.setitem(cli_module.CLI_CONFIG, "display", {})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hi")
+
+    fake_tty.write.assert_called_once_with("\x1b]9;hi\x07")
+
+
+def test_notify_robust_to_missing_display_config(monkeypatch):
+    """Missing ``display`` section entirely — fall back to default-on."""
+    # Replace the whole CLI_CONFIG with something that has no display key.
+    # Use a fresh dict so we don't bleed into other tests.
+    monkeypatch.setattr(cli_module, "CLI_CONFIG", {})
+
+    fake_tty = MagicMock()
+    m = mock_open()
+    m.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), \
+         patch("builtins.open", m):
+        cli_module._notify_input_needed("hi")
+
+    fake_tty.write.assert_called_once_with("\x1b]9;hi\x07")


### PR DESCRIPTION
## Summary

When the CLI blocks on an interactive prompt (clarify question, command approval, sudo password, secret capture), emit an OSC 9 terminal notification so notification-aware terminals can flash the pane/tab and play a system notification.

**Supported terminals (verified against the OSC 9 docs and Ethan's setup):** [cmux](https://manaflow-ai-cmux.mintlify.app/features/notifications), iTerm2, Ghostty, Kitty, WezTerm. Terminals that don't recognise the sequence silently discard it — `printf '\033]9;test\007'` is a no-op in plain `xterm` / Terminal.app.

## Motivation

Long-running Hermes turns are common (image gen, multi-step delegation, CI builds, large codebase scans). When the agent finally needs me to approve a `git push` or answer a clarify, I'm usually Cmd-Tab'd into another window and miss it for 30+ seconds.

Sibling to the existing `display.bell_on_complete` (which fires on agent finish), but for the inverse case — agent is *blocked* and waiting on me. Fills a gap that Claude Code, Aider, and Codex all already cover.

## Two implementation details worth flagging in review

### Why `/dev/tty` and not `sys.stdout`

The naive version (`sys.stdout.write(...)`) **does not work**. While prompt_toolkit's `Application` is active — which it always is when these four callbacks fire, because the prompt panel is mid-render — `sys.stdout` is wrapped by its renderer and raw escape sequences get stripped/buffered by the diff-redraw loop. I verified this: bytes written through `sys.stdout` from inside `_clarify_callback` never reach the terminal (cmux pane stays dark). Writing directly to `/dev/tty` bypasses that wrapping and lands the bytes on the underlying TTY where the terminal's OSC parser can see them.

For the same reason, `display.bell_on_complete` happens to work because by the time it fires the Application has paused rendering. Different timing, same lesson.

### Why BEL terminator, not ST

OSC sequences accept either `\x07` (BEL) or `\x1b\\` (ST) as terminator. cmux accepts both per the spec, but BEL is the iTerm-canonical form and is what `printf '\033]9;…\007'` (the standard reference invocation in every notification-tooling article) uses. Verified working with cmux + Ghostty.

## Config

```yaml
display:
  input_alert: true   # default — emit OSC 9 on input prompts
```

Default-on because:

- The sequence is silently ignored by terminals that don't parse OSC 9 (no harm)
- `isatty()` guard prevents log-file pollution when stdout is redirected
- It's a small QoL win for the (growing) population of users on cmux / iTerm / Ghostty / Kitty / WezTerm

Set `display.input_alert: false` to disable. Mirrors the `display.bell_on_complete` shape exactly.

## Tests

`tests/cli/test_cli_input_alert.py` — 6 tests:

- Sequence shape: `ESC ] 9 ; <body> BEL`
- Config disable short-circuits before any IO
- Non-TTY stdout short-circuits (redirected logs)
- Failed `/dev/tty` open is silently swallowed (sandbox / non-POSIX)
- Default-on when key is missing from config
- Robust to entirely missing `display` section

Verified failing on unpatched `cli.py` (regression coverage, not vacuous):

```
$ git stash push -- cli.py hermes_cli/config.py
$ pytest tests/cli/test_cli_input_alert.py -v
6 failed in 0.81s — all AttributeError: module 'cli' has no attribute '_notify_input_needed'
$ git stash pop
$ pytest tests/cli/test_cli_input_alert.py -v
6 passed in 0.76s
```

## Diff stat

```
 cli-config.yaml.example           | 13 +++++
 cli.py                            | 44 +++++++++++++++++
 hermes_cli/config.py              |  7 +++
 tests/cli/test_cli_input_alert.py | 99 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 163 insertions(+)
```

## Checklist

- [x] Conventional commit prefix (`feat(cli):`)
- [x] Branch: `feat/cli-input-needed-osc9`
- [x] Tests added, verified to fail on unpatched code
- [x] Ruff clean
- [x] No upstream code touched outside the four callback sites + helper + config defaults
- [x] Default-on but reversible via config — no surprise behavior on existing setups
