### PR TITLE
fix(gateway): resolve channel directory from active HERMES_HOME

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -17,6 +17,19 @@ from utils import atomic_json_write
 logger = logging.getLogger(__name__)
 
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+_INITIAL_DIRECTORY_PATH = DIRECTORY_PATH
+
+
+def _directory_path():
+    """Return the active channel-directory cache path.
+
+    Keep the public ``DIRECTORY_PATH`` override working for tests and callers
+    that monkeypatch it, but otherwise resolve HERMES_HOME at call time so
+    profile switches do not keep using the path captured at import.
+    """
+    if DIRECTORY_PATH != _INITIAL_DIRECTORY_PATH:
+        return DIRECTORY_PATH
+    return get_hermes_home() / "channel_directory.json"
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -61,7 +74,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     Build a channel directory from connected platform adapters and session data.
 
-    Returns the directory dict and writes it to DIRECTORY_PATH.
+    Returns the directory dict and writes it under the active HERMES_HOME.
     """
     from gateway.config import Platform
 
@@ -102,7 +115,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        atomic_json_write(DIRECTORY_PATH, directory)
+        atomic_json_write(_directory_path(), directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 
@@ -246,10 +259,11 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 
 def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
-    if not DIRECTORY_PATH.exists():
+    directory_path = _directory_path()
+    if not directory_path.exists():
         return {"updated_at": None, "platforms": {}}
     try:
-        with open(DIRECTORY_PATH, encoding="utf-8") as f:
+        with open(directory_path, encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return {"updated_at": None, "platforms": {}}

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -49,6 +49,26 @@ class TestLoadDirectory:
             result = load_directory()
         assert result["updated_at"] is None
 
+    def test_uses_current_hermes_home_after_import(self, tmp_path, monkeypatch):
+        first_home = tmp_path / "first"
+        second_home = tmp_path / "second"
+        first_home.mkdir()
+        second_home.mkdir()
+        (first_home / "channel_directory.json").write_text(json.dumps({
+            "updated_at": "2026-01-01T00:00:00",
+            "platforms": {"telegram": [{"id": "old", "name": "Old", "type": "dm"}]},
+        }))
+        (second_home / "channel_directory.json").write_text(json.dumps({
+            "updated_at": "2026-01-01T00:00:00",
+            "platforms": {"telegram": [{"id": "new", "name": "New", "type": "dm"}]},
+        }))
+
+        monkeypatch.setenv("HERMES_HOME", str(first_home))
+        assert load_directory()["platforms"]["telegram"][0]["id"] == "old"
+
+        monkeypatch.setenv("HERMES_HOME", str(second_home))
+        assert load_directory()["platforms"]["telegram"][0]["id"] == "new"
+
 
 class TestBuildChannelDirectoryWrites:
     def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes a profile-isolation bug in the gateway channel directory cache.

`gateway.channel_directory` computed `DIRECTORY_PATH` at module import time, so long-lived processes, tests, or profile-switching flows could keep reading or writing the `channel_directory.json` path captured when the module was first imported, even after `HERMES_HOME` changed.

This PR resolves the active channel directory path at read/write time while preserving the existing `DIRECTORY_PATH` override behavior used by tests.

## Why

Hermes supports profile-scoped state through `HERMES_HOME`. The channel directory is used by gateway routing and `send_message` helpers to resolve human-friendly channel names into platform IDs.

If the cache path is pinned to the wrong profile, Hermes can read stale channel metadata from another profile or write refreshed channel discovery data to the wrong location.

That can cause confusing behavior such as:

- Channel name resolution using stale profile state
- `/sethome` or channel discovery appearing inconsistent across profiles
- Long-lived gateway processes leaking channel directory state across `HERMES_HOME` changes

## Changes

- Added `_directory_path()` in `gateway/channel_directory.py`.
- Updated `build_channel_directory()` to write to the active `HERMES_HOME`.
- Updated `load_directory()` to read from the active `HERMES_HOME`.
- Preserved `DIRECTORY_PATH` monkeypatch compatibility for existing tests.
- Added a regression test proving `load_directory()` follows the current `HERMES_HOME` after module import.

## Testing

uv run pytest tests/gateway/test_channel_directory.py -q  34 passed

uv run pytest tests/tools/test_send_message_tool.py::TestSendMessageTool::test_display_label_target_resolves_via_channel_directory tests/tools/test_send_message_tool.py::TestSendMessageTool::test_resolved_telegram_topic_name_preserves_thread_id -q

2 passed

PYTHONIOENCODING=utf-8 uv run python scripts/check-windows-footguns.py gateway/channel_directory.py tests/gateway/test_channel_directory.py

No Windows footguns found
