### PR TITLE
Add Future Video Render optional skill

### DIFF
--- a/optional-skills/creative/future-video-render/SKILL.md
+++ b/optional-skills/creative/future-video-render/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: future-video-render
+description: Create cinematic AI videos with Future Video Studio through hosted MCP. Use for multi-shot scene renders, product teasers, music videos, reference-guided custom productions, account API-key renders, Link pay-as-you-go quotes, render status polling, cancellation, and final video retrieval.
+version: 1.0.0
+author: Future Video Studio
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [creative, video, ai-video, mcp, rendering, future-video-studio]
+    category: creative
+    related_skills: [kanban-video-orchestrator, hyperframes, blender-mcp, concept-diagrams, songwriting-and-ai-music, youtube-content, mcporter, native-mcp]
+    homepage: https://future.video
+    mcp_server: https://mcp.future.video/mcp
+---
+
+# Future Video Render
+
+Use this skill to create Future Video Studio renders through the hosted FVS MCP server.
+
+FVS turns creative briefs, scripts, shot lists, and public reference assets into finished cinematic videos. The MCP supports two billing paths:
+
+- account mode: the user configures `FVS_AGENT_API_KEY`, approves wallet-credit spending, and Hermes calls `fvs_submit_render`
+- pay-as-you-go mode: Hermes creates a Link payment quote with `fvs_create_paid_render_quote`, the user pays the returned URL, and Hermes polls with the claim token
+
+The hosted MCP endpoint is:
+
+```text
+https://mcp.future.video/mcp
+```
+
+For Hermes MCP setup details, load `references/hermes-mcp-config.md`.
+For request fields and response shapes, load `references/api.md`.
+
+## When to Use
+
+Use this skill when the user asks to:
+
+- generate a polished AI video from a written prompt, screenplay, or shot list
+- create a multi-shot video with continuity across shots
+- make a product launch teaser, brand video, narrative short, or music video
+- use public HTTPS image, audio, PDF, or style-guide URLs as references
+- get a pay-as-you-go quote before rendering
+- submit an account-wallet render with an FVS Agent API key
+- poll, cancel, or retrieve a Future Video Studio render
+
+Do not use this skill for local-only HTML or code-rendered videos that should be built directly in the workspace. Use `hyperframes`, `blender-mcp`, `concept-diagrams`, or direct FFmpeg workflows when those are a better fit.
+
+## Setup Check
+
+Before submitting or quoting a render, check whether the FVS MCP server is configured in Hermes.
+
+Recommended Hermes config:
+
+```yaml
+mcp_servers:
+  future_video_studio:
+    url: "https://mcp.future.video/mcp"
+```
+
+For account mode, add the API-key header:
+
+```yaml
+mcp_servers:
+  future_video_studio:
+    url: "https://mcp.future.video/mcp"
+    headers:
+      X-FVS-Agent-Key: "${FVS_AGENT_API_KEY}"
+```
+
+If the MCP tools are not available, tell the user to add the config above to `~/.hermes/config.yaml` and restart Hermes. Do not ask the user to paste API keys into chat.
+
+## Tool Names in Hermes
+
+Hermes prefixes MCP tools with the configured server name. If the server is named `future_video_studio`, the important tools are typically:
+
+- `mcp_future_video_studio_fvs_submit_render`
+- `mcp_future_video_studio_fvs_create_paid_render_quote`
+- `mcp_future_video_studio_fvs_get_render_status`
+- `mcp_future_video_studio_fvs_get_paid_render_status`
+- `mcp_future_video_studio_fvs_cancel_render`
+- `mcp_future_video_studio_fvs_download_final_video`
+- `mcp_future_video_studio_fvs_example_render_request`
+
+If the server uses another name, adjust the prefix accordingly. In normal reasoning, prefer the tool descriptions over hardcoding a prefixed name.
+
+## Core Workflow
+
+1. Convert the user's brief into an FVS render request.
+2. Ask for clarification only when missing details affect cost, legality, or feasibility.
+3. Choose the billing path:
+   - account mode if `FVS_AGENT_API_KEY` is configured and the user approves spending wallet credits
+   - pay-as-you-go mode if no key is configured or the user wants a visible price first
+4. For account mode, show a concise render summary and get explicit approval before calling `fvs_submit_render`.
+5. For pay-as-you-go mode, call `fvs_create_paid_render_quote`, return the `payment_url`, and explain that payment happens through Link.
+6. Poll with the matching status tool until the job completes, fails, halts for review, or the user asks to stop.
+7. Return the final signed `final_video_url` exactly as returned by FVS.
+
+## Request Shape
+
+Use `project_mode`:
+
+- `scene` for screenplay or shot-list videos without an uploaded soundtrack
+- `music` for soundtrack-led music videos
+- `custom` for brand, product, or reference-heavy productions
+
+Useful fields:
+
+- `name`
+- `project_mode`
+- `screenplay`
+- `instructions`
+- `additional_lore`
+- `visual_style_preset`
+- `visual_style_custom_instructions`
+- `scene_target_duration_seconds`
+- `shot_count`
+- `ingredients_mode_enabled`
+- `image_model`, `image_resolution`
+- `video_model`, `video_resolution`
+- `music_model`
+
+Hosted MCP clients must use public HTTPS `upload_urls` for assets. Local file paths are not visible to the hosted MCP. For trusted local-file account workflows only, use the bundled helper script in `scripts/future_video_render.py`.
+
+## Pay-As-You-Go Flow
+
+Use pay-as-you-go when the user does not have an FVS API key or wants to approve a one-off payment.
+
+1. Call `fvs_create_paid_render_quote` with the render request and any public HTTPS `upload_urls`.
+2. Return the quote amount and `payment_url`.
+3. Tell the user to pay through Link or the approved payment surface.
+4. After payment, poll with `fvs_get_paid_render_status` using either the returned `status_url` or `quote_id` plus `claim_token`.
+5. Return `final_video_url` when the render completes.
+
+Never ask for raw card details.
+
+## Account/API-Key Flow
+
+Use account mode only when `FVS_AGENT_API_KEY` is configured.
+
+Before submitting:
+
+- summarize the video request
+- include duration, shot count, resolution, and selected models when known
+- state that the render will spend FVS wallet credits
+- ask for explicit approval
+
+Then call `fvs_submit_render`. Poll with `fvs_get_render_status`.
+
+## Safety And Cost Rules
+
+- Never submit an account render without explicit user approval.
+- Never create a second paid render after a failed or halted render unless the user approves the extra spend.
+- Never invent or rewrite final video URLs.
+- Report exact FVS error messages if a render fails or halts.
+- Use status polling instead of long blocking waits.
+- Keep `scene_target_duration_seconds` between 4 and 600.
+- Keep `shot_count` between 1 and 64.
+
+## Local Helper Fallback
+
+The bundled Python helper is for account-mode direct Agent API calls when a trusted local-file workflow needs multipart uploads:
+
+```bash
+python ${HERMES_SKILL_DIR}/scripts/future_video_render.py submit --request-file request.json --file reference.png --poll
+```
+
+It uses only the Python standard library and reads `FVS_AGENT_API_KEY` from the environment. Prefer the hosted MCP tools whenever they are available.

