### PR TITLE
fix(windows): suppress console window flash on subprocess spawns

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -93,6 +93,7 @@ from toolsets import get_toolset_names
 VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
+_IS_WINDOWS = sys.platform == "win32"
 
 # A running task's claim is valid for 15 minutes; after that the next
 # dispatcher tick reclaims it.  Workers that outlive this window should call
@@ -4024,6 +4025,7 @@ def _default_spawn(
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
     except FileNotFoundError:
         log_f.close()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1238,6 +1238,7 @@ def execute_code(
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
@@ -1568,6 +1569,7 @@ def _is_usable_python(python_path: str) -> bool:
              "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"],
             timeout=5,
             capture_output=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
         return result.returncode == 0
     except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -513,6 +513,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
             cwd=_popen_cwd,
         )
         if not _IS_WINDOWS:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -557,6 +557,7 @@ class ProcessRegistry:
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
+            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
 
         session.process = proc


### PR DESCRIPTION
## Summary

On Windows, every `subprocess.Popen` in the agent spawns a visible CMD window that flashes on the desktop. This adds `creationflags=subprocess.CREATE_NO_WINDOW` (guarded by `_IS_WINDOWS`) to all 5 Popen sites across 4 files:

- `tools/environments/local.py`: foreground terminal spawn
- `tools/process_registry.py`: background process spawn
- `tools/code_execution_tool.py`: sandbox Popen + interpreter probe
- `hermes_cli/kanban_db.py`: kanban worker spawn (+ adds the missing `_IS_WINDOWS` module constant)

## Why

CMD window flashes are jarring during normal operation, especially when background agents or gateway workers spawn subprocesses. The fix is a single keyword argument per Popen site, no-op on non-Windows thanks to the `_IS_WINDOWS` guard.

`CREATE_NO_WINDOW` alone is sufficient to suppress the flash for these call sites. The full daemon flag combo from the cross-platform guide (`CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_BREAKAWAY_FROM_JOB`) is for detached daemons and not needed here.

## How to test

On Windows 11:

1. Run `hermes` and execute any terminal command. No CMD window flashes.
2. Start a background process via `terminal(background=True)`. No flash on spawn.
3. Dispatch a kanban worker. No flash on worker spawn.
4. Use `execute_code`. No flash on sandbox spawn.

Test suite: `pytest tests/tools/ tests/hermes_cli/` on Windows 11 shows identical results to main branch. All test failures are pre-existing platform issues (Winsock, tilde expansion, macOS-specific tests, docker detection), none related to this change.
