### PR TITLE
fix(telegram): restore typing indicator for DM topic lanes

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3504,14 +3504,6 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._bot:
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
-                # Skip the Bot API call entirely for Hermes-created DM topic
-                # lanes: send_chat_action only accepts message_thread_id, which
-                # Telegram's Bot API 10.0 rejects for these lanes. The send
-                # path uses the reply-anchor fallback instead, but typing has
-                # no equivalent — skipping avoids noisy "thread not found"
-                # debug logs on every typing tick.
-                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
-                    return
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
                 # No retry-without-thread fallback here: _message_thread_id_for_typing
                 # already maps the forum General topic to None, so any non-None value

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -236,14 +236,11 @@ async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
 
 
 @pytest.mark.asyncio
-async def test_send_typing_skips_api_call_for_dm_topic_reply_fallback():
-    """Hermes-created DM topic lanes have no working Bot API typing route.
+async def test_send_typing_makes_api_call_for_dm_topic_reply_fallback():
+    """Hermes-created DM topic lanes: send_chat_action with message_thread_id.
 
-    ``send_chat_action`` only accepts ``message_thread_id``, which Telegram's
-    Bot API 10.0 rejects for these lanes — the call would silently fail and
-    log a "thread not found" warning every typing tick (every 2s). Skipping
-    the call entirely keeps logs clean while preserving the user-visible
-    behavior (no typing indicator either way for these lanes).
+    ``send_chat_action`` does accept ``message_thread_id`` for private DM topic
+    lanes in practice — the typing indicator works when this call is made.
     """
     adapter = _make_adapter()
     call_log = []
@@ -262,7 +259,9 @@ async def test_send_typing_skips_api_call_for_dm_topic_reply_fallback():
         },
     )
 
-    assert call_log == []
+    assert call_log == [
+        {"chat_id": 12345, "action": "typing", "message_thread_id": 20197},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Removes the early return in `send_typing()` (introduced in `aef297a45`) that skipped `send_chat_action` when `telegram_dm_topic_reply_fallback` was set. The Bot API does accept `message_thread_id` for Hermes-created private DM topic lanes in practice — the typing indicator worked before this guard was added.

## Why
Users with `dm_topics` configured (private chat topic lanes like System, General, etc.) get no typing indicator during agent responses. The commit author assumed "no typing indicator either way for these lanes" but that was incorrect — it was working before the guard, as confirmed by live testing on a WSL2 instance.

## How to test
1. Configure a DM topic in config.yaml (e.g. `dm_topics:` under a Telegram chat)
2. Send a message in that topic
3. Observe the typing indicator appears while the agent prepares its response

## Related
- Introduced in `aef297a45` ("fix(telegram): skip send_chat_action for DM topic reply-fallback lanes")
- Updated corresponding test to expect the API call

## Checklist
- [x] Tests updated and passing (34/34 in `test_telegram_thread_fallback.py`)
- [x] Single logical change
- [x] Conventional commit format