--- a/optional-skills/creative/future-video-render/SKILL.md
+++ b/optional-skills/creative/future-video-render/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: future-video-render
-description: Create cinematic AI videos with Future Video Studio through hosted MCP. Use for multi-shot scene renders, product teasers, music videos, reference-guided custom productions, account API-key renders, Link pay-as-you-go quotes, render status polling, cancellation, and final video retrieval.
+description: Create hosted Future Video Studio renders.
 version: 1.0.0
 author: Future Video Studio
 license: MIT
@@ -16,21 +16,22 @@ metadata:
 
 # Future Video Render
 
-Use this skill to create Future Video Studio renders through the hosted FVS MCP server.
+Create Future Video Studio renders through the hosted FVS MCP server.
 
-FVS turns creative briefs, scripts, shot lists, and public reference assets into finished cinematic videos. The MCP supports two billing paths:
+Use this skill for multi-shot scenes, music videos, product teasers, reference-guided custom productions, account-wallet renders, Link pay-as-you-go quotes, status polling, cancellation, and final signed video URLs.
 
-- account mode: the user configures `FVS_AGENT_API_KEY`, approves wallet-credit spending, and Hermes calls `fvs_submit_render`
-- pay-as-you-go mode: Hermes creates a Link payment quote with `fvs_create_paid_render_quote`, the user pays the returned URL, and Hermes polls with the claim token
-
-The hosted MCP endpoint is:
-
-```text
-https://mcp.future.video/mcp
-```
+The MCP endpoint is `https://mcp.future.video/mcp`.
 
 For Hermes MCP setup details, load `references/hermes-mcp-config.md`.
 For request fields and response shapes, load `references/api.md`.
+
+## Prerequisites
+
+- Prefer the hosted MCP server at `https://mcp.future.video/mcp`.
+- Account mode uses `FVS_AGENT_API_KEY` or the MCP secret header `X-FVS-Agent-Key`.
+- Treat account keys as wallet-backed credentials. Show a concise render summary and get explicit approval before spending wallet credits.
+- Pay-as-you-go mode omits the API key and uses `fvs_create_paid_render_quote`.
+- Never ask for raw card details. Link payment happens through the returned `payment_url`.
 
 ## When to Use
 
@@ -46,7 +47,7 @@ Use this skill when the user asks to:
 
 Do not use this skill for local-only HTML or code-rendered videos that should be built directly in the workspace. Use `hyperframes`, `blender-mcp`, `concept-diagrams`, or direct FFmpeg workflows when those are a better fit.
 
-## Setup Check
+## Hermes Setup
 
 Before submitting or quoting a render, check whether the FVS MCP server is configured in Hermes.
 
@@ -68,7 +69,7 @@ mcp_servers:
       X-FVS-Agent-Key: "${FVS_AGENT_API_KEY}"
 ```
 
-If the MCP tools are not available, tell the user to add the config above to `~/.hermes/config.yaml` and restart Hermes. Do not ask the user to paste API keys into chat.
+If the MCP tools are unavailable, tell the user to add the config above to `~/.hermes/config.yaml` and restart Hermes. Do not ask the user to paste API keys into chat.
 
 ## Tool Names in Hermes
 
@@ -84,7 +85,7 @@ Hermes prefixes MCP tools with the configured server name. If the server is name
 
 If the server uses another name, adjust the prefix accordingly. In normal reasoning, prefer the tool descriptions over hardcoding a prefixed name.
 
-## Core Workflow
+## How to Run
 
 1. Convert the user's brief into an FVS render request.
 2. Ask for clarification only when missing details affect cost, legality, or feasibility.
@@ -121,6 +122,23 @@ Useful fields:
 - `music_model`
 
 Hosted MCP clients must use public HTTPS `upload_urls` for assets. Local file paths are not visible to the hosted MCP. For trusted local-file account workflows only, use the bundled helper script in `scripts/future_video_render.py`.
+
+## Verification
+
+Poll with the matching status tool until the render completes, fails, halts for review, or the user asks to stop.
+
+Inspect:
+
+- `status`
+- `current_stage`
+- `is_running`
+- `final_video_url`
+- `last_error`
+- `payment_url`, `quote_id`, and `claim_token` for paid quotes
+
+Treat the job as terminal when `status` is `completed` or `failed`, `current_stage` is `halted_for_review`, or the job is not running and has no active queued or running state.
+
+Return `final_video_url` promptly when present. If the signed URL expires, poll status again for a fresh result URL.
 
 ## Pay-As-You-Go Flow
 
@@ -165,4 +183,4 @@ The bundled Python helper is for account-mode direct Agent API calls when a trus
 python ${HERMES_SKILL_DIR}/scripts/future_video_render.py submit --request-file request.json --file reference.png --poll
 ```
 
-It uses only the Python standard library and reads `FVS_AGENT_API_KEY` from the environment. Prefer the hosted MCP tools whenever they are available.
+It uses only the Python standard library and reads `FVS_AGENT_API_KEY` from the environment. It does not accept API keys on the command line. Prefer the hosted MCP tools whenever they are available.

