### PR TITLE
fix(docker): bake messaging extras into the image (#27100)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,20 @@ RUN npm install --prefer-offline --no-audit && \
 # frontend stats the readme path during dep resolution, so we `touch` an
 # empty placeholder — the real README is restored by `COPY . .` below.
 #
-# `uv sync --frozen --no-install-project --extra all` installs only the
-# deps reachable through the composite `[all]` extra (handpicked set
-# intended for the production image).  We do NOT use `--all-extras`:
+# `uv sync --frozen --no-install-project --extra all --extra messaging`
+# installs the deps reachable through `[all]` plus the `[messaging]` extra
+# (python-telegram-bot, discord.py, slack-bolt/sdk, …).  `[all]` deliberately
+# excludes messaging because most extras lazy-install at first use via
+# `tools/lazy_deps.py`, but that path requires a hermes-writable `.venv`.
+# When a user runs the container with `docker run --user $(id -u):$(id -g)`
+# the entrypoint enters directly as the host UID and skips the root branch
+# that re-chowns `/opt/hermes/.venv` to match — so lazy installs of telegram
+# / discord / slack fail with EACCES and the gateway adapters silently
+# refuse to start (see #27100).  Baking messaging deps into the image makes
+# the common chat-gateway path work out of the box under `--user`, matching
+# what the Nix build now does (#27056 / NixOS #27047).
+#
+# We do NOT use `--all-extras`:
 # that would pull in `[rl]` (atroposlib + tinker + torch + wandb from
 # git), `[yc-bench]` (another git dep), and `[termux-all]` (Android
 # redundancy), none of which belong in the published container.
@@ -76,7 +87,7 @@ RUN npm install --prefer-offline --no-audit && \
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all
+RUN uv sync --frozen --no-install-project --extra all --extra messaging
 
 # ---------- Source code ----------
 # .dockerignore excludes node_modules, so the installs above survive.


### PR DESCRIPTION
## Summary
Fixes #27100.

v0.14.0 moved `python-telegram-bot`, `discord.py`, and `slack-bolt/sdk` out of `[all]` into the `[messaging]` extra, with the expectation that `tools/lazy_deps.py` will install them at first use. That path needs a hermes-writable `.venv`.

When users run the container with `docker run --user $(id -u):$(id -g)`, the entrypoint enters directly as the host UID and skips the `if [ "$(id -u)" = "0" ]` branch that re-chowns `/opt/hermes/.venv`. The venv is shipped owned by `hermes` (UID 10000), so `uv pip install python-telegram-bot` fails with EACCES and the Telegram / Discord / Slack gateway adapters silently never load.

The reporter's documented workaround:

```bash
docker exec -u root hermes chown -R 1000:1000 /opt/hermes/.venv
docker exec hermes uv pip install python-telegram-bot --python /opt/hermes/.venv/bin/python3
docker restart hermes
```

…confirms both halves of the failure: the venv permission and the missing package.

## Fix
Bake the `[messaging]` extra into the eager `uv sync` step:

```diff
- RUN uv sync --frozen --no-install-project --extra all
+ RUN uv sync --frozen --no-install-project --extra all --extra messaging
```

No more first-boot lazy install for the chat-gateway base case, so the EACCES path is sidestepped under `--user`.

## Why this matches the Nix fix
PR #27056 (closes #27047) made the Nix build include `messaging` by default for the same class of failure on NixOS (no pip-at-runtime path). Docker has the same property under `--user`: the image is effectively sealed once UID is dropped. Keeping messaging out of `[all]` only really works for the unconstrained `docker run` (UID 10000) case where lazy_deps can still write to `.venv`.

## Scope
Single-line dependency change in `Dockerfile`. No code paths touched, no tests practical for Dockerfile content. CI Docker build will exercise the new `uv sync` step.

## Out of scope (follow-ups)
- The `.venv` ownership mismatch under `--user` is still a latent problem for *any* future lazy-install (e.g. `feishu`, `dingtalk`, `voice`). A separate change could either always chmod `.venv` group-writable for an "any-UID-can-write" mode, or document that lazy_deps will not work under `--user`. Out of scope for this PR.
- `[all]` policy on messaging: I left `[all]` itself unchanged so non-Docker installs continue to lazy-install. Only the Docker image gets messaging eagerly.
