### PR TITLE
fix(api-server): restore notify_on_complete routing for background terminal tasks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -35,6 +35,7 @@ import re
 import sqlite3
 import time
 import uuid
+from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 try:
@@ -50,6 +51,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.session import SessionSource, build_session_key
 
 logger = logging.getLogger(__name__)
 
@@ -635,6 +637,45 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self.gateway_runner = None
+
+    @staticmethod
+    def _build_gateway_session_source(
+        session_id: Optional[str],
+        gateway_session_key: Optional[str],
+    ) -> tuple[SessionSource, str]:
+        """Return a stable synthetic gateway source for API-server turns.
+
+        API clients may use arbitrary ``X-Hermes-Session-Key`` values such as
+        ``webui:user-42`` that are not valid gateway ``session_key`` strings.
+        Background process notifications, however, route through the gateway's
+        synthetic-event machinery which expects a parseable
+        ``agent:main:<platform>:<chat_type>:<chat_id>`` key.
+
+        Use a deterministic hash as the synthetic chat_id so the session remains
+        stable across turns without leaking raw client-provided identifiers into
+        the gateway routing grammar.
+        """
+        raw_scope = (gateway_session_key or session_id or "api_server").strip() or "api_server"
+        digest = hashlib.sha256(raw_scope.encode("utf-8")).hexdigest()[:16]
+        chat_id = f"api-{digest}"
+        source = SessionSource(
+            platform=Platform.API_SERVER,
+            chat_id=chat_id,
+            chat_name=gateway_session_key or session_id or chat_id,
+            chat_type="dm",
+            user_id=chat_id,
+            user_name="api_server",
+        )
+        return source, build_session_key(source)
+
+    async def _schedule_pending_process_watchers(self, watchers: List[Dict[str, Any]]) -> None:
+        """Start any new background-process watcher tasks via the live gateway runner."""
+        runner = getattr(self, "gateway_runner", None)
+        if not runner or not watchers:
+            return
+        for watcher in watchers:
+            asyncio.create_task(runner._run_process_watcher(watcher))
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -2722,8 +2763,15 @@ class APIServerAdapter(BasePlatformAdapter):
         another thread to stop in-progress LLM calls.
         """
         loop = asyncio.get_running_loop()
+        session_source, gateway_bg_session_key = self._build_gateway_session_source(
+            session_id=session_id,
+            gateway_session_key=gateway_session_key,
+        )
 
         def _run():
+            from gateway.session_context import clear_session_vars, set_session_vars
+            from tools.process_registry import process_registry
+
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -2736,25 +2784,42 @@ class APIServerAdapter(BasePlatformAdapter):
             if agent_ref is not None:
                 agent_ref[0] = agent
             effective_task_id = session_id or str(uuid.uuid4())
-            result = agent.run_conversation(
-                user_message=user_message,
-                conversation_history=conversation_history,
-                task_id=effective_task_id,
+            session_tokens = set_session_vars(
+                platform=session_source.platform.value,
+                chat_id=session_source.chat_id,
+                chat_name=session_source.chat_name or "",
+                thread_id="",
+                user_id=session_source.user_id or "",
+                user_name=session_source.user_name or "",
+                session_key=gateway_bg_session_key,
             )
-            usage = {
-                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-            }
-            # Include the effective session ID in the result so callers
-            # (e.g. X-Hermes-Session-Id header) can track compression-
-            # triggered session rotations. (#16938)
-            _eff_sid = getattr(agent, "session_id", session_id)
-            if isinstance(_eff_sid, str) and _eff_sid:
-                result["session_id"] = _eff_sid
-            return result, usage
+            try:
+                result = agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=conversation_history,
+                    task_id=effective_task_id,
+                )
+                usage = {
+                    "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                    "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                    "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                }
+                # Include the effective session ID in the result so callers
+                # (e.g. X-Hermes-Session-Id header) can track compression-
+                # triggered session rotations. (#16938)
+                _eff_sid = getattr(agent, "session_id", session_id)
+                if isinstance(_eff_sid, str) and _eff_sid:
+                    result["session_id"] = _eff_sid
+                pending_watchers = list(process_registry.pending_watchers)
+                process_registry.pending_watchers.clear()
+                return result, usage, pending_watchers
+            finally:
+                with suppress(Exception):
+                    clear_session_vars(session_tokens)
 
-        return await loop.run_in_executor(None, _run)
+        result, usage, pending_watchers = await loop.run_in_executor(None, _run)
+        await self._schedule_pending_process_watchers(pending_watchers)
+        return result, usage
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming
@@ -2976,18 +3041,28 @@ class APIServerAdapter(BasePlatformAdapter):
                         set_current_session_key,
                         unregister_gateway_notify,
                     )
+                    from tools.process_registry import process_registry
 
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
+                    session_source, gateway_bg_session_key = self._build_gateway_session_source(
+                        session_id=session_id,
+                        gateway_session_key=gateway_session_key,
+                    )
                     try:
                         # Bind approval/session identity for this API run via
                         # contextvars so concurrent runs do not share process
                         # environment state.
                         approval_token = set_current_session_key(approval_session_key)
                         session_tokens = set_session_vars(
-                            platform="api_server",
-                            session_key=approval_session_key,
+                            platform=session_source.platform.value,
+                            chat_id=session_source.chat_id,
+                            chat_name=session_source.chat_name or "",
+                            thread_id="",
+                            user_id=session_source.user_id or "",
+                            user_name=session_source.user_name or "",
+                            session_key=gateway_bg_session_key,
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
                         r = agent.run_conversation(
@@ -2995,6 +3070,8 @@ class APIServerAdapter(BasePlatformAdapter):
                             conversation_history=conversation_history,
                             task_id=effective_task_id,
                         )
+                        pending_watchers = list(process_registry.pending_watchers)
+                        process_registry.pending_watchers.clear()
                     finally:
                         try:
                             unregister_gateway_notify(approval_session_key)
@@ -3014,9 +3091,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                     }
-                    return r, u
+                    return r, u, pending_watchers
 
-                result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                result, usage, pending_watchers = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+                await self._schedule_pending_process_watchers(pending_watchers)
                 # Check for structured failure (non-retryable client errors like
                 # 401/400 return failed=True instead of raising, so the except
                 # block below never fires — issue #15561).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5429,7 +5429,9 @@ class GatewayRunner:
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            return APIServerAdapter(config)
+            adapter = APIServerAdapter(config)
+            adapter.gateway_runner = self  # For background process watcher routing
+            return adapter
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import time
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -430,6 +431,78 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    async def test_run_agent_binds_parseable_gateway_session_context(self, adapter):
+        captured = {}
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def _run_conversation(**kwargs):
+            from gateway.session_context import get_session_env
+
+            captured["platform"] = get_session_env("HERMES_SESSION_PLATFORM", "")
+            captured["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID", "")
+            captured["session_key"] = get_session_env("HERMES_SESSION_KEY", "")
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = _run_conversation
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+                gateway_session_key="webui:user-42",
+            )
+
+        assert result["final_response"] == "ok"
+        assert captured["platform"] == "api_server"
+        assert captured["chat_id"].startswith("api-")
+        assert captured["session_key"].startswith("agent:main:api_server:dm:api-")
+
+    @pytest.mark.asyncio
+    async def test_run_agent_starts_pending_process_watchers_via_gateway_runner(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        watcher_seen = asyncio.Event()
+        captured = {}
+
+        async def _fake_run_process_watcher(watcher):
+            captured.update(watcher)
+            watcher_seen.set()
+
+        def _run_conversation(**kwargs):
+            from tools.process_registry import process_registry
+
+            process_registry.pending_watchers.append({
+                "session_id": "proc_123",
+                "check_interval": 5,
+                "session_key": "agent:main:api_server:dm:api-abc123",
+                "platform": "api_server",
+                "chat_id": "api-abc123",
+                "notify_on_complete": True,
+            })
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = _run_conversation
+        adapter.gateway_runner = SimpleNamespace(_run_process_watcher=_fake_run_process_watcher)
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+
+        assert result["final_response"] == "ok"
+        await asyncio.wait_for(watcher_seen.wait(), timeout=1.0)
+        assert captured["session_id"] == "proc_123"
+        assert captured["platform"] == "api_server"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1924,8 +1924,9 @@ def terminal_tool(
             # For non-local backends: runs inside the sandbox via env.execute().
             from tools.approval import get_current_session_key
             from tools.process_registry import process_registry
+            from gateway.session_context import get_session_env as _gse
 
-            session_key = get_current_session_key(default="")
+            session_key = _gse("HERMES_SESSION_KEY", "") or get_current_session_key(default="")
             effective_cwd = workdir or cwd
             try:
                 if env_type == "local":
@@ -1962,7 +1963,6 @@ def terminal_tool(
                 # watch-pattern and completion notifications can be
                 # routed back to the correct chat/thread.
                 if background and (notify_on_complete or watch_patterns):
-                    from gateway.session_context import get_session_env as _gse
                     _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
                     if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")


### PR DESCRIPTION
## Summary
API server runs were not binding a gateway-style session context, so background
terminal tasks started through the API/WebUI path could not register parseable
watcher routing metadata. Because of that, `notify_on_complete` could silently
fail for API-server sessions.

This patch restores the missing routing contract by:
- generating a stable synthetic `SessionSource` / `session_key` for API-server turns
- binding `HERMES_SESSION_*` contextvars during API-server agent execution
- draining `process_registry.pending_watchers` after API runs and scheduling them through the live gateway runner
- making terminal background session-key resolution prefer session contextvars

## Tests

| Command | Result |
| --- | --- |
| `uv run python -m pytest -q tests/gateway/test_api_server.py -k "run_agent_binds_parseable_gateway_session_context or run_agent_starts_pending_process_watchers_via_gateway_runner or run_agent_uses_session_id_as_task_id"` | `3 passed in 5.69s` |
| `uv run python -m pytest -q tests/gateway/test_api_server.py` | `148 passed, 95 warnings in 4.17s` |

