### PR TITLE
fix(session-search): surface 4 hard-coded cost knobs as auxiliary.session_search.* config (#27059)

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -10,9 +10,14 @@ from tools.session_search_tool import (
     _format_conversation,
     _truncate_around_matches,
     _get_session_search_max_concurrency,
+    _get_session_search_max_chars,
+    _get_session_search_max_summary_tokens,
+    _get_session_search_default_limit,
+    _get_session_search_max_retries,
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
     MAX_SESSION_CHARS,
+    MAX_SUMMARY_TOKENS,
     SESSION_SEARCH_SCHEMA,
 )
 
@@ -239,6 +244,216 @@ class TestSessionSearchConcurrency:
         assert result["success"] is True
         assert result["count"] == 3
         assert max_seen["value"] == 1
+
+
+class TestSessionSearchCostKnobs:
+    """auxiliary.session_search.{max_session_chars, max_summary_tokens,
+    default_limit, max_retries} — config knobs added so users on slow local
+    backends can tune session_search without forking the file (#27059)."""
+
+    def test_max_chars_defaults_to_module_constant(self):
+        assert _get_session_search_max_chars() == MAX_SESSION_CHARS
+
+    def test_max_chars_reads_and_clamps_low(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_session_chars": 500}}},
+        )
+        # min clamp at 1000 — anything smaller starves the summarizer
+        assert _get_session_search_max_chars() == 1000
+
+    def test_max_chars_reads_configured_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_session_chars": 30000}}},
+        )
+        assert _get_session_search_max_chars() == 30000
+
+    def test_max_chars_invalid_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_session_chars": "abc"}}},
+        )
+        assert _get_session_search_max_chars() == MAX_SESSION_CHARS
+
+    def test_max_summary_tokens_defaults_to_module_constant(self):
+        assert _get_session_search_max_summary_tokens() == MAX_SUMMARY_TOKENS
+
+    def test_max_summary_tokens_clamps_to_128(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_summary_tokens": 10}}},
+        )
+        assert _get_session_search_max_summary_tokens() == 128
+
+    def test_max_summary_tokens_clamps_to_32000(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_summary_tokens": 100000}}},
+        )
+        assert _get_session_search_max_summary_tokens() == 32000
+
+    def test_max_summary_tokens_reads_configured_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_summary_tokens": 2000}}},
+        )
+        assert _get_session_search_max_summary_tokens() == 2000
+
+    def test_default_limit_defaults_to_three(self):
+        assert _get_session_search_default_limit() == 3
+
+    def test_default_limit_clamps_to_one(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"default_limit": 0}}},
+        )
+        assert _get_session_search_default_limit() == 1
+
+    def test_default_limit_clamps_to_five(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"default_limit": 50}}},
+        )
+        assert _get_session_search_default_limit() == 5
+
+    def test_default_limit_reads_configured_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"default_limit": 2}}},
+        )
+        assert _get_session_search_default_limit() == 2
+
+    def test_max_retries_defaults_to_three(self):
+        assert _get_session_search_max_retries() == 3
+
+    def test_max_retries_allows_zero(self, monkeypatch):
+        """0 is intentional: local reasoning-mode users opt out of retries
+        and fall through to the raw-preview path (see issue #27059)."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_retries": 0}}},
+        )
+        assert _get_session_search_max_retries() == 0
+
+    def test_max_retries_clamps_to_five(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_retries": 100}}},
+        )
+        assert _get_session_search_max_retries() == 5
+
+    def test_max_retries_reads_configured_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_retries": 1}}},
+        )
+        assert _get_session_search_max_retries() == 1
+
+    def test_knobs_unaffected_by_unrelated_aux_keys(self, monkeypatch):
+        """Adding the new knobs must not regress max_concurrency reading."""
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "auxiliary": {
+                    "session_search": {
+                        "max_concurrency": 2,
+                        "max_session_chars": 20000,
+                        "max_summary_tokens": 1500,
+                        "default_limit": 2,
+                        "max_retries": 1,
+                    }
+                }
+            },
+        )
+        assert _get_session_search_max_concurrency() == 2
+        assert _get_session_search_max_chars() == 20000
+        assert _get_session_search_max_summary_tokens() == 1500
+        assert _get_session_search_default_limit() == 2
+        assert _get_session_search_max_retries() == 1
+
+
+def _fake_llm_response(content: str):
+    """Build a duck-typed object matching ``async_call_llm``'s return shape
+    so ``extract_content_or_reasoning`` can do attribute access on it."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+class TestSummarizeSessionMaxRetriesZero:
+    """Setting max_retries=0 must short-circuit before calling the LLM and
+    return None so the caller falls through to the raw-preview path. Before
+    this change the for-loop simply never iterated and the function fell
+    through to an implicit None — same observable outcome, but ambiguous
+    intent and easy to break with a future refactor."""
+
+    def test_zero_retries_returns_none_without_llm_call(self, monkeypatch):
+        from tools.session_search_tool import _summarize_session
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_retries": 0}}},
+        )
+
+        called = {"n": 0}
+
+        async def fake_call(**_kwargs):
+            called["n"] += 1
+            return {"choices": [{"message": {"content": "should not run"}}]}
+
+        monkeypatch.setattr(
+            "tools.session_search_tool.async_call_llm", fake_call
+        )
+
+        result = asyncio.run(_summarize_session("transcript text", "query", {}))
+        assert result is None
+        assert called["n"] == 0, "LLM must not be called when max_retries=0"
+
+    def test_default_retries_still_calls_llm(self, monkeypatch):
+        from tools.session_search_tool import _summarize_session
+
+        called = {"n": 0, "max_tokens": None}
+
+        async def fake_call(**kwargs):
+            called["n"] += 1
+            called["max_tokens"] = kwargs.get("max_tokens")
+            return _fake_llm_response("ok")
+
+        monkeypatch.setattr(
+            "tools.session_search_tool.async_call_llm", fake_call
+        )
+
+        result = asyncio.run(_summarize_session("transcript text", "query", {}))
+        assert result == "ok"
+        assert called["n"] == 1
+        assert called["max_tokens"] == MAX_SUMMARY_TOKENS, (
+            "default max_tokens should match MAX_SUMMARY_TOKENS module constant"
+        )
+
+    def test_configured_max_summary_tokens_flows_into_llm_call(self, monkeypatch):
+        from tools.session_search_tool import _summarize_session
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"max_summary_tokens": 2000}}},
+        )
+
+        seen = {"max_tokens": None}
+
+        async def fake_call(**kwargs):
+            seen["max_tokens"] = kwargs.get("max_tokens")
+            return _fake_llm_response("ok")
+
+        monkeypatch.setattr(
+            "tools.session_search_tool.async_call_llm", fake_call
+        )
+
+        result = asyncio.run(_summarize_session("transcript text", "query", {}))
+        assert result == "ok"
+        assert seen["max_tokens"] == 2000
 
 
 class TestRecentSessionListing:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -29,8 +29,19 @@ MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
 
 
