### PR TITLE
fix(telegram): recover when a polling-conflict retry fails

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -910,8 +910,21 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
             except Exception as retry_err:
                 logger.warning("[%s] Telegram polling retry failed: %s", self.name, retry_err)
-                # Don't fall through to fatal yet — wait for the next conflict
-                # to trigger another retry attempt (up to MAX_CONFLICT_RETRIES).
+                # start_polling() failed, so polling is dead and no further
+                # error callback will fire — there is no "next conflict" to
+                # drive another retry. Self-schedule recovery, mirroring the
+                # network-error handler: a transient network failure
+                # (TimedOut/NetworkError) goes through the network reconnect
+                # ladder (which can escalate to a retryable-fatal gateway
+                # restart); anything else re-enters the conflict ladder.
+                if not self.has_fatal_error:
+                    if self._looks_like_network_error(retry_err):
+                        recover = self._handle_polling_network_error(retry_err)
+                    else:
+                        recover = self._handle_polling_conflict(retry_err)
+                    task = asyncio.ensure_future(recover)
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
                 return
 
         # Exhausted retries — fatal

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -309,3 +309,83 @@ async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     app.stop.assert_not_awaited()
     app.shutdown.assert_awaited_once()
     warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_conflict_retry_network_failure_schedules_recovery(monkeypatch):
+    """A conflict retry whose start_polling() fails with a network error must
+    self-schedule recovery via the network reconnect ladder.
+
+    Regression: previously the conflict handler's retry ``except`` block just
+    ``return``ed, expecting a "next conflict" callback to drive another retry.
+    But once start_polling() fails, polling is dead and no error callback can
+    ever fire again — so the bot stayed wedged until a manual restart.
+    """
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    captured = {}
+    call_count = {"n": 0}
+    timed_out = type("TimedOut", (OSError,), {})
+
+    async def start_polling(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Initial connect succeeds and captures the error callback.
+            captured["error_callback"] = kwargs["error_callback"]
+        else:
+            # The conflict-retry reconnect fails with a transient network error.
+            raise timed_out("Timed out")
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(set_my_commands=AsyncMock(), delete_webhook=AsyncMock())
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+
+    network_handler = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_polling_network_error", network_handler)
+
+    conflict = type("Conflict", (Exception,), {})
+    await adapter._handle_polling_conflict(
+        conflict("Conflict: terminated by other getUpdates request")
+    )
+
+    # Drain the scheduled recovery task(s).
+    if adapter._background_tasks:
+        await asyncio.gather(*list(adapter._background_tasks))
+
+    assert network_handler.await_count >= 1, (
+        "a conflict retry that fails with a network error must route into "
+        "the network reconnect ladder instead of dead-ending"
+    )
+    assert adapter.has_fatal_error is False


### PR DESCRIPTION
## Problem

When Telegram returns a 409 `Conflict: terminated by other getUpdates request`, `_handle_polling_conflict` stops the updater, waits, and retries `start_polling()`. If that retry **itself fails** (e.g. a `TimedOut`/`NetworkError` because the host's connectivity is also flaky at that moment), the `except` block only logs the failure and `return`s — relying on a comment that says *"wait for the next conflict to trigger another retry attempt"*.

But once `start_polling()` fails, the long-poll is dead and **no error callback can ever fire again**. There is no "next conflict". The bot is left permanently wedged with polling stopped, until the gateway process is manually restarted. Outbound sends keep working, which masks the failure — cron-driven messages still go out while the bot silently stops receiving anything.

Observed in production: a 409 conflict at the same time as a brief network blip → one retry → `start_polling()` raised `TimedOut` → handler returned → ~2h of dropped inbound messages until a manual restart.

## Fix

The network-error handler (`_handle_polling_network_error`) already guards against this exact dead-end: when its retry's `start_polling()` fails, it self-schedules the next attempt instead of relying on a callback that can't fire.

This applies the same pattern to the conflict handler. When a conflict retry's `start_polling()` fails:
- a transient network failure routes into `_handle_polling_network_error` (exponential-backoff ladder, which can escalate to a retryable-fatal gateway restart);
- anything else re-enters the conflict ladder.

Either way the recovery is self-scheduled as a background task, so the poller is never left wedged with nothing to wake it.

## Test

Adds `test_conflict_retry_network_failure_schedules_recovery` to `tests/gateway/test_telegram_conflict.py`, asserting a conflict retry that fails with a network error routes into the network reconnect ladder. Full suite (`test_telegram_conflict.py` + `test_telegram_network_reconnect.py`) passes — 22 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)