### PR TITLE
fix(run_agent): stamp session_type + parent_session_id on trajectory JSON (#26952)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1801,6 +1801,25 @@ class AIAgent:
             return redacted
         return content
 
+    def _classify_session_type(self) -> str:
+        """Return the trajectory-file label for this agent instance.
+
+        Background-review forks and ``delegate_task`` subagents otherwise
+        produce JSON payloads structurally identical to a normal user
+        conversation, which forces post-mortem classification by inspecting
+        message content.  The agent already carries unambiguous lineage
+        attributes — surface them as a single label so trajectories are
+        self-describing.  ``getattr`` keeps this safe for the ``object.__new__``
+        test stubs that skip ``__init__``.
+        """
+        write_origin = getattr(self, "_memory_write_origin", "") or ""
+        write_context = getattr(self, "_memory_write_context", "") or ""
+        if "background_review" in (write_origin, write_context):
+            return "background_review"
+        if getattr(self, "_subagent_id", None) or getattr(self, "_delegate_depth", 0) > 0:
+            return "subagent"
+        return "primary"
+
     def _save_session_log(self, messages: List[Dict[str, Any]] = None):
         """Optional per-session JSON snapshot writer.
 
@@ -1864,6 +1883,8 @@ class AIAgent:
 
             entry = {
                 "session_id": self.session_id,
+                "session_type": self._classify_session_type(),
+                "parent_session_id": getattr(self, "_parent_session_id", None) or None,
                 "model": self.model,
                 "base_url": self.base_url,
                 "platform": self.platform,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4800,6 +4800,55 @@ class TestSafeWriter:
 
 
 
+class TestSaveSessionLogTypeMetadata:
+    """Trajectory JSON must carry session_type and parent_session_id so a
+    review fork, delegate_task subagent, and primary user conversation are
+    distinguishable from the payload alone (#26952)."""
+
+    def _capture_payload(self, agent, tmp_path):
+        agent.session_log_file = tmp_path / "session.json"
+        with patch("run_agent.atomic_json_write", create=True) as mock_atomic_write:
+            agent._save_session_log([{"role": "user", "content": "hi"}])
+        return mock_atomic_write.call_args.args[1]
+
+    def test_primary_session_is_labeled_primary(self, agent, tmp_path):
+        payload = self._capture_payload(agent, tmp_path)
+        assert payload["session_type"] == "primary"
+        assert payload["parent_session_id"] is None
+
+    def test_background_review_fork_is_labeled_via_write_origin(self, agent, tmp_path):
+        agent._memory_write_origin = "background_review"
+        agent._memory_write_context = "background_review"
+        agent._parent_session_id = "parent-abc"
+        payload = self._capture_payload(agent, tmp_path)
+        assert payload["session_type"] == "background_review"
+        assert payload["parent_session_id"] == "parent-abc"
+
+    def test_subagent_detected_via_subagent_id(self, agent, tmp_path):
+        agent._subagent_id = "delegate-1"
+        agent._parent_session_id = "parent-xyz"
+        payload = self._capture_payload(agent, tmp_path)
+        assert payload["session_type"] == "subagent"
+        assert payload["parent_session_id"] == "parent-xyz"
+
+    def test_subagent_detected_via_delegate_depth(self, agent, tmp_path):
+        agent._delegate_depth = 1
+        agent._parent_session_id = "parent-xyz"
+        payload = self._capture_payload(agent, tmp_path)
+        assert payload["session_type"] == "subagent"
+        assert payload["parent_session_id"] == "parent-xyz"
+
+    def test_review_label_wins_over_delegate_depth(self, agent, tmp_path):
+        agent._memory_write_origin = "background_review"
+        agent._delegate_depth = 1
+        payload = self._capture_payload(agent, tmp_path)
+        assert payload["session_type"] == "background_review"
+
+    def test_classify_safe_for_init_skipping_stubs(self):
+        stub = AIAgent.__new__(AIAgent)
+        assert stub._classify_session_type() == "primary"
+
+
 # ===================================================================
 # Anthropic adapter integration fixes
 # ===================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4806,10 +4806,15 @@ class TestSaveSessionLogTypeMetadata:
     distinguishable from the payload alone (#26952)."""
 
     def _capture_payload(self, agent, tmp_path):
-        agent.session_log_file = tmp_path / "session.json"
-        with patch("run_agent.atomic_json_write", create=True) as mock_atomic_write:
-            agent._save_session_log([{"role": "user", "content": "hi"}])
-        return mock_atomic_write.call_args.args[1]
+        # _save_session_log is opt-in (sessions.write_json_snapshots) and
+        # writes to logs_dir/session_{session_id}.json on main — set the
+        # flag + logs_dir and read the resulting JSON back rather than
+        # patching atomic_json_write (which can be referenced via either
+        # name depending on which helper module the writer routes through).
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        agent._save_session_log([{"role": "user", "content": "hi"}])
+        return json.loads((tmp_path / f"session_{agent.session_id}.json").read_text())
 
     def test_primary_session_is_labeled_primary(self, agent, tmp_path):
         payload = self._capture_payload(agent, tmp_path)


### PR DESCRIPTION
## Summary

- Add ``session_type`` and ``parent_session_id`` fields to every trajectory JSON written by ``_save_session_log()`` so post-mortem readers can tell a primary conversation, a background-review fork, and a ``delegate_task`` subagent apart from the payload alone.
- Derive ``session_type`` from existing agent state (``_memory_write_origin``/``_memory_write_context`` for review forks, ``_subagent_id``/``_delegate_depth`` for delegated children) — no new constructor wiring required.

## The bug

``_save_session_log()`` ([run_agent.py:5358](run_agent.py)) writes exactly ten keys: ``session_id``, ``model``, ``base_url``, ``platform``, ``session_start``, ``last_updated``, ``system_prompt``, ``tools``, ``message_count``, ``messages``. None of them identify the kind of agent that produced the file, so a forensic reader has to crack open ``messages`` and look for system-injected review prompts to tell a review fork from a primary session. The lineage is already on the agent — just not on disk.

Trigger paths for non-primary sessions:

- ``run_agent.py:4350-4396`` builds the background-review fork and flips ``_memory_write_origin``/``_memory_write_context`` to ``background_review``.
- ``tools/delegate_tool.py:1101-1142`` spawns the child agent, threads ``parent_session_id`` through ``AIAgent.__init__``, and sets ``_subagent_id`` + ``_delegate_depth`` on the returned instance.

## The fix

A new ``_classify_session_type()`` helper folds those signals into a single string:

- ``background_review`` when ``_memory_write_origin`` or ``_memory_write_context`` is ``background_review`` (wins over delegate-depth so a review fork spawned inside a subagent still labels as review).
- ``subagent`` when ``_subagent_id`` is set or ``_delegate_depth > 0``.
- ``primary`` otherwise.

The two new fields are emitted right after ``session_id`` to keep the identity block together. ``getattr`` defaults protect the ``AIAgent.__new__`` test stubs used elsewhere in the suite.

## Test plan

- [x] Focused regression class ``TestSaveSessionLogTypeMetadata`` covering primary, review-via-write-origin, subagent-via-id, subagent-via-depth, review-wins-over-depth, and the ``object.__new__`` stub path.
- [x] Adjacent suite: ``tests/run_agent/`` — 1384 passed, 3 skipped, no regressions.
- [x] Regression guard: stashed the production change locally and reran the new class — all 6 tests fail with ``KeyError: 'session_type'`` (and ``AttributeError`` on the stub case). Restoring the change brings them green again.

## Related

- Fixes #26952.