-def _get_session_search_max_concurrency(default: int = 3) -> int:
-    """Read auxiliary.session_search.max_concurrency with sane bounds."""
+def _get_session_search_int(
+    key: str,
+    default: int,
+    min_v: int = 0,
+    max_v: Optional[int] = None,
+) -> int:
+    """Read an integer from ``auxiliary.session_search.<key>`` with bounds.
+
+    Returns ``default`` if the config can't be loaded, the key is missing, or
+    the value isn't coercible to ``int``. Otherwise clamps to ``[min_v, max_v]``
+    (``max_v`` is optional). Mirrors the contract of
+    ``_get_session_search_max_concurrency`` so all knobs share one parser.
+    """
     try:
         from hermes_cli.config import load_config
         config = load_config()
@@ -40,14 +51,64 @@ def _get_session_search_max_concurrency(default: int = 3) -> int:
     task_config = aux.get("session_search", {}) if isinstance(aux, dict) else {}
     if not isinstance(task_config, dict):
         return default
-    raw = task_config.get("max_concurrency")
+    raw = task_config.get(key)
     if raw is None:
         return default
     try:
         value = int(raw)
     except (TypeError, ValueError):
         return default
-    return max(1, min(value, 5))
+    value = max(min_v, value)
+    if max_v is not None:
+        value = min(max_v, value)
+    return value
+
+
+def _get_session_search_max_concurrency(default: int = 3) -> int:
+    """Read auxiliary.session_search.max_concurrency with sane bounds."""
+    return _get_session_search_int("max_concurrency", default, min_v=1, max_v=5)
+
+
+def _get_session_search_max_chars(default: int = MAX_SESSION_CHARS) -> int:
+    """Read auxiliary.session_search.max_session_chars with sane bounds.
+
+    Hard minimum 1000 chars — anything smaller starves the summarizer of
+    context. No hard upper bound: very large contexts are legitimate for
+    frontier-model users; the existing transcript size is already the
+    natural ceiling.
+    """
+    return _get_session_search_int("max_session_chars", default, min_v=1000)
+
+
+def _get_session_search_max_summary_tokens(default: int = MAX_SUMMARY_TOKENS) -> int:
+    """Read auxiliary.session_search.max_summary_tokens with sane bounds.
+
+    Clamped to ``[128, 32000]`` — below 128 makes summaries useless; above
+    32k risks pathological generation costs without obvious benefit.
+    """
+    return _get_session_search_int(
+        "max_summary_tokens", default, min_v=128, max_v=32000
+    )
+
+
+def _get_session_search_default_limit(default: int = 3) -> int:
+    """Read auxiliary.session_search.default_limit with sane bounds.
+
+    Clamped to ``[1, 5]`` to match the per-call ``limit`` argument's
+    existing clamp at the call site.
+    """
+    return _get_session_search_int("default_limit", default, min_v=1, max_v=5)
+
+
+def _get_session_search_max_retries(default: int = 3) -> int:
+    """Read auxiliary.session_search.max_retries with sane bounds.
+
+    Clamped to ``[0, 5]``. ``0`` is intentional: for local reasoning-mode
+    backends where empty-content responses are the norm rather than the
+    exception, users can opt out of the retry loop entirely and fall
+    through to the ``[Raw preview — summarization unavailable]`` path.
+    """
+    return _get_session_search_int("max_retries", default, min_v=0, max_v=5)
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -222,7 +283,13 @@ async def _summarize_session(
         f"Summarize this conversation with focus on: {query}"
     )
 
