### PR TITLE
fix(metadata): qwen3.6-plus has a 1M context window (#27008)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -194,6 +194,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
+    "qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -747,6 +747,16 @@ class TestGetModelContextLength:
         assert get_model_context_length("qwen3-coder") == 262144
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_qwen3_6_plus_context_length(self, mock_fetch):
+        """qwen3.6-plus has a 1M context window, not the generic 128K Qwen default."""
+        mock_fetch.return_value = {}
+        assert get_model_context_length("qwen3.6-plus") == 1048576
+        # Provider-prefixed variants must resolve to the same explicit entry
+        # via the longest-substring fallback (no portal/OR cache available).
+        assert get_model_context_length("qwen/qwen3.6-plus") == 1048576
+        assert get_model_context_length("dashscope/qwen3.6-plus") == 1048576
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen_generic_context_length(self, mock_fetch):
         """Generic qwen models still get the 128K default."""
         mock_fetch.return_value = {}


### PR DESCRIPTION
## Summary
Fixes #27008.

`qwen3.6-plus` was missing from `DEFAULT_CONTEXT_LENGTHS` in `agent/model_metadata.py`. The longest-substring fallback then matched the generic `"qwen": 131072` catch-all, dropping the effective context limit from **1,048,576 → 131,072 tokens**, prematurely lowering the compression threshold and producing misleading "compression model context lower than main model" warnings during long sessions on DashScope / Alibaba / OpenRouter.

## Fix
Add an explicit entry before the generic catch-all:

```python
"qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
"qwen3-coder-plus": 1000000,
"qwen3-coder": 262144,
"qwen": 131072,
```

The lookup is longest-key-first substring matching, so this works for bare `qwen3.6-plus` and all provider-prefixed variants (`qwen/qwen3.6-plus`, `dashscope/qwen3.6-plus`, …).

## Not a duplicate of #6599
PR #6599's description mentions touching `agent/model_metadata.py` but its actual diff only adds the model to `hermes_cli/models.py` (the curated model list). The metadata table is independent and still defaults to 128K without this PR.

## Tests
```
bash scripts/run_tests.sh tests/agent/test_model_metadata.py -k qwen -q
# 4 passed in 69.15s
```

New `test_qwen3_6_plus_context_length` asserts 1,048,576 for bare and both provider-prefixed variants. Existing `test_qwen_generic_context_length` (asserting 131072 for unknown `qwen*` IDs) still passes — no regression.
