### PR TITLE
docs(delegation): document api_mode wire-protocol override from #26824

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1667,6 +1667,7 @@ delegation:
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
+  # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
@@ -1675,6 +1676,8 @@ delegation:
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
+
+**Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.
 
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -274,6 +274,7 @@ delegation:
   model: "qwen2.5-coder"
   base_url: "http://localhost:1234/v1"
   api_key: "local-key"
+  # api_mode: "anthropic_messages"  # Optional. Wire protocol override for base_url ("chat_completions", "codex_responses", or "anthropic_messages"). Empty = auto-detect from URL (e.g. /anthropic suffix). Set explicitly for endpoints the heuristic can't classify (Azure AI Foundry, MiniMax, Zhipu GLM, LiteLLM proxies, …).
 ```
 
 :::tip


### PR DESCRIPTION
## Summary

#26824 (salvage of #10273, merged 2026-05-16) added a new `delegation.api_mode` config key so subagent delegation can honor an explicit wire-protocol override when `_detect_api_mode_for_url()` can't classify a custom `base_url` (Azure AI Foundry, MiniMax, Zhipu GLM, LiteLLM proxies, …). `hermes_cli/config.py` documents the key inline, but the user-facing website docs still only mention `model`, `provider`, `base_url`, and `api_key` for the direct-endpoint path, so users hitting the 404 #26824 fixes have no docs to point at.

This patch surfaces `api_mode` in the two user-guide pages that already enumerate the delegation YAML keys.

## Changes

- `website/docs/user-guide/configuration.md` (**Delegation** section): add the `# api_mode: ""` line to the commented YAML example next to `api_key`, and a new **Wire protocol (`api_mode`)** paragraph after **Direct endpoint override** that paraphrases the auto-detect rules and lists the three valid values.
- `website/docs/user-guide/features/delegation.md` (**Configuration** subsection): add a commented `api_mode` line to the "Or use a direct custom endpoint" YAML block so the example matches the one in `configuration.md`.

Value set (`chat_completions`, `codex_responses`, `anthropic_messages`) and auto-detect behavior are taken verbatim from the `hermes_cli/config.py` docstring written by #26824. No claim is made about auto-detect handling endpoints beyond the URL/known-host heuristics in `_detect_api_mode_for_url()`.

4 LOC additive total; no source-code change.

## Test plan

- Documentation-only change.
- Verified the value set against `hermes_cli/config.py` lines 1149-1152 (added by #26824).
- Verified auto-detect rules against #26824's PR description: `/anthropic` suffix → `anthropic_messages`, plus retained `chatgpt.com/backend-api/codex`, `api.anthropic.com`, `api.kimi.com/coding` hostname overrides.
- Sibling-PR poach guard: no OPEN PR touches `website/docs/user-guide/configuration.md` Delegation section or `features/delegation.md` for `api_mode` (#7176 covers `model.api_mode` in `integrations/providers.md`, different config namespace).

