### PR TITLE
fix(gateway): synthetic/queued messages routed to wrong Telegram DM topic

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12178,6 +12178,12 @@ class GatewayRunner:
             and getattr(source, "chat_type", None) == "dm"
         ):
             metadata["telegram_dm_topic_reply_fallback"] = True
+            # Telegram DM topic lanes need direct_messages_topic_id in metadata
+            # so synthetic/queued messages (goal continuations, status notices)
+            # route to the correct topic even when reply anchor is unavailable.
+            tid = str(thread_id)
+            if tid and tid not in {"", "1"}:
+                metadata["direct_messages_topic_id"] = tid
             anchor = reply_to_message_id or getattr(source, "message_id", None)
             if anchor is not None:
                 metadata["telegram_reply_to_message_id"] = str(anchor)


### PR DESCRIPTION
Fixes #27139

## Bug
When `/goal` is active in a Telegram DM thread and the judge decides to continue, the continuation message is generated as a synthetic `MessageEvent` (via `_defer_goal_status_notice_after_delivery`). These synthetic events have `message_id=None` and are queued via `_enqueue_fifo` for deferred delivery.

Because the reply anchor is missing, `_thread_metadata_for_source` only set `telegram_dm_topic_reply_fallback=True` but never included `direct_messages_topic_id`. The Telegram adapter then falls back to `message_thread_id=None`, causing the message to land in the root "All Messages" thread instead of the active topic lane.

Session context and transcripts were still correct (session key includes `thread_id`), but replies were visually lost to the user.

## Fix
Include `direct_messages_topic_id` in thread metadata for all non-General Telegram DM topics. This ensures queued/synthetic messages (goal continuations, status notices) are routed to the correct thread even when no reply anchor exists.

### Files changed
- `gateway/run.py`: added `direct_messages_topic_id` assignment in `_thread_metadata_for_source` for Telegram DM topics.

## Test
- [ ] Tested with `/goal` continuation in a Telegram DM topic thread.
- [ ] Confirmed messages now appear in the correct topic lane, not "All Messages".