### PR TITLE
fix(gateway): make interim commentary spacing configurable

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -34,6 +34,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "show_reasoning": False,
     "tool_preview_length": 0,
+    "interim_assistant_spacing": "dense",
     "streaming": None,  # None = follow top-level streaming config
     # Gateway-only assistant/status chatter controls. These default on for
     # back-compat, but mobile platforms can opt down to final-answer-first.
@@ -243,4 +244,7 @@ def _normalise(setting: str, value: Any) -> Any:
             return int(value)
         except (TypeError, ValueError):
             return 0
+    if setting == "interim_assistant_spacing":
+        value = str(value or "dense").lower()
+        return value if value in {"dense", "spaced"} else "dense"
     return value

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13981,6 +13981,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if source.platform == Platform.TELEGRAM
                             else 0.0
                         )
+                        _interim_spacing = resolve_display_setting(
+                            user_config,
+                            platform_key,
+                            "interim_assistant_spacing",
+                            "dense",
+                        )
                         _consumer_cfg = StreamConsumerConfig(
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
@@ -13989,6 +13995,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             fresh_final_after_seconds=_fresh_final_secs,
                             transport=_scfg.transport or "edit",
                             chat_type=getattr(source, "chat_type", "") or "",
+                            interim_assistant_spacing=_interim_spacing,
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,
@@ -14021,10 +14028,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 if already_streamed or not _status_adapter or not str(text or "").strip():
                     return
+                try:
+                    from gateway.stream_consumer import GatewayStreamConsumer
+                    display_text = GatewayStreamConsumer.format_interim_commentary(
+                        text,
+                        resolve_display_setting(
+                            user_config,
+                            platform_key,
+                            "interim_assistant_spacing",
+                            "dense",
+                        ),
+                    )
+                except Exception:
+                    logger.debug("interim commentary formatting failed", exc_info=True)
+                    display_text = str(text)
                 safe_schedule_threadsafe(
                     _status_adapter.send(
                         _status_chat_id,
-                        text,
+                        display_text,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -74,6 +74,11 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+    # Formatting for interim assistant commentary messages. "dense" preserves
+    # legacy single-newline rendering; "spaced" adds breathing room inside
+    # prose-only updates and after each interim bubble while preserving
+    # Markdown structures.
+    interim_assistant_spacing: str = "dense"
 
 
 class GatewayStreamConsumer:
@@ -1066,9 +1071,76 @@ class GatewayStreamConsumer:
         except Exception:
             pass  # best-effort — don't let this block the fallback path
 
+    @staticmethod
+    def _is_markdown_structure_line(line: str) -> bool:
+        """Return True for lines whose single-newline layout is meaningful."""
+        stripped = line.strip()
+        if not stripped:
+            return True
+        if stripped.startswith(("```", "> ", "# ", "## ", "### ", "#### ", "##### ", "###### ")):
+            return True
+        if re.match(r"^([-*+]\s+|\d+[.)]\s+)", stripped):
+            return True
+        if "|" in stripped and stripped.count("|") >= 2:
+            return True
+        return False
+
+    @classmethod
+    def _space_commentary_for_display(cls, text: str) -> str:
+        """Add breathing room between batched prose-only interim updates.
+
+        Discord and several mobile clients render single-newline paragraphs as
+        one dense block.  Interim assistant updates can be batched into one
+        commentary send, so separate plain prose lines with blank lines while
+        preserving Markdown lists, tables, blockquotes, headings, and fenced
+        code blocks where single-newline structure is significant.
+        """
+        if "\n" not in text:
+            return text
+
+        lines = text.split("\n")
+        spaced: list[str] = []
+        in_fence = False
+        for line in lines:
+            stripped = line.strip()
+            starts_or_ends_fence = stripped.startswith("```")
+            if spaced and stripped and spaced[-1].strip():
+                prev = spaced[-1]
+                prev_stripped = prev.strip()
+                preserve_tight = (
+                    in_fence
+                    or starts_or_ends_fence
+                    or prev_stripped.startswith("```")
+                    or prev_stripped.endswith(":")
+                    or cls._is_markdown_structure_line(prev)
+                    or cls._is_markdown_structure_line(line)
+                )
+                if not preserve_tight:
+                    spaced.append("")
+            spaced.append(line)
+            if starts_or_ends_fence:
+                in_fence = not in_fence
+        return "\n".join(spaced)
+
+    @classmethod
+    def format_interim_commentary(cls, text: str, spacing: str = "dense") -> str:
+        """Clean and format interim assistant commentary for display."""
+        cleaned = cls._clean_for_display(str(text or ""))
+        if str(spacing or "dense").lower() == "spaced":
+            cleaned = cls._space_commentary_for_display(cleaned)
+            if cleaned.strip():
+                # Discord trims trailing blank lines. Anchor the gap with a
+                # zero-width space so separate interim bubbles do not visually
+                # pile up, while still leaving the message content unchanged.
+                return cleaned.rstrip() + "\n\u200b"
+        return cleaned
+
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
-        text = self._clean_for_display(text)
+        text = self.format_interim_commentary(
+            text,
+            getattr(self.cfg, "interim_assistant_spacing", "dense"),
+        )
         if not text.strip():
             return False
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1469,6 +1469,7 @@ DEFAULT_CONFIG = {
             "last_lines": 2,
         },
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
+        "interim_assistant_spacing": "dense",  # Gateway: dense | spaced formatting for batched interim assistant messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -78,6 +78,27 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
+    def test_interim_assistant_spacing_defaults_to_dense(self):
+        """Interim assistant spacing preserves legacy dense rendering by default."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "discord", "interim_assistant_spacing") == "dense"
+
+    def test_interim_assistant_spacing_global_and_platform_override(self):
+        """Interim assistant spacing supports global and platform-specific values."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "interim_assistant_spacing": "dense",
+                "platforms": {
+                    "discord": {"interim_assistant_spacing": "spaced"},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "discord", "interim_assistant_spacing") == "spaced"
+        assert resolve_display_setting(config, "telegram", "interim_assistant_spacing") == "dense"
+
 
 # ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides

--- a/tests/gateway/test_stream_consumer_commentary_spacing.py
+++ b/tests/gateway/test_stream_consumer_commentary_spacing.py
@@ -1,0 +1,107 @@
+"""Regression tests for gateway interim commentary readability."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _make_adapter():
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_commentary_send_defaults_to_dense_updates():
+    """Dense mode preserves old single-newline rendering by default."""
+    adapter = _make_adapter()
+    consumer = GatewayStreamConsumer(adapter, "chat_123")
+
+    await consumer._send_commentary(
+        "I'll check the repo state.\n"
+        "Source is clean and committed locally.\n"
+        "Tests are green; I'm pushing now."
+    )
+
+    sent = adapter.send.call_args.kwargs["content"]
+    assert sent == (
+        "I'll check the repo state.\n"
+        "Source is clean and committed locally.\n"
+        "Tests are green; I'm pushing now."
+    )
+
+
+@pytest.mark.asyncio
+async def test_commentary_send_spaces_batched_prose_updates_when_configured():
+    """Spaced mode separates prose updates and adds a preserved bubble gap."""
+    adapter = _make_adapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        config=StreamConsumerConfig(interim_assistant_spacing="spaced"),
+    )
+
+    await consumer._send_commentary(
+        "I'll check the repo state.\n"
+        "Memory says there were several POC commits.\n"
+        "Source is clean and committed locally.\n"
+        "Tests are green; I'm pushing now."
+    )
+
+    sent = adapter.send.call_args.kwargs["content"]
+    assert sent == (
+        "I'll check the repo state.\n\n"
+        "Memory says there were several POC commits.\n\n"
+        "Source is clean and committed locally.\n\n"
+        "Tests are green; I'm pushing now.\n\u200b"
+    )
+
+
+@pytest.mark.asyncio
+async def test_commentary_send_spaced_single_line_adds_preserved_message_gap():
+    """Spaced mode gives separate single-line interim bubbles visual room."""
+    adapter = _make_adapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        config=StreamConsumerConfig(interim_assistant_spacing="spaced"),
+    )
+
+    await consumer._send_commentary("I'm checking the gateway path.")
+
+    sent = adapter.send.call_args.kwargs["content"]
+    assert sent == "I'm checking the gateway path.\n\u200b"
+
+
+@pytest.mark.asyncio
+async def test_commentary_spacing_preserves_lists_and_code_blocks():
+    """Readability spacing must not explode normal Markdown structures."""
+    adapter = _make_adapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        config=StreamConsumerConfig(interim_assistant_spacing="spaced"),
+    )
+
+    await consumer._send_commentary(
+        "Validation:\n"
+        "- py_compile passed\n"
+        "- pytest passed\n"
+        "```bash\n"
+        "python -m pytest tests/gateway -q\n"
+        "```"
+    )
+
+    sent = adapter.send.call_args.kwargs["content"]
+    assert sent == (
+        "Validation:\n"
+        "- py_compile passed\n"
+        "- pytest passed\n"
+        "```bash\n"
+        "python -m pytest tests/gateway -q\n"
+        "```\n\u200b"
+    )

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -938,6 +938,9 @@ class TestInterimAssistantMessageConfig:
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
 
+    def test_default_config_uses_dense_interim_assistant_spacing(self):
+        assert DEFAULT_CONFIG["display"]["interim_assistant_spacing"] == "dense"
+
     def test_migrate_to_v15_adds_interim_assistant_message_gate(self, tmp_path):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1250,6 +1250,7 @@ display:
   platforms: {}           # Per-platform display overrides (see below)
   tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  interim_assistant_spacing: dense   # Gateway: dense | spaced formatting for interim updates
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
@@ -1348,7 +1349,7 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
-`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming. Use `interim_assistant_spacing: dense` to preserve legacy compact formatting, or `spaced` to add blank lines between prose-only lines and a small preserved gap after each interim update bubble. The spacing option can also be set per platform under `display.platforms.<platform>.interim_assistant_spacing`.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary
- add `display.interim_assistant_spacing` with `dense` default and `spaced` opt-in
- support per-platform overrides via `display.platforms.<platform>.interim_assistant_spacing`
- keep `dense` as legacy compact interim-commentary formatting
- make `spaced` add blank lines between prose-only lines and a small preserved visual gap after each interim update bubble
- preserve Markdown list/table/code-block structure when spacing prose-only interim assistant updates
- apply the same formatting path to stream-consumer commentary and fallback interim sends
- document the option in the configuration guide

## Validation
- `python -m py_compile gateway/run.py gateway/stream_consumer.py gateway/display_config.py hermes_cli/config.py`
- `python -m pytest -q tests/gateway/test_stream_consumer_commentary_spacing.py tests/gateway/test_display_config.py::TestResolveDisplaySetting::test_interim_assistant_spacing_defaults_to_dense tests/gateway/test_display_config.py::TestResolveDisplaySetting::test_interim_assistant_spacing_global_and_platform_override tests/hermes_cli/test_config.py::TestInterimAssistantMessageConfig -o 'addopts='`

## Status
Draft while we tune the exact visual behavior in Discord.