### PR TITLE
fix(slack): lift own-message echo guard outside DM conditional to prevent inter-agent relay loops

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1704,7 +1704,7 @@ class SlackAdapter(BasePlatformAdapter):
         #   "none"     — ignore all bot messages (default, backward-compatible)
         #   "mentions" — accept bot messages only when they @mention us
         #   "all"      — accept all bot messages (except our own)
-        if event.get("bot_id") or event.get("subtype") == "bot_message":
+        if (event.get("bot_id") or event.get("subtype") == "bot_message") and not event.get("channel", "").startswith("D"):
             allow_bots = self.config.extra.get("allow_bots", "")
             if not allow_bots:
                 allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none")

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1700,10 +1700,20 @@ class SlackAdapter(BasePlatformAdapter):
         if event_ts and self._dedup.is_duplicate(event_ts):
             return
 
+        # Always ignore our own messages to prevent echo loops.
+        # This guard MUST run for ALL channel types — DM channels (starting with "D")
+        # must never process their own bot's messages as inbound, or two Hermes
+        # agents in a DM thread will ping-pong responses indefinitely.
+        msg_user = event.get("user", "")
+        if msg_user and self._bot_user_id and msg_user == self._bot_user_id:
+            return
+
         # Bot message filtering (SLACK_ALLOW_BOTS / config allow_bots):
         #   "none"     — ignore all bot messages (default, backward-compatible)
         #   "mentions" — accept bot messages only when they @mention us
-        #   "all"      — accept all bot messages (except our own)
+        #   "all"      — accept all bot messages
+        # Note: DM channels are excluded from allow_bots filtering below so that
+        # human-to-bot DMs always work regardless of settings.
         if (event.get("bot_id") or event.get("subtype") == "bot_message") and not event.get("channel", "").startswith("D"):
             allow_bots = self.config.extra.get("allow_bots", "")
             if not allow_bots:
@@ -1716,10 +1726,6 @@ class SlackAdapter(BasePlatformAdapter):
                 if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
                     return
             # "all" falls through to process the message
-            # Always ignore our own messages to prevent echo loops
-            msg_user = event.get("user", "")
-            if msg_user and self._bot_user_id and msg_user == self._bot_user_id:
-                return
 
         # Ignore message edits and deletions
         subtype = event.get("subtype")


### PR DESCRIPTION
## Problem

When two Hermes agents communicate in a Slack DM thread, they enter an infinite ping-pong loop (~12s intervals) because each gateway processes the other agent's responses as new inbound messages.

## Root Cause

In `gateway/platforms/slack.py`, the own-message echo prevention check (`msg_user == self._bot_user_id`) was inside a `if (bot_id) and not DM channel` block at line ~1726. DM channels (starting with `"D"`) were excluded from ALL bot message filtering, including the own-message guard.

## Fix

Move the own-message guard to **before** the bot-message filtering block so it applies universally regardless of channel type. A gateway must NEVER process its own bot's messages as inbound.

See: `/home/ubuntu/.hermes/profiles/junior/skills/autonomous-ai-agents/hermes-agent/references/gateway-relay-loop-dm-channels.md` for full reproduction details.

## Verification

- Two-agent DM thread D0B47FGQUBG (Junior ↔ Maria) reproduced the loop consistently before the fix
- Log evidence: `grep "D0B47FGQUBG" ~/.hermes/profiles/*/logs/gateway.log | grep "inbound message"`
- Loop terminated at `Interrupt recursion depth 3` after ~4 min and 9+ iterations