### PR TITLE
feat(mcp): add codex preset for built-in MCP server discovery

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -31,7 +31,12 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-_MCP_PRESETS: Dict[str, Dict[str, Any]] = {}
+_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+    "codex": {
+        "command": "codex",
+        "args": ["mcp-server"],
+    },
+}
 
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `codex` to the MCP server presets registry so users can integrate Codex CLI as an MCP server with a single command:

    hermes mcp add codex --preset codex

This spawns `codex mcp-server` as a stdio MCP server, and Hermes's native MCP client discovers Codex's tools (file operations, terminal, search, etc.) — making them available as first-class Hermes tools.

## What This Does

6 lines in `hermes_cli/mcp_config.py` — adds a single preset entry to the existing `_MCP_PRESETS` registry:

```python
"codex": {
    "command": "codex",
    "args": ["mcp-server"],
},
```

## Changes

1 file changed, 6 insertions(+), 1 deletion(-)

---

Replaces closed PR #22663. Same commit, same diff.