### PR TITLE
fix(agent): improve empty-response recovery with truncation fallback

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1486,21 +1486,60 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     )
             compressed.append(msg)
 
-        # If LLM summary failed, insert a static fallback so the model
-        # knows context was lost rather than silently dropping everything.
+        # If LLM summary failed, use truncation fallback: keep head + last N
+        # turns, discard the middle entirely. This is more robust than injecting
+        # a static placeholder that still consumes tokens without useful context.
+        # The truncation approach prevents the OOM / context-overflow errors
+        # that result from failed compression leaving the context too large.
         if not summary:
-            if not self.quiet_mode:
-                logger.warning("Summary generation failed — inserting static fallback context marker")
             n_dropped = compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
-            summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
-            )
+            if not self.quiet_mode:
+                logger.warning(
+                    "Summary generation failed — using truncation fallback "
+                    "(keep head + last %d messages, dropped %d middle messages)",
+                    n_messages - compress_end,
+                    n_dropped,
+                )
+            # Build truncated output: head messages + tail messages only,
+            # with a brief truncation notice between them.
+            truncated = []
+            for i in range(compress_start):
+                msg = messages[i].copy()
+                if i == 0 and msg.get("role") == "system":
+                    existing = msg.get("content")
+                    _truncation_note = (
+                        "[Note: Earlier conversation turns were truncated to free context space "
+                        "because summary generation failed. The current session state may still "
+                        "reflect earlier work — build on visible state rather than re-doing work. "
+                        "Your persistent memory (MEMORY.md, USER.md) remains fully authoritative.]"
+                    )
+                    if _truncation_note not in _content_text_for_contains(existing):
+                        msg["content"] = _append_text_to_content(
+                            existing,
+                            "\n\n" + _truncation_note if isinstance(existing, str) and existing else _truncation_note,
+                        )
+                truncated.append(msg)
+
+            for i in range(compress_end, n_messages):
+                truncated.append(messages[i].copy())
+
+            truncated = self._sanitize_tool_pairs(truncated)
+
+            self.compression_count += 1
+            new_estimate = estimate_messages_tokens_rough(truncated)
+            saved_estimate = display_tokens - new_estimate
+            savings_pct = (saved_estimate / display_tokens * 100) if display_tokens > 0 else 0
+            self._last_compression_savings_pct = savings_pct
+
+            if not self.quiet_mode:
+                logger.info(
+                    "Truncated (fallback): %d -> %d messages (~%d tokens saved, %.0f%%)",
+                    n_messages, len(truncated), saved_estimate, savings_pct,
+                )
+
+            return truncated
 
         _merge_summary_into_tail = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -138,7 +138,12 @@ DEFAULT_AGENT_IDENTITY = (
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations.\n\n"
+    "NEVER return empty content. If you are uncertain about what to do next, say so "
+    "explicitly (e.g. 'I need clarification on...' or 'I am unsure whether...'). "
+    "After executing tool calls, always process the tool results and continue with "
+    "your task or provide a summary of what was accomplished. An empty response "
+    "after tool execution means the user sees nothing — always produce visible output."
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (

--- a/run_agent.py
+++ b/run_agent.py
@@ -15471,9 +15471,7 @@ class AIAgent:
                             messages.append({
                                 "role": "user",
                                 "content": (
-                                    "You just executed tool calls but returned an "
-                                    "empty response. Please process the tool "
-                                    "results above and continue with the task."
+                                    "Continue with your task based on the tool results above."
                                 ),
                                 "_empty_recovery_synthetic": True,
                             })
@@ -15530,16 +15528,16 @@ class AIAgent:
                             _has_structured
                             and self._thinking_prefill_retries >= 2
                         )
-                        if _truly_empty and (not _has_structured or _prefill_exhausted) and self._empty_content_retries < 3:
+                        if _truly_empty and (not _has_structured or _prefill_exhausted) and self._empty_content_retries < 2:
                             self._empty_content_retries += 1
                             logger.warning(
                                 "Empty response (no content or reasoning) — "
-                                "retry %d/3 (model=%s)",
+                                "retry %d/2 (model=%s)",
                                 self._empty_content_retries, self.model,
                             )
                             self._emit_status(
                                 f"⚠️ Empty response from model — retrying "
-                                f"({self._empty_content_retries}/3)"
+                                f"({self._empty_content_retries}/2)"
                             )
                             continue
 


### PR DESCRIPTION
## Summary

When the LLM summarization-based context compression fails, Hermes currently injects a static placeholder string that still consumes tokens without providing useful context. This PR replaces that with a truncation fallback strategy.

## Changes

### `agent/context_compressor.py`
- Replace static fallback with truncation: keep head messages + last N messages, discard the middle
- Inject a brief truncation notice into the system message instead of a large placeholder
- Add logging for truncated message count and token savings

### `agent/prompt_builder.py`
- Add "NEVER return empty content" directive to `DEFAULT_AGENT_IDENTITY`
- Explicitly instruct the model to process tool results and produce visible output

### `run_agent.py`
- Simplify empty-response recovery prompt from verbose to concise
- Reduce empty-response retry limit from 3 to 2 (faster fail-forward)

## Motivation

The static fallback approach had two problems:
1. The placeholder itself consumed significant tokens without adding actionable context
2. Failed compression could leave the context oversized, causing OOM/context-overflow errors on the next turn

The truncation approach is more robust — it guarantees the context shrinks by dropping middle messages, while preserving the system prompt and recent conversation.

## Testing

- Verified truncation fallback fires correctly when summarization fails
- Confirmed context size reduction after truncation
- Model continues working after truncation with the notice in system prompt