### PR TITLE
docs: add hermes-eval — skill regression testing + trajectory scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🛠️ [hermes-eval](https://github.com/Saurav0989/hermes-eval) — Skill regression testing and trajectory quality scoring. Catch skill drift before it propagates. Exports quality-filtered trajectories in Atropos RL format. GitHub Actions CI template included.
 
 ---
 


### PR DESCRIPTION
Adds hermes-eval — a skill regression testing + trajectory quality scoring library.

Addresses the skill drift problem documented in issue #13737 and multiple community posts.

The Atropos adapter outputs quality-scored ShareGPT trajectories directly in the format Atropos RL environments consume. MIT licensed, all tests offline (no LLM calls required).