-    max_retries = 3
+    max_retries = _get_session_search_max_retries()
+    max_tokens = _get_session_search_max_summary_tokens()
+    if max_retries <= 0:
+        # User opted out of retries entirely (typical for local reasoning-mode
+        # backends that produce empty content as the norm). Fall through to the
+        # raw-preview fallback at the call site without ever invoking the LLM.
+        return None
     for attempt in range(max_retries):
         try:
             response = await async_call_llm(
@@ -232,7 +299,7 @@ async def _summarize_session(
                     {"role": "user", "content": user_prompt},
                 ],
                 temperature=0.1,
-                max_tokens=MAX_SUMMARY_TOKENS,
+                max_tokens=max_tokens,
             )
             content = extract_content_or_reasoning(response)
             if content:
@@ -353,7 +420,7 @@ def session_search(
         try:
             limit = int(limit)
         except (TypeError, ValueError):
-            limit = 3
+            limit = _get_session_search_default_limit()
     limit = max(1, min(limit, 5))  # Clamp to [1, 5]
 
     # Recent sessions mode: when query is empty, return metadata for recent sessions.
@@ -447,7 +514,9 @@ def session_search(
                     continue
                 session_meta = db.get_session(session_id) or {}
                 conversation_text = _format_conversation(messages)
-                conversation_text = _truncate_around_matches(conversation_text, query)
+                conversation_text = _truncate_around_matches(
+                    conversation_text, query, max_chars=_get_session_search_max_chars()
+                )
                 tasks.append((session_id, match_info, conversation_text, session_meta))
             except Exception as e:
                 logging.warning(
@@ -604,7 +673,7 @@ registry.register(
     handler=lambda args, **kw: session_search(
         query=args.get("query") or "",
         role_filter=args.get("role_filter"),
-        limit=args.get("limit", 3),
+        limit=args.get("limit") if args.get("limit") is not None else _get_session_search_default_limit(),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id")),
     check_fn=check_session_search_requirements,


### PR DESCRIPTION
## Summary

`tools/session_search_tool.py` hard-codes four cost-relevant values that drive `session_search` timeouts on slow / local-quantized auxiliary backends:

- `MAX_SESSION_CHARS = 100_000` — transcript prefill per summarization call
- `MAX_SUMMARY_TOKENS = 10_000` — generation cap per call
- `default limit = 3` — sessions summarized per query
- `max_retries = 3` inside `_summarize_session()` — retries on empty/transient

`auxiliary.session_search.*` already supports `provider`, `model`, `timeout`, `extra_body`, and `max_concurrency` (commit `6ab78401c`). The four values above logically belong in the same block but aren't surfaced. Users on slower backends currently have no remediation short of editing the file (conflicts on every `git pull`).

## The bug

From #27059 (reproducer: llama.cpp serving Qwen3.6-35B-A3B Q4_K_XL, 96-session DB):

| Run | Result | Time |
|-----|--------|------|
| 1 | success | 9.2s |
| 2 | timeout | 120.1s |
| 3 | success | 99.6s |
| 4 | timeout | 120.0s |
| 5 | timeout | 120.1s |

3/5 timeouts at defaults. After locally lowering `MAX_SESSION_CHARS` and `MAX_SUMMARY_TOKENS` by 3-5×, **the retry loop becomes the dominant cost** — 15/15 timeouts at 180s because 3 attempts × 30s timeout + (1+2+3)s backoff ≈ 96s per failed call. Empty-content responses (common with local reasoning-mode models where `extract_content_or_reasoning()` returns empty when only thinking tokens emit) trigger the retry path. Both knobs are needed; either alone leaves a tail.

## The fix

Extend the existing `auxiliary.session_search.*` pattern with four new optional keys, all preserving today's defaults:

\`\`\`yaml
auxiliary:
  session_search:
    # ...existing keys (provider, model, timeout, extra_body, max_concurrency)
    max_session_chars: 100000   # NEW, transcript truncation per session
    max_summary_tokens: 10000   # NEW, LLM output cap per session
    default_limit: 3            # NEW, default for the limit argument
    max_retries: 3              # NEW, retries on empty/transient failure
\`\`\`

Implementation factors `_get_session_search_max_concurrency` through a new generic `_get_session_search_int(key, default, min_v, max_v)` helper so all knobs share one parser. Bounds:

| Knob | min | max | rationale |
|---|---|---|---|
| `max_session_chars` | 1000 | (none) | <1000 starves the summarizer; no upper bound for frontier-model users |
| `max_summary_tokens` | 128 | 32000 | <128 useless; 32k matches typical context-window ceilings |
| `default_limit` | 1 | 5 | matches existing per-call \`limit\` clamp |
| `max_retries` | 0 | 5 | 0 intentional — see below |

\`max_retries = 0\` is the highest-impact knob for local reasoning-mode backends and is intentionally allowed. When set, \`_summarize_session()\` short-circuits and returns \`None\` before calling the LLM, falling through to the existing \`[Raw preview — summarization unavailable]\` fallback at the call site (line 524). This is what users in #27059 actually need: for backends that legitimately produce empty content on every call, retries add no value and dominate latency.

The existing \`max_concurrency\` contract is preserved unchanged: the refactored helper still clamps to \`[1, 5]\` and falls back to the default on parse failure.

## Test plan

- [x] Focused regression test: \`uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_session_search.py -v\` — 58 passed (16 new tests across 2 classes covering all 4 knobs + bounds + retries=0 short-circuit + max_tokens flow-through to the LLM call)
- [x] Adjacent suite: \`tests/tools/test_session_search.py tests/tools/test_mcp_tool_session_expired.py tests/tools/test_init_session_cwd_respect.py\` — 80 passed
- [x] Ruff: \`ruff check tools/session_search_tool.py tests/tools/test_session_search.py\` — clean
- [x] Regression guard: without any config keys set, \`_get_session_search_max_chars() == MAX_SESSION_CHARS\`, \`_get_session_search_max_summary_tokens() == MAX_SUMMARY_TOKENS\`, \`_get_session_search_default_limit() == 3\`, \`_get_session_search_max_retries() == 3\`, and \`async_call_llm\` is called with \`max_tokens=MAX_SUMMARY_TOKENS\` — behavior is byte-for-byte identical for users who don't set the new keys

## Behavior preservation

- All defaults match the current hard-coded values — zero behavior change for users who don't opt in
- Bounds clamping prevents pathological values (same pattern as the existing \`max_concurrency\` helper)
- No schema change — these are additive optional keys in an existing \`auxiliary.*\` block

> Sibling code paths that may need the same fix: \`tools/web_extract_tool.py\` and \`tools/web_search_tool.py\` likely share the same cost-knob shape for their auxiliary tasks. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

## Related

- Fixes #27059
- Extends \`auxiliary.session_search.*\` config pattern established in \`6ab78401c fix(aux): add session_search extra_body and concurrency controls\`