### PR TITLE
fix(gateway): add missing logger definition to prevent NameError in _all_platforms

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import logging
 import os
 import shutil
 import signal
@@ -38,6 +39,7 @@ from hermes_cli.setup import (
 )
 from hermes_cli.colors import Colors, color
 
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Process Management (for manual gateway runs)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -559,3 +559,9 @@ class TestStopProfileGateway:
         assert calls["kill"] == 1          # one SIGTERM
         assert calls["alive_probes"] == 20 # 20 liveness polls over the 2s window
         assert calls["remove"] == 0
+
+
+def test_module_has_logger():
+    """Verify module has a logger instance (regression guard for #27154)."""
+    assert hasattr(gateway, "logger")
+    assert gateway.logger.name == "hermes_cli.gateway"


### PR DESCRIPTION

## Summary

`hermes_cli/gateway.py:3702` referenced `logger.debug()` but `logger` was never defined anywhere in the module. This causes a `NameError` at runtime whenever the `try/except` block around `discover_plugins()` in the `_all_platforms()` function catches an exception.

## Root Cause

The `_all_platforms()` function (line 3674) is responsible for enumerating all available messaging platforms for the `hermes setup gateway` menu. It combines built-in platforms with plugin-registered ones by calling `discover_plugins()`.

If `discover_plugins()` fails — for example, due to a corrupted plugin directory, a missing dependency, or a user-installed platform plugin with a syntax error — the `except Exception as e:` block at line 3703 attempts to log the failure:

```python
except Exception as e:
    logger.debug("plugin discovery failed during platform enumeration: %s", e)
