### PR TITLE
fix: allow kanban children to stay/become ready when parent is running

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1525,11 +1525,11 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
+        # If child was ready but parent is not yet done nor running, demote child to todo.
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
-        if parent_status != "done":
+        if parent_status not in ("done", "running"):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -1844,7 +1844,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in {"done", "archived"} for p in parents):
+            if all(p["status"] in {"done", "archived", "running"} for p in parents):
                 conn.execute(
                     "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                     (task_id,),


### PR DESCRIPTION
## Problem

The kanban dependency engine forces **strict waterfall** between linked tasks. If parent A → child B, B stays in `todo` until A reaches `done`. But in real pipelines, children often only need the parent to have **started**, not completed.

Example: a research task spawns 5 analysis subtasks. The parent runs for 45 minutes. All 5 children sit blocked the entire time, even though none of them needs the parent's output.

## What this changes

Two functions, two lines each:

**`link_tasks`**: don't demote children from `ready` → `todo` when parent is `running`. Only demote when parent is truly blocked (neither done nor running).

**`recompute_ready`**: promote children to `ready` when all parents are in `{done, archived, running}`. Previously only `{done, archived}` counted, so running parents blocked everything downstream.

## Why this is safe

- This relaxes sequencing from "parent must FINISH" to "parent must have STARTED"
- If a child truly needs the parent's output, the child's own prompt/skill should gate on that
- The dependency edge already encodes ordering (A before B). This just removes the unnecessary completion requirement
- No DB schema changes, no API changes

## Pain point

I run a multi-stage kanban pipeline in production. The waterfall behavior halves throughput because every stage waits for the previous one to complete, even when downstream work can overlap. This is a 3-line fix that preserves the dependency contract while enabling parallel execution where it makes sense.