### PR TITLE
feat: add live TUI session switcher

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.13.0",
+      "package": "hermes-agent[acp]==0.14.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2103,10 +2103,15 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
-def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
+def _build_service_path_dirs(
+    project_root: Path | None = None,
+    hermes_home: Path | None = None,
+) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
         project_root = PROJECT_ROOT
+    if hermes_home is None:
+        hermes_home = get_hermes_home()
 
     candidates = []
 
@@ -2120,7 +2125,6 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     if node_bin.is_dir():
         candidates.append(str(node_bin))
 
-    hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"
     if hermes_node.is_dir():
         candidates.append(str(hermes_node))
@@ -2131,18 +2135,22 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     return candidates
 
 
-def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
-    python_path = get_python_path()
-    working_dir = str(PROJECT_ROOT)
-    detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
-
-    path_entries = _build_service_path_dirs()
+def _build_service_path_entries(hermes_home: Path | None = None) -> list[str]:
+    """Build PATH entries and include the currently resolved node binary dir."""
+    path_entries = _build_service_path_dirs(hermes_home=hermes_home)
     resolved_node = shutil.which("node")
     if resolved_node:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
+    return path_entries
+
+
+def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
+    python_path = get_python_path()
+    working_dir = str(PROJECT_ROOT)
+    detected_venv = _detect_venv_dir()
+    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
 
     common_bin_paths = ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
     # systemd's TimeoutStopSec must exceed the gateway's drain_timeout so
@@ -2157,6 +2165,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
+        path_entries = _build_service_path_entries(Path(hermes_home))
         profile_arg = _profile_arg(hermes_home)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
@@ -2204,6 +2213,7 @@ WantedBy=multi-user.target
 """
 
     hermes_home = str(get_hermes_home().resolve())
+    path_entries = _build_service_path_entries(Path(hermes_home))
     profile_arg = _profile_arg(hermes_home)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9612,7 +9612,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
         "model", "pairing", "plugins", "postinstall", "profile", "proxy", "sessions", "setup",
-        "skills", "slack", "status", "tools", "uninstall", "update",
+        "send", "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -58,7 +58,7 @@ def _read_message_body(
         if file_path == "-":
             return sys.stdin.read()
         try:
-            return Path(file_path).read_text()
+            return Path(file_path).read_text(encoding="utf-8")
         except OSError as exc:
             print(f"hermes send: cannot read {file_path}: {exc}", file=sys.stderr)
             sys.exit(_USAGE_EXIT)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3721,6 +3721,98 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     assert text in ("", None), f"expected empty text, got {text!r}"
 
 
+# ── active live TUI sessions ─────────────────────────────────────────
+
+
+def test_session_active_list_reports_live_sessions(monkeypatch):
+    class _DB:
+        def get_session_title(self, key):
+            return {"key-a": "Research", "key-b": "Implement"}.get(key, "")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    server._sessions["sid-a"] = _session(
+        agent=types.SimpleNamespace(model="model-a"),
+        history=[{"role": "user", "content": "find docs"}],
+        session_key="key-a",
+        created_at=10.0,
+        last_active=20.0,
+    )
+    server._sessions["sid-b"] = _session(
+        agent=types.SimpleNamespace(model="model-b"),
+        history=[{"role": "assistant", "content": "writing code"}],
+        running=True,
+        session_key="key-b",
+        created_at=11.0,
+        last_active=30.0,
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.active_list",
+                "params": {"current_session_id": "sid-a"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-a", None)
+        server._sessions.pop("sid-b", None)
+
+    rows = {row["id"]: row for row in resp["result"]["sessions"]}
+    assert rows["sid-a"] == {
+        "current": True,
+        "id": "sid-a",
+        "last_active": 20.0,
+        "message_count": 1,
+        "model": "model-a",
+        "preview": "find docs",
+        "session_key": "key-a",
+        "started_at": 10.0,
+        "status": "idle",
+        "title": "Research",
+    }
+    assert rows["sid-b"]["current"] is False
+    assert rows["sid-b"]["status"] == "working"
+    assert rows["sid-b"]["title"] == "Implement"
+    assert rows["sid-b"]["preview"] == "writing code"
+
+
+def test_session_activate_switches_live_session_without_closing_siblings(monkeypatch):
+    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    server._sessions["sid-a"] = _session(
+        agent=types.SimpleNamespace(model="model-a"),
+        history=[{"role": "user", "content": "old"}],
+        session_key="key-a",
+    )
+    server._sessions["sid-b"] = _session(
+        agent=types.SimpleNamespace(model="model-b"),
+        history=[
+            {"role": "user", "content": "new prompt"},
+            {"role": "assistant", "content": "new answer"},
+        ],
+        running=True,
+        session_key="key-b",
+    )
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.activate", "params": {"session_id": "sid-b"}}
+        )
+
+        assert "sid-a" in server._sessions
+        assert "sid-b" in server._sessions
+        assert resp["result"]["session_id"] == "sid-b"
+        assert resp["result"]["session_key"] == "key-b"
+        assert resp["result"]["running"] is True
+        assert resp["result"]["status"] == "working"
+        assert resp["result"]["info"] == {"model": "model-b"}
+        assert resp["result"]["messages"] == [
+            {"role": "user", "text": "new prompt"},
+            {"role": "assistant", "text": "new answer"},
+        ]
+    finally:
+        server._sessions.pop("sid-a", None)
+        server._sessions.pop("sid-b", None)
+
+
 # ── session.most_recent ──────────────────────────────────────────────
 
 

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -6,20 +6,21 @@ import os
 from typing import Dict
 
 try:
-    from hermes_cli.config import get_env_value as _hermes_get_env_value
+    import hermes_cli.config as _hermes_config
 except Exception:
-    _hermes_get_env_value = None
+    _hermes_config = None
 
 
 def get_env_value(name: str, default=None):
     """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
 
