### PR TITLE
fix(update): print snapshot restore hint so users can recover state (#26737)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7908,18 +7908,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print(f"→ Found {commit_count} new commit(s)")
 
-        # Snapshot critical state (state.db, config, pairing JSONs, etc.)
-        # before pulling so a user can recover if something goes wrong.
-        # Issue #15733 reported missing pairing data after an update; even
-        # though `git pull` can't touch $HERMES_HOME, this is cheap
-        # belt-and-suspenders insurance and gives the user something to
-        # restore from via `/snapshot list` / `/snapshot restore <id>`.
+        # Snapshot critical state (state.db, config, cron jobs, pairing JSONs,
+        # etc.) before pulling so a user can recover if something goes wrong.
+        # Issue #15733 reported missing pairing data after an update; #26737
+        # reported the same fear for cron jobs.  Even though `git pull` can't
+        # touch $HERMES_HOME, this is cheap belt-and-suspenders insurance and
+        # gives the user something to restore from.  We always print the
+        # restore hint so the safety net is discoverable even when the
+        # agent / LLM doesn't know where state lives.
         try:
             from hermes_cli.backup import create_quick_snapshot
 
             snap_id = create_quick_snapshot(label="pre-update")
             if snap_id:
                 print(f"  ✓ Pre-update snapshot: {snap_id}")
+                print(f"    Restore inside Hermes with:  /snapshot restore {snap_id}")
         except Exception as exc:
             # Never let a snapshot failure block an update.
             logger.debug("Pre-update snapshot failed: %s", exc)


### PR DESCRIPTION
## Summary
Closes #26737.

The reporter's cron jobs were not actually deleted by `hermes update` — `git pull` can't touch `$HERMES_HOME`, and `cron/jobs.json` is already in `_QUICK_STATE_FILES` so it's captured in the pre-update snapshot that always runs. The user just had no way to discover the recovery path. The agent they asked for help also couldn't find the jobs, because no surface in the update output points at the snapshot directory.

## Root cause
After looking through the code:

- `cmd_update` → `_cmd_update_impl` already calls `create_quick_snapshot(label="pre-update")` unconditionally before pulling.
- `_QUICK_STATE_FILES` in `hermes_cli/backup.py` already includes `cron/jobs.json` (also `state.db`, `config.yaml`, `.env`, `auth.json`, pairing JSONs, …).
- The update output prints only ``✓ Pre-update snapshot: <id>``. No restore command, no path hint.

So the safety net exists but is invisible. The reporter's frustration ("It can't find any. I've asked it to submit a Git issue to you. It now doesn't know how to do that anymore.") tracks with that — the LLM can't help if it doesn't know where state lives.

## Fix
One-line addition right after the snapshot id print:

```diff
 if snap_id:
     print(f"  ✓ Pre-update snapshot: {snap_id}")
+    print(f"    Restore inside Hermes with:  /snapshot restore {snap_id}")
```

Plus a comment update referencing #26737 and noting that the hint is intentionally always-on so it's discoverable even when the agent doesn't know where state lives.

## Scope
Output-only change to the always-on pre-update snapshot block in `_cmd_update_impl`. No tests assert on this print, so the existing 16 quick-snapshot tests still pass:

```
bash scripts/run_tests.sh tests/hermes_cli/test_backup.py -q -k snapshot
# 16 passed in 83.37s
```

## Out of scope (followups)
- The agent itself not knowing where cron jobs live when asked is a tooling / context problem (cron toolset must be enabled, or the agent needs a "where is my data" answer). Not blocking — this PR just guarantees the human always sees the recovery hint.
- The reporter is on `0.13.0+` with the FHS root install. PR #26719 / #22494 (closes #21457) covers the related uv-python-path FHS issue that can make a user perceive HERMES_HOME as having moved. That is a separate fix.
