### PR TITLE
fix: allow approval prompts without timeout

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -128,9 +128,9 @@ _START_ORDER_GATE_TIMEOUT_S = 120.0
 # Fallback bound a concurrent worker will wait for the authorization gate's
 # serialization lock before running its prompt unserialized. The effective
 # bound is derived from ``approvals.timeout`` plus a margin (see
-# _authorization_gate_lock_timeout): a legitimate holder is at worst a human
-# answering an approval prompt, which self-terminates at approvals.timeout —
-# so a holder that overstays it is wedged and must not starve the batch.
+# _authorization_gate_lock_timeout). Disabled approval timeouts use
+# ``threading.TIMEOUT_MAX`` through ``human_wait_ceiling`` so the lock remains
+# serialized without passing an overflowing infinity to the threading API.
 _AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 360.0
 
 
@@ -139,10 +139,9 @@ def _authorization_gate_lock_timeout() -> float:
 
     Delegates to ``tools.approval.human_wait_ceiling`` — the same bound that
     clamps a human-wait window's deadline contribution — so the two can't
-    drift. Long enough that serialization is never broken while a legitimate
-    approval prompt is still answerable; short enough that a wedged holder
-    (hanging ``pre_tool_call`` plugin, dead approval client) cannot park other
-    workers forever (#79719). Resolved once per gate (per batch), so a
+    drift. Finite approval prompts retain the bounded wedged-holder protection;
+    an explicitly disabled approval timeout intentionally keeps serialization
+    for the platform-safe maximum. Resolved once per gate (per batch), so a
     mid-process ``approvals.timeout`` change applies from the next batch.
     """
     try:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -105,9 +105,9 @@ _START_ORDER_GATE_TIMEOUT_S = 120.0
 # Fallback bound a concurrent worker will wait for the authorization gate's
 # serialization lock before running its prompt unserialized. The effective
 # bound is derived from ``approvals.timeout`` plus a margin (see
-# _authorization_gate_lock_timeout): a legitimate holder is at worst a human
-# answering an approval prompt, which self-terminates at approvals.timeout —
-# so a holder that overstays it is wedged and must not starve the batch.
+# _authorization_gate_lock_timeout). Disabled approval timeouts use
+# ``threading.TIMEOUT_MAX`` through ``human_wait_ceiling`` so the lock remains
+# serialized without passing an overflowing infinity to the threading API.
 _AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 360.0
 
 
@@ -116,10 +116,9 @@ def _authorization_gate_lock_timeout() -> float:
 
     Delegates to ``tools.approval.human_wait_ceiling`` — the same bound that
     clamps a human-wait window's deadline contribution — so the two can't
-    drift. Long enough that serialization is never broken while a legitimate
-    approval prompt is still answerable; short enough that a wedged holder
-    (hanging ``pre_tool_call`` plugin, dead approval client) cannot park other
-    workers forever (#79719). Resolved once per gate (per batch), so a
+    drift. Finite approval prompts retain the bounded wedged-holder protection;
+    an explicitly disabled approval timeout intentionally keeps serialization
+    for the platform-safe maximum. Resolved once per gate (per batch), so a
     mid-process ``approvals.timeout`` change applies from the next batch.
     """
     try:

--- a/cli.py
+++ b/cli.py
@@ -15677,9 +15677,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         and the shared _approval_state / _approval_deadline aren't clobbered.
         """
         import time as _time
+        from tools.approval import _normalize_approval_timeout
 
         with self._approval_lock:
-            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 300))
+            timeout = _normalize_approval_timeout(
+                CLI_CONFIG.get("approvals", {}).get("timeout", 300),
+                default=300,
+            )
             response_queue = queue.Queue()
 
             self._approval_state = {
@@ -15693,7 +15697,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 "selected": 0,
                 "response_queue": response_queue,
             }
-            self._approval_deadline = _time.monotonic() + timeout
+            self._approval_deadline = 0 if timeout is None else _time.monotonic() + timeout
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms
@@ -15721,9 +15725,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     )
                     return result
                 except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
+                    if timeout is not None:
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
                     now = _time.monotonic()
                     if now - _last_countdown_refresh >= 1.0:
                         _last_countdown_refresh = now
@@ -19158,10 +19163,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 ]
 
             if cli_ref._approval_state:
-                remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                countdown = ''
+                if cli_ref._approval_deadline:
+                    remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
                 return [
                     ('class:hint', '  ↑/↓ to select, Enter to confirm'),
-                    ('class:clarify-countdown', f'  ({remaining}s)'),
+                    ('class:clarify-countdown', countdown),
                 ]
 
             if cli_ref._slash_confirm_state:

--- a/cli.py
+++ b/cli.py
@@ -13484,9 +13484,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         and the shared _approval_state / _approval_deadline aren't clobbered.
         """
         import time as _time
+        from tools.approval import _normalize_approval_timeout
 
         with self._approval_lock:
-            timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 300))
+            timeout = _normalize_approval_timeout(
+                CLI_CONFIG.get("approvals", {}).get("timeout", 300),
+                default=300,
+            )
             response_queue = queue.Queue()
 
             self._approval_state = {
@@ -13500,7 +13504,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 "selected": 0,
                 "response_queue": response_queue,
             }
