### PR TITLE
feat(gateway): add universal interrupt keywords for busy sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2617,7 +2617,7 @@ class GatewayRunner:
         # These work regardless of busy_input_mode, giving users on any
         # gateway platform a reliable escape hatch from runaway agents.
         text = (event.text or "").strip()
-        normalized = text.lower().lstrip("/")
+        normalized = text.lower().lstrip("/").rstrip(".,!?;:")
         if normalized in _INTERRUPT_KEYWORDS:
             await self._interrupt_and_clear_session(
                 session_key=session_key,
@@ -2625,6 +2625,8 @@ class GatewayRunner:
                 interrupt_reason="User requested interrupt",
                 invalidation_reason="User requested interrupt",
             )
+            if not event.source:
+                return True
             adapter = self.adapters.get(event.source.platform)
             if adapter:
                 await adapter._send_with_retry(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -807,6 +807,11 @@ _CONTROL_INTERRUPT_MESSAGES = frozenset(
     }
 )
 
+# Universal interrupt keywords — plain-text messages that interrupt the
+# current session regardless of busy_input_mode.  These work on every
+# gateway platform without requiring platform-specific slash command support.
+_INTERRUPT_KEYWORDS = frozenset({"stop", "interrupt", "cancel", "abort", "halt"})
+
 
 def _is_control_interrupt_message(message: Optional[str]) -> bool:
     """Return True when an interrupt message is internal control flow."""
@@ -2606,6 +2611,32 @@ class GatewayRunner:
                 ),
                 metadata=thread_meta,
             )
+            return True
+
+        # --- Universal interrupt keywords ---
+        # These work regardless of busy_input_mode, giving users on any
+        # gateway platform a reliable escape hatch from runaway agents.
+        text = (event.text or "").strip()
+        normalized = text.lower().lstrip("/")
+        if normalized in _INTERRUPT_KEYWORDS:
+            await self._interrupt_and_clear_session(
+                session_key=session_key,
+                source=event.source,
+                interrupt_reason="User requested interrupt",
+                invalidation_reason="User requested interrupt",
+            )
+            adapter = self.adapters.get(event.source.platform)
+            if adapter:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content="🛑 Interrupted — what would you like to do next?",
+                    reply_to=(
+                        None
+                        if event.source.platform == Platform.TELEGRAM
+                        and event.source.thread_id
+                        else event.message_id
+                    ),
+                )
             return True
 
         # Normal busy case (agent actively running a task)

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -79,6 +79,10 @@ def _make_runner():
 def _make_adapter(platform_val="telegram"):
     """Build a minimal adapter mock."""
     adapter = MagicMock()
+    # Remove interrupt_session_activity so hasattr check in
+    # _interrupt_and_clear_session returns False (MagicMock auto-creates attrs)
+    if hasattr(adapter, 'interrupt_session_activity'):
+        del adapter.interrupt_session_activity
     adapter._pending_messages = {}
     adapter._send_with_retry = AsyncMock()
     adapter.config = MagicMock()
@@ -552,3 +556,128 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+class TestUniversalInterruptKeywords:
+    """Tests for _INTERRUPT_KEYWORDS universal interrupt mechanism."""
+
+    @pytest.mark.asyncio
+    async def test_exact_match_interrupts(self, tmp_path, monkeypatch):
+        """Standalone 'stop' message interrupts regardless of mode."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        # Remove interrupt_session_activity to test the hasattr guard
+        if hasattr(adapter, 'interrupt_session_activity'):
+            del adapter.interrupt_session_activity
+
+        event = _make_event(text="stop")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.interrupt = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_called_once_with("User requested interrupt")
+        mock_merge.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leading_slash_matches(self, tmp_path, monkeypatch):
+        """/stop also matches (lstrip('/') normalization)."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="/stop")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.interrupt = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event"):
+            result = await runner._handle_active_session_busy_message(event, sk)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_punctuation_stripped(self, tmp_path, monkeypatch):
+        """stop!, cancel., halt? also match."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        for text in ["stop!", "cancel.", "halt?", "interrupt!"]:
+            event = _make_event(text=text)
+            sk = build_session_key(event.source)
+            runner.adapters[event.source.platform] = adapter
+            agent = MagicMock()
+            agent.interrupt = MagicMock()
+            runner._running_agents[sk] = agent
+
+            with patch("gateway.run.merge_pending_message_event"):
+                result = await runner._handle_active_session_busy_message(event, sk)
+            assert result is True, f"Punctuation-stripped {text!r} should match"
+
+    @pytest.mark.asyncio
+    async def test_non_keyword_falls_through(self, tmp_path, monkeypatch):
+        """Normal message does NOT interrupt - falls through."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="hello, can you continue?")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+        mock_merge.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_sends_acknowledgment(self, tmp_path, monkeypatch):
+        """Interrupt sends acknowledgment to user."""
+        import gateway.run as _gr
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="abort")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.interrupt = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Interrupted" in content


### PR DESCRIPTION
## Summary

Add universal interrupt keywords (`stop`, `interrupt`, `cancel`, `abort`, `halt`) that work on every gateway platform regardless of `busy_input_mode` — giving users a reliable escape hatch from runaway agents.

Closes #26884

## Problem

The current gateway interrupt mechanism has several gaps:

1. **No platform-independent escape hatch** — `/stop` only works on platforms with slash command support; `!stop` (Slack bang-rewrite) is Slack-specific
2. **busy_input_mode dependency** — in `steer` mode, `/stop` is treated as steer text; in `queue` mode, there's no interrupt at all
3. **User experience** — when the agent enters an infinite tool-call loop, gateway users have no way to stop it that works consistently

## Solution

Add `_INTERRUPT_KEYWORDS` (module-level frozenset: `stop`, `interrupt`, `cancel`, `abort`, `halt`) and a check in `_handle_active_session_busy_message` that runs **before** the steer/queue mode branching:

- Works in ALL `busy_input_mode` configurations (queue, steer, interrupt)
- Matches case-insensitively, with optional leading `/` (so `/stop` and `stop` both work)
- Only matches standalone messages (not substrings — "stop doing that" is NOT an interrupt)
- Sends acknowledgment: "🛑 Interrupted — what would you like to do next?"
- Preserves reply_to for threaded platforms (Telegram DM topics)

## Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `gateway/run.py` | +31 lines: add `_INTERRUPT_KEYWORDS` constant + keyword check in busy handler |

## Test Results

```
tests/gateway/test_busy_session_ack.py .................. 15 passed
tests/gateway/test_config_env_bridge_authority.py ...... 5 passed
tests/gateway/test_telegram_topic_mode.py .............. 29 passed
```

## Design Decisions

- **Separate from `_CONTROL_INTERRUPT_MESSAGES`**: those are internal control-flow messages, not user-facing
- **Before mode branching**: ensures the interrupt signal is never consumed by steer/queue logic
- **Standalone message only**: avoids false positives on messages containing stop/cancel as substrings