### PR TITLE
fix(teams): fall back to default port on invalid port config

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -116,6 +116,13 @@ def _parse_bool(value: Any, *, default: bool = False) -> bool:
     return default
 
 
+def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class _StaticAccessTokenProvider:
     """Minimal token-provider shim so outbound Graph delivery can reuse the shared client."""
 
@@ -623,7 +630,9 @@ class TeamsAdapter(BasePlatformAdapter):
         self._client_id = extra.get("client_id") or os.getenv("TEAMS_CLIENT_ID", "")
         self._client_secret = extra.get("client_secret") or os.getenv("TEAMS_CLIENT_SECRET", "")
         self._tenant_id = extra.get("tenant_id") or os.getenv("TEAMS_TENANT_ID", "")
-        self._port = int(extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT)))
+        self._port = _coerce_port(
+            extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
+        )
         self._app: Optional["App"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._dedup = MessageDeduplicator(max_size=1000)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -283,6 +283,17 @@ class TestTeamsAdapterInit:
         adapter = TeamsAdapter(_make_config(client_id="id", client_secret="secret", tenant_id="tenant"))
         assert adapter._port == 5000
 
+    def test_invalid_port_from_extra_falls_back_to_default(self):
+        adapter = TeamsAdapter(
+            _make_config(client_id="id", client_secret="secret", tenant_id="tenant", port="abc")
+        )
+        assert adapter._port == 3978
+
+    def test_invalid_port_from_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_PORT", "abc")
+        adapter = TeamsAdapter(_make_config(client_id="id", client_secret="secret", tenant_id="tenant"))
+        assert adapter._port == 3978
+
     def test_platform_value(self):
         adapter = TeamsAdapter(_make_config(client_id="id", client_secret="secret", tenant_id="tenant"))
         assert adapter.platform.value == "teams"


### PR DESCRIPTION
## What does this PR do?

Fixes a startup robustness bug in the Teams gateway adapter when the configured port is invalid.

Today `TeamsAdapter.__init__()` parses the port with a direct `int(...)` call. If `TEAMS_PORT` or `platforms.teams.extra.port` contains a malformed value like `"abc"`, adapter initialization raises `ValueError` and can break gateway startup.

This change introduces a narrow `_coerce_port()` helper in the Teams adapter and falls back to the existing default port (`3978`) when the configured value is invalid. This matches the adapter’s existing env-seeding behavior, which already ignores invalid `TEAMS_PORT` values instead of crashing.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_coerce_port()` to [plugins/platforms/teams/adapter.py](plugins/platforms/teams/adapter.py) to safely parse the Teams listen port.
- Updated `TeamsAdapter.__init__()` to fall back to `_DEFAULT_PORT` instead of raising on invalid port values.
- Added regression tests in [tests/gateway/test_teams.py](tests/gateway/test_teams.py) for:
  - invalid `extra.port`
  - invalid `TEAMS_PORT` environment variable

## How to Test

1. Reproduce the pre-fix failure by setting an invalid Teams port:
   - `TEAMS_PORT=abc`, or
   - `platforms.teams.extra.port: "abc"`
2. Initialize the Teams adapter or start the gateway with Teams enabled.
3. Verify the adapter now falls back to port `3978` instead of raising `ValueError`.

Test command run:
- `pytest tests/gateway/test_teams.py -q`

Observed result:
- `46 passed in 4.39s`

Note:
- On Windows, pytest may emit a trailing temporary-directory cleanup `PermissionError (WinError 5)` at process exit. This did not affect test execution or results.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
..............................................    [100%]
46 passed in 4.39s