### PR TITLE
feat(xai): add xai code execution tool

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1624,8 +1624,24 @@ DEFAULT_CONFIG = {
         "retries": 2,
     },
 
+    # xAI hosted code execution via the Responses API code_interpreter tool.
+    # This is separate from local Hermes code_execution; code runs in xAI's
+    # server-side sandbox. Requires xAI credentials and the xai_code_execution
+    # toolset to be enabled in `hermes tools`.
+    "xai_code_execution": {
+        # xAI reasoning model used for the Responses call. The official xAI
+        # code execution examples use grok-4.3.
+        "model": "grok-4.3",
+        # Request timeout in seconds (minimum 30). Code execution can take
+        # longer than plain chat for data analysis and plotting tasks.
+        "timeout_seconds": 180,
+        # Number of automatic retries on 5xx / Timeout / ConnectionError.
+        # Each retry backs off (1.5x attempt seconds, capped at 5s).
+        "retries": 2,
+    },
+
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2108,24 +2108,30 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if project_root is None:
         project_root = PROJECT_ROOT
 
+    def is_accessible_dir(path: Path) -> bool:
+        try:
+            return path.is_dir()
+        except OSError:
+            return False
+
     candidates = []
 
     venv_bin = project_root / "venv" / "bin"
-    if venv_bin.is_dir():
+    if is_accessible_dir(venv_bin):
         candidates.append(str(venv_bin))
     elif sys.prefix != sys.base_prefix:
         candidates.append(str(Path(sys.prefix) / "bin"))
 
     node_bin = project_root / "node_modules" / ".bin"
-    if node_bin.is_dir():
+    if is_accessible_dir(node_bin):
         candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
-    if hermes_node.is_dir():
+    if is_accessible_dir(hermes_node):
         candidates.append(str(hermes_node))
     hermes_nm = hermes_home / "node_modules" / ".bin"
