### PR TITLE
fix: route Telegram DM topic deliveries correctly

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -351,17 +351,11 @@ class DeliveryRouter:
                     raise RuntimeError(
                         "Telegram adapter cannot refresh named private DM topics"
                     )
-                try:
-                    refreshed_thread_id = await ensure_dm_topic(
-                        target.chat_id,
-                        named_telegram_private_topic_name,
-                        force_create=True,
-                    )
-                except TypeError:
-                    refreshed_thread_id = await ensure_dm_topic(
-                        target.chat_id,
-                        named_telegram_private_topic_name,
-                    )
+                refreshed_thread_id = await ensure_dm_topic(
+                    target.chat_id,
+                    named_telegram_private_topic_name,
+                    force_create=True,
+                )
                 if not refreshed_thread_id:
                     raise RuntimeError(
                         f"Failed to refresh Telegram private DM topic '{named_telegram_private_topic_name}'"

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -25,6 +25,15 @@ from .config import Platform, GatewayConfig
 from .session import SessionSource
 
 
+def _looks_like_telegram_private_chat_id(chat_id: Optional[str]) -> bool:
+    if chat_id is None:
+        return False
+    try:
+        return int(chat_id) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 @dataclass
 class DeliveryTarget:
     """
@@ -249,9 +258,22 @@ class DeliveryRouter:
             )
         
         send_metadata = dict(metadata or {})
-        if target.thread_id and "thread_id" not in send_metadata:
-            send_metadata["thread_id"] = target.thread_id
-        return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+        if target.thread_id:
+            if (
+                target.platform == Platform.TELEGRAM
+                and _looks_like_telegram_private_chat_id(target.chat_id)
+                and "thread_id" not in send_metadata
+                and "message_thread_id" not in send_metadata
+                and "direct_messages_topic_id" not in send_metadata
+                and "telegram_direct_messages_topic_id" not in send_metadata
+            ):
+                send_metadata["telegram_direct_messages_topic_id"] = target.thread_id
+            elif "thread_id" not in send_metadata:
+                send_metadata["thread_id"] = target.thread_id
+        result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+        if getattr(result, "success", True) is False:
+            raise RuntimeError(getattr(result, "error", None) or f"{target.platform.value} delivery failed")
+        return result
 
 
 

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -259,16 +259,33 @@ class DeliveryRouter:
         
         send_metadata = dict(metadata or {})
         if target.thread_id:
+            has_explicit_direct_topic = (
+                "direct_messages_topic_id" in send_metadata
+                or "telegram_direct_messages_topic_id" in send_metadata
+            )
             if (
                 target.platform == Platform.TELEGRAM
                 and _looks_like_telegram_private_chat_id(target.chat_id)
                 and "thread_id" not in send_metadata
                 and "message_thread_id" not in send_metadata
-                and "direct_messages_topic_id" not in send_metadata
-                and "telegram_direct_messages_topic_id" not in send_metadata
+                and not has_explicit_direct_topic
             ):
-                send_metadata["telegram_direct_messages_topic_id"] = target.thread_id
-            elif "thread_id" not in send_metadata:
+                # Telegram has two similar-but-not-equivalent private topic modes:
+                # true Bot API Direct Messages topics use direct_messages_topic_id,
+                # while Hermes-created private DM lanes only route reliably with
+                # message_thread_id plus a reply anchor to a message in that lane.
+                # DeliveryRouter often handles proactive/cron sends, so an anchor
+                # may not exist. Refuse the send rather than reporting success for
+                # a message that lands in General/All Messages or is invisible.
+                reply_anchor = send_metadata.get("telegram_reply_to_message_id")
+                if reply_anchor is None:
+                    raise RuntimeError(
+                        "Telegram private DM topic delivery requires telegram_reply_to_message_id; "
+                        "send to the bare chat or provide a reply anchor"
+                    )
+                send_metadata["thread_id"] = target.thread_id
+                send_metadata["telegram_dm_topic_reply_fallback"] = True
+            elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
                 send_metadata["thread_id"] = target.thread_id
         result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
         if getattr(result, "success", True) is False:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -44,6 +44,25 @@ def _looks_like_int(value: Optional[str]) -> bool:
         return False
 
 
+def _send_result_failed(result: Any) -> bool:
+    if isinstance(result, dict):
+        return result.get("success") is False
+    return getattr(result, "success", True) is False
+
+
+def _send_result_error(result: Any) -> Optional[str]:
+    if isinstance(result, dict):
+        error = result.get("error")
+    else:
+        error = getattr(result, "error", None)
+    return str(error) if error else None
+
+
+def _is_thread_not_found_delivery_error(result: Any) -> bool:
+    error = _send_result_error(result)
+    return bool(error and "thread not found" in error.lower())
+
+
 @dataclass
 class DeliveryTarget:
     """
@@ -268,6 +287,8 @@ class DeliveryRouter:
             )
         
         send_metadata = dict(metadata or {})
