### PR TITLE
fix(acp): parse /model --provider flag for ACP clients

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1513,8 +1513,27 @@ class HermesACPAgent(acp.Agent):
             provider = getattr(state.agent, "provider", None) or "auto"
             return f"Current model: {model}\nProvider: {provider}"
 
+        # Parse --provider/--global flags the same way the CLI /model command
+        # does so ACP clients (Zed, Scarf, etc.) can route a model to an
+        # explicit provider via `/model <model> --provider <name>`. Without
+        # this the entire raw args string was passed through to model
+        # resolution and the current provider rejected it as an unknown model.
+        # See #27119.
+        from hermes_cli.model_switch import parse_model_flags
+
+        model_input, explicit_provider, _persist_global = parse_model_flags(args)
+
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
-        target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        requested_provider = explicit_provider or current_provider
+
+        new_model = model_input or state.model or ""
+
+        if new_model:
+            target_provider, new_model = self._resolve_model_selection(
+                new_model, requested_provider
+            )
+        else:
+            target_provider = requested_provider
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1408,6 +1408,105 @@ class TestSlashCommands:
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
 
+    def test_model_switch_parses_explicit_provider_flag(self, tmp_path, monkeypatch):
+        """`/model <name> --provider <p>` should route to <p>, not the current provider.
+
+        Regression test for #27119: ACP clients (Zed, Scarf, ...) pass the
+        raw args string to ``_cmd_model``. Without ``parse_model_flags`` the
+        entire string ``"inclusionai/ring-2.6-1t --provider openrouter"`` was
+        treated as a literal model id and resolved against the current
+        provider (e.g. Codex), which rejected it as unknown.
+        """
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            provider = requested or "openai-codex"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            # Pretend the active session is on a non-openrouter provider so
+            # we can verify the explicit flag overrides it.
+            state.agent = SimpleNamespace(model="gpt-5.5", provider="openai-codex")
+            result = acp_agent._cmd_model(
+                "inclusionai/ring-2.6-1t --provider openrouter", state
+            )
+
+        assert "Provider: openrouter" in result
+        assert state.model == "inclusionai/ring-2.6-1t"
+        assert state.agent.provider == "openrouter"
+        # The runtime resolver must see the explicit --provider value, not the
+        # session's current provider.
+        assert runtime_calls[-1] == "openrouter"
+
+    def test_model_switch_ignores_global_flag_quietly(self, tmp_path, monkeypatch):
+        """`--global` is a CLI persistence flag; ACP sessions should still
+        accept the rest of the command without treating ``--global`` as part of
+        the model id.
+        """
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            result = acp_agent._cmd_model("sonnet --provider anthropic --global", state)
+
+        assert state.model in {"sonnet", "claude-sonnet-4-6"}
+        assert state.agent.provider == "anthropic"
+        assert "Provider: anthropic" in result
+
 
 # ---------------------------------------------------------------------------
 # _register_session_mcp_servers


### PR DESCRIPTION
## Summary
- ACP's `_cmd_model` previously passed the raw args string straight into `_resolve_model_selection`, so `/model <id> --provider <name>` from an ACP client (Zed, Scarf, ...) was treated as one literal model id and resolved against the current session's provider. On a Codex-backed session this surfaced as `The 'inclusionai/ring-2.6-1t --provider openrouter' model is not supported when using Codex`.
- Parse `--provider`/`--global` flags via `hermes_cli.model_switch.parse_model_flags` first, matching the CLI `/model` behavior. The explicit `--provider` is used as the requested runtime provider when resolving the model. `--global` is a CLI persistence flag and is harmlessly stripped here so it never leaks into the model id.

## Duplicate PR check
- Exact open-PR search for #27119: no hits.
- Keyword searches for `acp /model provider`, `ACP model provider flag`, `acp slash command provider` returned only unrelated ACP runtime/provider PRs (e.g. #22430 custom provider colon-prefix, #22200 fallback providers, #18149 model.custom_provider). None of them touch the slash-command arg parsing path in `_cmd_model`.

## Test Plan
- [x] `python -m pytest tests/acp/test_server.py -q -o 'addopts=' -k test_model_switch` → 3 passed
- [x] `python -m pytest tests/acp/test_server.py -q -o 'addopts='` → 74 passed

Closes #27119