### PR TITLE
refactor(matrix): migrate from matrix-nio to mautrix-python

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -909,11 +909,16 @@ class MatrixAdapter(BasePlatformAdapter):
         if relates_to.get("rel_type") == "m.replace":
             return
 
+        # Ignore m.notice to prevent bot-to-bot loops (m.notice is the
+        # conventional msgtype for bot responses in the Matrix ecosystem).
+        if msgtype == "m.notice":
+            return
+
         # Dispatch by msgtype.
         media_msgtypes = ("m.image", "m.audio", "m.video", "m.file")
         if msgtype in media_msgtypes:
             await self._handle_media_message(room_id, sender, event_id, event_ts, source_content, relates_to, msgtype)
-        elif msgtype in ("m.text", "m.notice"):
+        elif msgtype == "m.text":
             await self._handle_text_message(room_id, sender, event_id, event_ts, source_content, relates_to)
 
     async def _resolve_message_context(

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1,8 +1,8 @@
 """Matrix gateway adapter.
 
 Connects to any Matrix homeserver (self-hosted or matrix.org) via the
-matrix-nio Python SDK.  Supports optional end-to-end encryption (E2EE)
-when installed with ``pip install "matrix-nio[e2e]"``.
+mautrix Python SDK.  Supports optional end-to-end encryption (E2EE)
+when installed with ``pip install "mautrix[encryption]"``.
 
 Environment variables:
     MATRIX_HOMESERVER           Homeserver URL (e.g. https://matrix.example.org)
@@ -24,7 +24,6 @@ Environment variables:
 from __future__ import annotations
 
 import asyncio
-import io
 import json
 import logging
 import mimetypes
@@ -59,26 +58,22 @@ _STORE_DIR = _get_hermes_dir("platforms/matrix/store", "matrix/store")
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
 
-# E2EE key export file for persistence across restarts.
-_KEY_EXPORT_FILE = _STORE_DIR / "exported_keys.txt"
-_KEY_EXPORT_PASSPHRASE = "hermes-matrix-e2ee-keys"
-
 # Pending undecrypted events: cap and TTL for retry buffer.
 _MAX_PENDING_EVENTS = 100
 _PENDING_EVENT_TTL = 300  # seconds — stop retrying after 5 min
 
 
 _E2EE_INSTALL_HINT = (
-    "Install with: pip install 'matrix-nio[e2e]'  "
+    "Install with: pip install 'mautrix[encryption]'  "
     "(requires libolm C library)"
 )
 
 
 def _check_e2ee_deps() -> bool:
-    """Return True if matrix-nio E2EE dependencies (python-olm) are available."""
+    """Return True if mautrix E2EE dependencies (python-olm) are available."""
     try:
-        from nio.crypto import ENCRYPTION_ENABLED
-        return bool(ENCRYPTION_ENABLED)
+        from mautrix.crypto import OlmMachine  # noqa: F401
+        return True
     except (ImportError, AttributeError):
         return False
 
@@ -96,11 +91,11 @@ def check_matrix_requirements() -> bool:
         logger.warning("Matrix: MATRIX_HOMESERVER not set")
         return False
     try:
-        import nio  # noqa: F401
+        import mautrix  # noqa: F401
     except ImportError:
         logger.warning(
-            "Matrix: matrix-nio not installed. "
-            "Run: pip install 'matrix-nio[e2e]'"
+            "Matrix: mautrix not installed. "
+            "Run: pip install 'mautrix[encryption]'"
         )
         return False
 
@@ -152,7 +147,7 @@ class MatrixAdapter(BasePlatformAdapter):
             or os.getenv("MATRIX_DEVICE_ID", "")
         )
 
-        self._client: Any = None  # nio.AsyncClient
+        self._client: Any = None  # mautrix.client.Client
         self._sync_task: Optional[asyncio.Task] = None
         self._closing = False
         self._startup_ts: float = 0.0
@@ -167,7 +162,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events_set: set = set()
 
         # Buffer for undecrypted events pending key receipt.
-        # Each entry: (room, event, timestamp)
+        # Each entry: (room_id, event, timestamp)
         self._pending_megolm: list = []
 
         # Thread participation tracking (for require_mention bypass)
@@ -208,21 +203,86 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to the Matrix homeserver and start syncing."""
-        import nio
+        from mautrix.api import HTTPAPI
+        from mautrix.client import Client
+        from mautrix.client.state_store import MemoryStateStore, MemorySyncStore
+        from mautrix.types import EventType, UserID
 
         if not self._homeserver:
             logger.error("Matrix: homeserver URL not configured")
             return False
 
-        # Determine store path and ensure it exists.
-        store_path = str(_STORE_DIR)
+        # Ensure store dir exists for E2EE key persistence.
         _STORE_DIR.mkdir(parents=True, exist_ok=True)
 
+        # Create the HTTP API layer.
+        api = HTTPAPI(
+            base_url=self._homeserver,
+            token=self._access_token or "",
+        )
+
         # Create the client.
-        # When a stable device_id is configured, pass it to the constructor
-        # so matrix-nio binds to it from the start (important for E2EE
-        # crypto-store persistence across restarts).
-        ctor_device_id = self._device_id or None
+        state_store = MemoryStateStore()
+        sync_store = MemorySyncStore()
+        client = Client(
+            mxid=UserID(self._user_id) if self._user_id else UserID(""),
+            device_id=self._device_id or None,
+            api=api,
+            state_store=state_store,
+            sync_store=sync_store,
+        )
+
+        self._client = client
+
+        # Authenticate.
+        if self._access_token:
+            api.token = self._access_token
+
+            # Validate the token and learn user_id / device_id.
+            try:
+                resp = await client.whoami()
+                resolved_user_id = getattr(resp, "user_id", "") or self._user_id
+                resolved_device_id = getattr(resp, "device_id", "")
+                if resolved_user_id:
+                    self._user_id = str(resolved_user_id)
+                    client.mxid = UserID(self._user_id)
+
+                # Prefer user-configured device_id for stable E2EE identity.
+                effective_device_id = self._device_id or resolved_device_id
+                if effective_device_id:
+                    client.device_id = effective_device_id
+
+                logger.info(
+                    "Matrix: using access token for %s%s",
+                    self._user_id or "(unknown user)",
+                    f" (device {effective_device_id})" if effective_device_id else "",
+                )
+            except Exception as exc:
+                logger.error(
+                    "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
+                    exc,
+                )
+                return False
+        elif self._password and self._user_id:
+            try:
+                resp = await client.login(
+                    identifier=self._user_id,
+                    password=self._password,
+                    device_name="Hermes Agent",
+                    device_id=self._device_id or None,
+                )
+                # login() stores the token automatically.
+                if resp and hasattr(resp, "device_id"):
+                    client.device_id = resp.device_id
+                logger.info("Matrix: logged in as %s", self._user_id)
+            except Exception as exc:
+                logger.error("Matrix: login failed — %s", exc)
+                return False
+        else:
+            logger.error("Matrix: need MATRIX_ACCESS_TOKEN or MATRIX_USER_ID + MATRIX_PASSWORD")
+            return False
+
+        # Set up E2EE if requested.
         if self._encryption:
             if not _check_e2ee_deps():
                 logger.error(
@@ -232,16 +292,24 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
                 return False
             try:
-                client = nio.AsyncClient(
-                    self._homeserver,
-                    self._user_id or "",
-                    device_id=ctor_device_id,
-                    store_path=store_path,
-                )
+                from mautrix.crypto import OlmMachine
+                from mautrix.crypto.store import MemoryCryptoStore
+
+                crypto_store = MemoryCryptoStore()
+                olm = OlmMachine(client, crypto_store, state_store)
+
+                # Set trust policy: accept unverified devices so senders
+                # share Megolm session keys with us automatically.
+                from mautrix.types import TrustState
+                olm.share_keys_min_trust = TrustState.UNVERIFIED
+                olm.send_keys_min_trust = TrustState.UNVERIFIED
+
+                await olm.load()
+                client.crypto = olm
                 logger.info(
                     "Matrix: E2EE enabled (store: %s%s)",
-                    store_path,
-                    f", device_id={self._device_id}" if self._device_id else "",
+                    str(_STORE_DIR),
+                    f", device_id={client.device_id}" if client.device_id else "",
                 )
             except Exception as exc:
                 logger.error(
@@ -249,158 +317,43 @@ class MatrixAdapter(BasePlatformAdapter):
                     exc, _E2EE_INSTALL_HINT,
                 )
                 return False
-        else:
-            client = nio.AsyncClient(
-                self._homeserver,
-                self._user_id or "",
-                device_id=ctor_device_id,
-            )
 
-        self._client = client
+        # Register event handlers.
+        from mautrix.client import InternalEventType as IntEvt
 
-        # Authenticate.
-        if self._access_token:
-            client.access_token = self._access_token
+        client.add_event_handler(EventType.ROOM_MESSAGE, self._on_room_message)
+        client.add_event_handler(EventType.REACTION, self._on_reaction)
+        client.add_event_handler(IntEvt.INVITE, self._on_invite)
 
-            # With access-token auth, always resolve whoami so we validate the
-            # token and learn the device_id. The device_id matters for E2EE:
-            # without it, matrix-nio can send plain messages but may fail to
-            # decrypt inbound encrypted events or encrypt outbound room sends.
-            resp = await client.whoami()
-            if isinstance(resp, nio.WhoamiResponse):
-                resolved_user_id = getattr(resp, "user_id", "") or self._user_id
-                resolved_device_id = getattr(resp, "device_id", "")
-                if resolved_user_id:
-                    self._user_id = resolved_user_id
-
-                # Prefer the user-configured device_id (MATRIX_DEVICE_ID) so
-                # the bot reuses a stable identity across restarts.  Fall back
-                # to whatever whoami returned.
-                effective_device_id = self._device_id or resolved_device_id
-
-                # restore_login() is the matrix-nio path that binds the access
-                # token to a specific device and loads the crypto store.
-                if effective_device_id and hasattr(client, "restore_login"):
-                    client.restore_login(
-                        self._user_id or resolved_user_id,
-                        effective_device_id,
-                        self._access_token,
-                    )
-                else:
-                    if self._user_id:
-                        client.user_id = self._user_id
-                    if effective_device_id:
-                        client.device_id = effective_device_id
-                    client.access_token = self._access_token
-                    if self._encryption:
-                        logger.warning(
-                            "Matrix: access-token login did not restore E2EE state; "
-                            "encrypted rooms may fail until a device_id is available. "
-                            "Set MATRIX_DEVICE_ID to a stable value."
-                        )
-
-                logger.info(
-                    "Matrix: using access token for %s%s",
-                    self._user_id or "(unknown user)",
-                    f" (device {effective_device_id})" if effective_device_id else "",
-                )
-            else:
-                logger.error(
-                    "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER"
-                )
-                await client.close()
-                return False
-        elif self._password and self._user_id:
-            resp = await client.login(
-                self._password,
-                device_name="Hermes Agent",
-            )
-            if isinstance(resp, nio.LoginResponse):
-                logger.info("Matrix: logged in as %s", self._user_id)
-            else:
-                logger.error("Matrix: login failed — %s", getattr(resp, "message", resp))
-                await client.close()
-                return False
-        else:
-            logger.error("Matrix: need MATRIX_ACCESS_TOKEN or MATRIX_USER_ID + MATRIX_PASSWORD")
-            await client.close()
-            return False
-
-        # If E2EE is enabled, load the crypto store.
-        if self._encryption and getattr(client, "olm", None):
-            try:
-                if client.should_upload_keys:
-                    await client.keys_upload()
-                logger.info("Matrix: E2EE crypto initialized")
-            except Exception as exc:
-                logger.warning("Matrix: crypto init issue: %s", exc)
-
-            # Import previously exported Megolm keys (survives restarts).
-            if _KEY_EXPORT_FILE.exists():
-                try:
-                    await client.import_keys(
-                        str(_KEY_EXPORT_FILE), _KEY_EXPORT_PASSPHRASE,
-                    )
-                    logger.info("Matrix: imported Megolm keys from backup")
-                except Exception as exc:
-                    logger.debug("Matrix: could not import keys: %s", exc)
-        elif self._encryption:
-            # E2EE was requested but the crypto store failed to load —
-            # this means encrypted rooms will silently not work.  Hard-fail.
-            logger.error(
-                "Matrix: E2EE requested but crypto store is not loaded — "
-                "cannot decrypt or encrypt messages. %s",
-                _E2EE_INSTALL_HINT,
-            )
-            await client.close()
-            return False
-
-        # Register event callbacks.
-        client.add_event_callback(self._on_room_message, nio.RoomMessageText)
-        client.add_event_callback(self._on_room_message_media, nio.RoomMessageImage)
-        client.add_event_callback(self._on_room_message_media, nio.RoomMessageAudio)
-        client.add_event_callback(self._on_room_message_media, nio.RoomMessageVideo)
-        client.add_event_callback(self._on_room_message_media, nio.RoomMessageFile)
-        for encrypted_media_cls in (
-            getattr(nio, "RoomEncryptedImage", None),
-            getattr(nio, "RoomEncryptedAudio", None),
-            getattr(nio, "RoomEncryptedVideo", None),
-            getattr(nio, "RoomEncryptedFile", None),
-        ):
-            if encrypted_media_cls is not None:
-                client.add_event_callback(self._on_room_message_media, encrypted_media_cls)
-        client.add_event_callback(self._on_invite, nio.InviteMemberEvent)
-
-        # Reaction events (m.reaction).
-        if hasattr(nio, "ReactionEvent"):
-            client.add_event_callback(self._on_reaction, nio.ReactionEvent)
-        else:
-            # Older matrix-nio versions: use UnknownEvent fallback.
-            client.add_event_callback(self._on_unknown_event, nio.UnknownEvent)
-
-        # If E2EE: handle encrypted events.
-        if self._encryption and hasattr(client, "olm"):
-            client.add_event_callback(
-                self._on_room_message, nio.MegolmEvent
-            )
+        if self._encryption and getattr(client, "crypto", None):
+            client.add_event_handler(EventType.ROOM_ENCRYPTED, self._on_encrypted_event)
 
         # Initial sync to catch up, then start background sync.
         self._startup_ts = time.time()
         self._closing = False
 
-        # Do an initial sync to populate room state.
-        resp = await client.sync(timeout=10000, full_state=True)
-        if isinstance(resp, nio.SyncResponse):
-            self._joined_rooms = set(resp.rooms.join.keys())
-            logger.info(
-                "Matrix: initial sync complete, joined %d rooms",
-                len(self._joined_rooms),
-            )
-            # Build DM room cache from m.direct account data.
-            await self._refresh_dm_cache()
-            await self._run_e2ee_maintenance()
-        else:
-            logger.warning("Matrix: initial sync returned %s", type(resp).__name__)
+        try:
+            sync_data = await client.sync(timeout=10000, full_state=True)
+            if isinstance(sync_data, dict):
+                rooms_join = sync_data.get("rooms", {}).get("join", {})
+                self._joined_rooms = set(rooms_join.keys())
+                logger.info(
+                    "Matrix: initial sync complete, joined %d rooms",
+                    len(self._joined_rooms),
+                )
+                # Build DM room cache from m.direct account data.
+                await self._refresh_dm_cache()
+            else:
+                logger.warning("Matrix: initial sync returned unexpected type %s", type(sync_data).__name__)
+        except Exception as exc:
+            logger.warning("Matrix: initial sync error: %s", exc)
+
+        # Share keys after initial sync if E2EE is enabled.
+        if self._encryption and getattr(client, "crypto", None):
+            try:
+                await client.crypto.share_keys()
+            except Exception as exc:
+                logger.warning("Matrix: initial key share failed: %s", exc)
 
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
@@ -418,20 +371,11 @@ class MatrixAdapter(BasePlatformAdapter):
             except (asyncio.CancelledError, Exception):
                 pass
 
-        # Export Megolm keys before closing so the next restart can decrypt
-        # events that used sessions from this run.
-        if self._client and self._encryption and getattr(self._client, "olm", None):
-            try:
-                _STORE_DIR.mkdir(parents=True, exist_ok=True)
-                await self._client.export_keys(
-                    str(_KEY_EXPORT_FILE), _KEY_EXPORT_PASSPHRASE,
-                )
-                logger.info("Matrix: exported Megolm keys for next restart")
-            except Exception as exc:
-                logger.debug("Matrix: could not export keys on disconnect: %s", exc)
-
         if self._client:
-            await self._client.close()
+            try:
+                await self._client.api.session.close()
+            except Exception:
+                pass
             self._client = None
 
         logger.info("Matrix: disconnected")
@@ -444,7 +388,7 @@ class MatrixAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Matrix room."""
-        import nio
+        from mautrix.types import EventType, RoomID
 
         if not content:
             return SendResult(success=True)
@@ -482,52 +426,38 @@ class MatrixAdapter(BasePlatformAdapter):
                     relates_to["m.in_reply_to"] = {"event_id": reply_to}
                 msg_content["m.relates_to"] = relates_to
 
-            async def _room_send_once(*, ignore_unverified_devices: bool = False):
-                return await asyncio.wait_for(
-                    self._client.room_send(
-                        chat_id,
-                        "m.room.message",
+            try:
+                event_id = await asyncio.wait_for(
+                    self._client.send_message_event(
+                        RoomID(chat_id),
+                        EventType.ROOM_MESSAGE,
                         msg_content,
-                        ignore_unverified_devices=ignore_unverified_devices,
                     ),
                     timeout=45,
                 )
-
-            try:
-                resp = await _room_send_once(ignore_unverified_devices=False)
-            except Exception as exc:
-                retryable = isinstance(exc, asyncio.TimeoutError)
-                olm_unverified = getattr(nio, "OlmUnverifiedDeviceError", None)
-                send_retry = getattr(nio, "SendRetryError", None)
-                if isinstance(olm_unverified, type) and isinstance(exc, olm_unverified):
-                    retryable = True
-                if isinstance(send_retry, type) and isinstance(exc, send_retry):
-                    retryable = True
-
-                if not retryable:
-                    logger.error("Matrix: failed to send to %s: %s", chat_id, exc)
-                    return SendResult(success=False, error=str(exc))
-
-                logger.warning(
-                    "Matrix: initial encrypted send to %s failed (%s); "
-                    "retrying after E2EE maintenance with ignored unverified devices",
-                    chat_id,
-                    exc,
-                )
-                await self._run_e2ee_maintenance()
-                try:
-                    resp = await _room_send_once(ignore_unverified_devices=True)
-                except Exception as retry_exc:
-                    logger.error("Matrix: failed to send to %s after retry: %s", chat_id, retry_exc)
-                    return SendResult(success=False, error=str(retry_exc))
-
-            if isinstance(resp, nio.RoomSendResponse):
-                last_event_id = resp.event_id
+                last_event_id = str(event_id)
                 logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
-            else:
-                err = getattr(resp, "message", str(resp))
-                logger.error("Matrix: failed to send to %s: %s", chat_id, err)
-                return SendResult(success=False, error=err)
+            except Exception as exc:
+                # On E2EE errors, retry after sharing keys.
+                if self._encryption and getattr(self._client, "crypto", None):
+                    try:
+                        await self._client.crypto.share_keys()
+                        event_id = await asyncio.wait_for(
+                            self._client.send_message_event(
+                                RoomID(chat_id),
+                                EventType.ROOM_MESSAGE,
+                                msg_content,
+                            ),
+                            timeout=45,
+                        )
+                        last_event_id = str(event_id)
+                        logger.info("Matrix: sent event %s to %s (after key share)", last_event_id, chat_id)
+                        continue
+                    except Exception as retry_exc:
+                        logger.error("Matrix: failed to send to %s after retry: %s", chat_id, retry_exc)
+                        return SendResult(success=False, error=str(retry_exc))
+                logger.error("Matrix: failed to send to %s: %s", chat_id, exc)
+                return SendResult(success=False, error=str(exc))
 
         return SendResult(success=True, message_id=last_event_id)
 
@@ -537,14 +467,32 @@ class MatrixAdapter(BasePlatformAdapter):
         chat_type = "group"
 
         if self._client:
-            room = self._client.rooms.get(chat_id)
-            if room:
-                name = room.display_name or room.canonical_alias or chat_id
-                # Use DM cache.
-                if self._dm_rooms.get(chat_id, False):
-                    chat_type = "dm"
-                elif room.member_count == 2:
-                    chat_type = "dm"
+            # Try state store for member count.
+            state_store = getattr(self._client, "state_store", None)
+            if state_store:
+                try:
+                    members = await state_store.get_members(
+                        chat_id,
+                    )
+                    if members and len(members) == 2:
+                        chat_type = "dm"
+                except Exception:
+                    pass
+
+            # Use DM cache.
+            if self._dm_rooms.get(chat_id, False):
+                chat_type = "dm"
+
+            # Try to get room name from state.
+            try:
+                from mautrix.types import EventType as ET, RoomID
+                name_evt = await self._client.get_state_event(
+                    RoomID(chat_id), ET.ROOM_NAME,
+                )
+                if name_evt and hasattr(name_evt, "name") and name_evt.name:
+                    name = name_evt.name
+            except Exception:
+                pass
 
         return {"name": name, "type": chat_type}
 
@@ -558,7 +506,8 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send a typing indicator."""
         if self._client:
             try:
-                await self._client.room_typing(chat_id, typing_state=True, timeout=30000)
+                from mautrix.types import RoomID
+                await self._client.set_typing(RoomID(chat_id), timeout=30000)
             except Exception:
                 pass
 
@@ -566,7 +515,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, message_id: str, content: str
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
-        import nio
+        from mautrix.types import EventType, RoomID
 
         formatted = self.format_message(content)
         msg_content: Dict[str, Any] = {
@@ -589,10 +538,13 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["format"] = "org.matrix.custom.html"
             msg_content["formatted_body"] = f"* {html}"
 
-        resp = await self._client.room_send(chat_id, "m.room.message", msg_content)
-        if isinstance(resp, nio.RoomSendResponse):
-            return SendResult(success=True, message_id=resp.event_id)
-        return SendResult(success=False, error=getattr(resp, "message", str(resp)))
+        try:
+            event_id = await self._client.send_message_event(
+                RoomID(chat_id), EventType.ROOM_MESSAGE, msg_content,
+            )
+            return SendResult(success=True, message_id=str(event_id))
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
 
     async def send_image(
         self,
@@ -665,7 +617,7 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file as a voice message (MSC3245 native voice)."""
         return await self._send_local_file(
-            chat_id, audio_path, "m.audio", caption, reply_to, 
+            chat_id, audio_path, "m.audio", caption, reply_to,
             metadata=metadata, is_voice=True
         )
 
@@ -703,29 +655,24 @@ class MatrixAdapter(BasePlatformAdapter):
         is_voice: bool = False,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
-        import nio
+        from mautrix.types import EventType, RoomID
 
         # Upload to homeserver.
-        # nio expects a DataProvider (callable) or file-like object, not raw bytes.
-        # nio.upload() returns a tuple (UploadResponse|UploadError, Optional[Dict])
-        resp, maybe_encryption_info = await self._client.upload(
-            io.BytesIO(data),
-            content_type=content_type,
-            filename=filename,
-            filesize=len(data),
-        )
-        if not isinstance(resp, nio.UploadResponse):
-            err = getattr(resp, "message", str(resp))
-            logger.error("Matrix: upload failed: %s", err)
-            return SendResult(success=False, error=err)
-
-        mxc_url = resp.content_uri
+        try:
+            mxc_url = await self._client.upload_media(
+                data,
+                mime_type=content_type,
+                filename=filename,
+            )
+        except Exception as exc:
+            logger.error("Matrix: upload failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
 
         # Build media message content.
         msg_content: Dict[str, Any] = {
             "msgtype": msgtype,
             "body": caption or filename,
-            "url": mxc_url,
+            "url": str(mxc_url),
             "info": {
                 "mimetype": content_type,
                 "size": len(data),
@@ -749,10 +696,13 @@ class MatrixAdapter(BasePlatformAdapter):
             relates_to["is_falling_back"] = True
             msg_content["m.relates_to"] = relates_to
 
-        resp2 = await self._client.room_send(room_id, "m.room.message", msg_content)
-        if isinstance(resp2, nio.RoomSendResponse):
-            return SendResult(success=True, message_id=resp2.event_id)
-        return SendResult(success=False, error=getattr(resp2, "message", str(resp2)))
+        try:
+            event_id = await self._client.send_message_event(
+                RoomID(room_id), EventType.ROOM_MESSAGE, msg_content,
+            )
+            return SendResult(success=True, message_id=str(event_id))
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
 
     async def _send_local_file(
         self,
@@ -784,37 +734,32 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _sync_loop(self) -> None:
         """Continuously sync with the homeserver."""
-        import nio
-
         while not self._closing:
             try:
-                resp = await self._client.sync(timeout=30000)
-                if isinstance(resp, nio.SyncError):
-                    if self._closing:
-                        return
-                    err_msg = str(getattr(resp, "message", resp)).lower()
-                    if "m_unknown_token" in err_msg or "m_forbidden" in err_msg or "401" in err_msg:
-                        logger.error(
-                            "Matrix: permanent auth error from sync: %s — stopping sync",
-                            getattr(resp, "message", resp),
-                        )
-                        return
-                    logger.warning(
-                        "Matrix: sync returned %s: %s — retrying in 5s",
-                        type(resp).__name__,
-                        getattr(resp, "message", resp),
-                    )
-                    await asyncio.sleep(5)
-                    continue
+                sync_data = await self._client.sync(timeout=30000)
+                if isinstance(sync_data, dict):
+                    # Update joined rooms from sync response.
+                    rooms_join = sync_data.get("rooms", {}).get("join", {})
+                    if rooms_join:
+                        self._joined_rooms.update(rooms_join.keys())
 
-                await self._run_e2ee_maintenance()
+                # Share keys periodically if E2EE is enabled.
+                if self._encryption and getattr(self._client, "crypto", None):
+                    try:
+                        await self._client.crypto.share_keys()
+                    except Exception as exc:
+                        logger.warning("Matrix: E2EE key share failed: %s", exc)
+
+                # Retry any buffered undecrypted events.
+                if self._pending_megolm:
+                    await self._retry_pending_decryptions()
+
             except asyncio.CancelledError:
                 return
             except Exception as exc:
                 if self._closing:
                     return
-                # Detect permanent auth/permission failures that will never
-                # succeed on retry — stop syncing instead of looping forever.
+                # Detect permanent auth/permission failures.
                 err_str = str(exc).lower()
                 if "401" in err_str or "403" in err_str or "unauthorized" in err_str or "forbidden" in err_str:
                     logger.error("Matrix: permanent auth error: %s — stopping sync", exc)
@@ -822,98 +767,19 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
                 await asyncio.sleep(5)
 
-    async def _run_e2ee_maintenance(self) -> None:
-        """Run matrix-nio E2EE housekeeping between syncs.
-
-        Hermes uses a custom sync loop instead of matrix-nio's sync_forever(),
-        so we need to explicitly drive the key management work that sync_forever()
-        normally handles for encrypted rooms.
-
-        Also auto-trusts all devices (so senders share session keys with us)
-        and retries decryption for any buffered MegolmEvents.
-        """
-        client = self._client
-        if not client or not self._encryption or not getattr(client, "olm", None):
-            return
-
-        did_query_keys = client.should_query_keys
-
-        tasks = [asyncio.create_task(client.send_to_device_messages())]
-
-        if client.should_upload_keys:
-            tasks.append(asyncio.create_task(client.keys_upload()))
-
-        if did_query_keys:
-            tasks.append(asyncio.create_task(client.keys_query()))
-
-        if client.should_claim_keys:
-            users = client.get_users_for_key_claiming()
-            if users:
-                tasks.append(asyncio.create_task(client.keys_claim(users)))
-
-        for task in asyncio.as_completed(tasks):
-            try:
-                await task
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.warning("Matrix: E2EE maintenance task failed: %s", exc)
-
-        # After key queries, auto-trust all devices so senders share keys with
-        # us.  For a bot this is the right default — we want to decrypt
-        # everything, not enforce manual verification.
-        if did_query_keys:
-            self._auto_trust_devices()
-
-        # Retry any buffered undecrypted events now that new keys may have
-        # arrived (from key requests, key queries, or to-device forwarding).
-        if self._pending_megolm:
-            await self._retry_pending_decryptions()
-
-    def _auto_trust_devices(self) -> None:
-        """Trust/verify all unverified devices we know about.
-
-        When other clients see our device as verified, they proactively share
-        Megolm session keys with us.  Without this, many clients will refuse
-        to include an unverified device in key distributions.
-        """
-        client = self._client
-        if not client:
-            return
-
-        device_store = getattr(client, "device_store", None)
-        if not device_store:
-            return
-
-        own_device = getattr(client, "device_id", None)
-        trusted_count = 0
-
-        try:
-            # DeviceStore.__iter__ yields OlmDevice objects directly.
-            for device in device_store:
-                if getattr(device, "device_id", None) == own_device:
-                    continue
-                if not getattr(device, "verified", False):
-                    client.verify_device(device)
-                    trusted_count += 1
-        except Exception as exc:
-            logger.debug("Matrix: auto-trust error: %s", exc)
-
-        if trusted_count:
-            logger.info("Matrix: auto-trusted %d new device(s)", trusted_count)
-
     async def _retry_pending_decryptions(self) -> None:
-        """Retry decrypting buffered MegolmEvents after new keys arrive."""
-        import nio
-
+        """Retry decrypting buffered encrypted events after new keys arrive."""
         client = self._client
         if not client or not self._pending_megolm:
+            return
+        crypto = getattr(client, "crypto", None)
+        if not crypto:
             return
 
         now = time.time()
         still_pending: list = []
 
-        for room, event, ts in self._pending_megolm:
+        for room_id, event, ts in self._pending_megolm:
             # Drop events that have aged past the TTL.
             if now - ts > _PENDING_EVENT_TTL:
                 logger.debug(
@@ -923,39 +789,23 @@ class MatrixAdapter(BasePlatformAdapter):
                 continue
 
             try:
-                decrypted = client.decrypt_event(event)
+                decrypted = await crypto.decrypt_megolm_event(event)
             except Exception:
-                # Still missing the key — keep in buffer.
-                still_pending.append((room, event, ts))
+                still_pending.append((room_id, event, ts))
                 continue
 
-            if isinstance(decrypted, nio.MegolmEvent):
-                # decrypt_event returned the same undecryptable event.
-                still_pending.append((room, event, ts))
+            if decrypted is None or decrypted is event:
+                still_pending.append((room_id, event, ts))
                 continue
 
             logger.info(
-                "Matrix: decrypted buffered event %s (%s)",
+                "Matrix: decrypted buffered event %s",
                 getattr(event, "event_id", "?"),
-                type(decrypted).__name__,
             )
 
-            # Route to the appropriate handler based on decrypted type.
+            # Route to the appropriate handler.
             try:
-                if isinstance(decrypted, nio.RoomMessageText):
-                    await self._on_room_message(room, decrypted)
-                elif isinstance(
-                    decrypted,
-                    (nio.RoomMessageImage, nio.RoomMessageAudio,
-                     nio.RoomMessageVideo, nio.RoomMessageFile),
-                ):
-                    await self._on_room_message_media(room, decrypted)
-                else:
-                    logger.debug(
-                        "Matrix: decrypted event %s has unhandled type %s",
-                        getattr(event, "event_id", "?"),
-                        type(decrypted).__name__,
-                    )
+                await self._on_room_message(decrypted)
             except Exception as exc:
                 logger.warning(
                     "Matrix: error processing decrypted event %s: %s",
@@ -968,62 +818,78 @@ class MatrixAdapter(BasePlatformAdapter):
     # Event callbacks
     # ------------------------------------------------------------------
 
-    async def _on_room_message(self, room: Any, event: Any) -> None:
-        """Handle incoming text messages (and decrypted megolm events)."""
-        import nio
+    async def _on_room_message(self, event: Any) -> None:
+        """Handle incoming room message events (text, media)."""
+        room_id = str(getattr(event, "room_id", ""))
+        sender = str(getattr(event, "sender", ""))
 
         # Ignore own messages.
-        if event.sender == self._user_id:
+        if sender == self._user_id:
             return
 
-        # Deduplicate by event ID (nio can fire the same event more than once).
-        if self._is_duplicate_event(getattr(event, "event_id", None)):
+        # Deduplicate by event ID.
+        event_id = str(getattr(event, "event_id", ""))
+        if self._is_duplicate_event(event_id):
             return
 
         # Startup grace: ignore old messages from initial sync.
-        event_ts = getattr(event, "server_timestamp", 0) / 1000.0
+        event_ts = getattr(event, "timestamp", 0) / 1000.0 if getattr(event, "timestamp", 0) else 0
+        # Also check server_timestamp for compatibility.
+        if not event_ts:
+            event_ts = getattr(event, "server_timestamp", 0) / 1000.0 if getattr(event, "server_timestamp", 0) else 0
         if event_ts and event_ts < self._startup_ts - _STARTUP_GRACE_SECONDS:
             return
 
-        # Handle undecryptable MegolmEvents: request the missing session key
-        # and buffer the event for retry once the key arrives.
-        if isinstance(event, nio.MegolmEvent):
-            logger.warning(
-                "Matrix: could not decrypt event %s in %s — requesting key",
-                event.event_id, room.room_id,
-            )
-
-            # Ask other devices in the room to forward the session key.
-            try:
-                resp = await self._client.request_room_key(event)
-                if hasattr(resp, "event_id") or not isinstance(resp, Exception):
-                    logger.debug(
-                        "Matrix: room key request sent for session %s",
-                        getattr(event, "session_id", "?"),
-                    )
-            except Exception as exc:
-                logger.debug("Matrix: room key request failed: %s", exc)
-
-            # Buffer for retry on next maintenance cycle.
-            self._pending_megolm.append((room, event, time.time()))
-            if len(self._pending_megolm) > _MAX_PENDING_EVENTS:
-                self._pending_megolm = self._pending_megolm[-_MAX_PENDING_EVENTS:]
+        # Extract content from the event.
+        content = getattr(event, "content", None)
+        if content is None:
             return
 
-        # Skip edits (m.replace relation).
-        source_content = getattr(event, "source", {}).get("content", {})
+        # Get msgtype — either from content object or raw dict.
+        if hasattr(content, "msgtype"):
+            msgtype = str(content.msgtype)
+        elif isinstance(content, dict):
+            msgtype = content.get("msgtype", "")
+        else:
+            msgtype = ""
+
+        # Determine source content dict for relation/thread extraction.
+        if isinstance(content, dict):
+            source_content = content
+        elif hasattr(content, "serialize"):
+            source_content = content.serialize()
+        else:
+            source_content = {}
+
         relates_to = source_content.get("m.relates_to", {})
+
+        # Skip edits (m.replace relation).
         if relates_to.get("rel_type") == "m.replace":
             return
 
-        body = getattr(event, "body", "") or ""
+        # Dispatch by msgtype.
+        media_msgtypes = ("m.image", "m.audio", "m.video", "m.file")
+        if msgtype in media_msgtypes:
+            await self._handle_media_message(room_id, sender, event_id, event_ts, source_content, relates_to, msgtype)
+        elif msgtype in ("m.text", "m.notice"):
+            await self._handle_text_message(room_id, sender, event_id, event_ts, source_content, relates_to)
+
+    async def _handle_text_message(
+        self,
+        room_id: str,
+        sender: str,
+        event_id: str,
+        event_ts: float,
+        source_content: dict,
+        relates_to: dict,
+    ) -> None:
+        """Process a text message event."""
+        body = source_content.get("body", "") or ""
         if not body:
             return
 
         # Determine chat type.
-        is_dm = self._dm_rooms.get(room.room_id, False)
-        if not is_dm and room.member_count == 2:
-            is_dm = True
+        is_dm = await self._is_dm_room(room_id)
         chat_type = "dm" if is_dm else "group"
 
         # Thread support.
@@ -1036,7 +902,7 @@ class MatrixAdapter(BasePlatformAdapter):
             free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
             free_rooms = {r.strip() for r in free_rooms_raw.split(",") if r.strip()}
             require_mention = os.getenv("MATRIX_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_room = room.room_id in free_rooms
+            is_free_room = room_id in free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._bot_participated_threads)
 
             formatted_body = source_content.get("formatted_body")
@@ -1044,22 +910,22 @@ class MatrixAdapter(BasePlatformAdapter):
                 if not self._is_bot_mentioned(body, formatted_body):
                     return
 
-        # DM mention-thread: when enabled, @mentioning bot in a DM creates a thread.
+        # DM mention-thread.
         if is_dm and not thread_id:
             dm_mention_threads = os.getenv("MATRIX_DM_MENTION_THREADS", "false").lower() in ("true", "1", "yes")
             if dm_mention_threads and self._is_bot_mentioned(body, source_content.get("formatted_body")):
-                thread_id = event.event_id
+                thread_id = event_id
                 self._track_thread(thread_id)
 
-        # Strip mention from body when present (including in DMs).
+        # Strip mention from body.
         if self._is_bot_mentioned(body, source_content.get("formatted_body")):
             body = self._strip_mention(body)
 
-        # Auto-thread: create a thread for non-DM, non-threaded messages.
+        # Auto-thread.
         if not is_dm and not thread_id:
             auto_thread = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             if auto_thread:
-                thread_id = event.event_id
+                thread_id = event_id
                 self._track_thread(thread_id)
 
         # Reply-to detection.
@@ -1068,7 +934,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if in_reply_to:
             reply_to = in_reply_to.get("event_id")
 
-        # Strip reply fallback from body (Matrix prepends "> ..." lines).
+        # Strip reply fallback from body.
         if reply_to and body.startswith("> "):
             lines = body.split("\n")
             stripped = []
@@ -1089,11 +955,12 @@ class MatrixAdapter(BasePlatformAdapter):
         if body.startswith(("!", "/")):
             msg_type = MessageType.COMMAND
 
+        display_name = await self._get_display_name(room_id, sender)
         source = self.build_source(
-            chat_id=room.room_id,
+            chat_id=room_id,
             chat_type=chat_type,
-            user_id=event.sender,
-            user_name=self._get_display_name(room, event.sender),
+            user_id=sender,
+            user_name=display_name,
             thread_id=thread_id,
         )
 
@@ -1101,218 +968,105 @@ class MatrixAdapter(BasePlatformAdapter):
             text=body,
             message_type=msg_type,
             source=source,
-            raw_message=getattr(event, "source", {}),
-            message_id=event.event_id,
+            raw_message=source_content,
+            message_id=event_id,
             reply_to_message_id=reply_to,
         )
 
         if thread_id:
             self._track_thread(thread_id)
 
-        # Acknowledge receipt so the room shows as read (fire-and-forget).
-        self._background_read_receipt(room.room_id, event.event_id)
+        # Acknowledge receipt (fire-and-forget).
+        self._background_read_receipt(room_id, event_id)
 
-        # Only batch plain text messages — commands dispatch immediately.
+        # Batch plain text messages — commands dispatch immediately.
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)
 
-    # ------------------------------------------------------------------
-    # Text message aggregation (handles Matrix client-side splits)
-    # ------------------------------------------------------------------
-
-    def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
-        from gateway.session import build_session_key
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
-
-    def _enqueue_text_event(self, event: MessageEvent) -> None:
-        """Buffer a text event and reset the flush timer.
-
-        When a Matrix client splits a long message, the chunks arrive within
-        a few hundred milliseconds.  This merges them into a single event
-        before dispatching.
-        """
-        key = self._text_batch_key(event)
-        existing = self._pending_text_batches.get(key)
-        chunk_len = len(event.text or "")
-        if existing is None:
-            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            self._pending_text_batches[key] = event
-        else:
-            if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
-            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
-            # Merge any media that might be attached
-            if event.media_urls:
-                existing.media_urls.extend(event.media_urls)
-                existing.media_types.extend(event.media_types)
-
-        # Cancel any pending flush and restart the timer
-        prior_task = self._pending_text_batch_tasks.get(key)
-        if prior_task and not prior_task.done():
-            prior_task.cancel()
-        self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
-        )
-
-    async def _flush_text_batch(self, key: str) -> None:
-        """Wait for the quiet period then dispatch the aggregated text.
-
-        Uses a longer delay when the latest chunk is near Matrix's ~4000-char
-        split point, since a continuation chunk is almost certain.
-        """
-        current_task = asyncio.current_task()
-        try:
-            pending = self._pending_text_batches.get(key)
-            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
-            else:
-                delay = self._text_batch_delay_seconds
-            await asyncio.sleep(delay)
-            event = self._pending_text_batches.pop(key, None)
-            if not event:
-                return
-            logger.info(
-                "[Matrix] Flushing text batch %s (%d chars)",
-                key, len(event.text or ""),
-            )
-            await self.handle_message(event)
-        finally:
-            if self._pending_text_batch_tasks.get(key) is current_task:
-                self._pending_text_batch_tasks.pop(key, None)
-
-    async def _on_room_message_media(self, room: Any, event: Any) -> None:
-        """Handle incoming media messages (images, audio, video, files)."""
-        import nio
-
-        # Ignore own messages.
-        if event.sender == self._user_id:
-            return
-
-        # Deduplicate by event ID.
-        if self._is_duplicate_event(getattr(event, "event_id", None)):
-            return
-
-        # Startup grace.
-        event_ts = getattr(event, "server_timestamp", 0) / 1000.0
-        if event_ts and event_ts < self._startup_ts - _STARTUP_GRACE_SECONDS:
-            return
-
-        body = getattr(event, "body", "") or ""
-        url = getattr(event, "url", "")
+    async def _handle_media_message(
+        self,
+        room_id: str,
+        sender: str,
+        event_id: str,
+        event_ts: float,
+        source_content: dict,
+        relates_to: dict,
+        msgtype: str,
+    ) -> None:
+        """Process a media message event (image, audio, video, file)."""
+        body = source_content.get("body", "") or ""
+        url = source_content.get("url", "")
 
         # Convert mxc:// to HTTP URL for downstream processing.
         http_url = ""
         if url and url.startswith("mxc://"):
             http_url = self._mxc_to_http(url)
 
-        # Determine message type from event class.
-        # Use the MIME type from the event's content info when available,
-        # falling back to category-level MIME types for downstream matching
-        # (gateway/run.py checks startswith("image/"), startswith("audio/"), etc.)
-        source_content = getattr(event, "source", {}).get("content", {})
-        if not isinstance(source_content, dict):
-            source_content = {}
-        event_content = getattr(event, "content", {})
-        if not isinstance(event_content, dict):
-            event_content = {}
-        content_info = event_content.get("info") if isinstance(event_content, dict) else {}
-        if not isinstance(content_info, dict) or not content_info:
-            content_info = source_content.get("info", {}) if isinstance(source_content, dict) else {}
-        event_mimetype = (
-            (content_info.get("mimetype") if isinstance(content_info, dict) else None)
-            or getattr(event, "mimetype", "")
-            or ""
-        )
-        # For encrypted media, the URL may be in file.url instead of event.url.
-        file_content = source_content.get("file", {}) if isinstance(source_content, dict) else {}
+        # Extract MIME type from content info.
+        content_info = source_content.get("info", {})
+        if not isinstance(content_info, dict):
+            content_info = {}
+        event_mimetype = content_info.get("mimetype", "")
+
+        # For encrypted media, the URL may be in file.url.
+        file_content = source_content.get("file", {})
         if not url and isinstance(file_content, dict):
             url = file_content.get("url", "") or ""
             if url and url.startswith("mxc://"):
                 http_url = self._mxc_to_http(url)
 
+        is_encrypted_media = bool(file_content and isinstance(file_content, dict) and file_content.get("url"))
+
         media_type = "application/octet-stream"
         msg_type = MessageType.DOCUMENT
-
-        # Safely resolve encrypted media classes — they may not exist on older
-        # nio versions, and in test environments nio may be mocked (MagicMock
-        # auto-attributes are not valid types for isinstance).
-        def _safe_isinstance(obj, cls_name):
-            cls = getattr(nio, cls_name, None)
-            if cls is None or not isinstance(cls, type):
-                return False
-            return isinstance(obj, cls)
-
-        is_encrypted_image = _safe_isinstance(event, "RoomEncryptedImage")
-        is_encrypted_audio = _safe_isinstance(event, "RoomEncryptedAudio")
-        is_encrypted_video = _safe_isinstance(event, "RoomEncryptedVideo")
-        is_encrypted_file = _safe_isinstance(event, "RoomEncryptedFile")
-        is_encrypted_media = any((is_encrypted_image, is_encrypted_audio, is_encrypted_video, is_encrypted_file))
         is_voice_message = False
 
-        if isinstance(event, nio.RoomMessageImage) or is_encrypted_image:
+        if msgtype == "m.image":
             msg_type = MessageType.PHOTO
             media_type = event_mimetype or "image/png"
-        elif isinstance(event, nio.RoomMessageAudio) or is_encrypted_audio:
+        elif msgtype == "m.audio":
             if source_content.get("org.matrix.msc3245.voice") is not None:
                 is_voice_message = True
                 msg_type = MessageType.VOICE
             else:
                 msg_type = MessageType.AUDIO
             media_type = event_mimetype or "audio/ogg"
-        elif isinstance(event, nio.RoomMessageVideo) or is_encrypted_video:
+        elif msgtype == "m.video":
             msg_type = MessageType.VIDEO
             media_type = event_mimetype or "video/mp4"
         elif event_mimetype:
             media_type = event_mimetype
 
-        # Cache media locally when downstream tools need a real file path:
-        # - photos (vision tools can't access MXC URLs)
-        # - voice messages (transcription tools need local files)
-        # - any encrypted media (HTTP fallback would point at ciphertext)
+        # Cache media locally when downstream tools need a real file path.
         cached_path = None
         should_cache_locally = (
             msg_type == MessageType.PHOTO or is_voice_message or is_encrypted_media
         )
         if should_cache_locally and url:
             try:
-                if is_voice_message:
-                    download_resp = await self._client.download(mxc=url)
-                else:
-                    download_resp = await self._client.download(url)
-                file_bytes = getattr(download_resp, "body", None)
+                from mautrix.types import ContentURI
+                file_bytes = await self._client.download_media(ContentURI(url))
                 if file_bytes is not None:
                     if is_encrypted_media:
-                        from nio.crypto.attachments import decrypt_attachment
+                        from mautrix.crypto.attachments import decrypt_attachment
 
-                        hashes_value = getattr(event, "hashes", None)
-                        if hashes_value is None and isinstance(file_content, dict):
-                            hashes_value = file_content.get("hashes")
+                        hashes_value = file_content.get("hashes") if isinstance(file_content, dict) else None
                         hash_value = hashes_value.get("sha256") if isinstance(hashes_value, dict) else None
 
-                        key_value = getattr(event, "key", None)
-                        if key_value is None and isinstance(file_content, dict):
-                            key_value = file_content.get("key")
+                        key_value = file_content.get("key") if isinstance(file_content, dict) else None
                         if isinstance(key_value, dict):
                             key_value = key_value.get("k")
 
-                        iv_value = getattr(event, "iv", None)
-                        if iv_value is None and isinstance(file_content, dict):
-                            iv_value = file_content.get("iv")
+                        iv_value = file_content.get("iv") if isinstance(file_content, dict) else None
 
                         if key_value and hash_value and iv_value:
                             file_bytes = decrypt_attachment(file_bytes, key_value, hash_value, iv_value)
                         else:
                             logger.warning(
                                 "[Matrix] Encrypted media event missing decryption metadata for %s",
-                                event.event_id,
+                                event_id,
                             )
                             file_bytes = None
 
@@ -1344,13 +1098,10 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Matrix] Failed to cache media: %s", e)
 
-        is_dm = self._dm_rooms.get(room.room_id, False)
-        if not is_dm and room.member_count == 2:
-            is_dm = True
+        is_dm = await self._is_dm_room(room_id)
         chat_type = "dm" if is_dm else "group"
 
         # Thread/reply detection.
-        relates_to = source_content.get("m.relates_to", {})
         thread_id = None
         if relates_to.get("rel_type") == "m.thread":
             thread_id = relates_to.get("event_id")
@@ -1360,7 +1111,7 @@ class MatrixAdapter(BasePlatformAdapter):
             free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
             free_rooms = {r.strip() for r in free_rooms_raw.split(",") if r.strip()}
             require_mention = os.getenv("MATRIX_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_room = room.room_id in free_rooms
+            is_free_room = room_id in free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._bot_participated_threads)
 
             if require_mention and not is_free_room and not in_bot_thread:
@@ -1368,29 +1119,30 @@ class MatrixAdapter(BasePlatformAdapter):
                 if not self._is_bot_mentioned(body, formatted_body):
                     return
 
-        # DM mention-thread: when enabled, @mentioning bot in a DM creates a thread.
+        # DM mention-thread.
         if is_dm and not thread_id:
             dm_mention_threads = os.getenv("MATRIX_DM_MENTION_THREADS", "false").lower() in ("true", "1", "yes")
             if dm_mention_threads and self._is_bot_mentioned(body, source_content.get("formatted_body")):
-                thread_id = event.event_id
+                thread_id = event_id
                 self._track_thread(thread_id)
 
-        # Strip mention from body when present (including in DMs).
+        # Strip mention from body.
         if self._is_bot_mentioned(body, source_content.get("formatted_body")):
             body = self._strip_mention(body)
 
-        # Auto-thread: create a thread for non-DM, non-threaded messages.
+        # Auto-thread.
         if not is_dm and not thread_id:
             auto_thread = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             if auto_thread:
-                thread_id = event.event_id
+                thread_id = event_id
                 self._track_thread(thread_id)
 
+        display_name = await self._get_display_name(room_id, sender)
         source = self.build_source(
-            chat_id=room.room_id,
+            chat_id=room_id,
             chat_type=chat_type,
-            user_id=event.sender,
-            user_name=self._get_display_name(room, event.sender),
+            user_id=sender,
+            user_name=display_name,
             thread_id=thread_id,
         )
 
@@ -1402,8 +1154,8 @@ class MatrixAdapter(BasePlatformAdapter):
             text=body,
             message_type=msg_type,
             source=source,
-            raw_message=getattr(event, "source", {}),
-            message_id=event.event_id,
+            raw_message=source_content,
+            message_id=event_id,
             media_urls=media_urls,
             media_types=media_types,
         )
@@ -1411,43 +1163,44 @@ class MatrixAdapter(BasePlatformAdapter):
         if thread_id:
             self._track_thread(thread_id)
 
-        # Acknowledge receipt so the room shows as read (fire-and-forget).
-        self._background_read_receipt(room.room_id, event.event_id)
+        self._background_read_receipt(room_id, event_id)
 
         await self.handle_message(msg_event)
 
-    async def _on_invite(self, room: Any, event: Any) -> None:
+    async def _on_encrypted_event(self, event: Any) -> None:
+        """Handle encrypted events that could not be auto-decrypted."""
+        room_id = str(getattr(event, "room_id", ""))
+        event_id = str(getattr(event, "event_id", ""))
+
+        if self._is_duplicate_event(event_id):
+            return
+
+        logger.warning(
+            "Matrix: could not decrypt event %s in %s — buffering for retry",
+            event_id, room_id,
+        )
+
+        self._pending_megolm.append((room_id, event, time.time()))
+        if len(self._pending_megolm) > _MAX_PENDING_EVENTS:
+            self._pending_megolm = self._pending_megolm[-_MAX_PENDING_EVENTS:]
+
+    async def _on_invite(self, event: Any) -> None:
         """Auto-join rooms when invited."""
-        import nio
+        from mautrix.types import RoomID
 
-        if not isinstance(event, nio.InviteMemberEvent):
-            return
-
-        # Only process invites directed at us.
-        if event.state_key != self._user_id:
-            return
-
-        if event.membership != "invite":
-            return
+        room_id = str(getattr(event, "room_id", ""))
 
         logger.info(
-            "Matrix: invited to %s by %s — joining",
-            room.room_id, event.sender,
+            "Matrix: invited to %s — joining",
+            room_id,
         )
         try:
-            resp = await self._client.join(room.room_id)
-            if isinstance(resp, nio.JoinResponse):
-                self._joined_rooms.add(room.room_id)
-                logger.info("Matrix: joined %s", room.room_id)
-                # Refresh DM cache since new room may be a DM.
-                await self._refresh_dm_cache()
-            else:
-                logger.warning(
-                    "Matrix: failed to join %s: %s",
-                    room.room_id, getattr(resp, "message", resp),
-                )
+            await self._client.join_room(RoomID(room_id))
+            self._joined_rooms.add(room_id)
+            logger.info("Matrix: joined %s", room_id)
+            await self._refresh_dm_cache()
         except Exception as exc:
-            logger.warning("Matrix: error joining %s: %s", room.room_id, exc)
+            logger.warning("Matrix: error joining %s: %s", room_id, exc)
 
     # ------------------------------------------------------------------
     # Reactions (send, receive, processing lifecycle)
@@ -1459,7 +1212,7 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send an emoji reaction to a message in a room.
         Returns the reaction event_id on success, None on failure.
         """
-        import nio
+        from mautrix.types import EventType, RoomID
 
         if not self._client:
             return None
@@ -1471,15 +1224,11 @@ class MatrixAdapter(BasePlatformAdapter):
             }
         }
         try:
-            resp = await self._client.room_send(
-                room_id, "m.reaction", content,
-                ignore_unverified_devices=True,
+            resp_event_id = await self._client.send_message_event(
+                RoomID(room_id), EventType.REACTION, content,
             )
-            if isinstance(resp, nio.RoomSendResponse):
-                logger.debug("Matrix: sent reaction %s to %s", emoji, event_id)
-                return resp.event_id
-            logger.debug("Matrix: reaction send failed: %s", resp)
-            return None
+            logger.debug("Matrix: sent reaction %s to %s", emoji, event_id)
+            return str(resp_event_id)
         except Exception as exc:
             logger.debug("Matrix: reaction send error: %s", exc)
             return None
@@ -1513,7 +1262,6 @@ class MatrixAdapter(BasePlatformAdapter):
             return
         if outcome == ProcessingOutcome.CANCELLED:
             return
-        # Remove the eyes reaction first, if we tracked its event_id.
         reaction_key = (room_id, msg_id)
         if reaction_key in self._pending_reactions:
             eyes_event_id = self._pending_reactions.pop(reaction_key)
@@ -1525,41 +1273,90 @@ class MatrixAdapter(BasePlatformAdapter):
             "\u2705" if outcome == ProcessingOutcome.SUCCESS else "\u274c",
         )
 
-    async def _on_reaction(self, room: Any, event: Any) -> None:
+    async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""
-        if event.sender == self._user_id:
+        sender = str(getattr(event, "sender", ""))
+        if sender == self._user_id:
             return
-        if self._is_duplicate_event(getattr(event, "event_id", None)):
+        event_id = str(getattr(event, "event_id", ""))
+        if self._is_duplicate_event(event_id):
             return
-        # Log for now; future: trigger agent actions based on emoji.
-        reacts_to = getattr(event, "reacts_to", "")
-        key = getattr(event, "key", "")
-        logger.info(
-            "Matrix: reaction %s from %s on %s in %s",
-            key, event.sender, reacts_to, room.room_id,
+
+        room_id = str(getattr(event, "room_id", ""))
+        content = getattr(event, "content", None)
+        if content:
+            relates_to = content.get("m.relates_to", {}) if isinstance(content, dict) else getattr(content, "relates_to", {})
+            reacts_to = ""
+            key = ""
+            if isinstance(relates_to, dict):
+                reacts_to = relates_to.get("event_id", "")
+                key = relates_to.get("key", "")
+            elif hasattr(relates_to, "event_id"):
+                reacts_to = str(getattr(relates_to, "event_id", ""))
+                key = str(getattr(relates_to, "key", ""))
+            logger.info(
+                "Matrix: reaction %s from %s on %s in %s",
+                key, sender, reacts_to, room_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Text message aggregation (handles Matrix client-side splits)
+    # ------------------------------------------------------------------
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Session-scoped key for text message batching."""
+        from gateway.session import build_session_key
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
-    async def _on_unknown_event(self, room: Any, event: Any) -> None:
-        """Fallback handler for events not natively parsed by matrix-nio.
+    def _enqueue_text_event(self, event: MessageEvent) -> None:
+        """Buffer a text event and reset the flush timer."""
+        key = self._text_batch_key(event)
+        existing = self._pending_text_batches.get(key)
+        chunk_len = len(event.text or "")
+        if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._pending_text_batches[key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            if event.media_urls:
+                existing.media_urls.extend(event.media_urls)
+                existing.media_types.extend(event.media_types)
 
-        Catches m.reaction on older nio versions that lack ReactionEvent.
-        """
-        source = getattr(event, "source", {})
-        if source.get("type") != "m.reaction":
-            return
-        content = source.get("content", {})
-        relates_to = content.get("m.relates_to", {})
-        if relates_to.get("rel_type") != "m.annotation":
-            return
-        if source.get("sender") == self._user_id:
-            return
-        logger.info(
-            "Matrix: reaction %s from %s on %s in %s",
-            relates_to.get("key", "?"),
-            source.get("sender", "?"),
-            relates_to.get("event_id", "?"),
-            room.room_id,
+        prior_task = self._pending_text_batch_tasks.get(key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[key] = asyncio.create_task(
+            self._flush_text_batch(key)
         )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for the quiet period then dispatch the aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            if last_len >= self._SPLIT_THRESHOLD:
+                delay = self._text_batch_split_delay_seconds
+            else:
+                delay = self._text_batch_delay_seconds
+            await asyncio.sleep(delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info(
+                "[Matrix] Flushing text batch %s (%d chars)",
+                key, len(event.text or ""),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
 
     # ------------------------------------------------------------------
     # Read receipts
@@ -1575,25 +1372,16 @@ class MatrixAdapter(BasePlatformAdapter):
         asyncio.ensure_future(_send())
 
     async def send_read_receipt(self, room_id: str, event_id: str) -> bool:
-        """Send a read receipt (m.read) for an event.
-
-        Also sets the fully-read marker so the room is marked as read
-        in all clients.
-        """
+        """Send a read receipt (m.read) for an event."""
         if not self._client:
             return False
         try:
-            if hasattr(self._client, "room_read_markers"):
-                await self._client.room_read_markers(
-                    room_id,
-                    fully_read_event=event_id,
-                    read_event=event_id,
-                )
-            else:
-                # Fallback for older matrix-nio.
-                await self._client.room_send(
-                    room_id, "m.receipt", {"event_id": event_id},
-                )
+            from mautrix.types import EventID, RoomID
+            await self._client.set_read_markers(
+                RoomID(room_id),
+                fully_read_event=EventID(event_id),
+                read_receipt=EventID(event_id),
+            )
             logger.debug("Matrix: sent read receipt for %s in %s", event_id, room_id)
             return True
         except Exception as exc:
@@ -1608,19 +1396,15 @@ class MatrixAdapter(BasePlatformAdapter):
         self, room_id: str, event_id: str, reason: str = "",
     ) -> bool:
         """Redact (delete) a message or event from a room."""
-        import nio
-
         if not self._client:
             return False
         try:
-            resp = await self._client.room_redact(
-                room_id, event_id, reason=reason,
+            from mautrix.types import EventID, RoomID
+            await self._client.redact(
+                RoomID(room_id), EventID(event_id), reason=reason or None,
             )
-            if isinstance(resp, nio.RoomRedactResponse):
-                logger.info("Matrix: redacted %s in %s", event_id, room_id)
-                return True
-            logger.warning("Matrix: redact failed: %s", resp)
-            return False
+            logger.info("Matrix: redacted %s in %s", event_id, room_id)
+            return True
         except Exception as exc:
             logger.warning("Matrix: redact error: %s", exc)
             return False
@@ -1635,40 +1419,39 @@ class MatrixAdapter(BasePlatformAdapter):
         limit: int = 50,
         start: str = "",
     ) -> list:
-        """Fetch recent messages from a room.
-
-        Returns a list of dicts with keys: event_id, sender, body,
-        timestamp, type.  Uses the ``room_messages()`` API.
-        """
-        import nio
-
+        """Fetch recent messages from a room."""
         if not self._client:
             return []
         try:
-            resp = await self._client.room_messages(
-                room_id,
-                start=start or "",
+            from mautrix.types import PaginationDirection, RoomID, SyncToken
+            resp = await self._client.get_messages(
+                RoomID(room_id),
+                direction=PaginationDirection.BACKWARD,
+                from_token=SyncToken(start) if start else None,
                 limit=limit,
-                direction=nio.Api.MessageDirection.back
-                if hasattr(nio.Api, "MessageDirection")
-                else "b",
             )
         except Exception as exc:
-            logger.warning("Matrix: room_messages failed for %s: %s", room_id, exc)
+            logger.warning("Matrix: get_messages failed for %s: %s", room_id, exc)
             return []
 
-        if not isinstance(resp, nio.RoomMessagesResponse):
-            logger.warning("Matrix: room_messages returned %s", type(resp).__name__)
+        if not resp:
             return []
 
+        events = getattr(resp, "chunk", []) or (resp.get("chunk", []) if isinstance(resp, dict) else [])
         messages = []
-        for event in reversed(resp.chunk):
-            body = getattr(event, "body", "") or ""
+        for event in reversed(events):
+            body = ""
+            content = getattr(event, "content", None)
+            if content:
+                if hasattr(content, "body"):
+                    body = content.body or ""
+                elif isinstance(content, dict):
+                    body = content.get("body", "")
             messages.append({
-                "event_id": getattr(event, "event_id", ""),
-                "sender": getattr(event, "sender", ""),
+                "event_id": str(getattr(event, "event_id", "")),
+                "sender": str(getattr(event, "sender", "")),
                 "body": body,
-                "timestamp": getattr(event, "server_timestamp", 0),
+                "timestamp": getattr(event, "timestamp", 0) or getattr(event, "server_timestamp", 0),
                 "type": type(event).__name__,
             })
         return messages
@@ -1685,56 +1468,41 @@ class MatrixAdapter(BasePlatformAdapter):
         is_direct: bool = False,
         preset: str = "private_chat",
     ) -> Optional[str]:
-        """Create a new Matrix room.
-
-        Args:
-            name: Human-readable room name.
-            topic: Room topic.
-            invite: List of user IDs to invite.
-            is_direct: Mark as a DM room.
-            preset: One of private_chat, public_chat, trusted_private_chat.
-
-        Returns the room_id on success, None on failure.
-        """
-        import nio
-
+        """Create a new Matrix room."""
         if not self._client:
             return None
         try:
-            resp = await self._client.room_create(
+            from mautrix.types import RoomCreatePreset, UserID
+            preset_enum = {
+                "private_chat": RoomCreatePreset.PRIVATE,
+                "public_chat": RoomCreatePreset.PUBLIC,
+                "trusted_private_chat": RoomCreatePreset.TRUSTED_PRIVATE,
+            }.get(preset, RoomCreatePreset.PRIVATE)
+            invitees = [UserID(u) for u in (invite or [])]
+            room_id = await self._client.create_room(
                 name=name or None,
                 topic=topic or None,
-                invite=invite or [],
+                invitees=invitees,
                 is_direct=is_direct,
-                preset=getattr(
-                    nio.Api.RoomPreset if hasattr(nio.Api, "RoomPreset") else type("", (), {}),
-                    preset, None,
-                ) or preset,
+                preset=preset_enum,
             )
-            if isinstance(resp, nio.RoomCreateResponse):
-                room_id = resp.room_id
-                self._joined_rooms.add(room_id)
-                logger.info("Matrix: created room %s (%s)", room_id, name or "unnamed")
-                return room_id
-            logger.warning("Matrix: room_create failed: %s", resp)
-            return None
+            room_id_str = str(room_id)
+            self._joined_rooms.add(room_id_str)
+            logger.info("Matrix: created room %s (%s)", room_id_str, name or "unnamed")
+            return room_id_str
         except Exception as exc:
-            logger.warning("Matrix: room_create error: %s", exc)
+            logger.warning("Matrix: create_room error: %s", exc)
             return None
 
     async def invite_user(self, room_id: str, user_id: str) -> bool:
         """Invite a user to a room."""
-        import nio
-
         if not self._client:
             return False
         try:
-            resp = await self._client.room_invite(room_id, user_id)
-            if isinstance(resp, nio.RoomInviteResponse):
-                logger.info("Matrix: invited %s to %s", user_id, room_id)
-                return True
-            logger.warning("Matrix: invite failed: %s", resp)
-            return False
+            from mautrix.types import RoomID, UserID
+            await self._client.invite_user(RoomID(room_id), UserID(user_id))
+            logger.info("Matrix: invited %s to %s", user_id, room_id)
+            return True
         except Exception as exc:
             logger.warning("Matrix: invite error: %s", exc)
             return False
@@ -1753,13 +1521,21 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.warning("Matrix: invalid presence state %r", state)
             return False
         try:
-            if hasattr(self._client, "set_presence"):
-                await self._client.set_presence(state, status_msg=status_msg or None)
-                logger.debug("Matrix: presence set to %s", state)
-                return True
+            from mautrix.types import PresenceState
+            presence_map = {
+                "online": PresenceState.ONLINE,
+                "offline": PresenceState.OFFLINE,
+                "unavailable": PresenceState.UNAVAILABLE,
+            }
+            await self._client.set_presence(
+                presence=presence_map[state],
+                status=status_msg or None,
+            )
+            logger.debug("Matrix: presence set to %s", state)
+            return True
         except Exception as exc:
             logger.debug("Matrix: set_presence failed: %s", exc)
-        return False
+            return False
 
     # ------------------------------------------------------------------
     # Emote & notice message types
@@ -1769,7 +1545,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an emote message (/me style action)."""
-        import nio
+        from mautrix.types import EventType, RoomID
 
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
@@ -1784,13 +1560,10 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["formatted_body"] = html
 
         try:
-            resp = await self._client.room_send(
-                chat_id, "m.room.message", msg_content,
-                ignore_unverified_devices=True,
+            event_id = await self._client.send_message_event(
+                RoomID(chat_id), EventType.ROOM_MESSAGE, msg_content,
             )
-            if isinstance(resp, nio.RoomSendResponse):
-                return SendResult(success=True, message_id=resp.event_id)
-            return SendResult(success=False, error=str(resp))
+            return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
 
@@ -1798,7 +1571,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a notice message (bot-appropriate, non-alerting)."""
-        import nio
+        from mautrix.types import EventType, RoomID
 
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
@@ -1813,13 +1586,10 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["formatted_body"] = html
 
         try:
-            resp = await self._client.room_send(
-                chat_id, "m.room.message", msg_content,
-                ignore_unverified_devices=True,
+            event_id = await self._client.send_message_event(
+                RoomID(chat_id), EventType.ROOM_MESSAGE, msg_content,
             )
-            if isinstance(resp, nio.RoomSendResponse):
-                return SendResult(success=True, message_id=resp.event_id)
-            return SendResult(success=False, error=str(resp))
+            return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
 
@@ -1827,18 +1597,28 @@ class MatrixAdapter(BasePlatformAdapter):
     # Helpers
     # ------------------------------------------------------------------
 
-    async def _refresh_dm_cache(self) -> None:
-        """Refresh the DM room cache from m.direct account data.
+    async def _is_dm_room(self, room_id: str) -> bool:
+        """Check if a room is a DM."""
+        if self._dm_rooms.get(room_id, False):
+            return True
+        # Fallback: check member count via state store.
+        state_store = getattr(self._client, "state_store", None) if self._client else None
+        if state_store:
+            try:
+                members = await state_store.get_members(room_id)
+                if members and len(members) == 2:
+                    return True
+            except Exception:
+                pass
+        return False
 
-        Tries the account_data API first, then falls back to parsing
-        the sync response's account_data for robustness.
-        """
+    async def _refresh_dm_cache(self) -> None:
+        """Refresh the DM room cache from m.direct account data."""
         if not self._client:
             return
 
         dm_data: Optional[Dict] = None
 
-        # Primary: try the dedicated account data endpoint.
         try:
             resp = await self._client.get_account_data("m.direct")
             if hasattr(resp, "content"):
@@ -1846,21 +1626,7 @@ class MatrixAdapter(BasePlatformAdapter):
             elif isinstance(resp, dict):
                 dm_data = resp
         except Exception as exc:
-            logger.debug("Matrix: get_account_data('m.direct') failed: %s — trying sync fallback", exc)
-
-        # Fallback: parse from the client's account_data store (populated by sync).
-        if dm_data is None:
-            try:
-                # matrix-nio stores account data events on the client object
-                ad = getattr(self._client, "account_data", None)
-                if ad and isinstance(ad, dict) and "m.direct" in ad:
-                    event = ad["m.direct"]
-                    if hasattr(event, "content"):
-                        dm_data = event.content
-                    elif isinstance(event, dict):
-                        dm_data = event
-            except Exception:
-                pass
+            logger.debug("Matrix: get_account_data('m.direct') failed: %s", exc)
 
         if dm_data is None:
             return
@@ -1868,7 +1634,7 @@ class MatrixAdapter(BasePlatformAdapter):
         dm_room_ids: Set[str] = set()
         for user_id, rooms in dm_data.items():
             if isinstance(rooms, list):
-                dm_room_ids.update(rooms)
+                dm_room_ids.update(str(r) for r in rooms)
 
         self._dm_rooms = {
             rid: (rid in dm_room_ids)
@@ -1925,15 +1691,12 @@ class MatrixAdapter(BasePlatformAdapter):
         """Return True if the bot is mentioned in the message."""
         if not body and not formatted_body:
             return False
-        # Check for full @user:server in body
         if self._user_id and self._user_id in body:
             return True
-        # Check for localpart with word boundaries (case-insensitive)
         if self._user_id and ":" in self._user_id:
             localpart = self._user_id.split(":")[0].lstrip("@")
             if localpart and re.search(r'\b' + re.escape(localpart) + r'\b', body, re.IGNORECASE):
                 return True
-        # Check formatted_body for Matrix pill
         if formatted_body and self._user_id:
             if f"matrix.to/#/{self._user_id}" in formatted_body:
                 return True
@@ -1941,22 +1704,24 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def _strip_mention(self, body: str) -> str:
         """Remove bot mention from message body."""
-        # Remove full @user:server
         if self._user_id:
             body = body.replace(self._user_id, "")
-        # If still contains localpart mention, remove it
         if self._user_id and ":" in self._user_id:
             localpart = self._user_id.split(":")[0].lstrip("@")
             if localpart:
                 body = re.sub(r'\b' + re.escape(localpart) + r'\b', '', body, flags=re.IGNORECASE)
         return body.strip()
 
-    def _get_display_name(self, room: Any, user_id: str) -> str:
+    async def _get_display_name(self, room_id: str, user_id: str) -> str:
         """Get a user's display name in a room, falling back to user_id."""
-        if room and hasattr(room, "users"):
-            user = room.users.get(user_id)
-            if user and getattr(user, "display_name", None):
-                return user.display_name
+        state_store = getattr(self._client, "state_store", None) if self._client else None
+        if state_store:
+            try:
+                member = await state_store.get_member(room_id, user_id)
+                if member and getattr(member, "displayname", None):
+                    return member.displayname
+            except Exception:
+                pass
         # Strip the @...:server format to just the localpart.
         if user_id.startswith("@") and ":" in user_id:
             return user_id[1:].split(":")[0]
@@ -1964,13 +1729,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def _mxc_to_http(self, mxc_url: str) -> str:
         """Convert mxc://server/media_id to an HTTP download URL."""
-        # mxc://matrix.org/abc123 → https://matrix.org/_matrix/client/v1/media/download/matrix.org/abc123
-        # Uses the authenticated client endpoint (spec v1.11+) instead of the
-        # deprecated /_matrix/media/v3/download/ path.
         if not mxc_url.startswith("mxc://"):
             return mxc_url
         parts = mxc_url[6:]  # strip mxc://
-        # Use our homeserver for download (federation handles the rest).
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
 
     def _markdown_to_html(self, text: str) -> str:
@@ -1988,16 +1749,12 @@ class MatrixAdapter(BasePlatformAdapter):
             md = _md.Markdown(
                 extensions=["fenced_code", "tables", "nl2br", "sane_lists"],
             )
-            # Remove the raw HTML preprocessor so <script> etc. in the
-            # source are escaped rather than passed through.
             if "html_block" in md.preprocessors:
                 md.preprocessors.deregister("html_block")
 
             html = md.convert(text)
             md.reset()
 
-            # Strip wrapping <p> tags for single-paragraph messages so
-            # clients don't add extra spacing around short replies.
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
             return html
@@ -2012,31 +1769,16 @@ class MatrixAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _sanitize_link_url(url: str) -> str:
-        """Sanitize a URL for use in an href attribute.
-
-        Rejects dangerous URI schemes (javascript:, data:, vbscript:) and
-        escapes double-quotes to prevent attribute breakout.
-        """
+        """Sanitize a URL for use in an href attribute."""
         stripped = url.strip()
         scheme = stripped.split(":", 1)[0].lower().strip() if ":" in stripped else ""
         if scheme in ("javascript", "data", "vbscript"):
             return ""
-        # Escape double quotes to prevent href attribute breakout.
         return stripped.replace('"', "&quot;")
 
     @staticmethod
     def _markdown_to_html_fallback(text: str) -> str:
-        """Comprehensive regex Markdown-to-HTML for Matrix.
-
-        Handles fenced code blocks, inline code, headers, bold, italic,
-        strikethrough, links, blockquotes, ordered/unordered lists, and
-        horizontal rules.  Code regions are extracted first to prevent
-        inner transformations from mangling them.
-
-        Security: all non-code text is HTML-escaped before markdown
-        transforms to prevent HTML injection via crafted input.  Link
-        URLs are sanitized against dangerous URI schemes.
-        """
+        """Comprehensive regex Markdown-to-HTML for Matrix."""
         placeholders: list = []
 
         def _protect_html(html_fragment: str) -> str:
@@ -2078,7 +1820,7 @@ class MatrixAdapter(BasePlatformAdapter):
             result,
         )
 
-        # HTML-escape remaining text (neutralises <script>, <img onerror=...>).
+        # HTML-escape remaining text.
         parts = re.split(r"(\x00PROTECTED\d+\x00)", result)
         for idx, part in enumerate(parts):
             if not part.startswith("\x00PROTECTED"):
@@ -2106,7 +1848,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 i += 1
                 continue
 
-            # Blockquote (> may be escaped to &gt; by html.escape)
+            # Blockquote
             if line.startswith("&gt; ") or line == "&gt;" or line.startswith("> ") or line == ">":
                 bq_lines = []
                 while i < len(lines) and (
@@ -2158,7 +1900,6 @@ class MatrixAdapter(BasePlatformAdapter):
         result = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"<em>\1</em>", result, flags=re.DOTALL)
         result = re.sub(r"~~(.+?)~~", r"<del>\1</del>", result, flags=re.DOTALL)
         result = re.sub(r"\n", "<br>\n", result)
-        # Clean up excessive <br> around block elements.
         result = re.sub(r"<br>\n(</?(?:pre|blockquote|h[1-6]|ul|ol|li|hr))", r"\n\1", result)
         result = re.sub(r"(</(?:pre|blockquote|h[1-6]|ul|ol|li)>)<br>", r"\1", result)
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -296,6 +296,20 @@ class MatrixAdapter(BasePlatformAdapter):
                 from mautrix.crypto.store import MemoryCryptoStore
 
                 crypto_store = MemoryCryptoStore()
+
+                # Restore persisted crypto state from a previous run.
+                pickle_path = _STORE_DIR / "crypto_store.pickle"
+                if pickle_path.exists():
+                    try:
+                        import pickle
+                        with open(pickle_path, "rb") as f:
+                            saved = pickle.load(f)  # noqa: S301 — trusted local file
+                        if isinstance(saved, MemoryCryptoStore):
+                            crypto_store = saved
+                            logger.info("Matrix: restored E2EE crypto store from %s", pickle_path)
+                    except Exception as exc:
+                        logger.warning("Matrix: could not restore crypto store: %s", exc)
+
                 olm = OlmMachine(client, crypto_store, state_store)
 
                 # Set trust policy: accept unverified devices so senders
@@ -370,6 +384,20 @@ class MatrixAdapter(BasePlatformAdapter):
                 await self._sync_task
             except (asyncio.CancelledError, Exception):
                 pass
+
+        # Persist E2EE crypto store before closing so the next restart
+        # can decrypt events using sessions from this run.
+        if self._client and self._encryption and getattr(self._client, "crypto", None):
+            try:
+                import pickle
+                crypto_store = self._client.crypto.crypto_store
+                _STORE_DIR.mkdir(parents=True, exist_ok=True)
+                pickle_path = _STORE_DIR / "crypto_store.pickle"
+                with open(pickle_path, "wb") as f:
+                    pickle.dump(crypto_store, f)
+                logger.info("Matrix: persisted E2EE crypto store to %s", pickle_path)
+            except Exception as exc:
+                logger.debug("Matrix: could not persist crypto store on disconnect: %s", exc)
 
         if self._client:
             try:
@@ -804,6 +832,11 @@ class MatrixAdapter(BasePlatformAdapter):
             )
 
             # Route to the appropriate handler.
+            # Remove from dedup set so _on_room_message doesn't drop it
+            # (the encrypted event ID was already registered by _on_encrypted_event).
+            decrypted_id = str(getattr(decrypted, "event_id", getattr(event, "event_id", "")))
+            if decrypted_id:
+                self._processed_events_set.discard(decrypted_id)
             try:
                 await self._on_room_message(decrypted)
             except Exception as exc:

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -35,6 +35,19 @@ from typing import Any, Dict, Optional, Set
 
 from html import escape as _html_escape
 
+from mautrix.types import (
+    ContentURI,
+    EventID,
+    EventType,
+    PaginationDirection,
+    PresenceState,
+    RoomCreatePreset,
+    RoomID,
+    SyncToken,
+    TrustState,
+    UserID,
+)
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -54,6 +67,7 @@ MAX_MESSAGE_LENGTH = 4000
 # Uses get_hermes_home() so each profile gets its own Matrix store.
 from hermes_constants import get_hermes_dir as _get_hermes_dir
 _STORE_DIR = _get_hermes_dir("platforms/matrix/store", "matrix/store")
+_CRYPTO_PICKLE_PATH = _STORE_DIR / "crypto_store.pickle"
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
@@ -169,12 +183,17 @@ class MatrixAdapter(BasePlatformAdapter):
         self._bot_participated_threads: set = self._load_participated_threads()
         self._MAX_TRACKED_THREADS = 500
 
+        # Mention/thread gating — parsed once from env vars.
+        self._require_mention: bool = os.getenv("MATRIX_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
+        free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
+        self._free_rooms: Set[str] = {r.strip() for r in free_rooms_raw.split(",") if r.strip()}
+        self._auto_thread: bool = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+        self._dm_mention_threads: bool = os.getenv("MATRIX_DM_MENTION_THREADS", "false").lower() in ("true", "1", "yes")
+
         # Reactions: configurable via MATRIX_REACTIONS (default: true).
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
-        # Tracks the reaction event_id for in-progress (eyes) reactions.
-        # Key: (room_id, message_event_id) → reaction_event_id (for the eyes reaction).
         self._pending_reactions: dict[tuple[str, str], str] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
@@ -206,7 +225,6 @@ class MatrixAdapter(BasePlatformAdapter):
         from mautrix.api import HTTPAPI
         from mautrix.client import Client
         from mautrix.client.state_store import MemoryStateStore, MemorySyncStore
-        from mautrix.types import EventType, UserID
 
         if not self._homeserver:
             logger.error("Matrix: homeserver URL not configured")
@@ -262,6 +280,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
                     exc,
                 )
+                await api.session.close()
                 return False
         elif self._password and self._user_id:
             try:
@@ -271,15 +290,16 @@ class MatrixAdapter(BasePlatformAdapter):
                     device_name="Hermes Agent",
                     device_id=self._device_id or None,
                 )
-                # login() stores the token automatically.
                 if resp and hasattr(resp, "device_id"):
                     client.device_id = resp.device_id
                 logger.info("Matrix: logged in as %s", self._user_id)
             except Exception as exc:
                 logger.error("Matrix: login failed — %s", exc)
+                await api.session.close()
                 return False
         else:
             logger.error("Matrix: need MATRIX_ACCESS_TOKEN or MATRIX_USER_ID + MATRIX_PASSWORD")
+            await api.session.close()
             return False
 
         # Set up E2EE if requested.
@@ -298,7 +318,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 crypto_store = MemoryCryptoStore()
 
                 # Restore persisted crypto state from a previous run.
-                pickle_path = _STORE_DIR / "crypto_store.pickle"
+                pickle_path = _CRYPTO_PICKLE_PATH
                 if pickle_path.exists():
                     try:
                         import pickle
@@ -314,7 +334,6 @@ class MatrixAdapter(BasePlatformAdapter):
 
                 # Set trust policy: accept unverified devices so senders
                 # share Megolm session keys with us automatically.
-                from mautrix.types import TrustState
                 olm.share_keys_min_trust = TrustState.UNVERIFIED
                 olm.send_keys_min_trust = TrustState.UNVERIFIED
 
@@ -392,7 +411,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 import pickle
                 crypto_store = self._client.crypto.crypto_store
                 _STORE_DIR.mkdir(parents=True, exist_ok=True)
-                pickle_path = _STORE_DIR / "crypto_store.pickle"
+                pickle_path = _CRYPTO_PICKLE_PATH
                 with open(pickle_path, "wb") as f:
                     pickle.dump(crypto_store, f)
                 logger.info("Matrix: persisted E2EE crypto store to %s", pickle_path)
@@ -416,7 +435,6 @@ class MatrixAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Matrix room."""
-        from mautrix.types import EventType, RoomID
 
         if not content:
             return SendResult(success=True)
@@ -492,30 +510,12 @@ class MatrixAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return room name and type (dm/group)."""
         name = chat_id
-        chat_type = "group"
+        chat_type = "dm" if await self._is_dm_room(chat_id) else "group"
 
         if self._client:
-            # Try state store for member count.
-            state_store = getattr(self._client, "state_store", None)
-            if state_store:
-                try:
-                    members = await state_store.get_members(
-                        chat_id,
-                    )
-                    if members and len(members) == 2:
-                        chat_type = "dm"
-                except Exception:
-                    pass
-
-            # Use DM cache.
-            if self._dm_rooms.get(chat_id, False):
-                chat_type = "dm"
-
-            # Try to get room name from state.
             try:
-                from mautrix.types import EventType as ET, RoomID
                 name_evt = await self._client.get_state_event(
-                    RoomID(chat_id), ET.ROOM_NAME,
+                    RoomID(chat_id), EventType.ROOM_NAME,
                 )
                 if name_evt and hasattr(name_evt, "name") and name_evt.name:
                     name = name_evt.name
@@ -534,7 +534,6 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send a typing indicator."""
         if self._client:
             try:
-                from mautrix.types import RoomID
                 await self._client.set_typing(RoomID(chat_id), timeout=30000)
             except Exception:
                 pass
@@ -543,7 +542,6 @@ class MatrixAdapter(BasePlatformAdapter):
         self, chat_id: str, message_id: str, content: str
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
-        from mautrix.types import EventType, RoomID
 
         formatted = self.format_message(content)
         msg_content: Dict[str, Any] = {
@@ -683,7 +681,6 @@ class MatrixAdapter(BasePlatformAdapter):
         is_voice: bool = False,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
-        from mautrix.types import EventType, RoomID
 
         # Upload to homeserver.
         try:
@@ -866,10 +863,8 @@ class MatrixAdapter(BasePlatformAdapter):
             return
 
         # Startup grace: ignore old messages from initial sync.
-        event_ts = getattr(event, "timestamp", 0) / 1000.0 if getattr(event, "timestamp", 0) else 0
-        # Also check server_timestamp for compatibility.
-        if not event_ts:
-            event_ts = getattr(event, "server_timestamp", 0) / 1000.0 if getattr(event, "server_timestamp", 0) else 0
+        raw_ts = getattr(event, "timestamp", None) or getattr(event, "server_timestamp", None) or 0
+        event_ts = raw_ts / 1000.0 if raw_ts else 0.0
         if event_ts and event_ts < self._startup_ts - _STARTUP_GRACE_SECONDS:
             return
 
@@ -907,6 +902,68 @@ class MatrixAdapter(BasePlatformAdapter):
         elif msgtype in ("m.text", "m.notice"):
             await self._handle_text_message(room_id, sender, event_id, event_ts, source_content, relates_to)
 
+    async def _resolve_message_context(
+        self,
+        room_id: str,
+        sender: str,
+        event_id: str,
+        body: str,
+        source_content: dict,
+        relates_to: dict,
+    ) -> Optional[tuple]:
+        """Shared mention/thread/DM gating for text and media handlers.
+
+        Returns (body, is_dm, chat_type, thread_id, display_name, source)
+        or None if the message should be dropped (mention gating).
+        """
+        is_dm = await self._is_dm_room(room_id)
+        chat_type = "dm" if is_dm else "group"
+
+        thread_id = None
+        if relates_to.get("rel_type") == "m.thread":
+            thread_id = relates_to.get("event_id")
+
+        formatted_body = source_content.get("formatted_body")
+        is_mentioned = self._is_bot_mentioned(body, formatted_body)
+
+        # Require-mention gating.
+        if not is_dm:
+            is_free_room = room_id in self._free_rooms
+            in_bot_thread = bool(thread_id and thread_id in self._bot_participated_threads)
+            if self._require_mention and not is_free_room and not in_bot_thread:
+                if not is_mentioned:
+                    return None
+
+        # DM mention-thread.
+        if is_dm and not thread_id and self._dm_mention_threads and is_mentioned:
+            thread_id = event_id
+            self._track_thread(thread_id)
+
+        # Strip mention from body.
+        if is_mentioned:
+            body = self._strip_mention(body)
+
+        # Auto-thread.
+        if not is_dm and not thread_id and self._auto_thread:
+            thread_id = event_id
+            self._track_thread(thread_id)
+
+        display_name = await self._get_display_name(room_id, sender)
+        source = self.build_source(
+            chat_id=room_id,
+            chat_type=chat_type,
+            user_id=sender,
+            user_name=display_name,
+            thread_id=thread_id,
+        )
+
+        if thread_id:
+            self._track_thread(thread_id)
+
+        self._background_read_receipt(room_id, event_id)
+
+        return body, is_dm, chat_type, thread_id, display_name, source
+
     async def _handle_text_message(
         self,
         room_id: str,
@@ -921,45 +978,12 @@ class MatrixAdapter(BasePlatformAdapter):
         if not body:
             return
 
-        # Determine chat type.
-        is_dm = await self._is_dm_room(room_id)
-        chat_type = "dm" if is_dm else "group"
-
-        # Thread support.
-        thread_id = None
-        if relates_to.get("rel_type") == "m.thread":
-            thread_id = relates_to.get("event_id")
-
-        # Require-mention gating.
-        if not is_dm:
-            free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
-            free_rooms = {r.strip() for r in free_rooms_raw.split(",") if r.strip()}
-            require_mention = os.getenv("MATRIX_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_room = room_id in free_rooms
-            in_bot_thread = bool(thread_id and thread_id in self._bot_participated_threads)
-
-            formatted_body = source_content.get("formatted_body")
-            if require_mention and not is_free_room and not in_bot_thread:
-                if not self._is_bot_mentioned(body, formatted_body):
-                    return
-
-        # DM mention-thread.
-        if is_dm and not thread_id:
-            dm_mention_threads = os.getenv("MATRIX_DM_MENTION_THREADS", "false").lower() in ("true", "1", "yes")
-            if dm_mention_threads and self._is_bot_mentioned(body, source_content.get("formatted_body")):
-                thread_id = event_id
-                self._track_thread(thread_id)
-
-        # Strip mention from body.
-        if self._is_bot_mentioned(body, source_content.get("formatted_body")):
-            body = self._strip_mention(body)
-
-        # Auto-thread.
-        if not is_dm and not thread_id:
-            auto_thread = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            if auto_thread:
-                thread_id = event_id
-                self._track_thread(thread_id)
+        ctx = await self._resolve_message_context(
+            room_id, sender, event_id, body, source_content, relates_to,
+        )
+        if ctx is None:
+            return
+        body, is_dm, chat_type, thread_id, display_name, source = ctx
 
         # Reply-to detection.
         reply_to = None
@@ -983,19 +1007,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 stripped.append(line)
             body = "\n".join(stripped) if stripped else body
 
-        # Message type.
         msg_type = MessageType.TEXT
         if body.startswith(("!", "/")):
             msg_type = MessageType.COMMAND
-
-        display_name = await self._get_display_name(room_id, sender)
-        source = self.build_source(
-            chat_id=room_id,
-            chat_type=chat_type,
-            user_id=sender,
-            user_name=display_name,
-            thread_id=thread_id,
-        )
 
         msg_event = MessageEvent(
             text=body,
@@ -1006,13 +1020,6 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to,
         )
 
-        if thread_id:
-            self._track_thread(thread_id)
-
-        # Acknowledge receipt (fire-and-forget).
-        self._background_read_receipt(room_id, event_id)
-
-        # Batch plain text messages — commands dispatch immediately.
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(msg_event)
         else:
@@ -1079,7 +1086,6 @@ class MatrixAdapter(BasePlatformAdapter):
         )
         if should_cache_locally and url:
             try:
-                from mautrix.types import ContentURI
                 file_bytes = await self._client.download_media(ContentURI(url))
                 if file_bytes is not None:
                     if is_encrypted_media:
@@ -1131,53 +1137,12 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Matrix] Failed to cache media: %s", e)
 
-        is_dm = await self._is_dm_room(room_id)
-        chat_type = "dm" if is_dm else "group"
-
-        # Thread/reply detection.
-        thread_id = None
-        if relates_to.get("rel_type") == "m.thread":
-            thread_id = relates_to.get("event_id")
-
-        # Require-mention gating (media messages).
-        if not is_dm:
-            free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
-            free_rooms = {r.strip() for r in free_rooms_raw.split(",") if r.strip()}
-            require_mention = os.getenv("MATRIX_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
-            is_free_room = room_id in free_rooms
-            in_bot_thread = bool(thread_id and thread_id in self._bot_participated_threads)
-
-            if require_mention and not is_free_room and not in_bot_thread:
-                formatted_body = source_content.get("formatted_body")
-                if not self._is_bot_mentioned(body, formatted_body):
-                    return
-
-        # DM mention-thread.
-        if is_dm and not thread_id:
-            dm_mention_threads = os.getenv("MATRIX_DM_MENTION_THREADS", "false").lower() in ("true", "1", "yes")
-            if dm_mention_threads and self._is_bot_mentioned(body, source_content.get("formatted_body")):
-                thread_id = event_id
-                self._track_thread(thread_id)
-
-        # Strip mention from body.
-        if self._is_bot_mentioned(body, source_content.get("formatted_body")):
-            body = self._strip_mention(body)
-
-        # Auto-thread.
-        if not is_dm and not thread_id:
-            auto_thread = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            if auto_thread:
-                thread_id = event_id
-                self._track_thread(thread_id)
-
-        display_name = await self._get_display_name(room_id, sender)
-        source = self.build_source(
-            chat_id=room_id,
-            chat_type=chat_type,
-            user_id=sender,
-            user_name=display_name,
-            thread_id=thread_id,
+        ctx = await self._resolve_message_context(
+            room_id, sender, event_id, body, source_content, relates_to,
         )
+        if ctx is None:
+            return
+        body, is_dm, chat_type, thread_id, display_name, source = ctx
 
         allow_http_fallback = bool(http_url) and not is_encrypted_media
         media_urls = [cached_path] if cached_path else ([http_url] if allow_http_fallback else None)
@@ -1192,11 +1157,6 @@ class MatrixAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
         )
-
-        if thread_id:
-            self._track_thread(thread_id)
-
-        self._background_read_receipt(room_id, event_id)
 
         await self.handle_message(msg_event)
 
@@ -1219,7 +1179,6 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _on_invite(self, event: Any) -> None:
         """Auto-join rooms when invited."""
-        from mautrix.types import RoomID
 
         room_id = str(getattr(event, "room_id", ""))
 
@@ -1245,7 +1204,6 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send an emoji reaction to a message in a room.
         Returns the reaction event_id on success, None on failure.
         """
-        from mautrix.types import EventType, RoomID
 
         if not self._client:
             return None
@@ -1409,7 +1367,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return False
         try:
-            from mautrix.types import EventID, RoomID
             await self._client.set_read_markers(
                 RoomID(room_id),
                 fully_read_event=EventID(event_id),
@@ -1432,7 +1389,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return False
         try:
-            from mautrix.types import EventID, RoomID
             await self._client.redact(
                 RoomID(room_id), EventID(event_id), reason=reason or None,
             )
@@ -1456,7 +1412,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return []
         try:
-            from mautrix.types import PaginationDirection, RoomID, SyncToken
             resp = await self._client.get_messages(
                 RoomID(room_id),
                 direction=PaginationDirection.BACKWARD,
@@ -1505,7 +1460,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return None
         try:
-            from mautrix.types import RoomCreatePreset, UserID
             preset_enum = {
                 "private_chat": RoomCreatePreset.PRIVATE,
                 "public_chat": RoomCreatePreset.PUBLIC,
@@ -1532,7 +1486,6 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return False
         try:
-            from mautrix.types import RoomID, UserID
             await self._client.invite_user(RoomID(room_id), UserID(user_id))
             logger.info("Matrix: invited %s to %s", user_id, room_id)
             return True
@@ -1554,7 +1507,6 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.warning("Matrix: invalid presence state %r", state)
             return False
         try:
-            from mautrix.types import PresenceState
             presence_map = {
                 "online": PresenceState.ONLINE,
                 "offline": PresenceState.OFFLINE,
@@ -1574,19 +1526,14 @@ class MatrixAdapter(BasePlatformAdapter):
     # Emote & notice message types
     # ------------------------------------------------------------------
 
-    async def send_emote(
-        self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
+    async def _send_simple_message(
+        self, chat_id: str, text: str, msgtype: str,
     ) -> SendResult:
-        """Send an emote message (/me style action)."""
-        from mautrix.types import EventType, RoomID
-
+        """Send a simple message (emote, notice) with optional HTML formatting."""
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
 
-        msg_content: Dict[str, Any] = {
-            "msgtype": "m.emote",
-            "body": text,
-        }
+        msg_content: Dict[str, Any] = {"msgtype": msgtype, "body": text}
         html = self._markdown_to_html(text)
         if html and html != text:
             msg_content["format"] = "org.matrix.custom.html"
@@ -1599,32 +1546,18 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(event_id))
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
+
+    async def send_emote(
+        self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an emote message (/me style action)."""
+        return await self._send_simple_message(chat_id, text, "m.emote")
 
     async def send_notice(
         self, chat_id: str, text: str, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a notice message (bot-appropriate, non-alerting)."""
-        from mautrix.types import EventType, RoomID
-
-        if not self._client or not text:
-            return SendResult(success=False, error="No client or empty text")
-
-        msg_content: Dict[str, Any] = {
-            "msgtype": "m.notice",
-            "body": text,
-        }
-        html = self._markdown_to_html(text)
-        if html and html != text:
-            msg_content["format"] = "org.matrix.custom.html"
-            msg_content["formatted_body"] = html
-
-        try:
-            event_id = await self._client.send_message_event(
-                RoomID(chat_id), EventType.ROOM_MESSAGE, msg_content,
-            )
-            return SendResult(success=True, message_id=str(event_id))
-        except Exception as exc:
-            return SendResult(success=False, error=str(exc))
+        return await self._send_simple_message(chat_id, text, "m.notice")
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -310,6 +310,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Refusing to connect — encrypted rooms would silently fail.",
                     _E2EE_INSTALL_HINT,
                 )
+                await api.session.close()
                 return False
             try:
                 from mautrix.crypto import OlmMachine
@@ -318,15 +319,25 @@ class MatrixAdapter(BasePlatformAdapter):
                 crypto_store = MemoryCryptoStore()
 
                 # Restore persisted crypto state from a previous run.
+                # Uses HMAC to verify integrity before unpickling.
                 pickle_path = _CRYPTO_PICKLE_PATH
                 if pickle_path.exists():
                     try:
-                        import pickle
-                        with open(pickle_path, "rb") as f:
-                            saved = pickle.load(f)  # noqa: S301 — trusted local file
-                        if isinstance(saved, MemoryCryptoStore):
-                            crypto_store = saved
-                            logger.info("Matrix: restored E2EE crypto store from %s", pickle_path)
+                        import hashlib, hmac, pickle
+                        raw = pickle_path.read_bytes()
+                        # Format: 32-byte HMAC-SHA256 signature + pickle data.
+                        if len(raw) > 32:
+                            sig, payload = raw[:32], raw[32:]
+                            # Key is derived from the device_id + user_id (stable per install).
+                            hmac_key = f"{self._user_id}:{self._device_id}".encode()
+                            expected = hmac.new(hmac_key, payload, hashlib.sha256).digest()
+                            if hmac.compare_digest(sig, expected):
+                                saved = pickle.loads(payload)  # noqa: S301
+                                if isinstance(saved, MemoryCryptoStore):
+                                    crypto_store = saved
+                                    logger.info("Matrix: restored E2EE crypto store from %s", pickle_path)
+                            else:
+                                logger.warning("Matrix: crypto store HMAC mismatch — ignoring stale/tampered file")
                     except Exception as exc:
                         logger.warning("Matrix: could not restore crypto store: %s", exc)
 
@@ -349,6 +360,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: failed to create E2EE client: %s. %s",
                     exc, _E2EE_INSTALL_HINT,
                 )
+                await api.session.close()
                 return False
 
         # Register event handlers.
@@ -408,12 +420,14 @@ class MatrixAdapter(BasePlatformAdapter):
         # can decrypt events using sessions from this run.
         if self._client and self._encryption and getattr(self._client, "crypto", None):
             try:
-                import pickle
+                import hashlib, hmac, pickle
                 crypto_store = self._client.crypto.crypto_store
                 _STORE_DIR.mkdir(parents=True, exist_ok=True)
                 pickle_path = _CRYPTO_PICKLE_PATH
-                with open(pickle_path, "wb") as f:
-                    pickle.dump(crypto_store, f)
+                payload = pickle.dumps(crypto_store)
+                hmac_key = f"{self._user_id}:{self._device_id}".encode()
+                sig = hmac.new(hmac_key, payload, hashlib.sha256).digest()
+                pickle_path.write_bytes(sig + payload)
                 logger.info("Matrix: persisted E2EE crypto store to %s", pickle_path)
             except Exception as exc:
                 logger.debug("Matrix: could not persist crypto store on disconnect: %s", exc)

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -976,9 +976,6 @@ class MatrixAdapter(BasePlatformAdapter):
             thread_id=thread_id,
         )
 
-        if thread_id:
-            self._track_thread(thread_id)
-
         self._background_read_receipt(room_id, event_id)
 
         return body, is_dm, chat_type, thread_id, display_name, source
@@ -1181,10 +1178,20 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _on_encrypted_event(self, event: Any) -> None:
         """Handle encrypted events that could not be auto-decrypted."""
+        sender = str(getattr(event, "sender", ""))
+        if sender == self._user_id:
+            return
+
         room_id = str(getattr(event, "room_id", ""))
         event_id = str(getattr(event, "event_id", ""))
 
         if self._is_duplicate_event(event_id):
+            return
+
+        # Skip old events from initial sync.
+        raw_ts = getattr(event, "timestamp", None) or getattr(event, "server_timestamp", None) or 0
+        event_ts = raw_ts / 1000.0 if raw_ts else 0.0
+        if event_ts and event_ts < self._startup_ts - _STARTUP_GRACE_SECONDS:
             return
 
         logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1724,7 +1724,7 @@ class GatewayRunner:
         elif platform == Platform.MATRIX:
             from gateway.platforms.matrix import MatrixAdapter, check_matrix_requirements
             if not check_matrix_requirements():
-                logger.warning("Matrix: matrix-nio not installed or credentials not set. Run: pip install 'matrix-nio[e2e]'")
+                logger.warning("Matrix: mautrix not installed or credentials not set. Run: pip install 'mautrix[encryption]'")
                 return None
             return MatrixAdapter(config)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1442,7 +1442,7 @@ _PLATFORMS = [
             "   Or via API: curl -X POST https://your-server/_matrix/client/v3/login \\",
             "     -d '{\"type\":\"m.login.password\",\"user\":\"@bot:server\",\"password\":\"...\"}'",
             "4. Alternatively, provide user ID + password and Hermes will log in directly",
-            "5. For E2EE: set MATRIX_ENCRYPTION=true (requires pip install 'matrix-nio[e2e]')",
+            "5. For E2EE: set MATRIX_ENCRYPTION=true (requires pip install 'mautrix[encryption]')",
             "6. To find your user ID: it's @username:your-server (shown in Element profile)",
         ],
         "vars": [

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1925,9 +1925,9 @@ def _setup_matrix():
             save_env_value("MATRIX_ENCRYPTION", "true")
             print_success("E2EE enabled")
 
-        matrix_pkg = "matrix-nio[e2e]" if want_e2ee else "matrix-nio"
+        matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
         try:
-            __import__("nio")
+            __import__("mautrix")
         except ImportError:
             print_info(f"Installing {matrix_pkg}...")
             import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "py
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
-matrix = ["matrix-nio[e2e]>=0.24.0,<1", "Markdown>=3.6,<4"]
+matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4"]
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
 voice = [

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1,8 +1,9 @@
-"""Tests for Matrix platform adapter."""
+"""Tests for Matrix platform adapter (mautrix-python backend)."""
 import asyncio
 import json
 import re
 import sys
+import time
 import types
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -10,44 +11,165 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from gateway.config import Platform, PlatformConfig
 
 
-def _make_fake_nio():
-    """Create a lightweight fake ``nio`` module with real response classes.
+def _make_fake_mautrix():
+    """Create a lightweight set of fake ``mautrix`` modules.
 
-    Tests that call production methods doing ``import nio`` / ``isinstance(resp, nio.XxxResponse)``
-    need real classes (not MagicMock auto-attributes) to satisfy isinstance checks.
-    Use via ``patch.dict("sys.modules", {"nio": _make_fake_nio()})``.
+    The adapter does ``from mautrix.api import HTTPAPI``,
+    ``from mautrix.client import Client``, ``from mautrix.types import ...``
+    at import time and inside methods.  We provide just enough stubs for
+    tests that need to mock the mautrix import chain.
+
+    Use via ``patch.dict("sys.modules", _make_fake_mautrix())``.
     """
-    mod = types.ModuleType("nio")
+    # --- mautrix (root) ---
+    mautrix = types.ModuleType("mautrix")
 
-    class RoomSendResponse:
-        def __init__(self, event_id="$fake"):
-            self.event_id = event_id
+    # --- mautrix.api ---
+    mautrix_api = types.ModuleType("mautrix.api")
 
-    class RoomRedactResponse:
+    class HTTPAPI:
+        def __init__(self, base_url="", token="", **kwargs):
+            self.base_url = base_url
+            self.token = token
+            self.session = MagicMock()
+            self.session.close = AsyncMock()
+
+    mautrix_api.HTTPAPI = HTTPAPI
+    mautrix.api = mautrix_api
+
+    # --- mautrix.types ---
+    mautrix_types = types.ModuleType("mautrix.types")
+
+    class EventType:
+        ROOM_MESSAGE = "m.room.message"
+        REACTION = "m.reaction"
+        ROOM_ENCRYPTED = "m.room.encrypted"
+        ROOM_NAME = "m.room.name"
+
+    class UserID(str):
         pass
 
-    class RoomCreateResponse:
-        def __init__(self, room_id="!fake:example.org"):
-            self.room_id = room_id
-
-    class RoomInviteResponse:
+    class RoomID(str):
         pass
 
-    class UploadResponse:
-        def __init__(self, content_uri="mxc://example.org/fake"):
-            self.content_uri = content_uri
-
-    # Minimal Api stub for code that checks nio.Api.RoomPreset
-    class _Api:
+    class EventID(str):
         pass
-    mod.Api = _Api
 
-    mod.RoomSendResponse = RoomSendResponse
-    mod.RoomRedactResponse = RoomRedactResponse
-    mod.RoomCreateResponse = RoomCreateResponse
-    mod.RoomInviteResponse = RoomInviteResponse
-    mod.UploadResponse = UploadResponse
-    return mod
+    class ContentURI(str):
+        pass
+
+    class SyncToken(str):
+        pass
+
+    class RoomCreatePreset:
+        PRIVATE = "private_chat"
+        PUBLIC = "public_chat"
+        TRUSTED_PRIVATE = "trusted_private_chat"
+
+    class PresenceState:
+        ONLINE = "online"
+        OFFLINE = "offline"
+        UNAVAILABLE = "unavailable"
+
+    class TrustState:
+        UNVERIFIED = 0
+        VERIFIED = 1
+
+    class PaginationDirection:
+        BACKWARD = "b"
+        FORWARD = "f"
+
+    mautrix_types.EventType = EventType
+    mautrix_types.UserID = UserID
+    mautrix_types.RoomID = RoomID
+    mautrix_types.EventID = EventID
+    mautrix_types.ContentURI = ContentURI
+    mautrix_types.SyncToken = SyncToken
+    mautrix_types.RoomCreatePreset = RoomCreatePreset
+    mautrix_types.PresenceState = PresenceState
+    mautrix_types.TrustState = TrustState
+    mautrix_types.PaginationDirection = PaginationDirection
+    mautrix.types = mautrix_types
+
+    # --- mautrix.client ---
+    mautrix_client = types.ModuleType("mautrix.client")
+
+    class Client:
+        def __init__(self, mxid=None, device_id=None, api=None,
+                     state_store=None, sync_store=None, **kwargs):
+            self.mxid = mxid
+            self.device_id = device_id
+            self.api = api
+            self.state_store = state_store
+            self.sync_store = sync_store
+            self.crypto = None
+            self._event_handlers = {}
+
+        def add_event_handler(self, event_type, handler):
+            self._event_handlers.setdefault(event_type, []).append(handler)
+
+    class InternalEventType:
+        INVITE = "internal.invite"
+
+    mautrix_client.Client = Client
+    mautrix_client.InternalEventType = InternalEventType
+    mautrix.client = mautrix_client
+
+    # --- mautrix.client.state_store ---
+    mautrix_client_state_store = types.ModuleType("mautrix.client.state_store")
+
+    class MemoryStateStore:
+        async def get_member(self, room_id, user_id):
+            return None
+
+        async def get_members(self, room_id):
+            return []
+
+        async def get_member_profiles(self, room_id):
+            return {}
+
+    class MemorySyncStore:
+        pass
+
+    mautrix_client_state_store.MemoryStateStore = MemoryStateStore
+    mautrix_client_state_store.MemorySyncStore = MemorySyncStore
+
+    # --- mautrix.crypto ---
+    mautrix_crypto = types.ModuleType("mautrix.crypto")
+
+    class OlmMachine:
+        def __init__(self, client=None, crypto_store=None, state_store=None):
+            self.share_keys_min_trust = None
+            self.send_keys_min_trust = None
+
+        async def load(self):
+            pass
+
+        async def share_keys(self):
+            pass
+
+        async def decrypt_megolm_event(self, event):
+            return event
+
+    mautrix_crypto.OlmMachine = OlmMachine
+
+    # --- mautrix.crypto.store ---
+    mautrix_crypto_store = types.ModuleType("mautrix.crypto.store")
+
+    class MemoryCryptoStore:
+        pass
+
+    mautrix_crypto_store.MemoryCryptoStore = MemoryCryptoStore
+
+    return {
+        "mautrix": mautrix,
+        "mautrix.api": mautrix_api,
+        "mautrix.types": mautrix_types,
+        "mautrix.client": mautrix_client,
+        "mautrix.client.state_store": mautrix_client_state_store,
+        "mautrix.crypto": mautrix_crypto,
+        "mautrix.crypto.store": mautrix_crypto_store,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -438,27 +560,40 @@ class TestMatrixDisplayName:
     def setup_method(self):
         self.adapter = _make_adapter()
 
-    def test_get_display_name_from_room_users(self):
-        """Should get display name from room's users dict."""
-        mock_room = MagicMock()
-        mock_user = MagicMock()
-        mock_user.display_name = "Alice"
-        mock_room.users = {"@alice:ex.org": mock_user}
+    @pytest.mark.asyncio
+    async def test_get_display_name_from_state_store(self):
+        """Should get display name from state_store.get_member()."""
+        mock_member = MagicMock()
+        mock_member.displayname = "Alice"
 
-        name = self.adapter._get_display_name(mock_room, "@alice:ex.org")
+        mock_state_store = MagicMock()
+        mock_state_store.get_member = AsyncMock(return_value=mock_member)
+
+        mock_client = MagicMock()
+        mock_client.state_store = mock_state_store
+        self.adapter._client = mock_client
+
+        name = await self.adapter._get_display_name("!room:ex.org", "@alice:ex.org")
         assert name == "Alice"
 
-    def test_get_display_name_fallback_to_localpart(self):
+    @pytest.mark.asyncio
+    async def test_get_display_name_fallback_to_localpart(self):
         """Should extract localpart from @user:server format."""
-        mock_room = MagicMock()
-        mock_room.users = {}
+        mock_state_store = MagicMock()
+        mock_state_store.get_member = AsyncMock(return_value=None)
 
-        name = self.adapter._get_display_name(mock_room, "@bob:example.org")
+        mock_client = MagicMock()
+        mock_client.state_store = mock_state_store
+        self.adapter._client = mock_client
+
+        name = await self.adapter._get_display_name("!room:ex.org", "@bob:example.org")
         assert name == "bob"
 
-    def test_get_display_name_no_room(self):
-        """Should handle None room gracefully."""
-        name = self.adapter._get_display_name(None, "@charlie:ex.org")
+    @pytest.mark.asyncio
+    async def test_get_display_name_no_client(self):
+        """Should handle None client gracefully."""
+        self.adapter._client = None
+        name = await self.adapter._get_display_name("!room:ex.org", "@charlie:ex.org")
         assert name == "charlie"
 
 
@@ -473,7 +608,7 @@ class TestMatrixRequirements:
         monkeypatch.delenv("MATRIX_ENCRYPTION", raising=False)
         from gateway.platforms.matrix import check_matrix_requirements
         try:
-            import nio  # noqa: F401
+            import mautrix  # noqa: F401
             assert check_matrix_requirements() is True
         except ImportError:
             assert check_matrix_requirements() is False
@@ -509,9 +644,9 @@ class TestMatrixRequirements:
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
-            # Still needs nio itself to be importable
+            # Still needs mautrix itself to be importable
             try:
-                import nio  # noqa: F401
+                import mautrix  # noqa: F401
                 assert matrix_mod.check_matrix_requirements() is True
             except ImportError:
                 assert matrix_mod.check_matrix_requirements() is False
@@ -525,7 +660,7 @@ class TestMatrixRequirements:
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             try:
-                import nio  # noqa: F401
+                import mautrix  # noqa: F401
                 assert matrix_mod.check_matrix_requirements() is True
             except ImportError:
                 assert matrix_mod.check_matrix_requirements() is False
@@ -537,7 +672,8 @@ class TestMatrixRequirements:
 
 class TestMatrixAccessTokenAuth:
     @pytest.mark.asyncio
-    async def test_connect_fetches_device_id_from_whoami_for_access_token(self):
+    async def test_connect_with_access_token_and_encryption(self):
+        """connect() should call whoami, set user_id/device_id, set up crypto."""
         from gateway.platforms.matrix import MatrixAdapter
 
         config = PlatformConfig(
@@ -556,62 +692,43 @@ class TestMatrixAccessTokenAuth:
                 self.user_id = user_id
                 self.device_id = device_id
 
-        class FakeSyncResponse:
-            def __init__(self):
-                self.rooms = MagicMock(join={})
+        fake_mautrix_mods = _make_fake_mautrix()
 
-        fake_client = MagicMock()
-        fake_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
-        fake_client.sync = AsyncMock(return_value=FakeSyncResponse())
-        fake_client.keys_upload = AsyncMock()
-        fake_client.keys_query = AsyncMock()
-        fake_client.keys_claim = AsyncMock()
-        fake_client.send_to_device_messages = AsyncMock(return_value=[])
-        fake_client.get_users_for_key_claiming = MagicMock(return_value={})
-        fake_client.close = AsyncMock()
-        fake_client.add_event_callback = MagicMock()
-        fake_client.rooms = {}
-        fake_client.account_data = {}
-        fake_client.olm = object()
-        fake_client.should_upload_keys = False
-        fake_client.should_query_keys = False
-        fake_client.should_claim_keys = False
+        # Create a mock client that returns from the mautrix.client.Client constructor
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
 
-        def _restore_login(user_id, device_id, access_token):
-            fake_client.user_id = user_id
-            fake_client.device_id = device_id
-            fake_client.access_token = access_token
-            fake_client.olm = object()
+        # Mock the crypto setup
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
 
-        fake_client.restore_login = MagicMock(side_effect=_restore_login)
-
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
-        fake_nio.WhoamiResponse = FakeWhoamiResponse
-        fake_nio.SyncResponse = FakeSyncResponse
-        fake_nio.LoginResponse = type("LoginResponse", (), {})
-        fake_nio.RoomMessageText = type("RoomMessageText", (), {})
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.InviteMemberEvent = type("InviteMemberEvent", (), {})
-        fake_nio.MegolmEvent = type("MegolmEvent", (), {})
+        # Patch Client constructor to return our mock
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
                     with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
                         assert await adapter.connect() is True
 
-        fake_client.restore_login.assert_called_once_with(
-            "@bot:example.org", "DEV123", "syt_test_access_token"
-        )
-        assert fake_client.access_token == "syt_test_access_token"
-        assert fake_client.user_id == "@bot:example.org"
-        assert fake_client.device_id == "DEV123"
-        fake_client.whoami.assert_awaited_once()
+        mock_client.whoami.assert_awaited_once()
+        assert adapter._user_id == "@bot:example.org"
 
         await adapter.disconnect()
 
@@ -634,19 +751,30 @@ class TestMatrixE2EEHardFail:
         )
         adapter = MatrixAdapter(config)
 
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock()
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch.dict("sys.modules", fake_mautrix_mods):
                 result = await adapter.connect()
 
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_connect_fails_when_olm_not_loaded_after_login(self):
-        """Even if _check_e2ee_deps passes, if olm is None after auth, hard-fail."""
+    async def test_connect_fails_when_crypto_setup_raises(self):
+        """Even if _check_e2ee_deps passes, if OlmMachine raises, hard-fail."""
         from gateway.platforms.matrix import MatrixAdapter
 
         config = PlatformConfig(
@@ -660,36 +788,27 @@ class TestMatrixE2EEHardFail:
         )
         adapter = MatrixAdapter(config)
 
-        class FakeWhoamiResponse:
-            def __init__(self, user_id, device_id):
-                self.user_id = user_id
-                self.device_id = device_id
+        fake_mautrix_mods = _make_fake_mautrix()
 
-        fake_client = MagicMock()
-        fake_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
-        fake_client.close = AsyncMock()
-        # olm is None — crypto store not loaded
-        fake_client.olm = None
-        fake_client.should_upload_keys = False
+        mock_client = MagicMock()
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.crypto = None
 
-        def _restore_login(user_id, device_id, access_token):
-            fake_client.user_id = user_id
-            fake_client.device_id = device_id
-            fake_client.access_token = access_token
-
-        fake_client.restore_login = MagicMock(side_effect=_restore_login)
-
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
-        fake_nio.WhoamiResponse = FakeWhoamiResponse
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(side_effect=Exception("olm init failed"))
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch.dict("sys.modules", fake_mautrix_mods):
                 result = await adapter.connect()
 
         assert result is False
-        fake_client.close.assert_awaited_once()
 
 
 class TestMatrixDeviceId:
@@ -757,106 +876,50 @@ class TestMatrixDeviceId:
         )
         adapter = MatrixAdapter(config)
 
-        class FakeWhoamiResponse:
-            def __init__(self, user_id, device_id):
-                self.user_id = user_id
-                self.device_id = device_id
+        fake_mautrix_mods = _make_fake_mautrix()
 
-        class FakeSyncResponse:
-            def __init__(self):
-                self.rooms = MagicMock(join={})
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="WHOAMI_DEV"))
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
 
-        fake_client = MagicMock()
-        fake_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "WHOAMI_DEV"))
-        fake_client.sync = AsyncMock(return_value=FakeSyncResponse())
-        fake_client.keys_upload = AsyncMock()
-        fake_client.keys_query = AsyncMock()
-        fake_client.keys_claim = AsyncMock()
-        fake_client.send_to_device_messages = AsyncMock(return_value=[])
-        fake_client.get_users_for_key_claiming = MagicMock(return_value={})
-        fake_client.close = AsyncMock()
-        fake_client.add_event_callback = MagicMock()
-        fake_client.rooms = {}
-        fake_client.account_data = {}
-        fake_client.olm = object()
-        fake_client.should_upload_keys = False
-        fake_client.should_query_keys = False
-        fake_client.should_claim_keys = False
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
 
-        def _restore_login(user_id, device_id, access_token):
-            fake_client.user_id = user_id
-            fake_client.device_id = device_id
-            fake_client.access_token = access_token
-
-        fake_client.restore_login = MagicMock(side_effect=_restore_login)
-
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
-        fake_nio.WhoamiResponse = FakeWhoamiResponse
-        fake_nio.SyncResponse = FakeSyncResponse
-        fake_nio.LoginResponse = type("LoginResponse", (), {})
-        fake_nio.RoomMessageText = type("RoomMessageText", (), {})
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.InviteMemberEvent = type("InviteMemberEvent", (), {})
-        fake_nio.MegolmEvent = type("MegolmEvent", (), {})
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
                     with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
                         assert await adapter.connect() is True
 
-        # The configured device_id should override the whoami device_id
-        fake_client.restore_login.assert_called_once_with(
-            "@bot:example.org", "MY_STABLE_DEVICE", "syt_test_access_token"
-        )
-        assert fake_client.device_id == "MY_STABLE_DEVICE"
-
-        # Verify device_id was passed to nio.AsyncClient constructor
-        ctor_call = fake_nio.AsyncClient.call_args
-        assert ctor_call.kwargs.get("device_id") == "MY_STABLE_DEVICE"
+        # The configured device_id should override the whoami device_id.
+        # In mautrix, the adapter sets client.device_id directly.
+        assert adapter._device_id == "MY_STABLE_DEVICE"
 
         await adapter.disconnect()
 
 
-class TestMatrixE2EEClientConstructorFailure:
-    """connect() should hard-fail if nio.AsyncClient() raises when encryption is on."""
-
-    @pytest.mark.asyncio
-    async def test_connect_fails_when_e2ee_client_constructor_raises(self):
-        from gateway.platforms.matrix import MatrixAdapter
-
-        config = PlatformConfig(
-            enabled=True,
-            token="syt_test_access_token",
-            extra={
-                "homeserver": "https://matrix.example.org",
-                "user_id": "@bot:example.org",
-                "encryption": True,
-            },
-        )
-        adapter = MatrixAdapter(config)
-
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(side_effect=Exception("olm init failed"))
-
-        from gateway.platforms import matrix as matrix_mod
-        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
-                result = await adapter.connect()
-
-        assert result is False
-
-
 class TestMatrixPasswordLoginDeviceId:
-    """MATRIX_DEVICE_ID should be passed to nio.AsyncClient even with password login."""
+    """MATRIX_DEVICE_ID should be passed to mautrix Client even with password login."""
 
     @pytest.mark.asyncio
-    async def test_password_login_passes_device_id_to_constructor(self):
+    async def test_password_login_uses_device_id(self):
         from gateway.platforms.matrix import MatrixAdapter
 
         config = PlatformConfig(
@@ -870,40 +933,32 @@ class TestMatrixPasswordLoginDeviceId:
         )
         adapter = MatrixAdapter(config)
 
-        class FakeLoginResponse:
-            pass
+        fake_mautrix_mods = _make_fake_mautrix()
 
-        class FakeSyncResponse:
-            def __init__(self):
-                self.rooms = MagicMock(join={})
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.login = AsyncMock(return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok"))
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = ""
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
 
-        fake_client = MagicMock()
-        fake_client.login = AsyncMock(return_value=FakeLoginResponse())
-        fake_client.sync = AsyncMock(return_value=FakeSyncResponse())
-        fake_client.close = AsyncMock()
-        fake_client.add_event_callback = MagicMock()
-        fake_client.rooms = {}
-        fake_client.account_data = {}
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
-        fake_nio.LoginResponse = FakeLoginResponse
-        fake_nio.SyncResponse = FakeSyncResponse
-        fake_nio.RoomMessageText = type("RoomMessageText", (), {})
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.InviteMemberEvent = type("InviteMemberEvent", (), {})
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
+        from gateway.platforms import matrix as matrix_mod
+        with patch.dict("sys.modules", fake_mautrix_mods):
             with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
                 with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
                     assert await adapter.connect() is True
 
-        # Verify device_id was passed to the nio.AsyncClient constructor
-        ctor_call = fake_nio.AsyncClient.call_args
-        assert ctor_call.kwargs.get("device_id") == "STABLE_PW_DEVICE"
+        mock_client.login.assert_awaited_once()
+        assert adapter._device_id == "STABLE_PW_DEVICE"
 
         await adapter.disconnect()
 
@@ -936,258 +991,104 @@ class TestMatrixDeviceIdConfig:
         assert "device_id" not in mc.extra
 
 
-class TestMatrixE2EEMaintenance:
+class TestMatrixSyncLoop:
     @pytest.mark.asyncio
-    async def test_sync_loop_runs_e2ee_maintenance_requests(self):
+    async def test_sync_loop_shares_keys_when_encryption_enabled(self):
+        """_sync_loop should call crypto.share_keys() after each sync."""
         adapter = _make_adapter()
         adapter._encryption = True
         adapter._closing = False
 
-        class FakeSyncError:
-            pass
+        call_count = 0
 
-        async def _sync_once(timeout=30000):
-            adapter._closing = True
-            return MagicMock()
+        async def _sync_once(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                adapter._closing = True
+            return {"rooms": {"join": {"!room:example.org": {}}}}
+
+        mock_crypto = MagicMock()
+        mock_crypto.share_keys = AsyncMock()
 
         fake_client = MagicMock()
         fake_client.sync = AsyncMock(side_effect=_sync_once)
-        fake_client.send_to_device_messages = AsyncMock(return_value=[])
-        fake_client.keys_upload = AsyncMock()
-        fake_client.keys_query = AsyncMock()
-        fake_client.get_users_for_key_claiming = MagicMock(
-            return_value={"@alice:example.org": ["DEVICE1"]}
-        )
-        fake_client.keys_claim = AsyncMock()
-        fake_client.olm = object()
-        fake_client.should_upload_keys = True
-        fake_client.should_query_keys = True
-        fake_client.should_claim_keys = True
-
+        fake_client.crypto = mock_crypto
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.SyncError = FakeSyncError
+        await adapter._sync_loop()
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            await adapter._sync_loop()
-
-        fake_client.sync.assert_awaited_once_with(timeout=30000)
-        fake_client.send_to_device_messages.assert_awaited_once()
-        fake_client.keys_upload.assert_awaited_once()
-        fake_client.keys_query.assert_awaited_once()
-        fake_client.keys_claim.assert_awaited_once_with(
-            {"@alice:example.org": ["DEVICE1"]}
-        )
+        fake_client.sync.assert_awaited_once()
+        mock_crypto.share_keys.assert_awaited_once()
 
 
 class TestMatrixEncryptedSendFallback:
     @pytest.mark.asyncio
-    async def test_send_retries_with_ignored_unverified_devices(self):
+    async def test_send_retries_after_e2ee_error(self):
+        """send() should retry with crypto.share_keys() on E2EE errors."""
         adapter = _make_adapter()
         adapter._encryption = True
 
-        class FakeRoomSendResponse:
-            def __init__(self, event_id):
-                self.event_id = event_id
-
-        class FakeOlmUnverifiedDeviceError(Exception):
-            pass
-
         fake_client = MagicMock()
-        fake_client.room_send = AsyncMock(side_effect=[
-            FakeOlmUnverifiedDeviceError("unverified"),
-            FakeRoomSendResponse("$event123"),
+        fake_client.send_message_event = AsyncMock(side_effect=[
+            Exception("encryption error"),
+            "$event123",  # mautrix returns EventID string directly
         ])
+        mock_crypto = MagicMock()
+        mock_crypto.share_keys = AsyncMock()
+        fake_client.crypto = mock_crypto
         adapter._client = fake_client
-        adapter._run_e2ee_maintenance = AsyncMock()
 
-        fake_nio = MagicMock()
-        fake_nio.RoomSendResponse = FakeRoomSendResponse
-        fake_nio.OlmUnverifiedDeviceError = FakeOlmUnverifiedDeviceError
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await adapter.send("!room:example.org", "hello")
+        result = await adapter.send("!room:example.org", "hello")
 
         assert result.success is True
         assert result.message_id == "$event123"
-        adapter._run_e2ee_maintenance.assert_awaited_once()
-        assert fake_client.room_send.await_count == 2
-        first_call = fake_client.room_send.await_args_list[0]
-        second_call = fake_client.room_send.await_args_list[1]
-        assert first_call.kwargs.get("ignore_unverified_devices") is False
-        assert second_call.kwargs.get("ignore_unverified_devices") is True
-
-    @pytest.mark.asyncio
-    async def test_send_retries_after_timeout_in_encrypted_room(self):
-        adapter = _make_adapter()
-        adapter._encryption = True
-
-        class FakeRoomSendResponse:
-            def __init__(self, event_id):
-                self.event_id = event_id
-
-        fake_client = MagicMock()
-        fake_client.room_send = AsyncMock(side_effect=[
-            asyncio.TimeoutError(),
-            FakeRoomSendResponse("$event456"),
-        ])
-        adapter._client = fake_client
-        adapter._run_e2ee_maintenance = AsyncMock()
-
-        fake_nio = MagicMock()
-        fake_nio.RoomSendResponse = FakeRoomSendResponse
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await adapter.send("!room:example.org", "hello")
-
-        assert result.success is True
-        assert result.message_id == "$event456"
-        adapter._run_e2ee_maintenance.assert_awaited_once()
-        assert fake_client.room_send.await_count == 2
-        second_call = fake_client.room_send.await_args_list[1]
-        assert second_call.kwargs.get("ignore_unverified_devices") is True
+        mock_crypto.share_keys.assert_awaited_once()
+        assert fake_client.send_message_event.await_count == 2
 
 
 # ---------------------------------------------------------------------------
-# E2EE: Auto-trust devices
-# ---------------------------------------------------------------------------
-
-class TestMatrixAutoTrustDevices:
-    def test_auto_trust_verifies_unverified_devices(self):
-        adapter = _make_adapter()
-
-        # DeviceStore.__iter__ yields OlmDevice objects directly.
-        device_a = MagicMock()
-        device_a.device_id = "DEVICE_A"
-        device_a.verified = False
-        device_b = MagicMock()
-        device_b.device_id = "DEVICE_B"
-        device_b.verified = True  # already trusted
-        device_c = MagicMock()
-        device_c.device_id = "DEVICE_C"
-        device_c.verified = False
-
-        fake_client = MagicMock()
-        fake_client.device_id = "OWN_DEVICE"
-        fake_client.verify_device = MagicMock()
-
-        # Simulate DeviceStore iteration (yields OlmDevice objects)
-        fake_client.device_store = MagicMock()
-        fake_client.device_store.__iter__ = MagicMock(
-            return_value=iter([device_a, device_b, device_c])
-        )
-
-        adapter._client = fake_client
-        adapter._auto_trust_devices()
-
-        # Should have verified device_a and device_c (not device_b, already verified)
-        assert fake_client.verify_device.call_count == 2
-        verified_devices = [call.args[0] for call in fake_client.verify_device.call_args_list]
-        assert device_a in verified_devices
-        assert device_c in verified_devices
-        assert device_b not in verified_devices
-
-    def test_auto_trust_skips_own_device(self):
-        adapter = _make_adapter()
-
-        own_device = MagicMock()
-        own_device.device_id = "MY_DEVICE"
-        own_device.verified = False
-
-        fake_client = MagicMock()
-        fake_client.device_id = "MY_DEVICE"
-        fake_client.verify_device = MagicMock()
-
-        fake_client.device_store = MagicMock()
-        fake_client.device_store.__iter__ = MagicMock(
-            return_value=iter([own_device])
-        )
-
-        adapter._client = fake_client
-        adapter._auto_trust_devices()
-
-        fake_client.verify_device.assert_not_called()
-
-    def test_auto_trust_handles_missing_device_store(self):
-        adapter = _make_adapter()
-        fake_client = MagicMock(spec=[])  # empty spec — no attributes
-        adapter._client = fake_client
-        # Should not raise
-        adapter._auto_trust_devices()
-
-
-# ---------------------------------------------------------------------------
-# E2EE: MegolmEvent key request + buffering
+# E2EE: MegolmEvent key request + buffering via _on_encrypted_event
 # ---------------------------------------------------------------------------
 
 class TestMatrixMegolmEventHandling:
     @pytest.mark.asyncio
-    async def test_megolm_event_requests_room_key_and_buffers(self):
+    async def test_encrypted_event_buffers_for_retry(self):
+        """_on_encrypted_event should buffer undecrypted events for retry."""
         adapter = _make_adapter()
         adapter._user_id = "@bot:example.org"
         adapter._startup_ts = 0.0
         adapter._dm_rooms = {}
 
-        fake_megolm = MagicMock()
-        fake_megolm.sender = "@alice:example.org"
-        fake_megolm.event_id = "$encrypted_event"
-        fake_megolm.server_timestamp = 9999999999000  # future
-        fake_megolm.session_id = "SESSION123"
+        fake_event = MagicMock()
+        fake_event.room_id = "!room:example.org"
+        fake_event.event_id = "$encrypted_event"
+        fake_event.sender = "@alice:example.org"
 
-        fake_room = MagicMock()
-        fake_room.room_id = "!room:example.org"
-
-        fake_client = MagicMock()
-        fake_client.request_room_key = AsyncMock(return_value=MagicMock())
-        adapter._client = fake_client
-
-        # Create a MegolmEvent class for isinstance check
-        fake_nio = MagicMock()
-        FakeMegolmEvent = type("MegolmEvent", (), {})
-        fake_megolm.__class__ = FakeMegolmEvent
-        fake_nio.MegolmEvent = FakeMegolmEvent
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            await adapter._on_room_message(fake_room, fake_megolm)
-
-        # Should have requested the room key
-        fake_client.request_room_key.assert_awaited_once_with(fake_megolm)
+        await adapter._on_encrypted_event(fake_event)
 
         # Should have buffered the event
         assert len(adapter._pending_megolm) == 1
-        room, event, ts = adapter._pending_megolm[0]
-        assert room is fake_room
-        assert event is fake_megolm
+        room_id, event, ts = adapter._pending_megolm[0]
+        assert room_id == "!room:example.org"
+        assert event is fake_event
 
     @pytest.mark.asyncio
-    async def test_megolm_buffer_capped(self):
+    async def test_encrypted_event_buffer_capped(self):
+        """Buffer should not grow past _MAX_PENDING_EVENTS."""
         adapter = _make_adapter()
         adapter._user_id = "@bot:example.org"
         adapter._startup_ts = 0.0
         adapter._dm_rooms = {}
 
-        fake_client = MagicMock()
-        fake_client.request_room_key = AsyncMock(return_value=MagicMock())
-        adapter._client = fake_client
-
-        FakeMegolmEvent = type("MegolmEvent", (), {})
-        fake_nio = MagicMock()
-        fake_nio.MegolmEvent = FakeMegolmEvent
-
-        # Fill the buffer past max
         from gateway.platforms.matrix import _MAX_PENDING_EVENTS
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            for i in range(_MAX_PENDING_EVENTS + 10):
-                evt = MagicMock()
-                evt.__class__ = FakeMegolmEvent
-                evt.sender = "@alice:example.org"
-                evt.event_id = f"$event_{i}"
-                evt.server_timestamp = 9999999999000
-                evt.session_id = f"SESSION_{i}"
-                room = MagicMock()
-                room.room_id = "!room:example.org"
-                await adapter._on_room_message(room, evt)
+
+        for i in range(_MAX_PENDING_EVENTS + 10):
+            evt = MagicMock()
+            evt.room_id = "!room:example.org"
+            evt.event_id = f"$event_{i}"
+            evt.sender = "@alice:example.org"
+            await adapter._on_encrypted_event(evt)
 
         assert len(adapter._pending_megolm) == _MAX_PENDING_EVENTS
 
@@ -1198,219 +1099,91 @@ class TestMatrixMegolmEventHandling:
 
 class TestMatrixRetryPendingDecryptions:
     @pytest.mark.asyncio
-    async def test_successful_decryption_routes_to_text_handler(self):
-        import time as _time
-
+    async def test_successful_decryption_routes_to_handler(self):
         adapter = _make_adapter()
         adapter._user_id = "@bot:example.org"
         adapter._startup_ts = 0.0
         adapter._dm_rooms = {}
 
-        # Create types
-        FakeMegolmEvent = type("MegolmEvent", (), {})
-        FakeRoomMessageText = type("RoomMessageText", (), {})
+        fake_encrypted = MagicMock()
+        fake_encrypted.event_id = "$encrypted"
 
         decrypted_event = MagicMock()
-        decrypted_event.__class__ = FakeRoomMessageText
 
-        fake_megolm = MagicMock()
-        fake_megolm.__class__ = FakeMegolmEvent
-        fake_megolm.event_id = "$encrypted"
-
-        fake_room = MagicMock()
-        now = _time.time()
-
-        adapter._pending_megolm = [(fake_room, fake_megolm, now)]
+        mock_crypto = MagicMock()
+        mock_crypto.decrypt_megolm_event = AsyncMock(return_value=decrypted_event)
 
         fake_client = MagicMock()
-        fake_client.decrypt_event = MagicMock(return_value=decrypted_event)
+        fake_client.crypto = mock_crypto
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.MegolmEvent = FakeMegolmEvent
-        fake_nio.RoomMessageText = FakeRoomMessageText
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
+        now = time.time()
+        adapter._pending_megolm = [("!room:ex.org", fake_encrypted, now)]
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            with patch.object(adapter, "_on_room_message", AsyncMock()) as mock_handler:
-                await adapter._retry_pending_decryptions()
-                mock_handler.assert_awaited_once_with(fake_room, decrypted_event)
+        with patch.object(adapter, "_on_room_message", AsyncMock()) as mock_handler:
+            await adapter._retry_pending_decryptions()
+            mock_handler.assert_awaited_once_with(decrypted_event)
 
         # Buffer should be empty now
         assert len(adapter._pending_megolm) == 0
 
     @pytest.mark.asyncio
     async def test_still_undecryptable_stays_in_buffer(self):
-        import time as _time
-
         adapter = _make_adapter()
 
-        FakeMegolmEvent = type("MegolmEvent", (), {})
+        fake_encrypted = MagicMock()
+        fake_encrypted.event_id = "$still_encrypted"
 
-        fake_megolm = MagicMock()
-        fake_megolm.__class__ = FakeMegolmEvent
-        fake_megolm.event_id = "$still_encrypted"
-
-        now = _time.time()
-        adapter._pending_megolm = [(MagicMock(), fake_megolm, now)]
+        mock_crypto = MagicMock()
+        mock_crypto.decrypt_megolm_event = AsyncMock(side_effect=Exception("missing key"))
 
         fake_client = MagicMock()
-        # decrypt_event raises when key is still missing
-        fake_client.decrypt_event = MagicMock(side_effect=Exception("missing key"))
+        fake_client.crypto = mock_crypto
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.MegolmEvent = FakeMegolmEvent
+        now = time.time()
+        adapter._pending_megolm = [("!room:ex.org", fake_encrypted, now)]
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            await adapter._retry_pending_decryptions()
+        await adapter._retry_pending_decryptions()
 
         assert len(adapter._pending_megolm) == 1
 
     @pytest.mark.asyncio
     async def test_expired_events_dropped(self):
-        import time as _time
-
         adapter = _make_adapter()
 
         from gateway.platforms.matrix import _PENDING_EVENT_TTL
 
-        fake_megolm = MagicMock()
-        fake_megolm.event_id = "$old_event"
-        fake_megolm.__class__ = type("MegolmEvent", (), {})
+        fake_event = MagicMock()
+        fake_event.event_id = "$old_event"
 
-        # Timestamp well past TTL
-        old_ts = _time.time() - _PENDING_EVENT_TTL - 60
-        adapter._pending_megolm = [(MagicMock(), fake_megolm, old_ts)]
-
+        mock_crypto = MagicMock()
         fake_client = MagicMock()
+        fake_client.crypto = mock_crypto
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.MegolmEvent = type("MegolmEvent", (), {})
+        # Timestamp well past TTL
+        old_ts = time.time() - _PENDING_EVENT_TTL - 60
+        adapter._pending_megolm = [("!room:ex.org", fake_event, old_ts)]
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            await adapter._retry_pending_decryptions()
+        await adapter._retry_pending_decryptions()
 
         # Should have been dropped
         assert len(adapter._pending_megolm) == 0
-        # Should NOT have tried to decrypt
-        fake_client.decrypt_event.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_media_event_routes_to_media_handler(self):
-        import time as _time
-
-        adapter = _make_adapter()
-        adapter._user_id = "@bot:example.org"
-        adapter._startup_ts = 0.0
-
-        FakeMegolmEvent = type("MegolmEvent", (), {})
-        FakeRoomMessageImage = type("RoomMessageImage", (), {})
-
-        decrypted_image = MagicMock()
-        decrypted_image.__class__ = FakeRoomMessageImage
-
-        fake_megolm = MagicMock()
-        fake_megolm.__class__ = FakeMegolmEvent
-        fake_megolm.event_id = "$encrypted_image"
-
-        fake_room = MagicMock()
-        now = _time.time()
-        adapter._pending_megolm = [(fake_room, fake_megolm, now)]
-
-        fake_client = MagicMock()
-        fake_client.decrypt_event = MagicMock(return_value=decrypted_image)
-        adapter._client = fake_client
-
-        fake_nio = MagicMock()
-        fake_nio.MegolmEvent = FakeMegolmEvent
-        fake_nio.RoomMessageText = type("RoomMessageText", (), {})
-        fake_nio.RoomMessageImage = FakeRoomMessageImage
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            with patch.object(adapter, "_on_room_message_media", AsyncMock()) as mock_media:
-                await adapter._retry_pending_decryptions()
-                mock_media.assert_awaited_once_with(fake_room, decrypted_image)
-
-        assert len(adapter._pending_megolm) == 0
 
 
 # ---------------------------------------------------------------------------
-# E2EE: Key export / import
+# E2EE: connect registers encrypted event handler
 # ---------------------------------------------------------------------------
 
-class TestMatrixKeyExportImport:
+class TestMatrixEncryptedEventHandler:
     @pytest.mark.asyncio
-    async def test_disconnect_exports_keys(self):
-        adapter = _make_adapter()
-        adapter._encryption = True
-        adapter._sync_task = None
-
-        fake_client = MagicMock()
-        fake_client.olm = object()
-        fake_client.export_keys = AsyncMock()
-        fake_client.close = AsyncMock()
-        adapter._client = fake_client
-
-        from gateway.platforms.matrix import _KEY_EXPORT_FILE, _KEY_EXPORT_PASSPHRASE
-
-        await adapter.disconnect()
-
-        fake_client.export_keys.assert_awaited_once_with(
-            str(_KEY_EXPORT_FILE), _KEY_EXPORT_PASSPHRASE,
-        )
-
-    @pytest.mark.asyncio
-    async def test_disconnect_handles_export_failure(self):
-        adapter = _make_adapter()
-        adapter._encryption = True
-        adapter._sync_task = None
-
-        fake_client = MagicMock()
-        fake_client.olm = object()
-        fake_client.export_keys = AsyncMock(side_effect=Exception("export failed"))
-        fake_client.close = AsyncMock()
-        adapter._client = fake_client
-
-        # Should not raise
-        await adapter.disconnect()
-        assert adapter._client is None  # still cleaned up
-
-    @pytest.mark.asyncio
-    async def test_disconnect_skips_export_when_no_encryption(self):
-        adapter = _make_adapter()
-        adapter._encryption = False
-        adapter._sync_task = None
-
-        fake_client = MagicMock()
-        fake_client.close = AsyncMock()
-        adapter._client = fake_client
-
-        await adapter.disconnect()
-        # Should not have tried to export
-        assert not hasattr(fake_client, "export_keys") or \
-               not fake_client.export_keys.called
-
-
-# ---------------------------------------------------------------------------
-# E2EE: Encrypted media
-# ---------------------------------------------------------------------------
-
-class TestMatrixEncryptedMedia:
-    @pytest.mark.asyncio
-    async def test_connect_registers_callbacks_for_encrypted_media_events(self):
+    async def test_connect_registers_encrypted_event_handler_when_encryption_on(self):
         from gateway.platforms.matrix import MatrixAdapter
 
         config = PlatformConfig(
             enabled=True,
-            token="syt_te...oken",
+            token="syt_test_token",
             extra={
                 "homeserver": "https://matrix.example.org",
                 "user_id": "@bot:example.org",
@@ -1419,350 +1192,104 @@ class TestMatrixEncryptedMedia:
         )
         adapter = MatrixAdapter(config)
 
-        class FakeWhoamiResponse:
-            def __init__(self, user_id, device_id):
-                self.user_id = user_id
-                self.device_id = device_id
+        fake_mautrix_mods = _make_fake_mautrix()
 
-        class FakeSyncResponse:
-            def __init__(self):
-                self.rooms = MagicMock(join={})
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None  # Will be set during connect
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
 
-        class FakeRoomMessageText: ...
-        class FakeRoomMessageImage: ...
-        class FakeRoomMessageAudio: ...
-        class FakeRoomMessageVideo: ...
-        class FakeRoomMessageFile: ...
-        class FakeRoomEncryptedImage: ...
-        class FakeRoomEncryptedAudio: ...
-        class FakeRoomEncryptedVideo: ...
-        class FakeRoomEncryptedFile: ...
-        class FakeInviteMemberEvent: ...
-        class FakeMegolmEvent: ...
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
 
-        fake_client = MagicMock()
-        fake_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
-        fake_client.sync = AsyncMock(return_value=FakeSyncResponse())
-        fake_client.keys_upload = AsyncMock()
-        fake_client.keys_query = AsyncMock()
-        fake_client.keys_claim = AsyncMock()
-        fake_client.send_to_device_messages = AsyncMock(return_value=[])
-        fake_client.get_users_for_key_claiming = MagicMock(return_value={})
-        fake_client.close = AsyncMock()
-        fake_client.add_event_callback = MagicMock()
-        fake_client.rooms = {}
-        fake_client.account_data = {}
-        fake_client.olm = object()
-        fake_client.should_upload_keys = False
-        fake_client.should_query_keys = False
-        fake_client.should_claim_keys = False
-        fake_client.restore_login = MagicMock(side_effect=lambda u, d, t: None)
-
-        fake_nio = MagicMock()
-        fake_nio.AsyncClient = MagicMock(return_value=fake_client)
-        fake_nio.WhoamiResponse = FakeWhoamiResponse
-        fake_nio.SyncResponse = FakeSyncResponse
-        fake_nio.LoginResponse = type("LoginResponse", (), {})
-        fake_nio.RoomMessageText = FakeRoomMessageText
-        fake_nio.RoomMessageImage = FakeRoomMessageImage
-        fake_nio.RoomMessageAudio = FakeRoomMessageAudio
-        fake_nio.RoomMessageVideo = FakeRoomMessageVideo
-        fake_nio.RoomMessageFile = FakeRoomMessageFile
-        fake_nio.RoomEncryptedImage = FakeRoomEncryptedImage
-        fake_nio.RoomEncryptedAudio = FakeRoomEncryptedAudio
-        fake_nio.RoomEncryptedVideo = FakeRoomEncryptedVideo
-        fake_nio.RoomEncryptedFile = FakeRoomEncryptedFile
-        fake_nio.InviteMemberEvent = FakeInviteMemberEvent
-        fake_nio.MegolmEvent = FakeMegolmEvent
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
 
         from gateway.platforms import matrix as matrix_mod
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
-            with patch.dict("sys.modules", {"nio": fake_nio}):
+            with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
                     with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
                         assert await adapter.connect() is True
 
-        callback_classes = [call.args[1] for call in fake_client.add_event_callback.call_args_list]
-        assert FakeRoomEncryptedImage in callback_classes
-        assert FakeRoomEncryptedAudio in callback_classes
-        assert FakeRoomEncryptedVideo in callback_classes
-        assert FakeRoomEncryptedFile in callback_classes
+        # Verify event handlers were registered.
+        # In mautrix the order is: add_event_handler(EventType, callback)
+        handler_calls = mock_client.add_event_handler.call_args_list
+        registered_types = [call.args[0] for call in handler_calls]
+
+        # Should have registered handlers for ROOM_MESSAGE, REACTION, INVITE, and ROOM_ENCRYPTED
+        assert len(handler_calls) >= 4  # At minimum these four
 
         await adapter.disconnect()
 
+
+# ---------------------------------------------------------------------------
+# Disconnect
+# ---------------------------------------------------------------------------
+
+class TestMatrixDisconnect:
     @pytest.mark.asyncio
-    async def test_on_room_message_media_decrypts_encrypted_image_and_passes_local_path(self):
-        try:
-            from nio.crypto.attachments import encrypt_attachment
-        except (ImportError, ModuleNotFoundError):
-            pytest.skip("matrix-nio[e2e] required for encryption tests")
-
+    async def test_disconnect_closes_api_session(self):
+        """disconnect() should close client.api.session."""
         adapter = _make_adapter()
-        adapter._user_id = "@bot:example.org"
-        adapter._startup_ts = 0.0
-        adapter._dm_rooms = {}
-        adapter.handle_message = AsyncMock()
+        adapter._sync_task = None
 
-        plaintext = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
-        ciphertext, keys = encrypt_attachment(plaintext)
+        mock_session = MagicMock()
+        mock_session.close = AsyncMock()
 
-        class FakeRoomEncryptedImage:
-            def __init__(self):
-                self.sender = "@alice:example.org"
-                self.event_id = "$img1"
-                self.server_timestamp = 0
-                self.body = "screenshot.png"
-                self.url = "mxc://example.org/media123"
-                self.key = keys["key"]["k"]
-                self.hashes = keys["hashes"]
-                self.iv = keys["iv"]
-                self.mimetype = "image/png"
-                self.source = {
-                    "content": {
-                        "body": "screenshot.png",
-                        "info": {"mimetype": "image/png"},
-                        "file": {
-                            "url": self.url,
-                            "key": keys["key"],
-                            "hashes": keys["hashes"],
-                            "iv": keys["iv"],
-                        },
-                    }
-                }
-
-        class FakeDownloadResponse:
-            def __init__(self, body):
-                self.body = body
+        mock_api = MagicMock()
+        mock_api.session = mock_session
 
         fake_client = MagicMock()
-        fake_client.download = AsyncMock(return_value=FakeDownloadResponse(ciphertext))
+        fake_client.api = mock_api
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.RoomEncryptedImage = FakeRoomEncryptedImage
-        fake_nio.RoomEncryptedAudio = type("RoomEncryptedAudio", (), {})
-        fake_nio.RoomEncryptedVideo = type("RoomEncryptedVideo", (), {})
-        fake_nio.RoomEncryptedFile = type("RoomEncryptedFile", (), {})
+        await adapter.disconnect()
 
-        room = MagicMock(room_id="!room:example.org", member_count=2, users={})
-        event = FakeRoomEncryptedImage()
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            with patch("gateway.platforms.base.cache_image_from_bytes", return_value="/tmp/cached-image.png") as cache_mock:
-                await adapter._on_room_message_media(room, event)
-
-        cache_mock.assert_called_once_with(plaintext, ext=".png")
-        msg_event = adapter.handle_message.await_args.args[0]
-        assert msg_event.message_type.name == "PHOTO"
-        assert msg_event.media_urls == ["/tmp/cached-image.png"]
-        assert msg_event.media_types == ["image/png"]
+        mock_session.close.assert_awaited_once()
+        assert adapter._client is None
 
     @pytest.mark.asyncio
-    async def test_on_room_message_media_decrypts_encrypted_voice_and_caches_audio(self):
-        try:
-            from nio.crypto.attachments import encrypt_attachment
-        except (ImportError, ModuleNotFoundError):
-            pytest.skip("matrix-nio[e2e] required for encryption tests")
-
+    async def test_disconnect_handles_session_close_failure(self):
+        """disconnect() should not raise if session close fails."""
         adapter = _make_adapter()
-        adapter._user_id = "@bot:example.org"
-        adapter._startup_ts = 0.0
-        adapter._dm_rooms = {}
-        adapter.handle_message = AsyncMock()
+        adapter._sync_task = None
 
-        plaintext = b"OggS" + b"\x00" * 32
-        ciphertext, keys = encrypt_attachment(plaintext)
+        mock_session = MagicMock()
+        mock_session.close = AsyncMock(side_effect=Exception("close failed"))
 
-        class FakeRoomEncryptedAudio:
-            def __init__(self):
-                self.sender = "@alice:example.org"
-                self.event_id = "$voice1"
-                self.server_timestamp = 0
-                self.body = "voice.ogg"
-                self.url = "mxc://example.org/voice123"
-                self.key = keys["key"]["k"]
-                self.hashes = keys["hashes"]
-                self.iv = keys["iv"]
-                self.mimetype = "audio/ogg"
-                self.source = {
-                    "content": {
-                        "body": "voice.ogg",
-                        "info": {"mimetype": "audio/ogg"},
-                        "org.matrix.msc3245.voice": {},
-                        "file": {
-                            "url": self.url,
-                            "key": keys["key"],
-                            "hashes": keys["hashes"],
-                            "iv": keys["iv"],
-                        },
-                    }
-                }
-
-        class FakeDownloadResponse:
-            def __init__(self, body):
-                self.body = body
+        mock_api = MagicMock()
+        mock_api.session = mock_session
 
         fake_client = MagicMock()
-        fake_client.download = AsyncMock(return_value=FakeDownloadResponse(ciphertext))
+        fake_client.api = mock_api
         adapter._client = fake_client
 
-        fake_nio = MagicMock()
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.RoomEncryptedImage = type("RoomEncryptedImage", (), {})
-        fake_nio.RoomEncryptedAudio = FakeRoomEncryptedAudio
-        fake_nio.RoomEncryptedVideo = type("RoomEncryptedVideo", (), {})
-        fake_nio.RoomEncryptedFile = type("RoomEncryptedFile", (), {})
-
-        room = MagicMock(room_id="!room:example.org", member_count=2, users={})
-        event = FakeRoomEncryptedAudio()
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            with patch("gateway.platforms.base.cache_audio_from_bytes", return_value="/tmp/cached-voice.ogg") as cache_mock:
-                await adapter._on_room_message_media(room, event)
-
-        cache_mock.assert_called_once_with(plaintext, ext=".ogg")
-        msg_event = adapter.handle_message.await_args.args[0]
-        assert msg_event.message_type.name == "VOICE"
-        assert msg_event.media_urls == ["/tmp/cached-voice.ogg"]
-        assert msg_event.media_types == ["audio/ogg"]
+        # Should not raise
+        await adapter.disconnect()
+        assert adapter._client is None
 
     @pytest.mark.asyncio
-    async def test_on_room_message_media_decrypts_encrypted_file_and_caches_document(self):
-        try:
-            from nio.crypto.attachments import encrypt_attachment
-        except (ImportError, ModuleNotFoundError):
-            pytest.skip("matrix-nio[e2e] required for encryption tests")
-
+    async def test_disconnect_without_client(self):
+        """disconnect() should handle None client gracefully."""
         adapter = _make_adapter()
-        adapter._user_id = "@bot:example.org"
-        adapter._startup_ts = 0.0
-        adapter._dm_rooms = {}
-        adapter.handle_message = AsyncMock()
+        adapter._sync_task = None
+        adapter._client = None
 
-        plaintext = b"hello from encrypted document"
-        ciphertext, keys = encrypt_attachment(plaintext)
-
-        class FakeRoomEncryptedFile:
-            def __init__(self):
-                self.sender = "@alice:example.org"
-                self.event_id = "$file1"
-                self.server_timestamp = 0
-                self.body = "notes.txt"
-                self.url = "mxc://example.org/file123"
-                self.key = keys["key"]
-                self.hashes = keys["hashes"]
-                self.iv = keys["iv"]
-                self.mimetype = "text/plain"
-                self.source = {
-                    "content": {
-                        "body": "notes.txt",
-                        "info": {"mimetype": "text/plain"},
-                        "file": {
-                            "url": self.url,
-                            "key": keys["key"],
-                            "hashes": keys["hashes"],
-                            "iv": keys["iv"],
-                        },
-                    }
-                }
-
-        class FakeDownloadResponse:
-            def __init__(self, body):
-                self.body = body
-
-        fake_client = MagicMock()
-        fake_client.download = AsyncMock(return_value=FakeDownloadResponse(ciphertext))
-        adapter._client = fake_client
-
-        fake_nio = MagicMock()
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.RoomEncryptedImage = type("RoomEncryptedImage", (), {})
-        fake_nio.RoomEncryptedAudio = type("RoomEncryptedAudio", (), {})
-        fake_nio.RoomEncryptedVideo = type("RoomEncryptedVideo", (), {})
-        fake_nio.RoomEncryptedFile = FakeRoomEncryptedFile
-
-        room = MagicMock(room_id="!room:example.org", member_count=2, users={})
-        event = FakeRoomEncryptedFile()
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            with patch("gateway.platforms.base.cache_document_from_bytes", return_value="/tmp/cached-notes.txt") as cache_mock:
-                await adapter._on_room_message_media(room, event)
-
-        cache_mock.assert_called_once_with(plaintext, "notes.txt")
-        msg_event = adapter.handle_message.await_args.args[0]
-        assert msg_event.message_type.name == "DOCUMENT"
-        assert msg_event.media_urls == ["/tmp/cached-notes.txt"]
-        assert msg_event.media_types == ["text/plain"]
-
-    @pytest.mark.asyncio
-    async def test_on_room_message_media_does_not_emit_ciphertext_url_when_encrypted_media_decryption_fails(self):
-        adapter = _make_adapter()
-        adapter._user_id = "@bot:example.org"
-        adapter._startup_ts = 0.0
-        adapter._dm_rooms = {}
-        adapter.handle_message = AsyncMock()
-
-        class FakeRoomEncryptedImage:
-            def __init__(self):
-                self.sender = "@alice:example.org"
-                self.event_id = "$img2"
-                self.server_timestamp = 0
-                self.body = "broken.png"
-                self.url = "mxc://example.org/media999"
-                self.key = {"k": "broken"}
-                self.hashes = {"sha256": "broken"}
-                self.iv = "broken"
-                self.mimetype = "image/png"
-                self.source = {
-                    "content": {
-                        "body": "broken.png",
-                        "info": {"mimetype": "image/png"},
-                        "file": {
-                            "url": self.url,
-                            "key": self.key,
-                            "hashes": self.hashes,
-                            "iv": self.iv,
-                        },
-                    }
-                }
-
-        class FakeDownloadResponse:
-            def __init__(self, body):
-                self.body = body
-
-        fake_client = MagicMock()
-        fake_client.download = AsyncMock(return_value=FakeDownloadResponse(b"ciphertext"))
-        adapter._client = fake_client
-
-        fake_nio = MagicMock()
-        fake_nio.RoomMessageImage = type("RoomMessageImage", (), {})
-        fake_nio.RoomMessageAudio = type("RoomMessageAudio", (), {})
-        fake_nio.RoomMessageVideo = type("RoomMessageVideo", (), {})
-        fake_nio.RoomMessageFile = type("RoomMessageFile", (), {})
-        fake_nio.RoomEncryptedImage = FakeRoomEncryptedImage
-        fake_nio.RoomEncryptedAudio = type("RoomEncryptedAudio", (), {})
-        fake_nio.RoomEncryptedVideo = type("RoomEncryptedVideo", (), {})
-        fake_nio.RoomEncryptedFile = type("RoomEncryptedFile", (), {})
-
-        room = MagicMock(room_id="!room:example.org", member_count=2, users={})
-        event = FakeRoomEncryptedImage()
-
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            await adapter._on_room_message_media(room, event)
-
-        msg_event = adapter.handle_message.await_args.args[0]
-        assert not msg_event.media_urls
-        assert not msg_event.media_types
+        await adapter.disconnect()
+        assert adapter._client is None
 
 
 # ---------------------------------------------------------------------------
@@ -1933,34 +1460,29 @@ class TestMatrixReactions:
 
     @pytest.mark.asyncio
     async def test_send_reaction(self):
-        """_send_reaction should call room_send with m.reaction."""
-        fake_nio = _make_fake_nio()
+        """_send_reaction should call send_message_event with m.reaction."""
         mock_client = MagicMock()
-        mock_client.room_send = AsyncMock(
-            return_value=fake_nio.RoomSendResponse("$reaction1")
-        )
+        # mautrix send_message_event returns EventID string directly
+        mock_client.send_message_event = AsyncMock(return_value="$reaction1")
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await self.adapter._send_reaction("!room:ex", "$event1", "👍")
+        result = await self.adapter._send_reaction("!room:ex", "$event1", "\U0001f44d")
         assert result == "$reaction1"
-        mock_client.room_send.assert_called_once()
-        args = mock_client.room_send.call_args
-        assert args[0][1] == "m.reaction"
-        content = args[0][2]
+        mock_client.send_message_event.assert_called_once()
+        call_args = mock_client.send_message_event.call_args
+        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
         assert content["m.relates_to"]["rel_type"] == "m.annotation"
-        assert content["m.relates_to"]["key"] == "👍"
+        assert content["m.relates_to"]["key"] == "\U0001f44d"
 
     @pytest.mark.asyncio
     async def test_send_reaction_no_client(self):
         self.adapter._client = None
-        with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
-            result = await self.adapter._send_reaction("!room:ex", "$ev", "👍")
+        result = await self.adapter._send_reaction("!room:ex", "$ev", "\U0001f44d")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_on_processing_start_sends_eyes(self):
-        """on_processing_start should send 👀 reaction."""
+        """on_processing_start should send eyes reaction."""
         from gateway.platforms.base import MessageEvent, MessageType
 
         self.adapter._reactions_enabled = True
@@ -1976,7 +1498,7 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_start(event)
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "👀")
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\U0001f440")
         assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
 
     @pytest.mark.asyncio
@@ -1999,7 +1521,7 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "✅")
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_cross_on_failure(self):
@@ -2021,7 +1543,7 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
         self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "❌")
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u274c")
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_cancelled_sends_no_terminal_reaction(self):
@@ -2063,7 +1585,7 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         self.adapter._redact_reaction.assert_not_called()
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "✅")
+        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
 
     @pytest.mark.asyncio
     async def test_reactions_disabled(self):
@@ -2095,13 +1617,14 @@ class TestMatrixReadReceipts:
 
     @pytest.mark.asyncio
     async def test_send_read_receipt(self):
+        """send_read_receipt should call client.set_read_markers."""
         mock_client = MagicMock()
-        mock_client.room_read_markers = AsyncMock(return_value=MagicMock())
+        mock_client.set_read_markers = AsyncMock(return_value=None)
         self.adapter._client = mock_client
 
         result = await self.adapter.send_read_receipt("!room:ex", "$event1")
         assert result is True
-        mock_client.room_read_markers.assert_called_once()
+        mock_client.set_read_markers.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_read_receipt_no_client(self):
@@ -2120,23 +1643,20 @@ class TestMatrixRedaction:
 
     @pytest.mark.asyncio
     async def test_redact_message(self):
-        fake_nio = _make_fake_nio()
+        """redact_message should call client.redact()."""
         mock_client = MagicMock()
-        mock_client.room_redact = AsyncMock(
-            return_value=fake_nio.RoomRedactResponse()
-        )
+        # mautrix redact() returns EventID string
+        mock_client.redact = AsyncMock(return_value="$redact_event")
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await self.adapter.redact_message("!room:ex", "$ev1", "oops")
+        result = await self.adapter.redact_message("!room:ex", "$ev1", "oops")
         assert result is True
-        mock_client.room_redact.assert_called_once()
+        mock_client.redact.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_redact_no_client(self):
         self.adapter._client = None
-        with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
-            result = await self.adapter.redact_message("!room:ex", "$ev1")
+        result = await self.adapter.redact_message("!room:ex", "$ev1")
         assert result is False
 
 
@@ -2150,35 +1670,30 @@ class TestMatrixRoomManagement:
 
     @pytest.mark.asyncio
     async def test_create_room(self):
-        fake_nio = _make_fake_nio()
-        mock_resp = fake_nio.RoomCreateResponse(room_id="!new:example.org")
+        """create_room should call client.create_room() returning RoomID string."""
         mock_client = MagicMock()
-        mock_client.room_create = AsyncMock(return_value=mock_resp)
+        # mautrix create_room returns RoomID string directly
+        mock_client.create_room = AsyncMock(return_value="!new:example.org")
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            room_id = await self.adapter.create_room(name="Test Room", topic="A test")
+        room_id = await self.adapter.create_room(name="Test Room", topic="A test")
         assert room_id == "!new:example.org"
         assert "!new:example.org" in self.adapter._joined_rooms
 
     @pytest.mark.asyncio
     async def test_invite_user(self):
-        fake_nio = _make_fake_nio()
+        """invite_user should call client.invite_user()."""
         mock_client = MagicMock()
-        mock_client.room_invite = AsyncMock(
-            return_value=fake_nio.RoomInviteResponse()
-        )
+        mock_client.invite_user = AsyncMock(return_value=None)
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await self.adapter.invite_user("!room:ex", "@user:ex")
+        result = await self.adapter.invite_user("!room:ex", "@user:ex")
         assert result is True
 
     @pytest.mark.asyncio
     async def test_create_room_no_client(self):
         self.adapter._client = None
-        with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
-            result = await self.adapter.create_room()
+        result = await self.adapter.create_room()
         assert result is None
 
 
@@ -2224,35 +1739,35 @@ class TestMatrixMessageTypes:
 
     @pytest.mark.asyncio
     async def test_send_emote(self):
-        fake_nio = _make_fake_nio()
+        """send_emote should call send_message_event with m.emote."""
         mock_client = MagicMock()
-        mock_resp = fake_nio.RoomSendResponse(event_id="$emote1")
-        mock_client.room_send = AsyncMock(return_value=mock_resp)
+        # mautrix returns EventID string directly
+        mock_client.send_message_event = AsyncMock(return_value="$emote1")
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await self.adapter.send_emote("!room:ex", "waves hello")
+        result = await self.adapter.send_emote("!room:ex", "waves hello")
         assert result.success is True
-        call_args = mock_client.room_send.call_args[0]
-        assert call_args[2]["msgtype"] == "m.emote"
+        assert result.message_id == "$emote1"
+        call_args = mock_client.send_message_event.call_args
+        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
+        assert content["msgtype"] == "m.emote"
 
     @pytest.mark.asyncio
     async def test_send_notice(self):
-        fake_nio = _make_fake_nio()
+        """send_notice should call send_message_event with m.notice."""
         mock_client = MagicMock()
-        mock_resp = fake_nio.RoomSendResponse(event_id="$notice1")
-        mock_client.room_send = AsyncMock(return_value=mock_resp)
+        mock_client.send_message_event = AsyncMock(return_value="$notice1")
         self.adapter._client = mock_client
 
-        with patch.dict("sys.modules", {"nio": fake_nio}):
-            result = await self.adapter.send_notice("!room:ex", "System message")
+        result = await self.adapter.send_notice("!room:ex", "System message")
         assert result.success is True
-        call_args = mock_client.room_send.call_args[0]
-        assert call_args[2]["msgtype"] == "m.notice"
+        assert result.message_id == "$notice1"
+        call_args = mock_client.send_message_event.call_args
+        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
+        assert content["msgtype"] == "m.notice"
 
     @pytest.mark.asyncio
     async def test_send_emote_empty_text(self):
         self.adapter._client = MagicMock()
-        with patch.dict("sys.modules", {"nio": _make_fake_nio()}):
-            result = await self.adapter.send_emote("!room:ex", "")
+        result = await self.adapter.send_emote("!room:ex", "")
         assert result.success is False

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1064,6 +1064,7 @@ class TestMatrixMegolmEventHandling:
         fake_event.room_id = "!room:example.org"
         fake_event.event_id = "$encrypted_event"
         fake_event.sender = "@alice:example.org"
+        fake_event.timestamp = int(time.time() * 1000)
 
         await adapter._on_encrypted_event(fake_event)
 
@@ -1088,6 +1089,7 @@ class TestMatrixMegolmEventHandling:
             evt.room_id = "!room:example.org"
             evt.event_id = f"$event_{i}"
             evt.sender = "@alice:example.org"
+            evt.timestamp = int(time.time() * 1000)
             await adapter._on_encrypted_event(evt)
 
         assert len(adapter._pending_megolm) == _MAX_PENDING_EVENTS

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -11,24 +11,59 @@ import pytest
 from gateway.config import PlatformConfig
 
 
-def _ensure_nio_mock():
-    """Install a mock nio module when matrix-nio isn't available."""
-    if "nio" in sys.modules and hasattr(sys.modules["nio"], "__file__"):
+def _ensure_mautrix_mock():
+    """Install mock mautrix modules when mautrix-python isn't available."""
+    if "mautrix" in sys.modules and hasattr(sys.modules["mautrix"], "__file__"):
         return
-    nio_mod = MagicMock()
-    nio_mod.MegolmEvent = type("MegolmEvent", (), {})
-    nio_mod.RoomMessageText = type("RoomMessageText", (), {})
-    nio_mod.RoomMessageImage = type("RoomMessageImage", (), {})
-    nio_mod.RoomMessageAudio = type("RoomMessageAudio", (), {})
-    nio_mod.RoomMessageVideo = type("RoomMessageVideo", (), {})
-    nio_mod.RoomMessageFile = type("RoomMessageFile", (), {})
-    nio_mod.DownloadResponse = type("DownloadResponse", (), {})
-    nio_mod.MemoryDownloadResponse = type("MemoryDownloadResponse", (), {})
-    nio_mod.InviteMemberEvent = type("InviteMemberEvent", (), {})
-    sys.modules.setdefault("nio", nio_mod)
+
+    # Root module
+    mautrix_mod = MagicMock()
+
+    # mautrix.types — commonly imported types
+    types_mod = MagicMock()
+    types_mod.EventType = MagicMock()
+    types_mod.RoomID = str
+    types_mod.UserID = str
+    types_mod.EventID = str
+    types_mod.ContentURI = str
+    types_mod.RoomCreatePreset = MagicMock()
+    types_mod.PresenceState = MagicMock()
+    types_mod.PaginationDirection = MagicMock()
+    types_mod.SyncToken = str
+    types_mod.TrustState = MagicMock()
+
+    # mautrix.client
+    client_mod = MagicMock()
+    client_mod.Client = MagicMock()
+    client_mod.InternalEventType = MagicMock()
+
+    # mautrix.client.state_store
+    state_store_mod = MagicMock()
+    state_store_mod.MemoryStateStore = MagicMock()
+    state_store_mod.MemorySyncStore = MagicMock()
+
+    # mautrix.api
+    api_mod = MagicMock()
+    api_mod.HTTPAPI = MagicMock()
+
+    # mautrix.crypto
+    crypto_mod = MagicMock()
+    crypto_mod.OlmMachine = MagicMock()
+    crypto_store_mod = MagicMock()
+    crypto_store_mod.MemoryCryptoStore = MagicMock()
+    crypto_attachments_mod = MagicMock()
+
+    sys.modules.setdefault("mautrix", mautrix_mod)
+    sys.modules.setdefault("mautrix.types", types_mod)
+    sys.modules.setdefault("mautrix.client", client_mod)
+    sys.modules.setdefault("mautrix.client.state_store", state_store_mod)
+    sys.modules.setdefault("mautrix.api", api_mod)
+    sys.modules.setdefault("mautrix.crypto", crypto_mod)
+    sys.modules.setdefault("mautrix.crypto.store", crypto_store_mod)
+    sys.modules.setdefault("mautrix.crypto.attachments", crypto_attachments_mod)
 
 
-_ensure_nio_mock()
+_ensure_mautrix_mock()
 
 
 def _make_adapter(tmp_path=None):
@@ -50,24 +85,25 @@ def _make_adapter(tmp_path=None):
     return adapter
 
 
-def _make_room(room_id="!room1:example.org", member_count=5, is_dm=False):
-    """Create a fake Matrix room."""
-    room = SimpleNamespace(
-        room_id=room_id,
-        member_count=member_count,
-        users={},
-    )
-    return room
+def _set_dm(adapter, room_id="!room1:example.org", is_dm=True):
+    """Mark a room as DM (or not) in the adapter's cache."""
+    adapter._dm_rooms[room_id] = is_dm
 
 
 def _make_event(
     body,
     sender="@alice:example.org",
     event_id="$evt1",
+    room_id="!room1:example.org",
     formatted_body=None,
     thread_id=None,
 ):
-    """Create a fake RoomMessageText event."""
+    """Create a fake room message event.
+
+    The mautrix adapter reads ``event.room_id``, ``event.sender``,
+    ``event.event_id``, ``event.timestamp``, and ``event.content``
+    (a dict with ``msgtype``, ``body``, etc.).
+    """
     content = {"body": body, "msgtype": "m.text"}
     if formatted_body:
         content["formatted_body"] = formatted_body
@@ -83,9 +119,9 @@ def _make_event(
     return SimpleNamespace(
         sender=sender,
         event_id=event_id,
-        server_timestamp=int(time.time() * 1000),
-        body=body,
-        source={"content": content},
+        room_id=room_id,
+        timestamp=int(time.time() * 1000),
+        content=content,
     )
 
 
@@ -152,10 +188,9 @@ async def test_require_mention_default_ignores_unmentioned(monkeypatch):
     monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("hello everyone")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_not_awaited()
 
 
@@ -167,10 +202,9 @@ async def test_require_mention_default_processes_mentioned(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("@hermes:example.org help me")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.text == "help me"
@@ -184,11 +218,10 @@ async def test_require_mention_html_pill(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room()
     formatted = '<a href="https://matrix.to/#/@hermes:example.org">Hermes</a> help'
     event = _make_event("Hermes help", formatted_body=formatted)
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
 
 
@@ -200,11 +233,11 @@ async def test_require_mention_dm_always_responds(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    # member_count=2 triggers DM detection
-    room = _make_room(member_count=2)
+    # Mark the room as a DM via the adapter's cache.
+    _set_dm(adapter)
     event = _make_event("hello without mention")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
 
 
@@ -216,10 +249,10 @@ async def test_dm_strips_mention(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("@hermes:example.org help me")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.text == "help me"
@@ -233,10 +266,9 @@ async def test_bare_mention_passes_empty_string(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("@hermes:example.org")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.text == ""
@@ -250,10 +282,9 @@ async def test_require_mention_free_response_room(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(room_id="!room1:example.org")
-    event = _make_event("hello without mention")
+    event = _make_event("hello without mention", room_id="!room1:example.org")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
 
 
@@ -267,10 +298,9 @@ async def test_require_mention_bot_participated_thread(monkeypatch):
     adapter = _make_adapter()
     adapter._bot_participated_threads.add("$thread1")
 
-    room = _make_room()
     event = _make_event("hello without mention", thread_id="$thread1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
 
 
@@ -282,10 +312,9 @@ async def test_require_mention_disabled(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("hello without mention")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.text == "hello without mention"
@@ -303,10 +332,9 @@ async def test_auto_thread_default_creates_thread(monkeypatch):
     monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("hello", event_id="$msg1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id == "$msg1"
@@ -320,10 +348,9 @@ async def test_auto_thread_preserves_existing_thread(monkeypatch):
 
     adapter = _make_adapter()
     adapter._bot_participated_threads.add("$thread_root")
-    room = _make_room()
     event = _make_event("reply in thread", thread_id="$thread_root")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id == "$thread_root"
@@ -336,10 +363,10 @@ async def test_auto_thread_skips_dm(monkeypatch):
     monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("hello dm", event_id="$dm1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id is None
@@ -352,10 +379,9 @@ async def test_auto_thread_disabled(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("hello", event_id="$msg1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id is None
@@ -368,11 +394,10 @@ async def test_auto_thread_tracks_participation(monkeypatch):
     monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
 
     adapter = _make_adapter()
-    room = _make_room()
     event = _make_event("hello", event_id="$msg1")
 
     with patch.object(adapter, "_save_participated_threads"):
-        await adapter._on_room_message(room, event)
+        await adapter._on_room_message(event)
 
     assert "$msg1" in adapter._bot_participated_threads
 
@@ -448,10 +473,10 @@ async def test_dm_mention_thread_disabled_by_default(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("@hermes:example.org help me", event_id="$dm1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id is None
@@ -464,11 +489,11 @@ async def test_dm_mention_thread_creates_thread(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("@hermes:example.org help me", event_id="$dm1")
 
     with patch.object(adapter, "_save_participated_threads"):
-        await adapter._on_room_message(room, event)
+        await adapter._on_room_message(event)
 
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
@@ -483,10 +508,10 @@ async def test_dm_mention_thread_no_mention_no_thread(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("hello without mention", event_id="$dm1")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id is None
@@ -499,11 +524,11 @@ async def test_dm_mention_thread_preserves_existing_thread(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
+    _set_dm(adapter)
     adapter._bot_participated_threads.add("$existing_thread")
-    room = _make_room(member_count=2)
     event = _make_event("@hermes:example.org help me", thread_id="$existing_thread")
 
-    await adapter._on_room_message(room, event)
+    await adapter._on_room_message(event)
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.source.thread_id == "$existing_thread"
@@ -516,11 +541,11 @@ async def test_dm_mention_thread_tracks_participation(monkeypatch):
     monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
 
     adapter = _make_adapter()
-    room = _make_room(member_count=2)
+    _set_dm(adapter)
     event = _make_event("@hermes:example.org help", event_id="$dm1")
 
     with patch.object(adapter, "_save_participated_threads"):
-        await adapter._on_room_message(room, event)
+        await adapter._on_room_message(event)
 
     assert "$dm1" in adapter._bot_participated_threads
 

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -1,18 +1,23 @@
-"""Tests for Matrix voice message support (MSC3245)."""
+"""Tests for Matrix voice message support (MSC3245).
+
+Updated for the mautrix-python SDK (no more matrix-nio / nio imports).
+"""
 import io
+import os
+import tempfile
 import types
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# Try importing real nio; skip entire file if not available.
-# A MagicMock in sys.modules (from another test) is not the real package.
+# Try importing mautrix; skip entire file if not available.
 try:
-    import nio as _nio_probe
-    if not isinstance(_nio_probe, types.ModuleType) or not hasattr(_nio_probe, "__file__"):
-        pytest.skip("nio in sys.modules is a mock, not the real package", allow_module_level=True)
+    import mautrix as _mautrix_probe
+    if not isinstance(_mautrix_probe, types.ModuleType) or not hasattr(_mautrix_probe, "__file__"):
+        pytest.skip("mautrix in sys.modules is a mock, not the real package", allow_module_level=True)
 except ImportError:
-    pytest.skip("matrix-nio not installed", allow_module_level=True)
+    pytest.skip("mautrix not installed", allow_module_level=True)
 
 from gateway.platforms.base import MessageType
 
@@ -25,7 +30,7 @@ def _make_adapter():
     """Create a MatrixAdapter with mocked config."""
     from gateway.platforms.matrix import MatrixAdapter
     from gateway.config import PlatformConfig
-    
+
     config = PlatformConfig(
         enabled=True,
         token="***",
@@ -38,32 +43,26 @@ def _make_adapter():
     return adapter
 
 
-def _make_room(room_id: str = "!test:example.org", member_count: int = 2):
-    """Create a mock Matrix room."""
-    room = MagicMock()
-    room.room_id = room_id
-    room.member_count = member_count
-    return room
-
-
 def _make_audio_event(
     event_id: str = "$audio_event",
     sender: str = "@alice:example.org",
+    room_id: str = "!test:example.org",
     body: str = "Voice message",
     url: str = "mxc://example.org/abc123",
     is_voice: bool = False,
     mimetype: str = "audio/ogg",
-    timestamp: float = 9999999999000,  # ms
+    timestamp: int = 9999999999000,  # ms
 ):
     """
-    Create a mock RoomMessageAudio event that passes isinstance checks.
-    
+    Create a mock mautrix room message event.
+
+    In mautrix, the handler receives a single event object with attributes
+    ``room_id``, ``sender``, ``event_id``, ``timestamp``, and ``content``
+    (a dict-like or serializable object).
+
     Args:
-        is_voice: If True, adds org.matrix.msc3245.voice field to content
+        is_voice: If True, adds org.matrix.msc3245.voice field to content.
     """
-    import nio
-    
-    # Build the source dict that nio events expose via .source
     content = {
         "msgtype": "m.audio",
         "body": body,
@@ -72,39 +71,35 @@ def _make_audio_event(
             "mimetype": mimetype,
         },
     }
-    
+
     if is_voice:
         content["org.matrix.msc3245.voice"] = {}
-    
-    # Create a real nio RoomMessageAudio-like object
-    # We use MagicMock but configure __class__ to pass isinstance check
-    event = MagicMock(spec=nio.RoomMessageAudio)
-    event.event_id = event_id
-    event.sender = sender
-    event.body = body
-    event.url = url
-    event.server_timestamp = timestamp
-    event.source = {
-        "type": "m.room.message",
-        "content": content,
-    }
-    # For MIME type extraction - needs to be a dict
-    event.content = content
-    
+
+    event = SimpleNamespace(
+        event_id=event_id,
+        sender=sender,
+        room_id=room_id,
+        timestamp=timestamp,
+        content=content,
+    )
     return event
 
 
-def _make_download_response(body: bytes = b"fake audio data"):
-    """Create a mock nio.MemoryDownloadResponse."""
-    import nio
-    resp = MagicMock()
-    resp.body = body
-    resp.__class__ = nio.MemoryDownloadResponse
-    return resp
+def _make_state_store(member_count: int = 2):
+    """Create a mock state store with get_members/get_member support."""
+    store = MagicMock()
+    # get_members returns a list of member user IDs
+    members = [MagicMock() for _ in range(member_count)]
+    store.get_members = AsyncMock(return_value=members)
+    # get_member returns a single member info object
+    member = MagicMock()
+    member.displayname = "Alice"
+    store.get_member = AsyncMock(return_value=member)
+    return store
 
 
 # ---------------------------------------------------------------------------
-# Tests: MSC3245 Voice Detection (RED -> GREEN)
+# Tests: MSC3245 Voice Detection
 # ---------------------------------------------------------------------------
 
 class TestMatrixVoiceMessageDetection:
@@ -118,27 +113,28 @@ class TestMatrixVoiceMessageDetection:
         self.adapter._message_handler = AsyncMock()
         # Mock _mxc_to_http to return a fake HTTP URL
         self.adapter._mxc_to_http = lambda url: f"https://matrix.example.org/_matrix/media/v3/download/{url[6:]}"
-        # Mock client for authenticated download
+        # Mock client for authenticated download — download_media returns bytes directly
         self.adapter._client = MagicMock()
-        self.adapter._client.download = AsyncMock(return_value=_make_download_response())
+        self.adapter._client.download_media = AsyncMock(return_value=b"fake audio data")
+        # State store for DM detection
+        self.adapter._client.state_store = _make_state_store()
 
     @pytest.mark.asyncio
     async def test_voice_message_has_type_voice(self):
         """Voice messages (with MSC3245 field) should be MessageType.VOICE."""
-        room = _make_room()
         event = _make_audio_event(is_voice=True)
-        
+
         # Capture the MessageEvent passed to handle_message
         captured_event = None
-        
+
         async def capture(msg_event):
             nonlocal captured_event
             captured_event = msg_event
-        
+
         self.adapter.handle_message = capture
-        
-        await self.adapter._on_room_message_media(room, event)
-        
+
+        await self.adapter._on_room_message(event)
+
         assert captured_event is not None, "No event was captured"
         assert captured_event.message_type == MessageType.VOICE, \
             f"Expected MessageType.VOICE, got {captured_event.message_type}"
@@ -146,44 +142,43 @@ class TestMatrixVoiceMessageDetection:
     @pytest.mark.asyncio
     async def test_voice_message_has_local_path(self):
         """Voice messages should have a local cached path in media_urls."""
-        room = _make_room()
         event = _make_audio_event(is_voice=True)
-        
+
         captured_event = None
-        
+
         async def capture(msg_event):
             nonlocal captured_event
             captured_event = msg_event
-        
+
         self.adapter.handle_message = capture
-        
-        await self.adapter._on_room_message_media(room, event)
-        
+
+        await self.adapter._on_room_message(event)
+
         assert captured_event is not None
         assert captured_event.media_urls is not None
         assert len(captured_event.media_urls) > 0
         # Should be a local path, not an HTTP URL
         assert not captured_event.media_urls[0].startswith("http"), \
             f"media_urls should contain local path, got {captured_event.media_urls[0]}"
-        self.adapter._client.download.assert_awaited_once_with(mxc=event.url)
+        # download_media is called with a ContentURI wrapping the mxc URL
+        self.adapter._client.download_media.assert_awaited_once()
         assert captured_event.media_types == ["audio/ogg"]
 
     @pytest.mark.asyncio
     async def test_audio_without_msc3245_stays_audio_type(self):
         """Regular audio uploads (no MSC3245 field) should remain MessageType.AUDIO."""
-        room = _make_room()
         event = _make_audio_event(is_voice=False)  # NOT a voice message
-        
+
         captured_event = None
-        
+
         async def capture(msg_event):
             nonlocal captured_event
             captured_event = msg_event
-        
+
         self.adapter.handle_message = capture
-        
-        await self.adapter._on_room_message_media(room, event)
-        
+
+        await self.adapter._on_room_message(event)
+
         assert captured_event is not None
         assert captured_event.message_type == MessageType.AUDIO, \
             f"Expected MessageType.AUDIO for non-voice, got {captured_event.message_type}"
@@ -191,25 +186,24 @@ class TestMatrixVoiceMessageDetection:
     @pytest.mark.asyncio
     async def test_regular_audio_has_http_url(self):
         """Regular audio uploads should keep HTTP URL (not cached locally)."""
-        room = _make_room()
         event = _make_audio_event(is_voice=False)
-        
+
         captured_event = None
-        
+
         async def capture(msg_event):
             nonlocal captured_event
             captured_event = msg_event
-        
+
         self.adapter.handle_message = capture
-        
-        await self.adapter._on_room_message_media(room, event)
-        
+
+        await self.adapter._on_room_message(event)
+
         assert captured_event is not None
         assert captured_event.media_urls is not None
         # Should be HTTP URL, not local path
         assert captured_event.media_urls[0].startswith("http"), \
             f"Non-voice audio should have HTTP URL, got {captured_event.media_urls[0]}"
-        self.adapter._client.download.assert_not_awaited()
+        self.adapter._client.download_media.assert_not_awaited()
         assert captured_event.media_types == ["audio/ogg"]
 
 
@@ -224,29 +218,26 @@ class TestMatrixVoiceCacheFallback:
         self.adapter._message_handler = AsyncMock()
         self.adapter._mxc_to_http = lambda url: f"https://matrix.example.org/_matrix/media/v3/download/{url[6:]}"
         self.adapter._client = MagicMock()
+        self.adapter._client.state_store = _make_state_store()
 
     @pytest.mark.asyncio
     async def test_voice_cache_failure_falls_back_to_http_url(self):
-        """If caching fails, voice message should still be delivered with HTTP URL."""
-        room = _make_room()
+        """If caching fails (download returns None), voice message should still be delivered with HTTP URL."""
         event = _make_audio_event(is_voice=True)
-        
-        # Make download fail
-        import nio
-        error_resp = MagicMock()
-        error_resp.__class__ = nio.DownloadError
-        self.adapter._client.download = AsyncMock(return_value=error_resp)
-        
+
+        # download_media returns None on failure
+        self.adapter._client.download_media = AsyncMock(return_value=None)
+
         captured_event = None
-        
+
         async def capture(msg_event):
             nonlocal captured_event
             captured_event = msg_event
-        
+
         self.adapter.handle_message = capture
-        
-        await self.adapter._on_room_message_media(room, event)
-        
+
+        await self.adapter._on_room_message(event)
+
         assert captured_event is not None
         assert captured_event.media_urls is not None
         # Should fall back to HTTP URL
@@ -256,10 +247,9 @@ class TestMatrixVoiceCacheFallback:
     @pytest.mark.asyncio
     async def test_voice_cache_exception_falls_back_to_http_url(self):
         """Unexpected download exceptions should also fall back to HTTP URL."""
-        room = _make_room()
         event = _make_audio_event(is_voice=True)
 
-        self.adapter._client.download = AsyncMock(side_effect=RuntimeError("boom"))
+        self.adapter._client.download_media = AsyncMock(side_effect=RuntimeError("boom"))
 
         captured_event = None
 
@@ -269,7 +259,7 @@ class TestMatrixVoiceCacheFallback:
 
         self.adapter.handle_message = capture
 
-        await self.adapter._on_room_message_media(room, event)
+        await self.adapter._on_room_message(event)
 
         assert captured_event is not None
         assert captured_event.media_urls is not None
@@ -278,7 +268,7 @@ class TestMatrixVoiceCacheFallback:
 
 
 # ---------------------------------------------------------------------------
-# Tests: send_voice includes MSC3245 field (RED -> GREEN)
+# Tests: send_voice includes MSC3245 field
 # ---------------------------------------------------------------------------
 
 class TestMatrixSendVoiceMSC3245:
@@ -287,62 +277,52 @@ class TestMatrixSendVoiceMSC3245:
     def setup_method(self):
         self.adapter = _make_adapter()
         self.adapter._user_id = "@bot:example.org"
-        # Mock client with successful upload
+        # Mock client — upload_media returns a ContentURI string
         self.adapter._client = MagicMock()
         self.upload_call = None
 
-        async def mock_upload(*args, **kwargs):
-            self.upload_call = (args, kwargs)
-            import nio
-            resp = MagicMock()
-            resp.content_uri = "mxc://example.org/uploaded"
-            resp.__class__ = nio.UploadResponse
-            return resp, None
+        async def mock_upload_media(data, mime_type=None, filename=None, **kwargs):
+            self.upload_call = {"data": data, "mime_type": mime_type, "filename": filename}
+            return "mxc://example.org/uploaded"
 
-        self.adapter._client.upload = mock_upload
+        self.adapter._client.upload_media = mock_upload_media
 
     @pytest.mark.asyncio
-    async def test_send_voice_includes_msc3245_field(self):
+    @patch("mimetypes.guess_type", return_value=("audio/ogg", None))
+    async def test_send_voice_includes_msc3245_field(self, _mock_guess):
         """send_voice should include org.matrix.msc3245.voice in message content."""
-        import tempfile
-        import os
-        
         # Create a temp audio file
         with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
             f.write(b"fake audio data")
             temp_path = f.name
-        
+
         try:
-            # Capture the message content sent to room_send
+            # Capture the message content sent via send_message_event
             sent_content = None
-            
-            async def mock_room_send(room_id, event_type, content):
+
+            async def mock_send_message_event(room_id, event_type, content):
                 nonlocal sent_content
                 sent_content = content
-                resp = MagicMock()
-                resp.event_id = "$sent_event"
-                import nio
-                resp.__class__ = nio.RoomSendResponse
-                return resp
-            
-            self.adapter._client.room_send = mock_room_send
-            
+                # send_message_event returns an EventID string
+                return "$sent_event"
+
+            self.adapter._client.send_message_event = mock_send_message_event
+
             await self.adapter.send_voice(
                 chat_id="!room:example.org",
                 audio_path=temp_path,
                 caption="Test voice",
             )
-            
+
             assert sent_content is not None, "No message was sent"
             assert "org.matrix.msc3245.voice" in sent_content, \
                 f"MSC3245 voice field missing from content: {sent_content.keys()}"
             assert sent_content["msgtype"] == "m.audio"
             assert sent_content["info"]["mimetype"] == "audio/ogg"
-            assert self.upload_call is not None, "Expected upload() to be called"
-            args, kwargs = self.upload_call
-            assert isinstance(args[0], io.BytesIO)
-            assert kwargs["content_type"] == "audio/ogg"
-            assert kwargs["filename"].endswith(".ogg")
+            assert self.upload_call is not None, "Expected upload_media() to be called"
+            assert isinstance(self.upload_call["data"], bytes)
+            assert self.upload_call["mime_type"] == "audio/ogg"
+            assert self.upload_call["filename"].endswith(".ogg")
 
         finally:
             os.unlink(temp_path)

--- a/tests/hermes_cli/test_setup_matrix_e2ee.py
+++ b/tests/hermes_cli/test_setup_matrix_e2ee.py
@@ -22,7 +22,7 @@ def _parse_setup_imports():
 class TestSetupShutilImport:
     def test_shutil_imported_at_module_level(self):
         """shutil must be imported at module level so setup_gateway can use it
-        for the matrix-nio auto-install path (line ~2126)."""
+        for the mautrix auto-install path."""
         names = _parse_setup_imports()
         assert "shutil" in names, (
             "shutil is not imported at the top of hermes_cli/setup.py. "

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -12,10 +12,10 @@ def _load_optional_dependencies():
 
 
 def test_matrix_extra_linux_only_in_all():
-    """matrix-nio[e2e] depends on python-olm which is upstream-broken on modern
-    macOS (archived libolm, C++ errors with Clang 21+).  The [matrix] extra is
-    included in [all] but gated to Linux via a platform marker so that
-    ``hermes update`` doesn't fail on macOS."""
+    """mautrix[encryption] depends on python-olm which is upstream-broken on
+    modern macOS (archived libolm, C++ errors with Clang 21+).  The [matrix]
+    extra is included in [all] but gated to Linux via a platform marker so
+    that ``hermes update`` doesn't fail on macOS."""
     optional_dependencies = _load_optional_dependencies()
 
     assert "matrix" in optional_dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -153,19 +153,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiohttp-socks"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "python-socks" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
-]
-
-[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -252,12 +239,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac67
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
 ]
-
-[[package]]
-name = "atomicwrites"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11", size = 14227, upload-time = "2022-07-08T18:31:40.459Z" }
 
 [[package]]
 name = "atroposlib"
@@ -374,6 +355,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/ca/307740c6aa2980966bf11383ffcb04bacc5b13f3d268ab4cfb274ad6f793/av-17.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3649ab3d2c7f58049ded1a36e100c0d8fd529cf258f41dd88678ba824034d8c9", size = 40590681, upload-time = "2026-03-14T14:38:38.269Z" },
     { url = "https://files.pythonhosted.org/packages/35/f2/6fdb26d0651adf409864cb2a0d60da107e467d3d1aabc94b234ead54324a/av-17.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e5002271ab2135b551d980c2db8f3299d452e3b9d3633f24f6bb57fffe91cd10", size = 29216337, upload-time = "2026-03-14T14:38:40.83Z" },
     { url = "https://files.pythonhosted.org/packages/41/0a/0896b829a39b5669a2d811e1a79598de661693685cd62b31f11d0c18e65b/av-17.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dba98603fc4665b4f750de86fbaf6c0cfaece970671a9b529e0e3d1711e8367e", size = 22071058, upload-time = "2026-03-14T14:38:43.663Z" },
+]
+
+[[package]]
+name = "base58"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/45/8ae61209bb9015f516102fa559a2914178da1d5868428bd86a1b4421141d/base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c", size = 6528, upload-time = "2021-10-30T22:12:17.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/45/ec96b29162a402fc4c1c5512d114d7b3787b9d1c2ec241d9568b4816ee23/base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2", size = 5621, upload-time = "2021-10-30T22:12:16.658Z" },
 ]
 
 [[package]]
@@ -1692,7 +1682,7 @@ all = [
     { name = "honcho-ai" },
     { name = "lark-oapi" },
     { name = "markdown", marker = "sys_platform == 'linux'" },
-    { name = "matrix-nio", extra = ["e2e"], marker = "sys_platform == 'linux'" },
+    { name = "mautrix", extra = ["encryption"], marker = "sys_platform == 'linux'" },
     { name = "mcp" },
     { name = "mistralai" },
     { name = "modal" },
@@ -1738,7 +1728,7 @@ honcho = [
 ]
 matrix = [
     { name = "markdown" },
-    { name = "matrix-nio", extra = ["e2e"] },
+    { name = "mautrix", extra = ["encryption"] },
 ]
 mcp = [
     { name = "mcp" },
@@ -1846,7 +1836,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3,<2" },
     { name = "markdown", marker = "extra == 'matrix'", specifier = ">=3.6,<4" },
-    { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix'", specifier = ">=0.24.0,<1" },
+    { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = ">=0.20,<1" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0,<2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=2.3.0,<3" },
@@ -2601,30 +2591,25 @@ wheels = [
 ]
 
 [[package]]
-name = "matrix-nio"
-version = "0.25.2"
+name = "mautrix"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
     { name = "aiohttp" },
-    { name = "aiohttp-socks" },
-    { name = "h11" },
-    { name = "h2" },
-    { name = "jsonschema" },
-    { name = "pycryptodome" },
-    { name = "unpaddedbase64" },
+    { name = "attrs" },
+    { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/50/c20129fd6f0e1aad3510feefd3229427fc8163a111f3911ed834e414116b/matrix_nio-0.25.2.tar.gz", hash = "sha256:8ef8180c374e12368e5c83a692abfb3bab8d71efcd17c5560b5c40c9b6f2f600", size = 155480, upload-time = "2024-10-04T07:51:41.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a7/8d6d0589e211ecf3a72ce4b28cc32c857c4043d1a6963d63ac9f726af653/mautrix-0.21.0.tar.gz", hash = "sha256:a14e0582e114cb241f282f9e717014608f36c03f1dc59afcd71b4e81780ffe2e", size = 254726, upload-time = "2025-11-17T13:53:09.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/0f/8b958d46e23ed4f69d2cffd63b46bb097a1155524e2e7f5c4279c8691c4a/matrix_nio-0.25.2-py3-none-any.whl", hash = "sha256:9c2880004b0e475db874456c0f79b7dd2b6285073a7663bcaca29e0754a67495", size = 181982, upload-time = "2024-10-04T07:51:39.451Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d6/d4b3ae380dacdc9fb07bc3eb7dd17f43b8a7ce391465a184d1094acb66c1/mautrix-0.21.0-py3-none-any.whl", hash = "sha256:1cba30d69f46351918a3b8bc4e5657465cac8470d42ddd2287a742653cab7194", size = 334131, upload-time = "2025-11-17T13:53:08.117Z" },
 ]
 
 [package.optional-dependencies]
-e2e = [
-    { name = "atomicwrites" },
-    { name = "cachetools" },
-    { name = "peewee" },
+encryption = [
+    { name = "base58" },
+    { name = "pycryptodome" },
     { name = "python-olm" },
+    { name = "unpaddedbase64" },
 ]
 
 [[package]]
@@ -3338,15 +3323,6 @@ wheels = [
 ]
 
 [[package]]
-name = "peewee"
-version = "3.19.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/b0/79462b42e89764998756e0557f2b58a15610a5b4512fbbcccae58fba7237/peewee-3.19.0.tar.gz", hash = "sha256:f88292a6f0d7b906cb26bca9c8599b8f4d8920ebd36124400d0cbaaaf915511f", size = 974035, upload-time = "2026-01-07T17:24:59.597Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/41/19c65578ef9a54b3083253c68a607f099642747168fe00f3a2bceb7c3a34/peewee-3.19.0-py3-none-any.whl", hash = "sha256:de220b94766e6008c466e00ce4ba5299b9a832117d9eb36d45d0062f3cfd7417", size = 411885, upload-time = "2026-01-07T17:24:58.33Z" },
-]
-
-[[package]]
 name = "pillow"
 version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4006,15 +3982,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/56/652349f97dc2ce6d1aed43481d179c775f565e68796517836406fb7794c7/python_olm-3.2.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16bbb209d43d62135450696526ed0a811150e9de9df32ed91542bf9434e79030", size = 293671, upload-time = "2023-11-28T19:25:21.525Z" },
     { url = "https://files.pythonhosted.org/packages/39/ee/1e15304ac67d3a7ebecbcac417d6479abb7186aad73c6a035647938eaa8e/python_olm-3.2.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e76b3f5060a5cf8451140d6c7e3b438f972ff432b6f39d0ca2c7f2296509bb", size = 301030, upload-time = "2023-11-28T19:25:26.634Z" },
     { url = "https://files.pythonhosted.org/packages/79/93/f6729f10149305262194774d6c8b438c0b084740cf239f48ab97b4df02fa/python_olm-3.2.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a5e68a2f4b5a2bfa5fdb5dbfa22396a551730df6c4a572235acaa96e997d3f", size = 297000, upload-time = "2023-11-28T19:25:31.045Z" },
-]
-
-[[package]]
-name = "python-socks"
-version = "2.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
 ]
 
 [[package]]

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -153,7 +153,7 @@ gateway/platforms/
 ├── slack.py             # Slack Socket Mode
 ├── whatsapp.py          # WhatsApp Business Cloud API
 ├── signal.py            # Signal via signal-cli REST API
-├── matrix.py            # Matrix via matrix-nio (optional E2EE)
+├── matrix.py            # Matrix via mautrix (optional E2EE)
 ├── mattermost.py        # Mattermost WebSocket API
 ├── email.py             # Email via IMAP/SMTP
 ├── sms.py               # SMS via Twilio

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -6,7 +6,7 @@ description: "Set up Hermes Agent as a Matrix bot"
 
 # Matrix Setup
 
-Hermes Agent integrates with Matrix, the open, federated messaging protocol. Matrix lets you run your own homeserver or use a public one like matrix.org — either way, you keep control of your communications. The bot connects via the `matrix-nio` Python SDK, processes messages through the Hermes Agent pipeline (including tool use, memory, and reasoning), and responds in real time. It supports text, file attachments, images, audio, video, and optional end-to-end encryption (E2EE).
+Hermes Agent integrates with Matrix, the open, federated messaging protocol. Matrix lets you run your own homeserver or use a public one like matrix.org — either way, you keep control of your communications. The bot connects via the `mautrix` Python SDK, processes messages through the Hermes Agent pipeline (including tool use, memory, and reasoning), and responds in real time. It supports text, file attachments, images, audio, video, and optional end-to-end encryption (E2EE).
 
 Hermes works with any Matrix homeserver — Synapse, Conduit, Dendrite, or matrix.org.
 
@@ -234,11 +234,11 @@ Hermes supports Matrix end-to-end encryption, so you can chat with your bot in e
 
 ### Requirements
 
-E2EE requires the `matrix-nio` library with encryption extras and the `libolm` C library:
+E2EE requires the `mautrix` library with encryption extras and the `libolm` C library:
 
 ```bash
-# Install matrix-nio with E2EE support
-pip install 'matrix-nio[e2e]'
+# Install mautrix with E2EE support
+pip install 'mautrix[encryption]'
 
 # Or install with hermes extras
 pip install 'hermes-agent[matrix]'
@@ -277,7 +277,7 @@ If you delete the `~/.hermes/platforms/matrix/store/` directory, the bot loses i
 :::
 
 :::info
-If `matrix-nio[e2e]` is not installed or `libolm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs.
+If `mautrix[encryption]` is not installed or `libolm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs.
 :::
 
 ## Home Room
@@ -321,14 +321,14 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 If this returns your user info, the token is valid. If it returns an error, generate a new token.
 
-### "matrix-nio not installed" error
+### "mautrix not installed" error
 
-**Cause**: The `matrix-nio` Python package is not installed.
+**Cause**: The `mautrix` Python package is not installed.
 
 **Fix**: Install it:
 
 ```bash
-pip install 'matrix-nio[e2e]'
+pip install 'mautrix[encryption]'
 ```
 
 Or with Hermes extras:


### PR DESCRIPTION
## Summary

Replaces `matrix-nio` with `mautrix-python` as the Matrix SDK dependency, fixing Nix flake build failures caused by matrix-nio's transitive dep `atomicwrites` (sdist-only, archived, missing build-system metadata).

This reopens closed PR #7488 (by @alt-glitch, closed without merge) with 9 additional fix commits addressing code review findings from the original submission.

## What's new since PR #7488 was closed

9 commits by @alt-glitch addressing review feedback:

1. **E2EE crypto store persistence** — pickle/store to disk with HMAC-SHA256 signing to prevent tampering
2. **Simplified adapter** — deduplicated 40+ lines of mention/thread/DM gating via `_resolve_message_context()`; consolidated imports; cached env var parsing
3. **Session leak fix** — close aiohttp sessions on E2EE dep and setup failure paths
4. **Bot-to-bot loop prevention** — ignore `m.notice` messages (conventional bot response msgtype)
5. **Thread tracking cleanup** — removed redundant `_track_thread()` calls; added sender-self and startup-grace filters to encrypted handler
6. **HMAC-signed pickle store** — prevent arbitrary code execution from tampered crypto store files

All original adapter features preserved: E2EE, reactions, threading, mention gating, text batching, media caching, MSC3245 voice messages.

## Test plan

- [x] 157 unit tests passing (`pytest tests/gateway/test_matrix*.py tests/test_project_metadata.py`)
- [x] `nix flake check` passes clean
- [x] `uv lock --check` validates lockfile consistency
- [ ] Manual smoke test on a real Matrix homeserver