### PR TITLE
feat(xai): add opt-in Grok operational guidance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1217,6 +1217,11 @@ def init_agent(
     # targets.
     agent._task_completion_guidance = bool(_agent_section.get("task_completion_guidance", True))
 
+    # Opt-in xAI/Grok Claim-Action-Evidence operational guidance.  Default
+    # False (opt-in) because this model-specific prompt layer can regress
+    # task routing; only injected for grok models when explicitly enabled.
+    agent._xai_operational_guidance = bool(_agent_section.get("xai_operational_guidance", False))
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -394,6 +394,29 @@ GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
     "Don't stop with a plan — execute it.\n"
 )
 
+XAI_MODEL_OPERATIONAL_GUIDANCE = (
+    "# xAI/Grok operational guidance\n"
+    "Preserve Claim-Action-Evidence discipline in this Hermes runtime:\n"
+    "- Treat Hermes tools as the only evidence that external state changed. "
+    "Do not claim that files, config, git state, messages, tickets, memory, "
+    "or remote machines were changed unless a recent tool result supports it.\n"
+    "- When the user asks for an action and a relevant tool is available, call "
+    "the tool instead of narrating the intended action. If no safe tool path "
+    "exists, report the blocker precisely.\n"
+    "- After any state-changing action, verify the observable post-state before "
+    "finalizing. Scope the final claim to what was actually observed.\n"
+    "- If a tool call fails, adapt on the next attempt: inspect the error, "
+    "check the schema or runtime state when possible, and change the arguments "
+    "or strategy. Do not repeat the same invalid call.\n"
+    "- For runtime-capability questions, inspect the available tools, config, "
+    "filesystem, or shell environment when those tools are available. Do not "
+    "turn a hidden-system-prompt boundary into a broad claim that you have no "
+    "runtime introspection.\n"
+    "- Route by target, not by habit: distinguish local vs remote machines, "
+    "the current repo vs another checkout, web pages vs X posts, and existing "
+    "collections or files vs general search.\n"
+)
+
 
 # Guidance injected into the system prompt when the computer_use toolset
 # is active. Universal — works for any model (Claude, GPT, open models).

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -40,6 +40,7 @@ from agent.prompt_builder import (
     TASK_COMPLETION_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    XAI_MODEL_OPERATIONAL_GUIDANCE,
 )
 from agent.runtime_cwd import resolve_context_cwd
 