-    if hermes_nm.is_dir():
+    if is_accessible_dir(hermes_nm):
         candidates.append(str(hermes_nm))
 
     return candidates

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -62,6 +62,7 @@ CONFIGURABLE_TOOLSETS = [
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
+    ("xai_code_execution", "🧮 xAI Code Execution",      "xai_code_execution (server-side sandbox; requires xAI credentials)"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -92,7 +93,7 @@ CONFIGURABLE_TOOLSETS = [
 # or XAI_API_KEY). Users opt in via `hermes tools` → X (Twitter) Search,
 # which walks them through credential setup. The tool's check_fn means
 # the schema won't appear to the model even if enabled without credentials.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "xai_code_execution"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset
@@ -325,6 +326,38 @@ TOOL_CATEGORIES = {
             "(uses your subscription quota instead of API spend)."
         ),
         "icon": "🐦",
+        "providers": [
+            {
+                "name": "xAI Grok OAuth (SuperGrok Subscription)",
+                "badge": "subscription",
+                "tag": "Browser login at accounts.x.ai — no API key required",
+                "env_vars": [],
+                "post_setup": "xai_grok",
+            },
+            {
+                "name": "xAI API key",
+                "badge": "paid",
+                "tag": "Direct xAI API billing via XAI_API_KEY",
+                "env_vars": [
+                    {
+                        "key": "XAI_API_KEY",
+                        "prompt": "xAI API key",
+                        "url": "https://console.x.ai/",
+                    },
+                ],
+            },
+        ],
+    },
+    "xai_code_execution": {
+        "name": "xAI Code Execution",
+        "setup_title": "Select xAI Credential Source",
+        "setup_note": (
+            "Hermes routes code-backed analysis through xAI's hosted "
+            "code_interpreter Responses tool. Code runs in xAI's server-side "
+            "sandbox, not on this machine. SuperGrok OAuth is preferred when "
+            "both credential sources are set."
+        ),
+        "icon": "🧮",
         "providers": [
             {
                 "name": "xAI Grok OAuth (SuperGrok Subscription)",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -77,6 +77,13 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+
+def test_configurable_toolsets_include_xai_code_execution_default_off():
+    assert any(ts_key == "xai_code_execution" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+    assert "xai_code_execution" in _DEFAULT_OFF_TOOLSETS
+    assert "xai_code_execution" in TOOL_CATEGORIES
+
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -32,6 +32,11 @@ class TestGetToolset:
         assert ts is not None
         assert "web_search" in ts["tools"]
 
+    def test_xai_code_execution_toolset(self):
+        ts = get_toolset("xai_code_execution")
+        assert ts is not None
+        assert ts["tools"] == ["xai_code_execution"]
+
     def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
         reg = ToolRegistry()
         reg.register(

--- a/tests/tools/test_xai_code_execution_tool.py
+++ b/tests/tools/test_xai_code_execution_tool.py
@@ -1,0 +1,355 @@
+"""Tests for xAI hosted code execution via the Responses API."""
+
+import json
+
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def _no_xai_env(monkeypatch):
+    for var in ("XAI_API_KEY", "XAI_BASE_URL", "HERMES_XAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_xai_code_execution_posts_responses_request(monkeypatch):
+    from hermes_cli import __version__
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "The result is 55.",
+                "tool_calls": [{"type": "code_interpreter", "id": "call_1"}],
+                "server_side_tool_usage": {"code_interpreter": 1},
+                "usage": {"input_tokens": 12, "output_tokens": 8},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_code_execution_tool(
+            prompt="Use Python to sum integers from 1 through 10."
+        )
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["Authorization"] == "Bearer xai-test-key"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.3"
+    assert captured["json"]["store"] is False
+    assert captured["json"]["tools"] == [{"type": "code_interpreter"}]
+    assert captured["json"]["input"][0]["content"] == (
+        "Use Python to sum integers from 1 through 10."
+    )
+    assert captured["timeout"] == 180
+    assert result["success"] is True
+    assert result["tool"] == "xai_code_execution"
+    assert result["xai_tool"] == "code_interpreter"
+    assert result["answer"] == "The result is 55."
+    assert result["tool_calls"] == [{"type": "code_interpreter", "id": "call_1"}]
+    assert result["server_side_tool_usage"] == {"code_interpreter": 1}
+    assert result["usage"] == {"input_tokens": 12, "output_tokens": 8}
+
+
+def test_xai_code_execution_empty_prompt_returns_tool_error(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(xai_code_execution_tool(prompt="  "))
+
+    assert result["error"] == "prompt is required for xai_code_execution"
+
+
+def test_xai_code_execution_extracts_output_and_code_calls(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "code_interpreter_call",
+                        "id": "ci_1",
+                        "code": "sum(range(1, 11))",
+                        "outputs": [{"type": "logs", "logs": "55"}],
+                    },
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Python returns 55.",
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_execution_tool(prompt="Calculate 1+...+10"))
+
+    assert result["success"] is True
+    assert result["answer"] == "Python returns 55."
+    assert result["code_interpreter_calls"] == [
+        {
+            "type": "code_interpreter_call",
+            "id": "ci_1",
+            "code": "sum(range(1, 11))",
+            "outputs": [{"type": "logs", "logs": "55"}],
+        }
+    ]
+
+
+def test_xai_code_execution_normalizes_single_tool_call(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output_text": "Code ran.",
+                "tool_calls": {"type": "code_interpreter", "id": "call_1"},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_execution_tool(prompt="run code"))
+
+    assert result["success"] is True
+    assert result["tool_calls"] == [{"type": "code_interpreter", "id": "call_1"}]
+
+
+def test_xai_code_execution_returns_structured_http_error(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"code_interpreter is not enabled"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "code_interpreter is not enabled",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate pi"))
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "xai_code_execution"
+    assert result["xai_tool"] == "code_interpreter"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: code_interpreter is not enabled"
+
+
+def test_xai_code_execution_http_error_supports_nested_error_message(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    class _FailingResponse:
+        status_code = 400
+        text = '{"error":{"message":"bad request"}}'
+
+        def json(self):
+            return {"error": {"message": "bad request"}}
+
+        def raise_for_status(self):
+            err = requests.HTTPError("400 Client Error: Bad Request")
+            err.response = self
+            raise err
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate pi"))
+
+    assert result["success"] is False
+    assert result["error"] == "bad request"
+
+
+def test_xai_code_execution_retries_timeout_then_succeeds(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse({"output_text": "Recovered after retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_code_execution_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_xai_code_execution_retries_5xx_then_succeeds(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "server_error", "error": "temporary failure"},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_code_execution_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."
+
+
+def test_xai_code_execution_uses_xai_oauth_when_available(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_code_execution_tool import (
+        check_xai_code_execution_requirements,
+        xai_code_execution_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+
+    def _fake_resolve():
+        return {
+            "provider": "xai-oauth",
+            "api_key": "oauth-bearer-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.xai_code_execution_tool.resolve_xai_http_credentials",
+        _fake_resolve,
+    )
+    invalidate_check_fn_cache()
+
+    assert check_xai_code_execution_requirements() is True
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        return _FakeResponse({"output_text": "OAuth worked."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate"))
+
+    assert result["success"] is True
+    assert result["credential_source"] == "xai-oauth"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-bearer-token"
+
+
+def test_xai_code_execution_returns_tool_error_when_no_credentials(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_code_execution_tool import (
+        check_xai_code_execution_requirements,
+        xai_code_execution_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+
+    def _fake_resolve():
+        return {
+            "provider": "xai",
+            "api_key": "",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "tools.xai_code_execution_tool.resolve_xai_http_credentials",
+        _fake_resolve,
+    )
+    invalidate_check_fn_cache()
+
+    assert check_xai_code_execution_requirements() is False
+
+    result = xai_code_execution_tool(prompt="calculate")
+    assert "No xAI credentials available" in result
+    assert "hermes auth add xai-oauth" in result
+
+
+def test_xai_code_execution_honors_config_model_timeout_and_retries(monkeypatch):
+    from tools.xai_code_execution_tool import xai_code_execution_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr(
+        "tools.xai_code_execution_tool._load_xai_code_execution_config",
+        lambda: {"model": "grok-custom-test", "timeout_seconds": 45, "retries": 0},
+    )
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["model"] = json["model"]
+        captured["timeout"] = timeout
+        return _FakeResponse({"output_text": "Custom config OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_execution_tool(prompt="calculate"))
+
+    assert result["success"] is True
+    assert captured["model"] == "grok-custom-test"
+    assert captured["timeout"] == 45
+
+
+def test_xai_code_execution_registered_in_registry_with_check_fn():
+    import tools.xai_code_execution_tool  # noqa: F401 - ensures registration runs
+    from tools.registry import registry
+
+    entry = registry.get_entry("xai_code_execution")
+    assert entry is not None
+    assert entry.toolset == "xai_code_execution"
+    assert entry.check_fn is not None
+    assert entry.check_fn.__name__ == "check_xai_code_execution_requirements"
+    assert "XAI_API_KEY" in entry.requires_env
+    assert entry.emoji == "🧮"

--- a/tools/xai_code_execution_tool.py
+++ b/tools/xai_code_execution_tool.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""xAI server-side code execution via the Responses API.
+
+This tool is intentionally separate from Hermes' local ``execute_code`` tool.
+It asks Grok to solve a natural-language task while giving it xAI's hosted
+``code_interpreter`` sandbox, so code runs on xAI infrastructure rather than on
+the user's machine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_CODE_EXECUTION_MODEL = "grok-4.3"
+DEFAULT_XAI_CODE_EXECUTION_TIMEOUT_SECONDS = 180
+DEFAULT_XAI_CODE_EXECUTION_RETRIES = 2
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_xai_code_execution_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("xai_code_execution", {}) or {}
+    except Exception:
+        return {}
+
+
+def _get_xai_code_execution_model() -> str:
+    cfg = _load_xai_code_execution_config()
+    return (
+        str(cfg.get("model") or "").strip()
+        or DEFAULT_XAI_CODE_EXECUTION_MODEL
+    )
+
+
+def _get_xai_code_execution_timeout_seconds() -> int:
+    cfg = _load_xai_code_execution_config()
+    raw_value = cfg.get(
+        "timeout_seconds",
+        DEFAULT_XAI_CODE_EXECUTION_TIMEOUT_SECONDS,
+    )
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_CODE_EXECUTION_TIMEOUT_SECONDS
+
+
+def _get_xai_code_execution_retries() -> int:
+    cfg = _load_xai_code_execution_config()
+    raw_value = cfg.get("retries", DEFAULT_XAI_CODE_EXECUTION_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_CODE_EXECUTION_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_xai_bearer() -> Tuple[str, str, str]:
+    """Return ``(api_key, base_url, source)`` or raise on missing credentials."""
+    creds = resolve_xai_http_credentials()
+    api_key = str(creds.get("api_key") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "No xAI credentials available. Run `hermes auth add xai-oauth` "
+            "to sign in with your SuperGrok subscription, or set XAI_API_KEY."
+        )
+    base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    source = str(creds.get("provider") or "xai")
+    return api_key, base_url, source
+
+
+def check_xai_code_execution_requirements() -> bool:
+    """Return True when xAI credentials are available and non-empty."""
+    try:
+        creds = resolve_xai_http_credentials()
+        return bool(str(creds.get("api_key") or "").strip())
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_code_interpreter_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    calls: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "")
+        if item_type in ("code_interpreter_call", "code_execution_call"):
+            calls.append(item)
+    return calls
+
+
+def _extract_tool_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_calls = payload.get("tool_calls") or []
+    if isinstance(raw_calls, dict):
+        return [raw_calls]
+    if isinstance(raw_calls, list):
+        return [call for call in raw_calls if isinstance(call, dict)]
+    return []
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error_value = payload.get("error")
+        if isinstance(error_value, dict):
+            error = str(error_value.get("message") or "").strip()
+        else:
+            error = str(error_value or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+
+def xai_code_execution_tool(prompt: str) -> str:
+    if not prompt or not prompt.strip():
+        return tool_error("prompt is required for xai_code_execution")
+
+    try:
+        api_key, base_url, source = _resolve_xai_bearer()
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+
+    try:
+        payload = {
+            "model": _get_xai_code_execution_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": prompt.strip(),
+                }
+            ],
+            "tools": [{"type": "code_interpreter"}],
+            "store": False,
+        }
+
+        timeout_seconds = _get_xai_code_execution_timeout_seconds()
+        max_retries = _get_xai_code_execution_retries()
+        response: Optional[requests.Response] = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{base_url}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_code_execution upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.Timeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_code_execution transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("xai_code_execution request did not return a response")
+
+        data = response.json()
+        answer = _extract_response_text(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "credential_source": source,
+                "tool": "xai_code_execution",
+                "xai_tool": "code_interpreter",
+                "model": payload["model"],
+                "prompt": prompt.strip(),
+                "answer": answer,
+                "tool_calls": _extract_tool_calls(data),
+                "code_interpreter_calls": _extract_code_interpreter_calls(data),
+                "server_side_tool_usage": data.get("server_side_tool_usage") or {},
+                "usage": data.get("usage") or {},
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("xai_code_execution failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_execution",
+                "xai_tool": "code_interpreter",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.Timeout as e:
+        logger.error("xai_code_execution timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_execution",
+                "xai_tool": "code_interpreter",
+                "error": (
+                    "xAI code execution timed out after "
+                    f"{_get_xai_code_execution_timeout_seconds()} seconds"
+                ),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("xai_code_execution failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_execution",
+                "xai_tool": "code_interpreter",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+XAI_CODE_EXECUTION_SCHEMA = {
+    "name": "xai_code_execution",
+    "description": (
+        "Ask Grok to solve a task using xAI's hosted code_interpreter "
+        "sandbox. Use this for calculations, data analysis, simulations, or "
+        "Python-backed verification when the user wants xAI/Grok server-side "
+        "code execution rather than local Hermes execute_code."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Natural-language task or data for Grok to analyze using "
+                    "xAI's server-side Python sandbox."
+                ),
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _handle_xai_code_execution(args, **kw):
+    if not isinstance(args, dict):
+        args = {}
+    return xai_code_execution_tool(prompt=args.get("prompt", ""))
+
+
+registry.register(
+    name="xai_code_execution",
+    toolset="xai_code_execution",
+    schema=XAI_CODE_EXECUTION_SCHEMA,
+    handler=_handle_xai_code_execution,
+    check_fn=check_xai_code_execution_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🧮",
+    max_result_size_chars=100_000,
+)

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -2,24 +2,24 @@
 
 from __future__ import annotations
 
-import os
 from typing import Dict
-
-try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
-except Exception:
-    _hermes_get_env_value = None
+import os
 
 
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
-    Wraps :func:`hermes_cli.config.get_env_value` so tests can patch
-    ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
-    xAI credential resolver.
+    Import the Hermes helper at call time so tests that temporarily patch or
+    reload ``hermes_cli.config`` cannot leave this module holding a stale
+    patched function.
     """
-    if _hermes_get_env_value is not None:
-        value = _hermes_get_env_value(name)
+    try:
+        from hermes_cli.config import get_env_value as hermes_get_env_value
+    except Exception:
+        hermes_get_env_value = None
+
+    if hermes_get_env_value is not None:
+        value = hermes_get_env_value(name)
         if value is not None:
             return value
     return os.environ.get(name, default)

--- a/toolsets.py
+++ b/toolsets.py
@@ -99,6 +99,17 @@ TOOLSETS = {
         "tools": ["x_search"],
         "includes": []
     },
+
+    "xai_code_execution": {
+        "description": (
+            "Run calculations and data analysis through xAI's hosted "
+            "code_interpreter Responses tool. This is separate from local "
+            "Hermes execute_code; code runs in xAI's server-side sandbox. "
+            "Off by default; enable in `hermes tools` → xAI Code Execution."
+        ),
+        "tools": ["xai_code_execution"],
+        "includes": []
+    },
     
     "vision": {
         "description": "Image analysis and vision tools",


### PR DESCRIPTION
## Summary

Adds an opt-in `xai_code_execution` toolset and tool for xAI hosted Code Execution through the Responses API `code_interpreter` tool. This is separate from Hermes' local `execute_code`: code runs in xAI's server-side sandbox and uses existing xAI API key / Grok OAuth credential resolution.

The PR also wires the tool into Hermes config, static toolsets, and the tools setup UI, with the new toolset default-off for new installs.

## Notes

- Default model is `grok-4.3`, matching the current xAI Code Execution docs examples.
- Requests use `POST /v1/responses` with `tools: [{"type": "code_interpreter"}]` and `store: false`.
- Response output includes the final answer, server-side code interpreter calls when returned, server-side usage, token usage, and credential source.
- Includes small CI hygiene fixes already needed on current upstream main: ACP manifest version/package update, dynamic `xai_http.get_env_value` import, and gateway service path permission guard.

## Validation

- `uv run --extra dev pytest tests/tools/test_xai_code_execution_tool.py tests/tools/test_x_search_tool.py tests/hermes_cli/test_tools_config.py tests/test_toolsets.py -q` → 120 passed
- `uv run --extra dev pytest tests/acp/test_registry_manifest.py tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome tests/tools/test_transcription_dotenv_fallback.py -q` → 19 passed
- `uv run --extra dev ruff check tools/xai_code_execution_tool.py tools/xai_http.py hermes_cli/config.py hermes_cli/tools_config.py hermes_cli/gateway.py toolsets.py tests/tools/test_xai_code_execution_tool.py tests/hermes_cli/test_tools_config.py tests/test_toolsets.py` → passed
- `git diff --check` → passed
- `uv run --extra dev python -m py_compile tools/xai_code_execution_tool.py` → passed

Dogfood on my main Hermes instance (Alfred/mac-mini) with the real xAI API key succeeded:

```json
{
  "success": true,
  "tool": "xai_code_execution",
  "xai_tool": "code_interpreter",
  "model": "grok-4.3",
  "answer": "83810205 (code was used)",
  "code_interpreter_calls_count": 2
}
```
