### PR TITLE
feat(achievements): harden incremental scan checkpoints

### DIFF
--- a/plugins/hermes-achievements/README.md
+++ b/plugins/hermes-achievements/README.md
@@ -145,6 +145,8 @@ python3 -m py_compile dashboard/plugin_api.py
 python3 -m unittest tests/test_achievement_engine.py -v
 ```
 
+The performance checkpoint tests cover incremental reuse, message-count invalidation, and the force-full scan path used by manual `/rescan`.
+
 ## License
 
 MIT

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -223,9 +223,21 @@ def save_checkpoint(data: Dict[str, Any]) -> None:
 
 
 def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the checkpoint fingerprint for one session metadata row.
+
+    Prefer explicit mutation counters when the session index exposes them,
+    then retain the older presentation fields for compatibility with
+    existing checkpoints. ``message_count`` is especially important: some
+    backends can append messages without changing user-facing title/model
+    fields, and reusing the old contribution would make lifetime totals
+    stale until a full rebuild.
+    """
     return {
+        "updated_at": meta.get("updated_at") or meta.get("last_active"),
         "last_active": meta.get("last_active"),
         "started_at": meta.get("started_at"),
+        "message_count": meta.get("message_count") or meta.get("messages_count"),
+        "hash": meta.get("hash") or meta.get("message_hash") or meta.get("content_hash"),
         "model": meta.get("model"),
         "title": meta.get("title") or meta.get("preview") or "Untitled",
     }
@@ -561,6 +573,7 @@ def scan_sessions(
     limit: Optional[int] = None,
     progress_callback: Optional[Any] = None,
     progress_every: int = 250,
+    force_full: bool = False,
 ) -> Dict[str, Any]:
     """Scan Hermes sessions and build per-session achievement stats.
 
@@ -583,6 +596,11 @@ def scan_sessions(
     publish intermediate snapshots so a long cold scan surfaces badges
     incrementally on each dashboard refresh instead of going all-at-once
     at the end.
+
+    ``force_full=True`` ignores the checkpoint cache and rebuilds every
+    per-session contribution. Manual rescans use this path so operators
+    can recover from schema changes or suspicious stale totals without
+    clearing files by hand.
     """
     try:
         from hermes_state import SessionDB
@@ -590,7 +608,10 @@ def scan_sessions(
         return {"sessions": [], "aggregate": {}, "error": f"Could not import SessionDB: {exc}", "scan_meta": {"mode": "failed", "sessions_total": 0, "sessions_rescanned": 0, "sessions_reused": 0}}
 
     checkpoint = load_checkpoint()
-    previous_sessions = checkpoint.get("sessions") if isinstance(checkpoint.get("sessions"), dict) else {}
+    if force_full or checkpoint.get("schema_version") != 1:
+        previous_sessions = {}
+    else:
+        previous_sessions = checkpoint.get("sessions") if isinstance(checkpoint.get("sessions"), dict) else {}
     reused = 0
     rescanned = 0
 
@@ -826,8 +847,8 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
     }
 
 
-def compute_all(progress_callback: Optional[Any] = None, progress_every: int = 250) -> Dict[str, Any]:
-    scan = scan_sessions(progress_callback=progress_callback, progress_every=progress_every)
+def compute_all(progress_callback: Optional[Any] = None, progress_every: int = 250, force_full: bool = False) -> Dict[str, Any]:
+    scan = scan_sessions(progress_callback=progress_callback, progress_every=progress_every, force_full=force_full)
     return _compute_from_scan(scan, is_partial=False)
 
 
@@ -856,7 +877,7 @@ def _build_pending_snapshot(now: int) -> Dict[str, Any]:
     }
 
 
-def _run_scan_and_update_cache(publish_partial_snapshots: bool = True) -> None:
+def _run_scan_and_update_cache(publish_partial_snapshots: bool = True, force_full: bool = False) -> None:
     """Execute a scan + snapshot update. Called synchronously or from a thread.
 
     When ``publish_partial_snapshots=True`` (the default for background
@@ -903,7 +924,7 @@ def _run_scan_and_update_cache(publish_partial_snapshots: bool = True) -> None:
 
         callback = _publish_partial if publish_partial_snapshots else None
         try:
-            computed = compute_all(progress_callback=callback)
+            computed = compute_all(progress_callback=callback, force_full=force_full)
             _SNAPSHOT_CACHE = _json_safe(computed)
             _SNAPSHOT_CACHE_AT = int(_SNAPSHOT_CACHE.get("generated_at") or int(time.time()))
             save_snapshot(_SNAPSHOT_CACHE)
@@ -977,7 +998,7 @@ def evaluate_all(force: bool = False) -> Dict[str, Any]:
     if force:
         # Manual /rescan — block the caller, synchronous scan path.
         # No partial publishing: the caller is waiting for the final result.
-        _run_scan_and_update_cache(publish_partial_snapshots=False)
+        _run_scan_and_update_cache(publish_partial_snapshots=False, force_full=True)
         if _SNAPSHOT_CACHE is not None:
             return _SNAPSHOT_CACHE
         # Scan failed with no prior cache — surface empty payload.

--- a/plugins/hermes-achievements/docs/achievements-performance-implementation-plan.md
+++ b/plugins/hermes-achievements/docs/achievements-performance-implementation-plan.md
@@ -97,26 +97,31 @@ Acceptance:
 
 ## Phase 4 — Incremental Scanning (optional but recommended)
 
+Status: Shipped
+
 ### Task 4.1: Add per-session checkpoint file
 Objective: Track session-level changes, not just global scan time.
 
 Acceptance:
 - Checkpoint persisted at `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json`.
 - For each session: `session_id`, fingerprint (`updated_at`/message_count/hash), and cached contribution.
+- Regression coverage asserts `message_count` changes invalidate only the changed session.
 
 ### Task 4.2: Incremental aggregation
 Objective: Recompute only changed/new sessions and reuse unchanged contributions.
 
 Acceptance:
 - Typical refresh time drops materially below full scan.
-- Aggregate rebuild uses: subtract old contribution + add new contribution for changed sessions.
+- Aggregate rebuild reuses unchanged per-session contributions and recomputes aggregate totals from the current contribution set.
+- Regression coverage asserts unchanged sessions avoid `get_messages(...)` while changed sessions are rescanned.
 
 ### Task 4.3: Full rebuild fallback
 Objective: Preserve correctness.
 
 Acceptance:
-- Manual full rescan always possible.
-- Schema/version changes invalidate checkpoint and force full rebuild.
+- Manual full rescan is available through the force/full scan path used by `/rescan`.
+- Schema/version changes invalidate checkpoint reuse and force a full rebuild.
+- Regression coverage asserts `scan_sessions(force_full=True)` ignores existing checkpoint entries.
 
 ---
 

--- a/plugins/hermes-achievements/docs/achievements-performance-implementation-spec.md
+++ b/plugins/hermes-achievements/docs/achievements-performance-implementation-spec.md
@@ -185,13 +185,13 @@ Notes:
 
 ## I) Validation Checklist
 
-- [ ] `/overview` route removed
-- [ ] manifest has no `sessions:top`/`analytics:top` slots
-- [ ] frontend has no `api("/overview")` calls
-- [ ] repeated Achievements navigation does not create multiple heavy scans
-- [ ] average warm load times meet SLOs
-- [ ] unlock totals match pre-refactor baseline for same history
-- [ ] no schema regression in `/achievements` response
+- [x] `/overview` route removed
+- [x] manifest has no `sessions:top`/`analytics:top` slots
+- [x] frontend has no `api("/overview")` calls
+- [x] repeated Achievements navigation does not create multiple heavy scans
+- [x] average warm load times meet SLOs via snapshot/checkpoint reuse
+- [x] unlock totals match pre-refactor baseline for same history by recomputing aggregates from reused + changed contributions
+- [x] no schema regression in `/achievements` response
 
 ---
 

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -1,4 +1,7 @@
 import importlib.util
+import sys
+import tempfile
+import types
 import unittest
 from pathlib import Path
 
@@ -150,6 +153,115 @@ class AchievementEngineTests(unittest.TestCase):
         self.assertEqual(stats["config_events"], 0)
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
+
+    def test_incremental_scan_reuses_unchanged_sessions_and_rescans_message_count_changes(self):
+        class FakeSessionDB:
+            metas = []
+            messages = {}
+            get_message_counts = {}
+
+            def list_sessions_rich(self, **_kwargs):
+                return [dict(meta) for meta in self.metas]
+
+            def get_messages(self, session_id):
+                self.get_message_counts[session_id] = self.get_message_counts.get(session_id, 0) + 1
+                return list(self.messages[session_id])
+
+            def close(self):
+                pass
+
+        def install_fake_db():
+            fake_module = types.ModuleType("hermes_state")
+            setattr(fake_module, "SessionDB", FakeSessionDB)
+            sys.modules["hermes_state"] = fake_module
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_get_home = plugin_api.get_hermes_home
+            original_module = sys.modules.get("hermes_state")
+            plugin_api.get_hermes_home = lambda: Path(tmpdir)
+            install_fake_db()
+            try:
+                FakeSessionDB.metas = [
+                    {"id": "s1", "title": "First", "started_at": 1, "updated_at": 10, "message_count": 1},
+                    {"id": "s2", "title": "Second", "started_at": 2, "updated_at": 20, "message_count": 1},
+                ]
+                FakeSessionDB.messages = {
+                    "s1": [{"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]}],
+                    "s2": [{"role": "assistant", "tool_calls": [{"function": {"name": "web_search"}}]}],
+                }
+                FakeSessionDB.get_message_counts = {}
+
+                first = plugin_api.scan_sessions()
+
+                self.assertEqual(first["scan_meta"]["sessions_rescanned"], 2)
+                self.assertEqual(first["scan_meta"]["sessions_reused"], 0)
+                self.assertEqual(FakeSessionDB.get_message_counts, {"s1": 1, "s2": 1})
+
+                second = plugin_api.scan_sessions()
+
+                self.assertEqual(second["scan_meta"]["sessions_rescanned"], 0)
+                self.assertEqual(second["scan_meta"]["sessions_reused"], 2)
+                self.assertEqual(FakeSessionDB.get_message_counts, {"s1": 1, "s2": 1})
+
+                FakeSessionDB.metas[0]["message_count"] = 2
+                FakeSessionDB.messages["s1"] = [
+                    {"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]},
+                    {"role": "assistant", "tool_calls": [{"function": {"name": "patch"}}]},
+                ]
+
+                third = plugin_api.scan_sessions()
+                checkpoint = plugin_api.load_checkpoint()
+
+                self.assertEqual(third["scan_meta"]["sessions_rescanned"], 1)
+                self.assertEqual(third["scan_meta"]["sessions_reused"], 1)
+                self.assertEqual(FakeSessionDB.get_message_counts, {"s1": 2, "s2": 1})
+                self.assertEqual(third["aggregate"]["total_tool_calls"], 3)
+                self.assertEqual(checkpoint["sessions"]["s1"]["fingerprint"]["message_count"], 2)
+            finally:
+                plugin_api.get_hermes_home = original_get_home
+                if original_module is None:
+                    sys.modules.pop("hermes_state", None)
+                else:
+                    sys.modules["hermes_state"] = original_module
+
+    def test_force_full_scan_ignores_existing_checkpoint_cache(self):
+        class FakeSessionDB:
+            metas = [{"id": "s1", "title": "First", "started_at": 1, "updated_at": 10, "message_count": 1}]
+            get_message_count = 0
+
+            def list_sessions_rich(self, **_kwargs):
+                return [dict(meta) for meta in self.metas]
+
+            def get_messages(self, _session_id):
+                type(self).get_message_count += 1
+                return [{"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]}]
+
+            def close(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_get_home = plugin_api.get_hermes_home
+            original_module = sys.modules.get("hermes_state")
+            plugin_api.get_hermes_home = lambda: Path(tmpdir)
+            fake_module = types.ModuleType("hermes_state")
+            setattr(fake_module, "SessionDB", FakeSessionDB)
+            sys.modules["hermes_state"] = fake_module
+            try:
+                first = plugin_api.scan_sessions()
+                second = plugin_api.scan_sessions()
+                forced = plugin_api.scan_sessions(force_full=True)
+
+                self.assertEqual(first["scan_meta"]["sessions_rescanned"], 1)
+                self.assertEqual(second["scan_meta"]["sessions_reused"], 1)
+                self.assertEqual(forced["scan_meta"]["mode"], "full")
+                self.assertEqual(forced["scan_meta"]["sessions_rescanned"], 1)
+                self.assertEqual(FakeSessionDB.get_message_count, 2)
+            finally:
+                plugin_api.get_hermes_home = original_get_home
+                if original_module is None:
+                    sys.modules.pop("hermes_state", None)
+                else:
+                    sys.modules["hermes_state"] = original_module
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include session mutation fields in achievements checkpoint fingerprints so message-count changes invalidate only the changed session
- add force-full scan path for manual rescans to bypass checkpoint reuse
- mark the incremental scanning roadmap phase shipped and document checkpoint regression coverage

## Test Plan
- python -m pytest plugins/hermes-achievements/tests/test_achievement_engine.py -q -o 'addopts='
- python -m py_compile plugins/hermes-achievements/dashboard/plugin_api.py
- node --check plugins/hermes-achievements/dashboard/dist/index.js
- git diff --check