### PR TITLE
feat(xai): add xai collections search tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2468,6 +2468,26 @@ DEFAULT_CONFIG = {
         "retries": 2,
     },
 
+    # xAI Collections Search / RAG via the Responses API file_search tool.
+    # This searches existing xAI Collections / vector stores. It does not
+    # upload files or create collections. Requires xAI credentials and the
+    # xai_collections_search toolset to be enabled in `hermes tools`.
+    "xai_collections_search": {
+        # xAI model used for the Responses call.
+        "model": "grok-4.3",
+        # Optional default collection IDs. The tool call can also pass
+        # collection_ids explicitly.
+        "collection_ids": [],
+        # Default retrieval breadth for file_search.
+        "max_num_results": 10,
+        # Request timeout in seconds (minimum 30). Collection search can take
+        # longer than plain chat for larger stores.
+        "timeout_seconds": 180,
+        # Number of automatic retries on 5xx / ReadTimeout / ConnectionError.
+        # Each retry backs off (1.5x attempt seconds, capped at 5s).
+        "retries": 2,
+    },
+
     # =========================================================================
     # External secret sources
     # =========================================================================
@@ -2530,7 +2550,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 29,
+    "_config_version": 30,
 }
 
 # =============================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
+    ("xai_collections_search", "🗂️ xAI Collections Search", "xai_collections_search (RAG over existing xAI collections)"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -112,7 +113,10 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+#
+# xAI Collections Search is also off by default — it requires xAI credentials
+# plus existing collection IDs, and does not create/upload collections.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "xai_collections_search"}
 
 
 def _xai_credentials_present() -> bool:
@@ -421,6 +425,39 @@ TOOL_CATEGORIES = {
         "providers": [
             {
                 "name": "xAI Grok OAuth (SuperGrok / Premium+)",
+                "badge": "subscription",
+                "tag": "Browser login at accounts.x.ai — no API key required",
+                "env_vars": [],
+                "post_setup": "xai_grok",
+            },
+            {
+                "name": "xAI API key",
+                "badge": "paid",
+                "tag": "Direct xAI API billing via XAI_API_KEY",
+                "env_vars": [
+                    {
+                        "key": "XAI_API_KEY",
+                        "prompt": "xAI API key",
+                        "url": "https://console.x.ai/",
+                    },
+                ],
+            },
+        ],
+    },
+    "xai_collections_search": {
+        "name": "xAI Collections Search",
+        "setup_title": "Select xAI Credential Source",
+        "setup_note": (
+            "Hermes routes RAG over existing xAI Collections through xAI's "
+            "Responses API file_search tool. This tool searches collections "
+            "that already exist on xAI; it does not upload files or create "
+            "new collections. SuperGrok OAuth is preferred when both "
+            "credential sources are set."
+        ),
+        "icon": "🗂️",
+        "providers": [
+            {
+                "name": "xAI Grok OAuth (SuperGrok Subscription)",
                 "badge": "subscription",
                 "tag": "Browser login at accounts.x.ai — no API key required",
                 "env_vars": [],

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -91,6 +91,15 @@ def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
 
+def test_configurable_toolsets_include_xai_collections_search_default_off():
+    assert any(
+        ts_key == "xai_collections_search"
+        for ts_key, _, _ in CONFIGURABLE_TOOLSETS
+    )
+    assert "xai_collections_search" in _DEFAULT_OFF_TOOLSETS
+    assert "xai_collections_search" in TOOL_CATEGORIES
+
+
 def test_configurable_toolsets_include_context_engine():
     assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -31,6 +31,11 @@ class TestGetToolset:
         assert ts is not None
         assert "web_search" in ts["tools"]
 
+    def test_xai_collections_search_toolset(self):
+        ts = get_toolset("xai_collections_search")
+        assert ts is not None
+        assert ts["tools"] == ["xai_collections_search"]
+
     def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
         reg = ToolRegistry()
         reg.register(

--- a/tests/tools/test_xai_collections_search_tool.py
+++ b/tests/tools/test_xai_collections_search_tool.py
@@ -1,0 +1,488 @@
+"""Tests for xAI Collections Search via the Responses API file_search tool."""
+
+import json
+
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def _fake_credentials(monkeypatch, *, provider="xai", api_key="xai-test-key"):
+    monkeypatch.setattr(
+        "tools.xai_collections_search_tool.resolve_xai_http_credentials",
+        lambda: {
+            "provider": provider,
+            "api_key": api_key,
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+
+
+def _no_xai_env(monkeypatch):
+    for var in ("XAI_API_KEY", "XAI_BASE_URL", "HERMES_XAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_xai_collections_search_posts_responses_request(monkeypatch):
+    from hermes_cli import __version__
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "The collection says Hermes supports tools.",
+                "citations": [
+                    {
+                        "url": "collections://collection_123/files/file_123",
+                    }
+                ],
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "collections_search",
+                            "arguments": '{"query":"Hermes tools","limit":7}',
+                        },
+                    }
+                ],
+                "server_side_tool_usage": {
+                    "SERVER_SIDE_TOOL_COLLECTIONS_SEARCH": 1,
+                },
+                "usage": {"input_tokens": 12, "output_tokens": 8},
+            }
+        )
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_collections_search_tool(
+            query="What does the collection say about Hermes tools?",
+            collection_ids=["collection_123", "collection_456"],
+            max_num_results=7,
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["Authorization"] == "Bearer xai-test-key"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.3"
+    assert captured["json"]["store"] is False
+    assert captured["json"]["input"][0]["content"] == (
+        "What does the collection say about Hermes tools?"
+    )
+    assert captured["timeout"] == 180
+    assert tool_def == {
+        "type": "file_search",
+        "vector_store_ids": ["collection_123", "collection_456"],
+        "max_num_results": 7,
+    }
+    assert result["success"] is True
+    assert result["tool"] == "xai_collections_search"
+    assert result["xai_tool"] == "file_search"
+    assert result["xai_sdk_tool"] == "collections_search"
+    assert result["answer"] == "The collection says Hermes supports tools."
+    assert result["citations"] == [{"url": "collections://collection_123/files/file_123"}]
+    assert result["tool_calls"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "collections_search",
+                "arguments": '{"query":"Hermes tools","limit":7}',
+            },
+        }
+    ]
+    assert result["server_side_tool_usage"] == {
+        "SERVER_SIDE_TOOL_COLLECTIONS_SEARCH": 1,
+    }
+    assert result["usage"] == {"input_tokens": 12, "output_tokens": 8}
+
+
+def test_xai_collections_search_uses_config_collection_ids(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    monkeypatch.setattr(
+        "tools.xai_collections_search_tool._load_xai_collections_search_config",
+        lambda: {
+            "collection_ids": ["collection_config"],
+            "max_num_results": 3,
+        },
+    )
+    _fake_credentials(monkeypatch)
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["tool_def"] = json["tools"][0]
+        return _FakeResponse({"output_text": "Configured collection OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_collections_search_tool(query="Search configured docs"))
+
+    assert result["success"] is True
+    assert captured["tool_def"] == {
+        "type": "file_search",
+        "vector_store_ids": ["collection_config"],
+        "max_num_results": 3,
+    }
+
+
+def test_xai_collections_search_accepts_single_collection_id_string(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    _fake_credentials(monkeypatch)
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["tool_def"] = json["tools"][0]
+        return _FakeResponse({"output_text": "Single ID OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_collections_search_tool(
+            query="Search docs",
+            collection_ids="collection_single",
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["tool_def"]["vector_store_ids"] == ["collection_single"]
+
+
+def test_xai_collections_search_empty_query_returns_tool_error(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    _fake_credentials(monkeypatch)
+
+    result = json.loads(xai_collections_search_tool(query="  ", collection_ids=["collection_1"]))
+
+    assert result["error"] == "query is required for xai_collections_search"
+
+
+def test_xai_collections_search_requires_collection_ids(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr(
+        "tools.xai_collections_search_tool._load_xai_collections_search_config",
+        lambda: {},
+    )
+
+    result = json.loads(xai_collections_search_tool(query="Search docs"))
+
+    assert "collection_ids is required for xai_collections_search" in result["error"]
+
+
+def test_xai_collections_search_rejects_invalid_max_num_results(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    _fake_credentials(monkeypatch)
+
+    result = json.loads(
+        xai_collections_search_tool(
+            query="Search docs",
+            collection_ids=["collection_1"],
+            max_num_results=0,
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "max_num_results must be a positive integer"
+
+
+def test_xai_collections_search_extracts_output_citations_and_calls(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "file_search_call",
+                        "id": "fs_1",
+                        "queries": ["Hermes tools"],
+                        "results": [{"file_id": "file_1", "score": 0.91}],
+                    },
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Hermes has toolsets.",
+                                "annotations": [
+                                    {
+                                        "type": "file_citation",
+                                        "file_id": "file_1",
+                                        "filename": "hermes.md",
+                                        "start_index": 0,
+                                        "end_index": 6,
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_collections_search_tool(
+            query="What does Hermes have?",
+            collection_ids=["collection_1"],
+        )
+    )
+
+    assert result["success"] is True
+    assert result["answer"] == "Hermes has toolsets."
+    assert result["inline_citations"] == [
+        {
+            "type": "file_citation",
+            "url": "",
+            "title": "",
+            "file_id": "file_1",
+            "filename": "hermes.md",
+            "start_index": 0,
+            "end_index": 6,
+        }
+    ]
+    assert result["file_search_calls"] == [
+        {
+            "type": "file_search_call",
+            "id": "fs_1",
+            "queries": ["Hermes tools"],
+            "results": [{"file_id": "file_1", "score": 0.91}],
+        }
+    ]
+
+
+def test_xai_collections_search_returns_structured_http_error(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"file_search is not enabled"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "file_search is not enabled",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(
+        xai_collections_search_tool(query="Search docs", collection_ids=["collection_1"])
+    )
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "xai_collections_search"
+    assert result["xai_tool"] == "file_search"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: file_search is not enabled"
+
+
+def test_xai_collections_search_http_error_supports_nested_error(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    class _FailingResponse:
+        status_code = 400
+        text = '{"error":{"message":"bad collection id"}}'
+
+        def json(self):
+            return {"error": {"message": "bad collection id"}}
+
+        def raise_for_status(self):
+            err = requests.HTTPError("400 Client Error: Bad Request")
+            err.response = self
+            raise err
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(
+        xai_collections_search_tool(query="Search docs", collection_ids=["bad"])
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "bad collection id"
+
+
+def test_xai_collections_search_retries_timeout_then_succeeds(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse({"output_text": "Recovered after retry."})
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_collections_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(
+        xai_collections_search_tool(query="Search docs", collection_ids=["collection_1"])
+    )
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_xai_collections_search_retries_5xx_then_succeeds(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "server_error", "error": "temporary failure"},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_collections_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(
+        xai_collections_search_tool(query="Search docs", collection_ids=["collection_1"])
+    )
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."
+
+
+def test_xai_collections_search_uses_xai_oauth_when_available(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_collections_search_tool import (
+        check_xai_collections_search_requirements,
+        xai_collections_search_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+    _fake_credentials(monkeypatch, provider="xai-oauth", api_key="oauth-token")
+    invalidate_check_fn_cache()
+
+    assert check_xai_collections_search_requirements() is True
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        return _FakeResponse({"output_text": "OAuth worked."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_collections_search_tool(query="Search docs", collection_ids=["collection_1"])
+    )
+
+    assert result["success"] is True
+    assert result["credential_source"] == "xai-oauth"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-token"
+
+
+def test_xai_collections_search_returns_tool_error_when_no_credentials(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_collections_search_tool import (
+        check_xai_collections_search_requirements,
+        xai_collections_search_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+    _fake_credentials(monkeypatch, api_key="")
+    invalidate_check_fn_cache()
+
+    assert check_xai_collections_search_requirements() is False
+
+    result = xai_collections_search_tool(query="Search docs", collection_ids=["collection_1"])
+
+    assert "No xAI credentials available" in result
+    assert "hermes auth add xai-oauth" in result
+
+
+def test_xai_collections_search_honors_config_model_timeout_and_retries(monkeypatch):
+    from tools.xai_collections_search_tool import xai_collections_search_tool
+
+    monkeypatch.setattr(
+        "tools.xai_collections_search_tool._load_xai_collections_search_config",
+        lambda: {
+            "model": "grok-custom-test",
+            "timeout_seconds": 45,
+            "retries": 0,
+        },
+    )
+    _fake_credentials(monkeypatch)
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["model"] = json["model"]
+        captured["timeout"] = timeout
+        return _FakeResponse({"output_text": "Custom config OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_collections_search_tool(
+            query="Search docs",
+            collection_ids=["collection_1"],
+        )
+    )
+
+    assert result["success"] is True
+    assert captured["model"] == "grok-custom-test"
+    assert captured["timeout"] == 45
+
+
+def test_xai_collections_search_registered_in_registry_with_check_fn():
+    import tools.xai_collections_search_tool  # noqa: F401 - ensures registration runs
+    from tools.registry import registry
+
+    entry = registry.get_entry("xai_collections_search")
+    assert entry is not None
+    assert entry.toolset == "xai_collections_search"
+    assert entry.check_fn is not None
+    assert entry.check_fn.__name__ == "check_xai_collections_search_requirements"
+    assert "XAI_API_KEY" in entry.requires_env
+    assert entry.emoji == "🗂️"

--- a/tools/xai_collections_search_tool.py
+++ b/tools/xai_collections_search_tool.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""xAI Collections Search / RAG via the Responses API ``file_search`` tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_COLLECTIONS_SEARCH_MODEL = "grok-4.3"
+DEFAULT_XAI_COLLECTIONS_SEARCH_TIMEOUT_SECONDS = 180
+DEFAULT_XAI_COLLECTIONS_SEARCH_RETRIES = 2
+DEFAULT_XAI_COLLECTIONS_SEARCH_MAX_RESULTS = 10
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_xai_collections_search_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("xai_collections_search", {}) or {}
+    except Exception:
+        return {}
+
+
+def _get_xai_collections_search_model() -> str:
+    cfg = _load_xai_collections_search_config()
+    return (
+        str(cfg.get("model") or "").strip()
+        or DEFAULT_XAI_COLLECTIONS_SEARCH_MODEL
+    )
+
+
+def _get_xai_collections_search_timeout_seconds() -> int:
+    cfg = _load_xai_collections_search_config()
+    raw_value = cfg.get(
+        "timeout_seconds",
+        DEFAULT_XAI_COLLECTIONS_SEARCH_TIMEOUT_SECONDS,
+    )
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_COLLECTIONS_SEARCH_TIMEOUT_SECONDS
+
+
+def _get_xai_collections_search_retries() -> int:
+    cfg = _load_xai_collections_search_config()
+    raw_value = cfg.get("retries", DEFAULT_XAI_COLLECTIONS_SEARCH_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_COLLECTIONS_SEARCH_RETRIES
+
+
+def _get_xai_collections_search_max_num_results() -> int:
+    cfg = _load_xai_collections_search_config()
+    raw_value = cfg.get(
+        "max_num_results",
+        DEFAULT_XAI_COLLECTIONS_SEARCH_MAX_RESULTS,
+    )
+    try:
+        return max(1, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_COLLECTIONS_SEARCH_MAX_RESULTS
+
+
+def _get_xai_collections_search_collection_ids() -> List[str]:
+    cfg = _load_xai_collections_search_config()
+    return _normalize_string_list(
+        cfg.get("collection_ids") or cfg.get("vector_store_ids"),
+        "collection_ids",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_xai_bearer() -> Tuple[str, str, str]:
+    """Return ``(api_key, base_url, source)`` or raise on missing credentials."""
+    creds = resolve_xai_http_credentials()
+    api_key = str(creds.get("api_key") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "No xAI credentials available. Run `hermes auth add xai-oauth` "
+            "to sign in with your SuperGrok subscription, or set XAI_API_KEY."
+        )
+    base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    source = str(creds.get("provider") or "xai")
+    return api_key, base_url, source
+
+
+def check_xai_collections_search_requirements() -> bool:
+    """Return True when xAI credentials are available and non-empty."""
+    try:
+        creds = resolve_xai_http_credentials()
+        return bool(str(creds.get("api_key") or "").strip())
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_string_list(value: Any, field_name: str) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_items = [value]
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = list(value)
+    else:
+        raise ValueError(f"{field_name} must be a string or list of strings")
+
+    cleaned: List[str] = []
+    seen = set()
+    for item in raw_items:
+        normalized = str(item or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        cleaned.append(normalized)
+        seen.add(normalized)
+    return cleaned
+
+
+def _normalize_max_num_results(value: Optional[int]) -> int:
+    if value is None:
+        return _get_xai_collections_search_max_num_results()
+    try:
+        normalized = int(value)
+    except Exception as exc:
+        raise ValueError("max_num_results must be a positive integer") from exc
+    if normalized < 1:
+        raise ValueError("max_num_results must be a positive integer")
+    return normalized
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    citations: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            for annotation in content.get("annotations", []) or []:
+                if not isinstance(annotation, dict):
+                    continue
+                citation_type = annotation.get("type")
+                if citation_type not in ("url_citation", "file_citation"):
+                    continue
+                citations.append(
+                    {
+                        "type": citation_type,
+                        "url": annotation.get("url", ""),
+                        "title": annotation.get("title", ""),
+                        "file_id": annotation.get("file_id"),
+                        "filename": annotation.get("filename"),
+                        "start_index": annotation.get("start_index"),
+                        "end_index": annotation.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _extract_file_search_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    calls: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "")
+        if item_type in ("file_search_call", "collections_search_call"):
+            calls.append(item)
+    return calls
+
+
+def _extract_tool_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_calls = payload.get("tool_calls") or []
+    if isinstance(raw_calls, dict):
+        return [raw_calls]
+    if isinstance(raw_calls, list):
+        return [call for call in raw_calls if isinstance(call, dict)]
+    return []
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error_value = payload.get("error")
+        if isinstance(error_value, dict):
+            error = str(error_value.get("message") or "").strip()
+        else:
+            error = str(error_value or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+def xai_collections_search_tool(
+    query: str,
+    collection_ids: Optional[List[str]] = None,
+    max_num_results: Optional[int] = None,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required for xai_collections_search")
+
+    try:
+        api_key, base_url, source = _resolve_xai_bearer()
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+
+    try:
+        resolved_collection_ids = _normalize_string_list(
+            collection_ids,
+            "collection_ids",
+        ) or _get_xai_collections_search_collection_ids()
+        if not resolved_collection_ids:
+            return tool_error(
+                "collection_ids is required for xai_collections_search "
+                "(pass collection_ids or configure xai_collections_search.collection_ids)"
+            )
+
+        resolved_max_num_results = _normalize_max_num_results(max_num_results)
+        tool_def = {
+            "type": "file_search",
+            "vector_store_ids": resolved_collection_ids,
+            "max_num_results": resolved_max_num_results,
+        }
+
+        payload = {
+            "model": _get_xai_collections_search_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": query.strip(),
+                }
+            ],
+            "tools": [tool_def],
+            "store": False,
+        }
+
+        timeout_seconds = _get_xai_collections_search_timeout_seconds()
+        max_retries = _get_xai_collections_search_retries()
+        response: Optional[requests.Response] = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{base_url}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_collections_search upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.ReadTimeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_collections_search transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("xai_collections_search request did not return a response")
+
+        data = response.json()
+        answer = _extract_response_text(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "credential_source": source,
+                "tool": "xai_collections_search",
+                "xai_tool": "file_search",
+                "xai_sdk_tool": "collections_search",
+                "model": payload["model"],
+                "query": query.strip(),
+                "collection_ids": resolved_collection_ids,
+                "max_num_results": resolved_max_num_results,
+                "answer": answer,
+                "citations": list(data.get("citations") or []),
+                "inline_citations": _extract_inline_citations(data),
+                "tool_calls": _extract_tool_calls(data),
+                "file_search_calls": _extract_file_search_calls(data),
+                "server_side_tool_usage": data.get("server_side_tool_usage") or {},
+                "usage": data.get("usage") or {},
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("xai_collections_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_collections_search",
+                "xai_tool": "file_search",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.ReadTimeout as e:
+        logger.error("xai_collections_search timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_collections_search",
+                "xai_tool": "file_search",
+                "error": (
+                    "xAI collections search timed out after "
+                    f"{_get_xai_collections_search_timeout_seconds()} seconds"
+                ),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("xai_collections_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_collections_search",
+                "xai_tool": "file_search",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+XAI_COLLECTIONS_SEARCH_SCHEMA = {
+    "name": "xai_collections_search",
+    "description": (
+        "Search existing xAI Collections / vector stores using xAI's hosted "
+        "Responses API file_search tool. Use this for RAG over documents "
+        "already uploaded to xAI. This does not create or upload collections."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Question or search query to answer from the xAI collection.",
+            },
+            "collection_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Existing xAI collection / vector store IDs to search. "
+                    "Can be omitted only if configured in xai_collections_search.collection_ids."
+                ),
+            },
+            "max_num_results": {
+                "type": "integer",
+                "description": "Maximum number of matching chunks to retrieve. Defaults to config value or 10.",
+                "minimum": 1,
+                "default": DEFAULT_XAI_COLLECTIONS_SEARCH_MAX_RESULTS,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def _handle_xai_collections_search(args, **kw):
+    if not isinstance(args, dict):
+        args = {}
+    return xai_collections_search_tool(
+        query=args.get("query", ""),
+        collection_ids=args.get("collection_ids"),
+        max_num_results=args.get("max_num_results"),
+    )
+
+
+registry.register(
+    name="xai_collections_search",
+    toolset="xai_collections_search",
+    schema=XAI_COLLECTIONS_SEARCH_SCHEMA,
+    handler=_handle_xai_collections_search,
+    check_fn=check_xai_collections_search_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🗂️",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -112,7 +112,17 @@ TOOLSETS = {
         "tools": ["x_search"],
         "includes": []
     },
-    
+
+    "xai_collections_search": {
+        "description": (
+            "Search existing xAI Collections / vector stores via xAI's "
+            "Responses API file_search tool. Off by default; enable in "
+            "`hermes tools` → xAI Collections Search."
+        ),
+        "tools": ["xai_collections_search"],
+        "includes": []
+    },
+
     "vision": {
         "description": "Image analysis and vision tools",
         "tools": ["vision_analyze"],


### PR DESCRIPTION
## Summary

Adds an opt-in `xai_collections_search` toolset and tool for xAI Collections Search / RAG through the Responses API `file_search` tool.

This is intentionally narrow: it searches existing xAI Collections / vector stores and does not create collections, upload files, or manage collection metadata. Users can pass `collection_ids` per call or configure defaults under `xai_collections_search.collection_ids`.

## What changed

- Added `tools/xai_collections_search_tool.py`.
- Added default `xai_collections_search` config with model, collection IDs, retrieval count, timeout, and retries.
- Added `xai_collections_search` to `hermes tools` as a default-off xAI credential-gated toolset.
- Added static toolset registration in `toolsets.py`.
- Added unit coverage for request shape, collection ID normalization, config defaults, citations, server-side file search calls, error handling, retries, OAuth/API-key credential paths, and registry registration.
- Includes the ACP manifest version/package hygiene fix currently needed on `upstream/main` for the registry manifest tests to pass.

## Notes

- xAI SDK names this capability `collections_search`; the OpenAI-compatible Responses API shape uses `file_search` with `vector_store_ids`.
- The Hermes-facing name is `xai_collections_search` to avoid confusing it with generic file tools or local search.
- This PR does not combine with `code_interpreter`; that can stay separate and composable with the xAI Code Execution PR.

Docs: https://docs.x.ai/developers/tools/collections-search

## Validation

- `uv run --extra dev pytest tests/tools/test_xai_collections_search_tool.py tests/tools/test_x_search_tool.py tests/hermes_cli/test_tools_config.py tests/test_toolsets.py -q` → 123 passed
- `uv run --extra dev pytest tests/acp/test_registry_manifest.py tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome tests/tools/test_transcription_dotenv_fallback.py -q` → 19 passed
- `uv run --extra dev ruff check tools/xai_collections_search_tool.py hermes_cli/config.py hermes_cli/tools_config.py toolsets.py tests/tools/test_xai_collections_search_tool.py tests/hermes_cli/test_tools_config.py tests/test_toolsets.py` → passed
- `git diff --check` → passed
- `uv run --extra dev python -m py_compile tools/xai_collections_search_tool.py` → passed

Dogfood on my main Hermes instance (Alfred/mac-mini) with the real xAI API key succeeded against the Responses API `file_search` tool. I do not currently have a populated xAI Collection configured, so this proves the live API/tool path rather than full retrieval over real documents:

```json
{
  "success": true,
  "tool": "xai_collections_search",
  "xai_tool": "file_search",
  "model": "grok-4.3",
  "answer": "There are no documents in this collection.",
  "file_search_calls_count": 2
}
```
