### PR TITLE
fix(telegram): restore DM topic typing indicator

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3504,14 +3504,6 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._bot:
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
-                # Skip the Bot API call entirely for Hermes-created DM topic
-                # lanes: send_chat_action only accepts message_thread_id, which
-                # Telegram's Bot API 10.0 rejects for these lanes. The send
-                # path uses the reply-anchor fallback instead, but typing has
-                # no equivalent — skipping avoids noisy "thread not found"
-                # debug logs on every typing tick.
-                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
-                    return
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
                 # No retry-without-thread fallback here: _message_thread_id_for_typing
                 # already maps the forum General topic to None, so any non-None value

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -236,14 +236,13 @@ async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
 
 
 @pytest.mark.asyncio
-async def test_send_typing_skips_api_call_for_dm_topic_reply_fallback():
-    """Hermes-created DM topic lanes have no working Bot API typing route.
+async def test_send_typing_attempts_api_call_for_dm_topic_reply_fallback():
+    """Hermes-created DM topic lanes should still attempt scoped typing.
 
-    ``send_chat_action`` only accepts ``message_thread_id``, which Telegram's
-    Bot API 10.0 rejects for these lanes — the call would silently fail and
-    log a "thread not found" warning every typing tick (every 2s). Skipping
-    the call entirely keeps logs clean while preserving the user-visible
-    behavior (no typing indicator either way for these lanes).
+    Some private DM topic lanes route message sends through reply-anchor
+    fallback, but live Telegram testing shows sendChatAction accepts the lane's
+    message_thread_id. If Telegram rejects a stale or invalid thread later,
+    send_typing already swallows that failure as non-fatal.
     """
     adapter = _make_adapter()
     call_log = []
@@ -262,7 +261,9 @@ async def test_send_typing_skips_api_call_for_dm_topic_reply_fallback():
         },
     )
 
-    assert call_log == []
+    assert call_log == [
+        {"chat_id": 12345, "action": "typing", "message_thread_id": 20197},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Restores Telegram typing indicators for Hermes-created private DM topic lanes.

Commit `aef297a45` skipped `send_chat_action()` whenever metadata had `telegram_dm_topic_reply_fallback=True`, based on the assumption that Telegram would reject `message_thread_id` for those lanes. A Discord support report from FictionBuddy says live testing shows Telegram accepts `sendChatAction` with `message_thread_id` for bot-created private DM topic lanes, and that removing the skip restores the typing indicator.

This PR removes that early return and keeps the existing non-fatal DEBUG exception handling around `send_chat_action()`, so stale/deleted threads still do not break responses.

## Related Issue

Discord support thread: "Bug Report - Telegram Typing Indicator Broken for DM Topics"

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: remove the early return that skipped typing for `telegram_dm_topic_reply_fallback` metadata.
- `tests/gateway/test_telegram_thread_fallback.py`: update the regression test to assert that DM topic reply-fallback metadata attempts `send_chat_action()` with the scoped `message_thread_id`.

## How to Test

1. Configure Telegram `dm_topics` so Hermes uses a private DM topic lane.
2. Send a message in that lane and trigger a normal Hermes response.
3. Verify Telegram shows the typing indicator in the topic lane while the agent is generating.

Automated targeted test run:

- `.venv/bin/python -m pytest tests/gateway/test_telegram_thread_fallback.py -q`
  - `34 passed in 5.95s`

Full non-integration suite attempted:

- `HERMES_TEST_WORKERS=4 scripts/run_tests.sh`
  - `49 failed, 23494 passed, 54 skipped, 252 warnings, 19 errors in 632.17s`
  - `HERMES_HOME` before/after remained empty.
  - Failures/errors were broad local-suite failures outside the touched Telegram fallback test file, including browser supervisor teardown live-system guard errors and unrelated CLI/gateway/tool timeout/config tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux local checkout; targeted gateway test passed; full non-integration suite attempted and failed on unrelated local-suite failures

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

`34 passed in 5.95s`

Full suite output summary:

`49 failed, 23494 passed, 54 skipped, 252 warnings, 19 errors in 632.17s`
