### PR TITLE
fix: handle Codex auxiliary stream read failures

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -619,6 +619,237 @@ class _CodexCompletionsAdapter:
         self._client = real_client
         self._model = model
 
+    @staticmethod
+    def _walk_exception_chain(exc: Exception) -> List[Any]:
+        seen: set[int] = set()
+        stack: List[Any] = [exc]
+        out: List[Any] = []
+        while stack:
+            current = stack.pop()
+            obj_id = id(current)
+            if obj_id in seen:
+                continue
+            seen.add(obj_id)
+            out.append(current)
+            for attr in ("__cause__", "__context__"):
+                nested = getattr(current, attr, None)
+                if nested is not None:
+                    stack.append(nested)
+            for arg in getattr(current, "args", ()):
+                if isinstance(arg, BaseException):
+                    stack.append(arg)
+        return out
+
+    @classmethod
+    def _responses_stream_rejected_event_order(cls, exc: Exception) -> bool:
+        """True when the SDK stream helper rejects a pre-created custom event.
+
+        codex-lb can emit ``codex.rate_limits`` before ``response.created``.
+        The OpenAI SDK's ``responses.stream()`` helper enforces OpenAI event
+        ordering and raises before consumers can ignore that custom frame.
+        ``responses.create(stream=True)`` yields events without that helper
+        state machine, so it is a safe fallback for auxiliary summarization.
+        """
+        for current in cls._walk_exception_chain(exc):
+            text = str(current)
+            if (
+                "Expected to have received" in text
+                and "response.created" in text
+            ):
+                return True
+        return False
+
+    @classmethod
+    def _responses_stream_read_failed(cls, exc: Exception) -> bool:
+        """True for broken SSE reads where a non-stream retry is safer.
+
+        Some custom Responses-compatible proxies can accept the request and then
+        close the streaming socket while httpx/httpcore is iterating it.  The
+        OpenAI SDK surfaces this as ReadError/OSError text such as
+        ``[Errno 9] Bad file descriptor``.  Retrying the same request with
+        streaming still exercises the fragile path; a plain non-stream
+        ``responses.create`` avoids the SSE reader entirely.
+        """
+        needles = (
+            "bad file descriptor",
+            "readerror",
+            "connection reset",
+            "connection aborted",
+            "incomplete chunked read",
+            "response ended prematurely",
+            "peer closed connection",
+            "unexpected eof",
+        )
+        for current in cls._walk_exception_chain(exc):
+            text = f"{current.__class__.__name__}: {current}".lower()
+            if any(needle in text for needle in needles):
+                return True
+        return False
+
+    @staticmethod
+    def _item_get(obj: Any, key: str, default: Any = None) -> Any:
+        val = getattr(obj, key, None)
+        if val is None and isinstance(obj, dict):
+            val = obj.get(key, default)
+        return val if val is not None else default
+
+    def _backfill_empty_output(
+        self,
+        final: Any,
+        *,
+        collected_output_items: List[Any],
+        collected_text_deltas: List[str],
+        has_function_calls: bool,
+        source: str,
+    ) -> None:
+        _output = getattr(final, "output", None)
+        if not (isinstance(_output, list) and not _output):
+            return
+        if collected_output_items:
+            final.output = list(collected_output_items)
+            logger.debug(
+                "Codex auxiliary %s: backfilled %d output items",
+                source,
+                len(collected_output_items),
+            )
+        elif collected_text_deltas and not has_function_calls:
+            # Only synthesize text when no tool calls were streamed —
+            # a function_call response with incidental text should not
+            # be collapsed into a plain-text message.
+            assembled = "".join(collected_text_deltas)
+            final.output = [SimpleNamespace(
+                type="message", role="assistant", status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )]
+            logger.debug(
+                "Codex auxiliary %s: synthesized from %d deltas (%d chars)",
+                source,
+                len(collected_text_deltas),
+                len(assembled),
+            )
+
+    def _responses_create_stream_fallback(
+        self,
+        resp_kwargs: Dict[str, Any],
+        *,
+        check_cancelled,
+    ) -> Any:
+        fallback_kwargs = dict(resp_kwargs)
+        fallback_kwargs["stream"] = True
+        stream_or_response = self._client.responses.create(**fallback_kwargs)
+
+        if hasattr(stream_or_response, "output"):
+            return stream_or_response
+        if not hasattr(stream_or_response, "__iter__"):
+            return stream_or_response
+
+        terminal_response = None
+        collected_output_items: List[Any] = []
+        collected_text_deltas: List[str] = []
+        has_function_calls = False
+        try:
+            for event in stream_or_response:
+                check_cancelled()
+                event_type = self._item_get(event, "type", "")
+                if event_type == "response.output_item.done":
+                    done_item = self._item_get(event, "item")
+                    if done_item is not None:
+                        collected_output_items.append(done_item)
+                elif "output_text.delta" in event_type:
+                    delta = self._item_get(event, "delta", "")
+                    if delta:
+                        collected_text_deltas.append(delta)
+                elif "function_call" in event_type:
+                    has_function_calls = True
+
+                if event_type not in {
+                    "response.completed",
+                    "response.incomplete",
+                    "response.failed",
+                }:
+                    continue
+
+                terminal_response = self._item_get(event, "response")
+                if terminal_response is not None:
+                    self._backfill_empty_output(
+                        terminal_response,
+                        collected_output_items=collected_output_items,
+                        collected_text_deltas=collected_text_deltas,
+                        has_function_calls=has_function_calls,
+                        source="create(stream=True) fallback",
+                    )
+                    return terminal_response
+        finally:
+            close_fn = getattr(stream_or_response, "close", None)
+            if callable(close_fn):
+                try:
+                    close_fn()
+                except Exception:
+                    pass
+
+        if terminal_response is not None:
+            return terminal_response
+        raise RuntimeError(
+            "Responses create(stream=True) fallback did not emit a terminal response."
+        )
+
+    def _responses_create_nonstream_fallback(self, resp_kwargs: Dict[str, Any]) -> Any:
+        fallback_kwargs = dict(resp_kwargs)
+        fallback_kwargs["stream"] = False
+        final = self._client.responses.create(**fallback_kwargs)
+        if hasattr(final, "output"):
+            return final
+        raise RuntimeError(
+            "Responses create(stream=False) fallback did not return a response object."
+        )
+
+    def _to_chat_completion_response(self, final: Any, *, model: str) -> Any:
+        text_parts: List[str] = []
+        tool_calls_raw: List[Any] = []
+        usage = None
+
+        for item in getattr(final, "output", []):
+            item_type = self._item_get(item, "type")
+            if item_type == "message":
+                for part in (self._item_get(item, "content") or []):
+                    ptype = self._item_get(part, "type")
+                    if ptype in {"output_text", "text"}:
+                        text_parts.append(self._item_get(part, "text", ""))
+            elif item_type == "function_call":
+                tool_calls_raw.append(SimpleNamespace(
+                    id=self._item_get(item, "call_id", ""),
+                    type="function",
+                    function=SimpleNamespace(
+                        name=self._item_get(item, "name", ""),
+                        arguments=self._item_get(item, "arguments", "{}"),
+                    ),
+                ))
+
+        resp_usage = getattr(final, "usage", None)
+        if resp_usage:
+            usage = SimpleNamespace(
+                prompt_tokens=getattr(resp_usage, "input_tokens", 0),
+                completion_tokens=getattr(resp_usage, "output_tokens", 0),
+                total_tokens=getattr(resp_usage, "total_tokens", 0),
+            )
+
+        content = "".join(text_parts).strip() or None
+        message = SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls_raw or None,
+        )
+        choice = SimpleNamespace(
+            index=0,
+            message=message,
+            finish_reason="stop" if not tool_calls_raw else "tool_calls",
+        )
+        return SimpleNamespace(
+            choices=[choice],
+            model=model,
+            usage=usage,
+        )
+
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
@@ -708,9 +939,6 @@ class _CodexCompletionsAdapter:
                 resp_kwargs["tools"] = converted
 
         # Stream and collect the response
