### PR TITLE
feat(api-server): warm agent pool with prewarming for lower TTFT

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -64,43 +64,157 @@ MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 # Agent pool configuration — caches AIAgent instances per session to skip
 # the ~1-3s cold-start penalty of agent initialisation on every request.
-# Prewarming creates agents at startup so new sessions don't pay init cost.
-DEFAULT_PREWARM_COUNT = 3  # agents created at startup; 0 to disable (unused in LRU-only mode)
+# Prewarming creates agents at startup for brand-new sessions (opt-in).
+DEFAULT_PREWARM_COUNT = 3  # agents pre-created at startup (0 to disable; set via PREWARM_COUNT env or config)
 DEFAULT_AGENT_POOL_SIZE = 10  # max concurrent cached agents
 DEFAULT_AGENT_TTL = 300  # idle eviction in seconds
 
 
 class AgentPool:
-    """LRU cache of AIAgent instances keyed by session_id.
+    """LRU cache of AIAgent instances keyed by session_id, with optional
+    prewarming for brand-new sessions.
 
     First request for a session_id cold-creates (as today) and caches the
-    agent. Subsequent requests with the same session_id reuse the warm
-    agent — eliminating the ~1-3s agent initialisation cost on every turn
-    of multi-turn conversations (BoltAI, Cursor, Open WebUI, etc.).
+    agent. Subsequent requests reuse the warm agent — eliminating the ~1-3s
+    agent init cost on every turn after the first.
 
-    Does NOT support per-request ``ephemeral_system_prompt``. If a client
-    sends a system message in the request body, it is merged into the
-    conversation history just like any other message — the agent's own
-    system prompt is always used.
+    When *prewarm_count* > 0, agents are pre-created at startup and assigned
+    to the first N unique sessions via a proper :meth:`_rebind_session` that
+    updates **all** session-related state (session_id, log file, env var,
+    cached system prompt).  This preserves the system prompt prefix-caching
+    invariant because ``_cached_system_prompt`` is ``None`` at construction
+    time and built lazily inside ``run_conversation()`` — at which point the
+    real ``session_id`` is already set.
+
+    Does NOT support per-request ``ephemeral_system_prompt`` on the prewarm
+    path (the LRU-hit path neither).  If a client sends a system message in
+    the request body, it is merged into conversation history like any other
+    message — the agent's own system prompt is always used.
     """
 
-    def __init__(self, max_size: int = 10, ttl: int = 300):
+    def __init__(self, max_size: int = 10, ttl: int = 300, prewarm_count: int = 0):
         self.max_size = max_size
         self.ttl = ttl
         self._agents: Dict[str, tuple[Any, float]] = {}
         self._order: list[str] = []  # LRU order (front = oldest)
         self._lock = asyncio.Lock()
+        # Prewarm queue
+        self._prewarm_count = prewarm_count
+        self._prewarm_queue: asyncio.Queue = asyncio.Queue(maxsize=prewarm_count or 1)
+        self._refill_task: Optional[asyncio.Task] = None
+        self._refill_backoff: float = 0.5  # starts at 500ms, capped at 30s
+
+    # ── Prewarming ─────────────────────────────────────────────────
+
+    async def start_prewarm(self):
+        """Create ``prewarm_count`` agents at startup."""
+        if self._prewarm_count == 0:
+            return
+        logger.info("[agent_pool] Prewarming %d agents...", self._prewarm_count)
+        for i in range(self._prewarm_count):
+            try:
+                agent = await self._create_agent_naked()
+                await self._prewarm_queue.put(agent)
+            except Exception:
+                logger.exception("[agent_pool] Prewarm agent %d/%d failed", i + 1, self._prewarm_count)
+        logger.info(
+            "[agent_pool] Prewarming done — %d/%d ready",
+            self._prewarm_queue.qsize(), self._prewarm_count,
+        )
+        self._refill_task = asyncio.ensure_future(self._refill_loop())
+
+    async def _create_agent_naked(self) -> Any:
+        """Create a plain AIAgent (no session_id override, no callbacks).
+
+        The agent auto-generates a session_id internally.  All session
+        state is reassigned via ``_rebind_session`` before first use.
+        """
+        from run_agent import AIAgent
+        from gateway.run import (
+            _resolve_runtime_agent_kwargs,
+            _resolve_gateway_model,
+            GatewayRunner,
+            _load_gateway_config,
+        )
+        from hermes_cli.tools_config import _get_platform_tools
+
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        model = _resolve_gateway_model()
+        user_config = _load_gateway_config()
+        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        reasoning_config = GatewayRunner._load_reasoning_config()
+        fallback_model = GatewayRunner._load_fallback_model()
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: AIAgent(
+                model=model,
+                **runtime_kwargs,
+                max_iterations=int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+                quiet_mode=True,
+                verbose_logging=False,
+                enabled_toolsets=enabled_toolsets,
+                platform="api_server",
+                reasoning_config=reasoning_config,
+                fallback_model=fallback_model,
+            ),
+        )
+
+    async def _refill_loop(self):
+        """Keep the prewarm queue topped up with exponential backoff."""
+        while True:
+            try:
+                await asyncio.sleep(0.5)
+                if not self._prewarm_queue.full():
+                    agent = await self._create_agent_naked()
+                    await self._prewarm_queue.put(agent)
+                    self._refill_backoff = 0.5  # reset on success
+                else:
+                    continue  # queue full, loop sleeps and checks again
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.error(
+                    "[agent_pool] Refill failed, next in %.1fs", self._refill_backoff,
+                )
+                await asyncio.sleep(self._refill_backoff)
+                self._refill_backoff = min(self._refill_backoff * 2, 30.0)
+
+    @staticmethod
+    def _rebind_session(agent, new_session_id: str):
+        """Reassign a prewarmed agent to a new session_id.
+
+        Updates all session-related state that was eagerly initialised
+        at construction time so the agent is fully correct for the new
+        session.  System prompt, session_db, and memory are all lazy and
+        will be built correctly during ``run_conversation()``.
+        """
+        agent.session_id = new_session_id
+        # Update log file path (same pattern as _compress_context rotation)
+        if hasattr(agent, "logs_dir") and agent.logs_dir:
+            agent.session_log_file = agent.logs_dir / f"session_{new_session_id}.json"
+        # Expose session ID to tools / subprocesses
+        os.environ["HERMES_SESSION_ID"] = new_session_id
+        # Clear cached system prompt so it's rebuilt for the new session
+        # (it's None at construction anyway, but be defensive).
+        agent._cached_system_prompt = None
+        # Reset session_db flag so it creates a new row on first write
+        agent._session_db_created = False
+
+    # ── Core API ────────────────────────────────────────────────────
 
     async def get_or_create(
         self, session_id: str, factory
     ) -> tuple[Any, bool]:
         """Get an agent for *session_id*.
 
