### PR TITLE
fix(gemini): include role in native systemInstruction payload

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -323,7 +323,7 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        system_instruction = {"parts": [{"text": joined_system}]}
+        system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
     return contents, system_instruction
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -52,6 +52,24 @@ def test_build_native_request_preserves_thought_signature_on_tool_replay():
     assert parts[0]["thoughtSignature"] == "sig-123"
 
 
+def test_build_native_request_includes_role_on_system_instruction():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hello"},
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    assert request["systemInstruction"] == {
+        "role": "system",
+        "parts": [{"text": "Be concise."}],
+    }
+
+
 def test_build_native_request_uses_original_function_name_for_tool_result():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary

Fixes the native Gemini request builder so `systemInstruction` includes the required `role: "system"` field.

The CloudCode Gemini adapter already emits this shape, but the native Google AI Studio adapter only emitted `parts`. This caused native Gemini/Gemma requests with system messages to use a subtly different payload shape and can trigger provider-side failures.

Closes #27121.

## What Changed

- Added `role: "system"` to `systemInstruction` in `agent/gemini_native_adapter.py`
- Added a regression test covering the native Gemini request payload shape

## Reproduction

Before this change, native Gemini requests with system messages produced a `systemInstruction` object without a role.

After this change, the native adapter emits `role: "system"` alongside the existing text parts, matching the CloudCode Gemini adapter behavior.

## Tests

- `pytest tests/agent/test_gemini_native_adapter.py -q`

Result:

- `12 passed`

## Risk

Low. The change is limited to the native Gemini request payload for system instructions. Existing request content, tool call replay, tool result mapping, and response translation behavior are unchanged.