### PR TITLE
fix(anthropic): guard keychain reader against non-string stdout (#27003)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -706,6 +706,9 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
+    if not isinstance(data, dict):
+        logger.debug("Keychain: credentials payload is not a JSON object")
+        return None
 
     oauth_data = data.get("claudeAiOauth")
     if oauth_data and isinstance(oauth_data, dict):
@@ -745,6 +748,9 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     if cred_path.exists():
         try:
             data = json.loads(cred_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                logger.debug("~/.claude/.credentials.json did not contain a JSON object")
+                return None
             oauth_data = data.get("claudeAiOauth")
             if oauth_data and isinstance(oauth_data, dict):
                 access_token = oauth_data.get("accessToken", "")

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -690,13 +690,20 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         logger.debug("Keychain: no entry found for 'Claude Code-credentials'")
         return None
 
-    raw = result.stdout.strip()
+    raw = result.stdout
+    # Be defensive: subprocess wrappers (and test mocks) sometimes hand back
+    # a non-string stdout. Bail out cleanly instead of crashing the whole
+    # credential resolution chain — the caller will fall back to the JSON
+    # credential file.
+    if not isinstance(raw, str):
+        return None
+    raw = raw.strip()
     if not raw:
         return None
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -203,6 +203,17 @@ class TestReadClaudeCodeCredentials:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert read_claude_code_credentials() is None
 
+    def test_returns_none_for_non_object_credentials_file(self, tmp_path, monkeypatch):
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text("[]")
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+        assert read_claude_code_credentials() is None
+
 
 class TestIsClaudeCodeTokenValid:
     def test_valid_token(self):
@@ -519,6 +530,15 @@ class TestReadClaudeCodeCredentialsFromKeychain:
         monkeypatch.setattr(mod.platform, "system", lambda: "Darwin")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="not-json\n")
+            result = _read_claude_code_credentials_from_keychain()
+        assert result is None
+
+    def test_non_object_json_stdout_returns_none(self, monkeypatch):
+        import agent.anthropic_adapter as mod
+
+        monkeypatch.setattr(mod.platform, "system", lambda: "Darwin")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="[]\n")
             result = _read_claude_code_credentials_from_keychain()
         assert result is None
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -10,6 +10,7 @@ import pytest
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_oauth_token,
+    _read_claude_code_credentials_from_keychain,
     _refresh_oauth_token,
     _to_plain_data,
     _write_claude_code_credentials,
@@ -494,6 +495,32 @@ class TestRunOauthSetupToken:
             token = run_oauth_setup_token()
 
         assert token is None
+
+
+class TestReadClaudeCodeCredentialsFromKeychain:
+    """Regression coverage for issue #27003 — the keychain reader must not
+    crash when subprocess.run hands back a non-string stdout (e.g. a
+    MagicMock left unconfigured by a higher-level test mocking subprocess)."""
+
+    def test_non_string_stdout_returns_none(self, monkeypatch):
+        import agent.anthropic_adapter as mod
+
+        monkeypatch.setattr(mod.platform, "system", lambda: "Darwin")
+        with patch("subprocess.run") as mock_run:
+            # Unconfigured MagicMock — .stdout is itself a MagicMock,
+            # which previously crashed json.loads with a TypeError.
+            mock_run.return_value = MagicMock(returncode=0)
+            result = _read_claude_code_credentials_from_keychain()
+        assert result is None
+
+    def test_invalid_json_stdout_returns_none(self, monkeypatch):
+        import agent.anthropic_adapter as mod
+
+        monkeypatch.setattr(mod.platform, "system", lambda: "Darwin")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not-json\n")
+            result = _read_claude_code_credentials_from_keychain()
+        assert result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #27003.

The macOS keychain credential reader did:

```python
raw = result.stdout.strip()
...
data = json.loads(raw)
```

When a test patched `subprocess.run` with an unconfigured `MagicMock`, `result.stdout` was itself a `MagicMock`, `.strip()` returned another `MagicMock`, and `json.loads` blew up with `TypeError: the JSON object must be str, bytes or bytearray, not MagicMock`. That took down `test_returns_token_from_credential_files`, which mocks subprocess specifically because it cares about the credential-file fallback path, not the keychain path.

## Fix
Validate `result.stdout` is a `str` before stripping; treat `TypeError` the same as `JSONDecodeError` on the parse path. Both paths fall through to the existing JSON-file reader, which is the documented behavior when keychain has no entry.

## Tests
- Adds `TestReadClaudeCodeCredentialsFromKeychain` with two cases (non-string stdout, invalid-JSON stdout) — both return `None` cleanly.
- Existing `TestRunOauthSetupToken::test_returns_token_from_credential_files` now passes alongside the rest of the suite.

```
bash scripts/run_tests.sh \
  tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken \
  tests/agent/test_anthropic_adapter.py::TestReadClaudeCodeCredentialsFromKeychain -q
# 7 passed in 65.38s
```