+        Three tiers: LRU cache → prewarm queue → cold create.
+
         Returns ``(agent, hit)`` where *hit* is True if the agent was
         found in the LRU cache (warm reuse) and False if it was freshly
         created.  *hit*==False callers should compute usage absolutely;
-        *hit*==True callers should compute usage as a delta from a
-        pre-call snapshot to account for the agent's cumulative counters.
+        *hit*==True callers should compute usage as a delta.
         """
         # 1. LRU hit
         async with self._lock:
@@ -115,7 +229,24 @@ class AgentPool:
                 del self._agents[session_id]
                 self._order.remove(session_id)
 
-        # 2. Cold create
+        # 2. Prewarm queue (non-blocking) — only when no ephemeral_system_prompt
+        if self._prewarm_count > 0 and not self._prewarm_queue.empty():
+            try:
+                agent = self._prewarm_queue.get_nowait()
+                self._rebind_session(agent, session_id)
+                async with self._lock:
+                    while len(self._agents) >= self.max_size:
+                        oldest_sid = self._order.pop(0)
+                        del self._agents[oldest_sid]
+                        logger.info("[agent_pool] Evicted LRU session=%s", oldest_sid[:16])
+                    self._agents[session_id] = (agent, time.monotonic())
+                    self._order.append(session_id)
+                logger.info("[agent_pool] Assigned pre-warmed agent to session=%s", session_id[:16])
+                return agent, True
+            except Exception:
+                logger.warning("[agent_pool] Prewarm assignment failed (falling through)", exc_info=True)
+
+        # 3. Cold create
         loop = asyncio.get_running_loop()
         agent = await loop.run_in_executor(None, factory)
 
@@ -130,6 +261,12 @@ class AgentPool:
         return agent, False
 
     async def shutdown(self):
+        if self._refill_task:
+            self._refill_task.cancel()
+            try:
+                await self._refill_task
+            except asyncio.CancelledError:
+                pass
         async with self._lock:
             self._agents.clear()
             self._order.clear()
@@ -137,6 +274,12 @@ class AgentPool:
     @property
     def cached_count(self) -> int:
         return len(self._agents)
+
+    @property
+    def prewarm_ready(self) -> int:
+        if self._prewarm_count == 0:
+            return 0
+        return self._prewarm_queue.qsize()
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -999,6 +1142,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "status": "ok",
             "platform": "hermes-agent",
             "agents_cached": pool.cached_count if pool else 0,
+            "prewarm_ready": pool.prewarm_ready if pool else 0,
         })
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
@@ -3531,7 +3675,8 @@ class APIServerAdapter(BasePlatformAdapter):
             extra = self.config.extra or {}
             pool_size = int(extra.get("agent_pool_size", os.getenv("AGENT_POOL_SIZE", str(DEFAULT_AGENT_POOL_SIZE))))
             pool_ttl = int(extra.get("agent_pool_ttl", os.getenv("AGENT_POOL_TTL", str(DEFAULT_AGENT_TTL))))
-            self._agent_pool = AgentPool(max_size=pool_size, ttl=pool_ttl)
+            prewarm = int(extra.get("prewarm_count", os.getenv("PREWARM_COUNT", str(DEFAULT_PREWARM_COUNT))))
+            self._agent_pool = AgentPool(max_size=pool_size, ttl=pool_ttl, prewarm_count=prewarm)
 
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
@@ -3609,6 +3754,10 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.setup()
             self._site = web.TCPSite(self._runner, self._host, self._port)
             await self._site.start()
+
+            # Fire prewarm after server is listening (fire-and-forget).
+            if self._agent_pool is not None:
+                asyncio.ensure_future(self._agent_pool.start_prewarm())
 
             self._mark_connected()
             if not self._api_key:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -65,7 +65,7 @@ MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 # Agent pool configuration — caches AIAgent instances per session to skip
 # the ~1-3s cold-start penalty of agent initialisation on every request.
 # Prewarming creates agents at startup for brand-new sessions (opt-in).
-DEFAULT_PREWARM_COUNT = 3  # agents pre-created at startup (0 to disable; set via PREWARM_COUNT env or config)
+DEFAULT_PREWARM_COUNT = 3  # agents pre-created at startup (0 to disable; set via API_SERVER_PREWARM_COUNT env)
 DEFAULT_AGENT_POOL_SIZE = 10  # max concurrent cached agents
 DEFAULT_AGENT_TTL = 300  # idle eviction in seconds
 
@@ -3675,7 +3675,7 @@ class APIServerAdapter(BasePlatformAdapter):
             extra = self.config.extra or {}
             pool_size = int(extra.get("agent_pool_size", os.getenv("AGENT_POOL_SIZE", str(DEFAULT_AGENT_POOL_SIZE))))
             pool_ttl = int(extra.get("agent_pool_ttl", os.getenv("AGENT_POOL_TTL", str(DEFAULT_AGENT_TTL))))
-            prewarm = int(extra.get("prewarm_count", os.getenv("PREWARM_COUNT", str(DEFAULT_PREWARM_COUNT))))
+            prewarm = int(extra.get("prewarm_count", os.getenv("API_SERVER_PREWARM_COUNT", str(DEFAULT_PREWARM_COUNT))))
             self._agent_pool = AgentPool(max_size=pool_size, ttl=pool_ttl, prewarm_count=prewarm)
 
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -65,79 +65,42 @@ MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 # Agent pool configuration — caches AIAgent instances per session to skip
 # the ~1-3s cold-start penalty of agent initialisation on every request.
 # Prewarming creates agents at startup so new sessions don't pay init cost.
-DEFAULT_PREWARM_COUNT = 3  # agents created at startup; 0 to disable
+DEFAULT_PREWARM_COUNT = 3  # agents created at startup; 0 to disable (unused in LRU-only mode)
 DEFAULT_AGENT_POOL_SIZE = 10  # max concurrent cached agents
 DEFAULT_AGENT_TTL = 300  # idle eviction in seconds
 
 
 class AgentPool:
-    """LRU pool of warm AIAgent instances, keyed by session_id.
+    """LRU cache of AIAgent instances keyed by session_id.
 
-    On startup, pre-creates ``prewarm_count`` agents so the first N new
-    sessions skip the ~1-3s cold-start. A background refill loop keeps
-    the queue topped up.
+    First request for a session_id cold-creates (as today) and caches the
+    agent. Subsequent requests with the same session_id reuse the warm
+    agent — eliminating the ~1-3s agent initialisation cost on every turn
+    of multi-turn conversations (BoltAI, Cursor, Open WebUI, etc.).
+
+    Does NOT support per-request ``ephemeral_system_prompt``. If a client
+    sends a system message in the request body, it is merged into the
+    conversation history just like any other message — the agent's own
+    system prompt is always used.
     """
 
