### PR TITLE
fix(nix): include messaging dependencies by default

### DIFF
--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -4,6 +4,7 @@
 # Users override via:
 #   pkgs.hermes-agent.override { extraPythonPackages = [...]; }
 #   pkgs.hermes-agent.override { extraDependencyGroups = [ "hindsight" ]; }
+#   pkgs.hermes-agent.override { includeMessagingDependencies = false; }
 {
   lib,
   stdenv,
@@ -28,12 +29,16 @@
   # Overridable parameters
   extraPythonPackages ? [ ],
   extraDependencyGroups ? [ ],
+  includeMessagingDependencies ? true,
 }:
 let
   nodejs = nodejs_22;
+  defaultDependencyGroups = [ "all" ] ++ lib.optional includeMessagingDependencies "messaging";
   hermesVenv = callPackage ./python.nix {
     inherit uv2nix pyproject-nix pyproject-build-systems;
-    dependency-groups = [ "all" ] ++ extraDependencyGroups;
+    dependency-groups =
+      defaultDependencyGroups
+      ++ lib.filter (group: !(lib.elem group defaultDependencyGroups)) extraDependencyGroups;
   };
 
   hermesNpmLib = callPackage ./lib.nix {

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -29,9 +29,9 @@
   let
     cfg = config.services.hermes-agent;
     effectivePackage =
-      if cfg.extraPythonPackages == [ ] && cfg.extraDependencyGroups == [ ]
+      if cfg.extraPythonPackages == [ ] && cfg.extraDependencyGroups == [ ] && cfg.includeMessagingDependencies
       then cfg.package
-      else cfg.package.override { inherit (cfg) extraPythonPackages extraDependencyGroups; };
+      else cfg.package.override { inherit (cfg) extraPythonPackages extraDependencyGroups includeMessagingDependencies; };
     hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
@@ -531,6 +531,17 @@
           Use extraPythonPackages for external packages not in pyproject.toml.
         '';
         example = [ "hindsight" ];
+      };
+
+      includeMessagingDependencies = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Include the messaging optional-dependency group in the sealed Python
+          venv by default. This provides Telegram, Discord, and Slack gateway
+          dependencies for Nix installs without runtime pip installs. Set to
+          false for minimal installs that do not use messaging platforms.
+        '';
       };
 
       restart = mkOption {

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -647,7 +647,7 @@ The package's `site-packages` is added to PYTHONPATH in the hermes wrapper. `imp
 
 ### Optional Dependency Groups (`extraDependencyGroups`)
 
-For optional extras already declared in hermes-agent's `pyproject.toml` (e.g., memory providers like `hindsight` or `honcho`), use `extraDependencyGroups` to include them in the sealed venv at build time:
+For optional extras already declared in hermes-agent's `pyproject.toml` (e.g., memory providers like `hindsight` or `honcho`), use `extraDependencyGroups` to include them in the sealed venv at build time. The Nix package includes `all` and, by default, `messaging`, so Telegram/Discord/Slack gateway dependencies are available for `nix run`, `nix profile install`, and the NixOS module without runtime pip installs.
 
 ```nix
 services.hermes-agent = {
@@ -658,11 +658,26 @@ services.hermes-agent = {
 
 This is resolved by uv alongside core dependencies in a single pass — no PYTHONPATH patching, no collision risk. Available groups match the `[project.optional-dependencies]` keys in `pyproject.toml` (e.g., `"hindsight"`, `"honcho"`, `"voice"`, `"matrix"`, `"mistral"`, `"bedrock"`).
 
+For a minimal NixOS install that does not use messaging platforms:
+
+```nix
+services.hermes-agent.includeMessagingDependencies = false;
+```
+
+For package overrides outside the NixOS module:
+
+```nix
+pkgs.hermes-agent.override {
+  includeMessagingDependencies = false;
+}
+```
+
 **When to use which:**
 
 | Need | Option |
 |------|--------|
 | Enable a pyproject.toml optional extra | `extraDependencyGroups` |
+| Disable default Telegram/Discord/Slack deps | `includeMessagingDependencies = false` |
 | Add an external Python plugin not in pyproject.toml | `extraPythonPackages` |
 | Add a system binary (pandoc, jq, etc.) | `extraPackages` |
 | Add a directory-based plugin source tree | `extraPlugins` |
@@ -837,6 +852,7 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 | `extraPlugins` | `listOf package` | `[]` | Directory plugin packages to symlink into `$HERMES_HOME/plugins/`. Each must contain `plugin.yaml` |
 | `extraPythonPackages` | `listOf package` | `[]` | Python packages added to PYTHONPATH for entry-point plugin discovery. Build with `python312Packages` |
 | `extraDependencyGroups` | `listOf str` | `[]` | pyproject.toml optional extras to include in the sealed venv (e.g. `["hindsight"]`). Resolved by uv — no collisions |
+| `includeMessagingDependencies` | `bool` | `true` | Include Telegram/Discord/Slack Python dependencies in the sealed venv |
 | `restart` | `str` | `"always"` | systemd `Restart=` policy |
 | `restartSec` | `int` | `5` | systemd `RestartSec=` value |
 


### PR DESCRIPTION
## Summary
- include the pyproject `messaging` dependency group by default in the Nix package so Telegram/Discord/Slack adapters are present in the sealed venv
- add `includeMessagingDependencies` as a default-on opt-out for minimal Nix package and NixOS module users
- document the default behavior and opt-out path

## Rationale
Fixes #27047.

Including messaging dependencies by default is a sane default for Nix installs because Hermes lazy-installs optional platform dependencies at runtime, but the Nix-built Python environment lives in the read-only Nix store. Users who do not use the flake/NixOS module path, but still want to use Hermes with Nix via `nix run` or `nix profile install`, may reasonably expect Telegram and other messaging gateways to work without custom package overrides.

The opt-out keeps minimal installs possible:

```nix
pkgs.hermes-agent.override {
  includeMessagingDependencies = false;
}
```

or, in the NixOS module:

```nix
services.hermes-agent.includeMessagingDependencies = false;
```

## Verification
- `git diff --check`
- `nix eval .#packages.x86_64-linux.default.drvPath`
- `nix build .#packages.x86_64-linux.default --no-link --print-out-paths`
- default build: `import telegram; print(telegram.__version__)` -> `22.6`
- opt-out build: `importlib.util.find_spec("telegram")` -> `None`
- NixOS module eval with `includeMessagingDependencies = false` -> `false`