### PR TITLE
fix(acp): use parse_model_flags + persist_global in ACP _cmd_model

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1513,8 +1513,17 @@ class HermesACPAgent(acp.Agent):
             provider = getattr(state.agent, "provider", None) or "auto"
             return f"Current model: {model}\nProvider: {provider}"
 
+        # Parse flags using CLI's shared utility (supports --provider, --global)
+        from hermes_cli.model_switch import parse_model_flags
+        raw_model, explicit_provider, is_global = parse_model_flags(args)
+
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
-        target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        effective_provider = explicit_provider or current_provider
+
+        # Resolve model using the ACP's existing resolution pipeline
+        target_provider, new_model = self._resolve_model_selection(
+            raw_model or args, effective_provider
+        )
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -1523,9 +1532,16 @@ class HermesACPAgent(acp.Agent):
             model=new_model,
             requested_provider=target_provider,
         )
+        if is_global:
+            from hermes_cli.model_switch import persist_global
+            persist_global(target_provider or current_provider, new_model)
+
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
-        logger.info("Session %s: model switched to %s", state.session_id, new_model)
+        logger.info(
+            "Session %s: model switched to %s (global=%s)",
+            state.session_id, new_model, is_global,
+        )
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
 
     def _cmd_tools(self, args: str, state: SessionState) -> str:


### PR DESCRIPTION
## Summary

The ACP  handler silently ignored  and  flags by calling  which discards  output.

## Problem

ACP users typing `/model sonnet --global` or `/model --provider my-ollama` had their flags silently ignored — the model switch was session-only even when  was explicitly requested.

This is a documented gap from [Issue #27149](https://github.com/NousResearch/hermes-agent/issues/27149) (Phase 1: audit all ACP `_cmd_*` handlers for CLI shared utility usage).

## Solution

- Call `parse_model_flags()` directly (was previously called but result discarded by wrapper)
- Pass `explicit_provider` through to resolution pipeline instead of current provider
- When `is_global=True`, call `persist_global()` for cross-session persistence
- Log the `is_global` flag for debugging

## Files Changed

| File | Changes |
|------|---------|
| `acp_adapter/server.py` | +18/-2 — Parse flags directly, pass explicit provider, persist global |

## Test Results

72/72 ACP server tests pass, including `test_model_switch_uses_requested_provider`.

## Design Decisions

- Minimal Phase 1 fix as scoped in #27149 — audit + fix gaps (18 lines added)
- Phase 2 (CommandParser registry) remains for future work
- Import inside method body (lazy import) to match existing ACP patterns

Related: #27130 (previous partial fix), #27119 (original /model bug report)
Closes #27149