### PR TITLE
fix(codex): strip oversized message item ids on replay to prevent HTTP 400

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -349,9 +349,13 @@ def _chat_messages_to_responses_input(
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
-                        item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                        # Strip the server-assigned message id on replay.
+                        # With store=False (Hermes default), the API cannot look up
+                        # items by id server-side, and Codex returns ids up to 408
+                        # chars which exceed the 64-char input id limit.  Omitting
+                        # the id is consistent with how reasoning items are handled
+                        # (see ~line 307) and avoids HTTP 400 on session replay.
+                        # phase is preserved for cache performance.
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -603,9 +607,9 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 "status": _normalize_responses_message_status(item.get("status")),
                 "content": normalized_content,
             }
-            item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+            # Omit message item id — same rationale as replay path above.
+            # The preflight normalizer is a safety net for any code path that
+            # might inject oversized ids.
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()
@@ -945,7 +949,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     "content": [{"type": "output_text", "text": message_text}],
                 }
                 item_id = getattr(item, "id", None)
-                if isinstance(item_id, str) and item_id:
+                if isinstance(item_id, str) and item_id and len(item_id) <= 64:
                     raw_message_item["id"] = item_id
                 if normalized_phase:
                     raw_message_item["phase"] = normalized_phase

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1965,3 +1965,152 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #27038: Codex Responses API rejects replayed assistant
+# message items with long (>64 char) id fields.
+# ---------------------------------------------------------------------------
+
+
+def test_replay_strips_oversized_message_item_id():
+    """Message items with long ids (>64 chars) must NOT include id on replay.
+
+    The Codex backend enforces a 64-char maximum on input[N].id but returns
+    ids up to 408 chars.  With store=False, server-side id lookup fails
+    anyway, so stripping is safe and consistent with reasoning-item handling.
+    """
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    long_id = "A" * 408  # Simulate a 408-char Codex-assigned id
+
+    messages = [
+        {
+            "role": "assistant",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Hello"}],
+                    "id": long_id,
+                    "phase": "final_answer",
+                }
+            ],
+        },
+    ]
+
+    result = _chat_messages_to_responses_input(messages)
+
+    # Find the message item in the output
+    msg_items = [i for i in result if isinstance(i, dict) and i.get("type") == "message"]
+    assert len(msg_items) == 1
+    # id must NOT be present (stripped on replay)
+    assert "id" not in msg_items[0], f"id should be stripped but found: {msg_items[0]['id']}"
+    # phase must be preserved for cache performance
+    assert msg_items[0].get("phase") == "final_answer"
+
+
+def test_preflight_strips_message_item_id():
+    """Preflight normalizer must omit message item ids as a safety net."""
+    from agent.codex_responses_adapter import _preflight_codex_input_items
+
+    long_id = "B" * 408
+    items = [
+        {"role": "user", "content": "hi"},
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "Response"}],
+            "id": long_id,
+            "phase": "final_answer",
+        },
+    ]
+
+    result = _preflight_codex_input_items(items)
+
+    msg_items = [i for i in result if i.get("type") == "message"]
+    assert len(msg_items) == 1
+    assert "id" not in msg_items[0]
+    assert msg_items[0].get("phase") == "final_answer"
+
+
+def test_normalize_rejects_oversized_message_item_id():
+    """_normalize_codex_response must not capture ids longer than 64 chars."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+    from types import SimpleNamespace
+
+    long_id = "C" * 408
+    short_id = "D" * 32
+
+    # Build mock response with a message item carrying a long id
+    item_long = SimpleNamespace(
+        type="message",
+        id=long_id,
+        status="completed",
+        role="assistant",
+        content=[SimpleNamespace(type="output_text", text="Hello")],
+    )
+    resp_long = SimpleNamespace(
+        id="resp-1",
+        status="completed",
+        output=[item_long],
+        model="gpt-5-codex",
+    )
+
+    assistant_msg, _ = _normalize_codex_response(resp_long)
+    # codex_message_items should not contain the long id
+    items = getattr(assistant_msg, "codex_message_items", [])
+    msg_dicts = [i for i in items if isinstance(i, dict)]
+    for d in msg_dicts:
+        assert "id" not in d, f"Long id should be filtered at capture, got: {d.get('id')}"
+
+    # Short id should still be captured
+    item_short = SimpleNamespace(
+        type="message",
+        id=short_id,
+        status="completed",
+        role="assistant",
+        content=[SimpleNamespace(type="output_text", text="World")],
+    )
+    resp_short = SimpleNamespace(
+        id="resp-2",
+        status="completed",
+        output=[item_short],
+        model="gpt-5-codex",
+    )
+    assistant_msg2, _ = _normalize_codex_response(resp_short)
+    items2 = getattr(assistant_msg2, "codex_message_items", [])
+    msg_dicts2 = [i for i in items2 if isinstance(i, dict)]
+    found_short = any(d.get("id") == short_id for d in msg_dicts2)
+    assert found_short, "Short id (<=64 chars) should be preserved"
+
+
+def test_replay_preserves_phase_without_id():
+    """Phase field is preserved for cache performance even when id is stripped."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    messages = [
+        {
+            "role": "assistant",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Answer"}],
+                    "id": "X" * 200,
+                    "phase": "final_answer",
+                }
+            ],
+        },
+    ]
+
+    result = _chat_messages_to_responses_input(messages)
+
+    msg_items = [i for i in result if isinstance(i, dict) and i.get("type") == "message"]
+    assert len(msg_items) == 1
+    assert "id" not in msg_items[0]
+    assert msg_items[0]["phase"] == "final_answer"
+    assert msg_items[0]["content"][0]["text"] == "Answer"


### PR DESCRIPTION
## Problem

The Codex Responses API (`chatgpt.com/backend-api/codex`) enforces a **64-character maximum** on `input[N].id`, but Codex itself returns message item ids that are **408 characters long** (base64-encoded encrypted blobs). On session replay, Hermes passed these ids verbatim, causing non-retryable HTTP 400 errors that made sessions permanently unrecoverable.

Closes #27038

## Root Cause

Three locations in `agent/codex_responses_adapter.py` passed through message item `id` without length validation:
1. `_normalize_codex_response` (capture) — stored 408-char id verbatim
2. `_chat_messages_to_responses_input` (replay) — replayed id as-is  
3. `_preflight_codex_input_items` (validation) — passed id through

**Contrast**: reasoning items already strip `id` on replay (line ~307) with a comment about `store=False` making server-side lookup fail. Message items had no equivalent protection.

## Solution (Option C — belt and suspenders)

| Location | Change |
|----------|--------|
| `_chat_messages_to_responses_input` | **Strip id entirely** on replay (like reasoning items) |
| `_preflight_codex_input_items` | **Omit id** as safety net |
| `_normalize_codex_response` | **Guard at 64 chars** (keeps short ids, drops oversized) |

`phase` field is always preserved for cache performance.

## Test Results

```
67 passed (full codex_responses test suite — no regression)
4 passed (new regression tests for #27038)
```

## New Tests

- `test_replay_strips_oversized_message_item_id` — 408-char id stripped, phase preserved
- `test_preflight_strips_message_item_id` — preflight omits id  
- `test_normalize_rejects_oversized_message_item_id` — 408-char filtered, 32-char kept
- `test_replay_preserves_phase_without_id` — phase survives id stripping