### PR TITLE
fix(status): harden gateway and credential status checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ cli-config.yaml
 
 # Skills Hub state (lives in ~/.hermes/skills/.hub/ at runtime, but just in case)
 skills/.hub/
+
+# here.now publish state (local cache; may contain claim tokens/claim URLs)
+.herenow/
 ignored/
 .worktrees/
 environments/benchmarks/evals/

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -274,6 +274,30 @@ def _read_gateway_lock_record(lock_path: Optional[Path] = None) -> Optional[dict
     return _read_pid_record(lock_path or _get_gateway_lock_path())
 
 
+def _lock_record_points_to_live_gateway(lock_path: Path) -> bool:
+    """Best-effort read-only fallback for status checks.
+
+    Some constrained runners can read ``gateway.lock`` but cannot open it in
+    append mode to test the advisory lock.  In that case, trust the lock record
+    only if it points at a live process and carries Hermes gateway metadata.
+    """
+    record = _read_gateway_lock_record(lock_path)
+    pid = _pid_from_record(record)
+    if pid is None or not _pid_exists(pid):
+        return False
+
+    recorded_start = record.get("start_time")
+    current_start = _get_process_start_time(pid)
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and current_start != recorded_start
+    ):
+        return False
+
+    return _record_looks_like_gateway(record)
+
+
 def _pid_from_record(record: Optional[dict[str, Any]]) -> Optional[int]:
     if not record:
         return None
@@ -463,7 +487,10 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     if not resolved_lock_path.exists():
         return False
 
-    handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    try:
+        handle = open(resolved_lock_path, "a+", encoding="utf-8")
+    except PermissionError:
+        return _lock_record_points_to_live_gateway(resolved_lock_path)
     try:
         if _try_acquire_file_lock(handle):
             _release_file_lock(handle)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -89,7 +89,6 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
     deep = getattr(args, 'deep', False)
 
     print()
@@ -163,12 +162,16 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # `--all` expands component detail elsewhere but must never reveal raw
+        # credentials.  The CLI help promises status output is redacted for
+        # sharing, and Paperclip/Hermes agents routinely persist status output
+        # into reports.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -157,6 +157,33 @@ class TestGatewayPidState:
 
         assert status.is_gateway_runtime_lock_active() is False
 
+    def test_runtime_lock_status_uses_record_when_append_open_denied(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record = {
+            "pid": 4242,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": None,
+        }
+        (tmp_path / "gateway.pid").write_text(json.dumps(record))
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text(json.dumps(record))
+
+        real_open = open
+
+        def _deny_append_open(path, mode="r", *args, **kwargs):
+            if Path(path) == lock_path and mode == "a+":
+                raise PermissionError("operation not permitted")
+            return real_open(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _deny_append_open)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 4242)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.is_gateway_runtime_lock_active() is True
+        assert status.get_running_pid() == 4242
+
     def test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,43 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_redacts_provider_token_values(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    minimax_secret = "minimax-secret-token-1234567890"
+    github_secret = "github-token-1234567890"
+    anthropic_secret = "sk-ant...7890"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MINIMAX_API_KEY", minimax_secret)
+    monkeypatch.setenv("GITHUB_TOKEN", github_secret)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", anthropic_secret)
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "MiniMax" in output
+    assert "GitHub" in output
+    assert minimax_secret not in output
+    assert github_secret not in output
+    assert anthropic_secret not in output
+    assert "mini...7890" in output
+    assert "gith...7890" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- Keep provider/API key rows redacted in `hermes status --all` so shareable status output never prints raw credentials.
- Add a read-only fallback for gateway runtime lock checks when a constrained runner can read `gateway.lock` but cannot open it in append mode.
- Ignore local here.now publish state caches (`.herenow/`) so claim metadata is not accidentally staged.

## Safety / privacy posture
- No connector changes, secret rotation, service restart, deploy, or merge performed.
- Prepared from a clean worktree based on current `origin/main`; Connor's dirty local checkout was left untouched.
- The PR intentionally excludes the unrelated Obsidian capture-gate docs/scripts from the dirty local checkout.

## Validation
- `HOME=/Users/connorlaughlin scripts/run_tests.sh tests/gateway/test_status.py tests/hermes_cli/test_status.py`
- Result: `56 passed`.
