### PR TITLE
feat(dashboard): allow trusted reverse-proxy Host headers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -97,7 +97,10 @@ _REVEAL_WINDOW_SECONDS = 30
 
 # CORS: restrict to localhost origins only.  The web UI is intended to run
 # locally; binding to 0.0.0.0 with allow_origins=["*"] would let any website
-# read/modify config and secrets.
+# read/modify config and secrets.  Trusted reverse-proxy hostnames allowed via
+# HERMES_DASHBOARD_ALLOWED_HOSTS are intentionally not added here: navigating
+# directly to a proxied dashboard origin (for example via Tailscale Serve) is
+# not a cross-origin browser fetch.
 
 app.add_middleware(
     CORSMiddleware,
@@ -159,6 +162,38 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _host_header_name(host_header: str) -> str:
+    """Return the hostname portion of a Host header, lower-cased.
+
+    Accepts plain hosts, host:port, [IPv6], and [IPv6]:port forms.
+    """
+    h = host_header.strip()
+    if h.startswith("["):
+        close = h.find("]")
+        if close != -1:
+            return h[1:close].lower()
+        return h.strip("[]").lower()
+    return (h.rsplit(":", 1)[0] if ":" in h else h).lower()
+
+
+def _configured_allowed_host_values() -> set[str]:
+    """Explicit extra Host values accepted for trusted reverse proxies.
+
+    This is intentionally opt-in so loopback dashboard binds keep their DNS
+    rebinding protection by default, while local tailnet proxies such as
+    ``tailscale serve`` can forward requests using their public tailnet
+    hostname without requiring the dashboard itself to bind to 0.0.0.0.
+    Values are matched literally after host/port normalization; wildcards
+    and globs are not expanded.
+    """
+    raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    return {
+        _host_header_name(part)
+        for part in raw.replace(";", ",").split(",")
+        if part.strip()
+    }
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -176,17 +211,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     # Plain hosts/v4:
     #   localhost:9119
     #   127.0.0.1:9119
-    h = host_header.strip()
-    if h.startswith("["):
-        # IPv6 bracketed — port (if any) follows "]:"
-        close = h.find("]")
-        if close != -1:
-            host_only = h[1:close]  # strip brackets
-        else:
-            host_only = h.strip("[]")
-    else:
-        host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
+    host_only = _host_header_name(host_header)
+
+    if host_only in _configured_allowed_host_values():
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -83,6 +83,42 @@ class TestHostHeaderValidator:
         assert _is_accepted_host("LOCALHOST", "127.0.0.1")
         assert _is_accepted_host("LocalHost:9119", "127.0.0.1")
 
+    def test_bracketed_ipv6_host_headers_strip_port(self):
+        """IPv6 Host headers use bracket notation when a port is present."""
+        from hermes_cli.web_server import _host_header_name, _is_accepted_host
+
+        assert _host_header_name("[::1]") == "::1"
+        assert _host_header_name("[::1]:9119") == "::1"
+        assert _host_header_name("[2001:db8::1]") == "2001:db8::1"
+        assert _host_header_name("[2001:db8::1]:9119") == "2001:db8::1"
+        assert _is_accepted_host("[::1]:9119", "::1")
+        assert _is_accepted_host("[2001:db8::1]:9119", "2001:db8::1")
+
+    def test_explicit_allowed_host_env_for_trusted_proxy(self, monkeypatch):
+        """Trusted local proxies can opt in an external Host while the
+        dashboard remains bound to loopback."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "dashboard.example.ts.net")
+
+        assert _is_accepted_host("dashboard.example.ts.net", "127.0.0.1")
+        assert _is_accepted_host("dashboard.example.ts.net:443", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+
+    def test_allowed_host_env_normalizes_multiple_hosts(self, monkeypatch):
+        """The proxy allowlist accepts comma/semicolon-delimited hosts and ports."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_HOSTS",
+            "Dashboard.Example.TS.net:443, other.example.ts.net; [2001:db8::1]:443",
+        )
+
+        assert _is_accepted_host("dashboard.example.ts.net", "127.0.0.1")
+        assert _is_accepted_host("OTHER.EXAMPLE.TS.NET:8443", "127.0.0.1")
+        assert _is_accepted_host("[2001:db8::1]:8443", "127.0.0.1")
+        assert not _is_accepted_host("unlisted.example.ts.net", "127.0.0.1")
+
 
 class TestHostHeaderMiddleware:
     """End-to-end test via the FastAPI app — verify the middleware

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -16,6 +16,16 @@ hermes dashboard
 
 This starts a local web server and opens `http://127.0.0.1:9119` in your browser. The dashboard runs entirely on your machine — no data leaves localhost.
 
+### Reverse proxies and Tailscale Serve
+
+Keep the dashboard bound to `127.0.0.1` when publishing it through a trusted local reverse proxy such as Tailscale Serve. The dashboard validates the HTTP `Host` header to defend against DNS rebinding attacks, so proxied requests with an external hostname must be explicitly allowed:
+
+```bash
+HERMES_DASHBOARD_ALLOWED_HOSTS=dashboard.example.ts.net hermes dashboard --no-open
+```
+
+`HERMES_DASHBOARD_ALLOWED_HOSTS` accepts comma- or semicolon-delimited hostnames. Ports are normalized away, and values are matched literally; wildcards such as `*.example.ts.net` are not expanded. Only add hostnames from reverse proxies you trust.
+
 ### Options
 
 | Flag | Default | Description |


### PR DESCRIPTION
## What does this PR do?

Adds an explicit trusted Host-header allowlist for the Hermes dashboard so operators can keep the dashboard bound to loopback while accessing it through a trusted local reverse proxy such as Tailscale Serve.

Today, that safer setup can fail with `Invalid Host header` because the browser reaches the dashboard using the reverse proxy's external hostname while Hermes is bound to `127.0.0.1`. Binding the dashboard directly to `0.0.0.0 --insecure` works around that, but it weakens the default safety model.

This PR keeps the existing DNS-rebinding protection by default and adds an opt-in `HERMES_DASHBOARD_ALLOWED_HOSTS` environment variable for trusted reverse-proxy hostnames. Host values are normalized before comparison, including `host:port` and bracketed IPv6 forms such as `[::1]:9119`.

It also documents the Tailscale Serve/reverse-proxy pattern and clarifies why these trusted proxy hosts are not added to CORS origins: navigating directly to the proxied dashboard hostname is not a cross-origin browser fetch.

## Related Issue

Related to #10567 and #15731.

Also related to the currently open #20136, which takes a broader config-based approach for trusted reverse proxy hosts and WebSocket validation. This PR is the smaller environment-variable scoped approach for HTTP Host-header validation and documentation.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Add `_host_header_name()` to normalize Host headers consistently.
  - Add `_configured_allowed_host_values()` to parse `HERMES_DASHBOARD_ALLOWED_HOSTS` as comma- or semicolon-delimited hostnames.
  - Accept explicitly configured trusted hosts in `_is_accepted_host()` while preserving default localhost/DNS-rebinding protections.
  - Document that allowed hosts are matched literally and do not support wildcards/globs.
  - Clarify why reverse-proxy hostnames are intentionally not added to CORS origins.
- `tests/hermes_cli/test_web_server_host_header.py`
  - Add coverage for trusted proxy host allowlisting.
  - Add regression coverage for bracketed IPv6 Host headers with and without ports.
  - Add coverage for comma/semicolon-delimited allowlist entries, case normalization, port stripping, and IPv6 allowlist entries.
- `website/docs/user-guide/features/web-dashboard.md`
  - Add a short reverse-proxy/Tailscale Serve section showing loopback binding plus `HERMES_DASHBOARD_ALLOWED_HOSTS`.
  - Document delimiter behavior, port normalization, literal matching, and wildcard non-support.

## How to Test

1. Run the Host-header test suite:

   ```bash
   python -m pytest tests/hermes_cli/test_web_server_host_header.py -q -o 'addopts='
   ```

   Expected result:

   ```text
   11 passed
   ```

2. For a manual Tailscale Serve/local reverse-proxy setup, keep Hermes bound to loopback and set the trusted proxy hostname:

   ```bash
   HERMES_DASHBOARD_ALLOWED_HOSTS=dashboard.example.ts.net hermes dashboard --host 127.0.0.1 --no-open
   ```

3. Verify accepted and rejected Host headers against the loopback-bound dashboard:

   ```bash
   curl -i -H 'Host: dashboard.example.ts.net' http://127.0.0.1:9119/api/status
   curl -i -H 'Host: evil.example' http://127.0.0.1:9119/api/status
   ```

   The configured trusted host should be accepted, while an unlisted external host should still be rejected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (`HERMES_DASHBOARD_ALLOWED_HOSTS` is an environment variable, not a config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests pass:

```text
$ python -m pytest tests/hermes_cli/test_web_server_host_header.py -q -o 'addopts='
...........                                                              [100%]
11 passed in 0.73s
```

I also attempted the full suite with:

```bash
python -m pytest tests/ -q -o 'addopts='
```

The run does not complete cleanly on the current branch because of an existing baseline failure that is also present on `origin/main`:

```text
FAILED tests/acp/test_registry_manifest.py::test_agent_json_version_matches_pyproject
FAILED tests/acp/test_registry_manifest.py::test_agent_json_pins_uvx_package_to_pyproject_version
```

Both `origin/main` and this branch currently have:

```text
acp_registry/agent.json: 0.13.0
pyproject.toml: 0.14.0
```

So the full-suite checkbox is intentionally left unchecked; the targeted dashboard tests for this change pass.
