### PR TITLE
fix(skills): return None instead of truthy stub when skill load fails

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -425,7 +425,7 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -466,6 +466,14 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_when_skill_load_fails(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "broken-skill")
+            scan_skill_commands()
+            with patch("agent.skill_commands._load_skill_payload", return_value=None):
+                msg = build_skill_invocation_message("/broken-skill", "do stuff")
+        assert msg is None
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []


### PR DESCRIPTION
## Summary

`build_skill_invocation_message()` returns a non-empty placeholder string (`[Failed to load skill: ...]`) when the skill exists in the command cache but loading the actual SKILL.md payload fails. CLI/gateway callers treat any truthy return value as success (using `if msg:` checks), so the failure text gets injected into the model as a user prompt.

## What does this PR do?

Changes the failure return value from a truthy error string to `None`, matching the existing behavior for unknown commands (`/nonexistent` → `None`). This way callers using `if msg:` properly detect the failure instead of routing bogus prompt text to the LLM.

## Changes Made

- `agent/skill_commands.py:428` — `return f"[Failed to load skill: ...]"` → `return None`

## How to Test

1. Scan a skill, then delete its `SKILL.md`
2. Call `build_skill_invocation_message("/skill-name", "hello")`
3. Previously: returns truthy string → injected as user prompt
4. Now: returns `None` → callers detect failure properly

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: macOS