-            self._approval_deadline = _time.monotonic() + timeout
+            self._approval_deadline = 0 if timeout is None else _time.monotonic() + timeout
 
             # Modal prompt — paint immediately, bypassing the throttle/resize
             # guard. A throttled paint here can be silently dropped (250ms
@@ -13528,9 +13532,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     )
                     return result
                 except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
+                    if timeout is not None:
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
                     now = _time.monotonic()
                     if now - _last_countdown_refresh >= 1.0:
                         _last_countdown_refresh = now
@@ -16718,10 +16723,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 ]
 
             if cli_ref._approval_state:
-                remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                countdown = ''
+                if cli_ref._approval_deadline:
+                    remaining = max(0, int(cli_ref._approval_deadline - time.monotonic()))
+                    countdown = f'  ({remaining}s)'
                 return [
                     ('class:hint', '  ↑/↓ to select, Enter to confirm'),
-                    ('class:clarify-countdown', f'  ({remaining}s)'),
+                    ('class:clarify-countdown', countdown),
                 ]
 
             if cli_ref._slash_confirm_state:

--- a/hermes_cli/approval_transport.py
+++ b/hermes_cli/approval_transport.py
@@ -51,7 +51,7 @@ class ApprovalRequest:
     pattern_key: str
     pattern_keys: tuple[str, ...]
     surface: str
-    timeout_seconds: float
+    timeout_seconds: float | None
     allowed_choices: tuple[ApprovalChoice, ...]
 
     @classmethod
@@ -66,7 +66,7 @@ class ApprovalRequest:
         surface: str,
         allow_session: bool,
         allow_permanent: bool,
-        timeout_seconds: float = 300,
+        timeout_seconds: float | None = 300,
     ) -> "ApprovalRequest":
         request_id = uuid.uuid4().hex
         choices: list[ApprovalChoice] = ["once"]