+        is_named_telegram_private_topic = False
+        named_telegram_private_topic_name: Optional[str] = None
         if target.thread_id:
             has_explicit_direct_topic = (
                 "direct_messages_topic_id" in send_metadata
@@ -283,6 +304,7 @@ class DeliveryRouter:
                 and not has_explicit_direct_topic
             )
             if is_named_telegram_private_topic:
+                named_telegram_private_topic_name = target_thread_id
                 ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
                 if ensure_dm_topic is None:
                     raise RuntimeError(
@@ -318,8 +340,37 @@ class DeliveryRouter:
             elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
                 send_metadata["thread_id"] = target_thread_id
         result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
-        if getattr(result, "success", True) is False:
-            raise RuntimeError(getattr(result, "error", None) or f"{target.platform.value} delivery failed")
+        if _send_result_failed(result):
+            if (
+                is_named_telegram_private_topic
+                and named_telegram_private_topic_name
+                and _is_thread_not_found_delivery_error(result)
+            ):
+                ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
+                if ensure_dm_topic is None:
+                    raise RuntimeError(
+                        "Telegram adapter cannot refresh named private DM topics"
+                    )
+                try:
+                    refreshed_thread_id = await ensure_dm_topic(
+                        target.chat_id,
+                        named_telegram_private_topic_name,
+                        force_create=True,
+                    )
+                except TypeError:
+                    refreshed_thread_id = await ensure_dm_topic(
+                        target.chat_id,
+                        named_telegram_private_topic_name,
+                    )
+                if not refreshed_thread_id:
+                    raise RuntimeError(
+                        f"Failed to refresh Telegram private DM topic '{named_telegram_private_topic_name}'"
+                    )
+                send_metadata["thread_id"] = str(refreshed_thread_id)
+                send_metadata["telegram_dm_topic_created_for_send"] = True
+                result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+            if _send_result_failed(result):
+                raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
 
 

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -34,6 +34,16 @@ def _looks_like_telegram_private_chat_id(chat_id: Optional[str]) -> bool:
         return False
 
 
+def _looks_like_int(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    try:
+        int(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
 @dataclass
 class DeliveryTarget:
     """
@@ -263,30 +273,50 @@ class DeliveryRouter:
                 "direct_messages_topic_id" in send_metadata
                 or "telegram_direct_messages_topic_id" in send_metadata
             )
-            if (
+            target_thread_id = target.thread_id
+            is_named_telegram_private_topic = (
+                target.platform == Platform.TELEGRAM
+                and _looks_like_telegram_private_chat_id(target.chat_id)
+                and not _looks_like_int(target_thread_id)
+                and "thread_id" not in send_metadata
+                and "message_thread_id" not in send_metadata
+                and not has_explicit_direct_topic
+            )
+            if is_named_telegram_private_topic:
+                ensure_dm_topic = getattr(adapter, "ensure_dm_topic", None)
+                if ensure_dm_topic is None:
+                    raise RuntimeError(
+                        "Telegram adapter cannot create named private DM topics"
+                    )
+                created_thread_id = await ensure_dm_topic(target.chat_id, target_thread_id)
+                if not created_thread_id:
+                    raise RuntimeError(
+                        f"Failed to create Telegram private DM topic '{target_thread_id}'"
+                    )
+                target_thread_id = str(created_thread_id)
+                send_metadata["thread_id"] = target_thread_id
+                send_metadata["telegram_dm_topic_created_for_send"] = True
+            elif (
                 target.platform == Platform.TELEGRAM
                 and _looks_like_telegram_private_chat_id(target.chat_id)
                 and "thread_id" not in send_metadata
                 and "message_thread_id" not in send_metadata
                 and not has_explicit_direct_topic
             ):
-                # Telegram has two similar-but-not-equivalent private topic modes:
-                # true Bot API Direct Messages topics use direct_messages_topic_id,
-                # while Hermes-created private DM lanes only route reliably with
-                # message_thread_id plus a reply anchor to a message in that lane.
-                # DeliveryRouter often handles proactive/cron sends, so an anchor
-                # may not exist. Refuse the send rather than reporting success for
-                # a message that lands in General/All Messages or is invisible.
+                # Legacy private topic/thread ids that were not created by this
+                # send path may still need a reply anchor to stay visible in the
+                # requested lane. Named targets are created above via
+                # createForumTopic and can use message_thread_id directly.
                 reply_anchor = send_metadata.get("telegram_reply_to_message_id")
                 if reply_anchor is None:
                     raise RuntimeError(
                         "Telegram private DM topic delivery requires telegram_reply_to_message_id; "
                         "send to the bare chat or provide a reply anchor"
                     )
-                send_metadata["thread_id"] = target.thread_id
+                send_metadata["thread_id"] = target_thread_id
                 send_metadata["telegram_dm_topic_reply_fallback"] = True
             elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
-                send_metadata["thread_id"] = target.thread_id
+                send_metadata["thread_id"] = target_thread_id
         result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
         if getattr(result, "success", True) is False:
             raise RuntimeError(getattr(result, "error", None) or f"{target.platform.value} delivery failed")

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -547,6 +547,8 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         if cls._metadata_direct_messages_topic_id(metadata) is not None:
             return False
+        if metadata and metadata.get("telegram_dm_topic_created_for_send"):
+            return False
         return bool(
             thread_id
             and (
@@ -1029,6 +1031,59 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id = await self._create_dm_topic(chat_id_int, name=name)
         return str(thread_id) if thread_id else None
 
+    async def ensure_dm_topic(self, chat_id: str, topic_name: str) -> Optional[str]:
+        """Return a private DM topic thread id, creating and persisting it if needed."""
+        name = str(topic_name or "").strip()
+        if not name:
+            return None
+        try:
+            chat_id_int = int(chat_id)
+        except (TypeError, ValueError):
+            return None
+
+        cache_key = f"{chat_id_int}:{name}"
+        cached = self._dm_topics.get(cache_key)
+        if cached:
+            return str(cached)
+
+        topic_conf: Optional[Dict[str, Any]] = None
+        chat_entry: Optional[Dict[str, Any]] = None
+        for entry in self._dm_topics_config:
+            if str(entry.get("chat_id")) != str(chat_id_int):
+                continue
+            chat_entry = entry
+            for candidate in entry.get("topics", []):
+                if candidate.get("name") == name:
+                    topic_conf = candidate
+                    break
+            break
+
+        if topic_conf and topic_conf.get("thread_id"):
+            thread_id = int(topic_conf["thread_id"])
+            self._dm_topics[cache_key] = thread_id
+            return str(thread_id)
+
+        if chat_entry is None:
+            chat_entry = {"chat_id": chat_id_int, "topics": []}
+            self._dm_topics_config.append(chat_entry)
+        if topic_conf is None:
+            topic_conf = {"name": name}
+            chat_entry.setdefault("topics", []).append(topic_conf)
+
+        thread_id = await self._create_dm_topic(
+            chat_id_int,
+            name=name,
+            icon_color=topic_conf.get("icon_color"),
+            icon_custom_emoji_id=topic_conf.get("icon_custom_emoji_id"),
+        )
+        if not thread_id:
+            return None
+
+        topic_conf["thread_id"] = thread_id
+        self._dm_topics[cache_key] = int(thread_id)
+        self._persist_dm_topic_thread_id(chat_id_int, name, int(thread_id))
+        return str(thread_id)
+
     async def rename_dm_topic(
         self,
         chat_id: int,
@@ -1065,25 +1120,43 @@ class TelegramAdapter(BasePlatformAdapter):
             with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
-            # Navigate to platforms.telegram.extra.dm_topics
-            dm_topics = (
-                config.get("platforms", {})
-                .get("telegram", {})
-                .get("extra", {})
-                .get("dm_topics", [])
-            )
-            if not dm_topics:
-                return
+            # Navigate to platforms.telegram.extra.dm_topics, creating the path
+            # when a named delivery target asks us to create a topic that was
+            # not predeclared in config.yaml.
+            platforms = config.setdefault("platforms", {})
+            telegram_config = platforms.setdefault("telegram", {})
+            extra = telegram_config.setdefault("extra", {})
+            dm_topics = extra.setdefault("dm_topics", [])
 
             changed = False
+            matching_chat_entry = None
             for chat_entry in dm_topics:
-                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
+                try:
+                    chat_matches = int(chat_entry.get("chat_id", 0)) == int(chat_id)
+                except (TypeError, ValueError):
+                    chat_matches = False
+                if not chat_matches:
                     continue
-                for t in chat_entry.get("topics", []):
-                    if t.get("name") == topic_name and not t.get("thread_id"):
-                        t["thread_id"] = thread_id
-                        changed = True
+                matching_chat_entry = chat_entry
+                for t in chat_entry.setdefault("topics", []):
+                    if t.get("name") == topic_name:
+                        if not t.get("thread_id"):
+                            t["thread_id"] = thread_id
+                            changed = True
                         break
+                else:
+                    chat_entry.setdefault("topics", []).append(
+                        {"name": topic_name, "thread_id": thread_id}
+                    )
+                    changed = True
+                break
+
+            if matching_chat_entry is None:
+                dm_topics.append({
+                    "chat_id": chat_id,
+                    "topics": [{"name": topic_name, "thread_id": thread_id}],
+                })
+                changed = True
 
             if changed:
                 fd, tmp_path = tempfile.mkstemp(

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1031,7 +1031,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id = await self._create_dm_topic(chat_id_int, name=name)
         return str(thread_id) if thread_id else None
 
-    async def ensure_dm_topic(self, chat_id: str, topic_name: str) -> Optional[str]:
+    async def ensure_dm_topic(self, chat_id: str, topic_name: str, force_create: bool = False) -> Optional[str]:
         """Return a private DM topic thread id, creating and persisting it if needed."""
         name = str(topic_name or "").strip()
         if not name:
@@ -1043,7 +1043,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         cache_key = f"{chat_id_int}:{name}"
         cached = self._dm_topics.get(cache_key)
-        if cached:
+        if cached and not force_create:
             return str(cached)
 
         topic_conf: Optional[Dict[str, Any]] = None
@@ -1058,7 +1058,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
             break
 
-        if topic_conf and topic_conf.get("thread_id"):
+        if topic_conf and topic_conf.get("thread_id") and not force_create:
             thread_id = int(topic_conf["thread_id"])
             self._dm_topics[cache_key] = thread_id
             return str(thread_id)
@@ -1081,7 +1081,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         topic_conf["thread_id"] = thread_id
         self._dm_topics[cache_key] = int(thread_id)
-        self._persist_dm_topic_thread_id(chat_id_int, name, int(thread_id))
+        self._persist_dm_topic_thread_id(chat_id_int, name, int(thread_id), replace_existing=force_create)
         return str(thread_id)
 
     async def rename_dm_topic(
@@ -1107,7 +1107,13 @@ class TelegramAdapter(BasePlatformAdapter):
             self.name, chat_id, thread_id, name,
         )
 
-    def _persist_dm_topic_thread_id(self, chat_id: int, topic_name: str, thread_id: int) -> None:
+    def _persist_dm_topic_thread_id(
+        self,
+        chat_id: int,
+        topic_name: str,
+        thread_id: int,
+        replace_existing: bool = False,
+    ) -> None:
         """Save a newly created thread_id back into config.yaml so it persists across restarts."""
         try:
             from hermes_constants import get_hermes_home
@@ -1140,9 +1146,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 matching_chat_entry = chat_entry
                 for t in chat_entry.setdefault("topics", []):
                     if t.get("name") == topic_name:
-                        if not t.get("thread_id"):
-                            t["thread_id"] = thread_id
-                            changed = True
+                        if replace_existing or not t.get("thread_id"):
+                            if t.get("thread_id") != thread_id:
+                                t["thread_id"] = thread_id
+                                changed = True
                         break
                 else:
                     chat_entry.setdefault("topics", []).append(
@@ -1707,8 +1714,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         # specific cases instead of blindly retrying.
                         if _BadReq and isinstance(send_err, _BadReq):
                             if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
-                                if private_dm_topic_send:
-                                    raise
+                                if private_dm_topic_send or (metadata and metadata.get("telegram_dm_topic_created_for_send")):
+                                    return SendResult(
+                                        success=False,
+                                        error=str(send_err),
+                                        retryable=False,
+                                    )
                                 # Thread doesn't exist — retry without
                                 # message_thread_id so the message still
                                 # reaches the chat.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -531,6 +531,34 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
 
+    @staticmethod
+    def _looks_like_private_chat_id(chat_id: str) -> bool:
+        try:
+            return int(chat_id) > 0
+        except (TypeError, ValueError):
+            return False
+
+    @classmethod
+    def _is_private_dm_topic_send(
+        cls,
+        chat_id: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        if cls._metadata_direct_messages_topic_id(metadata) is not None:
+            return False
+        return bool(
+            thread_id
+            and (
+                metadata and metadata.get("telegram_dm_topic_reply_fallback")
+                or cls._looks_like_private_chat_id(chat_id)
+            )
+        )
+
+    @staticmethod
+    def _dm_topic_missing_anchor_error() -> str:
+        return "Telegram DM topic delivery requires a reply anchor; refusing to send outside the requested topic"
+
     @classmethod
     def _reply_to_message_id_for_send(
         cls,
@@ -1545,15 +1573,21 @@ class TelegramAdapter(BasePlatformAdapter):
 
             for i, chunk in enumerate(chunks):
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
+                private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
                 reply_to_source = reply_to or (
-                    str(metadata_reply_to)
-                    if metadata and metadata.get("telegram_dm_topic_reply_fallback") and metadata_reply_to is not None else None
+                    str(metadata_reply_to) if private_dm_topic_send and metadata_reply_to is not None else None
                 )
-                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
+                if private_dm_topic_send:
                     should_thread = reply_to_source is not None
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)
                 reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
+                if private_dm_topic_send and reply_to_id is None:
+                    return SendResult(
+                        success=False,
+                        error=self._dm_topic_missing_anchor_error(),
+                        retryable=False,
+                    )
                 thread_kwargs = self._thread_kwargs_for_send(
                     chat_id,
                     thread_id,
@@ -1600,6 +1634,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         # specific cases instead of blindly retrying.
                         if _BadReq and isinstance(send_err, _BadReq):
                             if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
+                                if private_dm_topic_send:
+                                    raise
                                 # Thread doesn't exist — retry without
                                 # message_thread_id so the message still
                                 # reaches the chat.
@@ -1612,6 +1648,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                             err_lower = str(send_err).lower()
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
+                                if private_dm_topic_send:
+                                    return SendResult(
+                                        success=False,
+                                        error=str(send_err),
+                                        retryable=False,
+                                    )
                                 # Original message was deleted before we
                                 # could reply. For private-topic fallback
                                 # sends, message_thread_id is only valid with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,6 +271,15 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "WECOM_HOME_CHANNEL",
     "WECOM_HOME_CHANNEL_THREAD_ID",
     "WECOM_HOME_CHANNEL_NAME",
+    # API server bind/auth settings are common in local gateway profiles and
+    # change adapter defaults plus load_gateway_config() enablement. Tests that
+    # need them set opt in explicitly with monkeypatch.
+    "API_SERVER_ENABLED",
+    "API_SERVER_HOST",
+    "API_SERVER_PORT",
+    "API_SERVER_KEY",
+    "API_SERVER_CORS_ORIGINS",
+    "API_SERVER_MODEL_NAME",
     # Platform gating — set by load_gateway_config() as a side effect when
     # a config.yaml is present, so individual test bodies that call the
     # loader leak these values into later tests on the same xdist worker.

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -135,23 +135,58 @@ class RecordingAdapter:
 
 
 @pytest.mark.asyncio
-async def test_explicit_telegram_private_thread_uses_direct_messages_topic_id(tmp_path, monkeypatch):
+async def test_explicit_telegram_private_thread_requires_reply_anchor(tmp_path, monkeypatch):
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
     adapter = RecordingAdapter()
     router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
     target = DeliveryTarget.parse("telegram:722341991:32344")
 
-    await router._deliver_to_platform(target, "hello", metadata=None)
+    with pytest.raises(RuntimeError, match="requires telegram_reply_to_message_id"):
+        await router._deliver_to_platform(target, "hello", metadata=None)
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_telegram_private_thread_uses_reply_fallback_with_anchor(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:722341991:32344")
+
+    await router._deliver_to_platform(
+        target,
+        "hello",
+        metadata={"telegram_reply_to_message_id": "9001"},
+    )
 
     assert adapter.calls == [
         {
             "chat_id": "722341991",
             "content": "hello",
             "metadata": {
-                "telegram_direct_messages_topic_id": "32344",
+                "telegram_reply_to_message_id": "9001",
+                "thread_id": "32344",
+                "telegram_dm_topic_reply_fallback": True,
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_telegram_direct_messages_topic_metadata_is_respected(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:722341991:32344")
+
+    await router._deliver_to_platform(
+        target,
+        "hello",
+        metadata={"telegram_direct_messages_topic_id": "32344"},
+    )
+
+    assert adapter.calls[0]["metadata"] == {"telegram_direct_messages_topic_id": "32344"}
 
 
 @pytest.mark.asyncio
@@ -178,4 +213,4 @@ async def test_platform_send_failure_raises_for_delivery_result(tmp_path, monkey
     target = DeliveryTarget.parse("telegram:722341991:32344")
 
     with pytest.raises(RuntimeError, match="route failed"):
-        await router._deliver_to_platform(target, "hello", metadata=None)
+        await router._deliver_to_platform(target, "hello", metadata={"telegram_reply_to_message_id": "9001"})

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -1,7 +1,10 @@
 """Tests for the delivery routing module."""
 
-from gateway.config import Platform
-from gateway.delivery import DeliveryTarget
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.delivery import DeliveryRouter, DeliveryTarget
+from gateway.platforms.base import SendResult
 from gateway.session import SessionSource
 
 
@@ -122,5 +125,57 @@ class TestPlatformNameCaseInsensitivity:
         assert target.platform == Platform.TELEGRAM
         assert target.chat_id == "12345"
 
+class RecordingAdapter:
+    def __init__(self):
+        self.calls = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.calls.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return {"success": True}
 
 
+@pytest.mark.asyncio
+async def test_explicit_telegram_private_thread_uses_direct_messages_topic_id(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:722341991:32344")
+
+    await router._deliver_to_platform(target, "hello", metadata=None)
+
+    assert adapter.calls == [
+        {
+            "chat_id": "722341991",
+            "content": "hello",
+            "metadata": {
+                "telegram_direct_messages_topic_id": "32344",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_telegram_group_thread_does_not_mark_dm_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:-100123:42")
+
+    await router._deliver_to_platform(target, "hello", metadata=None)
+
+    assert adapter.calls[0]["metadata"] == {"thread_id": "42"}
+
+
+class FailingAdapter:
+    async def send(self, chat_id, content, metadata=None):
+        return SendResult(success=False, error="route failed", retryable=False)
+
+
+@pytest.mark.asyncio
+async def test_platform_send_failure_raises_for_delivery_result(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: FailingAdapter()})
+    target = DeliveryTarget.parse("telegram:722341991:32344")
+
+    with pytest.raises(RuntimeError, match="route failed"):
+        await router._deliver_to_platform(target, "hello", metadata=None)

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -134,9 +134,29 @@ class RecordingAdapter:
         self.calls.append({"chat_id": chat_id, "content": content, "metadata": metadata})
         return {"success": True}
 
-    async def ensure_dm_topic(self, chat_id, topic_name):
-        self.ensure_dm_topic_calls.append({"chat_id": chat_id, "topic_name": topic_name})
+    async def ensure_dm_topic(self, chat_id, topic_name, force_create=False):
+        self.ensure_dm_topic_calls.append(
+            {"chat_id": chat_id, "topic_name": topic_name, "force_create": force_create}
+        )
         return "38049"
+
+
+class StaleTopicAdapter:
+    def __init__(self):
+        self.calls = []
+        self.ensure_dm_topic_calls = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.calls.append({"chat_id": chat_id, "content": content, "metadata": dict(metadata or {})})
+        if len(self.calls) == 1:
+            return SendResult(success=False, error="Bad Request: message thread not found")
+        return SendResult(success=True, message_id="fresh-message")
+
+    async def ensure_dm_topic(self, chat_id, topic_name, force_create=False):
+        self.ensure_dm_topic_calls.append(
+            {"chat_id": chat_id, "topic_name": topic_name, "force_create": force_create}
+        )
+        return "38064" if force_create else "32343"
 
 
 @pytest.mark.asyncio
@@ -162,7 +182,7 @@ async def test_named_telegram_private_topic_is_created_before_delivery(tmp_path,
     await router._deliver_to_platform(target, "hello", metadata=None)
 
     assert adapter.ensure_dm_topic_calls == [
-        {"chat_id": "722341991", "topic_name": "Hermes API Test"}
+        {"chat_id": "722341991", "topic_name": "Hermes API Test", "force_create": False}
     ]
     assert adapter.calls == [
         {
@@ -174,6 +194,24 @@ async def test_named_telegram_private_topic_is_created_before_delivery(tmp_path,
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_named_telegram_private_topic_refreshes_stale_thread_id(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = StaleTopicAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:722341991:Personal")
+
+    result = await router._deliver_to_platform(target, "hello", metadata=None)
+
+    assert getattr(result, "message_id", None) == "fresh-message"
+    assert adapter.ensure_dm_topic_calls == [
+        {"chat_id": "722341991", "topic_name": "Personal", "force_create": False},
+        {"chat_id": "722341991", "topic_name": "Personal", "force_create": True},
+    ]
+    assert [call["metadata"]["thread_id"] for call in adapter.calls] == ["32343", "38064"]
+    assert all(call["metadata"]["telegram_dm_topic_created_for_send"] is True for call in adapter.calls)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -128,10 +128,15 @@ class TestPlatformNameCaseInsensitivity:
 class RecordingAdapter:
     def __init__(self):
         self.calls = []
+        self.ensure_dm_topic_calls = []
 
     async def send(self, chat_id, content, metadata=None):
         self.calls.append({"chat_id": chat_id, "content": content, "metadata": metadata})
         return {"success": True}
+
+    async def ensure_dm_topic(self, chat_id, topic_name):
+        self.ensure_dm_topic_calls.append({"chat_id": chat_id, "topic_name": topic_name})
+        return "38049"
 
 
 @pytest.mark.asyncio
@@ -145,6 +150,30 @@ async def test_explicit_telegram_private_thread_requires_reply_anchor(tmp_path, 
         await router._deliver_to_platform(target, "hello", metadata=None)
 
     assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_named_telegram_private_topic_is_created_before_delivery(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+    target = DeliveryTarget.parse("telegram:722341991:Hermes API Test")
+
+    await router._deliver_to_platform(target, "hello", metadata=None)
+
+    assert adapter.ensure_dm_topic_calls == [
+        {"chat_id": "722341991", "topic_name": "Hermes API Test"}
+    ]
+    assert adapter.calls == [
+        {
+            "chat_id": "722341991",
+            "content": "hello",
+            "metadata": {
+                "thread_id": "38049",
+                "telegram_dm_topic_created_for_send": True,
+            },
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -198,6 +198,28 @@ async def test_create_dm_topic_returns_none_without_bot():
     assert result is None
 
 
+@pytest.mark.asyncio
+async def test_ensure_dm_topic_creates_on_demand_and_persists():
+    """Named delivery targets should create missing private DM topics on demand."""
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    adapter._bot.create_forum_topic.return_value = SimpleNamespace(message_thread_id=444)
+    adapter._persist_dm_topic_thread_id = MagicMock()
+
+    result = await adapter.ensure_dm_topic("111", "On Demand")
+
+    assert result == "444"
+    adapter._bot.create_forum_topic.assert_called_once_with(
+        chat_id=111,
+        name="On Demand",
+    )
+    assert adapter._dm_topics["111:On Demand"] == 444
+    assert adapter._dm_topics_config == [
+        {"chat_id": 111, "topics": [{"name": "On Demand", "thread_id": 444}]}
+    ]
+    adapter._persist_dm_topic_thread_id.assert_called_once_with(111, "On Demand", 444)
+
+
 # ── _persist_dm_topic_thread_id ──
 
 

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -217,7 +217,33 @@ async def test_ensure_dm_topic_creates_on_demand_and_persists():
     assert adapter._dm_topics_config == [
         {"chat_id": 111, "topics": [{"name": "On Demand", "thread_id": 444}]}
     ]
-    adapter._persist_dm_topic_thread_id.assert_called_once_with(111, "On Demand", 444)
+    adapter._persist_dm_topic_thread_id.assert_called_once_with(
+        111, "On Demand", 444, replace_existing=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_dm_topic_force_create_replaces_persisted_thread_id():
+    """Refreshing a stale named topic should replace the cached persisted thread_id."""
+    adapter = _make_adapter()
+    bot = AsyncMock()
+    bot.create_forum_topic.return_value = SimpleNamespace(message_thread_id=777)
+    adapter._bot = bot
+    adapter._persist_dm_topic_thread_id = MagicMock()
+    adapter._dm_topics = {"111:General": 500}
+    adapter._dm_topics_config = [
+        {"chat_id": 111, "topics": [{"name": "General", "thread_id": 500}]}
+    ]
+
+    result = await adapter.ensure_dm_topic("111", "General", force_create=True)
+
+    assert result == "777"
+    bot.create_forum_topic.assert_called_once_with(chat_id=111, name="General")
+    assert adapter._dm_topics["111:General"] == 777
+    assert adapter._dm_topics_config[0]["topics"][0]["thread_id"] == 777
+    adapter._persist_dm_topic_thread_id.assert_called_once_with(
+        111, "General", 777, replace_existing=True
+    )
 
 
 # ── _persist_dm_topic_thread_id ──
@@ -300,6 +326,45 @@ def test_persist_dm_topic_thread_id_skips_if_already_set(tmp_path):
 
     topics = result["platforms"]["telegram"]["extra"]["dm_topics"][0]["topics"]
     assert topics[0]["thread_id"] == 500  # unchanged
+
+
+def test_persist_dm_topic_thread_id_replaces_existing_when_requested(tmp_path):
+    """Forced refresh should overwrite a stale persisted thread_id."""
+    import yaml
+
+    config_data = {
+        "platforms": {
+            "telegram": {
+                "extra": {
+                    "dm_topics": [
+                        {
+                            "chat_id": 111,
+                            "topics": [
+                                {"name": "General", "icon_color": 123, "thread_id": 500},
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    config_file = tmp_path / ".hermes" / "config.yaml"
+    config_file.parent.mkdir(parents=True)
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    adapter = _make_adapter()
+
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
+        adapter._persist_dm_topic_thread_id(111, "General", 999, replace_existing=True)
+
+    with open(config_file) as f:
+        result = yaml.safe_load(f)
+
+    topics = result["platforms"]["telegram"]["extra"]["dm_topics"][0]["topics"]
+    assert topics[0]["thread_id"] == 999
 
 
 # ── _get_dm_topic_info ──

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -282,7 +282,7 @@ async def test_send_retries_without_thread_on_thread_not_found():
     adapter._bot = SimpleNamespace(send_message=mock_send_message)
 
     result = await adapter.send(
-        chat_id="123",
+        chat_id="-100123",
         content="test message",
         metadata={"thread_id": "99999"},
     )
@@ -530,8 +530,8 @@ async def test_send_model_picker_uses_metadata_reply_fallback_for_dm_topics():
 
 
 @pytest.mark.asyncio
-async def test_send_dm_topic_fallback_without_anchor_does_not_crash():
-    """DM-topic fallback without an anchor must not use message_thread_id alone."""
+async def test_send_dm_topic_fallback_without_anchor_fails_closed():
+    """DM-topic fallback without an anchor must not send outside the topic."""
     adapter = _make_adapter()
     call_log = []
 
@@ -550,23 +550,21 @@ async def test_send_dm_topic_fallback_without_anchor_does_not_crash():
         },
     )
 
-    assert result.success is True
-    assert call_log[0]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[0]
-    assert "direct_messages_topic_id" not in call_log[0]
+    assert result.success is False
+    assert result.retryable is False
+    assert "requires a reply anchor" in (result.error or "")
+    assert call_log == []
 
 
 @pytest.mark.asyncio
-async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
-    """If Telegram deletes the reply anchor, private-topic retry must drop thread id too."""
+async def test_send_dm_topic_reply_not_found_fails_closed():
+    """If Telegram deletes the reply anchor, private-topic sends must not fall back elsewhere."""
     adapter = _make_adapter()
     call_log = []
 
     async def mock_send_message(**kwargs):
         call_log.append(dict(kwargs))
-        if len(call_log) == 1:
-            raise FakeBadRequest("Message to be replied not found")
-        return SimpleNamespace(message_id=781)
+        raise FakeBadRequest("Message to be replied not found")
 
     adapter._bot = SimpleNamespace(send_message=mock_send_message)
 
@@ -580,12 +578,11 @@ async def test_send_dm_topic_reply_not_found_retry_drops_thread_id():
         },
     )
 
-    assert result.success is True
+    assert result.success is False
+    assert result.retryable is False
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
-    assert call_log[1]["reply_to_message_id"] is None
-    assert "message_thread_id" not in call_log[1]
-    assert "direct_messages_topic_id" not in call_log[1]
+    assert len(call_log) == 1
 
 
 @pytest.mark.asyncio
@@ -926,7 +923,7 @@ async def test_send_raises_on_other_bad_request():
     adapter._bot = SimpleNamespace(send_message=mock_send_message)
 
     result = await adapter.send(
-        chat_id="123",
+        chat_id="-100123",
         content="test message",
         metadata={"thread_id": "99999"},
     )
@@ -1029,7 +1026,7 @@ async def test_thread_fallback_only_fires_once():
     # Send a long message that gets split into chunks
     long_msg = "A" * 5000  # Exceeds Telegram's 4096 limit
     result = await adapter.send(
-        chat_id="123",
+        chat_id="-100123",
         content=long_msg,
         metadata={"thread_id": "99999"},
     )

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -467,6 +467,33 @@ async def test_send_created_private_topic_uses_message_thread_without_anchor():
 
 
 @pytest.mark.asyncio
+async def test_created_private_topic_thread_not_found_fails_without_root_fallback():
+    """Created private-topic sends must not retry into All Messages on stale thread IDs."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="created topic message",
+        metadata={
+            "thread_id": "32343",
+            "telegram_dm_topic_created_for_send": True,
+        },
+    )
+
+    assert result.success is False
+    assert "thread not found" in str(result.error).lower()
+    assert len(call_log) == 1
+    assert call_log[0]["message_thread_id"] == 32343
+
+
+@pytest.mark.asyncio
 async def test_send_uses_metadata_reply_fallback_for_streaming_dm_topics():
     """Metadata-only sends still stay in Hermes-created Telegram DM topics."""
     adapter = _make_adapter()

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -440,6 +440,33 @@ async def test_send_uses_reply_fallback_for_hermes_dm_topics():
 
 
 @pytest.mark.asyncio
+async def test_send_created_private_topic_uses_message_thread_without_anchor():
+    """Topics created via createForumTopic are addressable by message_thread_id directly."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(kwargs)
+        return SimpleNamespace(message_id=781)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="created topic message",
+        metadata={
+            "thread_id": "38049",
+            "telegram_dm_topic_created_for_send": True,
+        },
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] is None
+    assert call_log[0]["message_thread_id"] == 38049
+    assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
 async def test_send_uses_metadata_reply_fallback_for_streaming_dm_topics():
     """Metadata-only sends still stay in Hermes-created Telegram DM topics."""
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Route Telegram private DM topic deliveries through the correct mode instead of treating every private topic as a Direct Messages topic.
- Require anchors for legacy/ambiguous numeric private DM topic sends, while preserving explicit `telegram_direct_messages_topic_id` support for true Bot API Direct Messages topics.
- Add named private DM topic creation via `createForumTopic`, persistence of returned `message_thread_id`, and stale-thread refresh/retry behavior.
- Isolate API server environment variables in gateway tests so local installs do not alter test defaults.

## Related Issues
- Related to #22773. I did not use a closing keyword because the existing issue is specifically framed around cron/standalone delivery via `tools/send_message_tool.py`; this PR fixes the shared Telegram DM-topic routing pieces and live adapter/router behavior, but maintainers should decide whether it fully closes that cron-focused report.
- Also overlaps with the already-closed DM-topic reports #21981 and #22022.

## Test Plan
- `python -m pytest -q tests/gateway/test_delivery.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_dm_topics.py -o 'addopts='`
- `python -m pytest -q tests/gateway`
- Live verification via Hermes `DeliveryRouter` to configured Telegram DM topics: Personal, Test, Debug, Installation, and smoke topic all returned successful Telegram message ids.