-        text_parts: List[str] = []
-        tool_calls_raw: List[Any] = []
-        usage = None
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
@@ -782,89 +1010,51 @@ class _CodexCompletionsAdapter:
                 _check_cancelled()
                 final = stream.get_final_response()
 
-            # Backfill empty output from collected stream events
-            _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
-                    final.output = list(collected_output_items)
-                    logger.debug(
-                        "Codex auxiliary: backfilled %d output items from stream events",
-                        len(collected_output_items),
-                    )
-                elif collected_text_deltas and not has_function_calls:
-                    # Only synthesize text when no tool calls were streamed —
-                    # a function_call response with incidental text should not
-                    # be collapsed into a plain-text message.
-                    assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
-                    logger.debug(
-                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
-                        len(collected_text_deltas), len(assembled),
-                    )
-
-            # Extract text and tool calls from the Responses output.
-            # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
-            # so use a helper that handles both shapes.
-            def _item_get(obj: Any, key: str, default: Any = None) -> Any:
-                val = getattr(obj, key, None)
-                if val is None and isinstance(obj, dict):
-                    val = obj.get(key, default)
-                return val if val is not None else default
-
-            for item in getattr(final, "output", []):
-                item_type = _item_get(item, "type")
-                if item_type == "message":
-                    for part in (_item_get(item, "content") or []):
-                        ptype = _item_get(part, "type")
-                        if ptype in {"output_text", "text"}:
-                            text_parts.append(_item_get(part, "text", ""))
-                elif item_type == "function_call":
-                    tool_calls_raw.append(SimpleNamespace(
-                        id=_item_get(item, "call_id", ""),
-                        type="function",
-                        function=SimpleNamespace(
-                            name=_item_get(item, "name", ""),
-                            arguments=_item_get(item, "arguments", "{}"),
-                        ),
-                    ))
-
-            resp_usage = getattr(final, "usage", None)
-            if resp_usage:
-                usage = SimpleNamespace(
-                    prompt_tokens=getattr(resp_usage, "input_tokens", 0),
-                    completion_tokens=getattr(resp_usage, "output_tokens", 0),
-                    total_tokens=getattr(resp_usage, "total_tokens", 0),
-                )
+            self._backfill_empty_output(
+                final,
+                collected_output_items=collected_output_items,
+                collected_text_deltas=collected_text_deltas,
+                has_function_calls=has_function_calls,
+                source="stream",
+            )
+            return self._to_chat_completion_response(final, model=model)
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
+            if self._responses_stream_rejected_event_order(exc):
+                logger.debug(
+                    "Codex auxiliary Responses stream helper rejected event order; "
+                    "falling back to create(stream=True): %s",
+                    exc,
+                )
+                try:
+                    final = self._responses_create_stream_fallback(
+                        resp_kwargs,
+                        check_cancelled=_check_cancelled,
+                    )
+                except Exception as fallback_exc:
+                    if not self._responses_stream_read_failed(fallback_exc):
+                        raise
+                    logger.warning(
+                        "Codex auxiliary create(stream=True) fallback failed while "
+                        "reading SSE; retrying once without streaming: %s",
+                        fallback_exc,
+                    )
+                    final = self._responses_create_nonstream_fallback(resp_kwargs)
+                return self._to_chat_completion_response(final, model=model)
+            if self._responses_stream_read_failed(exc):
+                logger.warning(
+                    "Codex auxiliary Responses stream failed while reading SSE; "
+                    "retrying once without streaming: %s",
+                    exc,
+                )
+                final = self._responses_create_nonstream_fallback(resp_kwargs)
+                return self._to_chat_completion_response(final, model=model)
             logger.debug("Codex auxiliary Responses API call failed: %s", exc)
             raise
         finally:
             if timeout_timer is not None:
                 timeout_timer.cancel()