@@ -181,6 +182,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # existing tools, replies with plans instead of executing).
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+            # Opt-in xAI/Grok Claim-Action-Evidence layer.  Gated OFF by
+            # default behind agent.xai_operational_guidance because
+            # model-specific prompt tuning can regress task routing.
+            if "grok" in _model_lower and getattr(agent, "_xai_operational_guidance", False):
+                stable_parts.append(XAI_MODEL_OPERATIONAL_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -23,6 +23,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    XAI_MODEL_OPERATIONAL_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -1342,6 +1343,38 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_is_string(self):
         assert isinstance(OPENAI_MODEL_EXECUTION_GUIDANCE, str)
         assert len(OPENAI_MODEL_EXECUTION_GUIDANCE) > 100
+
+
+class TestXAIModelOperationalGuidance:
+    """Tests for xAI/Grok-specific operational guidance."""
+
+    def test_guidance_covers_claim_action_evidence(self):
+        text = XAI_MODEL_OPERATIONAL_GUIDANCE.lower()
+        assert "claim-action-evidence" in text
+        assert "external state changed" in text
+        assert "recent tool result" in text
+
+    def test_guidance_covers_verification_and_scope(self):
+        text = XAI_MODEL_OPERATIONAL_GUIDANCE.lower()
+        assert "verify" in text
+        assert "post-state" in text
+        assert "scope the final claim" in text
+
+    def test_guidance_covers_tool_error_recovery(self):
+        text = XAI_MODEL_OPERATIONAL_GUIDANCE.lower()
+        assert "tool call fails" in text
+        assert "schema" in text
+        assert "do not repeat" in text
+
+    def test_guidance_covers_runtime_self_awareness(self):
+        text = XAI_MODEL_OPERATIONAL_GUIDANCE.lower()
+        assert "runtime-capability" in text
+        assert "hidden-system-prompt" in text
+        assert "runtime introspection" in text
+
+    def test_guidance_is_string(self):
+        assert isinstance(XAI_MODEL_OPERATIONAL_GUIDANCE, str)
+        assert len(XAI_MODEL_OPERATIONAL_GUIDANCE) > 100
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1152,8 +1152,17 @@ class TestBuildSystemPrompt:
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""
 
-    def _make_agent(self, model="openai/gpt-4.1", tool_use_enforcement="auto"):
+    def _make_agent(
+        self,
+        model="openai/gpt-4.1",
+        tool_use_enforcement="auto",
+        xai_operational_guidance=False,
+    ):
         """Create an agent with tools and a specific enforcement config."""
+        agent_config = {
+            "tool_use_enforcement": tool_use_enforcement,
+            "xai_operational_guidance": xai_operational_guidance,
+        }
         with (
             patch(
                 "run_agent.get_tool_definitions",
@@ -1163,7 +1172,7 @@ class TestToolUseEnforcementConfig:
             patch("run_agent.OpenAI"),
             patch(
                 "hermes_cli.config.load_config",
-                return_value={"agent": {"tool_use_enforcement": tool_use_enforcement}},
+                return_value={"agent": agent_config},
             ),
         ):
             a = AIAgent(
@@ -1201,6 +1210,45 @@ class TestToolUseEnforcementConfig:
         agent = self._make_agent(model="x-ai/grok-4.3", tool_use_enforcement="auto")
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_xai_guidance_skipped_for_grok_by_default(self):
+        """The opt-in xAI layer is OFF by default, even for grok models."""
+        from agent.prompt_builder import (
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+            XAI_MODEL_OPERATIONAL_GUIDANCE,
+        )
+        agent = self._make_agent(model="x-ai/grok-4.3", tool_use_enforcement="auto")
+        assert agent._xai_operational_guidance is False
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+        assert XAI_MODEL_OPERATIONAL_GUIDANCE not in prompt
+
+    def test_xai_guidance_injected_for_grok_when_opted_in(self):
+        """With the flag on, the xAI layer is injected for grok models."""
+        from agent.prompt_builder import (
+            TOOL_USE_ENFORCEMENT_GUIDANCE,
+            XAI_MODEL_OPERATIONAL_GUIDANCE,
+        )
+        agent = self._make_agent(
+            model="x-ai/grok-4.3",
+            tool_use_enforcement="auto",
+            xai_operational_guidance=True,
+        )
+        assert agent._xai_operational_guidance is True
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+        assert XAI_MODEL_OPERATIONAL_GUIDANCE in prompt
+
+    def test_xai_guidance_skipped_for_non_grok_even_when_opted_in(self):
+        """The xAI layer is grok-only; a GPT model never gets it."""
+        from agent.prompt_builder import XAI_MODEL_OPERATIONAL_GUIDANCE
+        agent = self._make_agent(
+            model="openai/gpt-4.1",
+            tool_use_enforcement="auto",
+            xai_operational_guidance=True,
+        )
+        prompt = agent._build_system_prompt()
+        assert XAI_MODEL_OPERATIONAL_GUIDANCE not in prompt
 
     def test_auto_injects_for_qwen(self):
         """Qwen models default to chatty/hallucinatory tool use without enforcement."""

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1166,6 +1166,7 @@ Some models occasionally describe intended actions as text instead of making too
 ```yaml
 agent:
   tool_use_enforcement: "auto"   # "auto" | true | false | ["model-substring", ...]
+  xai_operational_guidance: false # experimental opt-in for Grok/xAI models
 ```
 
 | Value | Behavior |
@@ -1177,7 +1178,7 @@ agent:
 
 ### What it injects
 
-When enabled, three layers of guidance may be added to the system prompt:
+When enabled, up to four layers of guidance may be added to the system prompt:
 
 1. **General tool-use enforcement** (all matched models) — instructs the model to make tool calls immediately instead of describing intentions, keep working until the task is complete, and never end a turn with a promise of future action.
 
@@ -1185,7 +1186,11 @@ When enabled, three layers of guidance may be added to the system prompt:
 
 3. **Google operational guidance** (Gemini and Gemma models only) — conciseness, absolute paths, parallel tool calls, and verify-before-edit patterns.
 
+4. **xAI/Grok operational guidance** (Grok/xAI models only, disabled by default) — experimental Claim-Action-Evidence discipline for Hermes runtimes: verify post-state before final claims,
+   recover from tool errors by changing strategy, inspect runtime capabilities when tools are available, and route actions to the correct environment or domain.
+
 These are transparent to the user and only affect the system prompt. Models that already use tools reliably (like Claude) don't need this guidance, which is why `"auto"` excludes them.
+The xAI/Grok-specific layer is additionally guarded by `agent.xai_operational_guidance: true` because model-specific prompt tuning can regress task routing.
 
 ### When to turn it on
 


### PR DESCRIPTION
## Summary

Adds a Grok/xAI-specific operational guidance block to Hermes' existing tool-use enforcement prompt path, but keeps it disabled by default behind `agent.xai_operational_guidance: true`.

The guidance focuses on Claim-Action-Evidence discipline in Hermes runtimes: only claim external state changes when tool evidence supports them, verify post-state after state-changing actions, adapt after tool errors, inspect runtime capabilities when tools are available, and route actions to the correct environment/domain.

## Why

Hermes already has provider/model-specific prompt guidance for GPT/Codex and Gemini/Gemma. Grok models currently receive the generic tool-use enforcement block, and this PR adds an experimental Grok-specific layer for operators who want to dogfood it explicitly.

This is intentionally opt-in. A quick A/B dogfood run showed mixed behavioral results, including a possible routing regression, so the PR no longer changes default Grok behavior.

## Validation

- `uv run --python 3.11 --extra dev ruff check agent/prompt_builder.py run_agent.py tests/agent/test_prompt_builder.py tests/run_agent/test_run_agent.py`
- `git diff --check`
- `uv run --python 3.11 --extra dev pytest tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance tests/agent/test_prompt_builder.py::TestOpenAIModelExecutionGuidance tests/agent/test_prompt_builder.py::TestXAIModelOperationalGuidance tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig -q`
- `uv run --python 3.11 --extra dev pytest tests/agent/test_prompt_builder.py tests/run_agent/test_run_agent.py -q`
- GitHub Actions on `4ea07596`: green