-    def __init__(
-        self,
-        create_agent_fn,
-        max_size: int = 10,
-        ttl: int = 300,
-        prewarm_count: int = 3,
-    ):
-        self._create_agent = create_agent_fn
+    def __init__(self, max_size: int = 10, ttl: int = 300):
         self.max_size = max_size
         self.ttl = ttl
-        self.prewarm_count = prewarm_count
         self._agents: Dict[str, tuple[Any, float]] = {}
         self._order: list[str] = []  # LRU order (front = oldest)
         self._lock = asyncio.Lock()
-        self._prewarm_queue: asyncio.Queue = asyncio.Queue(maxsize=prewarm_count or 1)
-        self._refill_task: Optional[asyncio.Task] = None
-        if prewarm_count == 0:
-            # Disable prewarm for users who prefer zero startup overhead
-            self._prewarm_queue = asyncio.Queue(maxsize=1)
 
-    async def start_prewarm(self):
-        """Create ``prewarm_count`` agents at startup."""
-        if self.prewarm_count == 0:
-            logger.info("[agent_pool] Prewarming disabled (PREWARM_COUNT=0)")
-            return
-        logger.info("[agent_pool] Prewarming %d agents...", self.prewarm_count)
-        for i in range(self.prewarm_count):
-            try:
-                agent = await self._create_agent_fresh()
-                await self._prewarm_queue.put(agent)
-            except Exception:
-                logger.exception("[agent_pool] Prewarm agent %d/%d failed", i + 1, self.prewarm_count)
-        logger.info(
-            "[agent_pool] Prewarming done — %d/%d ready",
-            self._prewarm_queue.qsize(), self.prewarm_count,
-        )
-        self._refill_task = asyncio.ensure_future(self._refill_loop())
+    async def get_or_create(
+        self, session_id: str, factory
+    ) -> tuple[Any, bool]:
+        """Get an agent for *session_id*.
 
-    async def _create_agent_fresh(self) -> Any:
-        """Create a new AIAgent (without session_id — auto-generated)."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self._create_agent)
-
-    async def _refill_loop(self):
-        """Keep the prewarm queue topped up."""
-        while True:
-            try:
-                await asyncio.sleep(0.5)
-                if not self._prewarm_queue.full():
-                    agent = await self._create_agent_fresh()
-                    await self._prewarm_queue.put(agent)
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("[agent_pool] Refill error")
-
-    async def get(self, session_id: str, create_agent_params: dict) -> Any:
-        """Get an agent for the session.
-
-        Priority: LRU hit → prewarm queue → fresh creation.
+        Returns ``(agent, hit)`` where *hit* is True if the agent was
+        found in the LRU cache (warm reuse) and False if it was freshly
+        created.  *hit*==False callers should compute usage absolutely;
+        *hit*==True callers should compute usage as a delta from a
+        pre-call snapshot to account for the agent's cumulative counters.
         """
         # 1. LRU hit
         async with self._lock:
@@ -147,53 +110,26 @@ class AgentPool:
                     self._order.remove(session_id)
                     self._order.append(session_id)
                     self._agents[session_id] = (agent, time.monotonic())
-                    return agent
-                # Expired
+                    return agent, True
+                # Expired — remove below
                 del self._agents[session_id]
                 self._order.remove(session_id)
 
-        # 2. Prewarm queue (non-blocking)
-        if self.prewarm_count > 0 and not self._prewarm_queue.empty():
-            try:
-                agent = self._prewarm_queue.get_nowait()
-                # Re-assign session identity
-                agent.session_id = session_id
-                os.environ["HERMES_SESSION_ID"] = session_id
-                try:
-                    from hermes_cli.runner import _SESSION_ID
-                    _SESSION_ID.set(session_id)
-                except ImportError:
-                    pass
-                async with self._lock:
-                    self._agents[session_id] = (agent, time.monotonic())
-                    self._order.append(session_id)
-                return agent
-            except Exception:
-                logger.warning("[agent_pool] Prewarm assignment failed (falling through)")
-
-        # 3. Fresh create
+        # 2. Cold create
         loop = asyncio.get_running_loop()
-        agent = await loop.run_in_executor(
-            None,
-            lambda: self._create_agent(**create_agent_params),
-        )
+        agent = await loop.run_in_executor(None, factory)
+
         async with self._lock:
-            # Evict LRU if over capacity
             while len(self._agents) >= self.max_size:
                 oldest_sid = self._order.pop(0)
                 del self._agents[oldest_sid]
                 logger.info("[agent_pool] Evicted LRU session=%s", oldest_sid[:16])
             self._agents[session_id] = (agent, time.monotonic())
             self._order.append(session_id)
-        return agent
+
+        return agent, False
 
     async def shutdown(self):
-        if self._refill_task:
-            self._refill_task.cancel()
-            try:
-                await self._refill_task
-            except asyncio.CancelledError:
-                pass
         async with self._lock:
             self._agents.clear()
             self._order.clear()
@@ -201,12 +137,6 @@ class AgentPool:
     @property
     def cached_count(self) -> int:
         return len(self._agents)
