### PR TITLE
fix(mcp+moonshot): resolve #/properties/... refs and strip unresolvable $ref values

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -159,6 +159,23 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # target node, which Moonshot accepts.
     # (Ported from anomalyco/opencode#24730.)
     if "$ref" in repaired:
+        ref_val = repaired["$ref"]
+        # Moonshot also requires that $ref values point into $defs
+        # (e.g. '#/$defs/StrokeColor').  Local property refs like
+        # '#/properties/x' are rejected even after sibling stripping.
+        # If the $ref doesn't match an accepted pattern, strip it so
+        # _fill_missing_type can infer a replacement schema instead of
+        # sending a guaranteed-400 ref to the API.
+        if isinstance(ref_val, str):
+            if ref_val.startswith("#/definitions/"):
+                repaired["$ref"] = "#/$defs/" + ref_val[len("#/definitions/"):]
+            elif not ref_val.startswith("#/$defs/"):
+                # Unacceptable $ref — strip it. The missing-type filler
+                # below will provide a best-effort type.
+                repaired.pop("$ref")
+                repaired.pop("type", None)  # let _fill_missing_type re-infer
+                repaired = _fill_missing_type(repaired)
+                return repaired
         return {"$ref": repaired["$ref"]}
 
     return repaired

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -79,6 +79,7 @@ Thread safety:
 
 import asyncio
 import concurrent.futures
+import copy
 import inspect
 import json
 import logging
@@ -2717,19 +2718,57 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     if not schema:
         return {"type": "object", "properties": {}}
 
-    def _rewrite_local_refs(node):
+    def _rewrite_local_refs(node, root=None):
+        if root is None:
+            root = node
         if isinstance(node, dict):
             normalized = {}
             for key, value in node.items():
                 out_key = "$defs" if key == "definitions" else key
-                normalized[out_key] = _rewrite_local_refs(value)
+                normalized[out_key] = _rewrite_local_refs(value, root)
             ref = normalized.get("$ref")
-            if isinstance(ref, str) and ref.startswith("#/definitions/"):
-                normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
+            if isinstance(ref, str):
+                if ref.startswith("#/definitions/"):
+                    normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
+                elif ref.startswith("#/properties/") and isinstance(root, dict):
+                    # Resolve property-local $ref by walking the root's properties tree
+                    resolved = _resolve_json_pointer(root, ref[1:])
+                    if resolved is not None:
+                        # Inline the resolved schema at this node (keep other
+                        # keywords from the parent so required/default etc.
+                        # survive; $ref is replaced with the inlined schema).
+                        normalized.pop("$ref")
+                        resolved_copy = _rewrite_local_refs(
+                            copy.deepcopy(resolved), root
+                        )
+                        if isinstance(resolved_copy, dict):
+                            for rk, rv in resolved_copy.items():
+                                if rk not in normalized:
+                                    normalized[rk] = rv
             return normalized
         if isinstance(node, list):
-            return [_rewrite_local_refs(item) for item in node]
+            return [_rewrite_local_refs(item, root) for item in node]
         return node
+
+    def _resolve_json_pointer(root, pointer):
+        """Resolve a JSON Pointer (RFC 6901) within *root*, or return None."""
+        if not pointer or not isinstance(root, (dict, list)):
+            return None
+        parts = pointer.lstrip("/").split("/")
+        current = root
+        for part in parts:
+            part = part.replace("~1", "/").replace("~0", "~")
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            elif isinstance(current, list):
+                try:
+                    idx = int(part)
+                    current = current[idx]
+                except (ValueError, IndexError):
+                    return None
+            else:
+                return None
+        return current
 
     def _strip_nullable_union(node):
         """Collapse JSON Schema nullable unions to provider-safe non-null schemas.


### PR DESCRIPTION
## Problem

The MCP normalizer in `tools/mcp_tool.py` already handled `#/definitions/X` refs by rewriting to `#/$defs/X`. However, some MCP servers (notably Photopea) emit schemas with **property-local cross-references** like `"$ref": "#/properties/strokeColor"` — where one property references another property in the same schema. These JSON Pointer refs were passed through unchanged.

When the normalized schema reached the Moonshot provider (`agent/moonshot_schema.py`), any `$ref` value not starting with `#/$defs/` triggered an **HTTP 400 BadRequest** from the Moonshot API. This caused a cascade of failed API calls, fallback storms, and ultimately gateway instability.

## Fix — Two Layers

### Layer 1: MCP Normalizer (`tools/mcp_tool.py`)
Extended `_rewrite_local_refs` with RFC 6901 JSON Pointer resolution via a new `_resolve_json_pointer` helper. When the normalizer encounters `$ref: "#/properties/X"`, it walks the schema tree to locate property `X` and **inlines its schema** directly into the referencing location. This eliminates all property-local refs before any provider ever sees them.

Also added `import copy` for safe deepcopy operations during schema mutation.

### Layer 2: Moonshot Safety Net (`agent/moonshot_schema.py`)
Added defense-in-depth in `_repair_schema` Rule 4: any `$ref` value that does not start with `#/$defs/` or `#/definitions/` is **stripped** and `_fill_missing_type` infers a replacement schema from context. This guarantees that even if a future MCP server emits an unexpected ref pattern, the Moonshot provider will never again throw HTTP 400 on schema submission.

Also added `#/definitions/` → `#/$defs/` rewriting in Rule 4 for consistency.

## Testing

- 235 existing tests pass (42 moonshot + 193 MCP tool)
- Smoke-tested with Photopea `$ref: "#/properties/strokeColor"` pattern — correctly inlined to a string schema with `pattern /^#[0-9a-fA-F]{6}$/`
- Full pipeline: MCP normalize → Moonshot sanitize produces only `#/$defs/...` refs

## Impact

- Fixes gateway crashes when using Photopea MCP tools with Moonshot-backed models (kimi-k2.6, etc.)
- Provider-agnostic: Layer 1 benefits ALL providers, Layer 2 prevents future Moonshot-specific failures
- No breaking changes to existing schema handling

Signed-off-by: Volmarr <hrabanazviking>