--- a/optional-skills/creative/future-video-render/assets/future-video-render-large.svg
+++ b/optional-skills/creative/future-video-render/assets/future-video-render-large.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Future Video Render logo</title>
+  <desc id="desc">Wide cinematic logo for the Future Video Render OpenClaw skill.</desc>
+  <defs>
+    <linearGradient id="backdrop" x1="120" y1="60" x2="860" y2="500" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#0F8BFF"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="240" y1="130" x2="460" y2="320" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E0F2FE"/>
+      <stop offset="1" stop-color="#38BDF8"/>
+    </linearGradient>
+    <linearGradient id="play" x1="286" y1="170" x2="390" y2="296" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FAFC"/>
+      <stop offset="1" stop-color="#7DD3FC"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" rx="36" fill="url(#backdrop)"/>
+  <g opacity="0.18">
+    <circle cx="792" cy="120" r="84" fill="#38BDF8"/>
+    <circle cx="690" cy="410" r="128" fill="#1D4ED8"/>
+    <circle cx="192" cy="422" r="96" fill="#7DD3FC"/>
+  </g>
+  <g transform="translate(120 112)">
+    <rect x="0" y="0" width="252" height="252" rx="44" fill="#07111D" opacity="0.94"/>
+    <rect x="24" y="24" width="204" height="204" rx="30" fill="none" stroke="#38BDF8" stroke-width="10"/>
+    <rect x="52" y="52" width="148" height="148" rx="28" fill="url(#panel)" opacity="0.12"/>
+    <path d="M102 82.5 174 126 102 169.5Z" fill="url(#play)"/>
+    <path d="M238 42h18M238 76h18M238 176h18M238 210h18M-4 42h18M-4 76h18M-4 176h18M-4 210h18" stroke="#E0F2FE" stroke-linecap="round" stroke-width="10"/>
+  </g>
+  <g fill="#F8FAFC" font-family="Inter, Arial, sans-serif">
+    <text x="430" y="210" font-size="56" font-weight="700" textLength="400" lengthAdjust="spacingAndGlyphs">
+      Future Video Render
+    </text>
+    <text x="430" y="272" font-size="22" opacity="0.88">
+      <tspan x="430" dy="0">OpenClaw skill for screenplay-driven renders,</tspan>
+      <tspan x="430" dy="32">reference assets, and final video delivery</tspan>
+    </text>
+    <text x="430" y="360" font-size="22" opacity="0.88">
+      <tspan x="430" dy="0">Uses the existing Future Video Studio agent API,</tspan>
+      <tspan x="430" dy="32">wallet, and project defaults</tspan>
+    </text>
+  </g>
+</svg>

--- a/optional-skills/creative/future-video-render/assets/future-video-render-small.svg
+++ b/optional-skills/creative/future-video-render/assets/future-video-render-small.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Future Video Render icon</title>
+  <desc id="desc">Rounded square icon with a play symbol and layered cinematic frames.</desc>
+  <defs>
+    <linearGradient id="bg" x1="16" y1="12" x2="112" y2="116" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#0F8BFF"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="40" y1="36" x2="90" y2="92" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7DD3FC"/>
+      <stop offset="1" stop-color="#F8FAFC"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="url(#bg)"/>
+  <rect x="28" y="28" width="72" height="72" rx="16" fill="#0B1220" opacity="0.92"/>
+  <rect x="34" y="34" width="60" height="60" rx="12" fill="none" stroke="#38BDF8" stroke-width="4"/>
+  <path d="M56 48.5 79 64 56 79.5Z" fill="url(#accent)"/>
+  <path d="M96 32h8M96 48h8M24 32h8M24 48h8M96 80h8M96 96h8M24 80h8M24 96h8" stroke="#E0F2FE" stroke-linecap="round" stroke-width="4"/>
+</svg>

--- a/optional-skills/creative/future-video-render/references/api.md
+++ b/optional-skills/creative/future-video-render/references/api.md
@@ -1,0 +1,310 @@
+## Future Video Studio MCP And Agent API
+
+Preferred MCP:
+
+- Remote endpoint: `https://mcp.future.video/mcp`
+- Manifest: `https://mcp.future.video/server.json`
+- Well-known manifest: `https://mcp.future.video/.well-known/mcp-server.json`
+
+Direct API base:
+
+- `https://app.future.video/api/agent`
+
+### MCP tools
+
+- `fvs_submit_render`: submit an account/API-key render request, optionally with public HTTPS `upload_urls`
+- `fvs_create_paid_render_quote`: create a no-account Link pay-per-render quote
+- `fvs_get_render_status`: check an account render by `project_id` or `status_url`
+- `fvs_get_paid_render_status`: check a paid quote/render by `status_url` or `quote_id` plus `claim_token`
+- `fvs_cancel_render`: cancel an account-owned running render
+- `fvs_download_final_video`: download a completed signed `final_video_url`
+
+### Billing paths
+
+Account mode:
+
+- Configure `FVS_AGENT_API_KEY` or send the remote MCP secret header `X-FVS-Agent-Key`.
+- Agent API keys are owned by a normal Future Video Studio user account.
+- Account renders consume that account's wallet balance under the same credit model used by the app UI.
+- The backend applies the owning account's saved pipeline defaults before it creates the render job.
+- Account-mode submissions require explicit user approval to spend wallet credits. Show the render summary, requested duration/resolution, and any available estimate or user-approved budget before calling `fvs_submit_render`.
+
+Pay-per-render mode:
+
+- Omit `FVS_AGENT_API_KEY` / `X-FVS-Agent-Key`.
+- Call `fvs_create_paid_render_quote` with the same render request shape.
+- The quote response includes `payment_url`, `status_url`, `quote_id`, `claim_token`, `amount_cents`, `currency`, and `credits_quoted`.
+- Pay `payment_url` through Link/MPP, then poll with `fvs_get_paid_render_status`.
+- Paid quotes use the same FVS credit estimates and wallet accounting. In current FVS accounting, `credits_quoted` maps to cents in the quote response.
+- Paid quote mode supports text-only requests and public HTTPS `upload_urls`; local multipart file uploads require account mode through the direct Agent API helper.
+
+### Direct API endpoints
+
+Account mode:
+
+- `POST /renders`
+- `GET /renders/{project_id}`
+- `POST /renders/{project_id}/cancel`
+
+Paid quote mode:
+
+- `POST /render-quotes`
+- `GET /paid-renders/{quote_id}?claim_token=...`
+- `GET` or `POST /render-quotes/{quote_id}/pay?claim_token=...`
+
+Account header:
+
+- `X-FVS-Agent-Key: fvs_live_...`
+
+### MCP account render example
+
+```json
+{
+  "tool": "fvs_submit_render",
+  "arguments": {
+    "request": {
+      "name": "Archive corridor test",
+      "project_mode": "scene",
+      "screenplay": "Shot 1: A young woman enters a glowing archive corridor lined with suspended photographs. Shot 2: She reaches toward one moving photograph and the corridor bends into a luminous tunnel around her. Shot 3: She steps through the tunnel and arrives in a sunlit memory chamber as the photographs orbit overhead.",
+      "instructions": "Create exactly three cinematic shots totaling about 24 seconds. Keep the subject visually consistent across all shots. Favor strong camera motion, realistic lighting, and clean transitions. No subtitles or text overlays.",
+      "shot_count": 3,
+      "scene_target_duration_seconds": 24,
+      "visual_style_preset": "realistic_cinematic",
+      "video_model": "veo-3.1-fast-generate-001",
+      "video_resolution": "720p"
+    },
+    "poll_until_complete": false
+  }
+}
+```
+
+### MCP paid quote example
+
+```json
+{
+  "tool": "fvs_create_paid_render_quote",
+  "arguments": {
+    "request": {
+      "name": "Agent paid demo",
+      "project_mode": "scene",
+      "screenplay": "Shot 1: A glass airship drifts over a frozen city.",
+      "shot_count": 1,
+      "scene_target_duration_seconds": 4,
+      "video_resolution": "720p"
+    },
+    "upload_urls": [
+      {
+        "url": "https://example.com/reference.jpg",
+        "filename": "reference.jpg"
+      }
+    ]
+  }
+}
+```
+
+Expected paid quote response shape:
+
+```json
+{
+  "quote_id": "quote_...",
+  "amount_cents": 120,
+  "currency": "usd",
+  "credits_quoted": 120,
+  "payment_url": "https://app.future.video/api/agent/render-quotes/quote_.../pay?claim_token=...",
+  "status_url": "https://app.future.video/api/agent/paid-renders/quote_...?claim_token=...",
+  "claim_token": "...",
+  "expires_at": "2026-04-30T12:30:00Z"
+}
+```
+
+After payment succeeds, call `fvs_get_paid_render_status` with either the full `status_url` or `quote_id` plus `claim_token`.
+
+### Request transport
+
+For direct account API calls, use `multipart/form-data`.
+
+Required field:
+
+- `request_json`: JSON string for the render payload
+
+Optional repeated field:
+
+- `files`: uploaded assets
+
+### Core payload fields
+
+- `name`
+- `project_mode`: `music` | `scene` | `custom`
+- `screenplay`
+- `instructions`
+- `additional_lore`
+- `visual_style_preset`
+- `visual_style_custom_instructions`
+- `scene_target_duration_seconds`
+- `shot_count`
+- `ingredients_mode_enabled`
+- `image_model`, `image_resolution`
+- `video_model`, `video_resolution`
+- `music_model`
+- `stage_voice_briefs_enabled`
+- `wait_for_completion_seconds`
+
+Asset labeling:
+
+- `assets[]` entries can include `filename`, `label`, and `purpose`
+- `filename` must match the uploaded file basename
+
+### Important rules
+
+- `scene_target_duration_seconds` must be between `4` and `600`
+- `shot_count` must be between `1` and `64`
+- `wait_for_completion_seconds` must be between `0` and `600`
+- `music_workflow='uploaded_track'` requires at least one uploaded audio file
+- prefer status polling over long blocking waits
+- hosted or remote MCP clients must use public HTTPS `upload_urls`
+- local file paths are not exposed by the hosted MCP; use the direct helper script in account mode, or a trusted local MCP server that explicitly supports local uploads
+- paid quote mode does not accept local multipart file uploads
+
+### Direct API scene payload
+
+```json
+{
+  "name": "Archive corridor test",
+  "project_mode": "scene",
+  "screenplay": "Shot 1: A young woman enters a glowing archive corridor lined with suspended photographs. Shot 2: She reaches toward one moving photograph and the corridor bends into a luminous tunnel around her. Shot 3: She steps through the tunnel and arrives in a sunlit memory chamber as the photographs orbit overhead.",
+  "instructions": "Create exactly three cinematic shots totaling about 24 seconds. Keep the subject visually consistent across all shots. Favor strong camera motion, realistic lighting, and clean transitions. No subtitles or text overlays.",
+  "shot_count": 3,
+  "scene_target_duration_seconds": 24,
+  "visual_style_preset": "realistic_cinematic",
+  "video_model": "veo-3.1-fast-generate-001",
+  "video_resolution": "720p",
+  "wait_for_completion_seconds": 0
+}
+```
+
+### Direct API custom payload with uploads
+
+```json
+{
+  "name": "Custom branded launch teaser",
+  "project_mode": "custom",
+  "screenplay": "A branded teaser with three short hero shots and a dramatic final reveal.",
+  "instructions": "Use the uploaded references for brand palette, lead character continuity, and prop styling.",
+  "shot_count": 3,
+  "scene_target_duration_seconds": 18,
+  "ingredients_mode_enabled": true,
+  "assets": [
+    {
+      "filename": "lead-reference.png",
+      "label": "Lead character reference",
+      "purpose": "character"
+    },
+    {
+      "filename": "brand-guidelines.pdf",
+      "label": "Brand guidelines",
+      "purpose": "document"
+    }
+  ],
+  "wait_for_completion_seconds": 0
+}
+```
+
+### Direct API uploaded soundtrack payload
+
+```json
+{
+  "name": "Uploaded soundtrack music video",
+  "project_mode": "music",
+  "screenplay": "Cut a moody three-shot performance sequence against the uploaded song.",
+  "instructions": "Match the edit rhythm to the uploaded track and keep the lead visually consistent.",
+  "music_workflow": "uploaded_track",
+  "shot_count": 3,
+  "scene_target_duration_seconds": 20,
+  "wait_for_completion_seconds": 0
+}
+```
+
+### Response fields to inspect
+
+- `quote_id`
+- `payment_url`
+- `claim_token`
+- `project_id`
+- `status`
+- `current_stage`
+- `is_running`
+- `run_id`
+- `final_video_url`
+- `last_error`
+- `status_url`
+- `cancel_url`
+
+### Safety and recovery
+
+- Treat a `402 Payment Required` from `/render-quotes` as successful quote data.
+- Do not guess or brute-force `claim_token`, API keys, or payment credentials.
+- Keep `payment_url`, `status_url`, and `claim_token` together until the render finishes.
+- If a signed `final_video_url` expires, poll status again to get a fresh signed URL.
+- Do not resubmit paid renders after payment unless status confirms the quote failed and the user approves a new charge.
+- Do not send `X-FVS-Agent-Key` to arbitrary hosts. Use project-id-derived status and cancel calls when possible, and only use full `status_url` or `cancel_url` values returned by Future Video Studio.
+- The direct helper validates `base_url`, `status_url`, and `cancel_url` before attaching credentials. It permits `https://app.future.video` by default; trusted local or staging FVS hosts require `--allow-custom-host` or `FVS_ALLOW_CUSTOM_AGENT_HOST=1`.
+- Confirm that local upload files are intended for Future Video Studio processing before attaching them.
+
+### OpenClaw config example
+
+Remote MCP account mode:
+
+```json
+{
+  "mcpServers": {
+    "future-video-studio": {
+      "url": "https://mcp.future.video/mcp",
+      "headers": {
+        "X-FVS-Agent-Key": "fvs_live_replace_me"
+      }
+    }
+  }
+}
+```
+
+Remote MCP pay-per-render mode:
+
+```json
+{
+  "mcpServers": {
+    "future-video-studio": {
+      "url": "https://mcp.future.video/mcp"
+    }
+  }
+}
+```
+
+Skill environment fallback for direct API helper:
+
+```json
+{
+  "skills": {
+    "entries": {
+      "future-video-render": {
+        "env": {
+          "FVS_AGENT_API_KEY": "fvs_live_replace_me",
+          "FVS_AGENT_BASE_URL": "https://app.future.video"
+        }
+      }
+    }
+  }
+}
+```
+
+### Publishing
+
+Single skill publish:
+
+```powershell
+clawhub skill publish ./future-video-render --slug future-video-render --name "Future Video Render" --version 1.0.0 --tags latest
+```
+
+Registry docs:
+
+- `https://docs.openclaw.ai/tools/skills`
+- `https://docs.openclaw.ai/tools/clawhub`

--- a/optional-skills/creative/future-video-render/references/api.md
+++ b/optional-skills/creative/future-video-render/references/api.md
@@ -260,7 +260,7 @@ Remote MCP account mode:
     "future-video-studio": {
       "url": "https://mcp.future.video/mcp",
       "headers": {
-        "X-FVS-Agent-Key": "fvs_live_replace_me"
+        "X-FVS-Agent-Key": "<set through secret manager>"
       }
     }
   }