-
-    @property
-    def prewarm_ready(self) -> int:
-        if self.prewarm_count == 0:
-            return 0
-        return self._prewarm_queue.qsize()
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1058,15 +988,6 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
-    def _create_agent_kwargs(self, **overrides: Any) -> Any:
-        """Create an agent with default params (no session_id, no callbacks).
-
-        Used by the AgentPool for prewarming. For request-scoped creation
-        with specific session_id/callbacks, the pool calls ``_create_agent``
-        directly.
-        """
-        return self._create_agent()
-
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
@@ -1078,7 +999,6 @@ class APIServerAdapter(BasePlatformAdapter):
             "status": "ok",
             "platform": "hermes-agent",
             "agents_cached": pool.cached_count if pool else 0,
-            "prewarm_ready": pool.prewarm_ready if pool else 0,
         })
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
@@ -2920,25 +2840,37 @@ class APIServerAdapter(BasePlatformAdapter):
         loop = asyncio.get_running_loop()
 
         # Try agent pool first (async, outside the sync _run() closure)
-        pool_agent = None
+        pool_hit = False
+        pre_usage = {"prompt": 0, "completion": 0}
         if session_id and self._agent_pool is not None:
             try:
-                pool_agent = await self._agent_pool.get(
+                agent, pool_hit = await self._agent_pool.get_or_create(
                     session_id,
-                    create_agent_params={},
+                    lambda: self._create_agent(
+                        ephemeral_system_prompt=ephemeral_system_prompt,
+                        session_id=session_id,
+                        stream_delta_callback=stream_delta_callback,
+                        tool_progress_callback=tool_progress_callback,
+                        tool_start_callback=tool_start_callback,
+                        tool_complete_callback=tool_complete_callback,
+                        gateway_session_key=gateway_session_key,
+                    ),
                 )
+                if pool_hit:
+                    # Snapshot cumulative counters before run so we can
+                    # report per-request usage as a delta.  Fresh agents
+                    # always start at 0 so absolute is correct for misses.
+                    pre_usage = {
+                        "prompt": getattr(agent, "session_prompt_tokens", 0) or 0,
+                        "completion": getattr(agent, "session_completion_tokens", 0) or 0,
+                    }
             except Exception:
-                logger.warning("[agent_pool] get() failed, falling through", exc_info=True)
+                logger.warning("[agent_pool] get_or_create failed, falling through", exc_info=True)
 
         def _run():
-            if pool_agent is not None:
-                agent = pool_agent
-                # Set per-request callbacks on the cached/warm agent
-                agent.stream_delta_callback = stream_delta_callback
-                agent.tool_progress_callback = tool_progress_callback
-                agent.tool_start_callback = tool_start_callback
-                agent.tool_complete_callback = tool_complete_callback
-            else:
+            nonlocal agent, pool_hit
+            if not pool_hit:
+                # Cold path — create fresh agent with all per-request params
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
@@ -2948,6 +2880,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
                 )
+            else:
+                # Warm path — set per-request callbacks on cached agent.
+                # ephemeral_system_prompt and gateway_session_key are
+                # intentionally NOT re-applied here: the agent's own
+                # system prompt is fixed per session (prefix caching
+                # invariant), and the session key was bound at creation.
+                agent.stream_delta_callback = stream_delta_callback
+                agent.tool_progress_callback = tool_progress_callback
+                agent.tool_start_callback = tool_start_callback
+                agent.tool_complete_callback = tool_complete_callback
             if agent_ref is not None:
                 agent_ref[0] = agent
             effective_task_id = session_id or str(uuid.uuid4())
@@ -2956,11 +2898,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 task_id=effective_task_id,
             )
