### PR TITLE
fix: remove unused import and fix: remove unused import and hoist module-level constant module-level constant

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -54,6 +54,13 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+_BUILTIN_DELIVER_PLATFORMS = {
+    "telegram", "discord", "slack", "signal", "sms", "whatsapp",
+    "matrix", "mattermost", "homeassistant", "email", "dingtalk",
+    "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
+    "qqbot", "yuanbao",
+}
+
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
@@ -238,12 +245,6 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
-        _BUILTIN_DELIVER_PLATFORMS = {
-            "telegram", "discord", "slack", "signal", "sms", "whatsapp",
-            "matrix", "mattermost", "homeassistant", "email", "dingtalk",
-            "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
-            "qqbot", "yuanbao",
-        }
         _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
         if not _is_known_platform:
             try:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -44,7 +44,6 @@ import queue
 import re
 import shlex
 import shutil
-import signal
 import subprocess
 import tempfile
 import threading


### PR DESCRIPTION
- Remove unused `import signal` from `tools/tts_tool.py` (dead code)
- Move `_BUILTIN_DELIVER_PLATFORMS` set from `send()` method to module scope in `gateway/platforms/webhook.py` to avoid reallocation on every call

## What does this PR do?

Two independent fixes:

1. **Dead code removal**: `import signal` in `tools/tts_tool.py` is never referenced anywhere in the file. Removed it to clean up module scope.

2. **Performance**: The `send()` method in `gateway/platforms/webhook.py` defines `_BUILTIN_DELIVER_PLATFORMS` — a 17-element set literal — as a local variable. This causes a new set allocation on every call. Hoisted to module level so the set is allocated once at import time.

## Changes Made

- `tools/tts_tool.py` — removed unused `import signal`
- `gateway/platforms/webhook.py` — moved `_BUILTIN_DELIVER_PLATFORMS` from `send()` method scope to module level

## How to Test

1. `grep -rn '\bsignal\b' tools/tts_tool.py` — confirms no usage beyond the removed import
2. Import `webhook.py` — `_BUILTIN_DELIVER_PLATFORMS` is now accessible at module scope

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: macOS
