### PR TITLE
fix(plugins): surface sub-category plugins in hermes plugins list; drop dead hermes tools Langfuse path

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -134,8 +134,7 @@ _EXTRA_ENV_KEYS = frozenset({
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable
-    # observability/langfuse` or `hermes tools → Langfuse`); credentials gate
-    # the plugin at runtime.
+    # observability/langfuse`); credentials gate the plugin at runtime.
     "HERMES_LANGFUSE_ENV",
     "HERMES_LANGFUSE_RELEASE",
     "HERMES_LANGFUSE_SAMPLE_RATE",

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -762,11 +762,12 @@ def _discover_all_plugins() -> list:
                     except Exception:
                         pass
                 key = f"{prefix}/{d.name}" if prefix else manifest_name
-                if key in seen and source == "bundled":
-                    continue
                 src_label = source
                 if source == "user" and (d / ".git").exists():
                     src_label = "git"
+                # Bundled is scanned before user, so the user pass overwrites
+                # bundled entries with the same key — matches
+                # PluginManager.discover_and_load's "user wins" semantics.
                 seen[key] = (key, version, description, src_label, d)
                 continue
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -708,55 +708,79 @@ def _plugin_exists(name: str) -> bool:
 
 
 def _discover_all_plugins() -> list:
-    """Return a list of (name, version, description, source, dir_path) for
-    every plugin the loader can see — user + bundled + project.
+    """Return a list of (key, version, description, source, dir_path) for
+    every plugin the loader can see — user + bundled.
 
-    Matches the ordering/dedup of ``PluginManager.discover_and_load``:
-    bundled first, then user, then project; user overrides bundled on
-    name collision.
+    Mirrors :meth:`PluginManager._scan_directory_level` so category-namespaced
+    plugins (``observability/langfuse``, ``image_gen/openai``) surface here
+    just like flat ones (``disk-cleanup``). A subdirectory with no
+    ``plugin.yaml`` of its own is treated as a category and recursed into
+    one level deeper (depth capped at 2, same as the loader).
+
+    The returned ``key`` is the path-derived registry key — the value the
+    user types into ``hermes plugins enable <key>``. For category-namespaced
+    plugins that's ``<category>/<dirname>``; for flat plugins it's the
+    manifest's ``name`` (or the directory name if the manifest omits it).
+
+    User entries override bundled on key collision, matching
+    ``PluginManager.discover_and_load``.
     """
     try:
         import yaml
     except ImportError:
         yaml = None
 
-    seen: dict = {}  # name -> (name, version, description, source, path)
+    seen: dict = {}  # key -> (key, version, description, source, path)
 
-    # Bundled (<repo>/plugins/<name>/), excluding memory/ and context_engine/
-    from hermes_cli.plugins import get_bundled_plugins_dir
-    repo_plugins = get_bundled_plugins_dir()
-    for base, source in ((repo_plugins, "bundled"), (_plugins_dir(), "user")):
+    def _scan(base: Path, source: str, prefix: str, depth: int) -> None:
         if not base.is_dir():
-            continue
+            return
         for d in sorted(base.iterdir()):
             if not d.is_dir():
                 continue
-            if source == "bundled" and d.name in {"memory", "context_engine"}:
+            if (
+                depth == 0
+                and source == "bundled"
+                and d.name in {"memory", "context_engine"}
+            ):
                 continue
             manifest_file = d / "plugin.yaml"
             if not manifest_file.exists():
                 manifest_file = d / "plugin.yml"
-            if not manifest_file.exists():
+
+            if manifest_file.exists():
+                manifest_name = d.name
+                version = ""
+                description = ""
+                if yaml:
+                    try:
+                        with open(manifest_file, encoding="utf-8") as f:
+                            manifest = yaml.safe_load(f) or {}
+                        manifest_name = manifest.get("name", d.name)
+                        version = manifest.get("version", "")
+                        description = manifest.get("description", "")
+                    except Exception:
+                        pass
+                key = f"{prefix}/{d.name}" if prefix else manifest_name
+                if key in seen and source == "bundled":
+                    continue
+                src_label = source
+                if source == "user" and (d / ".git").exists():
+                    src_label = "git"
+                seen[key] = (key, version, description, src_label, d)
                 continue
-            name = d.name
-            version = ""
-            description = ""
-            if yaml:
-                try:
-                    with open(manifest_file, encoding="utf-8") as f:
-                        manifest = yaml.safe_load(f) or {}
-                    name = manifest.get("name", d.name)
-                    version = manifest.get("version", "")
-                    description = manifest.get("description", "")
-                except Exception:
-                    pass
-            # User plugins override bundled on name collision.
-            if name in seen and source == "bundled":
+
+            # No manifest at this level — treat as a category namespace and
+            # recurse one level deeper. Cap at depth 2 (same as the loader).
+            if depth >= 1:
                 continue
-            src_label = source
-            if source == "user" and (d / ".git").exists():
-                src_label = "git"
-            seen[name] = (name, version, description, src_label, d)
+            sub_prefix = f"{prefix}/{d.name}" if prefix else d.name
+            _scan(d, source, sub_prefix, depth + 1)
+
+    from hermes_cli.plugins import get_bundled_plugins_dir
+    _scan(get_bundled_plugins_dir(), "bundled", "", 0)
+    _scan(_plugins_dir(), "user", "", 0)
+
     return list(seen.values())
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -761,6 +761,11 @@ def _discover_all_plugins() -> list:
                         description = manifest.get("description", "")
                     except Exception:
                         pass
+                # Path-derived key, intentionally ignoring the manifest
+                # ``name:`` field for category-namespaced plugins — mirrors
+                # ``PluginManager._parse_manifest`` in plugins.py:1027-1028
+                # so renaming a directory (without touching plugin.yaml) shifts
+                # the registry key in both places consistently.
                 key = f"{prefix}/{d.name}" if prefix else manifest_name
                 src_label = source
                 if source == "user" and (d / ".git").exists():

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -461,31 +461,6 @@ TOOL_CATEGORIES = {
             },
         ],
     },
-    "langfuse": {
-        "name": "Langfuse Observability",
-        "icon": "📊",
-        "providers": [
-            {
-                "name": "Langfuse Cloud",
-                "tag": "Hosted Langfuse (cloud.langfuse.com)",
-                "env_vars": [
-                    {"key": "HERMES_LANGFUSE_PUBLIC_KEY", "prompt": "Langfuse public key (pk-lf-...)", "url": "https://cloud.langfuse.com"},
-                    {"key": "HERMES_LANGFUSE_SECRET_KEY", "prompt": "Langfuse secret key (sk-lf-...)", "url": "https://cloud.langfuse.com"},
-                ],
-                "post_setup": "langfuse",
-            },
-            {
-                "name": "Langfuse Self-Hosted",
-                "tag": "Self-hosted Langfuse instance",
-                "env_vars": [
-                    {"key": "HERMES_LANGFUSE_PUBLIC_KEY", "prompt": "Langfuse public key (pk-lf-...)"},
-                    {"key": "HERMES_LANGFUSE_SECRET_KEY", "prompt": "Langfuse secret key (sk-lf-...)"},
-                    {"key": "HERMES_LANGFUSE_BASE_URL", "prompt": "Langfuse server URL (e.g. http://localhost:3000)", "default": "http://localhost:3000"},
-                ],
-                "post_setup": "langfuse",
-            },
-        ],
-    },
 }
 
 # Simple env-var requirements for toolsets NOT in TOOL_CATEGORIES.
@@ -946,36 +921,6 @@ def _run_post_setup(post_setup_key: str):
         except Exception as exc:
             _print_warning(f"    Spotify login failed: {exc}")
             _print_info("    Run manually: hermes auth spotify")
-
-    elif post_setup_key == "langfuse":
-        # Install the langfuse SDK.
-        try:
-            __import__("langfuse")
-            _print_success("    langfuse SDK already installed")
-        except ImportError:
-            _print_info("    Installing langfuse SDK...")
-            result = _pip_install(["langfuse", "--quiet"], timeout=120)
-            if result.returncode == 0:
-                _print_success("    langfuse SDK installed")
-            else:
-                _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
-        # Opt the bundled observability/langfuse plugin into plugins.enabled.
-        # The plugin ships in the repo but doesn't load until the user enables
-        # it (standalone plugins are opt-in).
-        try:
-            from hermes_cli.plugins_cmd import _get_enabled_set, _save_enabled_set
-            enabled = _get_enabled_set()
-            if "observability/langfuse" in enabled or "langfuse" in enabled:
-                _print_success("    Plugin observability/langfuse already enabled")
-            else:
-                enabled.add("observability/langfuse")
-                _save_enabled_set(enabled)
-                _print_success("    Plugin observability/langfuse enabled")
-        except Exception as exc:
-            _print_warning(f"    Could not enable plugin automatically: {exc}")
-            _print_info("    Run manually: hermes plugins enable observability/langfuse")
-        _print_info("    Restart Hermes for tracing to take effect.")
-        _print_info("    Verify: hermes plugins list")
 
     elif post_setup_key == "xai_grok":
         # Shared credential bootstrap for any picker entry that talks to xAI

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -5,20 +5,16 @@ you explicitly enable it.
 
 ## Enable
 
-Pick one:
-
 ```bash
-# Interactive: walks you through credentials + SDK install + enable
-hermes tools  # → Langfuse Observability
-
-# Manual
 pip install langfuse
 hermes plugins enable observability/langfuse
 ```
 
+Or check the box in the interactive `hermes plugins` UI.
+
 ## Required credentials
 
-Set these in `~/.hermes/.env` (or via `hermes tools`):
+Set these in `~/.hermes/.env`:
 
 ```bash
 HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -4,11 +4,11 @@ Traces Hermes conversations, LLM calls, and tool usage to Langfuse.
 
 Activation is handled by the Hermes plugin system — standalone plugins only
 load when listed in ``plugins.enabled`` (via ``hermes plugins enable
-observability/langfuse`` or ``hermes tools → Langfuse Observability``). At
-runtime the plugin also requires the ``langfuse`` SDK and credentials; if
-either is missing the hooks are inert.
+observability/langfuse``, or by checking the box in the interactive
+``hermes plugins`` UI). At runtime the plugin also requires the
+``langfuse`` SDK and credentials; if either is missing the hooks are inert.
 
-Required env vars (set via ``hermes tools`` or ~/.hermes/.env):
+Required env vars (set in ~/.hermes/.env):
   HERMES_LANGFUSE_PUBLIC_KEY  - Langfuse project public key (pk-lf-...)
   HERMES_LANGFUSE_SECRET_KEY  - Langfuse project secret key (sk-lf-...)
   HERMES_LANGFUSE_BASE_URL    - Langfuse server URL (default: https://cloud.langfuse.com)

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -1,6 +1,6 @@
 name: langfuse
 version: "1.0.0"
-description: "Optional Langfuse observability for Hermes — traces conversations, LLM calls, and tool usage. Opt-in via `hermes plugins enable observability/langfuse` or `hermes tools → Langfuse Observability`."
+description: "Optional Langfuse observability for Hermes — traces conversations, LLM calls, and tool usage. Opt-in via `hermes plugins enable observability/langfuse` (or check the box in `hermes plugins`)."
 author: NousResearch
 requires_env:
   - HERMES_LANGFUSE_PUBLIC_KEY

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -396,6 +396,117 @@ class TestCmdList:
         cmd_list()
 
 
+# ── _discover_all_plugins tests ───────────────────────────────────────────────
+
+
+class TestDiscoverAllPlugins:
+    """Exercise the recursive scan that powers ``hermes plugins list``.
+
+    Mirrors the layouts the runtime loader handles
+    (:meth:`PluginManager._scan_directory_level`): flat plugins at the root,
+    category-namespaced plugins one level deeper, and user-overrides-bundled
+    on key collision.
+    """
+
+    @staticmethod
+    def _write_plugin(root: Path, segments: list, manifest_name: str = None) -> None:
+        plugin_dir = root
+        for seg in segments:
+            plugin_dir = plugin_dir / seg
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": manifest_name or segments[-1],
+            "version": "0.1.0",
+            "description": f"Test plugin {'/'.join(segments)}",
+        }
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump(manifest))
+
+    def _entries_by_key(self, tmp_path, monkeypatch) -> dict:
+        from hermes_cli import plugins_cmd
+        bundled = tmp_path / "bundled"
+        user = tmp_path / "user"
+        bundled.mkdir()
+        user.mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled
+        )
+        monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user)
+        return bundled, user, lambda: {
+            e[0]: e for e in plugins_cmd._discover_all_plugins()
+        }
+
+    def test_flat_plugin_uses_manifest_name_as_key(self, tmp_path, monkeypatch):
+        bundled, _, discover = self._entries_by_key(tmp_path, monkeypatch)
+        self._write_plugin(bundled, ["disk-cleanup"])
+
+        entries = discover()
+        assert "disk-cleanup" in entries
+        assert entries["disk-cleanup"][3] == "bundled"
+
+    def test_category_namespaced_plugin_uses_path_derived_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression test for the original bug — ``observability/langfuse``
+        and ``image_gen/openai`` must surface under their path-derived key,
+        not vanish because the category directory has no ``plugin.yaml``."""
+        bundled, _, discover = self._entries_by_key(tmp_path, monkeypatch)
+        # langfuse's real manifest declares ``name: langfuse`` (bare), but it
+        # lives under ``observability/`` — the key must reflect the path.
+        self._write_plugin(
+            bundled, ["observability", "langfuse"], manifest_name="langfuse"
+        )
+        self._write_plugin(bundled, ["image_gen", "openai"])
+
+        entries = discover()
+        assert "observability/langfuse" in entries
+        assert "image_gen/openai" in entries
+        # Bare manifest name must NOT leak through as a top-level key.
+        assert "langfuse" not in entries
+        assert "openai" not in entries
+
+    def test_user_overrides_bundled_on_key_collision(self, tmp_path, monkeypatch):
+        bundled, user, discover = self._entries_by_key(tmp_path, monkeypatch)
+        self._write_plugin(bundled, ["observability", "langfuse"])
+        self._write_plugin(user, ["observability", "langfuse"])
+
+        entries = discover()
+        assert entries["observability/langfuse"][3] == "user"
+
+    def test_depth_cap_skips_third_level(self, tmp_path, monkeypatch):
+        """Anything deeper than ``<root>/<category>/<plugin>/`` is ignored,
+        matching the loader's depth cap."""
+        bundled, _, discover = self._entries_by_key(tmp_path, monkeypatch)
+        # plugins/a/b/c/plugin.yaml — too deep, must NOT be discovered.
+        self._write_plugin(bundled, ["a", "b", "c"])
+
+        entries = discover()
+        assert not any(k.startswith("a/") for k in entries), entries
+
+    def test_bundled_memory_and_context_engine_skipped(self, tmp_path, monkeypatch):
+        """``plugins/memory/`` and ``plugins/context_engine/`` use their own
+        loaders; bundled entries inside them must not appear in the general
+        list (matches the pre-refactor skip set)."""
+        bundled, _, discover = self._entries_by_key(tmp_path, monkeypatch)
+        self._write_plugin(bundled, ["memory", "honcho"])
+        self._write_plugin(bundled, ["context_engine", "compressor"])
+        self._write_plugin(bundled, ["observability", "langfuse"])
+
+        entries = discover()
+        assert "memory/honcho" not in entries
+        assert "context_engine/compressor" not in entries
+        assert "observability/langfuse" in entries
+
+    def test_user_memory_subdir_is_still_scanned(self, tmp_path, monkeypatch):
+        """The memory/context_engine skip only applies to *bundled* — a user
+        plugin at ``~/.hermes/plugins/memory/<x>/`` should still be discovered
+        so the user can see what they installed."""
+        bundled, user, discover = self._entries_by_key(tmp_path, monkeypatch)
+        self._write_plugin(user, ["memory", "my-custom-store"])
+
+        entries = discover()
+        assert "memory/my-custom-store" in entries
+
+
 # ── _copy_example_files tests ─────────────────────────────────────────────────
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -156,7 +156,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 ### Langfuse Observability
 
-Environment variables for the bundled [`observability/langfuse`](/docs/user-guide/features/built-in-plugins#observabilitylangfuse) plugin. Set these with `hermes tools → Langfuse Observability` or manually in `~/.hermes/.env`. The plugin must also be enabled (`hermes plugins enable observability/langfuse`) before any of these take effect.
+Environment variables for the bundled [`observability/langfuse`](/docs/user-guide/features/built-in-plugins#observabilitylangfuse) plugin. Set these in `~/.hermes/.env`. The plugin must also be enabled (`hermes plugins enable observability/langfuse`, or check the box in `hermes plugins`) before any of these take effect.
 
 | Variable | Description |
 |----------|-------------|

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -121,22 +121,14 @@ Traces Hermes turns, LLM calls, and tool invocations to [Langfuse](https://langf
 
 The plugin is fail-open: no SDK installed, no credentials, or a transient Langfuse error — all turn into a silent no-op in the hook. The agent loop is never impacted.
 
-**Setup (interactive — recommended):**
-
-```bash
-hermes tools          # → Langfuse Observability → Cloud or Self-Hosted
-```
-
-The wizard collects your keys, `pip install`s the `langfuse` SDK, and adds `observability/langfuse` to `plugins.enabled` for you. Restart Hermes and the next turn ships a trace.
-
-**Setup (manual):**
+**Setup:**
 
 ```bash
 pip install langfuse
 hermes plugins enable observability/langfuse
 ```
 
-Then put the credentials in `~/.hermes/.env`:
+Or check the box in the interactive `hermes plugins` UI. Then put the credentials in `~/.hermes/.env`:
 
 ```bash
 HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -142,6 +142,8 @@ Within each source, Hermes also recognizes sub-category directories that route p
 
 User plugins at `~/.hermes/plugins/model-providers/<name>/` and `~/.hermes/plugins/memory/<name>/` override bundled plugins of the same name — last-writer-wins in `register_provider()` / `register_memory_provider()`. Drop a directory in, and it replaces the built-in without any repo edits.
 
+Sub-category plugins surface in `hermes plugins list` and the interactive `hermes plugins` UI under their **path-derived key** — e.g. `observability/langfuse`, `image_gen/openai`, `platforms/teams`. That key (not the bare manifest `name:`) is the value you pass to `hermes plugins enable …` / `disable …` and the string to add under `plugins.enabled` in `config.yaml`.
+
 ## Plugins are opt-in (with a few exceptions)
 
 **General plugins and user-installed backends are disabled by default** — discovery finds them (so they show up in `hermes plugins` and `/plugins`), but nothing with hooks or tools loads until you add the plugin's name to `plugins.enabled` in `~/.hermes/config.yaml`. This stops third-party code from running without your explicit consent.
@@ -263,16 +265,19 @@ Declarative plugins are symlinked with a `nix-managed-` prefix — they coexist 
 ## Managing plugins
 
 ```bash
-hermes plugins                               # unified interactive UI
-hermes plugins list                          # table: enabled / disabled / not enabled
-hermes plugins install user/repo             # install from Git, then prompt Enable? [y/N]
-hermes plugins install user/repo --enable    # install AND enable (no prompt)
-hermes plugins install user/repo --no-enable # install but leave disabled (no prompt)
-hermes plugins update my-plugin              # pull latest
-hermes plugins remove my-plugin              # uninstall
-hermes plugins enable my-plugin              # add to allow-list
-hermes plugins disable my-plugin             # remove from allow-list + add to disabled
+hermes plugins                                       # unified interactive UI
+hermes plugins list                                  # table: enabled / disabled / not enabled
+hermes plugins install user/repo                     # install from Git, then prompt Enable? [y/N]
+hermes plugins install user/repo --enable            # install AND enable (no prompt)
+hermes plugins install user/repo --no-enable         # install but leave disabled (no prompt)
+hermes plugins update my-plugin                      # pull latest
+hermes plugins remove my-plugin                      # uninstall
+hermes plugins enable my-plugin                      # add to allow-list (flat plugin)
+hermes plugins enable observability/langfuse         # add to allow-list (sub-category plugin)
+hermes plugins disable my-plugin                     # remove from allow-list + add to disabled
 ```
+
+For plugins under a sub-category directory (e.g. `plugins/observability/langfuse/`, `plugins/image_gen/openai/`), use the full `<category>/<plugin>` key — that's exactly what `hermes plugins list` shows in the **Name** column.
 
 ### Interactive UI
 
@@ -286,6 +291,7 @@ Plugins
  → [✓] my-tool-plugin — Custom search tool
    [ ] webhook-notifier — Event hooks
    [ ] disk-cleanup — Auto-cleanup of ephemeral files [bundled]
+   [ ] observability/langfuse — Trace turns / LLM calls / tools to Langfuse [bundled]
 
   Provider Plugins
      Memory Provider          ▸ honcho


### PR DESCRIPTION
This PR fixes two related bugs that prevented the bundled `observability/langfuse` plugin (and other sub-category plugins like `image_gen/openai`, `platforms/teams`, every `model-providers/*`) from being discoverable through the CLI.

---

## Bug 1 — `hermes plugins list` silently drops sub-category plugins

`hermes plugins list` (and the interactive `hermes plugins` UI) silently omits every category-namespaced bundled plugin — `observability/langfuse`, `image_gen/openai`, `platforms/teams`, every entry under `model-providers/`, `web/`, `video_gen/`. The plugins **do** load at runtime, but they're invisible in the CLI, so users have no way to discover what's enableable.

This breaks the documented contract that bundled plugins ship disabled but appear in `hermes plugins list` and the interactive UI before being enabled (see `website/docs/user-guide/features/built-in-plugins.md`, "Bundled plugins are opt-in"). It also makes `observability/langfuse` look like it doesn't exist — even the langfuse README's verify step (`hermes plugins list # observability/langfuse should show "enabled"`) silently failed.

### Root cause

`_discover_all_plugins()` in `hermes_cli/plugins_cmd.py:710` does a single-level scan: for each direct child of `<repo>/plugins/` and `~/.hermes/plugins/`, it reads `<child>/plugin.yaml` and bails if absent. Category directories (`observability/`, `image_gen/`, `platforms/`, …) have no `plugin.yaml` of their own — they're namespaces — so nested plugins one level deeper are never visited.

The runtime loader (`PluginManager._scan_directory_level` in `hermes_cli/plugins.py:954`) already handles this layout correctly: when a top-level child has no manifest, it recurses one level, builds a path-derived key like `observability/langfuse`, and registers the plugin. The CLI display code just never picked up the same recursion.

### Fix

Refactor `_discover_all_plugins()` to mirror the loader exactly:

- Recurse into category directories that lack a `plugin.yaml` (depth cap = 2 — anything deeper is ignored, same as the loader).
- Keep the existing skip set (`memory/`, `context_engine/`) — those have their own discovery paths.
- Return the **path-derived registry key** (`observability/langfuse`, `image_gen/openai`, `disk-cleanup`) as the displayed name — exactly the string the user passes to `hermes plugins enable …` or writes under `plugins.enabled` in `config.yaml`. For flat plugins this is unchanged; for nested ones it's now `<category>/<plugin>` instead of bare `<plugin>` (so two `openai`-named backends under different categories don't collide).
- Preserve user-overrides-bundled on key collision (matches `PluginManager.discover_and_load`).

### Verification

Before:

```
$ hermes plugins list
# observability/langfuse, image_gen/*, platforms/*, model-providers/*,
# web/*, video_gen/* — none shown
```

After (smoke-tested locally):

```
disk-cleanup                             | bundled
google_meet                              | bundled
image_gen/openai                         | bundled
image_gen/openai-codex                   | bundled
image_gen/xai                            | bundled
model-providers/ai-gateway               | bundled
…
observability/langfuse                   | bundled
platforms/google_chat                    | bundled
platforms/irc                            | bundled
…
web/brave_free                           | bundled
web/tavily                               | bundled
```

### Docs (Bug 1)

`website/docs/user-guide/features/plugins.md`:

- New paragraph in **Plugin sub-categories** explicitly stating that sub-category plugins surface in `hermes plugins list` and the interactive UI by their path-derived `<category>/<plugin>` key — and that this is the value to pass to `hermes plugins enable …` / write under `plugins.enabled`.
- **Managing plugins** code block: added `hermes plugins enable observability/langfuse` as an explicit second example next to the existing flat-plugin example, plus a one-liner pointing users at the **Name** column of `hermes plugins list`.
- **Interactive UI** mock: added `observability/langfuse — Trace turns / LLM calls / tools to Langfuse [bundled]` to the example so the nested form is visible.

---

## Bug 2 — `hermes tools → Langfuse Observability` was unreachable

The langfuse README, plugin description, module docstring, `config.py` comment, and two doc pages all promised an interactive setup flow at `hermes tools → Langfuse Observability` (pip install + key prompts + auto-enable). That flow was unreachable.

### Root cause

`tools_command` shows toolsets from `_get_effective_configurable_toolsets()` = `CONFIGURABLE_TOOLSETS` + plugin-registered toolsets. The langfuse plugin is hooks-only (no toolsets), and `"langfuse"` isn't in `CONFIGURABLE_TOOLSETS`. So the entry in `TOOL_CATEGORIES["langfuse"]` (a complete provider/key-collection wizard) and its companion `post_setup: "langfuse"` hook (pip install + write `plugins.enabled`) had no caller — pure dead code, with six places pointing users at it.

### Fix

Doc-first fix; `hermes tools` is conceptually "what tools does the LLM see + what keys do they need", and langfuse is observability (a hook plugin, not a tool). The right home for the wizard is `hermes plugins` (e.g. auto-running a plugin's post-setup hook on enable), which is a generic plugin-setup mechanism worth designing properly rather than shoehorning langfuse back into `hermes tools`. Until that exists, point users at the working manual flow.

Code (`hermes_cli/tools_config.py`):
- Delete `TOOL_CATEGORIES["langfuse"]` (24 lines) — unreachable.
- Delete the `post_setup_key == "langfuse"` branch in `_run_post_setup` (29 lines) — only caller was the deleted `TOOL_CATEGORIES` entry.

Docs / comments (all now point at `hermes plugins enable observability/langfuse` + the interactive `hermes plugins`):
- `plugins/observability/langfuse/README.md` — collapse the two-option setup section to the single working flow.
- `plugins/observability/langfuse/plugin.yaml` — update `description`.
- `plugins/observability/langfuse/__init__.py` — update module docstring.
- `hermes_cli/config.py` — update inline comment above the `LANGFUSE_*` env-var allow-list.
- `website/docs/user-guide/features/built-in-plugins.md` — collapse "Setup (interactive)" + "Setup (manual)" into one accurate block.
- `website/docs/reference/environment-variables.md` — update the cross-reference in the Langfuse env-vars section.

---

## Test plan

- [x] `pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugin_scanner_recursion.py tests/hermes_cli/test_startup_plugin_gating.py tests/plugins/test_langfuse_plugin.py` — **220 passed**
- [x] Full `pytest tests/hermes_cli/` (minus a module that needs `fastapi`, not installed in this env) — only pre-existing failures unrelated to this PR (kanban DB, launchd plist, web-server PTY).
- [x] Local smoke: `python -c "from hermes_cli.plugins_cmd import _discover_all_plugins; [print(e[0], '|', e[3]) for e in _discover_all_plugins()]"` shows every bundled category-namespaced plugin.
- [x] `python -c "from hermes_cli import tools_config; print(list(tools_config.TOOL_CATEGORIES.keys()))"` — confirms `langfuse` key is gone and the remaining 9 categories are intact.
- [x] Reviewer to confirm `hermes plugins enable observability/langfuse` round-trips after the fix (it already worked — `_plugin_exists()` accepts slashed names since path concatenation handles them — but worth a manual sanity check).

---

## Commits

1. `fix(plugins): surface category-namespaced plugins in hermes plugins list` — the discovery + display fix and the corresponding `plugins.md` docs (Bug 1).
2. `fix(plugins): remove unreachable hermes tools → Langfuse path` — dead-code removal + doc/comment sweep (Bug 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)