### PR TITLE
fix(model-switch): route Copilot through live discovery in Section 1

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1243,7 +1243,19 @@ def list_authenticated_providers(
         # For preferred providers, merge models.dev entries into the curated
         # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
         # show up in the picker without requiring a Hermes release.
-        model_ids = curated.get(hermes_id, [])
+        if hermes_id == "copilot":
+            # Use live OAuth-backed discovery so the picker matches what the
+            # user's authenticated Copilot backend actually serves (mirrors
+            # the section-2 branch at ~line 1349). Without this, Section 1
+            # emits Copilot first with the stale ``_PROVIDER_MODELS["copilot"]``
+            # snapshot, adds the slug to ``seen_slugs``, and Section 2's
+            # live-discovery branch is skipped — so new GitHub-Copilot models
+            # never appear in /model. ``provider_model_ids()`` falls back to
+            # the curated list when the live endpoint is unreachable, so this
+            # is safe for offline and unauthenticated callers too.
+            model_ids = provider_model_ids(hermes_id)
+        else:
+            model_ids = curated.get(hermes_id, [])
         if hermes_id in _MODELS_DEV_PREFERRED:
             model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)

--- a/tests/hermes_cli/test_copilot_live_discovery_section1.py
+++ b/tests/hermes_cli/test_copilot_live_discovery_section1.py
@@ -1,0 +1,106 @@
+"""Regression tests for GitHub Copilot live-catalog discovery in /model.
+
+These complement ``test_copilot_in_model_list.py``. Those tests mock
+``fetch_models_dev`` to ``{}``, which makes ``list_authenticated_providers``
+skip Section 1 (``PROVIDER_TO_MODELS_DEV`` loop) for ``copilot`` because no
+``pdata`` is found, and Section 2 (``HERMES_OVERLAYS`` loop) emits the row
+via its existing live-discovery branch.
+
+In production, however, ``fetch_models_dev`` returns the real models.dev
+manifest, which **does** include ``github-copilot``. Section 1 then emits
+the Copilot row *first*, adds the slug to ``seen_slugs``, and Section 2's
+live-discovery branch is skipped — so without the fix the picker shows the
+stale ``_PROVIDER_MODELS["copilot"]`` snapshot and new GitHub-Copilot models
+never appear.
+
+These tests pin that real-data path: ``fetch_models_dev`` returns a manifest
+that includes ``github-copilot``, and the picker is expected to reflect live
+discovery instead of the curated stub.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# Minimal models.dev payload containing a github-copilot entry. The real
+# manifest has many more providers, but only this entry is load-bearing for
+# the Section 1 dispatch — anything else just gets skipped for lack of creds.
+_MDEV_WITH_COPILOT = {
+    "github-copilot": {
+        "id": "github-copilot",
+        "name": "GitHub Copilot",
+        "env": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],
+        "models": {},
+    },
+}
+
+
+@patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)
+def test_copilot_picker_uses_live_catalog_when_models_dev_includes_copilot():
+    """Section 1 must route Copilot through live discovery.
+
+    Reproducer for the bug where ``list_authenticated_providers`` emitted
+    Copilot from Section 1 with the stale curated catalog whenever models.dev
+    knew about ``github-copilot`` — which is the production path.
+    """
+    live_models = [
+        "gpt-5.4",
+        "claude-sonnet-4.6",
+        "gemini-3.1-pro-preview",
+        "brand-new-live-only-model",
+    ]
+
+    with patch(
+        "agent.models_dev.fetch_models_dev",
+        return_value=_MDEV_WITH_COPILOT,
+    ), patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key",
+        return_value="gh-token",
+    ), patch(
+        "hermes_cli.models._fetch_github_models",
+        return_value=live_models,
+    ):
+        providers = list_authenticated_providers(
+            current_provider="openrouter", max_models=50
+        )
+
+    copilot = next((p for p in providers if p["slug"] == "copilot"), None)
+    assert copilot is not None, "copilot row missing from picker"
+    # The live-only entry must appear — proves live discovery ran instead of
+    # the static ``_PROVIDER_MODELS["copilot"]`` snapshot.
+    assert "brand-new-live-only-model" in copilot["models"]
+    assert copilot["models"] == live_models
+    assert copilot["total_models"] == len(live_models)
+
+
+@patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)
+def test_copilot_picker_falls_back_to_curated_when_live_unreachable():
+    """``provider_model_ids`` returns ``None`` on offline / auth failures.
+
+    When the live catalog can't be reached, the picker must still emit a
+    Copilot row populated from the curated ``_PROVIDER_MODELS["copilot"]``
+    snapshot — otherwise offline users would see an empty model list.
+    """
+    with patch(
+        "agent.models_dev.fetch_models_dev",
+        return_value=_MDEV_WITH_COPILOT,
+    ), patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key",
+        return_value="gh-token",
+    ), patch(
+        "hermes_cli.models._fetch_github_models",
+        return_value=None,
+    ):
+        providers = list_authenticated_providers(
+            current_provider="openrouter", max_models=50
+        )
+
+    copilot = next((p for p in providers if p["slug"] == "copilot"), None)
+    assert copilot is not None, "copilot row missing from picker"
+    # Curated stub must still be present for offline users.
+    assert "gpt-5.4" in copilot["models"]
+    assert "claude-sonnet-4.6" in copilot["models"]
+    # And it must not be empty.
+    assert copilot["total_models"] > 0


### PR DESCRIPTION
## Summary

`list_authenticated_providers()` walks three sections to emit `/model` picker rows. Section 1 iterates `PROVIDER_TO_MODELS_DEV` (which contains `copilot` → `github-copilot`) and was using the stale `_PROVIDER_MODELS["copilot"]` snapshot. The slug then landed in `seen_slugs`, so Section 2's existing live-discovery branch (~line 1349) never ran for Copilot in production — only when `fetch_models_dev` returned empty (offline or mocked).

The picker therefore lagged the actual `/v1/models` catalog: new GitHub Copilot models (Sonnet 4.6, Haiku 4.5, Gemini 3.1, etc.) didn't show up in `/model` until a Hermes release bumped the static list.

## Fix

Route Copilot through `provider_model_ids()` in Section 1 to match Section 2's behavior. `provider_model_ids()` falls back to the curated snapshot when the live endpoint is unreachable, so offline and unauthenticated callers still get a populated row.

## Tests

Added `tests/hermes_cli/test_copilot_live_discovery_section1.py` covering the production path where `fetch_models_dev` returns a manifest that includes `github-copilot`. Two cases: live discovery used when available, curated fallback used when `_fetch_github_models` returns `None`.

The existing `test_copilot_in_model_list.py` mocks `fetch_models_dev` to `{}`, which exercises Section 2 instead — that's why it didn't catch this. Verified the new tests fail on stock `main` and pass with the fix applied.

## Repro on `main`

```python
import os
from unittest.mock import patch
os.environ["GH_TOKEN"] = "test-key"
with patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
     patch("hermes_cli.models._fetch_github_models", return_value=["live-only-model"]):
    from hermes_cli.model_switch import list_authenticated_providers
    rows = list_authenticated_providers(current_provider="openrouter", max_models=50)
    cp = next(r for r in rows if r["slug"] == "copilot")
    assert "live-only-model" in cp["models"]  # fails on main, passes with fix
```
