### PR TITLE
fix(nix): load google_chat platform under Nix

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -174,10 +174,22 @@ class Platform(Enum):
 
     @classmethod
     def _scan_bundled_plugin_platforms(cls) -> set:
-        """Return names of bundled platform plugins under ``plugins/platforms/``."""
+        """Return names of bundled platform plugins under ``plugins/platforms/``.
+
+        Packaged installs may relocate bundled plugins outside the source tree
+        and advertise that directory through ``HERMES_BUNDLED_PLUGINS``.
+        Keep this scanner aligned with the main plugin loader so dynamic
+        platform enum members are available before plugin adapters import.
+        """
         names: set = set()
         try:
-            platforms_dir = Path(__file__).parent.parent / "plugins" / "platforms"
+            bundled_plugins = os.getenv("HERMES_BUNDLED_PLUGINS")
+            plugins_dir = (
+                Path(bundled_plugins)
+                if bundled_plugins
+                else Path(__file__).parent.parent / "plugins"
+            )
+            platforms_dir = plugins_dir / "platforms"
             if platforms_dir.is_dir():
                 for child in platforms_dir.iterdir():
                     if (


### PR DESCRIPTION
## Problem

When starting hermes gateway under nix, get this warning:

```
WARNING hermes_cli.plugins: Failed to load plugin 'google_chat-platform': 'google_chat' is not a valid Platform
```

## Summary
- honor HERMES_BUNDLED_PLUGINS when scanning bundled gateway platform plugins
- allow Platform("google_chat") to resolve before the Google Chat adapter imports under Nix packaging
- keep the existing repo-relative plugins/platforms fallback for development checkouts

## Verification
- .venv/bin/python direct regression check for a Nix-like HERMES_BUNDLED_PLUGINS plugin tree