-
-        content = "".join(text_parts).strip() or None
-
-        # Build a response that looks like chat.completions
-        message = SimpleNamespace(
-            role="assistant",
-            content=content,
-            tool_calls=tool_calls_raw or None,
-        )
-        choice = SimpleNamespace(
-            index=0,
-            message=message,
-            finish_reason="stop" if not tool_calls_raw else "tool_calls",
-        )
-        return SimpleNamespace(
-            choices=[choice],
-            model=model,
-            usage=usage,
-        )
 
 
 class _CodexChatShim:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6935,6 +6935,38 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
+    @staticmethod
+    def _codex_stream_rejected_event_order(exc: BaseException) -> bool:
+        """Detect OpenAI SDK rejection of custom SSE events before creation.
+
+        codex-lb can emit ``codex.rate_limits`` before ``response.created``.
+        The SDK's ``responses.stream()`` helper treats that as an invalid
+        event order, while ``responses.create(stream=True)`` lets Hermes ignore
+        the custom frame and collect the terminal response.
+        """
+        seen: set[int] = set()
+        stack: list[BaseException] = [exc]
+        while stack:
+            current = stack.pop()
+            obj_id = id(current)
+            if obj_id in seen:
+                continue
+            seen.add(obj_id)
+            text = str(current)
+            if (
+                "Expected to have received" in text
+                and "response.created" in text
+            ):
+                return True
+            for attr in ("__cause__", "__context__"):
+                nested = getattr(current, attr, None)
+                if isinstance(nested, BaseException):
+                    stack.append(nested)
+            for arg in getattr(current, "args", ()):
+                if isinstance(arg, BaseException):
+                    stack.append(arg)
+        return False
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
@@ -7042,6 +7074,14 @@ class AIAgent:
                 )
                 return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             except RuntimeError as exc:
+                if self._codex_stream_rejected_event_order(exc):
+                    logger.debug(
+                        "Responses stream helper rejected event order; falling back "
+                        "to create(stream=True). %s error=%s",
+                        self._client_log_context(),
+                        exc,
+                    )
+                    return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text
                 if missing_completed and attempt < max_stream_retries:
@@ -7056,6 +7096,16 @@ class AIAgent:
                     logger.debug(
                         "Responses stream did not emit response.completed; falling back to create(stream=True). %s",
                         self._client_log_context(),
+                    )
+                    return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                raise
+            except Exception as exc:
+                if self._codex_stream_rejected_event_order(exc):
+                    logger.debug(
+                        "Responses stream helper rejected event order; falling back "
+                        "to create(stream=True). %s error=%s",
+                        self._client_log_context(),
+                        exc,
                     )
                     return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 raise

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2046,6 +2046,173 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 class TestCodexAuxiliaryAdapterTimeout:
+    def test_stream_helper_event_order_error_falls_back_to_create_stream(self):
+        class BrokenStream:
+            def __enter__(self):
+                inner = RuntimeError(
+                    "Expected to have received "
+                    "`response.created` before `codex.rate_limits`"
+                )
+                outer = RuntimeError("API call failed after 3 retries: Connection error.")
+                outer.__cause__ = inner
+                raise outer
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeCreateStream:
+            closed = False
+
+            def __iter__(self):
+                return iter((
+                    SimpleNamespace(type="codex.rate_limits", rate_limits={}),
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(type="response.output_text.delta", delta="summary"),
+                    SimpleNamespace(
+                        type="response.completed",
+                        response=SimpleNamespace(
+                            output=[],
+                            usage=SimpleNamespace(
+                                input_tokens=3,
+                                output_tokens=1,
+                                total_tokens=4,
+                            ),
+                        ),
+                    ),
+                ))
+
+            def close(self):
+                self.closed = True
+
+        class FakeResponses:
+            def __init__(self):
+                self.stream_kwargs = None
+                self.create_kwargs = None
+                self.create_stream = FakeCreateStream()
+
+            def stream(self, **kwargs):
+                self.stream_kwargs = kwargs
+                return BrokenStream()
+
+            def create(self, **kwargs):
+                self.create_kwargs = kwargs
+                return self.create_stream
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=12.5,
+        )
+
+        assert fake_client.responses.create_kwargs["stream"] is True
+        assert fake_client.responses.create_kwargs["timeout"] == 12.5
+        assert fake_client.responses.create_stream.closed is True
+        assert response.choices[0].message.content == "summary"
+        assert response.usage.total_tokens == 4
+
+    def test_read_error_falls_back_to_nonstream_create(self):
+        class BrokenStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                raise OSError(9, "Bad file descriptor")
+
+            def get_final_response(self):
+                raise AssertionError("stream should fail before final response")
+
+        class FakeResponses:
+            def __init__(self):
+                self.stream_kwargs = None
+                self.create_kwargs = []
+
+            def stream(self, **kwargs):
+                self.stream_kwargs = kwargs
+                return BrokenStream()
+
+            def create(self, **kwargs):
+                self.create_kwargs.append(kwargs)
+                assert kwargs.get("stream") is False
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="nonstream ok")],
+                    )],
+                    usage=SimpleNamespace(input_tokens=3, output_tokens=2, total_tokens=5),
+                )
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=12.5,
+        )
+
+        assert fake_client.responses.create_kwargs[0]["stream"] is False
+        assert fake_client.responses.create_kwargs[0]["timeout"] == 12.5
+        assert response.choices[0].message.content == "nonstream ok"
+        assert response.usage.total_tokens == 5
+
+    def test_event_order_stream_fallback_read_error_uses_nonstream(self):
+        class BrokenInitialStream:
+            def __enter__(self):
+                inner = RuntimeError(
+                    "Expected to have received "
+                    "`response.created` before `codex.rate_limits`"
+                )
+                outer = RuntimeError("API call failed after 3 retries: Connection error.")
+                outer.__cause__ = inner
+                raise outer
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class BrokenCreateStream:
+            closed = False
+
+            def __iter__(self):
+                raise OSError(9, "Bad file descriptor")
+
+            def close(self):
+                self.closed = True
+
+        class FakeResponses:
+            def __init__(self):
+                self.create_kwargs = []
+                self.create_stream = BrokenCreateStream()
+
+            def stream(self, **kwargs):
+                return BrokenInitialStream()
+
+            def create(self, **kwargs):
+                self.create_kwargs.append(kwargs)
+                if kwargs.get("stream") is True:
+                    return self.create_stream
+                assert kwargs.get("stream") is False
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="nonstream after bfd")],
+                    )],
+                    usage=SimpleNamespace(input_tokens=4, output_tokens=3, total_tokens=7),
+                )
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize this"}])
+
+        assert [call["stream"] for call in fake_client.responses.create_kwargs] == [True, False]
+        assert fake_client.responses.create_stream.closed is True
+        assert response.choices[0].message.content == "nonstream after bfd"
+        assert response.usage.total_tokens == 7
+
     def test_forwards_timeout_to_responses_stream(self):
         class FakeStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -449,6 +449,53 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert response.output[0].content[0].text == "create fallback ok"
 
 