-    Wraps :func:`hermes_cli.config.get_env_value` so tests can patch
-    ``tools.xai_http.get_env_value`` to inject dotenv-only secrets into the
-    xAI credential resolver.
+    Resolve ``hermes_cli.config.get_env_value`` dynamically so test patches
+    and config reloads do not leave this module with a stale imported helper.
+    Tests can still patch ``tools.xai_http.get_env_value`` to inject
+    dotenv-only secrets into the xAI credential resolver.
     """
-    if _hermes_get_env_value is not None:
-        value = _hermes_get_env_value(name)
+    if _hermes_config is not None:
+        value = _hermes_config.get_env_value(name)
         if value is not None:
             return value
     return os.environ.get(name, default)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -118,6 +118,7 @@ from tui_gateway.render import make_stream_renderer, render_diff, render_message
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
+_pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
@@ -729,9 +730,13 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
     ev = threading.Event()
     _pending[rid] = (sid, ev)
     payload["request_id"] = rid
-    _emit(event, sid, payload)
-    ev.wait(timeout=timeout)
-    _pending.pop(rid, None)
+    _pending_prompt_payloads[rid] = (event, dict(payload))
+    try:
+        _emit(event, sid, payload)
+        ev.wait(timeout=timeout)
+    finally:
+        _pending.pop(rid, None)
+        _pending_prompt_payloads.pop(rid, None)
     return _answers.pop(rid, "")
 
 
@@ -1912,12 +1917,15 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
 
 
 def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
+    now = time.time()
     _sessions[sid] = {
         "agent": agent,
         "session_key": key,
         "history": history,
         "history_lock": threading.Lock(),
         "history_version": 0,
+        "created_at": now,
+        "last_active": now,
         "running": False,
         "attached_images": [],
         "image_counter": 0,
@@ -2100,6 +2108,7 @@ def _(rid, params: dict) -> dict:
     _enable_gateway_prompts()
 
     ready = threading.Event()
+    now = time.time()
 
     _sessions[sid] = {
         "agent": None,
@@ -2107,11 +2116,13 @@ def _(rid, params: dict) -> dict:
         "agent_ready": ready,
         "attached_images": [],
         "cols": cols,
+        "created_at": now,
         "edit_snapshots": {},
         "history": [],
         "history_lock": threading.Lock(),
         "history_version": 0,
         "image_counter": 0,
+        "last_active": now,
         "pending_title": None,
         "running": False,
         "session_key": key,
@@ -2280,6 +2291,127 @@ def _(rid, params: dict) -> dict:
             "message_count": len(messages),
             "messages": messages,
             "info": _session_info(agent),
+        },
+    )
+
+
+def _session_pending_kind(sid: str) -> str:
+    for rid, (owner_sid, _ev) in list(_pending.items()):
+        if owner_sid != sid:
+            continue
+        event, _payload = _pending_prompt_payloads.get(rid, ("input.request", {}))
+        return str(event).removesuffix(".request")
+    return ""
+
+
+def _session_live_status(sid: str, session: dict) -> str:
+    if _session_pending_kind(sid):
+        return "waiting"
+    ready = session.get("agent_ready")
+    if ready is not None and not ready.is_set():
+        return "starting"
+    if session.get("running"):
+        return "working"
+    return "idle"
+
+
+def _message_preview(history: list) -> str:
+    for msg in reversed(history or []):
+        text = _content_display_text(msg.get("content", msg.get("text", ""))).strip()
+        if text:
+            return " ".join(text.split())[:160]
+    return ""
+
+
+def _session_live_title(session: dict, key: str) -> str:
+    title = str(session.get("pending_title") or "").strip()
+    db = _get_db()
+    if db is not None:
+        try:
+            title = str(db.get_session_title(key) or title or "").strip()
+        except Exception:
+            pass
+    return title
+
+
+def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
+    key = str(session.get("session_key") or sid)
+    agent = session.get("agent")
+    history = list(session.get("history") or [])
+    status = _session_live_status(sid, session)
+    now = time.time()
+    return {
+        "current": sid == current_sid,
+        "id": sid,
+        "last_active": float(session.get("last_active") or session.get("created_at") or now),
+        "message_count": len(history),
+        "model": str(getattr(agent, "model", "") or _resolve_model()),
+        "preview": _message_preview(history),
+        "session_key": key,
+        "started_at": float(session.get("created_at") or now),
+        "status": status,
+        "title": _session_live_title(session, key),
+    }
+
+
+def _fallback_session_info(session: dict) -> dict:
+    agent = session.get("agent")
+    if agent is not None:
+        return _session_info(agent)
+    return {
+        "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
+        "lazy": True,
+        "model": _resolve_model(),
+        "skills": {},
+        "tools": {},
+    }
+
+
+@method("session.active_list")
+def _(rid, params: dict) -> dict:
+    """Return live TUI sessions in this gateway process.
+
+    Unlike ``session.list`` this is not a historical DB browser: it reports only
+    sessions with in-memory agents/workers that the current TUI can switch to
+    without closing siblings.
+    """
+    current = str(params.get("current_session_id") or "")
+    try:
+        snapshot = list(_sessions.items())
+    except Exception as e:
+        return _err(rid, 5036, f"could not enumerate active sessions: {e}")
+
+    rows = [_session_live_item(sid, session, current) for sid, session in snapshot]
+    rows.sort(key=lambda row: (not row.get("current", False), -float(row.get("last_active") or 0)))
+    return _ok(rid, {"sessions": rows})
+
+
+@method("session.activate")
+def _(rid, params: dict) -> dict:
+    """Attach the frontend to an already-live TUI session.
+
+    This intentionally does not close the previously focused session; it merely
+    returns enough state for Ink to redraw around another live session id.
+    """
+    sid = str(params.get("session_id") or "")
+    session, err = _sess_nowait({"session_id": sid}, rid)
+    if err:
+        return err
+
+    session["last_active"] = time.time()
+    history = list(session.get("display_history") or session.get("history") or [])
+    status = _session_live_status(sid, session)
+    return _ok(
+        rid,
+        {
+            "info": _fallback_session_info(session),
+            "message_count": len(history),
+            "messages": _history_to_messages(history),
+            "running": bool(session.get("running")),
+            "session_id": sid,
+            "session_key": session.get("session_key") or sid,
+            "started_at": float(session.get("created_at") or time.time()),
+            "status": status,
         },
     )
 
@@ -3008,6 +3140,7 @@ def _(rid, params: dict) -> dict:
         if session.get("running"):
             return _err(rid, 4009, "session busy")
         session["running"] = True
+        session["last_active"] = time.time()
 
     _start_agent_build(sid, session)
 
@@ -3463,6 +3596,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             _clear_session_context(session_tokens)
             with session["history_lock"]:
                 session["running"] = False
+                session["last_active"] = time.time()
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the
@@ -4384,6 +4518,7 @@ _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/compact", "Toggle compact display mode", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
     ("/mouse", "Toggle mouse/wheel tracking [on|off|toggle]", "TUI"),
+    ("/sessions", "Switch between live TUI sessions", "TUI"),
 ]
 
 # Commands that queue messages onto _pending_input in the CLI.

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -18,6 +18,16 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().picker).toBe(true)
   })
 
+  it('opens the live session switcher locally even when the current session is busy', () => {
+    patchUiState({ busy: true, sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/sessions')).toBe(true)
+    expect(getOverlayState().sessions).toBe(true)
+    expect(ctx.session.guardBusySessionSwitch).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('handles /redraw locally without slash worker fallback', () => {
     const ctx = buildCtx()
 
@@ -747,6 +757,7 @@ const buildSession = () => ({
   closeSession: vi.fn(() => Promise.resolve(null)),
   die: vi.fn(),
   guardBusySessionSwitch: vi.fn(() => false),
+  newLiveSession: vi.fn(),
   newSession: vi.fn(),
   resetVisibleHistory: vi.fn(),
   resumeById: vi.fn(),

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -79,6 +79,7 @@ export interface OverlayState {
   pager: null | PagerState
   picker: boolean
   secret: null | SecretReq
+  sessions: boolean
   skillsHub: boolean
   sudo: null | SudoReq
 }
@@ -278,6 +279,7 @@ export interface SlashHandlerContext {
     closeSession: (targetSid?: null | string) => Promise<unknown>
     die: () => void
     guardBusySessionSwitch: (what?: string) => boolean
+    newLiveSession: (msg?: string, title?: string) => void
     newSession: (msg?: string, title?: string) => void
     resetVisibleHistory: (info?: null | SessionInfo) => void
     resumeById: (id: string) => void
@@ -304,6 +306,8 @@ export interface AppLayoutActions {
   answerSecret: (value: string) => void
   answerSudo: (pw: string) => void
   clearSelection: () => void
+  activateLiveSession: (id: string) => void
+  newLiveSession: () => void
   onModelSelect: (value: string) => void
   resumeById: (id: string) => void
   setStickyPrompt: (value: string) => void
@@ -362,7 +366,9 @@ export interface AppOverlaysProps {
   completions: CompletionItem[]
   onApprovalChoice: (choice: string) => void
   onClarifyAnswer: (value: string) => void
+  onActiveSessionSelect: (sessionId: string) => void
   onModelSelect: (value: string) => void
+  onNewLiveSession: () => void
   onPickerSelect: (sessionId: string) => void
   onSecretSubmit: (value: string) => void
   onSudoSubmit: (pw: string) => void

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -12,6 +12,7 @@ const buildOverlayState = (): OverlayState => ({
   pager: null,
   picker: false,
   secret: null,
+  sessions: false,
   skillsHub: false,
   sudo: null
 })
@@ -20,8 +21,8 @@ export const $overlayState = atom<OverlayState>(buildOverlayState())
 
 export const $isBlocked = computed(
   $overlayState,
-  ({ agents, approval, clarify, confirm, modelPicker, pager, picker, secret, skillsHub, sudo }) =>
-    Boolean(agents || approval || clarify || confirm || modelPicker || pager || picker || secret || skillsHub || sudo)
+  ({ agents, approval, clarify, confirm, modelPicker, pager, picker, secret, sessions, skillsHub, sudo }) =>
+    Boolean(agents || approval || clarify || confirm || modelPicker || pager || picker || secret || sessions || skillsHub || sudo)
 )
 
 export const getOverlayState = () => $overlayState.get()
@@ -47,5 +48,6 @@ export const resetFlowOverlays = () =>
     agentsInitialHistoryIndex: $overlayState.get().agentsInitialHistoryIndex,
     modelPicker: $overlayState.get().modelPicker,
     picker: $overlayState.get().picker,
+    sessions: $overlayState.get().sessions,
     skillsHub: $overlayState.get().skillsHub
   })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -93,15 +93,15 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
-    help: 'browse and resume previous sessions',
+    aliases: ['switch'],
+    help: 'switch between live TUI sessions',
     name: 'sessions',
     run: (arg, ctx) => {
-      if (ctx.session.guardBusySessionSwitch('switch sessions')) {
-        return
+      if (arg.trim().toLowerCase() === 'new') {
+        return ctx.session.newLiveSession()
       }
-      if (!arg.trim()) {
-        return patchOverlayState({ picker: true })
-      }
+
+      patchOverlayState({ sessions: true })
     }
   },
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -479,6 +479,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return cActions.clearIn()
     }
 
+    if (isCtrl(key, ch, 'x')) {
+      return patchOverlayState({ sessions: true })
+    }
+
     if (key.ctrl && ch.toLowerCase() === 'c') {
       if (live.busy && live.sid) {
         return turnController.interruptTurn({

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -644,6 +644,7 @@ export function useMainApp(gw: GatewayClient) {
           closeSession: session.closeSession,
           die,
           guardBusySessionSwitch: session.guardBusySessionSwitch,
+          newLiveSession: session.newLiveSession,
           newSession: session.newSession,
           resetVisibleHistory: session.resetVisibleHistory,
           resumeById: session.resumeById,
@@ -771,16 +772,28 @@ export function useMainApp(gw: GatewayClient) {
 
   const appActions = useMemo(
     () => ({
+      activateLiveSession: session.activateLiveSession,
+      answerApproval,
+      answerClarify,
+      answerSecret,
+      answerSudo,
+      clearSelection,
+      newLiveSession: () => session.newLiveSession(),
+      onModelSelect,
+      resumeById: session.resumeById,
+      setStickyPrompt
+    }),
+    [
       answerApproval,
       answerClarify,
       answerSecret,
       answerSudo,
       clearSelection,
       onModelSelect,
-      resumeById: session.resumeById,
-      setStickyPrompt
-    }),
-    [answerApproval, answerClarify, answerSecret, answerSudo, clearSelection, onModelSelect, session.resumeById]
+      session.activateLiveSession,
+      session.newLiveSession,
+      session.resumeById
+    ]
   )
 
   const appComposer = useMemo(

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -9,6 +9,7 @@ import { introMsg, toTranscriptMessages } from '../domain/messages.js'
 import { ZERO } from '../domain/usage.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
+  SessionActivateResponse,
   SessionCloseResponse,
   SessionCreateResponse,
   SessionResumeResponse,
@@ -25,6 +26,18 @@ import { patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const usageFrom = (info: null | SessionInfo): Usage => (info?.usage ? { ...ZERO, ...info.usage } : ZERO)
+
+const statusFromLiveSession = (status?: string, running = false) => {
+  if (status === 'waiting') {
+    return 'waiting for input…'
+  }
+
+  if (status === 'starting') {
+    return 'starting agent…'
+  }
+
+  return running || status === 'working' ? 'running…' : 'ready'
+}
 
 export const writeActiveSessionFile = (sessionId: null | string, file = process.env.HERMES_TUI_ACTIVE_SESSION_FILE) => {
   if (!file || !sessionId) {
@@ -122,8 +135,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     [composerActions, setHistoryItems, setLastUserMsg, setStickyPrompt]
   )
 
-  const newSession = useCallback(
-    async (msg?: string, title?: string) => {
+  const startNewSession = useCallback(
+    async (msg?: string, title?: string, keepCurrent = false) => {
       const setup = await rpc<SetupStatusResponse>('setup.status', {})
 
       if (setup?.provider_configured === false) {
@@ -133,7 +146,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         return
       }
 
-      await closeSession(getUiState().sid)
+      if (!keepCurrent) {
+        await closeSession(getUiState().sid)
+      }
 
       const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
 
@@ -196,6 +211,58 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       }
     },
     [closeSession, colsRef, panel, resetSession, rpc, setHistoryItems, setSessionStartedAt, sys]
+  )
+
+  const newSession = useCallback(
+    (msg?: string, title?: string) => startNewSession(msg, title, false),
+    [startNewSession]
+  )
+
+  const newLiveSession = useCallback(
+    (msg = 'new live session started', title?: string) => {
+      patchOverlayState({ sessions: false })
+      void startNewSession(msg, title, true)
+    },
+    [startNewSession]
+  )
+
+  const activateLiveSession = useCallback(
+    (id: string) => {
+      patchOverlayState({ sessions: false })
+      patchUiState({ status: 'switching session…' })
+
+      gw.request<SessionActivateResponse>('session.activate', { session_id: id })
+        .then(raw => {
+          const r = asRpcResult<SessionActivateResponse>(raw)
+
+          if (!r) {
+            sys('error: invalid response: session.activate')
+
+            return patchUiState({ status: 'ready' })
+          }
+
+          const info = r.info ?? null
+          const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+
+          resetSession()
+          setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
+          setHistoryItems(info ? [introMsg(info), ...toTranscriptMessages(r.messages)] : toTranscriptMessages(r.messages))
+          writeActiveSessionFile(r.session_key ?? r.session_id)
+          patchUiState({
+            busy: running,
+            info,
+            sid: r.session_id,
+            status: statusFromLiveSession(r.status, running),
+            usage: usageFrom(info)
+          })
+          setTimeout(() => scrollRef.current?.scrollToBottom(), 0)
+        })
+        .catch((e: Error) => {
+          sys(`error: ${e.message}`)
+          patchUiState({ status: 'ready' })
+        })
+    },
+    [gw, resetSession, scrollRef, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const resumeById = useCallback(
@@ -262,8 +329,10 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   )
 
   return {
+    activateLiveSession,
     closeSession,
     guardBusySessionSwitch,
+    newLiveSession,
     newSession,
     resetSession,
     resetVisibleHistory,

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -1,0 +1,197 @@
+import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import { useCallback, useEffect, useState } from 'react'
+
+import type { GatewayClient } from '../gatewayClient.js'
+import type { SessionActiveItem, SessionActiveListResponse } from '../gatewayTypes.js'
+import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import type { Theme } from '../theme.js'
+
+import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
+
+const VISIBLE = 12
+const MIN_WIDTH = 64
+const MAX_WIDTH = 128
+
+const STATUS_GLYPH: Record<string, string> = {
+  idle: '✓',
+  starting: '…',
+  waiting: '?',
+  working: '▶'
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  idle: 'idle',
+  starting: 'starting',
+  waiting: 'waiting',
+  working: 'working'
+}
+
+const shortModel = (model = '') => model.replace(/^.*\//, '') || 'model?'
+
+export function ActiveSessionSwitcher({ currentSessionId, gw, onCancel, onNew, onSelect, t }: ActiveSessionSwitcherProps) {
+  const [items, setItems] = useState<SessionActiveItem[]>([])
+  const [err, setErr] = useState('')
+  const [sel, setSel] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const { stdout } = useStdout()
+  const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+
+  const load = useCallback(
+    (quiet = false) => {
+      if (!quiet) {
+        setLoading(true)
+      }
+
+      gw.request<SessionActiveListResponse>('session.active_list', { current_session_id: currentSessionId })
+        .then(raw => {
+          const r = asRpcResult<SessionActiveListResponse>(raw)
+
+          if (!r) {
+            setErr('invalid response: session.active_list')
+            setLoading(false)
+
+            return
+          }
+
+          const next = r.sessions ?? []
+          setItems(next)
+          setSel(s => Math.max(0, Math.min(s, next.length - 1)))
+          setErr('')
+          setLoading(false)
+        })
+        .catch((e: unknown) => {
+          setErr(rpcErrorMessage(e))
+          setLoading(false)
+        })
+    },
+    [currentSessionId, gw]
+  )
+
+  useOverlayKeys({ onClose: onCancel })
+
+  useEffect(() => {
+    load()
+    const timer = setInterval(() => load(true), 1500)
+
+    return () => clearInterval(timer)
+  }, [load])
+
+  useInput((ch, key) => {
+    if (key.upArrow && sel > 0) {
+      return setSel(s => s - 1)
+    }
+
+    if (key.downArrow && sel < items.length - 1) {
+      return setSel(s => s + 1)
+    }
+
+    if ((key.return || ch === ' ') && items[sel]) {
+      return onSelect(items[sel]!.id)
+    }
+
+    if (ch?.toLowerCase() === 'n') {
+      return onNew()
+    }
+
+    if (ch?.toLowerCase() === 'r') {
+      return load()
+    }
+
+    const n = parseInt(ch ?? '', 10)
+
+    if (n >= 1 && n <= Math.min(9, items.length)) {
+      onSelect(items[n - 1]!.id)
+    }
+  })
+
+  if (loading) {
+    return <Text color={t.color.muted}>loading live sessions…</Text>
+  }
+
+  if (err && !items.length) {
+    return (
+      <Box flexDirection="column">
+        <Text color={t.color.label}>error: {err}</Text>
+        <OverlayHint t={t}>r refresh · n new · Esc/q cancel</OverlayHint>
+      </Box>
+    )
+  }
+
+  if (!items.length) {
+    return (
+      <Box flexDirection="column">
+        <Text color={t.color.muted}>no live sessions</Text>
+        <OverlayHint t={t}>n new · Esc/q cancel</OverlayHint>
+      </Box>
+    )
+  }
+
+  const offset = windowOffset(items.length, sel, VISIBLE)
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Text bold color={t.color.accent}>
+        Live Sessions
+      </Text>
+
+      {offset > 0 && <Text color={t.color.muted}>  ↑ {offset} more</Text>}
+
+      {items.slice(offset, offset + VISIBLE).map((s, vi) => {
+        const i = offset + vi
+        const selected = sel === i
+        const status = s.status ?? 'idle'
+        const current = s.current || s.id === currentSessionId
+        const title = s.title || s.preview || '(untitled)'
+
+        return (
+          <Box key={s.id}>
+            <Text bold={selected} color={selected ? t.color.accent : t.color.muted} inverse={selected}>
+              {selected ? '▸ ' : '  '}
+            </Text>
+
+            <Box width={5}>
+              <Text bold={selected} color={selected ? t.color.accent : t.color.muted} inverse={selected}>
+                {String(i + 1).padStart(2)}.
+              </Text>
+            </Box>
+
+            <Box width={11}>
+              <Text bold={selected} color={selected ? t.color.accent : current ? t.color.label : t.color.muted} inverse={selected}>
+                {current ? 'current' : s.id}
+              </Text>
+            </Box>
+
+            <Box width={11}>
+              <Text color={status === 'working' ? t.color.ok : status === 'waiting' ? t.color.label : t.color.muted} inverse={selected}>
+                {STATUS_GLYPH[status] ?? '·'} {STATUS_LABEL[status] ?? status}
+              </Text>
+            </Box>
+
+            <Box width={18}>
+              <Text color={selected ? t.color.accent : t.color.muted} inverse={selected} wrap="truncate-end">
+                {shortModel(s.model)}
+              </Text>
+            </Box>
+
+            <Text bold={selected} color={selected ? t.color.accent : t.color.muted} inverse={selected} wrap="truncate-end">
+              {title}
+            </Text>
+          </Box>
+        )
+      })}
+
+      {offset + VISIBLE < items.length && <Text color={t.color.muted}>  ↓ {items.length - offset - VISIBLE} more</Text>}
+      {err && <Text color={t.color.label}>error: {err}</Text>}
+      <OverlayHint t={t}>↑/↓ select · Enter switch · 1-9 quick · n new · r refresh · Esc/q close</OverlayHint>
+    </Box>
+  )
+}
+
+interface ActiveSessionSwitcherProps {
+  currentSessionId: null | string
+  gw: GatewayClient
+  onCancel: () => void
+  onNew: () => void
+  onSelect: (id: string) => void
+  t: Theme
+}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -253,7 +253,9 @@ const ComposerPane = memo(function ComposerPane({
           cols={composer.cols}
           compIdx={composer.compIdx}
           completions={composer.completions}
+          onActiveSessionSelect={actions.activateLiveSession}
           onModelSelect={actions.onModelSelect}
+          onNewLiveSession={actions.newLiveSession}
           onPickerSelect={actions.resumeById}
           pagerPageSize={composer.pagerPageSize}
         />

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -6,6 +6,7 @@ import type { AppOverlaysProps } from '../app/interfaces.js'
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
 
+import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
 import { FloatBox } from './appChrome.js'
 import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
@@ -95,16 +96,29 @@ export function FloatingOverlays({
   cols,
   compIdx,
   completions,
+  onActiveSessionSelect,
   onModelSelect,
+  onNewLiveSession,
   onPickerSelect,
   pagerPageSize
-}: Pick<AppOverlaysProps, 'cols' | 'compIdx' | 'completions' | 'onModelSelect' | 'onPickerSelect' | 'pagerPageSize'>) {
+}: Pick<
+  AppOverlaysProps,
+  | 'cols'
+  | 'compIdx'
+  | 'completions'
+  | 'onActiveSessionSelect'
+  | 'onModelSelect'
+  | 'onNewLiveSession'
+  | 'onPickerSelect'
+  | 'pagerPageSize'
+>) {
   const { gw } = useGateway()
   const overlay = useStore($overlayState)
   const sid = useStore($uiSessionId)
   const theme = useStore($uiTheme)
 
-  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || overlay.skillsHub || completions.length
+  const hasAny =
+    overlay.modelPicker || overlay.pager || overlay.picker || overlay.sessions || overlay.skillsHub || completions.length
 
   if (!hasAny) {
     return null
@@ -125,6 +139,19 @@ export function FloatingOverlays({
             gw={gw}
             onCancel={() => patchOverlayState({ picker: false })}
             onSelect={onPickerSelect}
+            t={theme}
+          />
+        </FloatBox>
+      )}
+
+      {overlay.sessions && (
+        <FloatBox color={theme.color.border}>
+          <ActiveSessionSwitcher
+            currentSessionId={sid}
+            gw={gw}
+            onCancel={() => patchOverlayState({ sessions: false })}
+            onNew={onNewLiveSession}
+            onSelect={onActiveSessionSelect}
             t={theme}
           />
         </FloatBox>

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -23,7 +23,7 @@ export const HOTKEYS: [string, string][] = [
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],
-  ['Ctrl+X', 'delete the queued message you’re editing (Esc cancels edit)'],
+  ['Ctrl+X', 'open live session switcher (deletes queued message while editing)'],
   [action + '+A/E', 'home / end of line'],
   [action + '+Z / ' + action + '+Y', 'undo / redo input edits'],
   [action + '+W', 'delete word'],

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -122,6 +122,36 @@ export interface SessionResumeResponse {
   session_id: string
 }
 
+export type LiveSessionStatus = 'idle' | 'starting' | 'waiting' | 'working'
+
+export interface SessionActiveItem {
+  current?: boolean
+  id: string
+  last_active?: number
+  message_count?: number
+  model?: string
+  preview?: string
+  session_key?: string
+  started_at?: number
+  status: LiveSessionStatus
+  title?: string
+}
+
+export interface SessionActiveListResponse {
+  sessions?: SessionActiveItem[]
+}
+
+export interface SessionActivateResponse {
+  info?: SessionInfo
+  message_count?: number
+  messages: GatewayTranscriptMessage[]
+  running?: boolean
+  session_id: string
+  session_key?: string
+  started_at?: number
+  status?: LiveSessionStatus
+}
+
 export interface SessionListItem {
   id: string
   message_count: number


### PR DESCRIPTION
## What changed and why
- Adds live TUI session RPCs so the frontend can list and activate in-memory sessions without closing sibling sessions.
- Adds an Ink live session switcher overlay with keyboard navigation, quick-select numbers, refresh, and new-session dispatch.
- Wires the switcher to `/sessions`, `/switch`, and `Ctrl+X`; keeps historical transcript resume on `/resume`.
- Restores current CI baseline by syncing the ACP registry manifest to the pyproject version and building systemd service PATH entries from the target user's Hermes home for system services, adding the missing explicit encoding in `hermes send` file reads, registering `send` as a built-in subcommand, and making xAI env lookup dynamic so patched dotenv loaders are honored in tests.

## How to test
- `venv/bin/ruff check .`
- `venv/bin/python -m pytest tests/test_tui_gateway_server.py tests/acp/test_registry_manifest.py tests/hermes_cli/test_gateway_service.py::TestSystemUnitHermesHome tests/tools/test_transcription_dotenv_fallback.py -q`
- `cd ui-tui && npm test -- --run src/__tests__/createSlashHandler.test.ts`
- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm run build`
- `git diff --check`

Also attempted full `cd ui-tui && npm test`; it still fails in `terminalSetup.test.ts` on this SSH dev VM because those cases hit the existing “terminal setup must be run on the local machine, not inside an SSH session” guard. This PR does not touch `terminalSetup`.

## Platforms tested
- Fedora Linux dev VM over SSH
- Hermes TUI TypeScript build/test stack
- Python 3.11 gateway tests

## Related issues
Closes #25134

## Security notes
- No auth/token handling changes.
- New gateway RPCs expose only live sessions already owned by the current TUI gateway process.
