### PR TITLE
test(restart_drain): assert i18n catalog resolved

### DIFF
--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -33,7 +33,16 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
 
     result = await runner._handle_message(event)
 
-    assert result == t("gateway.draining", count=1)
+    expected = t("gateway.draining", count=1)
+    assert result == expected
+    # Guard against the silent-degradation regression in #22266: if the i18n
+    # catalog cannot be resolved (e.g. xdist workers losing the locales path)
+    # then ``t("gateway.draining", count=1)`` returns the bare key
+    # ``"gateway.draining"`` instead of the formatted English string, and both
+    # sides of the equality above would still match. Assert on the catalog
+    # output explicitly so a broken locale resolution fails loudly here.
+    assert expected != "gateway.draining"
+    assert "Draining" in expected and "1" in expected
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
 


### PR DESCRIPTION
## Summary
- `tests/gateway/test_restart_drain.py::test_restart_command_while_busy_requests_drain_without_interrupt` previously asserted that the runner's reply equals `t("gateway.draining", count=1)`. If the i18n catalog could not be resolved (e.g. an xdist worker losing the locales path — the original failure mode in #22266), `t()` returns the bare key `"gateway.draining"` instead of the formatted English string and **both sides of the equality still match silently**.
- Add explicit guards that the resolved string is not the raw catalog key and contains the English `Draining` text plus the `{count}` substitution, so locale resolution failures fail loudly here instead of being masked.

## Why test-only
The behavior bug in #22266 (test compared a hardcoded UI string to `t(...)`) was already fixed in commit `a4289d74a fix(test): use i18n t() for restart drain assertion`. The remaining gap is a regression hazard: the post-fix assertion happily passes even if i18n silently degrades. This PR keeps the existing assertion and adds the missing guardrail. No production code is touched.

## Test Plan
- [x] `python -m pytest tests/gateway/test_restart_drain.py -q -o 'addopts='` → 16 passed
- [x] `python -m pytest tests/agent/test_i18n.py -q -o 'addopts='` → 43 passed

## Duplicate PR check
- Exact open-PR search for #22266: no hits.
- Title/keyword search across open PRs: none found that touch this test.

Closes #22266