+def test_run_codex_stream_falls_back_when_custom_event_precedes_created(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="codex.rate_limits", state={}),
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(
+                type="response.completed",
+                response=_codex_message_response("event-order fallback ok"),
+            ),
+        ]
+    )
+
+    class BrokenStream:
+        def __enter__(self):
+            calls["stream"] += 1
+            inner = RuntimeError(
+                "Expected to have received `response.created` before "
+                "`codex.rate_limits`"
+            )
+            outer = RuntimeError("API call failed after 3 retries: Connection error.")
+            outer.__cause__ = inner
+            raise outer
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: BrokenStream(),
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls == {"stream": 1, "create": 1}
+    assert create_stream.closed is True
+    assert response.output[0].content[0].text == "event-order fallback ok"
+
+
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0, "create": 0}


### PR DESCRIPTION
## Summary
- Detect Codex/Responses auxiliary streaming read failures such as `[Errno 9] Bad file descriptor`
- Retry failed auxiliary compression calls once with non-streaming `responses.create(stream=False)`
- Preserve the existing custom-event-order fallback path for `codex.rate_limits` before `response.created`
- Add regression coverage for direct read failures and event-order fallback read failures

## Verification
- `python -m pytest tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
- Live compression probe returned successfully through the current `codex-lb` config

## Notes
This branch intentionally commits only the compression/Codex fallback fix files. Existing local changes to `RELEASE_v0.13.0.md` and `ui-tui/package-lock.json` were left unstaged.
