### PR TITLE
feat(gateway/discord): emit `discord:message` hook event for observers

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -15,6 +15,10 @@ Events:
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
   - command:*           -- Any slash command executed (wildcard match)
+  - discord:message     -- A Discord message reached the gateway (post-dedup,
+                           post-self-filter, post-system-message-filter; fires
+                           regardless of DISCORD_ALLOW_BOTS so observation
+                           hooks can see all third-party traffic)
 
 Errors in hooks are caught and logged but never block the main pipeline.
 """

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -739,6 +739,29 @@ class DiscordAdapter(BasePlatformAdapter):
                 if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
                     return
 
+                # Fire `discord:message` hook for any registered observer.
+                # Runs AFTER dedup + self-message + system-message filters but
+                # BEFORE the DISCORD_ALLOW_BOTS gate, so hooks observe all
+                # third-party traffic regardless of the agent's chat-command
+                # bot policy. Hook failures are swallowed by the registry.
+                _gw_runner = getattr(adapter_self, "gateway_runner", None)
+                _hook_registry = getattr(_gw_runner, "hooks", None) if _gw_runner is not None else None
+                if _hook_registry is not None:
+                    try:
+                        await _hook_registry.emit("discord:message", {
+                            "platform": "discord",
+                            "message_id": str(message.id),
+                            "channel_id": str(getattr(getattr(message, "channel", None), "id", "") or ""),
+                            "guild_id": str(getattr(getattr(message, "guild", None), "id", "") or ""),
+                            "author_id": str(getattr(message.author, "id", "") or ""),
+                            "author_username": str(getattr(message.author, "name", "") or getattr(message.author, "username", "") or ""),
+                            "author_bot": bool(getattr(message.author, "bot", False)),
+                            "content": message.content or "",
+                            "created_at": message.created_at.isoformat() if message.created_at else None,
+                        })
+                    except Exception:
+                        logger.debug("[hooks] discord:message emit failed", exc_info=True)
+
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
                 #   "mentions" — accept bot messages only when they @mention us


### PR DESCRIPTION
## Summary
Adds a single `await self.hooks.emit("discord:message", ctx)` call near the top of `gateway/platforms/discord.py:on_message` so registered hooks in `~/.hermes/hooks/` can observe inbound Discord messages without patching the daemon.

## Placement
After dedup + self-message + system-message filters, **before** the `DISCORD_ALLOW_BOTS` gate. This means observation hooks see all third-party traffic regardless of the agent's chat-command bot policy — which is what observers (as opposed to chat-command handlers) actually want.

## Context dict
```python
{
  "platform":        "discord",
  "message_id":      "1505...",
  "channel_id":      "1496...",
  "guild_id":        "...",
  "author_id":       "...",
  "author_username": "Github Bot",
  "author_bot":      True,
  "content":         "✅ **PR merged to main** — ...",
  "created_at":      "2026-05-16T19:00:16+00:00",
}
```
The minimal stable shape that lets hooks filter and react without coupling to `discord.py` internals.

## Use case
The motivating scenario is a third-party "react to a specific channel" hook — e.g., listen for GitHub-bot lifecycle posts in an `#infrastructure` channel and mutate an external project board. Today this requires patching `discord.py` directly because no platform-message event exists in the registry. A 6-line emit unblocks the pattern without expanding the daemon's responsibility.

Example consumer (in `~/.hermes/hooks/board-sync/handler.py`):
```python
async def handle(event_type, context):
    if context.get("channel_id") != "1496...":   return
    if not context.get("author_bot"):            return
    # parse + mutate external board
```

## Cost / risk
- **No new dependencies.**
- **Fast path** (no hooks registered for `discord:message`): one `getattr` + `is None` check. Measured no observable overhead in local benchmarks.
- **Hook failures swallowed** by the existing `HookRegistry.emit` contract — same guarantee as `agent:start` / `session:end` / `command:*`.
- **No change to existing event semantics** — purely additive.

## Docs
Updated the events list in `gateway/hooks.py`'s module docstring.

## Future / out of scope
This PR intentionally only adds `discord:message`. Parity events on other platforms (`slack:message`, `telegram:message`, `whatsapp:message`, `matrix:message`) could follow the same pattern but are deferred to keep this change single-concern.

## Test plan
- [x] `python -m py_compile gateway/platforms/discord.py gateway/hooks.py` clean.
- [x] Existing `tests/gateway/test_hooks.py` unaffected (registry semantics unchanged).
- [x] Manually verified end-to-end against a local Hermes 0.13.0 install: a custom `~/.hermes/hooks/<name>/` handler subscribing to `discord:message` receives the context for every inbound message in real time after a `hermes gateway restart`.

Happy to add a unit test that registers a `discord:message` hook against a tmp_path and asserts emit dispatches correctly, if reviewers want one.