### PR TITLE
feat(gateway): support {args} substitution in exec-type quick commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -757,6 +757,17 @@ def _try_resolve_fallback_provider() -> dict | None:
     return None
 
 
+def _substitute_quick_command_args(template: str, user_args: str) -> str:
+    """Substitute ``{args}`` in a quick-command exec template with the
+    user's input, shell-quoted so metacharacters can't break out of the
+    intended argument boundary.
+
+    Templates without ``{args}`` pass through unchanged, preserving
+    backward compatibility with fire-and-forget exec quick commands.
+    """
+    return template.replace("{args}", shlex.quote(user_args))
+
+
 def _build_media_placeholder(event) -> str:
     """Build a text placeholder for media-only events so they aren't dropped.
 
@@ -6679,6 +6690,12 @@ class GatewayRunner:
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        # Forward the user's typed args into the configured
+                        # shell template via the {args} placeholder. See
+                        # _substitute_quick_command_args for the shell-quoting
+                        # contract.
+                        user_args = event.get_command_args().strip()
+                        exec_cmd = _substitute_quick_command_args(exec_cmd, user_args)
                         try:
                             # Sanitize env to prevent credential leakage —
                             # quick commands run in the gateway process which

--- a/tests/gateway/test_quick_command_args.py
+++ b/tests/gateway/test_quick_command_args.py
@@ -1,0 +1,66 @@
+"""Tests for {args} substitution in exec-type quick commands."""
+
+from gateway.run import _substitute_quick_command_args
+
+
+class TestSubstituteQuickCommandArgs:
+    def test_simple_args_inserted(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "hello")
+        assert out == "/bin/echo hello"
+
+    def test_no_placeholder_passes_through(self):
+        out = _substitute_quick_command_args("/bin/date", "ignored")
+        assert out == "/bin/date"
+
+    def test_empty_args_quoted_as_empty_literal(self):
+        # shlex.quote("") -> "''" so the empty arg still occupies a slot
+        out = _substitute_quick_command_args("/bin/echo {args}", "")
+        assert out == "/bin/echo ''"
+
+    def test_ampersand_does_not_background(self):
+        # Without quoting, "eggs & bacon" would fork "eggs" into the
+        # background and treat "bacon" as a new command.
+        out = _substitute_quick_command_args("/bin/echo {args}", "eggs & bacon")
+        assert "&" in out
+        assert out.count("'") >= 2  # shell-quoted literal
+
+    def test_semicolon_does_not_chain_commands(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "a; rm -rf /tmp/x")
+        assert "; rm" not in out.replace("'", "")[:len("echo a; rm")]  # not raw
+
+    def test_pipe_does_not_pipe(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "x | cat")
+        # The pipe character is contained inside the single-quoted literal
+        assert "'x | cat'" in out
+
+    def test_dollar_command_substitution_disarmed(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "$(whoami)")
+        assert "'$(whoami)'" in out
+
+    def test_backticks_disarmed(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "`whoami`")
+        assert "'`whoami`'" in out
+
+    def test_redirection_disarmed(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "x > /tmp/y")
+        assert "'x > /tmp/y'" in out
+
+    def test_existing_single_quotes_escaped(self):
+        # shlex.quote handles embedded single quotes safely
+        out = _substitute_quick_command_args("/bin/echo {args}", "it's fine")
+        # shlex.quote produces: 'it'"'"'s fine'
+        assert out.startswith("/bin/echo ")
+        # The substituted portion must parse back to the original via shlex.split
+        import shlex
+        tokens = shlex.split(out)
+        assert tokens == ["/bin/echo", "it's fine"]
+
+    def test_multiple_placeholders_all_substituted(self):
+        out = _substitute_quick_command_args("/bin/echo {args} again {args}", "hi")
+        assert out == "/bin/echo hi again hi"
+
+    def test_unicode_passes_through(self):
+        out = _substitute_quick_command_args("/bin/echo {args}", "café ☕")
+        import shlex
+        tokens = shlex.split(out)
+        assert tokens == ["/bin/echo", "café ☕"]


### PR DESCRIPTION
## What does this PR do?

Adds an optional `{args}` placeholder to `type: exec` quick commands so the user's typed args reach the configured shell command. Today, exec-type quick commands run a fixed template with no way to receive user input — useful only for fire-and-forget actions. `type: alias` quick commands already forward args; this closes the gap for `exec`.

Example:

```yaml
quick_commands:
  meal:
    type: exec
    command: "/usr/local/bin/log-meal.sh {args}"
```

`/meal two eggs and toast` invokes the script with `two eggs and toast` as a single shell-safe argument.

Substitution flows through `_substitute_quick_command_args`, which wraps user input in `shlex.quote()` so shell metacharacters can't break out of the intended argument boundary. Without quoting, `/meal eggs & bacon` would fork "eggs" into the background and treat "bacon" as a new command — `shlex.quote()` makes the substitution safe by construction.

Templates without `{args}` pass through unchanged, preserving backward compatibility with existing fire-and-forget exec quick commands.

## Related Issue

No tracking issue — opportunistic feature addition.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: add `_substitute_quick_command_args(template, user_args)` helper that does `template.replace("{args}", shlex.quote(user_args))`.
- `gateway/run.py`: call the helper before invoking `asyncio.create_subprocess_shell` in the exec quick-command dispatch path.
- `tests/gateway/test_quick_command_args.py`: 12 unit tests covering substitution, no-placeholder passthrough, shell-metacharacter neutralization (`&`, `;`, `|`, `$()`, backticks, redirection), embedded single quotes, multiple placeholders, and unicode.

## How to Test

1. Add an exec quick command with `{args}` to `cli-config.yaml`:
   ```yaml
   quick_commands:
     greet:
       type: exec
       command: "/bin/echo got: {args}"
   ```
2. Restart the gateway, send `/greet hello world` from any platform — reply: `got: hello world`.
3. Send `/greet a & b` — reply: `got: a & b`. Without quoting, the `&` would background the process; with quoting the literal renders intact.
4. Run `pytest tests/gateway/test_quick_command_args.py -v` — all 12 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and the new tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Oracle ARM VPS)

### Documentation & Housekeeping

- [x] N/A — README/docs don't yet enumerate exec quick command syntax
- [x] N/A — `cli-config.yaml.example` has no `quick_commands` block to update
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform impact: `shlex.quote()` is stdlib and POSIX-shell-aware; this code path runs on the same `asyncio.create_subprocess_shell()` that already existed, so platform support is unchanged from the baseline
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

`pytest tests/gateway/test_quick_command_args.py -v` output:

```
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_simple_args_inserted PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_no_placeholder_passes_through PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_empty_args_quoted_as_empty_literal PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_ampersand_does_not_background PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_semicolon_does_not_chain_commands PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_pipe_does_not_pipe PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_dollar_command_substitution_disarmed PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_backticks_disarmed PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_redirection_disarmed PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_existing_single_quotes_escaped PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_multiple_placeholders_all_substituted PASSED
tests/gateway/test_quick_command_args.py::TestSubstituteQuickCommandArgs::test_unicode_passes_through PASSED
============================== 12 passed in 2.42s ==============================
```