@@ -134,7 +134,7 @@ def invoke_approval_transport(
     present: ApprovalPresentFn,
     request: ApprovalRequest,
     *,
-    timeout_seconds: float,
+    timeout_seconds: float | None,
     poll_interval: float = 1.0,
     on_poll: Callable[[], None] | None = None,
     is_interrupted: Callable[[], bool] | None = None,
@@ -142,8 +142,10 @@ def invoke_approval_transport(
     """Run a sync or async transport on a bounded daemon worker.
 
     Async callbacks are awaited with ``asyncio.run`` on that worker, never on a
-    gateway or TUI event loop. A callback must return before the host timeout;
-    late results are discarded and cannot authorize another request.
+    gateway or TUI event loop. With a finite timeout, a callback must return
+    before the host deadline; late results are discarded and cannot authorize
+    another request. With no timeout, the host waits until a result or an
+    explicit interruption.
     """
 
     if not _transport_worker_slots.acquire(blocking=False):
@@ -151,7 +153,11 @@ def invoke_approval_transport(
         return ApprovalTransportResult("deny", "busy")
 
     results: queue.Queue[tuple[str, object, float]] = queue.Queue(maxsize=1)
-    deadline = time.monotonic() + max(float(timeout_seconds), 0.0)
+    deadline = (
+        None
+        if timeout_seconds is None
+        else time.monotonic() + max(float(timeout_seconds), 0.0)
+    )
 
     async def _await_value(value):
         return await value
@@ -185,14 +191,15 @@ def invoke_approval_transport(
         if is_interrupted is not None and is_interrupted():
             logger.info("Approval transport wait interrupted for %s", request.request_id)
             return ApprovalTransportResult("deny", "interrupted")
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            logger.warning("Approval transport timed out for request %s", request.request_id)
-            return ApprovalTransportResult("deny", "timeout")
+        wait_seconds = max(float(poll_interval), 0.001)
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning("Approval transport timed out for request %s", request.request_id)
+                return ApprovalTransportResult("deny", "timeout")
+            wait_seconds = min(wait_seconds, remaining)
         try:
-            kind, value, completed_at = results.get(
-                timeout=min(max(float(poll_interval), 0.001), remaining)
-            )
+            kind, value, completed_at = results.get(timeout=wait_seconds)
             break
         except queue.Empty:
             if on_poll is not None:
@@ -201,7 +208,7 @@ def invoke_approval_transport(
                 except Exception:
                     logger.debug("Approval transport poll callback failed", exc_info=True)
 
-    if completed_at > deadline:
+    if deadline is not None and completed_at > deadline:
         logger.warning("Approval transport timed out for request %s", request.request_id)
         return ApprovalTransportResult("deny", "timeout")
     if kind == "error":

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -212,7 +212,12 @@ def approval_callback(cli, command: str, description: str) -> str:
 
     with lock:
         from cli import CLI_CONFIG
-        timeout = CLI_CONFIG.get("approvals", {}).get("timeout", 300)
+        from tools.approval import _normalize_approval_timeout
+
+        timeout = _normalize_approval_timeout(
+            CLI_CONFIG.get("approvals", {}).get("timeout", 300),
+            default=300,
+        )
         response_queue = queue.Queue()
         choices = ["once", "session", "always", "deny"]
         if len(command) > 70:
@@ -225,7 +230,7 @@ def approval_callback(cli, command: str, description: str) -> str:
             "selected": 0,
             "response_queue": response_queue,
         }
-        cli._approval_deadline = _time.monotonic() + timeout
+        cli._approval_deadline = 0 if timeout is None else _time.monotonic() + timeout
 
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()
@@ -239,9 +244,10 @@ def approval_callback(cli, command: str, description: str) -> str:
                     cli._app.invalidate()
                 return result
             except queue.Empty:
-                remaining = cli._approval_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
+                if timeout is not None:
+                    remaining = cli._approval_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
                 if hasattr(cli, "_app") and cli._app:
                     cli._app.invalidate()
 

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -124,6 +124,31 @@ class TestCliApprovalUi:
         assert cli._app.current_buffer.cursor_position == 5
 
 
+    def test_approval_timeout_zero_waits_until_response(self):
+        cli = _make_cli_stub()
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/example", "recursive delete")
+
+        with patch.dict(cli_module.CLI_CONFIG, {"approvals": {"timeout": 0}}):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+            assert cli._approval_deadline == 0
+            time.sleep(0.2)
+            assert result == {}
+
+            cli._approval_state["response_queue"].put("once")
+            thread.join(timeout=2)
+
+        assert result["value"] == "once"
+
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
         cli._approval_state = {

--- a/tests/hermes_cli/test_approval_transport.py
+++ b/tests/hermes_cli/test_approval_transport.py
@@ -202,6 +202,45 @@ def test_host_transport_wait_is_interruptible_and_pollable():
     assert polls
 
 
+def test_host_transport_without_timeout_accepts_delayed_response():
+    from hermes_cli.approval_transport import ApprovalRequest, invoke_approval_transport
+
+    release = threading.Event()
+    polls = []
+    request = ApprovalRequest.create(
+        command="dangerous",
+        description="dangerous",
+        pattern_key="danger",
+        pattern_keys=("danger",),
+        session_key="session-a",
+        surface="cli",
+        allow_session=False,
+        allow_permanent=False,
+        timeout_seconds=None,
+    )
+
+    def present(received):
+        assert received.timeout_seconds is None
+        release.wait()
+        return received.respond("once")
+
+    def on_poll():
+        polls.append(1)
+        release.set()
+
+    result = invoke_approval_transport(
+        present,
+        request,
+        timeout_seconds=None,
+        poll_interval=0.01,
+        on_poll=on_poll,
+    )
+
+    assert result.choice == "once"
+    assert result.failure is None
+    assert polls
+
+
 def test_host_rejects_decision_completed_after_deadline(monkeypatch):
     import hermes_cli.approval_transport as transport_module
 

--- a/tests/run_agent/test_authorization_gate.py
+++ b/tests/run_agent/test_authorization_gate.py
@@ -50,6 +50,18 @@ class TestHumanWaitTracker:
     def test_no_wait_reports_zero(self):
         assert approval_mod.human_wait_seconds(SESSION) == 0.0
 
+    def test_disabled_timeout_uses_platform_safe_ceiling(self, monkeypatch):
+        monkeypatch.setattr(approval_mod, "_get_approval_timeout", lambda: None)
+        assert approval_mod.human_wait_ceiling() == threading.TIMEOUT_MAX
+
+    def test_large_timeout_is_clamped_to_platform_safe_ceiling(self, monkeypatch):
+        monkeypatch.setattr(
+            approval_mod,
+            "_get_approval_timeout",
+            lambda: threading.TIMEOUT_MAX,
+        )
+        assert approval_mod.human_wait_ceiling() == threading.TIMEOUT_MAX
+
     def test_open_window_counts(self):
         opened = threading.Event()
         release = threading.Event()

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -15,6 +15,7 @@ from tools.approval import (
     _get_approval_mode,
     _normalize_approval_mode,
     _smart_approve,
+    _normalize_approval_timeout,
     approve_session,
     detect_dangerous_command,
     detect_hardline_command,
@@ -39,6 +40,19 @@ class TestApprovalModeParsing:
     def test_config_bool_false_maps_to_off(self):
         with mock_patch("hermes_cli.config.load_config_readonly", return_value={"approvals": {"mode": False}}):
             assert _get_approval_mode() == "off"
+
+
+class TestApprovalTimeoutParsing:
+    def test_positive_timeout_remains_seconds(self):
+        assert _normalize_approval_timeout(60) == 60
+        assert _normalize_approval_timeout("30") == 30
+
+    def test_zero_and_none_disable_timeout(self):
+        for raw in (0, "0", None, False, "none", "false", "never", "off", ""):
+            assert _normalize_approval_timeout(raw) is None
+
+    def test_invalid_timeout_falls_back_to_default(self):
+        assert _normalize_approval_timeout("bogus", default=42) == 42
 
 
 class TestSmartApproval:
@@ -1310,6 +1324,39 @@ class TestApprovalTimeoutIsNotConsent:
             "post_approval_response",
         ]
         assert hook_calls[-1][1]["choice"] == "notify_failed"
+    def test_zero_timeout_waits_for_explicit_gateway_response(self, monkeypatch):
+        """A disabled timeout stays pending but still accepts an explicit deny."""
+        from tools import approval as mod
+
+        self._force_short_timeout(monkeypatch, seconds=0)
+        mod.register_gateway_notify(self.SESSION_KEY, lambda _data: None)
+
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards(
+                "rm -rf .git", "local"
+            )
+
+        thread = threading.Thread(target=_check)
+        thread.start()
+
+        for _ in range(200):
+            if mod._gateway_queues.get(self.SESSION_KEY):
+                break
+            time.sleep(0.005)
+
+        assert mod._gateway_queues.get(self.SESSION_KEY)
+        time.sleep(0.1)
+        assert result_holder == {}
+
+        mod.resolve_gateway_approval(self.SESSION_KEY, "deny")
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert result_holder["r"]["approved"] is False
+        assert result_holder["r"]["outcome"] == "denied"
+
 
     def test_pending_approval_is_replayable_and_acknowledged(self, monkeypatch):
         from tools import approval as mod

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -15,6 +15,7 @@ from tools.approval import (
     _get_approval_mode,
     _normalize_approval_mode,
     _smart_approve,
+    _normalize_approval_timeout,
     approve_session,
     detect_dangerous_command,
     detect_hardline_command,
@@ -39,6 +40,19 @@ class TestApprovalModeParsing:
     def test_config_bool_false_maps_to_off(self):
         with mock_patch("hermes_cli.config.load_config_readonly", return_value={"approvals": {"mode": False}}):
             assert _get_approval_mode() == "off"
+
+
+class TestApprovalTimeoutParsing:
+    def test_positive_timeout_remains_seconds(self):
+        assert _normalize_approval_timeout(60) == 60
+        assert _normalize_approval_timeout("30") == 30
+
+    def test_zero_and_none_disable_timeout(self):
+        for raw in (0, "0", None, False, "none", "false", "never", "off", ""):
+            assert _normalize_approval_timeout(raw) is None
+
+    def test_invalid_timeout_falls_back_to_default(self):
+        assert _normalize_approval_timeout("bogus", default=42) == 42
 
 
 class TestSmartApproval:
@@ -1310,6 +1324,39 @@ class TestApprovalTimeoutIsNotConsent:
             "post_approval_response",
         ]
         assert hook_calls[-1][1]["choice"] == "notify_failed"
+    def test_zero_timeout_waits_for_explicit_gateway_response(self, monkeypatch):
+        """A disabled timeout stays pending but still accepts an explicit deny."""
+        from tools import approval as mod
+
+        self._force_short_timeout(monkeypatch, seconds=0)
+        mod.register_gateway_notify(self.SESSION_KEY, lambda _data: None)
+
+        result_holder = {}
+
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards(
+                "rm -rf .git", "local"
+            )
+
+        thread = threading.Thread(target=_check)
+        thread.start()
+
+        for _ in range(200):
+            if mod._gateway_queues.get(self.SESSION_KEY):
+                break
+            time.sleep(0.005)
+
+        assert mod._gateway_queues.get(self.SESSION_KEY)
+        time.sleep(0.1)
+        assert result_holder == {}
+
+        mod.resolve_gateway_approval(self.SESSION_KEY, "deny")
+        thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        assert result_holder["r"]["approved"] is False
+        assert result_holder["r"]["outcome"] == "denied"
+
 
 class TestTirithImportErrorFailOpenPolicy:
     """Regression guard for #20733.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2391,15 +2391,17 @@ HUMAN_WAIT_MARGIN_S = 60.0
 def human_wait_ceiling() -> float:
     """Max seconds a single window may contribute: approvals.timeout + margin.
 
-    Every legitimate human wait self-terminates at ``approvals.timeout`` (the
-    CLI prompt join and the gateway poll loop both enforce it), so a window
-    that overstays this ceiling is itself wedged and must not keep extending
-    a batch deadline. Also used by agent/tool_executor.py as the bound on the
-    authorization gate's serialization-lock acquire, so the two bounds cannot
-    drift. Never call while holding ``_human_wait_lock`` — it reads the
-    config cache.
+    Finite human waits self-terminate at ``approvals.timeout`` (the CLI prompt
+    join and gateway poll loop both enforce it), so an overlong finite window
+    is wedged and must not keep extending a batch deadline. A disabled timeout
+    uses ``threading.TIMEOUT_MAX``: effectively unlimited while remaining safe
+    for the authorization lock's numeric timeout API. Never call while holding
+    ``_human_wait_lock`` — it reads the config cache.
     """
-    return float(_get_approval_timeout()) + HUMAN_WAIT_MARGIN_S
+    timeout = _get_approval_timeout()
+    if timeout is None:
+        return threading.TIMEOUT_MAX
+    return min(float(timeout) + HUMAN_WAIT_MARGIN_S, threading.TIMEOUT_MAX)
 
 
 def _clamped_window_seconds(started: float, now: float, ceiling: float) -> float:
@@ -2482,11 +2484,9 @@ def human_wait_seconds(session_key: str | None = None) -> float:
     baseline delta to zero (the safe direction: the deadline fires sooner).
     Deadline consumers snapshot a baseline at batch start and use the delta.
 
-    Each window's contribution is clamped to :func:`human_wait_ceiling`:
-    every legitimate human wait self-terminates at ``approvals.timeout``
-    (both the CLI prompt join and the gateway poll loop enforce it), so a
-    window that overstays that bound is itself wedged and must not keep
-    extending a batch deadline (belt-and-braces for #79719).
+    Each window's contribution is clamped to :func:`human_wait_ceiling`.
+    Finite approval waits stop extending the deadline after their configured
+    timeout plus margin; disabled timeouts use the platform-safe maximum.
     """
     key = session_key if session_key is not None else get_current_session_key()
     now = time.monotonic()
@@ -2962,7 +2962,7 @@ def save_permanent_allowlist(patterns: set):
 # =========================================================================
 
 def prompt_dangerous_approval(command: str, description: str,
-                              timeout_seconds: int | None = None,
+                              timeout_seconds: int | float | None = None,
                               allow_permanent: bool = True,
                               approval_callback=None,
                               *, smart_denied: bool = False) -> str:
@@ -2987,6 +2987,8 @@ def prompt_dangerous_approval(command: str, description: str,
     """
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
+    else:
+        timeout_seconds = _normalize_approval_timeout(timeout_seconds)
 
     # Everything below is a human prompt: either the registered CLI callback
     # (prompt_toolkit panel, bounded by the approval deadline) or the input()
@@ -3004,7 +3006,7 @@ def prompt_dangerous_approval(command: str, description: str,
 
 
 def _prompt_dangerous_approval_inner(command: str, description: str,
-                                     timeout_seconds: int,
+                                     timeout_seconds: int | float | None,
                                      allow_permanent: bool = True,
                                      approval_callback=None,
                                      *, smart_denied: bool = False) -> str:
@@ -3218,18 +3220,46 @@ def is_approval_bypass_active() -> bool:
     )
 
 
-def _get_approval_timeout() -> int:
+def _normalize_approval_timeout(
+    raw, default: int | float = 300
+) -> int | float | None:
+    """Normalize ``approvals.timeout`` values.
+
+    Returns a positive number of seconds for finite timeouts. Returns
+    ``None`` when the configured value explicitly disables timeout-based
+    auto-denial. This lets a human approval prompt remain pending while the
+    user is away, instead of treating absence as denial.
+    """
+    if raw is None or raw is False:
+        return None
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"", "0", "none", "false", "never", "off"}:
+            return None
+        raw = normalized
+    if isinstance(raw, (int, float)):
+        value = raw
+    else:
+        try:
+            value = int(raw)
+        except (ValueError, TypeError):
+            return default
+    return None if value <= 0 else value
+
+
+def _get_approval_timeout() -> int | float | None:
     """Read the approval timeout from config. Defaults to 300 seconds.
 
+    Returns ``None`` when timeout-based auto-denial is explicitly disabled.
     The default matches DEFAULT_CONFIG["approvals"]["timeout"]. Gateway
     approvals arrive as push notifications the user may not see for a couple
     of minutes; 60s proved too tight in practice (Telegram taps landed after
     the wait had already failed closed).
     """
-    try:
-        return int(_get_approval_config().get("timeout", 300))
-    except (ValueError, TypeError):
-        return 300
+    return _normalize_approval_timeout(
+        _get_approval_config().get("timeout", 300),
+        default=300,
+    )
 
 
 def _get_cron_approval_mode() -> str:
@@ -4284,7 +4314,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         touch_activity_if_due = None
 
     _now = time.monotonic()
-    _deadline = _now + max(timeout, 0)
+    _deadline = None if timeout is None else _now + timeout
     _activity_state = {"last_touch": _now, "start": _now}
     resolved = False
     # The poll loop below is verifiably blocked on a human answer (the user
@@ -4310,10 +4340,14 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 entry.event.set()
                 resolved = True
                 break
-            _remaining = _deadline - time.monotonic()
-            if _remaining <= 0:
-                break
-            if entry.event.wait(timeout=min(1.0, _remaining)):
+            if _deadline is None:
+                _wait_seconds = 1.0
+            else:
+                _remaining = _deadline - time.monotonic()
+                if _remaining <= 0:
+                    break
+                _wait_seconds = min(1.0, _remaining)
+            if entry.event.wait(timeout=_wait_seconds):
                 resolved = True
                 break
             if touch_activity_if_due is not None:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2245,15 +2245,17 @@ HUMAN_WAIT_MARGIN_S = 60.0
 def human_wait_ceiling() -> float:
     """Max seconds a single window may contribute: approvals.timeout + margin.
 
-    Every legitimate human wait self-terminates at ``approvals.timeout`` (the
-    CLI prompt join and the gateway poll loop both enforce it), so a window
-    that overstays this ceiling is itself wedged and must not keep extending
-    a batch deadline. Also used by agent/tool_executor.py as the bound on the
-    authorization gate's serialization-lock acquire, so the two bounds cannot
-    drift. Never call while holding ``_human_wait_lock`` — it reads the
-    config cache.
+    Finite human waits self-terminate at ``approvals.timeout`` (the CLI prompt
+    join and gateway poll loop both enforce it), so an overlong finite window
+    is wedged and must not keep extending a batch deadline. A disabled timeout
+    uses ``threading.TIMEOUT_MAX``: effectively unlimited while remaining safe
+    for the authorization lock's numeric timeout API. Never call while holding
+    ``_human_wait_lock`` — it reads the config cache.
     """
-    return float(_get_approval_timeout()) + HUMAN_WAIT_MARGIN_S
+    timeout = _get_approval_timeout()
+    if timeout is None:
+        return threading.TIMEOUT_MAX
+    return min(float(timeout) + HUMAN_WAIT_MARGIN_S, threading.TIMEOUT_MAX)
 
 
 def _clamped_window_seconds(started: float, now: float, ceiling: float) -> float:
@@ -2336,11 +2338,9 @@ def human_wait_seconds(session_key: str | None = None) -> float:
     baseline delta to zero (the safe direction: the deadline fires sooner).
     Deadline consumers snapshot a baseline at batch start and use the delta.
 
-    Each window's contribution is clamped to :func:`human_wait_ceiling`:
-    every legitimate human wait self-terminates at ``approvals.timeout``
-    (both the CLI prompt join and the gateway poll loop enforce it), so a
-    window that overstays that bound is itself wedged and must not keep
-    extending a batch deadline (belt-and-braces for #79719).
+    Each window's contribution is clamped to :func:`human_wait_ceiling`.
+    Finite approval waits stop extending the deadline after their configured
+    timeout plus margin; disabled timeouts use the platform-safe maximum.
     """
     key = session_key if session_key is not None else get_current_session_key()
     now = time.monotonic()
@@ -2707,7 +2707,7 @@ def save_permanent_allowlist(patterns: set):
 # =========================================================================
 
 def prompt_dangerous_approval(command: str, description: str,
-                              timeout_seconds: int | None = None,
+                              timeout_seconds: int | float | None = None,
                               allow_permanent: bool = True,
                               approval_callback=None,
                               *, smart_denied: bool = False) -> str:
@@ -2732,6 +2732,8 @@ def prompt_dangerous_approval(command: str, description: str,
     """
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
+    else:
+        timeout_seconds = _normalize_approval_timeout(timeout_seconds)
 
     # Everything below is a human prompt: either the registered CLI callback
     # (prompt_toolkit panel, bounded by the approval deadline) or the input()
@@ -2749,7 +2751,7 @@ def prompt_dangerous_approval(command: str, description: str,
 
 
 def _prompt_dangerous_approval_inner(command: str, description: str,
-                                     timeout_seconds: int,
+                                     timeout_seconds: int | float | None,
                                      allow_permanent: bool = True,
                                      approval_callback=None,
                                      *, smart_denied: bool = False) -> str:
@@ -2963,18 +2965,46 @@ def is_approval_bypass_active() -> bool:
     )
 
 
-def _get_approval_timeout() -> int:
+def _normalize_approval_timeout(
+    raw, default: int | float = 300
+) -> int | float | None:
+    """Normalize ``approvals.timeout`` values.
+
+    Returns a positive number of seconds for finite timeouts. Returns
+    ``None`` when the configured value explicitly disables timeout-based
+    auto-denial. This lets a human approval prompt remain pending while the
+    user is away, instead of treating absence as denial.
+    """
+    if raw is None or raw is False:
+        return None
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"", "0", "none", "false", "never", "off"}:
+            return None
+        raw = normalized
+    if isinstance(raw, (int, float)):
+        value = raw
+    else:
+        try:
+            value = int(raw)
+        except (ValueError, TypeError):
+            return default
+    return None if value <= 0 else value
+
+
+def _get_approval_timeout() -> int | float | None:
     """Read the approval timeout from config. Defaults to 300 seconds.
 
+    Returns ``None`` when timeout-based auto-denial is explicitly disabled.
     The default matches DEFAULT_CONFIG["approvals"]["timeout"]. Gateway
     approvals arrive as push notifications the user may not see for a couple
     of minutes; 60s proved too tight in practice (Telegram taps landed after
     the wait had already failed closed).
     """
-    try:
-        return int(_get_approval_config().get("timeout", 300))
-    except (ValueError, TypeError):
-        return 300
+    return _normalize_approval_timeout(
+        _get_approval_config().get("timeout", 300),
+        default=300,
+    )
 
 
 def _get_cron_approval_mode() -> str:
@@ -3676,7 +3706,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         touch_activity_if_due = None
 
     _now = time.monotonic()
-    _deadline = _now + max(timeout, 0)
+    _deadline = None if timeout is None else _now + timeout
     _activity_state = {"last_touch": _now, "start": _now}
     resolved = False
     # The poll loop below is verifiably blocked on a human answer (the user
@@ -3702,10 +3732,14 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 entry.event.set()
                 resolved = True
                 break
-            _remaining = _deadline - time.monotonic()
-            if _remaining <= 0:
-                break
-            if entry.event.wait(timeout=min(1.0, _remaining)):
+            if _deadline is None:
+                _wait_seconds = 1.0
+            else:
+                _remaining = _deadline - time.monotonic()
+                if _remaining <= 0:
+                    break
+                _wait_seconds = min(1.0, _remaining)
+            if entry.event.wait(timeout=_wait_seconds):
                 resolved = True
                 break
             if touch_activity_if_due is not None:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -141,13 +141,20 @@ Deny rules are a guardrail against an honest-but-wrong agent, the same threat mo
 
 ### Approval Timeout
 
-When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).
+Positive integer values for `approvals.timeout` specify a finite number of seconds; if no response arrives, the command is **denied** (fail-closed).
 
-Configure the timeout in `~/.hermes/config.yaml`:
+The values `0`, negative numbers, `null`, `false`, an empty string, and the strings `none`, `false`, `never`, and `off` disable the timeout. In this mode, CLI and gateway approvals remain pending until an explicit response or interruption.
 
 ```yaml
+# Deny if there is no response after 300 seconds.
 approvals:
   timeout: 300  # seconds (default: 300)
+```
+
+```yaml
+# Wait for an explicit response or interruption.
+approvals:
+  timeout: 0
 ```
 
 ### What Triggers Approval

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -139,13 +139,20 @@ Deny rules are a guardrail against an honest-but-wrong agent, the same threat mo
 
 ### Approval Timeout
 
-When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).
+Positive integer values for `approvals.timeout` specify a finite number of seconds; if no response arrives, the command is **denied** (fail-closed).
 
-Configure the timeout in `~/.hermes/config.yaml`:
+The values `0`, negative numbers, `null`, `false`, an empty string, and the strings `none`, `false`, `never`, and `off` disable the timeout. In this mode, CLI and gateway approvals remain pending until an explicit response or interruption.
 
 ```yaml
+# Deny if there is no response after 300 seconds.
 approvals:
   timeout: 300  # seconds (default: 300)
+```
+
+```yaml
+# Wait for an explicit response or interruption.
+approvals:
+  timeout: 0
 ```
 
 ### What Triggers Approval


### PR DESCRIPTION
## Summary
- Allow `approvals.timeout` to disable timeout-based auto-denial with values like `0`, `none`, `never`, or `off`
- Keep approval prompts pending indefinitely when timeout is disabled instead of treating user absence as denial
- Hide the countdown in the TUI when there is no approval deadline

## Test Plan
- `git diff --check upstream/main..HEAD`
- `python -m py_compile tools/approval.py cli.py hermes_cli/callbacks.py`
- `python -m pytest tests/tools/test_approval.py tests/cli/test_cli_approval_ui.py -q -o 'addopts='`
