### PR TITLE
fix(cli): suppress resume hint after deleted exit session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2829,6 +2829,7 @@ class HermesCLI:
         # process_command() when the user runs /exit --delete or /quit --delete.
         # Ported from google-gemini/gemini-cli#19332.
         self._delete_session_on_exit = False
+        self._session_deleted_on_exit = False
         self._last_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
@@ -7665,6 +7666,7 @@ class HermesCLI:
             _args = (_rest[1] if len(_rest) > 1 else "").strip().lower()
             if _args in ("--delete", "-d"):
                 self._delete_session_on_exit = True
+                self._session_deleted_on_exit = False
             elif _args:
                 _cprint(f"  {_DIM}✗ Unknown argument: {_escape(_args)}. Use /exit --delete to also remove session history.{_RST}")
                 return True
@@ -11289,6 +11291,9 @@ class HermesCLI:
     
     def _print_exit_summary(self):
         """Print session resume info on exit, similar to Claude Code."""
+        if getattr(self, '_session_deleted_on_exit', False):
+            return
+
         print()
         msg_count = len(self.conversation_history)
         if msg_count > 0:
@@ -13845,6 +13850,7 @@ class HermesCLI:
                         _sessions_dir = _ghh() / "sessions"
                         _sid = self.agent.session_id
                         if self._session_db.delete_session(_sid, sessions_dir=_sessions_dir):
+                            self._session_deleted_on_exit = True
                             _cprint(f"  {_DIM}✓ Session {_escape(_sid)} deleted{_RST}")
                         else:
                             _cprint(f"  {_DIM}✗ Session {_escape(_sid)} not found for deletion{_RST}")

--- a/tests/cli/test_exit_delete_session.py
+++ b/tests/cli/test_exit_delete_session.py
@@ -6,6 +6,7 @@ flag that the CLI shutdown path uses to remove the current session from
 SQLite + on-disk transcripts before exit.
 """
 
+from datetime import datetime
 from unittest.mock import MagicMock
 
 
@@ -22,7 +23,10 @@ def _make_cli():
     cli.agent = None
     cli.conversation_history = []
     cli.session_id = "test-session"
+    cli.session_start = datetime.now()
+    cli._session_db = None
     cli._delete_session_on_exit = False
+    cli._session_deleted_on_exit = False
     return cli
 
 
@@ -58,10 +62,11 @@ class TestExitDeleteFlag:
         assert result is False
         assert cli._delete_session_on_exit is True
 
-    def test_quit_alias_q_is_not_quit(self):
+    def test_quit_alias_q_is_not_quit(self, monkeypatch):
         """`/q` is the alias for `/queue`, not `/quit`. This test documents
         that /q --delete does NOT arm session deletion — it would dispatch
         to /queue instead."""
+        monkeypatch.setattr("cli._cprint", lambda *_args, **_kwargs: None)
         cli = _make_cli()
         cli._pending_input = __import__("queue").Queue()
         # /q with no args shows a usage error and keeps the CLI running.
@@ -81,25 +86,40 @@ class TestExitDeleteFlag:
         assert result is False
         assert cli._delete_session_on_exit is True
 
-    def test_unknown_exit_argument_does_not_exit(self):
+    def test_unknown_exit_argument_does_not_exit(self, monkeypatch):
         """Unrecognised args should NOT exit the CLI — they surface an
         error message and stay in the session. This prevents accidental
         session destruction from typos like `/exit -delete`."""
+        monkeypatch.setattr("cli._cprint", lambda *_args, **_kwargs: None)
         cli = _make_cli()
         result = cli.process_command("/exit --delte")
         # process_command returns True = keep running
         assert result is True
         assert cli._delete_session_on_exit is False
 
-    def test_unknown_exit_argument_prints_help(self):
+    def test_unknown_exit_argument_prints_help(self, monkeypatch):
+        monkeypatch.setattr("cli._cprint", lambda *_args, **_kwargs: None)
         cli = _make_cli()
-        # _cprint goes through module-level print, so capture via console.
-        # We can't patch _cprint directly without import juggling; the
-        # previous assertion already proves the unknown-arg branch is
-        # reached (result True + flag False).
         result = cli.process_command("/exit garbage")
         assert result is True
         assert cli._delete_session_on_exit is False
+
+    def test_deleted_session_suppresses_resume_hint(self, capsys):
+        """A successfully deleted session must not advertise `hermes --resume`.
+
+        `/exit --delete` removes the SQLite row and transcript files during
+        shutdown. Printing the normal exit summary after that points users at a
+        session ID that no longer exists.
+        """
+        cli = _make_cli()
+        cli.conversation_history = [{"role": "user", "content": "hello"}]
+        cli._session_deleted_on_exit = True
+
+        cli._print_exit_summary()
+
+        out = capsys.readouterr().out
+        assert "Resume this session with:" not in out
+        assert "hermes --resume test-session" not in out
 
 
 class TestCommandRegistry:


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI exit UX bug where `/exit --delete` successfully deletes the current session but the normal exit summary still prints a stale `hermes --resume <session>` command.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `cli.py`: Track successful session deletion during `/exit --delete` / `/quit --delete` cleanup.
- `cli.py`: Suppress the resume summary when the session was deleted.
- `tests/cli/test_exit_delete_session.py`: Add regression coverage for the deleted-session summary path.

## How to Test

1. Run `/exit --delete` or `/quit --delete` in a CLI session with history.
2. Confirm the session deletion message appears.
3. Confirm no stale `hermes --resume <session>` hint is printed.

Tested with:

```bash
uv run --extra dev python -m pytest tests/cli/test_exit_delete_session.py -q

Result: 13 passed.

