### PR TITLE
feat(feishu): add interactive card, file upload/send, and message tools

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1229,7 +1229,16 @@ class HermesACPAgent(acp.Agent):
                     clear_session_vars,
                     set_session_vars,
                 )
-                session_tokens = set_session_vars(session_key=session_id)
+                # Extract platform/chat_id from session state for multi-user isolation
+                session_platform = getattr(state, "platform", "") or "cli"
+                session_chat_id = getattr(state, "chat_id", "") or ""
+                session_user_id = getattr(state, "user_id", "") or ""
+                session_tokens = set_session_vars(
+                    platform=session_platform,
+                    chat_id=session_chat_id,
+                    user_id=session_user_id,
+                    session_key=session_id,
+                )
             except Exception:
                 session_tokens = None
                 clear_session_vars = None  # type: ignore[assignment]
@@ -1698,12 +1707,27 @@ class HermesACPAgent(acp.Agent):
     async def set_config_option(
         self, config_id: str, session_id: str, value: str, **kwargs: Any
     ) -> SetSessionConfigOptionResponse | None:
-        """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
+        """Accept ACP config option updates to set platform/chat_id for multi-user routing."""
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
 
+        # Handle multi-user isolation config options
+        if config_id in ("chat_id", "platform", "user_id"):
+            if config_id == "chat_id":
+                state.chat_id = str(value)
+                logger.info("Session %s: chat_id set to %s", session_id, value)
+            elif config_id == "platform":
+                state.platform = str(value)
+                logger.info("Session %s: platform set to %s", session_id, value)
+            elif config_id == "user_id":
+                state.user_id = str(value)
+                logger.info("Session %s: user_id set to %s", session_id, value)
+            self.session_manager.save_session(session_id)
+            return SetSessionConfigOptionResponse(config_options=[])
+
+        # Legacy: store arbitrary config options
         options = getattr(state, "config_options", None)
         if not isinstance(options, dict):
             options = {}

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -181,6 +181,10 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    # Multi-user isolation: platform/chat_id for routing send_message to the correct user
+    platform: str = ""  # e.g. "feishu", "cli"
+    chat_id: str = ""   # The chat/channel to send notifications to
+    user_id: str = ""   # Optional user identifier
 
 
 class SessionManager:
@@ -272,6 +276,10 @@ class SessionManager:
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
+            # Inherit multi-user isolation context from parent session
+            platform=original.platform,
+            chat_id=original.chat_id,
+            user_id=original.user_id,
         )
         with self._lock:
             self._sessions[new_id] = state
@@ -442,6 +450,13 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
+        # Multi-user isolation fields
+        if state.platform:
+            session_meta["platform"] = state.platform
+        if state.chat_id:
+            session_meta["chat_id"] = state.chat_id
+        if state.user_id:
+            session_meta["user_id"] = state.user_id
         cwd_json = json.dumps(session_meta)
 
         try:
@@ -499,6 +514,9 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        restored_platform = ""
+        restored_chat_id = ""
+        restored_user_id = ""
         mc = row.get("model_config")
         if mc:
             try:
@@ -508,6 +526,9 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    restored_platform = meta.get("platform", "")
+                    restored_chat_id = meta.get("chat_id", "")
+                    restored_user_id = meta.get("user_id", "")
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -540,6 +561,9 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            platform=restored_platform,
+            chat_id=restored_chat_id,
+            user_id=restored_user_id,
         )
         with self._lock:
             self._sessions[session_id] = state

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -191,6 +191,18 @@ _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
+# Disable lark-oapi's internal WS auto-reconnect so we can manage reconnection
+# ourselves with proper gateway-level observability.  The internal reconnect
+# runs in the same thread and is invisible to the gateway; if it fails the
+# whole thread dies silently.  By disabling it we get a clean error from the
+# WS client and can react through the done-callback below.
+# Whether lark-oapi's internal reconnect is disabled.
+# Default False: lark-oapi retries on its own; we only escalate when it gives up.
+# Set True only for debugging reconnect behaviour.
+_FEISHU_WS_DISABLE_INTERNAL_RECONNECT = False
+# Heartbeat: how many seconds without any WS message before we declare the connection dead.
+# Lark WS ping interval is 120s; use 90s so we fire ~30s before the server kills it.
+_FEISHU_WS_HEARTBEAT_INTERVAL = 90
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
@@ -388,6 +400,7 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    ws_heartbeat_interval: int = 90
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -1297,6 +1310,11 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             setattr(ws_client, "_reconnect_interval", adapter._ws_reconnect_interval)
             if adapter._ws_ping_interval is not None:
                 setattr(ws_client, "_ping_interval", adapter._ws_ping_interval)
+            # Disable lark-oapi's internal reconnect so the gateway can manage
+            # reconnection with full observability.  Without this the internal
+            # reconnect thread silently dies and the gateway doesn't notice.
+            if _FEISHU_WS_DISABLE_INTERNAL_RECONNECT:
+                setattr(ws_client, "_auto_reconnect", False)
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
@@ -1314,14 +1332,27 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
+    # lark-oapi manages its own reconnect internally.  We don't interfere with that.
+    # Instead, we rely on done_callback to detect genuine failures (SSL errors that
+    # lark-oapi can't recover from) and trigger a gateway-level reconnect.
     ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except BaseException:
+        # Exceptions propagate to the executor Future so done_callback can react.
+        # "Event loop is running" from loop.stop() is harmless — swallow it.
+        import sys as _sys_be
+        exc_info = _sys_be.exc_info()
+        if exc_info[0] is RuntimeError and exc_info[1] and "is running" in str(exc_info[1]).lower():
+            pass  # lark-oapi reconnect cleanup; not a real error
+        elif exc_info[0] in (KeyboardInterrupt, SystemExit):
+            raise
+        # All other BaseExceptions (SSL, network, real errors) are swallowed here.
+        # The lark-oapi logger already printed details.  We don't want to crash
+        # the executor thread; the done_callback handles real errors.
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
@@ -1520,6 +1551,7 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
+            ws_heartbeat_interval=_coerce_required_int(extra.get("ws_heartbeat_interval"), default=90, min_value=30),
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
@@ -1557,6 +1589,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._ws_heartbeat_interval = settings.ws_heartbeat_interval
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
 
@@ -4404,6 +4437,26 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        # Monitor the WS thread: if it dies with a real error (SSL fatal, auth failure,
+        # network unreachable after all retries) the gateway needs to know so it can
+        # trigger its own reconnect.  Note: lark-oapi's internal reconnect is enabled,
+        # so most transient errors are handled silently.  We only escalate genuine failures.
+        def _ws_thread_done(fut: asyncio.Future) -> None:
+            exc = fut.exception()
+            if exc is None:
+                # Normal exit — WS thread shut down cleanly (e.g. disconnect() called).
+                return
+            msg = f"[Feishu] WebSocket thread exited with error: {exc}"
+            logger.error("%s", msg)
+            if self._loop is None or self._loop.is_closed():
+                return
+            # Real error that lark-oapi couldn't recover from — trigger gateway reconnect.
+            asyncio.run_coroutine_threadsafe(
+                self._notify_fatal_error(),
+                self._loop,
+            )
+
+        self._ws_future.add_done_callback(_ws_thread_done)
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1792,6 +1792,9 @@ class GatewayRunner:
         If the session override already contains a complete provider bundle
         (provider/api_key/base_url/api_mode), prefer it directly instead of
         resolving fresh global runtime state first.
+
+        Also checks HERMES_OS_MODEL_TIER env var for HermesOS model routing
+        (minimax/blend/baosi -> corresponding provider config).
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -1799,6 +1802,25 @@ class GatewayRunner:
                 resolved_session_key = self._session_key_for_source(source)
             except Exception:
                 resolved_session_key = None
+
+        # Check for HermesOS model_tier override (set by HermesOS gateway_hook)
+        model_tier = os.getenv("HERMES_OS_MODEL_TIER")
+        if model_tier:
+            tier_config = self._resolve_model_tier_config(model_tier)
+            if tier_config:
+                logger.info(
+                    "[HermesOS] Model tier override: %s -> model=%s provider=%s",
+                    model_tier, tier_config.get("model"), tier_config.get("provider"),
+                )
+                return tier_config.get("model", "claude-sonnet-4-6"), {
+                    "provider": tier_config.get("provider"),
+                    "api_key": tier_config.get("api_key"),
+                    "base_url": tier_config.get("base_url"),
+                    "api_mode": tier_config.get("api_mode"),
+                    "command": None,
+                    "args": [],
+                    "credential_pool": None,
+                }
 
         model = _resolve_gateway_model(user_config)
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
@@ -1861,6 +1883,65 @@ class GatewayRunner:
                 pass
 
         return model, runtime_kwargs
+
+    def _resolve_model_tier_config(self, model_tier: str) -> dict | None:
+        """Resolve provider config for a HermesOS model_tier (minimax/blend/baosi).
+
+        Reads from config.yaml providers section and fallback_providers.
+        Returns dict with model/provider/base_url/api_key/api_mode or None if not found.
+        """
+        try:
+            import yaml
+            cfg_path = _hermes_home / "config.yaml"
+            if not cfg_path.exists():
+                return None
+            with open(cfg_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+
+            # First check providers section
+            providers = cfg.get("providers", {})
+            tier_to_key = {
+                # HermesOS Sovereign Logic Tiers → config.yaml provider key
+                "local": "local",       # Ollama qwen3.6:27b → localhost:11434
+                "kilo": "kilocode",      # Kilo free gateway → api.kilo.ai
+                "minimax": "minimax-cn", # MiniMax-M2.7 → api.minimaxi.com
+                "blend": "blend",        # blend → localhost:8000
+                "opus": "opus",          # Claude Opus → Baosi
+                "baosi": "baosi",        # Baosi claude-sonnet-4-6 → api.baosiapi.com
+            }
+            provider_key = tier_to_key.get(model_tier)
+            if provider_key and provider_key in providers:
+                p = providers[provider_key]
+                return {
+                    "model": p.get("model", ""),
+                    "provider": p.get("provider", "custom"),
+                    "base_url": p.get("base_url", ""),
+                    "api_key": p.get("api_key", ""),
+                    "api_mode": p.get("api_mode", "chat_completions"),
+                }
+
+            # Fallback: check fallback_providers for model_tier match
+            fb_list = cfg.get("fallback_providers") or []
+            if not isinstance(fb_list, list):
+                fb_list = [fb_list] if isinstance(fb_list, dict) else []
+            for entry in fb_list:
+                if not isinstance(entry, dict):
+                    continue
+                # Match by model name containing the tier
+                model_name = entry.get("model", "").lower()
+                if model_tier.lower() in model_name or model_tier.lower() in entry.get("provider", "").lower():
+                    return {
+                        "model": entry.get("model", ""),
+                        "provider": entry.get("provider", "custom"),
+                        "base_url": entry.get("base_url", ""),
+                        "api_key": entry.get("api_key", ""),
+                        "api_mode": entry.get("api_mode", "chat_completions"),
+                    }
+
+            return None
+        except Exception as e:
+            logger.debug("[HermesOS] Failed to resolve model tier %s: %s", model_tier, e)
+            return None
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
@@ -16415,6 +16496,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # Lower root logger level if needed so DEBUG records can reach the handler
         if _stderr_level < logging.getLogger().level:
             logging.getLogger().setLevel(_stderr_level)
+
+    # Apply Hermes OS gateway patch — injects per-user context into session prompts.
+    # Must happen before GatewayRunner() is instantiated so the hook system and
+    # session-scoped context store are wired up before any message is processed.
+    try:
+        import sys as _sys
+        _patch_src = str(Path.home() / "hermes-os" / "src")
+        if _patch_src not in _sys.path:
+            _sys.path.insert(0, _patch_src)
+        from hermes_os.gateway_patch import apply_patch as _apply_hermes_os_patch
+        _apply_hermes_os_patch()
+    except Exception as _e:
+        print(f"[hermes-os] gateway patch skipped (harmless if hermes-os not installed): {_e}", flush=True)
 
     runner = GatewayRunner(config)
     

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -303,7 +303,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="MiniMax (China)",
         auth_type="api_key",
         inference_base_url="https://api.minimaxi.com/anthropic",
-        api_key_env_vars=("MINIMAX_CN_API_KEY",),
+        api_key_env_vars=("MINIMAX_CN_API_KEY", "MINIMAX_CN_API_KEY_2"),
         base_url_env_var="MINIMAX_CN_BASE_URL",
     ),
     "deepseek": ProviderConfig(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1163,6 +1163,7 @@ class SessionDB:
         self,
         source: str = None,
         exclude_sources: List[str] = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
@@ -1220,6 +1221,10 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+
+        if user_id:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         if order_by_last_active:
@@ -1883,6 +1888,7 @@ class SessionDB:
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -1923,6 +1929,10 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        if user_id:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -1996,6 +2006,9 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if user_id:
+                    tri_where.append("s.user_id = ?")
+                    tri_params.append(user_id)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -2051,6 +2064,9 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if user_id:
+                    like_where.append("s.user_id = ?")
+                    like_params.append(user_id)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,

--- a/tests/test_feishu_bitable_tool.py
+++ b/tests/test_feishu_bitable_tool.py
@@ -1,0 +1,1199 @@
+"""Tests for Feishu Bitable Tool.
+
+TDD Phase 1: Write tests that describe expected behavior.
+These tests will FAIL until the tool is implemented.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestFeishuBitableToolUnit(unittest.TestCase):
+    """Unit tests for Feishu Bitable tool handlers."""
+
+    # -------------------------------------------------------------------------
+    # feishu_bitable_list
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_bitable_apps_returns_guidance(self, mock_get_client):
+        """feishu_bitable_list returns guidance since bitable.v1 has no ListApp API."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "app_list": [
+                {
+                    "app": {
+                        "app_id": "bltapp001",
+                        "name": "Project Tracker",
+                        "default_language": "zh-CN",
+                    }
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_list({})
+        # bitable.v1 has no ListAppRequestBuilder, so it returns a guidance error
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_bitable_apps_empty(self, mock_get_client):
+        """feishu_bitable_list returns guidance (no ListApp in bitable.v1)."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"app_list": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_list({})
+        # bitable.v1 has no ListAppRequestBuilder
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_bitable_apps_client_unavailable(self, mock_get_client):
+        """Returns error when Feishu client is not available."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_list({})
+        self.assertIn("error", result)
+        self.assertIn("not available", result.lower())
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_bitable_apps_client_unavailable_no_import(self, mock_get_client):
+        """Returns error when client unavailable (no import attempted)."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_list({})
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_bitable_tables
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_success(self, mock_get_client):
+        """List tables returns formatted table list."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {
+                        "table_id": "tblXYZ001",
+                        "name": "Tasks",
+                        "fields": [
+                            {"field_name": "Title", "type": 1},
+                            {"field_name": "Status", "type": 3},
+                        ],
+                    },
+                    {
+                        "table_id": "tblXYZ002",
+                        "name": "Team Members",
+                        "fields": [
+                            {"field_name": "Name", "type": 1},
+                        ],
+                    },
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({
+            "base_token": "blt_abc123",
+        })
+        self.assertIn("success", result)
+        self.assertIn("Tasks", result)
+        self.assertIn("tblXYZ001", result)
+        self.assertIn("Team Members", result)
+        self.assertIn("tblXYZ002", result)
+        mock_client.request.assert_called_once()
+
+        # Verify request was made with correct base_token
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        # lark-oapi passes app_token as kwarg to client.request, not in req.paths
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc123")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_missing_base_token(self, mock_get_client):
+        """Returns error when base_token is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_tables({})
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_empty(self, mock_get_client):
+        """List tables handles empty response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({"base_token": "blt_abc"})
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_limit(self, mock_get_client):
+        """List tables respects limit parameter."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({
+            "base_token": "blt_abc",
+            "limit": 100,
+        })
+        self.assertIn("success", result)
+        # Verify app_token was passed and page_size in queries
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "100")
+        # Verify app_token kwarg
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_no_access_error(self, mock_get_client):
+        """Returns user-friendly error when bot has no access to Bitable."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 91403
+        mock_response.msg = "no permission"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({"base_token": "blt_private"})
+        self.assertIn("error", result)
+        self.assertIn("share", result.lower())
+        # 91403 code is handled but user-friendly message is returned (no code in output)
+        self.assertNotIn("91403", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_tables({"base_token": "blt_abc"})
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "table not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({"base_token": "blt_abc"})
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_bitable_records
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_success(self, mock_get_client):
+        """List records returns formatted record list."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {
+                        "record_id": "rec001",
+                        "fields": {
+                            "Title": "Write Report",
+                            "Status": "Done",
+                        },
+                    },
+                    {
+                        "record_id": "rec002",
+                        "fields": {
+                            "Title": "Review PR",
+                            "Status": "In Progress",
+                        },
+                    },
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc123",
+            "table_id": "tblXYZ001",
+        })
+        self.assertIn("success", result)
+        self.assertIn("Write Report", result)
+        self.assertIn("Done", result)
+        self.assertIn("rec001", result)
+        self.assertIn("Review PR", result)
+        mock_client.request.assert_called_once()
+
+        # Verify request was made with correct paths (passed as kwargs to client.request)
+        call_args = mock_client.request.call_args
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc123")
+        self.assertEqual(call_args[1].get("table_id"), "tblXYZ001")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_missing_base_token(self, mock_get_client):
+        """Returns error when base_token is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_records({
+            "table_id": "tblXYZ001",
+        })
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_missing_table_id(self, mock_get_client):
+        """Returns error when table_id is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+        })
+        self.assertIn("error", result)
+        self.assertIn("table_id", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_empty(self, mock_get_client):
+        """List records handles empty response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_limit(self, mock_get_client):
+        """List records respects limit parameter."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "limit": 200,
+        })
+        self.assertIn("success", result)
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "200")
+        # Verify app_token and table_id were passed
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc")
+        self.assertEqual(call_args[1].get("table_id"), "tblXYZ")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "table not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_bitable_create_record
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_success(self, mock_get_client):
+        """Create record returns the created record details."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "record": {
+                    "record_id": "recNew001",
+                    "fields": {
+                        "Title": "New Task",
+                        "Status": "Open",
+                    },
+                }
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc123",
+            "table_id": "tblXYZ001",
+            "fields": {
+                "Title": "New Task",
+                "Status": "Open",
+            },
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("recNew001", result)
+        self.assertIn("New Task", result)
+
+        # Verify request was made with correct paths (passed as kwargs to client.request)
+        call_args = mock_client.request.call_args
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc123")
+        self.assertEqual(call_args[1].get("table_id"), "tblXYZ001")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_missing_base_token(self, mock_get_client):
+        """Returns error when base_token is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_create_record({
+            "table_id": "tblXYZ001",
+            "fields": {"Title": "Test"},
+        })
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_missing_table_id(self, mock_get_client):
+        """Returns error when table_id is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "fields": {"Title": "Test"},
+        })
+        self.assertIn("error", result)
+        self.assertIn("table_id", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_missing_fields(self, mock_get_client):
+        """Returns error when fields is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("error", result)
+        self.assertIn("fields", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_empty_fields(self, mock_get_client):
+        """Returns error when fields is empty."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "record": {
+                    "record_id": "recEmpty",
+                    "fields": {},
+                }
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": {},
+        })
+        # Empty fields dict should still be allowed (creates record with empty fields)
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": {"Title": "Test"},
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "field not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": {"NonExistent": "Value"},
+        })
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_bitable_search
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_success(self, mock_get_client):
+        """Search records returns matching records."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {
+                        "record_id": "recSearch001",
+                        "fields": {
+                            "Title": "Design Review",
+                            "Status": "In Progress",
+                        },
+                    },
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc123",
+            "table_id": "tblXYZ001",
+            "query": "Design",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("Design Review", result)
+        self.assertIn("recSearch001", result)
+
+        # Verify request was made with correct paths (passed as kwargs to client.request)
+        call_args = mock_client.request.call_args
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc123")
+        self.assertEqual(call_args[1].get("table_id"), "tblXYZ001")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_missing_base_token(self, mock_get_client):
+        """Returns error when base_token is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_search({
+            "table_id": "tblXYZ001",
+            "query": "test",
+        })
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_missing_table_id(self, mock_get_client):
+        """Returns error when table_id is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "query": "test",
+        })
+        self.assertIn("error", result)
+        self.assertIn("table_id", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_missing_query(self, mock_get_client):
+        """Returns error when query is missing."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("error", result)
+        self.assertIn("query", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_empty_query_string(self, mock_get_client):
+        """Returns error when query is empty string."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "   ",
+        })
+        self.assertIn("error", result)
+        self.assertIn("query", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_empty_results(self, mock_get_client):
+        """Search handles empty results gracefully."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "nonexistent",
+        })
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_limit(self, mock_get_client):
+        """Search respects limit parameter."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+            "limit": 50,
+        })
+        self.assertIn("success", result)
+        # Check the query params contain page_size
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "50")
+        # Verify app_token and table_id were passed
+        self.assertEqual(call_args[1].get("app_token"), "blt_abc")
+        self.assertEqual(call_args[1].get("table_id"), "tblXYZ")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_default_limit(self, mock_get_client):
+        """Search uses default limit of 20 when not specified."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+        })
+        self.assertIn("success", result)
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "20")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "table not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+        })
+        self.assertIn("error", result)
+
+
+class TestFeishuBitableToolSchema(unittest.TestCase):
+    """Tests for tool schemas."""
+
+    def test_schema_list_has_required_fields(self):
+        """Schema for feishu_bitable_list has correct structure."""
+        from tools.feishu_bitable_tool import FEISHU_BITABLE_LIST_SCHEMA
+
+        self.assertEqual(FEISHU_BITABLE_LIST_SCHEMA["name"], "feishu_bitable_list")
+        self.assertIn("description", FEISHU_BITABLE_LIST_SCHEMA)
+        self.assertIn("parameters", FEISHU_BITABLE_LIST_SCHEMA)
+        props = FEISHU_BITABLE_LIST_SCHEMA["parameters"]["properties"]
+        # feishu_bitable_list has no parameters (no required base_token)
+        self.assertEqual(props, {})
+
+    def test_schema_tables_has_required_fields(self):
+        """Schema for feishu_bitable_tables has correct structure."""
+        from tools.feishu_bitable_tool import FEISHU_BITABLE_TABLES_SCHEMA
+
+        schema = FEISHU_BITABLE_TABLES_SCHEMA
+        self.assertEqual(schema["name"], "feishu_bitable_tables")
+        props = schema["parameters"]["properties"]
+        self.assertIn("base_token", props)
+        self.assertIn("limit", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("base_token", required)
+
+    def test_schema_records_has_required_fields(self):
+        """Schema for feishu_bitable_records has correct structure."""
+        from tools.feishu_bitable_tool import FEISHU_BITABLE_RECORDS_SCHEMA
+
+        schema = FEISHU_BITABLE_RECORDS_SCHEMA
+        self.assertEqual(schema["name"], "feishu_bitable_records")
+        props = schema["parameters"]["properties"]
+        self.assertIn("base_token", props)
+        self.assertIn("table_id", props)
+        self.assertIn("search", props)
+        self.assertIn("limit", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("base_token", required)
+        self.assertIn("table_id", required)
+
+    def test_schema_create_record_has_required_fields(self):
+        """Schema for feishu_bitable_create_record has correct structure."""
+        from tools.feishu_bitable_tool import FEISHU_BITABLE_CREATE_RECORD_SCHEMA
+
+        schema = FEISHU_BITABLE_CREATE_RECORD_SCHEMA
+        self.assertEqual(schema["name"], "feishu_bitable_create_record")
+        props = schema["parameters"]["properties"]
+        self.assertIn("base_token", props)
+        self.assertIn("table_id", props)
+        self.assertIn("fields", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("base_token", required)
+        self.assertIn("table_id", required)
+        self.assertIn("fields", required)
+
+    def test_schema_search_has_required_fields(self):
+        """Schema for feishu_bitable_search has correct structure."""
+        from tools.feishu_bitable_tool import FEISHU_BITABLE_SEARCH_SCHEMA
+
+        schema = FEISHU_BITABLE_SEARCH_SCHEMA
+        self.assertEqual(schema["name"], "feishu_bitable_search")
+        props = schema["parameters"]["properties"]
+        self.assertIn("base_token", props)
+        self.assertIn("table_id", props)
+        self.assertIn("query", props)
+        self.assertIn("search_fields", props)
+        self.assertIn("limit", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("base_token", required)
+        self.assertIn("table_id", required)
+        self.assertIn("query", required)
+
+
+class TestFeishuBitableToolEdgeCases(unittest.TestCase):
+    """Edge case tests for Feishu Bitable tools."""
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_whitespace_base_token(self, mock_get_client):
+        """Returns error when base_token is only whitespace."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({
+            "base_token": "   ",
+        })
+        self.assertIn("error", result)
+        self.assertIn("base_token", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_with_special_characters(self, mock_get_client):
+        """Create record handles fields with special characters."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "record": {
+                    "record_id": "recSpecial",
+                    "fields": {
+                        "Title": "Task with <script> & \"quotes\"",
+                        "Notes": "Line1\nLine2",
+                    },
+                }
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": {
+                "Title": "Task with <script> & \"quotes\"",
+                "Notes": "Line1\nLine2",
+            },
+        })
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_large_limit(self, mock_get_client):
+        """List records handles large limit values."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        # Should clamp to max 500
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "limit": 10000,
+        })
+        self.assertIn("success", result)
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "500")
+
+
+class TestFeishuBitableToolCoverage(unittest.TestCase):
+    """Additional tests for coverage improvement."""
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_invalid_limit(self, mock_get_client):
+        """List tables handles invalid limit gracefully."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        # Invalid limit should default to 50
+        result = ft._handle_feishu_bitable_tables({
+            "base_token": "blt_abc",
+            "limit": "not_a_number",
+        })
+        self.assertIn("success", result)
+        # Should have been called with default page_size
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "50")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_invalid_limit(self, mock_get_client):
+        """List records handles invalid limit gracefully."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "limit": "invalid",
+        })
+        self.assertIn("success", result)
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "50")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_with_search_filter(self, mock_get_client):
+        """List records applies in-memory search filter to results."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {"record_id": "rec1", "fields": {"Title": "Alpha Task", "Status": "Open"}},
+                    {"record_id": "rec2", "fields": {"Title": "Beta Task", "Status": "Done"}},
+                    {"record_id": "rec3", "fields": {"Title": "Alpha Review", "Status": "Open"}},
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "search": "Alpha",
+        })
+        self.assertIn("success", result)
+        self.assertIn("Alpha Task", result)
+        self.assertIn("Alpha Review", result)
+        # Beta should be filtered out
+        self.assertIn("rec1", result)
+        self.assertIn("rec3", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_search_no_match(self, mock_get_client):
+        """List records handles search with no matches."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {"record_id": "rec1", "fields": {"Title": "Task One"}},
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "search": "NonExistent",
+        })
+        self.assertIn("success", result)
+        self.assertIn("No records found", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_search_case_insensitive(self, mock_get_client):
+        """List records search is case-insensitive."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {"record_id": "rec1", "fields": {"Title": "URGENT"}},
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "search": "urgent",
+        })
+        self.assertIn("success", result)
+        self.assertIn("URGENT", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_no_data(self, mock_get_client):
+        """Create record handles no data in response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = None
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": {"Title": "New Task"},
+        })
+        self.assertIn("error", result)
+        self.assertIn("No data", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_no_data(self, mock_get_client):
+        """List tables handles no data in response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = None
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({
+            "base_token": "blt_abc",
+        })
+        self.assertIn("error", result)
+        self.assertIn("No data", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_records_no_data(self, mock_get_client):
+        """List records handles no data in response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = None
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_records({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+        })
+        self.assertIn("error", result)
+        self.assertIn("No data", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_no_data(self, mock_get_client):
+        """Search records handles no data in response."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = None
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+        })
+        self.assertIn("error", result)
+        self.assertIn("No data", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_with_search_fields(self, mock_get_client):
+        """Search with specific search_fields uses correct filter."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "data": {
+                "items": [
+                    {"record_id": "rec1", "fields": {"Title": "Design Doc", "Notes": "..."}},
+                ]
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "Design",
+            "search_fields": ["Title", "Notes"],
+            "limit": 10,
+        })
+        self.assertIn("success", result)
+        self.assertIn("Design Doc", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_search_records_invalid_limit(self, mock_get_client):
+        """Search handles invalid limit gracefully."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"data": {"items": []}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_search({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "query": "test",
+            "limit": "bad",
+        })
+        self.assertIn("success", result)
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "20")
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_list_tables_91403_no_code_in_output(self, mock_get_client):
+        """Error 91403 returns user-friendly message without exposing internal code."""
+        import tools.feishu_bitable_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 91403
+        mock_response.msg = "permission denied"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_bitable_tables({"base_token": "blt_private"})
+        self.assertIn("error", result)
+        self.assertIn("share", result.lower())
+        self.assertNotIn("91403", result)
+
+    @patch("tools.feishu_bitable_tool._get_client")
+    def test_create_record_fields_not_dict(self, mock_get_client):
+        """Returns error when fields is not a dictionary."""
+        import tools.feishu_bitable_tool as ft
+
+        result = ft._handle_feishu_bitable_create_record({
+            "base_token": "blt_abc",
+            "table_id": "tblXYZ",
+            "fields": "not_a_dict",
+        })
+        self.assertIn("error", result)
+        self.assertIn("dictionary", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feishu_calendar_tool.py
+++ b/tests/test_feishu_calendar_tool.py
@@ -1,0 +1,895 @@
+"""Tests for Feishu Calendar Tool.
+
+TDD Phase 1: Write tests that describe expected behavior.
+These tests will FAIL until the tool is implemented.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone, timedelta
+
+
+class TestFeishuCalendarToolUnit(unittest.TestCase):
+    """Unit tests for Feishu calendar tool functions."""
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_list
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_calendars_success(self, mock_get_client):
+        """List calendars returns a formatted list of calendars."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock response with calendars
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "calendar_list": [
+                {
+                    "calendar": {
+                        "calendar_id": "feishu_calendar_1",
+                        "summary": "Primary Calendar",
+                        "type": "primary",
+                        "summary_alias": "Main",
+                    }
+                },
+                {
+                    "calendar": {
+                        "calendar_id": "feishu_calendar_2",
+                        "summary": "Work Calendar",
+                        "type": "calendar",
+                        "summary_alias": "Work",
+                    }
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_list({})
+        self.assertIn("success", result)
+        self.assertIn("Primary Calendar", result)
+        self.assertIn("feishu_calendar_1", result)
+        self.assertIn("Work Calendar", result)
+        mock_client.request.assert_called_once()
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_calendars_primary_calendar(self, mock_get_client):
+        """List with calendar_id='primary' returns the user's primary calendar."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "calendar_list": [
+                {
+                    "calendar": {
+                        "calendar_id": "primary",
+                        "summary": "My Primary Calendar",
+                        "type": "primary",
+                    }
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_list({"calendar_id": "primary"})
+        self.assertIn("My Primary Calendar", result)
+        # Verify the request was made
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_calendars_client_unavailable(self, mock_get_client):
+        """Returns error when Feishu client is not available."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_list({})
+        self.assertIn("error", result)
+        self.assertIn("not available", result.lower())
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_calendars_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "app_access_token is invalid"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_list({})
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_events
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_success(self, mock_get_client):
+        """List events returns formatted events."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "items": [
+                {
+                    "event_id": "evt_abc123",
+                    "summary": "Team Meeting",
+                    "start_time": {"timestamp": "1743000000", "timezone": "Asia/Shanghai"},
+                    "end_time": {"timestamp": "1743003600", "timezone": "Asia/Shanghai"},
+                    "status": "confirmed",
+                },
+                {
+                    "event_id": "evt_def456",
+                    "summary": "Project Review",
+                    "start_time": {"timestamp": "1743100000", "timezone": "Asia/Shanghai"},
+                    "end_time": {"timestamp": "1743103600", "timezone": "Asia/Shanghai"},
+                    "status": "tentative",
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_events({
+            "calendar_id": "primary",
+        })
+        self.assertIn("success", result)
+        self.assertIn("Team Meeting", result)
+        self.assertIn("evt_abc123", result)
+        self.assertIn("Project Review", result)
+
+        # Verify request was made
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_missing_calendar_id(self, mock_get_client):
+        """Returns error when calendar_id is missing."""
+        import tools.feishu_calendar_tool as ft
+
+        result = ft._handle_feishu_calendar_events({})
+        self.assertIn("error", result)
+        self.assertIn("calendar_id", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_with_time_range(self, mock_get_client):
+        """List events respects start_time and end_time parameters."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        start = "2026-04-01T00:00:00Z"
+        end = "2026-04-30T23:59:59Z"
+        result = ft._handle_feishu_calendar_events({
+            "calendar_id": "primary",
+            "start_time": start,
+            "end_time": end,
+        })
+
+        self.assertIn("success", result)
+        # Verify time range in request
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        # Check that request has queries with start_time and end_time
+        queries_list = getattr(req, "queries", [])
+        query_keys = [k for k, v in queries_list]
+        self.assertIn("start_time", query_keys)
+        self.assertIn("end_time", query_keys)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_limit(self, mock_get_client):
+        """List events respects limit parameter."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_events({
+            "calendar_id": "primary",
+            "limit": 5,
+        })
+        self.assertIn("success", result)
+        # Verify page_size was set in request
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_dict = {k: v for k, v in queries_list}
+        self.assertEqual(query_dict.get("page_size"), "5")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "app_access_token is invalid"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_events({"calendar_id": "primary"})
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_create_event
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_create_event_success(self, mock_get_client):
+        """Create event returns the created event details."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "event": {
+                "event_id": "new_evt_789",
+                "summary": "New Meeting",
+                "start_time": {"timestamp": "1743000000"},
+                "end_time": {"timestamp": "1743003600"},
+                "status": "confirmed",
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "summary": "New Meeting",
+            "start_time": "2026-04-01T10:00:00Z",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("new_evt_789", result)
+        self.assertIn("New Meeting", result)
+
+        # Verify request was made to correct endpoint
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_create_event_missing_required_fields(self, mock_get_client):
+        """Returns error when required fields are missing."""
+        import tools.feishu_calendar_tool as ft
+
+        # Missing summary
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "start_time": "2026-04-01T10:00:00Z",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+        self.assertIn("error", result)
+        self.assertIn("summary", result)
+
+        # Missing start_time
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "summary": "Test",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+        self.assertIn("error", result)
+        self.assertIn("start_time", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_create_event_with_optional_fields(self, mock_get_client):
+        """Create event handles optional description, location, attendees."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "event": {
+                "event_id": "evt_xyz",
+                "summary": "Conference",
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "summary": "Conference",
+            "start_time": "2026-04-01T09:00:00Z",
+            "end_time": "2026-04-01T17:00:00Z",
+            "description": "Annual conference",
+            "location": "Beijing Office",
+            "attendees": [
+                {"type": "user", "user_id": "ou_abc123"},
+                {"type": "user", "user_id": "ou_def456"},
+            ],
+        })
+
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_create_event_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "summary": "Test",
+            "start_time": "2026-04-01T10:00:00Z",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_create_event_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "calendar not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "invalid",
+            "summary": "Test",
+            "start_time": "2026-04-01T10:00:00Z",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_update_event
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_update_event_success(self, mock_get_client):
+        """Update event returns the updated event details."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "event": {
+                "event_id": "evt_update",
+                "summary": "Updated Title",
+                "status": "confirmed",
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_update_event({
+            "calendar_id": "primary",
+            "event_id": "evt_update",
+            "summary": "Updated Title",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("evt_update", result)
+        self.assertIn("Updated Title", result)
+
+        # Verify PATCH request was made
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+        self.assertEqual(req.paths.get("event_id"), "evt_update")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_update_event_missing_event_id(self, mock_get_client):
+        """Returns error when event_id is missing."""
+        import tools.feishu_calendar_tool as ft
+
+        result = ft._handle_feishu_calendar_update_event({
+            "calendar_id": "primary",
+            "summary": "New Title",
+        })
+        self.assertIn("error", result)
+        self.assertIn("event_id", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_update_event_partial_update(self, mock_get_client):
+        """Update event allows partial updates (only summary, only time, etc)."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "event": {
+                "event_id": "evt_partial",
+                "summary": "Renamed",
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        # Only update summary
+        result = ft._handle_feishu_calendar_update_event({
+            "calendar_id": "primary",
+            "event_id": "evt_partial",
+            "summary": "Renamed",
+        })
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_update_event_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_update_event({
+            "calendar_id": "primary",
+            "event_id": "evt_123",
+            "summary": "New Title",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_update_event_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "event not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_update_event({
+            "calendar_id": "primary",
+            "event_id": "nonexistent",
+            "summary": "Title",
+        })
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_delete_event
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_delete_event_success(self, mock_get_client):
+        """Delete event returns success."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_delete_event({
+            "calendar_id": "primary",
+            "event_id": "evt_delete",
+        })
+
+        self.assertIn("success", result)
+
+        # Verify DELETE request was made
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+        self.assertEqual(req.paths.get("event_id"), "evt_delete")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_delete_event_missing_event_id(self, mock_get_client):
+        """Returns error when event_id is missing."""
+        import tools.feishu_calendar_tool as ft
+
+        result = ft._handle_feishu_calendar_delete_event({
+            "calendar_id": "primary",
+        })
+        self.assertIn("error", result)
+        self.assertIn("event_id", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_delete_event_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_delete_event({
+            "calendar_id": "primary",
+            "event_id": "evt_123",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_delete_event_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "event not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_delete_event({
+            "calendar_id": "primary",
+            "event_id": "nonexistent",
+        })
+        self.assertIn("error", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_calendar_attendees
+    # -------------------------------------------------------------------------
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_attendees_success(self, mock_get_client):
+        """List attendees returns formatted attendee list."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "items": [
+                {
+                    "attendee_id": {"user_id": "ou_abc123"},
+                    "display_name": "Alice",
+                    "type": "user",
+                    "rsvp_status": "accepted",
+                },
+                {
+                    "attendee_id": {"user_id": "ou_def456"},
+                    "display_name": "Bob",
+                    "type": "user",
+                    "rsvp_status": "tentative",
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+            "event_id": "evt_abc",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("Alice", result)
+        self.assertIn("Bob", result)
+        self.assertIn("accepted", result)
+
+        # Verify request was made
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        self.assertEqual(req.paths.get("calendar_id"), "primary")
+        self.assertEqual(req.paths.get("event_id"), "evt_abc")
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_attendees_missing_event_id(self, mock_get_client):
+        """Returns error when event_id is missing."""
+        import tools.feishu_calendar_tool as ft
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+        })
+        self.assertIn("error", result)
+        self.assertIn("event_id", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_add_attendees_success(self, mock_get_client):
+        """Add attendees to an event."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "items": [
+                {
+                    "attendee_id": {"user_id": "ou_new"},
+                    "display_name": "Charlie",
+                    "type": "user",
+                    "rsvp_status": "needs_action",
+                }
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+            "event_id": "evt_abc",
+            "attendees": [
+                {"type": "user", "user_id": "ou_new"},
+            ],
+        })
+
+        self.assertIn("success", result)
+        mock_client.request.assert_called_once()
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_attendees_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+            "event_id": "evt_123",
+        })
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_attendees_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "event not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+            "event_id": "nonexistent",
+        })
+        self.assertIn("error", result)
+
+
+class TestFeishuCalendarToolSchema(unittest.TestCase):
+    """Tests for tool schemas."""
+
+    def test_schema_list_calendars_has_required_fields(self):
+        """Schema for feishu_calendar_list has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_LIST_SCHEMA
+
+        self.assertEqual(FEISHU_CALENDAR_LIST_SCHEMA["name"], "feishu_calendar_list")
+        self.assertIn("description", FEISHU_CALENDAR_LIST_SCHEMA)
+        self.assertIn("parameters", FEISHU_CALENDAR_LIST_SCHEMA)
+        props = FEISHU_CALENDAR_LIST_SCHEMA["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+
+    def test_schema_events_has_required_fields(self):
+        """Schema for feishu_calendar_events has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_EVENTS_SCHEMA
+
+        self.assertEqual(FEISHU_CALENDAR_EVENTS_SCHEMA["name"], "feishu_calendar_events")
+        self.assertIn("parameters", FEISHU_CALENDAR_EVENTS_SCHEMA)
+        props = FEISHU_CALENDAR_EVENTS_SCHEMA["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+        self.assertIn("start_time", props)
+        self.assertIn("end_time", props)
+        self.assertIn("limit", props)
+        required = FEISHU_CALENDAR_EVENTS_SCHEMA["parameters"]["required"]
+        self.assertIn("calendar_id", required)
+
+    def test_schema_create_event_has_required_fields(self):
+        """Schema for feishu_calendar_create_event has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_CREATE_EVENT_SCHEMA
+
+        schema = FEISHU_CALENDAR_CREATE_EVENT_SCHEMA
+        self.assertEqual(schema["name"], "feishu_calendar_create_event")
+        props = schema["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+        self.assertIn("summary", props)
+        self.assertIn("start_time", props)
+        self.assertIn("end_time", props)
+        self.assertIn("description", props)
+        self.assertIn("location", props)
+        self.assertIn("attendees", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("calendar_id", required)
+        self.assertIn("summary", required)
+        self.assertIn("start_time", required)
+        self.assertIn("end_time", required)
+
+    def test_schema_update_event_has_required_fields(self):
+        """Schema for feishu_calendar_update_event has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_UPDATE_EVENT_SCHEMA
+
+        schema = FEISHU_CALENDAR_UPDATE_EVENT_SCHEMA
+        self.assertEqual(schema["name"], "feishu_calendar_update_event")
+        props = schema["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+        self.assertIn("event_id", props)
+        self.assertIn("summary", props)
+        self.assertIn("start_time", props)
+        self.assertIn("end_time", props)
+        self.assertIn("description", props)
+        self.assertIn("location", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("calendar_id", required)
+        self.assertIn("event_id", required)
+
+    def test_schema_delete_event_has_required_fields(self):
+        """Schema for feishu_calendar_delete_event has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_DELETE_EVENT_SCHEMA
+
+        schema = FEISHU_CALENDAR_DELETE_EVENT_SCHEMA
+        self.assertEqual(schema["name"], "feishu_calendar_delete_event")
+        props = schema["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+        self.assertIn("event_id", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("calendar_id", required)
+        self.assertIn("event_id", required)
+
+    def test_schema_attendees_has_required_fields(self):
+        """Schema for feishu_calendar_attendees has correct structure."""
+        from tools.feishu_calendar_tool import FEISHU_CALENDAR_ATTENDEES_SCHEMA
+
+        schema = FEISHU_CALENDAR_ATTENDEES_SCHEMA
+        self.assertEqual(schema["name"], "feishu_calendar_attendees")
+        props = schema["parameters"]["properties"]
+        self.assertIn("calendar_id", props)
+        self.assertIn("event_id", props)
+        self.assertIn("attendees", props)
+        self.assertIn("list_only", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("calendar_id", required)
+        self.assertIn("event_id", required)
+
+
+class TestFeishuCalendarToolEdgeCases(unittest.TestCase):
+    """Edge case tests for Feishu calendar tools."""
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_empty_calendar_list(self, mock_get_client):
+        """List calendars handles empty response."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"calendar_list": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_list({})
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_empty_events_list(self, mock_get_client):
+        """List events handles empty response."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_events({"calendar_id": "primary"})
+        self.assertIn("success", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_list_events_default_time_range(self, mock_get_client):
+        """List events uses reasonable default time range when not specified."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_events({"calendar_id": "primary"})
+        self.assertIn("success", result)
+        # Default range should be set in request
+        call_args = mock_client.request.call_args
+        req = call_args[0][0]
+        queries_list = getattr(req, "queries", [])
+        query_keys = [k for k, v in queries_list]
+        self.assertIn("start_time", query_keys)
+        self.assertIn("end_time", query_keys)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_invalid_iso8601_time(self, mock_get_client):
+        """Handles invalid ISO8601 timestamp gracefully."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        # Invalid time should either error or handle gracefully
+        result = ft._handle_feishu_calendar_create_event({
+            "calendar_id": "primary",
+            "summary": "Test",
+            "start_time": "not-a-valid-time",
+            "end_time": "2026-04-01T11:00:00Z",
+        })
+        # Should return an error for invalid ISO8601
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_lark_oapi_not_installed(self, mock_get_client):
+        """Handles case when lark_oapi is not installed."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_calendar_list({})
+        self.assertIn("error", result)
+
+    @patch("tools.feishu_calendar_tool._get_client")
+    def test_attendees_empty_list(self, mock_get_client):
+        """Handles empty attendees list."""
+        import tools.feishu_calendar_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_calendar_attendees({
+            "calendar_id": "primary",
+            "event_id": "evt_abc",
+            "attendees": [],
+        })
+        self.assertIn("success", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feishu_task_tool.py
+++ b/tests/test_feishu_task_tool.py
@@ -1,26 +1,12 @@
 """Tests for Feishu Task Tool.
 
-TDD Phase 1: Write tests that describe expected behavior.
-These tests will FAIL until the tool is implemented.
+Tests real lark_oapi library (installed in test env).
+sys.modules patching was removed — it caused cache conflicts under xdist.
 """
 
 import unittest
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
-
-
-# Shared mock for lark_oapi module tree
-_mock_lark_module = MagicMock()
-
-
-def _make_mock_builder_chain():
-    """Create a mock request builder that simulates the lark_oapi builder chain."""
-    mock_request = MagicMock()
-    # Simulate builder().build() returning a request with queries/paths
-    # queries is a list of (key, value) tuples in lark_oapi
-    mock_request.queries = []
-    mock_request.paths = {}
-    return mock_request
 
 
 class TestFeishuTaskToolUnit(unittest.TestCase):
@@ -30,7 +16,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_list
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_success(self, mock_get_client):
         """List tasks returns formatted tasks."""
@@ -69,7 +54,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("task_guid/abc123", result)
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_empty(self, mock_get_client):
         """List tasks handles empty response."""
@@ -87,7 +71,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("success", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_with_completed_filter(self, mock_get_client):
         """List tasks respects completed parameter."""
@@ -107,30 +90,21 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made with the builder
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_with_due_range(self, mock_get_client):
-        """List tasks respects due_start and due_end parameters."""
+        """List tasks returns error for due_start/due_end — not supported by SDK."""
         import tools.feishu_task_tool as ft
 
-        mock_client = MagicMock()
-        mock_get_client.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.code = 0
-        mock_response.data = {"items": []}
-        mock_client.request.return_value = mock_response
+        mock_get_client.return_value = MagicMock()
 
         result = ft._handle_feishu_task_list({
             "due_start": "2026-04-01T00:00:00Z",
             "due_end": "2026-04-30T23:59:59Z",
         })
 
-        self.assertIn("success", result)
-        # Verify request was made
-        mock_client.request.assert_called_once()
+        self.assertIn("error", result)
+        self.assertIn("not yet supported", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_limit(self, mock_get_client):
         """List tasks respects limit parameter."""
@@ -150,7 +124,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_client_unavailable(self, mock_get_client):
         """Returns error when Feishu client is not available."""
@@ -163,7 +136,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("not available", result.lower())
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_list_tasks_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -186,7 +158,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_create
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_success(self, mock_get_client):
         """Create task returns the created task details."""
@@ -222,7 +193,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("New Task", result)
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_minimal(self, mock_get_client):
         """Create task works with only required fields."""
@@ -248,7 +218,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("success", result)
         self.assertIn("Minimal Task", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_missing_summary(self, mock_get_client):
         """Returns error when summary is missing."""
@@ -259,7 +228,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("summary", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_with_follower(self, mock_get_client):
         """Create task handles follower parameter."""
@@ -288,7 +256,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("success", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_client_unavailable(self, mock_get_client):
         """Returns error when client is not available."""
@@ -302,7 +269,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_create_task_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -328,7 +294,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_complete
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_complete_task_success(self, mock_get_client):
         """Complete task returns success."""
@@ -356,7 +321,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_complete_task_missing_guid(self, mock_get_client):
         """Returns error when task_guid is missing."""
@@ -367,7 +331,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("task_guid", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_complete_task_client_unavailable(self, mock_get_client):
         """Returns error when client is not available."""
@@ -381,7 +344,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_complete_task_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -406,7 +368,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_reopen
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_reopen_task_success(self, mock_get_client):
         """Reopen task returns success."""
@@ -434,7 +395,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_reopen_task_missing_guid(self, mock_get_client):
         """Returns error when task_guid is missing."""
@@ -445,7 +405,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("task_guid", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_reopen_task_client_unavailable(self, mock_get_client):
         """Returns error when client is not available."""
@@ -459,7 +418,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_reopen_task_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -484,7 +442,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_search
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_success(self, mock_get_client):
         """Search tasks returns matching tasks."""
@@ -518,7 +475,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("Clean groceries closet", result)
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_empty_query(self, mock_get_client):
         """Returns error when query is empty."""
@@ -531,7 +487,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("query", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_empty_results(self, mock_get_client):
         """Search tasks handles empty response."""
@@ -551,7 +506,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("success", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_with_filters(self, mock_get_client):
         """Search tasks respects assignee, creator, completed filters."""
@@ -577,7 +531,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made with filters
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_client_unavailable(self, mock_get_client):
         """Returns error when client is not available."""
@@ -591,7 +544,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_search_tasks_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -616,7 +568,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
     # feishu_task_delete
     # -------------------------------------------------------------------------
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_delete_task_success(self, mock_get_client):
         """Delete task returns success."""
@@ -638,7 +589,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         # Verify request was made
         mock_client.request.assert_called_once()
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_delete_task_missing_guid(self, mock_get_client):
         """Returns error when task_guid is missing."""
@@ -649,7 +599,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("task_guid", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_delete_task_client_unavailable(self, mock_get_client):
         """Returns error when client is not available."""
@@ -663,7 +612,6 @@ class TestFeishuTaskToolUnit(unittest.TestCase):
 
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_delete_task_api_error(self, mock_get_client):
         """Returns error when API returns non-zero code."""
@@ -768,7 +716,6 @@ class TestFeishuTaskToolSchema(unittest.TestCase):
 class TestFeishuTaskToolEdgeCases(unittest.TestCase):
     """Edge case tests for Feishu task tools."""
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_invalid_iso8601_due_date(self, mock_get_client):
         """Create task handles invalid due date gracefully."""
@@ -790,7 +737,6 @@ class TestFeishuTaskToolEdgeCases(unittest.TestCase):
         # Should return error for invalid due date
         self.assertIn("error", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_empty_summary(self, mock_get_client):
         """Create task rejects empty summary."""
@@ -803,7 +749,6 @@ class TestFeishuTaskToolEdgeCases(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("summary", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_task_guid_whitespace_stripped(self, mock_get_client):
         """Task GUID is stripped of whitespace."""
@@ -823,7 +768,6 @@ class TestFeishuTaskToolEdgeCases(unittest.TestCase):
 
         self.assertIn("success", result)
 
-    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
     @patch("tools.feishu_task_tool._get_client")
     def test_all_task_fields_preserved(self, mock_get_client):
         """All task fields are preserved in response."""

--- a/tests/test_feishu_task_tool.py
+++ b/tests/test_feishu_task_tool.py
@@ -1,0 +1,866 @@
+"""Tests for Feishu Task Tool.
+
+TDD Phase 1: Write tests that describe expected behavior.
+These tests will FAIL until the tool is implemented.
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+from datetime import datetime, timezone
+
+
+# Shared mock for lark_oapi module tree
+_mock_lark_module = MagicMock()
+
+
+def _make_mock_builder_chain():
+    """Create a mock request builder that simulates the lark_oapi builder chain."""
+    mock_request = MagicMock()
+    # Simulate builder().build() returning a request with queries/paths
+    # queries is a list of (key, value) tuples in lark_oapi
+    mock_request.queries = []
+    mock_request.paths = {}
+    return mock_request
+
+
+class TestFeishuTaskToolUnit(unittest.TestCase):
+    """Unit tests for Feishu task tool functions."""
+
+    # -------------------------------------------------------------------------
+    # feishu_task_list
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_success(self, mock_get_client):
+        """List tasks returns formatted tasks."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "items": [
+                {
+                    "guid": "task_guid/abc123",
+                    "summary": "Review PR",
+                    "due": {"timestamp": "1743000000", "is_all_day": False},
+                    "origin": {"platform_i18n_name": {"zh_cn": "Lark"}},
+                    "completed_at": None,
+                },
+                {
+                    "guid": "task_guid/def456",
+                    "summary": "Write tests",
+                    "due": {"timestamp": "1743100000", "is_all_day": True},
+                    "origin": {"platform_i18n_name": {"zh_cn": "Lark"}},
+                    "completed_at": {"timestamp": "1742000000"},
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({})
+
+        self.assertIn("success", result)
+        self.assertIn("Review PR", result)
+        self.assertIn("Write tests", result)
+        self.assertIn("task_guid/abc123", result)
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_empty(self, mock_get_client):
+        """List tasks handles empty response."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({})
+
+        self.assertIn("success", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_with_completed_filter(self, mock_get_client):
+        """List tasks respects completed parameter."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({"completed": True})
+
+        self.assertIn("success", result)
+        # Verify request was made with the builder
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_with_due_range(self, mock_get_client):
+        """List tasks respects due_start and due_end parameters."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({
+            "due_start": "2026-04-01T00:00:00Z",
+            "due_end": "2026-04-30T23:59:59Z",
+        })
+
+        self.assertIn("success", result)
+        # Verify request was made
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_limit(self, mock_get_client):
+        """List tasks respects limit parameter."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({"limit": 10})
+
+        self.assertIn("success", result)
+        # Verify request was made
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_client_unavailable(self, mock_get_client):
+        """Returns error when Feishu client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_list({})
+
+        self.assertIn("error", result)
+        self.assertIn("not available", result.lower())
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_list_tasks_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "app_access_token is invalid"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_list({})
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_task_create
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_success(self, mock_get_client):
+        """Create task returns the created task details."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/new123",
+                "summary": "New Task",
+                "due": {"timestamp": "1743000000", "is_all_day": False},
+                "description": "Task description",
+                "members": [
+                    {"id": "ou_abc", "type": "user", "role": "assignee"},
+                ],
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "New Task",
+            "due": "2026-04-01T10:00:00Z",
+            "description": "Task description",
+            "assignee": "ou_abc",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("task_guid/new123", result)
+        self.assertIn("New Task", result)
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_minimal(self, mock_get_client):
+        """Create task works with only required fields."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/minimal",
+                "summary": "Minimal Task",
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Minimal Task",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("Minimal Task", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_missing_summary(self, mock_get_client):
+        """Returns error when summary is missing."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_create({})
+
+        self.assertIn("error", result)
+        self.assertIn("summary", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_with_follower(self, mock_get_client):
+        """Create task handles follower parameter."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/follower",
+                "summary": "Task with Follower",
+                "members": [
+                    {"id": "ou_follower", "type": "user", "role": "follower"},
+                ],
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Task with Follower",
+            "follower": "ou_follower",
+        })
+
+        self.assertIn("success", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Test Task",
+        })
+
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_create_task_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "permission denied"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Test Task",
+            "assignee": "ou_external",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_task_complete
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_complete_task_success(self, mock_get_client):
+        """Complete task returns success."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/complete123",
+                "summary": "Completed Task",
+                "completed_at": {"timestamp": "1743000000"},
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_complete({
+            "task_guid": "task_guid/complete123",
+        })
+
+        self.assertIn("success", result)
+        # Verify request was made
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_complete_task_missing_guid(self, mock_get_client):
+        """Returns error when task_guid is missing."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_complete({})
+
+        self.assertIn("error", result)
+        self.assertIn("task_guid", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_complete_task_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_complete({
+            "task_guid": "task_guid/abc",
+        })
+
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_complete_task_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "task not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_complete({
+            "task_guid": "task_guid/nonexistent",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_task_reopen
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_reopen_task_success(self, mock_get_client):
+        """Reopen task returns success."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/reopen123",
+                "summary": "Reopened Task",
+                "completed_at": None,
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_reopen({
+            "task_guid": "task_guid/reopen123",
+        })
+
+        self.assertIn("success", result)
+        # Verify request was made
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_reopen_task_missing_guid(self, mock_get_client):
+        """Returns error when task_guid is missing."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_reopen({})
+
+        self.assertIn("error", result)
+        self.assertIn("task_guid", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_reopen_task_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_reopen({
+            "task_guid": "task_guid/abc",
+        })
+
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_reopen_task_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "task not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_reopen({
+            "task_guid": "task_guid/nonexistent",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_task_search
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_success(self, mock_get_client):
+        """Search tasks returns matching tasks."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "items": [
+                {
+                    "guid": "task_guid/search1",
+                    "summary": "Buy groceries",
+                },
+                {
+                    "guid": "task_guid/search2",
+                    "summary": "Clean groceries closet",
+                },
+            ]
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_search({
+            "query": "groceries",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("Buy groceries", result)
+        self.assertIn("Clean groceries closet", result)
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_empty_query(self, mock_get_client):
+        """Returns error when query is empty."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_search({
+            "query": "",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("query", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_empty_results(self, mock_get_client):
+        """Search tasks handles empty response."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_search({
+            "query": "nonexistent",
+        })
+
+        self.assertIn("success", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_with_filters(self, mock_get_client):
+        """Search tasks respects assignee, creator, completed filters."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"items": []}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_search({
+            "query": "test",
+            "assignee": "ou_abc",
+            "creator": "ou_def",
+            "completed": True,
+            "limit": 5,
+        })
+
+        self.assertIn("success", result)
+        # Verify request was made with filters
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_search({
+            "query": "test",
+        })
+
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_search_tasks_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "search failed"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_search({
+            "query": "test",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+    # -------------------------------------------------------------------------
+    # feishu_task_delete
+    # -------------------------------------------------------------------------
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_delete_task_success(self, mock_get_client):
+        """Delete task returns success."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_delete({
+            "task_guid": "task_guid/delete123",
+        })
+
+        self.assertIn("success", result)
+        # Verify request was made
+        mock_client.request.assert_called_once()
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_delete_task_missing_guid(self, mock_get_client):
+        """Returns error when task_guid is missing."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_delete({})
+
+        self.assertIn("error", result)
+        self.assertIn("task_guid", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_delete_task_client_unavailable(self, mock_get_client):
+        """Returns error when client is not available."""
+        import tools.feishu_task_tool as ft
+
+        mock_get_client.return_value = None
+
+        result = ft._handle_feishu_task_delete({
+            "task_guid": "task_guid/abc",
+        })
+
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_delete_task_api_error(self, mock_get_client):
+        """Returns error when API returns non-zero code."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 99991663
+        mock_response.msg = "task not found"
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_delete({
+            "task_guid": "task_guid/nonexistent",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("99991663", result)
+
+
+class TestFeishuTaskToolSchema(unittest.TestCase):
+    """Tests for tool schemas."""
+
+    def test_schema_list_has_required_fields(self):
+        """Schema for feishu_task_list has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_LIST_SCHEMA
+
+        self.assertEqual(FEISHU_TASK_LIST_SCHEMA["name"], "feishu_task_list")
+        self.assertIn("description", FEISHU_TASK_LIST_SCHEMA)
+        self.assertIn("parameters", FEISHU_TASK_LIST_SCHEMA)
+        props = FEISHU_TASK_LIST_SCHEMA["parameters"]["properties"]
+        self.assertIn("completed", props)
+        self.assertIn("due_start", props)
+        self.assertIn("due_end", props)
+        self.assertIn("limit", props)
+
+    def test_schema_create_has_required_fields(self):
+        """Schema for feishu_task_create has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_CREATE_SCHEMA
+
+        schema = FEISHU_TASK_CREATE_SCHEMA
+        self.assertEqual(schema["name"], "feishu_task_create")
+        props = schema["parameters"]["properties"]
+        self.assertIn("summary", props)
+        self.assertIn("due", props)
+        self.assertIn("description", props)
+        self.assertIn("assignee", props)
+        self.assertIn("follower", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("summary", required)
+
+    def test_schema_complete_has_required_fields(self):
+        """Schema for feishu_task_complete has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_COMPLETE_SCHEMA
+
+        schema = FEISHU_TASK_COMPLETE_SCHEMA
+        self.assertEqual(schema["name"], "feishu_task_complete")
+        props = schema["parameters"]["properties"]
+        self.assertIn("task_guid", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("task_guid", required)
+
+    def test_schema_reopen_has_required_fields(self):
+        """Schema for feishu_task_reopen has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_REOPEN_SCHEMA
+
+        schema = FEISHU_TASK_REOPEN_SCHEMA
+        self.assertEqual(schema["name"], "feishu_task_reopen")
+        props = schema["parameters"]["properties"]
+        self.assertIn("task_guid", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("task_guid", required)
+
+    def test_schema_search_has_required_fields(self):
+        """Schema for feishu_task_search has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_SEARCH_SCHEMA
+
+        schema = FEISHU_TASK_SEARCH_SCHEMA
+        self.assertEqual(schema["name"], "feishu_task_search")
+        props = schema["parameters"]["properties"]
+        self.assertIn("query", props)
+        self.assertIn("assignee", props)
+        self.assertIn("creator", props)
+        self.assertIn("completed", props)
+        self.assertIn("limit", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("query", required)
+
+    def test_schema_delete_has_required_fields(self):
+        """Schema for feishu_task_delete has correct structure."""
+        from tools.feishu_task_tool import FEISHU_TASK_DELETE_SCHEMA
+
+        schema = FEISHU_TASK_DELETE_SCHEMA
+        self.assertEqual(schema["name"], "feishu_task_delete")
+        props = schema["parameters"]["properties"]
+        self.assertIn("task_guid", props)
+        required = schema["parameters"]["required"]
+        self.assertIn("task_guid", required)
+
+
+class TestFeishuTaskToolEdgeCases(unittest.TestCase):
+    """Edge case tests for Feishu task tools."""
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_invalid_iso8601_due_date(self, mock_get_client):
+        """Create task handles invalid due date gracefully."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"task": {"guid": "task_guid/test", "summary": "Test"}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Test",
+            "due": "not-a-valid-time",
+        })
+
+        # Should return error for invalid due date
+        self.assertIn("error", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_empty_summary(self, mock_get_client):
+        """Create task rejects empty summary."""
+        import tools.feishu_task_tool as ft
+
+        result = ft._handle_feishu_task_create({
+            "summary": "   ",
+        })
+
+        self.assertIn("error", result)
+        self.assertIn("summary", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_task_guid_whitespace_stripped(self, mock_get_client):
+        """Task GUID is stripped of whitespace."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {"task": {"guid": "task_guid/padded", "summary": "Test"}}
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_complete({
+            "task_guid": "  task_guid/padded  ",
+        })
+
+        self.assertIn("success", result)
+
+    @patch.dict("sys.modules", {"lark_oapi": _mock_lark_module, "lark_oapi.api": _mock_lark_module, "lark_oapi.api.task": _mock_lark_module, "lark_oapi.api.task.v2": _mock_lark_module})
+    @patch("tools.feishu_task_tool._get_client")
+    def test_all_task_fields_preserved(self, mock_get_client):
+        """All task fields are preserved in response."""
+        import tools.feishu_task_tool as ft
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.code = 0
+        mock_response.data = {
+            "task": {
+                "guid": "task_guid/full",
+                "summary": "Full Task",
+                "due": {"timestamp": "1743000000", "is_all_day": False},
+                "description": "Full description",
+                "completed_at": {"timestamp": "1743100000"},
+                "members": [
+                    {"id": "ou_assignee", "type": "user", "role": "assignee"},
+                    {"id": "ou_follower", "type": "user", "role": "follower"},
+                ],
+            }
+        }
+        mock_client.request.return_value = mock_response
+
+        result = ft._handle_feishu_task_create({
+            "summary": "Full Task",
+            "due": "2026-04-01T10:00:00Z",
+            "description": "Full description",
+            "assignee": "ou_assignee",
+            "follower": "ou_follower",
+        })
+
+        self.assertIn("success", result)
+        self.assertIn("Full Task", result)
+        self.assertIn("task_guid/full", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_feishu_card_tool.py
+++ b/tests/tools/test_feishu_card_tool.py
@@ -1,0 +1,232 @@
+"""Tests for feishu_card_tool — card senders, file upload/send, and template builders."""
+
+import importlib
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.registry import registry
+
+
+# Trigger tool discovery
+importlib.import_module("tools.feishu_card_tool")
+
+
+class TestCardTemplateBuilders(unittest.TestCase):
+    """Verify card template functions produce valid Feishu Message Card JSON."""
+
+    def test_task_card_pending(self):
+        from tools.feishu_card_tool import task_card
+
+        card = task_card("Review PR #42", "pending", "2026-04-30", "张三")
+        self.assertEqual(card["schema"], "2.0")
+        self.assertEqual(card["header"]["template"], "purple")
+        self.assertIn("⏳", card["header"]["title"]["content"])
+
+    def test_task_card_completed(self):
+        from tools.feishu_card_tool import task_card
+
+        card = task_card("Deploy v2", "completed", assignee_name="李四")
+        self.assertEqual(card["header"]["template"], "green")
+        self.assertIn("✅", card["header"]["title"]["content"])
+
+    def test_task_card_overdue(self):
+        from tools.feishu_card_tool import task_card
+
+        card = task_card("Overdue Task", "overdue", due_date="2026-04-01")
+        self.assertEqual(card["header"]["template"], "red")
+        self.assertIn("🔴", card["header"]["title"]["content"])
+
+    def test_task_card_with_url(self):
+        from tools.feishu_card_tool import task_card
+
+        card = task_card("Task", "pending", task_url="https://example.com/task/1")
+        # Has action button
+        action_elements = [e for e in card["elements"] if e.get("tag") == "action"]
+        self.assertEqual(len(action_elements), 1)
+        actions = action_elements[0]["actions"]
+        self.assertEqual(actions[0]["action_id"], "open_task")
+
+    def test_calendar_card(self):
+        from tools.feishu_card_tool import calendar_card
+
+        card = calendar_card(
+            event_title="Q2 Planning",
+            start_time="2026-04-30 09:00",
+            end_time="2026-04-30 11:00",
+            location="会议室A",
+            attendees=["张三", "李四"],
+            organizer="王五",
+        )
+        self.assertEqual(card["schema"], "2.0")
+        self.assertEqual(card["header"]["template"], "blue")
+        # Should have time, location, organizer, attendees fields
+        div_elements = [e for e in card["elements"] if e.get("tag") == "div"]
+        self.assertGreaterEqual(len(div_elements), 4)
+
+    def test_generic_card(self):
+        from tools.feishu_card_tool import generic_card
+
+        card = generic_card(
+            title="项目状态",
+            body_lines=[("状态", "进行中"), ("负责人", "张三")],
+            description="这是描述",
+            status="warning",
+        )
+        self.assertEqual(card["header"]["template"], "yellow")
+        # Two fields -> one field-div (paired), plus description -> one text-div
+        div_elements = [e for e in card["elements"] if e.get("tag") == "div"]
+        self.assertEqual(len(div_elements), 2)
+        # First div has 2 fields
+        self.assertEqual(len(div_elements[0]["fields"]), 2)
+
+    def test_generic_card_actions(self):
+        from tools.feishu_card_tool import generic_card
+
+        actions = [{"tag": "button", "text": {"tag": "plain_text", "content": "确认"}}]
+        card = generic_card("标题", actions=actions)
+        action_elements = [e for e in card["elements"] if e.get("tag") == "action"]
+        self.assertEqual(len(action_elements), 1)
+
+
+class TestToolRegistration(unittest.TestCase):
+    """Verify all feishu_card_tool tools are registered."""
+
+    EXPECTED = [
+        "feishu_send_card",
+        "feishu_send_message",
+        "feishu_upload_file",
+        "feishu_send_file",
+    ]
+
+    def test_all_tools_registered(self):
+        for name in self.EXPECTED:
+            entry = registry.get_entry(name)
+            self.assertIsNotNone(entry, f"{name} not registered")
+
+    def test_schemas_valid(self):
+        for name in self.EXPECTED:
+            entry = registry.get_entry(name)
+            schema = entry.schema
+            self.assertIn("name", schema)
+            self.assertEqual(schema["name"], name)
+            self.assertIn("description", schema)
+            self.assertIn("parameters", schema)
+            self.assertEqual(schema["parameters"]["type"], "object")
+
+    def test_send_card_requires_card_and_receive_id(self):
+        entry = registry.get_entry("feishu_send_card")
+        props = entry.schema["parameters"]["properties"]
+        required = entry.schema["parameters"].get("required", [])
+        self.assertIn("card", required)
+        self.assertIn("receive_id", required)
+        self.assertIn("card", props)
+        self.assertIn("receive_id", props)
+
+    def test_send_file_requires_file_path_and_receive_id(self):
+        entry = registry.get_entry("feishu_send_file")
+        required = entry.schema["parameters"].get("required", [])
+        self.assertIn("file_path", required)
+        self.assertIn("receive_id", required)
+
+
+class TestSendCardHandler(unittest.TestCase):
+    """Test feishu_send_card handler logic."""
+
+    @patch("tools.feishu_card_tool._get_client")
+    def test_send_card_success(self, mock_get_client):
+        from tools.feishu_card_tool import _handle_feishu_send_card
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.success.return_value = True
+        mock_resp.data.message_id = "om_123"
+        mock_client.im.v1.message.create.return_value = mock_resp
+        mock_get_client.return_value = mock_client
+
+        card = {"schema": "2.0", "header": {}, "elements": []}
+        result = _handle_feishu_send_card({
+            "card": card,
+            "receive_id": "ou_abc",
+            "receive_id_type": "open_id",
+        })
+        self.assertIn("om_123", result)
+        self.assertIn("success", result.lower())
+
+    def test_send_card_missing_card(self):
+        from tools.feishu_card_tool import _handle_feishu_send_card
+
+        result = _handle_feishu_send_card({"receive_id": "ou_abc"})
+        self.assertIn("error", result.lower())
+
+    def test_send_card_missing_receive_id(self):
+        from tools.feishu_card_tool import _handle_feishu_send_card
+
+        card = {"schema": "2.0", "header": {}, "elements": []}
+        result = _handle_feishu_send_card({"card": card})
+        self.assertIn("error", result.lower())
+
+
+class TestSendMessageHandler(unittest.TestCase):
+    """Test feishu_send_message handler."""
+
+    @patch("tools.feishu_card_tool._get_client")
+    def test_send_text_success(self, mock_get_client):
+        from tools.feishu_card_tool import _handle_feishu_send_message
+
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.success.return_value = True
+        mock_resp.data.message_id = "om_456"
+        mock_client.im.v1.message.create.return_value = mock_resp
+        mock_get_client.return_value = mock_client
+
+        result = _handle_feishu_send_message({
+            "text": "Hello, world!",
+            "receive_id": "ou_abc",
+        })
+        self.assertIn("om_456", result)
+        self.assertIn("success", result.lower())
+
+    def test_send_text_missing_text(self):
+        from tools.feishu_card_tool import _handle_feishu_send_message
+
+        result = _handle_feishu_send_message({"receive_id": "ou_abc"})
+        self.assertIn("error", result.lower())
+
+
+class TestUploadFileHandler(unittest.TestCase):
+    """Test feishu_upload_file handler."""
+
+    @patch("tools.feishu_card_tool._get_client")
+    def test_upload_file_missing(self, mock_get_client):
+        from tools.feishu_card_tool import _handle_feishu_upload_file
+
+        result = _handle_feishu_upload_file({"file_path": "/nonexistent/file.pdf"})
+        self.assertIn("not found", result.lower())
+
+    def test_upload_file_no_path(self):
+        from tools.feishu_card_tool import _handle_feishu_upload_file
+
+        result = _handle_feishu_upload_file({})
+        self.assertIn("error", result.lower())
+
+
+class TestSendFileHandler(unittest.TestCase):
+    """Test feishu_send_file handler."""
+
+    def test_send_file_missing_path(self):
+        from tools.feishu_card_tool import _handle_feishu_send_file
+
+        result = _handle_feishu_send_file({"receive_id": "ou_abc"})
+        self.assertIn("error", result.lower())
+
+    def test_send_file_missing_receive_id(self):
+        from tools.feishu_card_tool import _handle_feishu_send_file
+
+        result = _handle_feishu_send_file({"file_path": "/tmp/test.pdf"})
+        self.assertIn("error", result.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_feishu_oauth.py
+++ b/tests/tools/test_feishu_oauth.py
@@ -1,0 +1,262 @@
+"""Integration tests for feishu_oauth — FeishuUserTokenStore PKCE flow."""
+
+import json
+import time
+import tempfile
+import os
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_token_dir(monkeypatch, tmp_path):
+    """Override token storage to a temp directory."""
+    monkeypatch.setattr(
+        "tools.feishu_oauth._token_dir",
+        lambda: tmp_path / "feishu-user-tokens",
+    )
+    # Also patch FeishuOAuthConfig defaults so we don't need real env vars
+    monkeypatch.setenv("FEISHU_APP_ID", "test_app_id")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "test_app_secret")
+    return tmp_path
+
+
+@pytest.fixture
+def store(tmp_token_dir):
+    from tools.feishu_oauth import FeishuUserTokenStore
+    return FeishuUserTokenStore()
+
+
+# ---------------------------------------------------------------------------
+# PKCE helpers
+# ---------------------------------------------------------------------------
+
+class TestPKCEGeneration:
+    def test_pkce_pair_returns_verifier_and_challenge(self):
+        from tools.feishu_oauth import FeishuUserTokenStore
+        verifier, challenge = FeishuUserTokenStore._pkce_pair()
+        assert len(verifier) >= 32
+        assert len(challenge) >= 32
+        # S256 challenge should be base64url-encoded SHA256 digest
+        import base64, hashlib
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+        assert challenge == expected
+
+    def test_pkce_pair_is_unique_each_call(self):
+        from tools.feishu_oauth import FeishuUserTokenStore
+        v1, c1 = FeishuUserTokenStore._pkce_pair()
+        v2, c2 = FeishuUserTokenStore._pkce_pair()
+        assert v1 != v2
+        assert c1 != c2
+
+
+# ---------------------------------------------------------------------------
+# Token file I/O
+# ---------------------------------------------------------------------------
+
+class TestTokenStorage:
+    def test_no_token_returns_none(self, store, tmp_token_dir):
+        result = store.get_user_token("ou_no_such_user")
+        assert result is None
+
+    def test_auth_status_not_authorized_for_new_user(self, store):
+        status = store.get_auth_status("ou_no_such_user")
+        assert status["status"] == "not_authorized"
+        assert status["open_id"] == "ou_no_such_user"
+
+    def test_auth_status_expired_after_write(self, store, tmp_token_dir):
+        open_id = "ou_test_expired"
+        # Write an expired token directly
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(json.dumps({
+            "access_token": "old_token",
+            "refresh_token": "refresh_token",
+            "expires_at": time.time() - 100,  # expired 100s ago
+            "refresh_expires_at": time.time() + 86400,
+            "open_id": open_id,
+        }))
+        status = store.get_auth_status(open_id)
+        assert status["status"] == "expired"
+
+    def test_auth_status_expiring_soon(self, store, tmp_token_dir):
+        open_id = "ou_test_expiring"
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(json.dumps({
+            "access_token": "old_token",
+            "refresh_token": "refresh_token",
+            "expires_at": time.time() + 120,  # expires in 2 min (< 5 min threshold)
+            "refresh_expires_at": time.time() + 86400,
+            "open_id": open_id,
+        }))
+        status = store.get_auth_status(open_id)
+        assert status["status"] == "expiring_soon"
+
+    def test_auth_status_authorized(self, store, tmp_token_dir):
+        open_id = "ou_test_ok"
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(json.dumps({
+            "access_token": "valid_token",
+            "refresh_token": "refresh_token",
+            "expires_at": time.time() + 7200,
+            "refresh_expires_at": time.time() + 86400,
+            "open_id": open_id,
+        }))
+        status = store.get_auth_status(open_id)
+        assert status["status"] == "authorized"
+
+
+# ---------------------------------------------------------------------------
+# get_authorization_url
+# ---------------------------------------------------------------------------
+
+class TestAuthorizationUrl:
+    def test_url_contains_required_params(self, store):
+        open_id = "ou_test_user"
+        url, state = store.get_authorization_url(open_id)
+        assert url.startswith("https://open.feishu.cn/open-apis/authen/v1/authorize")
+        # URL params are URL-encoded; app_id value is percent-encoded
+        assert "app_id=" in url
+        assert "code_challenge_method=S256" in url
+        assert "code_challenge=" in url
+        assert "state=" in url
+        assert "scope=" in url
+        assert "redirect_uri=" in url
+        assert len(state) >= 16
+
+    def test_pending_file_created(self, store, tmp_token_dir):
+        open_id = "ou_pending_test"
+        store.get_authorization_url(open_id)
+        pending = store._pending_path(open_id)
+        assert pending.exists(), f"Expected {pending} to exist"
+        data = json.loads(pending.read_text())
+        assert "verifier" in data
+        assert "state" in data
+        assert "created_at" in data
+
+    def test_pending_file_expires_after_10_minutes(self, store, tmp_token_dir):
+        open_id = "ou_expired_pending"
+        url, _ = store.get_authorization_url(open_id)
+        # Simulate 11-minute-old pending by backdating created_at
+        pending = store._pending_path(open_id)
+        data = json.loads(pending.read_text())
+        data["created_at"] = time.time() - 660  # 11 min ago
+        pending.write_text(json.dumps(data))
+        # _read_pending should return None and delete the file
+        result = store._read_pending(open_id)
+        assert result is None
+
+    def test_pending_deleted_after_exchange_code_called_with_empty_pending(self, store, tmp_token_dir):
+        # If pending file doesn't exist, exchange_code should not crash
+        open_id = "ou_no_pending"
+        # Don't call get_authorization_url, so no pending file
+        # exchange_code should handle missing pending gracefully
+        try:
+            store.exchange_code(open_id, "fake_code")
+        except Exception:
+            pass  # Network call will fail but no file error
+
+
+# ---------------------------------------------------------------------------
+# get_user_token (no refresh needed)
+# ---------------------------------------------------------------------------
+
+class TestGetUserToken:
+    def test_returns_stored_token_when_valid(self, store, tmp_token_dir):
+        open_id = "ou_valid"
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(json.dumps({
+            "access_token": "stored_token_abc123",
+            "refresh_token": "refresh_xyz",
+            "expires_at": time.time() + 3600,
+            "refresh_expires_at": time.time() + 86400,
+            "open_id": open_id,
+        }))
+        token = store.get_user_token(open_id)
+        assert token == "stored_token_abc123"
+
+
+# ---------------------------------------------------------------------------
+# get_request_option
+# ---------------------------------------------------------------------------
+
+class TestGetRequestOption:
+    def test_returns_none_when_no_token(self, store):
+        option = store.get_request_option("ou_no_token")
+        assert option is None
+
+    def test_request_option_has_user_access_token(self, store, tmp_token_dir):
+        open_id = "ou_option_test"
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(json.dumps({
+            "access_token": "user_access_token_xyz",
+            "refresh_token": "refresh",
+            "expires_at": time.time() + 3600,
+            "refresh_expires_at": time.time() + 86400,
+            "open_id": open_id,
+        }))
+        option = store.get_request_option(open_id)
+        assert option is not None
+        # Verify the option has user_access_token set
+        assert hasattr(option, "user_access_token")
+        assert option.user_access_token == "user_access_token_xyz"
+
+
+# ---------------------------------------------------------------------------
+# revoke
+# ---------------------------------------------------------------------------
+
+class TestRevoke:
+    def test_revoke_deletes_token_file(self, store, tmp_token_dir):
+        open_id = "ou_to_revoke"
+        token_path = tmp_token_dir / "feishu-user-tokens" / f"{open_id}.json"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text('{"access_token": "x"}')
+        store.revoke(open_id)
+        assert not token_path.exists()
+
+    def test_revoke_idempotent(self, store):
+        # Revoking a non-existent token should not raise
+        store.revoke("ou_nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Disk I/O helpers
+# ---------------------------------------------------------------------------
+
+class TestDiskIO:
+    def test_read_json_missing_file_returns_none(self):
+        from tools.feishu_oauth import _read_json
+        from pathlib import Path
+        result = _read_json(Path("/nonexistent/path/file.json"))
+        assert result is None
+
+    def test_read_json_malformed_returns_none(self, tmp_path):
+        from tools.feishu_oauth import _read_json
+        f = tmp_path / "bad.json"
+        f.write_text("not valid json {{{")
+        result = _read_json(f)
+        assert result is None
+
+    def test_write_json_creates_file(self, tmp_path):
+        from tools.feishu_oauth import _write_json
+        p = tmp_path / "out.json"
+        _write_json(p, {"key": "value"})
+        assert p.exists()
+        assert json.loads(p.read_text()) == {"key": "value"}
+
+    def test_write_json_atomic(self, tmp_path):
+        from tools.feishu_oauth import _write_json
+        p = tmp_path / "atomic.json"
+        _write_json(p, {"atomic": True})
+        # File should exist and be valid
+        assert json.loads(p.read_text()) == {"atomic": True}

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -254,6 +254,7 @@ class TestRecentSessionListing:
         mock_db.list_sessions_rich.assert_called_once_with(
             limit=10,
             exclude_sources=["tool"],
+            user_id=None,
             order_by_last_active=True,
         )
 

--- a/tools/chief_agent_tool.py
+++ b/tools/chief_agent_tool.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+ChiefAgent Tool — Hermes OS Brain Layer
+
+Delegates complex tasks to Hermes OS ChiefAgent for intent parsing,
+task decomposition, and Labor execution routing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import os
+import asyncio
+from typing import Any
+
+# --- Robust path setup ---
+# Try multiple possible Hermes OS locations
+_HERMES_OS_SEARCH_PATHS = [
+    "/Volumes/LEGION/hermes",  # LEGION USB SSD (parent dir with hermes_os)
+    "/Volumes/LEGION/.hermes",  # LEGION symlink
+    "/Users/dongshenglu/hermes-os/src",  # MacBook local dev
+]
+
+for _path in _HERMES_OS_SEARCH_PATHS:
+    if os.path.exists(_path):
+        if _path not in sys.path:
+            sys.path.insert(0, _path)
+        # Also check if hermes_os is directly accessible
+        _hermes_os_subpath = os.path.join(_path, "hermes_os")
+        if os.path.isdir(_hermes_os_subpath) and _hermes_os_subpath not in sys.path:
+            sys.path.insert(0, _hermes_os_subpath)
+        break
+
+# --- Import Hermes OS ---
+HERMES_OS_AVAILABLE = False
+ChiefAgent = None
+
+try:
+    from hermes_os.chief_agent import ChiefAgent, Intent
+    HERMES_OS_AVAILABLE = True
+except ImportError:
+    try:
+        from hermes_os.chief_agent import ChiefAgent
+        HERMES_OS_AVAILABLE = True
+        Intent = None  # Intent not critical
+    except ImportError:
+        HERMES_OS_AVAILABLE = False
+
+
+def _run_async(coro):
+    """Run async coroutine in sync context."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+def chief_agent_tool(message: str, action: str = "parse_intent", user_id: str = "default") -> str:
+    """
+    Invoke Hermes OS ChiefAgent for intent parsing or response synthesis.
+
+    Args:
+        message: The user message to process
+        action: "parse_intent" (default) or "spring_breeze"
+        user_id: User identifier for context tracking
+
+    Returns:
+        JSON string with processing result
+    """
+    if not HERMES_OS_AVAILABLE:
+        return json.dumps({
+            "error": "Hermes OS not available",
+            "debug_paths": sys.path[:3],
+        }, ensure_ascii=False)
+
+    if not message or not message.strip():
+        return json.dumps({"error": "message is required"}, ensure_ascii=False)
+
+    chief = ChiefAgent()
+
+    if action == "spring_breeze":
+        result = _run_async(
+            chief.get_spring_breeze_response(
+                user_id=user_id,
+                message=message,
+                intent="unknown",
+            )
+        )
+        return json.dumps({"success": True, "response": result}, ensure_ascii=False)
+
+    # Default: parse_intent
+    parsed = _run_async(
+        chief.parse_intent(message, user_id=user_id)
+    )
+    return json.dumps({
+        "success": True,
+        "action": parsed.action.value,
+        "confidence": parsed.confidence,
+        "entities": parsed.entities,
+        "suggested_next": parsed.suggested_next,
+        "raw_text": parsed.raw_text,
+    }, ensure_ascii=False, indent=2)
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+CHIEF_AGENT_SCHEMA = {
+    "name": "chief_agent",
+    "description": (
+        "Delegate complex tasks to Hermes OS ChiefAgent brain layer.\n\n"
+        "Use this tool when:\n"
+        "- Task requires intent parsing and routing to specialized agents\n"
+        "- User wants Hermes OS to handle the full orchestration\n"
+        "- Complex tasks that need GoalTracker / TopicTracker context\n\n"
+        "Returns structured intent analysis with confidence scores."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "The user message to process",
+            },
+            "action": {
+                "type": "string",
+                "enum": ["parse_intent", "spring_breeze"],
+                "description": "Action: parse_intent (default) or spring_breeze",
+            },
+            "user_id": {
+                "type": "string",
+                "description": "User identifier for context tracking",
+            },
+        },
+        "required": ["message"],
+    },
+}
+
+
+# --- Registry ---
+def _chief_agent_handler(args, **kw):
+    return chief_agent_tool(
+        message=args.get("message", ""),
+        action=args.get("action", "parse_intent"),
+        user_id=args.get("user_id", "default"),
+    )
+
+# Registry.register must be at module level (bare Expr, not inside try/except)
+from tools.registry import registry
+registry.register(
+    name="chief_agent",
+    toolset="chief",
+    schema=CHIEF_AGENT_SCHEMA,
+    handler=_chief_agent_handler,
+    check_fn=lambda: HERMES_OS_AVAILABLE,
+    emoji="🧠",
+)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -172,6 +172,24 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     if _profile_home:
         sanitized["HOME"] = _profile_home
 
+    # Bypass cmux wrapper: use real claude binary, not the hook-injecting wrapper.
+    # cmux.app puts its bin first in PATH and injects SessionStart/Stop hooks
+    # that call back into cmux for UI updates. In non-cmux subprocesses (Hermes
+    # terminal backend, ACP delegate), the socket is either stale or unreachable,
+    # causing claude -p to hang waiting for hooks that can never complete.
+    # Fix: remove cmux bin from PATH, ensure homebrew claude is first.
+    import re as _re
+    _path = sanitized.get("PATH", "")
+    _path = _re.sub(r"/Applications/cmux\.app/Contents/Resources/bin:?", "", _path)
+    if "/opt/homebrew/bin" not in _path:
+        _path = "/opt/homebrew/bin:" + _path
+    sanitized["PATH"] = _path
+
+    # cmux wrapper checks these to decide "am I in a cmux terminal?"
+    # Unset so claude -p passes through to real binary without hook injection.
+    for _key in ("CMUX_SURFACE_ID", "CMUX_SOCKET_PATH", "CMUX_CLAUDE_HOOKS_DISABLED"):
+        sanitized.pop(_key, None)
+
     return sanitized
 
 

--- a/tools/feishu_bitable_tool.py
+++ b/tools/feishu_bitable_tool.py
@@ -1,0 +1,709 @@
+"""Feishu Bitable Tool -- manage Feishu/Lark Multi-dimensional Tables (Bitable) via API.
+
+Provides the following tools:
+  - feishu_bitable_list         : List all Bitable apps the user has access to
+  - feishu_bitable_tables       : List tables in a Bitable app
+  - feishu_bitable_records      : List or search records in a table
+  - feishu_bitable_create_record : Create a new record in a table
+  - feishu_bitable_search       : Search records across a Bitable app
+"""
+
+import logging
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Client helpers
+# ---------------------------------------------------------------------------
+
+_thread_local_client = None
+
+
+def set_client(client) -> None:
+    """Store a lark client for the current thread (called by feishu_comment)."""
+    global _thread_local_client
+    _thread_local_client = client
+
+
+def _get_client():
+    """Return the lark client for the current thread, or None."""
+    return _thread_local_client
+
+
+def _check_feishu():
+    """Return True if lark_oapi is installed."""
+    try:
+        import lark_oapi  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Response helpers
+# ---------------------------------------------------------------------------
+
+def _check_api_error(response) -> tuple[int | None, str | None]:
+    """Check response for errors. Returns (code, msg) or (None, None) if OK."""
+    code = getattr(response, "code", None)
+    msg = getattr(response, "msg", None)
+    return code, msg
+
+
+# ---------------------------------------------------------------------------
+# Response formatters
+# ---------------------------------------------------------------------------
+
+def _format_app_list(data: dict) -> str:
+    """Format Bitable app list response."""
+    app_list = data.get("app_list", [])
+    if not app_list:
+        return "No Bitable apps found."
+
+    lines = ["Bitable Apps:"]
+    for item in app_list:
+        app = item.get("app", {})
+        app_id = app.get("app_id", "")
+        name = app.get("name", "(no name)")
+        lang = app.get("default_language", "")
+        line = f"  - [{app_id}] {name}"
+        if lang:
+            line += f" ({lang})"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _format_table_list(data: dict) -> str:
+    """Format table list response."""
+    inner = data.get("data", data)
+    items = inner.get("items", []) if isinstance(inner, dict) else []
+    if not items:
+        return "No tables found."
+
+    lines = ["Tables:"]
+    for table in items:
+        table_id = table.get("table_id", "")
+        name = table.get("name", "(no name)")
+        fields = table.get("fields", [])
+        field_count = len(fields) if isinstance(fields, list) else 0
+        lines.append(f"  - [{table_id}] {name} ({field_count} fields)")
+        if field_count > 0 and isinstance(fields, list):
+            for f in fields[:5]:
+                fname = f.get("field_name", "?")
+                ftype = f.get("type", "?")
+                lines.append(f"      - {fname} (type={ftype})")
+            if field_count > 5:
+                lines.append(f"      ... and {field_count - 5} more fields")
+    return "\n".join(lines)
+
+
+def _format_record_list(data: dict, show_fields: bool = True) -> str:
+    """Format record list response."""
+    inner = data.get("data", data)
+    items = inner.get("items", []) if isinstance(inner, dict) else []
+    if not items:
+        return "No records found."
+
+    total = inner.get("total", len(items)) if isinstance(inner, dict) else len(items)
+    lines = [f"Records ({total} total):"]
+    for record in items:
+        record_id = record.get("record_id", "")
+        fields = record.get("fields", {})
+        if isinstance(fields, dict) and show_fields:
+            field_items = list(fields.items())
+            field_lines = []
+            for k, v in field_items[:3]:
+                v_str = str(v)
+                if len(v_str) > 50:
+                    v_str = v_str[:47] + "..."
+                field_lines.append(f"{k}: {v_str}")
+            if field_items[3:]:
+                field_lines.append(f"  ... +{len(field_items) - 3} more fields")
+            field_str = "; ".join(field_lines)
+            lines.append(f"  [{record_id}] {field_str}")
+        else:
+            lines.append(f"  [{record_id}]")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+FEISHU_BITABLE_LIST_SCHEMA = {
+    "name": "feishu_bitable_list",
+    "description": (
+        "List all Bitable apps (Multi-dimensional Tables) that the user has access to. "
+        "Use this to discover available Bitable apps before querying their tables."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+FEISHU_BITABLE_TABLES_SCHEMA = {
+    "name": "feishu_bitable_tables",
+    "description": (
+        "List all tables in a Bitable app. "
+        "The base_token is the Bitable app token (starts with 'blt_'), "
+        "which can be found in the Bitable URL or from the feishu_bitable_list tool."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_token": {
+                "type": "string",
+                "description": (
+                    "The Bitable app token (starts with 'blt_'). "
+                    "Found in the Bitable URL or from feishu_bitable_list."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of tables to return (default 50, max 500).",
+                "minimum": 1,
+                "maximum": 500,
+                "default": 50,
+            },
+        },
+        "required": ["base_token"],
+    },
+}
+
+FEISHU_BITABLE_RECORDS_SCHEMA = {
+    "name": "feishu_bitable_records",
+    "description": (
+        "List or search records in a Bitable table. "
+        "Use the 'search' parameter to filter records by keyword. "
+        "Use feishu_bitable_tables to find the table_id first."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_token": {
+                "type": "string",
+                "description": "The Bitable app token (starts with 'blt_').",
+            },
+            "table_id": {
+                "type": "string",
+                "description": (
+                    "The table ID (UUID format). "
+                    "Found from feishu_bitable_tables tool."
+                ),
+            },
+            "search": {
+                "type": "string",
+                "description": (
+                    "Keyword to filter records. Only records where any field "
+                    "contains this keyword will be returned."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of records to return (default 50, max 500).",
+                "minimum": 1,
+                "maximum": 500,
+                "default": 50,
+            },
+        },
+        "required": ["base_token", "table_id"],
+    },
+}
+
+FEISHU_BITABLE_CREATE_RECORD_SCHEMA = {
+    "name": "feishu_bitable_create_record",
+    "description": (
+        "Create a new record in a Bitable table. "
+        "Provide field values as a dictionary of field_name: value pairs. "
+        "Use feishu_bitable_tables to see available fields in a table."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_token": {
+                "type": "string",
+                "description": "The Bitable app token (starts with 'blt_').",
+            },
+            "table_id": {
+                "type": "string",
+                "description": (
+                    "The table ID (UUID format). "
+                    "Found from feishu_bitable_tables tool."
+                ),
+            },
+            "fields": {
+                "type": "object",
+                "description": (
+                    "Dictionary of field_name: value pairs for the new record. "
+                    "Example: {'Title': 'New Task', 'Status': 'Open', 'Assignee': 'ou_123'}"
+                ),
+            },
+        },
+        "required": ["base_token", "table_id", "fields"],
+    },
+}
+
+FEISHU_BITABLE_SEARCH_SCHEMA = {
+    "name": "feishu_bitable_search",
+    "description": (
+        "Search records in a Bitable table by keyword. "
+        "Searches across all text fields by default. "
+        "Use the 'search_fields' parameter to limit which fields are searched."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "base_token": {
+                "type": "string",
+                "description": "The Bitable app token (starts with 'blt_').",
+            },
+            "table_id": {
+                "type": "string",
+                "description": (
+                    "The table ID (UUID format). "
+                    "Found from feishu_bitable_tables tool."
+                ),
+            },
+            "query": {
+                "type": "string",
+                "description": "Keyword to search for in record fields.",
+            },
+            "search_fields": {
+                "type": "array",
+                "description": (
+                    "List of field names to search in. "
+                    "Defaults to searching all text fields if not specified."
+                ),
+                "items": {
+                    "type": "string",
+                },
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results to return (default 20, max 100).",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 20,
+            },
+        },
+        "required": ["base_token", "table_id", "query"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _handle_feishu_bitable_list(args: dict, **kwargs) -> str:
+    """Handle feishu_bitable_list tool calls."""
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    try:
+        # lark-oapi bitable.v1 uses app_token in path params
+        from lark_oapi.api.bitable.v1 import GetAppRequestBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    # List apps: use app list from response - call without app_token to get user's apps
+    # Note: bitable.v1 GetApp requires app_token; we need to use the API differently
+    # For now, return a helpful message that the user should provide a base_token
+    # (the list of apps requires pagination support at /open-apis/bitable/v1/apps)
+    # Since lark-oapi doesn't expose a ListApp builder for bitable.v1, we return
+    # a message directing users to the Feishu app directly.
+    return tool_error(
+        "feishu_bitable_list requires a base_token. "
+        "Please share the Bitable app with the bot and provide its token (blt_xxx) "
+        "directly to the feishu_bitable_tables or feishu_bitable_records tool. "
+        "You can find the Bitable token in the app URL: https://[tenant].feishu.cn/base/[blt_xxx]"
+    )
+
+
+def _handle_feishu_bitable_tables(args: dict, **kwargs) -> str:
+    """Handle feishu_bitable_tables tool calls."""
+    base_token = args.get("base_token", "").strip()
+    if not base_token:
+        return tool_error("base_token is required. It should be the Bitable app token (starts with 'blt_').")
+
+    limit = args.get("limit", 50)
+    try:
+        limit = max(1, min(500, int(limit)))
+    except (ValueError, TypeError):
+        limit = 50
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available. "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    try:
+        from lark_oapi.api.bitable.v1 import ListAppTableRequestBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed.")
+
+    request = (
+        ListAppTableRequestBuilder()
+        .page_size(limit)
+        .build()
+    )
+
+    response = client.request(request, app_token=base_token)
+    code, msg = _check_api_error(response)
+
+    # Special handling: bot has no access to this Bitable app
+    if code == 91403:
+        return tool_error(
+            "No access to this Bitable app. "
+            "Ask the user to share the Bitable app with the bot first."
+        )
+    if code != 0:
+        return tool_error(f"Failed: [{code}] {msg or 'unknown'}")
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from Bitable API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    formatted = _format_table_list(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_bitable_records(args: dict, **kwargs) -> str:
+    """Handle feishu_bitable_records tool calls."""
+    base_token = args.get("base_token", "").strip()
+    if not base_token:
+        return tool_error("base_token is required. It should be the Bitable app token (starts with 'blt_').")
+
+    table_id = args.get("table_id", "").strip()
+    if not table_id:
+        return tool_error("table_id is required. Use feishu_bitable_tables to find it.")
+
+    limit = args.get("limit", 50)
+    try:
+        limit = max(1, min(500, int(limit)))
+    except (ValueError, TypeError):
+        limit = 50
+
+    search = args.get("search", "").strip()
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available. "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    try:
+        from lark_oapi.api.bitable.v1 import ListAppTableRecordRequestBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed.")
+
+    request = (
+        ListAppTableRecordRequestBuilder()
+        .page_size(limit)
+        .build()
+    )
+
+    response = client.request(request, app_token=base_token, table_id=table_id)
+    code, msg = _check_api_error(response)
+
+    if code == 91403:
+        return tool_error(
+            "No access to this Bitable app. "
+            "Ask the user to share the Bitable app with the bot first."
+        )
+    if code != 0:
+        return tool_error(f"Failed: [{code}] {msg or 'unknown'}")
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from Bitable API")
+
+    data_dict = data if isinstance(data, dict) else {}
+
+    # Apply search filter in-memory if search keyword provided
+    if search:
+        inner = data_dict.get("data", data_dict)
+        items = inner.get("items", []) if isinstance(inner, dict) else []
+        if isinstance(items, list):
+            filtered = []
+            for record in items:
+                fields = record.get("fields", {})
+                if isinstance(fields, dict):
+                    field_values = " ".join(str(v).lower() for v in fields.values())
+                    if search.lower() in field_values:
+                        filtered.append(record)
+            data_dict = {"data": {"items": filtered, "total": len(filtered)}}
+
+    formatted = _format_record_list(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_bitable_create_record(args: dict, **kwargs) -> str:
+    """Handle feishu_bitable_create_record tool calls."""
+    base_token = args.get("base_token", "").strip()
+    if not base_token:
+        return tool_error("base_token is required. It should be the Bitable app token (starts with 'blt_').")
+
+    table_id = args.get("table_id", "").strip()
+    if not table_id:
+        return tool_error("table_id is required. Use feishu_bitable_tables to find it.")
+
+    fields = args.get("fields")
+    if fields is None:
+        return tool_error("fields is required. Provide field_name: value pairs as a dictionary.")
+    if not isinstance(fields, dict):
+        return tool_error("fields must be a dictionary of field_name: value pairs.")
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available. "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    try:
+        from lark_oapi.api.bitable.v1 import CreateAppTableRecordRequestBuilder, AppTableRecordBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed.")
+
+    record_body = AppTableRecordBuilder().fields(fields).build()
+    request = (
+        CreateAppTableRecordRequestBuilder()
+        .request_body(record_body)
+        .build()
+    )
+
+    response = client.request(request, app_token=base_token, table_id=table_id)
+    code, msg = _check_api_error(response)
+
+    if code == 91403:
+        return tool_error(
+            "No access to this Bitable app. "
+            "Ask the user to share the Bitable app with the bot first."
+        )
+    if code != 0:
+        return tool_error(f"Failed: [{code}] {msg or 'unknown'}")
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from Bitable API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    inner = data_dict.get("data", data_dict)
+    record = inner.get("record", {}) if isinstance(inner, dict) else {}
+
+    record_id = record.get("record_id", "")
+    created_fields = record.get("fields", {})
+
+    lines = ["Record created successfully."]
+    if record_id:
+        lines.append(f"  ID: {record_id}")
+    if created_fields:
+        for k, v in list(created_fields.items())[:5]:
+            lines.append(f"  {k}: {v}")
+        if len(created_fields) > 5:
+            lines.append(f"  ... and {len(created_fields) - 5} more fields")
+
+    return tool_result(success=True, content="\n".join(lines))
+
+
+def _handle_feishu_bitable_search(args: dict, **kwargs) -> str:
+    """Handle feishu_bitable_search tool calls."""
+    base_token = args.get("base_token", "").strip()
+    if not base_token:
+        return tool_error("base_token is required. It should be the Bitable app token (starts with 'blt_').")
+
+    table_id = args.get("table_id", "").strip()
+    if not table_id:
+        return tool_error("table_id is required. Use feishu_bitable_tables to find it.")
+
+    query = args.get("query", "").strip()
+    if not query:
+        return tool_error("query is required. Provide a keyword to search for.")
+
+    search_fields = args.get("search_fields")
+    if search_fields and not isinstance(search_fields, list):
+        search_fields = []
+
+    limit = args.get("limit", 20)
+    try:
+        limit = max(1, min(100, int(limit)))
+    except (ValueError, TypeError):
+        limit = 20
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available. "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    try:
+        from lark_oapi.api.bitable.v1 import (
+            SearchAppTableRecordRequestBuilder,
+            SearchAppTableRecordRequestBodyBuilder,
+            FilterInfoBuilder,
+            ConditionBuilder,
+        )
+    except ImportError:
+        return tool_error("lark_oapi not installed.")
+
+    # Build search filter using bitable.v1 filter API
+    # If search_fields specified, filter each field with 'contains' operator
+    # If not specified, use a single 'contains' filter on all fields
+    if search_fields:
+        conditions = []
+        for field_name in search_fields:
+            cond = (
+                ConditionBuilder()
+                .field_name(field_name)
+                .operator("contains")
+                .value([query])
+                .build()
+            )
+            conditions.append(cond)
+
+        # If multiple fields, combine with OR
+        if len(conditions) > 1:
+            filter_info = (
+                FilterInfoBuilder()
+                .conjunction("or")
+                .conditions(conditions)
+                .build()
+            )
+        else:
+            filter_info = (
+                FilterInfoBuilder()
+                .conjunction("and")
+                .conditions(conditions)
+                .build()
+            )
+    else:
+        # No search_fields specified: search across all fields using a single
+        # contains filter -- use a generic field_name placeholder that will
+        # match all records (the API will search all text fields)
+        # Since the API requires a specific field_name, we build a filter for
+        # the query as a catch-all; if no fields match the filter, we fall back
+        # to in-memory filtering below
+        cond = (
+            ConditionBuilder()
+            .field_name("*")
+            .operator("contains")
+            .value([query])
+            .build()
+        )
+        filter_info = (
+            FilterInfoBuilder()
+            .conjunction("and")
+            .conditions([cond])
+            .build()
+        )
+
+    request_body = (
+        SearchAppTableRecordRequestBodyBuilder()
+        .filter(filter_info)
+        .build()
+    )
+
+    request = (
+        SearchAppTableRecordRequestBuilder()
+        .page_size(limit)
+        .request_body(request_body)
+        .build()
+    )
+
+    response = client.request(request, app_token=base_token, table_id=table_id)
+    code, msg = _check_api_error(response)
+
+    if code == 91403:
+        return tool_error(
+            "No access to this Bitable app. "
+            "Ask the user to share the Bitable app with the bot first."
+        )
+    if code != 0:
+        return tool_error(f"Failed: [{code}] {msg or 'unknown'}")
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from Bitable API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    formatted = _format_record_list(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="feishu_bitable_list",
+    toolset="feishu_bitable",
+    schema=FEISHU_BITABLE_LIST_SCHEMA,
+    handler=_handle_feishu_bitable_list,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List all Feishu Bitable apps the user has access to",
+    emoji="\U0001f4ca",
+)
+
+registry.register(
+    name="feishu_bitable_tables",
+    toolset="feishu_bitable",
+    schema=FEISHU_BITABLE_TABLES_SCHEMA,
+    handler=_handle_feishu_bitable_tables,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List tables in a Feishu Bitable app",
+    emoji="\U0001f4ca",
+)
+
+registry.register(
+    name="feishu_bitable_records",
+    toolset="feishu_bitable",
+    schema=FEISHU_BITABLE_RECORDS_SCHEMA,
+    handler=_handle_feishu_bitable_records,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List or search records in a Feishu Bitable table",
+    emoji="\U0001f4ca",
+)
+
+registry.register(
+    name="feishu_bitable_create_record",
+    toolset="feishu_bitable",
+    schema=FEISHU_BITABLE_CREATE_RECORD_SCHEMA,
+    handler=_handle_feishu_bitable_create_record,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Create a new record in a Feishu Bitable table",
+    emoji="\U0001f4ca",
+)
+
+registry.register(
+    name="feishu_bitable_search",
+    toolset="feishu_bitable",
+    schema=FEISHU_BITABLE_SEARCH_SCHEMA,
+    handler=_handle_feishu_bitable_search,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Search records in a Feishu Bitable table",
+    emoji="\U0001f4ca",
+)

--- a/tools/feishu_calendar_tool.py
+++ b/tools/feishu_calendar_tool.py
@@ -1,0 +1,1010 @@
+"""Feishu Calendar Tool -- manage Feishu/Lark calendar events via API.
+
+Provides the following tools:
+  - feishu_calendar_list        : List calendars or get primary calendar
+  - feishu_calendar_events     : List events in a calendar
+  - feishu_calendar_create_event : Create a calendar event
+  - feishu_calendar_update_event : Update an existing event
+  - feishu_calendar_delete_event : Delete an event
+  - feishu_calendar_attendees  : List or add attendees to an event
+"""
+
+import json
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Any, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Client helpers
+# ---------------------------------------------------------------------------
+
+_thread_local_client = None
+
+
+def set_client(client) -> None:
+    """Store a lark client for the current thread (called by feishu_comment)."""
+    global _thread_local_client
+    _thread_local_client = client
+
+
+def _get_client():
+    """Return the lark client for the current thread, or None."""
+    return _thread_local_client
+
+
+def _get_user_request_option():
+    """Return a RequestOption with the current user's Feishu access token, or None."""
+    try:
+        from gateway.session_context import get_session_env
+        from tools import feishu_oauth
+
+        open_id = get_session_env("HERMES_SESSION_USER_ID", "")
+        if not open_id:
+            return None
+        store = feishu_oauth.FeishuUserTokenStore()
+        return store.get_request_option(open_id)
+    except Exception:
+        return None
+
+
+def _check_feishu():
+    """Return True if lark_oapi is installed."""
+    try:
+        import lark_oapi  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+def _parse_iso8601(ts: str) -> Optional[datetime]:
+    """Parse an ISO8601 timestamp string to datetime (UTC)."""
+    if not ts:
+        return None
+    try:
+        # Handle 'Z' suffix
+        ts_clean = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts_clean)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, OSError):
+        return None
+
+
+def _to_unix_ts(dt: datetime) -> str:
+    """Convert a datetime to Unix timestamp string (seconds)."""
+    return str(int(dt.timestamp()))
+
+
+# ---------------------------------------------------------------------------
+# Response formatters
+# ---------------------------------------------------------------------------
+
+def _format_calendar_list(data: dict) -> str:
+    """Format calendar list response."""
+    items = data.get("calendar_list", [])
+    if not items:
+        return "No calendars found."
+
+    lines = ["Calendars:"]
+    for item in items:
+        cal = item.get("calendar", {})
+        cal_id = cal.get("calendar_id", "")
+        summary = cal.get("summary", "(no title)")
+        alias = cal.get("summary_alias", "")
+        cal_type = cal.get("type", "")
+        line = f"  - [{cal_id}] {summary}"
+        if alias:
+            line += f" ({alias})"
+        lines.append(line)
+        if cal_type:
+            lines.append(f"    type: {cal_type}")
+    return "\n".join(lines)
+
+
+def _format_event_list(data: dict) -> str:
+    """Format event list response."""
+    items = data.get("items", [])
+    if not items:
+        return "No events found."
+
+    lines = ["Events:"]
+    for event in items:
+        event_id = event.get("event_id", "")
+        summary = event.get("summary", "(no title)")
+        status = event.get("status", "")
+        start = event.get("start_time", {})
+        end = event.get("end_time", {})
+
+        start_str = ""
+        end_str = ""
+        if isinstance(start, dict):
+            ts = start.get("timestamp", "")
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    start_str = dt.strftime("%Y-%m-%d %H:%M")
+                except (ValueError, OSError):
+                    start_str = ts
+        if isinstance(end, dict):
+            ts = end.get("timestamp", "")
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    end_str = dt.strftime("%Y-%m-%d %H:%M")
+                except (ValueError, OSError):
+                    end_str = ts
+
+        line = f"  - [{event_id}] {summary}"
+        if start_str and end_str:
+            line += f" | {start_str} ~ {end_str}"
+        if status:
+            line += f" | {status}"
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def _format_event(data: dict) -> str:
+    """Format single event response."""
+    event = data.get("event", data)
+    event_id = event.get("event_id", "")
+    summary = event.get("summary", "(no title)")
+    status = event.get("status", "")
+
+    lines = [f"Event: {summary}"]
+    if event_id:
+        lines.append(f"  ID: {event_id}")
+    if status:
+        lines.append(f"  Status: {status}")
+
+    # Format times
+    for key in ("start_time", "end_time"):
+        t = event.get(key, {})
+        if isinstance(t, dict):
+            ts = t.get("timestamp", "")
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    lines.append(f"  {key}: {dt.strftime('%Y-%m-%d %H:%M')}")
+                except (ValueError, OSError):
+                    lines.append(f"  {key}: {ts}")
+
+    # Format description
+    desc = event.get("description", "")
+    if desc:
+        lines.append(
+            f"  Description: {desc[:200]}" + ("..." if len(desc) > 200 else "")
+        )
+
+    # Format location
+    loc = event.get("location", {})
+    if isinstance(loc, dict):
+        name = loc.get("name", "")
+        if name:
+            lines.append(f"  Location: {name}")
+
+    return "\n".join(lines)
+
+
+def _format_attendees(data: dict) -> str:
+    """Format attendees list response."""
+    items = data.get("items", [])
+    if not items:
+        return "No attendees found."
+
+    lines = ["Attendees:"]
+    for attendee in items:
+        att_id = attendee.get("attendee_id", {})
+        uid = ""
+        if isinstance(att_id, dict):
+            uid = att_id.get("user_id", "")
+        name = attendee.get("display_name", uid or "(unknown)")
+        att_type = attendee.get("type", "")
+        rsvp = attendee.get("rsvp_status", "")
+        line = f"  - {name}" + (f" ({uid})" if uid else "")
+        lines.append(line)
+        if att_type:
+            lines.append(f"    type: {att_type}")
+        if rsvp:
+            lines.append(f"    rsvp: {rsvp}")
+
+    return "\n".join(lines)
+
+
+def _check_response_error(response) -> Optional[str]:
+    """Check response for errors. Returns error message or None if OK."""
+    code = getattr(response, "code", None)
+    if code != 0:
+        msg = getattr(response, "msg", "unknown error")
+        return f"Calendar API error: code={code} msg={msg}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+FEISHU_CALENDAR_LIST_SCHEMA = {
+    "name": "feishu_calendar_list",
+    "description": (
+        "List the user's calendars or get a specific calendar by ID. "
+        "Use 'primary' as calendar_id to get the user's primary calendar."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": (
+                    "Calendar ID. Use 'primary' for the user's primary calendar. "
+                    "Omit to list all calendars the user has access to."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+FEISHU_CALENDAR_EVENTS_SCHEMA = {
+    "name": "feishu_calendar_events",
+    "description": (
+        "List events in a Feishu calendar within a time range. "
+        "Defaults to now - 7 days to now + 30 days if start_time/end_time are not specified."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": "The calendar ID (use 'primary' for the user's primary calendar).",
+            },
+            "start_time": {
+                "type": "string",
+                "description": (
+                    "Start of time range in ISO8601 format (e.g. '2026-04-01T00:00:00Z'). "
+                    "Defaults to 7 days ago."
+                ),
+            },
+            "end_time": {
+                "type": "string",
+                "description": (
+                    "End of time range in ISO8601 format (e.g. '2026-04-30T23:59:59Z'). "
+                    "Defaults to 30 days from now."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of events to return (default 50, max 500). Note: Feishu API minimum is 50.",
+                "minimum": 1,
+                "maximum": 500,
+                "default": 50,
+            },
+        },
+        "required": ["calendar_id"],
+    },
+}
+
+FEISHU_CALENDAR_CREATE_EVENT_SCHEMA = {
+    "name": "feishu_calendar_create_event",
+    "description": (
+        "Create a new event in a Feishu calendar. "
+        "All times must be in ISO8601 format with timezone (e.g. '2026-04-01T09:00:00+08:00')."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": "The calendar ID (use 'primary' for the user's primary calendar).",
+            },
+            "summary": {
+                "type": "string",
+                "description": "Event title/summary.",
+            },
+            "start_time": {
+                "type": "string",
+                "description": "Event start time in ISO8601 format (required).",
+            },
+            "end_time": {
+                "type": "string",
+                "description": "Event end time in ISO8601 format (required).",
+            },
+            "description": {
+                "type": "string",
+                "description": "Event description/notes.",
+            },
+            "location": {
+                "type": "string",
+                "description": "Event location name.",
+            },
+            "attendees": {
+                "type": "array",
+                "description": (
+                    "List of attendees to invite. Each attendee should have 'type' "
+                    "(e.g. 'user') and 'user_id' (e.g. 'ou_xxx')."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string"},
+                        "user_id": {"type": "string"},
+                    },
+                    "required": ["type", "user_id"],
+                },
+            },
+        },
+        "required": ["calendar_id", "summary", "start_time", "end_time"],
+    },
+}
+
+FEISHU_CALENDAR_UPDATE_EVENT_SCHEMA = {
+    "name": "feishu_calendar_update_event",
+    "description": (
+        "Update an existing calendar event. All fields are optional -- only provided "
+        "fields will be updated (partial update supported)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": "The calendar ID (use 'primary' for the user's primary calendar).",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "The event ID to update.",
+            },
+            "summary": {
+                "type": "string",
+                "description": "New event title/summary.",
+            },
+            "start_time": {
+                "type": "string",
+                "description": "New start time in ISO8601 format.",
+            },
+            "end_time": {
+                "type": "string",
+                "description": "New end time in ISO8601 format.",
+            },
+            "description": {
+                "type": "string",
+                "description": "New event description.",
+            },
+            "location": {
+                "type": "string",
+                "description": "New event location.",
+            },
+        },
+        "required": ["calendar_id", "event_id"],
+    },
+}
+
+FEISHU_CALENDAR_DELETE_EVENT_SCHEMA = {
+    "name": "feishu_calendar_delete_event",
+    "description": "Delete a calendar event by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": "The calendar ID (use 'primary' for the user's primary calendar).",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "The event ID to delete.",
+            },
+        },
+        "required": ["calendar_id", "event_id"],
+    },
+}
+
+FEISHU_CALENDAR_ATTENDEES_SCHEMA = {
+    "name": "feishu_calendar_attendees",
+    "description": (
+        "List attendees of a calendar event, or add new attendees. "
+        "Provide the 'attendees' parameter to add attendees; omit it to list existing attendees."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "calendar_id": {
+                "type": "string",
+                "description": "The calendar ID (use 'primary' for the user's primary calendar).",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "The event ID.",
+            },
+            "attendees": {
+                "type": "array",
+                "description": (
+                    "List of attendees to add. Each attendee should have 'type' "
+                    "(e.g. 'user') and 'user_id' (e.g. 'ou_xxx')."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string"},
+                        "user_id": {"type": "string"},
+                    },
+                    "required": ["type", "user_id"],
+                },
+            },
+            "list_only": {
+                "type": "boolean",
+                "description": (
+                    "If True, only list attendees (do not add). "
+                    "If False and attendees provided, add the attendees. Default True."
+                ),
+                "default": True,
+            },
+        },
+        "required": ["calendar_id", "event_id"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _handle_feishu_calendar_list(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_list tool calls."""
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    calendar_id = args.get("calendar_id", "").strip()
+
+    try:
+        from lark_oapi.api.calendar.v4 import (
+            ListCalendarRequestBuilder,
+            GetCalendarRequestBuilder,
+        )
+    except ImportError:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    if calendar_id == "primary" or not calendar_id:
+        # Get primary calendar
+        request = (
+            GetCalendarRequestBuilder()
+            .calendar_id("primary")
+            .build()
+        )
+    else:
+        # List all calendars
+        request = (
+            ListCalendarRequestBuilder()
+            .page_size(50)
+            .build()
+        )
+
+    response = client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from calendar API")
+
+    formatted = _format_calendar_list(data if isinstance(data, dict) else {})
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_calendar_events(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_events tool calls."""
+    calendar_id = args.get("calendar_id", "").strip()
+    if not calendar_id:
+        return tool_error("calendar_id is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error("Feishu client not available")
+
+    start_time_str = args.get("start_time", "").strip()
+    end_time_str = args.get("end_time", "").strip()
+    limit = args.get("limit", 50)
+    try:
+        limit = max(1, min(500, int(limit)))
+    except (ValueError, TypeError):
+        limit = 50
+
+    now = datetime.now(timezone.utc)
+    if start_time_str:
+        start_dt = _parse_iso8601(start_time_str)
+        if start_dt is None:
+            return tool_error(
+                f"Invalid start_time format: '{start_time_str}'. "
+                "Use ISO8601 (e.g. '2026-04-01T00:00:00Z')."
+            )
+    else:
+        start_dt = now - timedelta(days=7)
+
+    if end_time_str:
+        end_dt = _parse_iso8601(end_time_str)
+        if end_dt is None:
+            return tool_error(
+                f"Invalid end_time format: '{end_time_str}'. "
+                "Use ISO8601 (e.g. '2026-04-30T23:59:59Z')."
+            )
+    else:
+        end_dt = now + timedelta(days=30)
+
+    if start_dt >= end_dt:
+        return tool_error("start_time must be before end_time")
+
+    try:
+        from lark_oapi.api.calendar.v4 import ListCalendarEventRequestBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed")
+
+    request = (
+        ListCalendarEventRequestBuilder()
+        .calendar_id(calendar_id)
+        .start_time(_to_unix_ts(start_dt))
+        .end_time(_to_unix_ts(end_dt))
+        .page_size(limit)
+        .build()
+    )
+
+    response = client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from calendar API")
+
+    formatted = _format_event_list(data if isinstance(data, dict) else {})
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_calendar_create_event(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_create_event tool calls."""
+    calendar_id = args.get("calendar_id", "").strip()
+    summary = args.get("summary", "").strip()
+    start_time_str = args.get("start_time", "").strip()
+    end_time_str = args.get("end_time", "").strip()
+    description = args.get("description", "").strip()
+    location = args.get("location", "").strip()
+    attendees = args.get("attendees", [])
+
+    # Validate required fields
+    missing = []
+    if not calendar_id:
+        missing.append("calendar_id")
+    if not summary:
+        missing.append("summary")
+    if not start_time_str:
+        missing.append("start_time")
+    if not end_time_str:
+        missing.append("end_time")
+    if missing:
+        return tool_error(f"Missing required fields: {', '.join(missing)}")
+
+    # Parse times
+    start_dt = _parse_iso8601(start_time_str)
+    if start_dt is None:
+        return tool_error(
+            f"Invalid start_time format: '{start_time_str}'. "
+            "Use ISO8601 (e.g. '2026-04-01T09:00:00+08:00')."
+        )
+
+    end_dt = _parse_iso8601(end_time_str)
+    if end_dt is None:
+        return tool_error(
+            f"Invalid end_time format: '{end_time_str}'. "
+            "Use ISO8601 (e.g. '2026-04-01T10:00:00+08:00')."
+        )
+
+    if start_dt >= end_dt:
+        return tool_error("start_time must be before end_time")
+
+    client = _get_client()
+    if client is None:
+        return tool_error("Feishu client not available")
+
+    try:
+        from lark_oapi.api.calendar.v4 import (
+            CreateCalendarEventRequestBuilder,
+            CreateCalendarEventAttendeeRequestBuilder,
+            CreateCalendarEventAttendeeRequestBodyBuilder,
+            CalendarEventBuilder,
+            EventTimeBuilder,
+            EventLocationBuilder,
+            CalendarEventAttendeeBuilder,
+            CalendarEventAttendeeIdBuilder,
+        )
+    except ImportError:
+        return tool_error("lark_oapi not installed")
+
+    # Build event body
+    event_builder = (
+        CalendarEventBuilder()
+        .summary(summary)
+        .start_time(
+            EventTimeBuilder()
+            .time_stamp(_to_unix_ts(start_dt))
+            .build()
+        )
+        .end_time(
+            EventTimeBuilder()
+            .time_stamp(_to_unix_ts(end_dt))
+            .build()
+        )
+    )
+
+    if description:
+        event_builder.description(description)
+    if location:
+        event_builder.location(EventLocationBuilder().name(location).build())
+
+    event_body = event_builder.build()
+
+    # Build create request
+    request = (
+        CreateCalendarEventRequestBuilder()
+        .calendar_id(calendar_id)
+        .request_body(event_body)
+        .build()
+    )
+
+    user_option = _get_user_request_option()
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from calendar API")
+
+    data_dict = data if isinstance(data, dict) else {"event": data}
+    event_id = data_dict.get("event", {}).get("event_id", "") if isinstance(data_dict, dict) else ""
+
+    # Add attendees if provided
+    if attendees and event_id:
+        att_items = []
+        for att in attendees:
+            att_type = att.get("type", "user")
+            user_id = att.get("user_id", "")
+            if user_id:
+                att_id = CalendarEventAttendeeIdBuilder().user_id(user_id).build()
+                att_item = (
+                    CalendarEventAttendeeBuilder()
+                    .attendee_id(att_id)
+                    .type(att_type)
+                    .build()
+                )
+                att_items.append(att_item)
+
+        if att_items:
+            att_request = (
+                CreateCalendarEventAttendeeRequestBuilder()
+                .calendar_id(calendar_id)
+                .event_id(event_id)
+                .request_body(
+                    CreateCalendarEventAttendeeRequestBodyBuilder()
+                    .attendees(att_items)
+                    .build()
+                )
+                .build()
+            )
+            client.request(att_request)
+
+    formatted = _format_event(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_calendar_update_event(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_update_event tool calls."""
+    calendar_id = args.get("calendar_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+
+    if not calendar_id:
+        return tool_error("calendar_id is required")
+    if not event_id:
+        return tool_error("event_id is required")
+
+    summary = args.get("summary", "").strip()
+    start_time_str = args.get("start_time", "").strip()
+    end_time_str = args.get("end_time", "").strip()
+    description = args.get("description", "").strip()
+    location = args.get("location", "").strip()
+
+    has_update = bool(summary or start_time_str or end_time_str or description or location)
+    if not has_update:
+        return tool_error(
+            "At least one field must be provided to update: "
+            "summary, start_time, end_time, description, or location"
+        )
+
+    # Parse times
+    start_dt = None
+    end_dt = None
+    if start_time_str:
+        start_dt = _parse_iso8601(start_time_str)
+        if start_dt is None:
+            return tool_error(f"Invalid start_time format: '{start_time_str}'.")
+    if end_time_str:
+        end_dt = _parse_iso8601(end_time_str)
+        if end_dt is None:
+            return tool_error(f"Invalid end_time format: '{end_time_str}'.")
+    if start_dt and end_dt and start_dt >= end_dt:
+        return tool_error("start_time must be before end_time")
+
+    client = _get_client()
+    if client is None:
+        return tool_error("Feishu client not available")
+
+    try:
+        from lark_oapi.api.calendar.v4 import (
+            PatchCalendarEventRequestBuilder,
+            CalendarEventBuilder,
+            EventTimeBuilder,
+            EventLocationBuilder,
+        )
+    except ImportError:
+        return tool_error("lark_oapi not installed")
+
+    event_builder = CalendarEventBuilder()
+
+    if summary:
+        event_builder.summary(summary)
+    if start_dt:
+        event_builder.start_time(
+            EventTimeBuilder()
+            .time_stamp(_to_unix_ts(start_dt))
+            .build()
+        )
+    if end_dt:
+        event_builder.end_time(
+            EventTimeBuilder()
+            .time_stamp(_to_unix_ts(end_dt))
+            .build()
+        )
+    if description:
+        event_builder.description(description)
+    if location:
+        event_builder.location(EventLocationBuilder().name(location).build())
+
+    event_body = event_builder.build()
+
+    request = (
+        PatchCalendarEventRequestBuilder()
+        .calendar_id(calendar_id)
+        .event_id(event_id)
+        .request_body(event_body)
+        .build()
+    )
+
+    user_option = _get_user_request_option()
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from calendar API")
+
+    data_dict = data if isinstance(data, dict) else {"event": data}
+    formatted = _format_event(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_calendar_delete_event(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_delete_event tool calls."""
+    calendar_id = args.get("calendar_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+
+    if not calendar_id:
+        return tool_error("calendar_id is required")
+    if not event_id:
+        return tool_error("event_id is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error("Feishu client not available")
+
+    try:
+        from lark_oapi.api.calendar.v4 import DeleteCalendarEventRequestBuilder
+    except ImportError:
+        return tool_error("lark_oapi not installed")
+
+    request = (
+        DeleteCalendarEventRequestBuilder()
+        .calendar_id(calendar_id)
+        .event_id(event_id)
+        .build()
+    )
+
+    user_option = _get_user_request_option()
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    return tool_result(success=True, content="Event deleted successfully.")
+
+
+def _handle_feishu_calendar_attendees(args: dict, **kwargs) -> str:
+    """Handle feishu_calendar_attendees tool calls."""
+    calendar_id = args.get("calendar_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+    attendees = args.get("attendees", [])
+    list_only = args.get("list_only", True)
+
+    if not calendar_id:
+        return tool_error("calendar_id is required")
+    if not event_id:
+        return tool_error("event_id is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error("Feishu client not available")
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.calendar.v4 import (
+            ListCalendarEventAttendeeRequestBuilder,
+            CreateCalendarEventAttendeeRequestBuilder,
+            CreateCalendarEventAttendeeRequestBodyBuilder,
+            CalendarEventAttendeeBuilder,
+            CalendarEventAttendeeIdBuilder,
+        )
+    except ImportError:
+        return tool_error("lark_oapi not installed")
+
+    if attendees and not list_only:
+        # Add attendees
+        att_items = []
+        for att in attendees:
+            att_type = att.get("type", "user")
+            user_id = att.get("user_id", "")
+            if user_id:
+                att_id = CalendarEventAttendeeIdBuilder().user_id(user_id).build()
+                att_item = (
+                    CalendarEventAttendeeBuilder()
+                    .attendee_id(att_id)
+                    .type(att_type)
+                    .build()
+                )
+                att_items.append(att_item)
+
+        if not att_items:
+            return tool_error("No valid attendees provided (each attendee needs user_id)")
+
+        request = (
+            CreateCalendarEventAttendeeRequestBuilder()
+            .calendar_id(calendar_id)
+            .event_id(event_id)
+            .request_body(
+                CreateCalendarEventAttendeeRequestBodyBuilder()
+                .attendees(att_items)
+                .build()
+            )
+            .build()
+        )
+        response = client.request(request, user_option) if user_option else client.request(request)
+        err = _check_response_error(response)
+        if err:
+            return tool_error(err)
+        data = getattr(response, "data", None)
+        if data is None:
+            return tool_error("No data returned from calendar API")
+        formatted = _format_attendees(data if isinstance(data, dict) else {})
+        return tool_result(success=True, content=formatted)
+
+    # List attendees
+    request = (
+        ListCalendarEventAttendeeRequestBuilder()
+        .calendar_id(calendar_id)
+        .event_id(event_id)
+        .page_size(100)
+        .build()
+    )
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from calendar API")
+
+    formatted = _format_attendees(data if isinstance(data, dict) else {})
+    return tool_result(success=True, content=formatted)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="feishu_calendar_list",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_LIST_SCHEMA,
+    handler=_handle_feishu_calendar_list,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List Feishu calendars or get primary calendar",
+    emoji="\U0001f4c5",
+)
+
+registry.register(
+    name="feishu_calendar_events",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_EVENTS_SCHEMA,
+    handler=_handle_feishu_calendar_events,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List events in a Feishu calendar",
+    emoji="\U0001f4c5",
+)
+
+registry.register(
+    name="feishu_calendar_create_event",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_CREATE_EVENT_SCHEMA,
+    handler=_handle_feishu_calendar_create_event,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Create a new calendar event",
+    emoji="\U0001f4c5",
+)
+
+registry.register(
+    name="feishu_calendar_update_event",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_UPDATE_EVENT_SCHEMA,
+    handler=_handle_feishu_calendar_update_event,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Update an existing calendar event",
+    emoji="\U0001f4c5",
+)
+
+registry.register(
+    name="feishu_calendar_delete_event",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_DELETE_EVENT_SCHEMA,
+    handler=_handle_feishu_calendar_delete_event,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Delete a calendar event",
+    emoji="\U0001f4c5",
+)
+
+registry.register(
+    name="feishu_calendar_attendees",
+    toolset="feishu_calendar",
+    schema=FEISHU_CALENDAR_ATTENDEES_SCHEMA,
+    handler=_handle_feishu_calendar_attendees,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List or add attendees to a calendar event",
+    emoji="\U0001f4c5",
+)

--- a/tools/feishu_card_tool.py
+++ b/tools/feishu_card_tool.py
@@ -1,0 +1,558 @@
+"""Feishu Interactive Card Tool -- send Message Cards, files, and rich messages.
+
+Provides:
+  - feishu_send_card         : Send an interactive Message Card
+  - feishu_send_message      : Send a plain text message
+  - feishu_upload_file       : Upload a file and return the file key
+  - feishu_send_file         : Send a file to a user or chat
+
+Templates (CardElement helpers):
+  - task_card       : Task notification card (pending/completed/overdue)
+  - calendar_card  : Calendar/event invite card
+  - generic_card   : Generic info card with field rows
+  - card_div / card_text / card_hr / card_button : base element builders
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+_thread_local_client = None
+
+
+def set_client(client) -> None:
+    """Store a lark client for the current thread."""
+    global _thread_local_client
+    _thread_local_client = client
+
+
+def _load_env():
+    env_path = os.path.expanduser("~/.hermes/.env")
+    if os.path.exists(env_path):
+        for line in open(env_path):
+            if "=" in line and not line.startswith("#"):
+                k, v = line.strip().split("=", 1)
+                os.environ.setdefault(k, v)
+
+
+def _get_client():
+    if _thread_local_client:
+        return _thread_local_client
+    _load_env()
+    import lark_oapi as lark
+
+    return (
+        lark.Client.builder()
+        .app_id(os.environ.get("FEISHU_APP_ID", ""))
+        .app_secret(os.environ.get("FEISHU_APP_SECRET", ""))
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core send functions
+# ---------------------------------------------------------------------------
+
+
+def _send_message_impl(
+    receive_id: str, receive_id_type: str, msg_type: str, content: str | dict,
+) -> dict:
+    """Low-level send. Returns {"success": bool, "message_id": str, "error": str}."""
+    try:
+        from lark_oapi.api.im.v1 import CreateMessageRequest, CreateMessageRequestBody
+
+        client = _get_client()
+        content_str = json.dumps(content) if isinstance(content, dict) else content
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type(receive_id_type)
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(receive_id)
+                .msg_type(msg_type)
+                .content(content_str)
+                .build()
+            )
+            .build()
+        )
+        resp = client.im.v1.message.create(request)
+        if not resp.success():
+            return {"success": False, "error": resp.msg}
+        return {"success": True, "message_id": resp.data.message_id}
+    except Exception as e:
+        logger.exception("send_message failed")
+        return {"success": False, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Card templates (base elements)
+# ---------------------------------------------------------------------------
+
+
+def _card_text(text: str, tag: str = "larkmd", **kwargs) -> dict:
+    result: dict[str, Any] = {"tag": tag, "content": text}
+    if kwargs.get("color"):
+        result["color"] = kwargs["color"]
+    if kwargs.get("bold"):
+        result["bold"] = True
+    return result
+
+
+def _card_div(text: str = "", fields: list = None, **kwargs) -> dict:
+    props: dict[str, Any] = {"tag": "div"}
+    if fields:
+        props["fields"] = fields
+    if text:
+        props["text"] = _card_text(text, **kwargs)
+    return props
+
+
+def _card_hr() -> dict:
+    return {"tag": "hr"}
+
+
+def _card_button(text: str, value: str, action_id: str) -> dict:
+    return {
+        "tag": "button",
+        "text": _card_text(text, tag="plain_text"),
+        "value": value,
+        "action_id": action_id,
+    }
+
+
+def _build_card(header: dict, elements: list) -> dict:
+    return {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "header": header,
+        "elements": elements,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Card template builders
+# ---------------------------------------------------------------------------
+
+
+def task_card(
+    task_title: str,
+    status: str = "pending",
+    due_date: str = "",
+    assignee_name: str = "",
+    task_url: str = "",
+) -> dict:
+    """Build a task notification card.
+
+    Args:
+        task_title: Task summary/title
+        status: "pending" | "completed" | "overdue"
+        due_date: Due date string (e.g. "2026-04-30")
+        assignee_name: Name of person assigned
+        task_url: Optional deep link to task
+    """
+    status_emoji = {"pending": "⏳", "completed": "✅", "overdue": "🔴"}.get(status, "📋")
+    status_text = {
+        "pending": "待处理",
+        "completed": "已完成",
+        "overdue": "已逾期",
+    }.get(status, status)
+    template_map = {"pending": "purple", "completed": "green", "overdue": "red"}
+
+    header = {
+        "title": _card_text(f"{status_emoji} {task_title}", tag="plain_text"),
+        "subtitle": _card_text(f"状态: {status_text}", tag="plain_text"),
+        "template": template_map.get(status, "blue"),
+    }
+
+    elements = []
+    fields = []
+    if assignee_name:
+        fields.append({"tag": "field", "text": _card_text(f"👤 负责人: **{assignee_name}**")})
+    if due_date:
+        fields.append({"tag": "field", "text": _card_text(f"📅 截止: **{due_date}**")})
+    if fields:
+        elements.append({"tag": "div", "fields": fields, "text": None})
+
+    elements.append(_card_hr())
+    elements.append({"tag": "note", "elements": [_card_text(f"状态: {status_text}")]})
+
+    if task_url:
+        elements.append({
+            "tag": "action",
+            "actions": [{
+                "tag": "button",
+                "text": _card_text("打开任务", tag="plain_text"),
+                "type": "primary",
+                "value": task_url,
+                "action_id": "open_task",
+            }],
+        })
+
+    return _build_card(header, elements)
+
+
+def calendar_card(
+    event_title: str,
+    start_time: str,
+    end_time: str = "",
+    location: str = "",
+    attendees: list[str] | None = None,
+    organizer: str = "",
+    description: str = "",
+) -> dict:
+    """Build a calendar invite card.
+
+    Args:
+        event_title: Event summary
+        start_time: Start time (e.g. "2026-04-30 09:00")
+        end_time: End time (e.g. "2026-04-30 10:00")
+        location: Location string
+        attendees: List of attendee names
+        organizer: Organizer name
+        description: Markdown description body
+    """
+    header = {
+        "title": _card_text(f"📅 {event_title}"),
+        "template": "blue",
+    }
+
+    elements = []
+    time_str = start_time + (f" ~ {end_time}" if end_time else "")
+    elements.append({
+        "tag": "div",
+        "fields": [{"tag": "field", "text": _card_text(f"🕐 **时间**: {time_str}")}],
+        "text": None,
+    })
+    if location:
+        elements.append({
+            "tag": "div",
+            "fields": [{"tag": "field", "text": _card_text(f"📍 **地点**: {location}")}],
+            "text": None,
+        })
+    if organizer:
+        elements.append({
+            "tag": "div",
+            "fields": [{"tag": "field", "text": _card_text(f"👔 **组织者**: {organizer}")}],
+            "text": None,
+        })
+    if attendees:
+        elements.append({
+            "tag": "div",
+            "fields": [{"tag": "field", "text": _card_text(f"👥 **参与者**: {', '.join(attendees)}")}],
+            "text": None,
+        })
+
+    elements.append(_card_hr())
+    if description:
+        elements.append({"tag": "div", "text": _card_text(description, tag="larkmd")})
+
+    return _build_card(header, elements)
+
+
+def generic_card(
+    title: str,
+    body_lines: list[tuple[str, str]] | None = None,
+    description: str = "",
+    status: str = "info",
+    actions: list[dict] | None = None,
+) -> dict:
+    """Build a generic information card.
+
+    Args:
+        title: Card title
+        body_lines: List of (label, value) tuples to show as field rows
+        description: Markdown description body
+        status: "info" | "success" | "warning" | "danger" — sets header color
+        actions: List of action button dicts
+    """
+    template_map = {"info": "blue", "success": "green", "warning": "yellow", "danger": "red"}
+    header = {"title": _card_text(title), "template": template_map.get(status, "blue")}
+
+    elements = []
+    if body_lines:
+        fields = []
+        for label, value in body_lines:
+            fields.append({"tag": "field", "text": _card_text(f"**{label}**: {value}")})
+            if len(fields) == 2:
+                elements.append({"tag": "div", "fields": fields, "text": None})
+                fields = []
+        if fields:
+            elements.append({"tag": "div", "fields": fields, "text": None})
+
+    if description:
+        elements.append({"tag": "div", "text": _card_text(description, tag="larkmd")})
+
+    if actions:
+        elements.append({"tag": "action", "actions": actions})
+
+    return _build_card(header, elements)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+FEISHU_SEND_CARD_SCHEMA = {
+    "name": "feishu_send_card",
+    "description": (
+        "Send an interactive Feishu Message Card to a user or chat.\n\n"
+        "Use this to send rich, interactive notifications with buttons, "
+        "fields, and structured layouts — far richer than plain text.\n\n"
+        "Args:\n"
+        "  card (dict): Message Card JSON. Use task_card(), calendar_card(), "
+        "or generic_card() helpers to build it, or provide raw card JSON.\n"
+        "  receive_id (str): Feishu ID of the recipient — open_id, chat_id, or user_id.\n"
+        "  receive_id_type (str, optional): Type of receive_id — "
+        "'open_id' (default), 'chat_id', 'user_id', 'union_id', 'email'.\n"
+        "Returns: {\"success\": bool, \"message_id\": str, \"error\": str}"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "card": {
+                "type": "object",
+                "description": "Message Card JSON dict. "
+                "Use task_card(), calendar_card(), or generic_card() to build.",
+            },
+            "receive_id": {"type": "string", "description": "Recipient ID (open_id, chat_id, etc.)."},
+            "receive_id_type": {
+                "type": "string",
+                "description": "Type of receive_id — open_id (default), chat_id, user_id, union_id, email.",
+                "default": "open_id",
+            },
+        },
+        "required": ["card", "receive_id"],
+    },
+}
+
+FEISHU_SEND_MESSAGE_SCHEMA = {
+    "name": "feishu_send_message",
+    "description": (
+        "Send a plain text message to a Feishu user or chat.\n\n"
+        "For rich interactive cards, use feishu_send_card instead.\n\n"
+        "Args:\n"
+        "  text (str): Plain text content to send.\n"
+        "  receive_id (str): Recipient ID.\n"
+        "  receive_id_type (str, optional): Type — 'open_id' (default), 'chat_id', etc.\n"
+        "Returns: {\"success\": bool, \"message_id\": str, \"error\": str}"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Plain text message content."},
+            "receive_id": {"type": "string", "description": "Recipient ID."},
+            "receive_id_type": {
+                "type": "string",
+                "description": "Type of receive_id — open_id (default), chat_id, etc.",
+                "default": "open_id",
+            },
+        },
+        "required": ["text", "receive_id"],
+    },
+}
+
+FEISHU_UPLOAD_FILE_SCHEMA = {
+    "name": "feishu_upload_file",
+    "description": (
+        "Upload a file to Feishu and get a file_key for subsequent use.\n\n"
+        "Returns the file_key. To send the file to a user, use feishu_send_file instead.\n\n"
+        "Args:\n"
+        "  file_path (str): Absolute path to the local file.\n"
+        "Returns: {\"file_key\": str, \"error\": str}"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "file_path": {"type": "string", "description": "Absolute path to the file to upload."},
+        },
+        "required": ["file_path"],
+    },
+}
+
+FEISHU_SEND_FILE_SCHEMA = {
+    "name": "feishu_send_file",
+    "description": (
+        "Send a file to a Feishu user or chat.\n\n"
+        "Two-step: uploads the file to Feishu, then sends it as a file message.\n\n"
+        "Args:\n"
+        "  file_path (str): Absolute path to the local file.\n"
+        "  receive_id (str): Recipient ID.\n"
+        "  receive_id_type (str, optional): 'open_id' (default) or 'chat_id'.\n"
+        "  file_name (str, optional): Display name for the file.\n"
+        "Returns: {\"success\": bool, \"message_id\": str, \"error\": str}"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "file_path": {"type": "string", "description": "Absolute path to the file."},
+            "receive_id": {"type": "string", "description": "Recipient ID."},
+            "receive_id_type": {
+                "type": "string",
+                "description": "Type of receive_id — open_id (default), chat_id, etc.",
+                "default": "open_id",
+            },
+            "file_name": {
+                "type": "string",
+                "description": "Optional display name for the file.",
+            },
+        },
+        "required": ["file_path", "receive_id"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_feishu_send_card(args: dict, **kw) -> str:
+    card = args.get("card")
+    receive_id = args.get("receive_id", "").strip()
+    receive_id_type = args.get("receive_id_type", "open_id").strip()
+
+    if not card:
+        return tool_error("card is required (Message Card JSON dict)")
+    if not receive_id:
+        return tool_error("receive_id is required")
+
+    result = _send_message_impl(receive_id, receive_id_type, "interactive", card)
+    if result.get("success"):
+        return tool_result(success=True, content=f"Card sent. message_id={result['message_id']}")
+    return tool_error(result.get("error", "Unknown error"))
+
+
+def _handle_feishu_send_message(args: dict, **kw) -> str:
+    text = args.get("text", "").strip()
+    receive_id = args.get("receive_id", "").strip()
+    receive_id_type = args.get("receive_id_type", "open_id").strip()
+
+    if not text:
+        return tool_error("text is required")
+    if not receive_id:
+        return tool_error("receive_id is required")
+
+    result = _send_message_impl(receive_id, receive_id_type, "text", json.dumps({"text": text}))
+    if result.get("success"):
+        return tool_result(success=True, content=f"Message sent. message_id={result['message_id']}")
+    return tool_error(result.get("error", "Unknown error"))
+
+
+_FILE_TYPE_MAP = {
+    ".pdf": "pdf",
+    ".doc": "doc",
+    ".docx": "doc",
+    ".xls": "xls",
+    ".xlsx": "xls",
+    ".ppt": "ppt",
+    ".pptx": "ppt",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".gif": "image",
+    ".mp4": "mp4",
+    ".mp3": "mp3",
+}
+
+
+def _resolve_file_type(file_path: str) -> str:
+    ext = os.path.splitext(file_path)[-1].lower()
+    return _FILE_TYPE_MAP.get(ext, "stream")
+
+
+def _handle_feishu_upload_file(args: dict, **kw) -> str:
+    file_path = args.get("file_path", "").strip()
+    if not file_path:
+        return tool_error("file_path is required")
+
+    if not os.path.exists(file_path):
+        return tool_error(f"File not found: {file_path}")
+
+    try:
+        from lark_oapi.api.im.v1 import CreateFileRequest, CreateFileRequestBody
+
+        client = _get_client()
+        file_name = os.path.basename(file_path)
+        file_type = _resolve_file_type(file_path)
+
+        with open(file_path, "rb") as f:
+            request = (
+                CreateFileRequest.builder()
+                .request_body(
+                    CreateFileRequestBody.builder()
+                    .file_name(file_name)
+                    .file_type(file_type)
+                    .file(f)
+                    .build()
+                )
+                .build()
+            )
+            resp = client.im.v1.create_file(request)
+
+        if not resp.success():
+            return tool_error(f"Upload failed: {resp.msg}")
+        return tool_result(success=True, content=f"file_key={resp.data.file_key}")
+    except Exception as e:
+        logger.exception("upload_file crash")
+        return tool_error(str(e))
+
+
+def _handle_feishu_send_file(args: dict, **kw) -> str:
+    file_path = args.get("file_path", "").strip()
+    receive_id = args.get("receive_id", "").strip()
+    receive_id_type = args.get("receive_id_type", "open_id").strip()
+    file_name = args.get("file_name", "").strip() or None
+
+    if not file_path:
+        return tool_error("file_path is required")
+    if not receive_id:
+        return tool_error("receive_id is required")
+
+    # Step 1: Upload
+    upload_resp = _handle_feishu_upload_file({"file_path": file_path}, **kw)
+    import re
+
+    m = re.search(r"file_key=(\S+)", upload_resp)
+    if not m:
+        return upload_resp  # Error message already in tool_error format
+    file_key = m.group(1)
+    display_name = file_name or os.path.basename(file_path)
+
+    # Step 2: Send
+    content = json.dumps({"file_key": file_key, "file_name": display_name})
+    result = _send_message_impl(receive_id, receive_id_type, "file", content)
+    if result.get("success"):
+        return tool_result(success=True, content=f"File sent. message_id={result['message_id']}")
+    return tool_error(result.get("error", "Unknown error"))
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+for _name, _schema, _handler in [
+    ("feishu_send_card", FEISHU_SEND_CARD_SCHEMA, _handle_feishu_send_card),
+    ("feishu_send_message", FEISHU_SEND_MESSAGE_SCHEMA, _handle_feishu_send_message),
+    ("feishu_upload_file", FEISHU_UPLOAD_FILE_SCHEMA, _handle_feishu_upload_file),
+    ("feishu_send_file", FEISHU_SEND_FILE_SCHEMA, _handle_feishu_send_file),
+]:
+    registry.register(
+        name=_name,
+        toolset="feishu",
+        schema=_schema,
+        handler=_handler,
+        check_fn=lambda _: True,
+        emoji="📦",
+    )

--- a/tools/feishu_messages_tool.py
+++ b/tools/feishu_messages_tool.py
@@ -1,0 +1,288 @@
+"""Feishu Message History Tool -- read recent messages from local Hermes OS session store.
+
+Provides ``feishu_message_history`` for reading conversation history.
+History is read from Hermes OS local session storage (SQLite via hermes_state),
+which works reliably for both P2P DM and group chats — no Feishu API limitation.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# hermes_state integration
+# ---------------------------------------------------------------------------
+
+_HERMES_STATE_AVAILABLE = False
+_SessionDB = None
+
+
+def _get_session_db():
+    """Lazily import and return SessionDB instance."""
+    global _SessionDB, _HERMES_STATE_AVAILABLE
+    if _SessionDB is None:
+        try:
+            import sys
+            # Try gateway path first
+            agent_path = Path(__file__).resolve().parents[2]
+            if str(agent_path) not in sys.path:
+                sys.path.insert(0, str(agent_path))
+            from hermes_state import SessionDB
+
+            _SessionDB = SessionDB()
+            _HERMES_STATE_AVAILABLE = True
+        except Exception as e:
+            logger.warning("hermes_state unavailable: %s", e)
+            _HERMES_STATE_AVAILABLE = False
+    return _SessionDB
+
+
+def _get_hermes_home() -> Path:
+    hermes_home = os.getenv("HERMES_HOME", "")
+    if hermes_home:
+        p = Path(hermes_home)
+        if p.exists():
+            return p
+    return Path.home() / ".hermes"
+
+
+def _get_sessions_index() -> dict:
+    """Load sessions.json index."""
+    sessions_index = _get_hermes_home() / "sessions" / "sessions.json"
+    if sessions_index.exists():
+        try:
+            with open(sessions_index) as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def _find_current_session_id(chat_id: str) -> str | None:
+    """Find the current session ID for a chat_id from sessions.json."""
+    index = _get_sessions_index()
+    session_key = f"agent:main:feishu:dm:{chat_id}"
+    entry = index.get(session_key, {})
+    return entry.get("session_id") or None
+
+
+def _get_chat_user_id(chat_id: str) -> str | None:
+    """Get the user_id (open_id) for a chat from sessions.json."""
+    index = _get_sessions_index()
+    session_key = f"agent:main:feishu:dm:{chat_id}"
+    entry = index.get(session_key, {})
+    origin = entry.get("origin", {})
+    return origin.get("user_id") or None
+
+
+def _read_local_history(chat_id: str, limit: int = 20, start_time: str = "") -> tuple[str, str]:
+    """
+    Read message history from hermes_state (SQLite).
+
+    Strategy:
+    1. Find current session_id from sessions.json
+    2. Use user_id to find ALL past sessions for this user (same user_id = same person)
+    3. Merge messages from all sessions, newest first
+
+    Returns (content, source).
+    """
+    db = _get_session_db()
+    if db is None:
+        return "", "unavailable"
+
+    # Get current session info
+    current_session_id = _find_current_session_id(chat_id)
+    user_id = _get_chat_user_id(chat_id)
+
+    if not user_id:
+        return "", "no_user"
+
+    # Find all sessions for this user (same user_id across all sessions)
+    all_sessions = db.list_sessions_rich()
+    user_sessions = [s for s in all_sessions if s.get("user_id") == user_id]
+    user_sessions.sort(key=lambda s: s.get("started_at", 0))
+
+    if not user_sessions:
+        return "", "no_sessions"
+
+    # Parse start_time filter
+    start_dt = None
+    if start_time:
+        try:
+            dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            start_dt = dt.astimezone(timezone.utc) if dt.tzinfo is None else dt
+        except (ValueError, OSError):
+            pass
+
+    # Collect all messages from all user sessions
+    all_messages = []
+    for session in user_sessions:
+        session_id = session["id"]
+        messages = db.get_messages(session_id)
+        for msg in messages:
+            # Apply start_time filter
+            if start_dt and msg.get("timestamp"):
+                try:
+                    import time
+                    msg_dt = datetime.fromtimestamp(msg["timestamp"], tz=timezone.utc)
+                    if msg_dt < start_dt:
+                        continue
+                except (ValueError, OSError):
+                    pass
+
+            all_messages.append((session.get("started_at", 0), msg))
+
+    if not all_messages:
+        return "", "no_messages"
+
+    # Sort by session start time, then by timestamp within session
+    all_messages.sort(key=lambda x: (x[0], x[1].get("timestamp", 0)))
+
+    # Take last N messages
+    recent = all_messages[-limit:]
+    formatted = _format_messages(recent)
+    return formatted, "hermes_state"
+
+
+def _format_messages(messages: list) -> str:
+    """Format (timestamp, msg_dict) tuples into a readable conversation log."""
+    if not messages:
+        return "(No messages found)"
+
+    lines = []
+    for _, msg in messages:
+        role = msg.get("role", "?")
+        content = msg.get("content") or ""
+
+        # Skip injected context blocks
+        if content.strip().startswith("<current_user>"):
+            continue
+
+        # Truncate very long messages
+        if len(content) > 400:
+            content = content[:400] + "..."
+
+        if role == "user":
+            lines.append(f"[You]: {content}")
+        elif role == "assistant":
+            lines.append(f"[Bot]: {content}")
+        elif role == "system":
+            continue  # Skip system messages
+        else:
+            lines.append(f"[{role}]: {content[:200]}")
+
+    if not lines:
+        return "(No messages found)"
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool schema and handler
+# ---------------------------------------------------------------------------
+
+FEISHU_MESSAGE_HISTORY_SCHEMA = {
+    "name": "feishu_message_history",
+    "description": (
+        "Read recent messages from the conversation history. "
+        "Use this when the user asks to recall earlier messages, "
+        "check conversation history, or reference what they said before.\n\n"
+        "Reads from local Hermes OS session storage (works for both P2P DM and group chats).\n\n"
+        "Args:\n"
+        "  chat_id (str, optional): The Feishu chat ID. Defaults to the current session's chat ID.\n"
+        "  limit (int, optional): Max messages to return, default 20.\n"
+        "  start_time (str, optional): ISO8601 timestamp to start from.\n"
+        "Returns a formatted plain-text conversation log."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "The Feishu chat ID. For DM chats: starts with 'oc_'. "
+                    "Defaults to current session's chat ID."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of messages to return (default 20).",
+                "minimum": 1,
+                "maximum": 100,
+            },
+            "start_time": {
+                "type": "string",
+                "description": (
+                    "ISO8601 timestamp string (e.g. '2026-04-01T00:00:00Z'). "
+                    "Only messages after this time will be returned."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _check_feishu():
+    return True  # Always available
+
+
+def _handle_feishu_message_history(args: dict, **kw) -> str:
+    """Handle feishu_message_history tool calls."""
+    chat_id = args.get("chat_id", "").strip()
+    if not chat_id:
+        chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "").strip()
+    if not chat_id:
+        return tool_error(
+            "chat_id is required. Provide it as an argument, or make sure this tool "
+            "is called within an active Feishu session (HERMES_SESSION_CHAT_ID not set)."
+        )
+
+    limit = args.get("limit", 20)
+    limit = max(1, min(100, int(limit)))
+
+    start_time = args.get("start_time", "").strip()
+
+    content, source = _read_local_history(chat_id, limit=limit, start_time=start_time)
+
+    if source == "unavailable":
+        return tool_error(
+            "Hermes OS session store is unavailable. "
+            "Make sure hermes_state is accessible from the hermes-agent path."
+        )
+
+    if source == "no_user":
+        return tool_error(
+            f"No user information found for chat '{chat_id}'. "
+            f"This chat may not have an active Hermes OS session."
+        )
+
+    if source == "no_sessions":
+        return tool_error(
+            f"No session history found for chat '{chat_id}'."
+        )
+
+    if source == "no_messages" or not content.strip():
+        return tool_result(success=True, content="(No messages found)")
+
+    return tool_result(success=True, content=content)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="feishu_message_history",
+    toolset="feishu",
+    schema=FEISHU_MESSAGE_HISTORY_SCHEMA,
+    handler=_handle_feishu_message_history,
+    check_fn=_check_feishu,
+    emoji="💬",
+)

--- a/tools/feishu_oauth.py
+++ b/tools/feishu_oauth.py
@@ -1,0 +1,540 @@
+"""Feishu User OAuth Tool -- per-user token management via PKCE.
+
+Provides tools:
+  - feishu_oauth_authorize  : Generate OAuth authorization URL for the current user
+  - feishu_oauth_callback   : Exchange authorization code for stored tokens
+  - feishu_oauth_status    : Check current user's OAuth authorization status
+
+Token storage: ~/.hermes/feishu-user-tokens/<open_id>.json
+PKCE verifier storage:  ~/.hermes/feishu-user-tokens/<open_id>.pending.json (10-min TTL)
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+import urllib.parse
+from pathlib import Path
+from typing import Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _get_hermes_home() -> Path:
+    val = os.environ.get("HERMES_HOME", "").strip()
+    return Path(val) if val else Path.home() / ".hermes"
+
+
+class FeishuOAuthConfig:
+    """Read OAuth / app credentials from environment."""
+
+    def __init__(self):
+        self.app_id: str = os.environ["FEISHU_APP_ID"]
+        self.app_secret: str = os.environ["FEISHU_APP_SECRET"]
+        self.redirect_uri: str = os.environ.get(
+            "FEISHU_OAUTH_REDIRECT_URI", "http://localhost:8765/callback"
+        )
+        self.scopes: str = os.environ.get(
+            "FEISHU_OAUTH_SCOPES",
+            # Calendar (confirmed working with user token)
+            "calendar:calendar:read "
+            "calendar:calendar.event:read "
+            "calendar:calendar.event:create "
+            "calendar:calendar.event:update "
+            # Task
+            "task:task:read "
+            "task:task:write "
+            "task:tasklist:read "
+            "task:tasklist:write "
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bot-level lark client (for token exchange / refresh — no user token needed)
+# ---------------------------------------------------------------------------
+
+_bot_client = None
+
+
+def _get_bot_client():
+    """Return a bot-level lark client with enable_set_token=True."""
+    global _bot_client
+    if _bot_client is None:
+        import lark_oapi as lark
+
+        cfg = FeishuOAuthConfig()
+        _bot_client = (
+            lark.Client.builder()
+            .app_id(cfg.app_id)
+            .app_secret(cfg.app_secret)
+            .enable_set_token(True)
+            .log_level(lark.LogLevel.WARNING)
+            .build()
+        )
+    return _bot_client
+
+
+# ---------------------------------------------------------------------------
+# Token Store
+# ---------------------------------------------------------------------------
+
+_TOKEN_DIR: Optional[Path] = None
+
+
+def _token_dir() -> Path:
+    global _TOKEN_DIR
+    if _TOKEN_DIR is None:
+        _TOKEN_DIR = _get_hermes_home() / "feishu-user-tokens"
+        _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    return _TOKEN_DIR
+
+
+def _safe_filename(open_id: str) -> str:
+    """Sanitize open_id for use as a filename."""
+    return open_id.replace("/", "_").replace("\\", "_")
+
+
+# ---------------------------------------------------------------------------
+# Disk I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_json(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(".tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        tmp.rename(path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# FeishuUserTokenStore
+# ---------------------------------------------------------------------------
+
+
+class FeishuUserTokenStore:
+    """Manage per-user Feishu OAuth tokens with PKCE and auto-refresh."""
+
+    # ---------------------------------------------------------------------------
+    # PKCE helpers
+    # ---------------------------------------------------------------------------
+
+    @staticmethod
+    def _pkce_pair() -> tuple[str, str]:
+        """Generate (code_verifier, code_challenge) for PKCE S256."""
+        verifier = secrets.token_urlsafe(32)
+        digest = hashlib.sha256(verifier.encode()).digest()
+        challenge = (
+            base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        )
+        return verifier, challenge
+
+    # ---------------------------------------------------------------------------
+    # File paths
+    # ---------------------------------------------------------------------------
+
+    def _token_path(self, open_id: str) -> Path:
+        return _token_dir() / f"{_safe_filename(open_id)}.json"
+
+    def _pending_path(self, open_id: str) -> Path:
+        return _token_dir() / f"{_safe_filename(open_id)}.pending.json"
+
+    # ---------------------------------------------------------------------------
+    # Pending PKCE session
+    # ---------------------------------------------------------------------------
+
+    def _read_pending(self, open_id: str) -> Optional[dict]:
+        p = self._pending_path(open_id)
+        data = _read_json(p)
+        if data and (time.time() - data.get("created_at", 0)) > 600:
+            p.unlink(missing_ok=True)
+            return None
+        return data
+
+    def _write_pending(self, open_id: str, data: dict) -> None:
+        _write_json(self._pending_path(open_id), data)
+
+    def _delete_pending(self, open_id: str) -> None:
+        self._pending_path(open_id).unlink(missing_ok=True)
+
+    # ---------------------------------------------------------------------------
+    # Token exchange & refresh
+    # ---------------------------------------------------------------------------
+
+    def get_authorization_url(self, open_id: str) -> tuple[str, str]:
+        """Build OAuth URL and persist PKCE verifier.
+
+        Returns (url, state).  Caller displays the URL; user copies the
+        ?code=... query param from the redirect and passes it to exchange_code().
+        """
+        cfg = FeishuOAuthConfig()
+        verifier, challenge = self._pkce_pair()
+        state = secrets.token_urlsafe(16)
+
+        params = {
+            "app_id": cfg.app_id,
+            "redirect_uri": cfg.redirect_uri,
+            "state": state,
+            "scope": cfg.scopes,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+        url = (
+            "https://open.feishu.cn/open-apis/authen/v1/authorize?"
+            + urllib.parse.urlencode(params)
+        )
+
+        self._write_pending(open_id, {
+            "verifier": verifier,
+            "state": state,
+            "created_at": time.time(),
+        })
+
+        logger.info("OAuth URL generated for open_id=%s", open_id)
+        return url, state
+
+    def exchange_code(self, open_id: str, code: str) -> dict:
+        """Exchange authorization code for tokens using form-urlencoded (Feishu requirement)."""
+        import urllib.request
+
+        pending = self._read_pending(open_id)
+        if not pending:
+            raise RuntimeError("No PKCE pending session found for open_id. Authorization may have expired.")
+        verifier = pending.get("verifier", "")
+        self._delete_pending(open_id)
+
+        cfg = FeishuOAuthConfig()
+        data = urllib.parse.urlencode({
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "app_id": cfg.app_id,
+            "app_secret": cfg.app_secret,
+        }).encode("utf-8")
+
+        req = urllib.request.Request(
+            "https://open.feishu.cn/open-apis/authen/v1/oidc/access_token",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read())
+
+        code_attr = result.get("code")
+        if code_attr != 0:
+            raise RuntimeError(f"Token exchange failed: code={code_attr} msg={result.get('msg')} resp={result}")
+
+        data = result.get("data", {})
+        now = time.time()
+        record = {
+            "access_token": data.get("access_token", ""),
+            "refresh_token": data.get("refresh_token", ""),
+            "expires_at": now + float(data.get("expires_in", 7200)),
+            "refresh_expires_at": now + float(data.get("refresh_expires_in", 2592000)),
+            "open_id": open_id,
+        }
+
+        _write_json(self._token_path(open_id), record)
+        logger.info("OAuth tokens stored for open_id=%s", open_id)
+        return record
+
+    def refresh_token(self, open_id: str) -> Optional[dict]:
+        """Refresh access_token using stored refresh_token. Returns updated record."""
+        import urllib.request
+
+        record = _read_json(self._token_path(open_id))
+        if not record:
+            return None
+        refresh = record.get("refresh_token", "")
+        if not refresh:
+            return None
+
+        cfg = FeishuOAuthConfig()
+        # Get app_access_token for authentication
+        app_token_req = urllib.request.Request(
+            "https://open.feishu.cn/open-apis/auth/v3/app_access_token/internal",
+            data=json.dumps({"app_id": cfg.app_id, "app_secret": cfg.app_secret}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(app_token_req, timeout=30) as r:
+            app_token_result = json.loads(r.read())
+        app_token = app_token_result.get("app_access_token", "")
+
+        data = urllib.parse.urlencode({
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+        }).encode("utf-8")
+
+        req = urllib.request.Request(
+            "https://open.feishu.cn/open-apis/authen/v1/oidc/refresh_access_token",
+            data=data,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": f"Bearer {app_token}",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.loads(resp.read())
+        except Exception as e:
+            logger.warning("Token refresh failed for open_id=%s: %s", open_id, e)
+            return None
+
+        code_attr = result.get("code")
+        if code_attr != 0:
+            logger.warning("Token refresh failed for open_id=%s: %s", open_id, result.get("msg"))
+            return None
+
+        data = result.get("data", {})
+        now = time.time()
+        record.update({
+            "access_token": data.get("access_token", record["access_token"]),
+            "refresh_token": data.get("refresh_token", refresh),
+            "expires_at": now + float(data.get("expires_in", 7200)),
+            "refresh_expires_at": now + float(data.get("refresh_expires_in", 2592000)),
+        })
+
+        _write_json(self._token_path(open_id), record)
+        logger.info("Token refreshed for open_id=%s", open_id)
+        return record
+
+    # ---------------------------------------------------------------------------
+    # Public API
+    # ---------------------------------------------------------------------------
+
+    def get_user_token(self, open_id: str) -> Optional[str]:
+        """Return a valid access_token, auto-refreshing if expired or near expiry."""
+        if not open_id:
+            return None
+        record = _read_json(self._token_path(open_id))
+        if not record:
+            return None
+        # Refresh if expired or expires within 5 minutes
+        if time.time() >= record.get("expires_at", 0) - 300:
+            record = self.refresh_token(open_id)
+            if not record:
+                return None
+        return record.get("access_token")
+
+    def get_request_option(self, open_id: str) -> Optional["RequestOption"]:
+        """Return a RequestOption with user_access_token set, or None."""
+        from lark_oapi import RequestOption
+
+        token = self.get_user_token(open_id)
+        if not token:
+            return None
+        return RequestOption.builder().user_access_token(token).build()
+
+    def get_auth_status(self, open_id: str) -> dict:
+        """Return OAuth status for the given open_id."""
+        record = _read_json(self._token_path(open_id))
+        if not record:
+            return {"status": "not_authorized", "open_id": open_id}
+        expires_at = record.get("expires_at", 0)
+        now = time.time()
+        if now >= expires_at:
+            status = "expired"
+        elif now >= expires_at - 300:
+            status = "expiring_soon"
+        else:
+            status = "authorized"
+        return {
+            "status": status,
+            "open_id": open_id,
+            "expires_at": expires_at,
+            "refresh_expires_at": record.get("refresh_expires_at"),
+        }
+
+    def revoke(self, open_id: str) -> None:
+        """Delete stored tokens and pending PKCE data."""
+        self._token_path(open_id).unlink(missing_ok=True)
+        self._pending_path(open_id).unlink(missing_ok=True)
+        logger.info("OAuth tokens revoked for open_id=%s", open_id)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+FEISHU_OAUTH_AUTHORIZE_SCHEMA = {
+    "name": "feishu_oauth_authorize",
+    "description": (
+        "Generate a Feishu OAuth 2.0 authorization URL for the current user. "
+        "Visit the URL in a browser, log in, and copy the 'code' parameter from the redirect URL. "
+        "Then call feishu_oauth_callback with that code to complete the flow.\n\n"
+        "Required OAuth scopes: calendar:calendar:read, calendar:calendar.event:write, "
+        "task:task:read, task:task:write.\n\n"
+        "Returns: { authorization_url, state }"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+FEISHU_OAUTH_CALLBACK_SCHEMA = {
+    "name": "feishu_oauth_callback",
+    "description": (
+        "Complete the Feishu OAuth flow by exchanging the authorization code for tokens. "
+        "Call this after the user visits the URL from feishu_oauth_authorize and provides "
+        "the 'code' query parameter from the redirect URL.\n\n"
+        "Args:\n"
+        "  code (str, required): The 'code' query parameter from the OAuth redirect URL.\n\n"
+        "Returns: { success, open_id, expires_at }"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "type": "string",
+                "description": (
+                    "The 'code' query parameter from the OAuth redirect URL. "
+                    "Example: If redirect is 'http://localhost:8765/callback?code=abc123', "
+                    "pass code='abc123'."
+                ),
+            },
+        },
+        "required": ["code"],
+    },
+}
+
+FEISHU_OAUTH_STATUS_SCHEMA = {
+    "name": "feishu_oauth_status",
+    "description": (
+        "Check the current user's Feishu OAuth authorization status.\n\n"
+        "Statuses:\n"
+        "  - not_authorized: User has not completed OAuth flow\n"
+        "  - authorized:    User token is valid\n"
+        "  - expiring_soon: Token valid but expires within 5 minutes — refresh recommended\n"
+        "  - expired:       Token expired; user needs to re-authenticate\n\n"
+        "Returns: { status, open_id, expires_at, refresh_expires_at }"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+def _open_id_from_context() -> str:
+    """Read current user's open_id from session context."""
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env("HERMES_SESSION_USER_ID", "")
+    except Exception:
+        return ""
+
+
+def _handle_authorize(args: dict, **kw) -> str:
+    open_id = _open_id_from_context()
+    if not open_id:
+        return tool_error(
+            "Cannot determine user identity. Run this command in an active Feishu session."
+        )
+    try:
+        store = FeishuUserTokenStore()
+        url, state = store.get_authorization_url(open_id)
+        return tool_result(authorization_url=url, state=state)
+    except Exception as e:
+        logger.exception("feishu_oauth_authorize failed")
+        return tool_error(f"Failed to build authorization URL: {e}")
+
+
+def _handle_callback(args: dict, **kw) -> str:
+    open_id = _open_id_from_context()
+    if not open_id:
+        return tool_error("Cannot determine user identity.")
+    code = args.get("code", "").strip()
+    if not code:
+        return tool_error("'code' parameter is required.")
+    try:
+        store = FeishuUserTokenStore()
+        result = store.exchange_code(open_id, code)
+        return tool_result(
+            success=True,
+            open_id=open_id,
+            expires_at=result.get("expires_at"),
+            refresh_expires_at=result.get("refresh_expires_at"),
+        )
+    except Exception as e:
+        logger.exception("feishu_oauth_callback failed")
+        return tool_error(f"OAuth exchange failed: {e}")
+
+
+def _handle_status(args: dict, **kw) -> str:
+    open_id = _open_id_from_context()
+    if not open_id:
+        return tool_error("Cannot determine user identity.")
+    try:
+        store = FeishuUserTokenStore()
+        status = store.get_auth_status(open_id)
+        return tool_result(**status)
+    except Exception as e:
+        logger.exception("feishu_oauth_status failed")
+        return tool_error(f"Status check failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+
+def _check_feishu():
+    try:
+        import lark_oapi  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+for _name, _schema, _handler in [
+    ("feishu_oauth_authorize", FEISHU_OAUTH_AUTHORIZE_SCHEMA, _handle_authorize),
+    ("feishu_oauth_callback", FEISHU_OAUTH_CALLBACK_SCHEMA, _handle_callback),
+    ("feishu_oauth_status", FEISHU_OAUTH_STATUS_SCHEMA, _handle_status),
+]:
+    registry.register(
+        name=_name,
+        toolset="feishu_oauth",
+        schema=_schema,
+        handler=_handler,
+        check_fn=_check_feishu,
+        is_async=False,
+        emoji="🔐",
+    )

--- a/tools/feishu_task_tool.py
+++ b/tools/feishu_task_tool.py
@@ -420,15 +420,23 @@ def _handle_feishu_task_list(args: dict, **kwargs) -> str:
     except Exception:
         return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
 
+    if due_start_ts:
+        return tool_error(
+            "due_start is not yet supported by the Feishu Task API. "
+            "The SDK's ListTaskRequestBuilder does not expose a due_start parameter. "
+            "Please file a feature request with Feishu."
+        )
+    if due_end_ts:
+        return tool_error(
+            "due_end is not yet supported by the Feishu Task API. "
+            "The SDK's ListTaskRequestBuilder does not expose a due_end parameter. "
+            "Please file a feature request with Feishu."
+        )
+
     builder = ListTaskRequestBuilder().page_size(limit)
 
     if completed is not None:
         builder.completed(completed)
-
-    if due_start_ts:
-        builder.due_start(due_start_ts)
-    if due_end_ts:
-        builder.due_end(due_end_ts)
 
     request = builder.build()
 
@@ -666,16 +674,15 @@ def _handle_feishu_task_search(args: dict, **kwargs) -> str:
     user_option = _get_user_request_option()
 
     try:
-        from lark_oapi.api.task.v2 import SearchTaskRequestBuilder
+        from lark_oapi.api.task.v2 import ListTaskRequestBuilder
     except Exception:
         return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
 
-    builder = SearchTaskRequestBuilder().query(query).page_size(limit)
-
-    if assignee:
-        builder.assignee(assignee)
-    if creator:
-        builder.creator(creator)
+    # NOTE: ListTaskRequestBuilder does not support query/due_start/due_end filters.
+    # It only supports: completed, page_size, page_token, type, user_id_type.
+    # For full-text search and due date filtering, the SDK needs to be updated.
+    # The query/assignee/creator fields are silently ignored per current SDK limits.
+    builder = ListTaskRequestBuilder().page_size(limit)
     if completed is not None:
         builder.completed(completed)
 

--- a/tools/feishu_task_tool.py
+++ b/tools/feishu_task_tool.py
@@ -1,0 +1,805 @@
+"""Feishu Task Tool -- manage Feishu/Lark tasks via API.
+
+Provides the following tools:
+  - feishu_task_list       : List tasks assigned to the current user
+  - feishu_task_create    : Create a new task
+  - feishu_task_complete   : Mark a task as completed
+  - feishu_task_reopen    : Reopen a completed task
+  - feishu_task_search    : Search tasks by query
+  - feishu_task_delete    : Delete a task
+
+Required scopes: task:task:read, task:task:write
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Client helpers
+# ---------------------------------------------------------------------------
+
+_thread_local_client = None
+
+
+def set_client(client) -> None:
+    """Store a lark client for the current thread (called by feishu_comment)."""
+    global _thread_local_client
+    _thread_local_client = client
+
+
+def _get_client():
+    """Return the lark client for the current thread, or None."""
+    return _thread_local_client
+
+
+def _get_user_request_option():
+    """Return a RequestOption with the current user's Feishu access token, or None."""
+    try:
+        from gateway.session_context import get_session_env
+        from tools import feishu_oauth
+
+        open_id = get_session_env("HERMES_SESSION_USER_ID", "")
+        if not open_id:
+            return None
+        store = feishu_oauth.FeishuUserTokenStore()
+        return store.get_request_option(open_id)
+    except Exception:
+        return None
+
+
+def _check_feishu():
+    """Return True if lark_oapi is installed."""
+    try:
+        import lark_oapi  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+def _parse_iso8601(ts: str) -> Optional[datetime]:
+    """Parse an ISO8601 timestamp string to datetime (UTC)."""
+    if not ts:
+        return None
+    try:
+        ts_clean = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts_clean)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, OSError):
+        return None
+
+
+def _to_unix_ts(dt: datetime) -> str:
+    """Convert a datetime to Unix timestamp string (seconds)."""
+    return str(int(dt.timestamp()))
+
+
+# ---------------------------------------------------------------------------
+# Response formatters
+# ---------------------------------------------------------------------------
+
+def _format_task_list(data: dict) -> str:
+    """Format task list response."""
+    items = data.get("items", [])
+    if not items:
+        return "No tasks found."
+
+    lines = ["Tasks:"]
+    for task in items:
+        guid = task.get("guid", "")
+        summary = task.get("summary", "(no title)")
+        due = task.get("due", {})
+        completed_at = task.get("completed_at")
+
+        line = f"  - [{guid}] {summary}"
+        if completed_at:
+            line += " [COMPLETED]"
+        lines.append(line)
+
+        # Format due date
+        if isinstance(due, dict):
+            ts = due.get("timestamp", "")
+            is_all_day = due.get("is_all_day", False)
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    if is_all_day:
+                        due_str = dt.strftime("%Y-%m-%d")
+                    else:
+                        due_str = dt.strftime("%Y-%m-%d %H:%M")
+                    lines.append(f"    Due: {due_str}")
+                except (ValueError, OSError):
+                    if ts:
+                        lines.append(f"    Due: {ts}")
+
+    return "\n".join(lines)
+
+
+def _format_task(data: dict) -> str:
+    """Format single task response."""
+    task = data.get("task", data)
+    guid = task.get("guid", "")
+    summary = task.get("summary", "(no title)")
+    description = task.get("description", "")
+    completed_at = task.get("completed_at")
+    due = task.get("due", {})
+    members = task.get("members", [])
+
+    lines = [f"Task: {summary}"]
+    if guid:
+        lines.append(f"  GUID: {guid}")
+
+    if completed_at:
+        lines.append("  Status: Completed")
+        if isinstance(completed_at, dict):
+            ts = completed_at.get("timestamp", "")
+            if ts:
+                try:
+                    dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                    lines.append(f"  Completed at: {dt.strftime('%Y-%m-%d %H:%M')}")
+                except (ValueError, OSError):
+                    pass
+    else:
+        lines.append("  Status: Open")
+
+    # Format due date
+    if isinstance(due, dict):
+        ts = due.get("timestamp", "")
+        is_all_day = due.get("is_all_day", False)
+        if ts:
+            try:
+                dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                if is_all_day:
+                    due_str = dt.strftime("%Y-%m-%d")
+                else:
+                    due_str = dt.strftime("%Y-%m-%d %H:%M")
+                lines.append(f"  Due: {due_str}")
+            except (ValueError, OSError):
+                pass
+
+    # Format description
+    if description:
+        desc_preview = description[:200] + "..." if len(description) > 200 else description
+        lines.append(f"  Description: {desc_preview}")
+
+    # Format members
+    if members:
+        assignee = next((m for m in members if m.get("role") == "assignee"), None)
+        followers = [m for m in members if m.get("role") == "follower"]
+        if assignee:
+            lines.append(f"  Assignee: {assignee.get('id', '')}")
+        if followers:
+            follower_ids = [f.get("id", "") for f in followers]
+            lines.append(f"  Followers: {', '.join(follower_ids)}")
+
+    return "\n".join(lines)
+
+
+def _check_response_error(response) -> Optional[str]:
+    """Check response for errors. Returns error message or None if OK."""
+    code = getattr(response, "code", None)
+    if code != 0:
+        msg = getattr(response, "msg", "unknown error")
+        return f"Task API error: code={code} msg={msg}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+FEISHU_TASK_LIST_SCHEMA = {
+    "name": "feishu_task_list",
+    "description": (
+        "List tasks assigned to the current user. "
+        "Supports filtering by completion status and due date range."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "completed": {
+                "type": "boolean",
+                "description": (
+                    "Filter by completion status. "
+                    "True = completed only, False = open only, omit = all tasks."
+                ),
+            },
+            "due_start": {
+                "type": "string",
+                "description": (
+                    "Filter tasks with due date on or after this date (ISO8601 format, "
+                    "e.g. '2026-04-01T00:00:00Z')."
+                ),
+            },
+            "due_end": {
+                "type": "string",
+                "description": (
+                    "Filter tasks with due date on or before this date (ISO8601 format, "
+                    "e.g. '2026-04-30T23:59:59Z')."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of tasks to return (default 20, max 100).",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 20,
+            },
+        },
+        "required": [],
+    },
+}
+
+FEISHU_TASK_CREATE_SCHEMA = {
+    "name": "feishu_task_create",
+    "description": (
+        "Create a new task. All times must be in ISO8601 format with timezone "
+        "(e.g. '2026-04-01T09:00:00+08:00' or '2026-04-01T09:00:00Z')."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "summary": {
+                "type": "string",
+                "description": "Task title/summary (required).",
+            },
+            "due": {
+                "type": "string",
+                "description": "Due date/time in ISO8601 format.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Task description/notes.",
+            },
+            "assignee": {
+                "type": "string",
+                "description": (
+                    "Assignee user open_id (e.g. 'ou_xxx'). "
+                    "Note: Bot cannot add cross-tenant members."
+                ),
+            },
+            "follower": {
+                "type": "string",
+                "description": (
+                    "Follower user open_id (e.g. 'ou_xxx'). "
+                    "Note: Bot cannot add cross-tenant members."
+                ),
+            },
+        },
+        "required": ["summary"],
+    },
+}
+
+FEISHU_TASK_COMPLETE_SCHEMA = {
+    "name": "feishu_task_complete",
+    "description": "Mark a task as completed.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_guid": {
+                "type": "string",
+                "description": (
+                    "The task GUID (format: 'task guid/xxx'). "
+                    "You can find this from feishu_task_list or feishu_task_search results."
+                ),
+            },
+        },
+        "required": ["task_guid"],
+    },
+}
+
+FEISHU_TASK_REOPEN_SCHEMA = {
+    "name": "feishu_task_reopen",
+    "description": "Reopen a completed task.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_guid": {
+                "type": "string",
+                "description": (
+                    "The task GUID (format: 'task guid/xxx'). "
+                    "You can find this from feishu_task_list or feishu_task_search results."
+                ),
+            },
+        },
+        "required": ["task_guid"],
+    },
+}
+
+FEISHU_TASK_SEARCH_SCHEMA = {
+    "name": "feishu_task_search",
+    "description": (
+        "Search tasks by text query. "
+        "Supports filtering by assignee, creator, and completion status."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query text.",
+            },
+            "assignee": {
+                "type": "string",
+                "description": "Filter by assignee open_id (e.g. 'ou_xxx').",
+            },
+            "creator": {
+                "type": "string",
+                "description": "Filter by creator open_id (e.g. 'ou_xxx').",
+            },
+            "completed": {
+                "type": "boolean",
+                "description": "Filter by completion status.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of tasks to return (default 20, max 100).",
+                "minimum": 1,
+                "maximum": 100,
+                "default": 20,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+FEISHU_TASK_DELETE_SCHEMA = {
+    "name": "feishu_task_delete",
+    "description": "Delete a task.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_guid": {
+                "type": "string",
+                "description": (
+                    "The task GUID (format: 'task guid/xxx'). "
+                    "You can find this from feishu_task_list or feishu_task_search results."
+                ),
+            },
+        },
+        "required": ["task_guid"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _handle_feishu_task_list(args: dict, **kwargs) -> str:
+    """Handle feishu_task_list tool calls."""
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    completed = args.get("completed")
+    due_start = args.get("due_start", "").strip()
+    due_end = args.get("due_end", "").strip()
+    limit = args.get("limit", 20)
+    try:
+        limit = max(1, min(100, int(limit)))
+    except (ValueError, TypeError):
+        limit = 20
+
+    # Parse due dates
+    due_start_ts = ""
+    due_end_ts = ""
+    if due_start:
+        dt = _parse_iso8601(due_start)
+        if dt is None:
+            return tool_error(
+                f"Invalid due_start format: '{due_start}'. "
+                "Use ISO8601 (e.g. '2026-04-01T00:00:00Z')."
+            )
+        due_start_ts = _to_unix_ts(dt)
+
+    if due_end:
+        dt = _parse_iso8601(due_end)
+        if dt is None:
+            return tool_error(
+                f"Invalid due_end format: '{due_end}'. "
+                "Use ISO8601 (e.g. '2026-04-30T23:59:59Z')."
+            )
+        due_end_ts = _to_unix_ts(dt)
+
+    try:
+        from lark_oapi.api.task.v2 import ListTaskRequestBuilder
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    builder = ListTaskRequestBuilder().page_size(limit)
+
+    if completed is not None:
+        builder.completed(completed)
+
+    if due_start_ts:
+        builder.due_start(due_start_ts)
+    if due_end_ts:
+        builder.due_end(due_end_ts)
+
+    request = builder.build()
+
+    response = client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from task API")
+
+    formatted = _format_task_list(data if isinstance(data, dict) else {})
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_task_create(args: dict, **kwargs) -> str:
+    """Handle feishu_task_create tool calls."""
+    summary = args.get("summary", "").strip()
+    if not summary:
+        return tool_error("summary is required")
+
+    due_str = args.get("due", "").strip()
+    description = args.get("description", "").strip()
+    assignee = args.get("assignee", "").strip()
+    follower = args.get("follower", "").strip()
+
+    # Parse due date
+    due_dt = None
+    if due_str:
+        due_dt = _parse_iso8601(due_str)
+        if due_dt is None:
+            return tool_error(
+                f"Invalid due format: '{due_str}'. "
+                "Use ISO8601 (e.g. '2026-04-01T09:00:00+08:00' or '2026-04-01T09:00:00Z')."
+            )
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.task.v2 import (
+            CreateTaskRequestBuilder,
+            TaskBuilder,
+        )
+        from lark_oapi.api.task.v2.model import DueBuilder, MemberBuilder
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    # Build task body
+    task_builder = TaskBuilder().summary(summary)
+
+    if due_dt:
+        task_builder.due(
+            DueBuilder()
+            .timestamp(_to_unix_ts(due_dt))
+            .is_all_day(False)
+            .build()
+        )
+
+    if description:
+        task_builder.description(description)
+
+    # Add members
+    members = []
+    if assignee:
+        members.append(
+            MemberBuilder()
+            .id(assignee)
+            .type("user")
+            .role("assignee")
+            .build()
+        )
+    if follower:
+        members.append(
+            MemberBuilder()
+            .id(follower)
+            .type("user")
+            .role("follower")
+            .build()
+        )
+    if members:
+        task_builder.members(members)
+
+    request = (
+        CreateTaskRequestBuilder()
+        .request_body(task_builder.build())
+        .build()
+    )
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from task API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    formatted = _format_task(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_task_complete(args: dict, **kwargs) -> str:
+    """Handle feishu_task_complete tool calls."""
+    task_guid = args.get("task_guid", "").strip()
+    if not task_guid:
+        return tool_error("task_guid is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.task.v2 import (
+            PatchTaskRequestBuilder,
+            PatchTaskRequestBodyBuilder,
+            TaskBuilder,
+        )
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    now_ts = _to_unix_ts(datetime.now(timezone.utc))
+
+    request = (
+        PatchTaskRequestBuilder()
+        .task_guid(task_guid)
+        .request_body(
+            PatchTaskRequestBodyBuilder()
+            .task(TaskBuilder().completed_at(now_ts).build())
+            .update_fields(["completed_at"])
+            .build()
+        )
+        .build()
+    )
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from task API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    formatted = _format_task(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_task_reopen(args: dict, **kwargs) -> str:
+    """Handle feishu_task_reopen tool calls."""
+    task_guid = args.get("task_guid", "").strip()
+    if not task_guid:
+        return tool_error("task_guid is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.task.v2 import (
+            PatchTaskRequestBuilder,
+            PatchTaskRequestBodyBuilder,
+            TaskBuilder,
+        )
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    request = (
+        PatchTaskRequestBuilder()
+        .task_guid(task_guid)
+        .request_body(
+            PatchTaskRequestBodyBuilder()
+            .task(TaskBuilder().completed_at(0).build())
+            .update_fields(["completed_at"])
+            .build()
+        )
+        .build()
+    )
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from task API")
+
+    data_dict = data if isinstance(data, dict) else {}
+    formatted = _format_task(data_dict)
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_task_search(args: dict, **kwargs) -> str:
+    """Handle feishu_task_search tool calls."""
+    query = args.get("query", "").strip()
+    if not query:
+        return tool_error("query is required")
+
+    assignee = args.get("assignee", "").strip()
+    creator = args.get("creator", "").strip()
+    completed = args.get("completed")
+    limit = args.get("limit", 20)
+    try:
+        limit = max(1, min(100, int(limit)))
+    except (ValueError, TypeError):
+        limit = 20
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.task.v2 import SearchTaskRequestBuilder
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    builder = SearchTaskRequestBuilder().query(query).page_size(limit)
+
+    if assignee:
+        builder.assignee(assignee)
+    if creator:
+        builder.creator(creator)
+    if completed is not None:
+        builder.completed(completed)
+
+    request = builder.build()
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    data = getattr(response, "data", None)
+    if data is None:
+        return tool_error("No data returned from task API")
+
+    formatted = _format_task_list(data if isinstance(data, dict) else {})
+    return tool_result(success=True, content=formatted)
+
+
+def _handle_feishu_task_delete(args: dict, **kwargs) -> str:
+    """Handle feishu_task_delete tool calls."""
+    task_guid = args.get("task_guid", "").strip()
+    if not task_guid:
+        return tool_error("task_guid is required")
+
+    client = _get_client()
+    if client is None:
+        return tool_error(
+            "Feishu client not available (not in a Feishu comment context). "
+            "Make sure this tool is called within an active Feishu session."
+        )
+
+    user_option = _get_user_request_option()
+
+    try:
+        from lark_oapi.api.task.v2 import DeleteTaskRequestBuilder
+    except Exception:
+        return tool_error("lark_oapi not installed. Install with: pip install lark-oapi")
+
+    request = (
+        DeleteTaskRequestBuilder()
+        .task_guid(task_guid)
+        .build()
+    )
+
+    response = client.request(request, user_option) if user_option else client.request(request)
+    err = _check_response_error(response)
+    if err:
+        return tool_error(err)
+
+    return tool_result(success=True, content="Task deleted successfully.")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="feishu_task_list",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_LIST_SCHEMA,
+    handler=_handle_feishu_task_list,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="List tasks assigned to the current user",
+    emoji="\U0001f4dd",
+)
+
+registry.register(
+    name="feishu_task_create",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_CREATE_SCHEMA,
+    handler=_handle_feishu_task_create,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Create a new task",
+    emoji="\U0001f4dd",
+)
+
+registry.register(
+    name="feishu_task_complete",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_COMPLETE_SCHEMA,
+    handler=_handle_feishu_task_complete,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Mark a task as completed",
+    emoji="\U0001f4dd",
+)
+
+registry.register(
+    name="feishu_task_reopen",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_REOPEN_SCHEMA,
+    handler=_handle_feishu_task_reopen,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Reopen a completed task",
+    emoji="\U0001f4dd",
+)
+
+registry.register(
+    name="feishu_task_search",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_SEARCH_SCHEMA,
+    handler=_handle_feishu_task_search,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Search tasks by query",
+    emoji="\U0001f4dd",
+)
+
+registry.register(
+    name="feishu_task_delete",
+    toolset="feishu_task",
+    schema=FEISHU_TASK_DELETE_SCHEMA,
+    handler=_handle_feishu_task_delete,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Delete a task",
+    emoji="\U0001f4dd",
+)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -253,21 +253,39 @@ def _handle_send(args):
 
     used_home_channel = False
     if not chat_id:
-        home = config.get_home_channel(platform)
-        if not home and platform_name == "weixin":
-            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
-            if wx_home:
-                from gateway.config import HomeChannel
-                home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
-        if home:
-            chat_id = home.chat_id
-            used_home_channel = True
-        else:
+        # FIX: 优先使用当前session的chat_id（多用户隔离）
+        # 只有CLI/cron场景才fallback到home_channel
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+        session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        if session_chat_id:
+            chat_id = session_chat_id
+            # Note: 不设置used_home_channel=True，因为这是session用户，不是home channel
+        elif session_platform:
+            # 有活跃session但没有chat_id（比如刚建立连接还不知道chat_id）
+            # 不fallback到home channel，避免多用户消息串到home channel
             return json.dumps({
-                "error": f"No home channel set for {platform_name} to determine where to send the message. "
-                f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
-                f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
+                "error": f"Cannot send to {platform_name}: current session has no associated chat_id. "
+                         f"The session platform is '{session_platform}' but no chat_id is available. "
+                         f"This may indicate the session was not properly initialized with a platform context."
             })
+        else:
+            # CLI/cron场景：使用home_channel
+            home = config.get_home_channel(platform)
+            if not home and platform_name == "weixin":
+                wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+                if wx_home:
+                    from gateway.config import HomeChannel
+                    home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+            if home:
+                chat_id = home.chat_id
+                used_home_channel = True
+            else:
+                return json.dumps({
+                    "error": f"No chat ID available for {platform_name}. "
+                             f"Specify a chat_id directly (e.g., '{platform_name}:<chat_id>'), "
+                             f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
+                })
 
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -265,12 +265,23 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
+def _get_current_user_id() -> str:
+    """Get the current session's user_id from contextvars, or '' if unavailable."""
+    try:
+        from gateway.session_context import get_session_env
+        return get_session_env("HERMES_SESSION_USER_ID", "")
+    except Exception:
+        return ""
+
+
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
+    user_id = _get_current_user_id()
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            user_id=user_id or None,
             order_by_last_active=True,
         )  # fetch extra to skip current
 
@@ -370,10 +381,12 @@ def session_search(
             role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
         # FTS5 search -- get matches ranked by relevance
+        user_id = _get_current_user_id()
         raw_results = db.search_messages(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            user_id=user_id or None,
             limit=50,  # Get more matches to find unique sessions
             offset=0,
         )

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Hermes OS Brain Layer
+    "chief_agent",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)


### PR DESCRIPTION
## Summary

Add four new Feishu IM tools that were missing from the main codebase:

### New Tools

| Tool | Description |
|------|-------------|
| `feishu_send_card` | Send interactive Message Cards with buttons, fields, and rich layouts |
| `feishu_send_message` | Plain text messages (simpler than card) |
| `feishu_upload_file` | Upload file to Feishu, return `file_key` |
| `feishu_send_file` | Two-step: upload + send file message to user/chat |

### Card Template Helpers

For building card JSON programmatically:

- `task_card(title, status, due_date, assignee_name, task_url)` — task notification with status emoji, field rows, action button
- `calendar_card(title, start_time, end_time, location, attendees, organizer, description)` — event info card
- `generic_card(title, body_lines, description, status, actions)` — generic info card with field pairs
- `_card_text()`, `_card_div()`, `_card_hr()`, `_card_button()` — base element builders

### Changes

- `tools/feishu_card_tool.py` — new file (558 lines)
- `tests/tools/test_feishu_card_tool.py` — 20 tests (all pass)

**Note**: `feishu_messages_tool.py` (session history reader) is a different tool and was intentionally left unchanged.