@@ -287,7 +287,7 @@ Skill environment fallback for direct API helper:
     "entries": {
       "future-video-render": {
         "env": {
-          "FVS_AGENT_API_KEY": "fvs_live_replace_me",
+          "FVS_AGENT_API_KEY": "<set through secret manager>",
           "FVS_AGENT_BASE_URL": "https://app.future.video"
         }
       }

--- a/optional-skills/creative/future-video-render/references/hermes-mcp-config.md
+++ b/optional-skills/creative/future-video-render/references/hermes-mcp-config.md
@@ -1,0 +1,75 @@
+# Hermes MCP Configuration For Future Video Studio
+
+Future Video Studio exposes a hosted HTTP MCP server:
+
+```text
+https://mcp.future.video/mcp
+```
+
+Hermes reads MCP configuration from `~/.hermes/config.yaml` under `mcp_servers`.
+
+## Pay-As-You-Go Mode
+
+No FVS account key is required. Configure only the remote endpoint:
+
+```yaml
+mcp_servers:
+  future_video_studio:
+    url: "https://mcp.future.video/mcp"
+```
+
+Use `fvs_create_paid_render_quote` to create a Link payment quote. The response includes a `payment_url`, `quote_id`, `claim_token`, and `status_url`. After payment, poll with `fvs_get_paid_render_status`.
+
+## Account/API-Key Mode
+
+Set the API key outside chat:
+
+```bash
+export FVS_AGENT_API_KEY="fvs_live_replace_me"
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:FVS_AGENT_API_KEY = "fvs_live_replace_me"
+```
+
+Then configure the MCP header:
+
+```yaml
+mcp_servers:
+  future_video_studio:
+    url: "https://mcp.future.video/mcp"
+    headers:
+      X-FVS-Agent-Key: "${FVS_AGENT_API_KEY}"
+```
+
+Account mode spends the owning FVS account's wallet credits. The agent must get explicit user approval before calling `fvs_submit_render`.
+
+## Optional Explicit Billing Mode
+
+Pay-as-you-go can also be requested explicitly:
+
+```yaml
+mcp_servers:
+  future_video_studio:
+    url: "https://mcp.future.video/mcp"
+    headers:
+      X-FVS-Billing-Mode: "pay-per-render"
+```
+
+Do not send an empty `X-FVS-Agent-Key` header if the user wants pay-as-you-go mode.
+
+## Tool Names
+
+Hermes prefixes MCP tools with the server name. With `future_video_studio`, tools are usually registered as:
+
+- `mcp_future_video_studio_fvs_submit_render`
+- `mcp_future_video_studio_fvs_create_paid_render_quote`
+- `mcp_future_video_studio_fvs_get_render_status`
+- `mcp_future_video_studio_fvs_get_paid_render_status`
+- `mcp_future_video_studio_fvs_cancel_render`
+- `mcp_future_video_studio_fvs_download_final_video`
+- `mcp_future_video_studio_fvs_example_render_request`
+
+If these tools are not visible, restart Hermes after editing `~/.hermes/config.yaml`.

--- a/optional-skills/creative/future-video-render/references/hermes-mcp-config.md
+++ b/optional-skills/creative/future-video-render/references/hermes-mcp-config.md
@@ -25,13 +25,13 @@ Use `fvs_create_paid_render_quote` to create a Link payment quote. The response 
 Set the API key outside chat:
 
 ```bash
-export FVS_AGENT_API_KEY="fvs_live_replace_me"
+export FVS_AGENT_API_KEY="<set through secret manager>"
 ```
 
 On Windows PowerShell:
 
 ```powershell
-$env:FVS_AGENT_API_KEY = "fvs_live_replace_me"
+$env:FVS_AGENT_API_KEY = "<set through secret manager>"
 ```
 
 Then configure the MCP header:

--- a/optional-skills/creative/future-video-render/scripts/future_video_render.py
+++ b/optional-skills/creative/future-video-render/scripts/future_video_render.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Submit, poll, and cancel Future Video Studio agent renders.
+
+This helper intentionally uses only the Python standard library so it can run in
+minimal OpenClaw environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_BASE_URL = "https://app.future.video"
+DEFAULT_POLL_INTERVAL_SECONDS = 15.0
+DEFAULT_TIMEOUT_SECONDS = 1800.0
+API_KEY_ENV = "FVS_AGENT_API_KEY"
+BASE_URL_ENV = "FVS_AGENT_BASE_URL"
+CUSTOM_HOST_ENV = "FVS_ALLOW_CUSTOM_AGENT_HOST"
+ALLOWED_AGENT_HOSTS = {"app.future.video"}
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except RenderToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Future Video Studio render helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    submit = subparsers.add_parser("submit", help="Submit a render request")
+    add_common_connection_args(submit)
+    submit.add_argument("--request-file", required=True, help="Path to request JSON")
+    submit.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        help="Upload file path. Repeat for multiple assets.",
+    )
+    submit.add_argument(
+        "--poll",
+        action="store_true",
+        help="Poll until the job reaches a terminal or review state.",
+    )
+    submit.add_argument(
+        "--poll-interval",
+        type=float,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help=f"Polling interval in seconds (default: {DEFAULT_POLL_INTERVAL_SECONDS})",
+    )
+    submit.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Overall poll timeout in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    submit.add_argument(
+        "--write-json",
+        help="Optional path for writing the last JSON response.",
+    )
+    submit.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print the submission target without sending the request.",
+    )
+    submit.set_defaults(func=handle_submit)
+
+    status = subparsers.add_parser("status", help="Check render status")
+    add_common_connection_args(status)
+    add_lookup_args(status)
+    status.add_argument("--write-json", help="Optional path for writing the JSON response.")
+    status.set_defaults(func=handle_status)
+
+    cancel = subparsers.add_parser("cancel", help="Cancel a render")
+    add_common_connection_args(cancel)
+    add_lookup_args(cancel)
+    cancel.add_argument("--write-json", help="Optional path for writing the JSON response.")
+    cancel.set_defaults(func=handle_cancel)
+
+    return parser
+
+
+def add_common_connection_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--api-key",
+        help=f"Agent API key. Defaults to ${API_KEY_ENV}.",
+    )
+    parser.add_argument(
+        "--base-url",
+        help=f"App origin or /api/agent base. Defaults to ${BASE_URL_ENV} or {DEFAULT_BASE_URL}.",
+    )
+    parser.add_argument(
+        "--allow-custom-host",
+        action="store_true",
+        help=(
+            "Allow a non-production FVS API host. Use only for trusted local or staging "
+            f"backends; can also be set with ${CUSTOM_HOST_ENV}=1."
+        ),
+    )
+
+
+def add_lookup_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--project-id", help="Render project id, e.g. proj_api_123")
+    parser.add_argument("--status-url", help="Full status URL from a previous response")
+    parser.add_argument("--cancel-url", help="Full cancel URL from a previous response")
+
+
+def handle_submit(args: argparse.Namespace) -> int:
+    api_key = resolve_api_key(args.api_key)
+    agent_base = normalize_agent_base(
+        args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
+        allow_custom_host=resolve_allow_custom_host(args),
+    )
+    request_path = Path(args.request_file)
+    if not request_path.is_file():
+        raise RenderToolError(f"request file not found: {request_path}")
+
+    request_json = read_request_json(request_path)
+    payload = json.loads(request_json)
+    file_paths = [Path(p) for p in args.file]
+    for path in file_paths:
+        if not path.is_file():
+            raise RenderToolError(f"upload file not found: {path}")
+
+    validate_asset_filenames(payload, file_paths)
+
+    if args.dry_run:
+        preview = {
+            "endpoint": f"{agent_base}/renders",
+            "request_file": str(request_path),
+            "files": [str(path) for path in file_paths],
+            "asset_count": len(payload.get("assets", []) or []),
+        }
+        emit_json(preview, args.write_json)
+        return 0
+
+    body, content_type = encode_multipart(
+        fields=[("request_json", request_json)],
+        file_fields=[("files", path) for path in file_paths],
+    )
+
+    response = request_json_api(
+        url=f"{agent_base}/renders",
+        method="POST",
+        api_key=api_key,
+        agent_base=agent_base,
+        body=body,
+        content_type=content_type,
+    )
+
+    if args.poll:
+        response = poll_job(
+            initial_response=response,
+            api_key=api_key,
+            agent_base=agent_base,
+            poll_interval=max(1.0, args.poll_interval),
+            timeout=max(1.0, args.timeout),
+        )
+
+    emit_json(response, args.write_json)
+    return 0
+
+
+def handle_status(args: argparse.Namespace) -> int:
+    api_key = resolve_api_key(args.api_key)
+    agent_base = normalize_agent_base(
+        args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
+        allow_custom_host=resolve_allow_custom_host(args),
+    )
+    url = resolve_status_url(args, agent_base)
+    response = request_json_api(url=url, method="GET", api_key=api_key, agent_base=agent_base)
+    emit_json(response, args.write_json)
+    return 0
+
+
+def handle_cancel(args: argparse.Namespace) -> int:
+    api_key = resolve_api_key(args.api_key)
+    agent_base = normalize_agent_base(
+        args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
+        allow_custom_host=resolve_allow_custom_host(args),
+    )
+    url = resolve_cancel_url(args, agent_base)
+    response = request_json_api(url=url, method="POST", api_key=api_key, agent_base=agent_base)
+    emit_json(response, args.write_json)
+    return 0
+
+
+def resolve_api_key(explicit_value: str | None) -> str:
+    value = explicit_value or os.getenv(API_KEY_ENV)
+    if not value:
+        raise RenderToolError(
+            f"missing API key; pass --api-key or set {API_KEY_ENV}"
+        )
+    return value.strip()
+
+
+def resolve_allow_custom_host(args: argparse.Namespace) -> bool:
+    env_value = str(os.getenv(CUSTOM_HOST_ENV) or "").strip().lower()
+    return bool(args.allow_custom_host or env_value in {"1", "true", "yes", "on"})
+
+
+def normalize_agent_base(base_url: str, *, allow_custom_host: bool = False) -> str:
+    cleaned = (base_url or "").strip().rstrip("/")
+    if not cleaned:
+        raise RenderToolError("base URL is empty")
+    parsed = urllib.parse.urlparse(cleaned)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RenderToolError("base URL must be an absolute http(s) URL")
+    validate_agent_origin(parsed, allow_custom_host=allow_custom_host)
+    if cleaned.endswith("/api/agent"):
+        return cleaned
+    return f"{cleaned}/api/agent"
+
+
+def validate_agent_origin(parsed: urllib.parse.ParseResult, *, allow_custom_host: bool) -> None:
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme == "https" and host in ALLOWED_AGENT_HOSTS:
+        return
+    if allow_custom_host:
+        return
+    allowed = ", ".join(sorted(ALLOWED_AGENT_HOSTS))
+    raise RenderToolError(
+        f"refusing to send an API key to {parsed.geturl()}; expected HTTPS host in {allowed}. "
+        f"For trusted local or staging FVS backends, pass --allow-custom-host or set {CUSTOM_HOST_ENV}=1."
+    )
+
+
+def detect_upload_mime_type(data: bytes) -> str | None:
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if len(data) >= 12 and data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    if len(data) >= 12 and data.startswith(b"RIFF") and data[8:12] == b"WAVE":
+        return "audio/wav"
+    if data.startswith(b"ID3") or (len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0):
+        return "audio/mpeg"
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        return "video/mp4"
+    if data.startswith(b"%PDF-"):
+        return "application/pdf"
+    return None
+
+
+def guess_upload_content_type(path: Path, data: bytes) -> str:
+    return detect_upload_mime_type(data) or mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+
+def resolve_status_url(args: argparse.Namespace, agent_base: str) -> str:
+    if args.status_url:
+        return validate_render_url(args.status_url.strip(), agent_base=agent_base, kind="status")
+    if args.project_id:
+        return f"{agent_base}/renders/{args.project_id.strip()}"
+    raise RenderToolError("provide --project-id or --status-url")
+
+
+def resolve_cancel_url(args: argparse.Namespace, agent_base: str) -> str:
+    if args.cancel_url:
+        return validate_render_url(args.cancel_url.strip(), agent_base=agent_base, kind="cancel")
+    if args.project_id:
+        return f"{agent_base}/renders/{args.project_id.strip()}/cancel"
+    raise RenderToolError("provide --project-id or --cancel-url")
+
+
+def validate_render_url(url: str, *, agent_base: str, kind: str) -> str:
+    validated_url = validate_api_request_url(url, agent_base=agent_base)
+    parsed = urllib.parse.urlparse(validated_url)
+    agent_path = urllib.parse.urlparse(agent_base).path.rstrip("/")
+    expected_prefix = f"{agent_path}/renders/"
+    if not parsed.path.startswith(expected_prefix):
+        raise RenderToolError(f"{kind} URL must be under {expected_prefix}")
+    if kind == "cancel" and not parsed.path.endswith("/cancel"):
+        raise RenderToolError("cancel URL must end with /cancel")
+    return validated_url
+
+
+def validate_asset_filenames(payload: dict, file_paths: list[Path]) -> None:
+    assets = payload.get("assets")
+    if not assets:
+        return
+    upload_names = {path.name for path in file_paths}
+    missing = []
+    for asset in assets:
+        filename = str((asset or {}).get("filename") or "").strip()
+        if filename and filename not in upload_names:
+            missing.append(filename)
+    if missing:
+        raise RenderToolError(
+            "assets[].filename entries must match uploaded file basenames; missing uploads for "
+            + ", ".join(sorted(missing))
+        )
+
+
+def read_request_json(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def encode_multipart(
+    *,
+    fields: Iterable[tuple[str, str]],
+    file_fields: Iterable[tuple[str, Path]],
+) -> tuple[bytes, str]:
+    boundary = f"----fvs-{uuid.uuid4().hex}"
+    lines: list[bytes] = []
+
+    for name, value in fields:
+        lines.extend(
+            [
+                f"--{boundary}".encode("utf-8"),
+                f'Content-Disposition: form-data; name="{name}"'.encode("utf-8"),
+                b"",
+                value.encode("utf-8"),
+            ]
+        )
+
+    for field_name, path in file_fields:
+        data = path.read_bytes()
+        content_type = guess_upload_content_type(path, data)
+        lines.extend(
+            [
+                f"--{boundary}".encode("utf-8"),
+                (
+                    f'Content-Disposition: form-data; name="{field_name}"; filename="{path.name}"'
+                ).encode("utf-8"),
+                f"Content-Type: {content_type}".encode("utf-8"),
+                b"",
+                data,
+            ]
+        )
+
+    lines.append(f"--{boundary}--".encode("utf-8"))
+    lines.append(b"")
+    body = b"\r\n".join(lines)
+    return body, f"multipart/form-data; boundary={boundary}"
+
+
+def request_json_api(
+    *,
+    url: str,
+    method: str,
+    api_key: str,
+    agent_base: str,
+    body: bytes | None = None,
+    content_type: str | None = None,
+) -> dict:
+    url = validate_api_request_url(url, agent_base=agent_base)
+    headers = {
+        "X-FVS-Agent-Key": api_key,
+        "Accept": "application/json",
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    request = urllib.request.Request(url=url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        detail = extract_error_detail(raw)
+        raise RenderToolError(f"HTTP {exc.code} from {url}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RenderToolError(f"network error while calling {url}: {exc.reason}") from exc
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RenderToolError(f"non-JSON response from {url}") from exc
+
+
+def validate_api_request_url(url: str, *, agent_base: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    base = urllib.parse.urlparse(agent_base)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RenderToolError("API URL must be an absolute http(s) URL")
+    if (parsed.scheme, parsed.netloc.lower()) != (base.scheme, base.netloc.lower()):
+        raise RenderToolError(
+            f"refusing to send an API key to {parsed.scheme}://{parsed.netloc}; "
+            f"expected {base.scheme}://{base.netloc}"
+        )
+    base_path = base.path.rstrip("/")
+    if not parsed.path.startswith(f"{base_path}/"):
+        raise RenderToolError(f"API URL path must stay under {base_path}/")
+    return urllib.parse.urlunparse(parsed)
+
+
+def extract_error_detail(raw: bytes) -> str:
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return "empty error response"
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text
+    if isinstance(parsed, dict):
+        detail = parsed.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+    return text
+
+
+def poll_job(
+    *,
+    initial_response: dict,
+    api_key: str,
+    agent_base: str,
+    poll_interval: float,
+    timeout: float,
+) -> dict:
+    response = initial_response
+    status_url = response.get("status_url")
+    if not status_url and response.get("project_id"):
+        status_url = f"{agent_base}/renders/{response['project_id']}"
+    if not status_url:
+        return response
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_terminal_response(response):
+            return response
+        time.sleep(poll_interval)
+        response = request_json_api(
+            url=str(status_url),
+            method="GET",
+            api_key=api_key,
+            agent_base=agent_base,
+        )
+    raise RenderToolError("poll timeout exceeded before the render reached a terminal state")
+
+
+def is_terminal_response(response: dict) -> bool:
+    status = str(response.get("status") or "").strip().lower()
+    current_stage = str(response.get("current_stage") or "").strip().lower()
+    is_running = bool(response.get("is_running"))
+    if status in {"completed", "failed"}:
+        return True
+    if current_stage == "halted_for_review":
+        return True
+    if not is_running and status not in {"queued", "running"}:
+        return True
+    return False
+
+
+def emit_json(payload: dict, output_path: str | None) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    print(text)
+    if output_path:
+        Path(output_path).write_text(text + "\n", encoding="utf-8")
+
+
+class RenderToolError(RuntimeError):
+    pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/creative/future-video-render/scripts/future_video_render.py
+++ b/optional-skills/creative/future-video-render/scripts/future_video_render.py
@@ -98,10 +98,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 def add_common_connection_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "--api-key",
-        help=f"Agent API key. Defaults to ${API_KEY_ENV}.",
-    )
-    parser.add_argument(
         "--base-url",
         help=f"App origin or /api/agent base. Defaults to ${BASE_URL_ENV} or {DEFAULT_BASE_URL}.",
     )
@@ -122,7 +118,7 @@ def add_lookup_args(parser: argparse.ArgumentParser) -> None:
 
 
 def handle_submit(args: argparse.Namespace) -> int:
-    api_key = resolve_api_key(args.api_key)
+    api_key = resolve_api_key()
     agent_base = normalize_agent_base(
         args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
         allow_custom_host=resolve_allow_custom_host(args),
@@ -132,7 +128,7 @@ def handle_submit(args: argparse.Namespace) -> int:
         raise RenderToolError(f"request file not found: {request_path}")
 
     request_json = read_request_json(request_path)
-    payload = json.loads(request_json)
+    payload = parse_request_payload(request_json, request_path)
     file_paths = [Path(p) for p in args.file]
     for path in file_paths:
         if not path.is_file():
@@ -178,7 +174,7 @@ def handle_submit(args: argparse.Namespace) -> int:
 
 
 def handle_status(args: argparse.Namespace) -> int:
-    api_key = resolve_api_key(args.api_key)
+    api_key = resolve_api_key()
     agent_base = normalize_agent_base(
         args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
         allow_custom_host=resolve_allow_custom_host(args),
@@ -190,7 +186,7 @@ def handle_status(args: argparse.Namespace) -> int:
 
 
 def handle_cancel(args: argparse.Namespace) -> int:
-    api_key = resolve_api_key(args.api_key)
+    api_key = resolve_api_key()
     agent_base = normalize_agent_base(
         args.base_url or os.getenv(BASE_URL_ENV) or DEFAULT_BASE_URL,
         allow_custom_host=resolve_allow_custom_host(args),
@@ -201,12 +197,10 @@ def handle_cancel(args: argparse.Namespace) -> int:
     return 0
 
 
-def resolve_api_key(explicit_value: str | None) -> str:
-    value = explicit_value or os.getenv(API_KEY_ENV)
+def resolve_api_key() -> str:
+    value = os.getenv(API_KEY_ENV)
     if not value:
-        raise RenderToolError(
-            f"missing API key; pass --api-key or set {API_KEY_ENV}"
-        )
+        raise RenderToolError(f"missing API key; set {API_KEY_ENV}")
     return value.strip()
 
 
@@ -310,6 +304,16 @@ def validate_asset_filenames(payload: dict, file_paths: list[Path]) -> None:
 
 def read_request_json(path: Path) -> str:
     return path.read_text(encoding="utf-8-sig")
+
+
+def parse_request_payload(request_json: str, path: Path) -> dict:
+    try:
+        payload = json.loads(request_json)
+    except json.JSONDecodeError as exc:
+        raise RenderToolError(f"invalid request JSON in {path}: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise RenderToolError(f"request JSON in {path} must be an object")
+    return payload
 
 
 def encode_multipart(

--- a/tests/skills/test_future_video_render_skill.py
+++ b/tests/skills/test_future_video_render_skill.py
@@ -1,0 +1,144 @@
+import importlib.util
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "optional-skills"
+    / "creative"
+    / "future-video-render"
+    / "scripts"
+    / "future_video_render.py"
+)
+
+
+@pytest.fixture()
+def render_tool():
+    spec = importlib.util.spec_from_file_location("future_video_render_helper", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_invalid_request_json_returns_render_tool_error(render_tool, monkeypatch, tmp_path, capsys):
+    request_file = tmp_path / "request.json"
+    request_file.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("FVS_AGENT_API_KEY", "fvs_live_test")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "future_video_render.py",
+            "submit",
+            "--request-file",
+            str(request_file),
+            "--dry-run",
+        ],
+    )
+
+    assert render_tool.main() == 1
+
+    captured = capsys.readouterr()
+    assert "invalid request JSON" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_render_url_validation_rejects_untrusted_hosts(render_tool):
+    agent_base = "https://app.future.video/api/agent"
+
+    with pytest.raises(render_tool.RenderToolError) as exc:
+        render_tool.validate_render_url(
+            "https://evil.example/api/agent/renders/proj_api_123",
+            agent_base=agent_base,
+            kind="status",
+        )
+
+    assert "refusing to send an API key" in str(exc.value)
+
+
+def test_submit_dry_run_validates_payload_and_avoids_network(render_tool, monkeypatch, tmp_path, capsys):
+    request_file = tmp_path / "request.json"
+    upload_file = tmp_path / "reference.png"
+    upload_file.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    request_file.write_text(
+        json.dumps(
+            {
+                "name": "Dry run",
+                "project_mode": "scene",
+                "screenplay": "Shot 1: A clean test.",
+                "assets": [{"filename": upload_file.name, "label": "Reference"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FVS_AGENT_API_KEY", "fvs_live_test")
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("dry-run must not make network calls")
+
+    monkeypatch.setattr(render_tool.urllib.request, "urlopen", fail_urlopen)
+    args = render_tool.build_parser().parse_args(
+        [
+            "submit",
+            "--request-file",
+            str(request_file),
+            "--file",
+            str(upload_file),
+            "--dry-run",
+        ]
+    )
+
+    assert args.func(args) == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["endpoint"] == "https://app.future.video/api/agent/renders"
+    assert output["asset_count"] == 1
+    assert output["files"] == [str(upload_file)]
+
+
+def test_api_error_is_wrapped_as_render_tool_error(render_tool, monkeypatch):
+    def fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            422,
+            "Unprocessable Entity",
+            hdrs=None,
+            fp=io.BytesIO(b'{"detail":"bad request payload"}'),
+        )
+
+    monkeypatch.setattr(render_tool.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(render_tool.RenderToolError) as exc:
+        render_tool.request_json_api(
+            url="https://app.future.video/api/agent/renders",
+            method="POST",
+            api_key="fvs_live_test",
+            agent_base="https://app.future.video/api/agent",
+            body=b"{}",
+            content_type="application/json",
+        )
+
+    message = str(exc.value)
+    assert "HTTP 422" in message
+    assert "bad request payload" in message
+
+
+def test_api_key_cli_argument_is_not_supported(render_tool):
+    with pytest.raises(SystemExit):
+        render_tool.build_parser().parse_args(
+            [
+                "status",
+                "--api-key",
+                "fvs_live_should_not_be_in_argv",
+                "--project-id",
+                "proj_api_123",
+            ]
+        )


### PR DESCRIPTION
## Summary

Adds `future-video-render` as an optional creative skill for creating cinematic AI videos through the hosted Future Video Studio MCP server.

The skill supports:

- account-wallet renders through an optional `FVS_AGENT_API_KEY`
- no-account Link pay-as-you-go quotes through the FVS MCP
- render status polling, cancellation, and final video URL retrieval
- public HTTPS reference assets through MCP `upload_urls`
- a stdlib Python fallback helper for trusted local-file account workflows

## Files

- `optional-skills/creative/future-video-render/SKILL.md`
- `references/api.md`
- `references/hermes-mcp-config.md`
- `scripts/future_video_render.py`
- `tests/skills/test_future_video_render_skill.py`
- SVG skill assets

## Validation

- Confirmed `SKILL.md` description is 42 characters, under the 60-character limit
- Added and ran mocked skill coverage for invalid JSON handling, URL validation, dry-run behavior, API error wrapping, and `--api-key` rejection: `python -m pytest -o addopts= tests/skills/test_future_video_render_skill.py`
- Compiled `optional-skills/creative/future-video-render/scripts/future_video_render.py` with `python -m py_compile`
- Ran `git diff --cached --check` before commit

Note: the focused pytest command clears repo-level `addopts` because this local environment does not have the `pytest-xdist` plugin required by the default `-n` setting.