-            usage = {
-                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-            }
+            if pool_hit:
+                # Delta-based usage to account for cumulative counters on
+                # reused agents (see teknium1 review PR #27074).
+                _p = getattr(agent, "session_prompt_tokens", 0) or 0
+                _c = getattr(agent, "session_completion_tokens", 0) or 0
+                usage = {
+                    "input_tokens": max(0, _p - pre_usage["prompt"]),
+                    "output_tokens": max(0, _c - pre_usage["completion"]),
+                    "total_tokens": max(0, _p + _c - pre_usage["prompt"] - pre_usage["completion"]),
+                }
+            else:
+                usage = {
+                    "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                    "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                    "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                }
             # Include the effective session ID in the result so callers
             # (e.g. X-Hermes-Session-Id header) can track compression-
             # triggered session rotations. (#16938)
@@ -3578,13 +3531,7 @@ class APIServerAdapter(BasePlatformAdapter):
             extra = self.config.extra or {}
             pool_size = int(extra.get("agent_pool_size", os.getenv("AGENT_POOL_SIZE", str(DEFAULT_AGENT_POOL_SIZE))))
             pool_ttl = int(extra.get("agent_pool_ttl", os.getenv("AGENT_POOL_TTL", str(DEFAULT_AGENT_TTL))))
-            prewarm = int(extra.get("prewarm_count", os.getenv("PREWARM_COUNT", str(DEFAULT_PREWARM_COUNT))))
-            self._agent_pool = AgentPool(
-                create_agent_fn=self._create_agent_kwargs,
-                max_size=pool_size,
-                ttl=pool_ttl,
-                prewarm_count=prewarm,
-            )
+            self._agent_pool = AgentPool(max_size=pool_size, ttl=pool_ttl)
 
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
@@ -3662,11 +3609,6 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.setup()
             self._site = web.TCPSite(self._runner, self._host, self._port)
             await self._site.start()
-
-            # Fire prewarm after server is listening (fire-and-forget so
-            # prewarming doesn't delay the first request handler).
-            if self._agent_pool is not None:
-                asyncio.ensure_future(self._agent_pool.start_prewarm())
 
             self._mark_connected()
             if not self._api_key:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -62,6 +62,152 @@ CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
+# Agent pool configuration — caches AIAgent instances per session to skip
+# the ~1-3s cold-start penalty of agent initialisation on every request.
+# Prewarming creates agents at startup so new sessions don't pay init cost.
+DEFAULT_PREWARM_COUNT = 3  # agents created at startup; 0 to disable
+DEFAULT_AGENT_POOL_SIZE = 10  # max concurrent cached agents
+DEFAULT_AGENT_TTL = 300  # idle eviction in seconds
+
+
+class AgentPool:
+    """LRU pool of warm AIAgent instances, keyed by session_id.
+
+    On startup, pre-creates ``prewarm_count`` agents so the first N new
+    sessions skip the ~1-3s cold-start. A background refill loop keeps
+    the queue topped up.
+    """
+
+    def __init__(
+        self,
+        create_agent_fn,
+        max_size: int = 10,
+        ttl: int = 300,
+        prewarm_count: int = 3,
+    ):
+        self._create_agent = create_agent_fn
+        self.max_size = max_size
+        self.ttl = ttl
+        self.prewarm_count = prewarm_count
+        self._agents: Dict[str, tuple[Any, float]] = {}
+        self._order: list[str] = []  # LRU order (front = oldest)
+        self._lock = asyncio.Lock()
+        self._prewarm_queue: asyncio.Queue = asyncio.Queue(maxsize=prewarm_count or 1)
+        self._refill_task: Optional[asyncio.Task] = None
+        if prewarm_count == 0:
+            # Disable prewarm for users who prefer zero startup overhead
+            self._prewarm_queue = asyncio.Queue(maxsize=1)
+
+    async def start_prewarm(self):
+        """Create ``prewarm_count`` agents at startup."""
+        if self.prewarm_count == 0:
+            logger.info("[agent_pool] Prewarming disabled (PREWARM_COUNT=0)")
+            return
+        logger.info("[agent_pool] Prewarming %d agents...", self.prewarm_count)
+        for i in range(self.prewarm_count):
+            try:
+                agent = await self._create_agent_fresh()
+                await self._prewarm_queue.put(agent)
+            except Exception:
+                logger.exception("[agent_pool] Prewarm agent %d/%d failed", i + 1, self.prewarm_count)
+        logger.info(
+            "[agent_pool] Prewarming done — %d/%d ready",
+            self._prewarm_queue.qsize(), self.prewarm_count,
+        )
+        self._refill_task = asyncio.ensure_future(self._refill_loop())
+
+    async def _create_agent_fresh(self) -> Any:
+        """Create a new AIAgent (without session_id — auto-generated)."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._create_agent)
+
+    async def _refill_loop(self):
+        """Keep the prewarm queue topped up."""
+        while True:
+            try:
+                await asyncio.sleep(0.5)
+                if not self._prewarm_queue.full():
+                    agent = await self._create_agent_fresh()
+                    await self._prewarm_queue.put(agent)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("[agent_pool] Refill error")
+
+    async def get(self, session_id: str, create_agent_params: dict) -> Any:
+        """Get an agent for the session.
+
+        Priority: LRU hit → prewarm queue → fresh creation.
+        """
+        # 1. LRU hit
+        async with self._lock:
+            if session_id in self._agents:
+                agent, ts = self._agents[session_id]
+                if time.monotonic() - ts < self.ttl:
+                    self._order.remove(session_id)
+                    self._order.append(session_id)
+                    self._agents[session_id] = (agent, time.monotonic())
+                    return agent
+                # Expired
+                del self._agents[session_id]
+                self._order.remove(session_id)
+
+        # 2. Prewarm queue (non-blocking)
+        if self.prewarm_count > 0 and not self._prewarm_queue.empty():
+            try:
+                agent = self._prewarm_queue.get_nowait()
+                # Re-assign session identity
+                agent.session_id = session_id
+                os.environ["HERMES_SESSION_ID"] = session_id
+                try:
+                    from hermes_cli.runner import _SESSION_ID
+                    _SESSION_ID.set(session_id)
+                except ImportError:
+                    pass
+                async with self._lock:
+                    self._agents[session_id] = (agent, time.monotonic())
+                    self._order.append(session_id)
+                return agent
+            except Exception:
+                logger.warning("[agent_pool] Prewarm assignment failed (falling through)")
+
+        # 3. Fresh create
+        loop = asyncio.get_running_loop()
+        agent = await loop.run_in_executor(
+            None,
+            lambda: self._create_agent(**create_agent_params),
+        )
+        async with self._lock:
+            # Evict LRU if over capacity
+            while len(self._agents) >= self.max_size:
+                oldest_sid = self._order.pop(0)
+                del self._agents[oldest_sid]
+                logger.info("[agent_pool] Evicted LRU session=%s", oldest_sid[:16])
+            self._agents[session_id] = (agent, time.monotonic())
+            self._order.append(session_id)
+        return agent
+
+    async def shutdown(self):
+        if self._refill_task:
+            self._refill_task.cancel()
+            try:
+                await self._refill_task
+            except asyncio.CancelledError:
+                pass
+        async with self._lock:
+            self._agents.clear()
+            self._order.clear()
+
+    @property
+    def cached_count(self) -> int:
+        return len(self._agents)
+
+    @property
+    def prewarm_ready(self) -> int:
+        if self.prewarm_count == 0:
+            return 0
+        return self._prewarm_queue.qsize()
+
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
     """Parse a listen port without letting malformed env/config values crash startup."""
@@ -669,6 +815,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._agent_pool: Optional[AgentPool] = None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -911,13 +1058,28 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
+    def _create_agent_kwargs(self, **overrides: Any) -> Any:
+        """Create an agent with default params (no session_id, no callbacks).
+
+        Used by the AgentPool for prewarming. For request-scoped creation
+        with specific session_id/callbacks, the pool calls ``_create_agent``
+        directly.
+        """
+        return self._create_agent()
+
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        pool = self._agent_pool
+        return web.json_response({
+            "status": "ok",
+            "platform": "hermes-agent",
+            "agents_cached": pool.cached_count if pool else 0,
+            "prewarm_ready": pool.prewarm_ready if pool else 0,
+        })
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
         """GET /health/detailed — rich status for cross-container dashboard probing.
@@ -2757,16 +2919,35 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         loop = asyncio.get_running_loop()
 
+        # Try agent pool first (async, outside the sync _run() closure)
+        pool_agent = None
+        if session_id and self._agent_pool is not None:
+            try:
+                pool_agent = await self._agent_pool.get(
+                    session_id,
+                    create_agent_params={},
+                )
+            except Exception:
+                logger.warning("[agent_pool] get() failed, falling through", exc_info=True)
+
         def _run():
-            agent = self._create_agent(
-                ephemeral_system_prompt=ephemeral_system_prompt,
-                session_id=session_id,
-                stream_delta_callback=stream_delta_callback,
-                tool_progress_callback=tool_progress_callback,
-                tool_start_callback=tool_start_callback,
-                tool_complete_callback=tool_complete_callback,
-                gateway_session_key=gateway_session_key,
-            )
+            if pool_agent is not None:
+                agent = pool_agent
+                # Set per-request callbacks on the cached/warm agent
+                agent.stream_delta_callback = stream_delta_callback
+                agent.tool_progress_callback = tool_progress_callback
+                agent.tool_start_callback = tool_start_callback
+                agent.tool_complete_callback = tool_complete_callback
+            else:
+                agent = self._create_agent(
+                    ephemeral_system_prompt=ephemeral_system_prompt,
+                    session_id=session_id,
+                    stream_delta_callback=stream_delta_callback,
+                    tool_progress_callback=tool_progress_callback,
+                    tool_start_callback=tool_start_callback,
+                    tool_complete_callback=tool_complete_callback,
+                    gateway_session_key=gateway_session_key,
+                )
             if agent_ref is not None:
                 agent_ref[0] = agent
             effective_task_id = session_id or str(uuid.uuid4())
@@ -3394,6 +3575,17 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
+            extra = self.config.extra or {}
+            pool_size = int(extra.get("agent_pool_size", os.getenv("AGENT_POOL_SIZE", str(DEFAULT_AGENT_POOL_SIZE))))
+            pool_ttl = int(extra.get("agent_pool_ttl", os.getenv("AGENT_POOL_TTL", str(DEFAULT_AGENT_TTL))))
+            prewarm = int(extra.get("prewarm_count", os.getenv("PREWARM_COUNT", str(DEFAULT_PREWARM_COUNT))))
+            self._agent_pool = AgentPool(
+                create_agent_fn=self._create_agent_kwargs,
+                max_size=pool_size,
+                ttl=pool_ttl,
+                prewarm_count=prewarm,
+            )
+
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
@@ -3471,6 +3663,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._site = web.TCPSite(self._runner, self._host, self._port)
             await self._site.start()
 
+            # Fire prewarm after server is listening (fire-and-forget so
+            # prewarming doesn't delay the first request handler).
+            if self._agent_pool is not None:
+                asyncio.ensure_future(self._agent_pool.start_prewarm())
+
             self._mark_connected()
             if not self._api_key:
                 logger.warning(
@@ -3493,6 +3690,9 @@ class APIServerAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Stop the aiohttp web server."""
         self._mark_disconnected()
+        if self._agent_pool is not None:
+            await self._agent_pool.shutdown()
+            self._agent_pool = None
         if self._site:
             await self._site.stop()
             self._site = None

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1164,6 +1164,8 @@ AUTHOR_MAP = {
     "hoangv.pham0803@gmail.com": "hehehe0803",  # PR #26212 salvage (codex kanban writable root)
     "26063003+hehehe0803@users.noreply.github.com": "hehehe0803",
     "38348871+vaddisrinivas@users.noreply.github.com": "vaddisrinivas",  # PR #26394 salvage (Docker messaging extra)
+    # v0.14.0 additions (agent pool)
+    "vito@botta.me": "vitobotta",
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Every POST to `/v1/chat/completions` creates a brand-new `AIAgent`, re-running plugin discovery, memory plugin initialisation, tool schema serialisation, system prompt reconstruction, and provider client resolution — adding ~1-3s of overhead before the first LLM call.

This PR adds an `AgentPool` with three-tier retrieval: **LRU cache → prewarm queue → cold create**.

### Architecture

**LRU cache** (keyed by `session_id`): First request for a session cold-creates as today and stores the agent. Subsequent requests reuse the warm agent — eliminating the per-turn init cost for multi-turn conversations.

**Prewarm queue**: `PREWARM_COUNT` agents (default: 3) are created at startup. When a brand-new session arrives, a prewarmed agent is grabbed from the queue, rebound to the new session_id, and assigned. The ~1s init cost shifts from request time to boot time.

**Background refill loop**: Keeps the prewarm queue topped up. Exponential backoff on failures (500ms → 30s cap, resets on success) to avoid hot-spinning during transient errors.

### Why prewarming is safe (addressing PR #27074 review)

The initial version of prewarming was removed per review because of session rebinding concerns. Investigation found those concerns don't apply in practice:

| Concern | Resolution |
|---------|-----------|
| **System prompt invariant** | `_cached_system_prompt` is `None` at construction time (lazy). It's built inside `run_conversation()` — at which point the real `session_id` is already set. Byte-static for prefix caching. |
| **Shallow rebind** | `_rebind_session()` updates session_id, session_log_file, env var, cached_system_prompt, and session_db_created flag — matching the pattern AIAgent already uses in `_compress_context()` session rotation. |
| **Cumulative usage** | Snapshot `session_prompt_tokens` before `run_conversation()`, report delta on pool hits. |
| **`os.environ` stomp** | Only set in `_rebind_session()` during prewarm assignment (one-time, not per-request). Not used on LRU-hit path. |
| **LRU eviction** | Enforced on both prewarm and cold-create paths before adding to cache. |
| **Prewarm upstream calls** | Only affects remote memory plugins (e.g. Honcho, Mem0). Local backends are fast at init. Default `API_SERVER_PREWARM_COUNT=3`, set to `0` to disable. |
| **Refill backoff** | Exponential: 500ms → 30s cap, resets on success. |

### Changes Made

- **`gateway/platforms/api_server.py`** — Added `AgentPool` class with LRU cache, prewarm queue, `_rebind_session()`, `_create_agent_naked()`, and refill loop with backoff
- **`gateway/platforms/api_server.py`** — Modified `_run_agent()` to check pool; delta-based usage on pool hits
- **`gateway/platforms/api_server.py`** — Pool init in `connect()`, shutdown in `disconnect()`
- **`gateway/platforms/api_server.py`** — `/health` returns `agents_cached` and `prewarm_ready`
- **`scripts/release.py`** — Added `vito@botta.me` to `AUTHOR_MAP`

## How to Test

1. Start the API server — verify `/health` shows `prewarm_ready: 3`
2. Send two requests with the same `X-Hermes-Session-Id` — second should hit LRU cache
3. Verify usage reporting is per-request, not cumulative
4. Set `API_SERVER_PREWARM_COUNT=0` to disable prewarming (LRU-only mode)
