### PR TITLE
fix(model-switch): probe /models for custom providers without api_key

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1688,7 +1688,11 @@ def list_authenticated_providers(
                 continue
             # Live model discovery from custom provider endpoints (matches
             # Section 3 behavior for user ``providers:`` entries).
-            if api_url and api_key:
+            # Also probes when no api_key is set (e.g. local llama.cpp /
+            # Ollama servers) — the /models endpoint often works without
+            # auth.  The CLI's _model_flow_named_custom always probes, so
+            # the Telegram/Discord picker should do the same for parity.
+            if api_url:
                 try:
                     from hermes_cli.models import fetch_api_models
 


### PR DESCRIPTION
## Summary

The Telegram/Discord model picker skipped live model discovery for custom providers (llama.cpp, Ollama) unless an `api_key` was configured. Local providers typically don't require authentication on the `/models` endpoint.

The CLI's `_model_flow_named_custom` always probes `/models`, so this brings the gateway picker into parity.

## Change

**File:** `hermes_cli/model_switch.py`

```diff
-            if api_url and api_key:
+            if api_url:
```

## Testing

- Verified locally: selecting llama.cpp in Telegram now shows the full list of available models from the `/models` endpoint instead of only the static `model` field.
