### PR TITLE
Add per-user USER.md isolation in MemoryStore

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1448,6 +1448,8 @@ def init_agent(
                 agent._memory_store = MemoryStore(
                     memory_char_limit=mem_config.get("memory_char_limit", 2200),
                     user_char_limit=mem_config.get("user_char_limit", 1375),
+                    user_id=user_id,
+                    platform=platform,
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1930,6 +1930,8 @@ def init_agent(
                     user_char_limit=mem_config.get("user_char_limit", 1375),
                     memory_enabled=agent._memory_enabled,
                     user_profile_enabled=agent._user_profile_enabled,
+                    user_id=user_id,
+                    platform=platform,
                 )
                 agent._memory_store.load_from_disk()
         except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3023,7 +3023,12 @@ class GatewaySlashCommandsMixin:
         # Apply approved writes against a fresh on-disk store (the gateway has
         # no long-lived agent; the store persists to the same MEMORY/USER.md).
         # load_on_disk_store() honors the user's configured char limits.
-        store = load_on_disk_store()
+        # Pass the sender's platform identity so approved target="user" writes
+        # land in the same per-user USER.md partition the live agent uses.
+        store = load_on_disk_store(
+            user_id=getattr(event.source, "user_id", None),
+            platform=getattr(event.source, "platform", None),
+        )
 
         out = handle_pending_subcommand(
             wa.MEMORY, args, memory_store=store, set_mode_fn=_set_approval,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4018,7 +4018,12 @@ class GatewaySlashCommandsMixin:
         # Apply approved writes against a fresh on-disk store (the gateway has
         # no long-lived agent; the store persists to the same MEMORY/USER.md).
         # load_on_disk_store() honors the user's configured char limits.
-        store = load_on_disk_store()
+        # Pass the sender's platform identity so approved target="user" writes
+        # land in the same per-user USER.md partition the live agent uses.
+        store = load_on_disk_store(
+            user_id=getattr(event.source, "user_id", None),
+            platform=getattr(event.source, "platform", None),
+        )
 
         out = handle_pending_subcommand(
             wa.MEMORY, args, memory_store=store, set_mode_fn=_set_approval,

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
+    load_on_disk_store,
+    safe_user_key,
     _scan_memory_content,
     MEMORY_SCHEMA,
 )
@@ -915,3 +917,130 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Per-user USER.md isolation (#27182)
+#
+# When a platform user identity is present, USER.md is partitioned at
+# memories/users/<safe_key>/USER.md so one gateway user's preferences never
+# leak into another user's conversations. MEMORY.md stays global. No
+# identity (TUI, one-shot, single-user default) keeps the global USER.md —
+# byte-for-byte the old behavior.
+# =========================================================================
+
+
+def _make_store(tmp_path, monkeypatch, **kwargs):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    s = MemoryStore(memory_char_limit=500, user_char_limit=300, **kwargs)
+    s.load_from_disk()
+    return s
+
+
+class TestSafeUserKey:
+    def test_safe_token_passes_through(self):
+        assert safe_user_key("U03G89W2A10") == "U03G89W2A10"
+        assert safe_user_key("123456789") == "123456789"
+
+    def test_platform_qualification(self):
+        assert safe_user_key("12345", "telegram") == "telegram-12345"
+        assert safe_user_key("12345", "discord") == "discord-12345"
+        # Same raw ID on two platforms → distinct keys (no collision).
+        assert safe_user_key("12345", "telegram") != safe_user_key("12345", "discord")
+
+    def test_traversal_and_separator_ids_are_hashed(self):
+        for hostile in ("../../etc/passwd", "..", ".", "a/b", "a\\b",
+                        "user:with:colons", "name with spaces", "e@mail.com"):
+            key = safe_user_key(hostile)
+            assert key.startswith("h-"), hostile
+            assert "/" not in key and "\\" not in key and ".." not in key
+
+    def test_unicode_id_is_hashed(self):
+        key = safe_user_key("\u7528\u6237\u540d")
+        assert key.startswith("h-")
+
+    def test_hashing_is_stable(self):
+        assert safe_user_key("a/b", "slack") == safe_user_key("a/b", "slack")
+
+    def test_hostile_platform_forces_hash_even_with_safe_id(self):
+        key = safe_user_key("U123", "../evil")
+        assert key.startswith("h-")
+
+    def test_overlong_id_is_hashed(self):
+        key = safe_user_key("x" * 65)
+        assert key.startswith("h-")
+        assert len(key) <= 64
+
+
+class TestPerUserIsolation:
+    def test_no_user_id_uses_global_paths(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch)
+        assert store._path_for("user") == tmp_path / "USER.md"
+        assert store._path_for("memory") == tmp_path / "MEMORY.md"
+
+    def test_user_id_partitions_user_md_only(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="U_ALICE", platform="slack")
+        assert store._path_for("user") == tmp_path / "users" / "slack-U_ALICE" / "USER.md"
+        # MEMORY.md stays global regardless of identity.
+        assert store._path_for("memory") == tmp_path / "MEMORY.md"
+
+    def test_empty_user_id_falls_back_to_global(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="")
+        assert store._path_for("user") == tmp_path / "USER.md"
+
+    def test_two_users_are_isolated_round_trip(self, tmp_path, monkeypatch):
+        alice = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        assert alice.add("user", "Prefers metric units.")["success"] is True
+
+        bob = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert bob.user_entries == []
+        assert bob.add("user", "Prefers imperial units.")["success"] is True
+
+        # Reload each from disk — entries stayed in their own partitions.
+        alice2 = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        assert alice2.user_entries == ["Prefers metric units."]
+        bob2 = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert bob2.user_entries == ["Prefers imperial units."]
+
+        # Global USER.md untouched by either user's writes.
+        no_id = _make_store(tmp_path, monkeypatch)
+        assert no_id.user_entries == []
+
+    def test_global_memory_shared_across_users(self, tmp_path, monkeypatch):
+        alice = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        alice.add("memory", "Project uses Python 3.12.")
+        bob = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert "Project uses Python 3.12." in bob.memory_entries
+
+    def test_traversal_id_stays_inside_memory_dir(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="../../escape")
+        user_path = store._path_for("user").resolve()
+        assert user_path.is_relative_to(tmp_path.resolve())
+        assert user_path.parent.parent == (tmp_path / "users").resolve()
+        # Writes land inside the partition, not at the escaped location.
+        assert store.add("user", "Safe entry.")["success"] is True
+        assert user_path.exists()
+
+    def test_load_from_disk_creates_partition_dir(self, tmp_path, monkeypatch):
+        _make_store(tmp_path, monkeypatch, user_id="U_NEW")
+        assert (tmp_path / "users" / "U_NEW").is_dir()
+
+
+class TestLoadOnDiskStoreIdentity:
+    """The gateway /memory approval path must write to the same per-user
+    partition the live agent uses (review blocker on #27183)."""
+
+    def test_identity_scoped_store_matches_agent_partition(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        agent_store = MemoryStore(user_id="U_CARL", platform="slack")
+        agent_store.load_from_disk()
+        agent_store.add("user", "Wants weekly summaries.")
+
+        approval_store = load_on_disk_store(user_id="U_CARL", platform="slack")
+        assert approval_store._path_for("user") == agent_store._path_for("user")
+        assert "Wants weekly summaries." in approval_store.user_entries
+
+    def test_no_identity_store_keeps_global_behavior(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = load_on_disk_store()
+        assert store._path_for("user") == tmp_path / "USER.md"

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
+    load_on_disk_store,
+    safe_user_key,
     _scan_memory_content,
 )
 
@@ -706,3 +708,130 @@ class TestBomToleranceInMemoryFiles:
         raw, read_ok = MemoryStore._read_raw_checked(path)
         assert read_ok is False
         assert raw == ""
+
+
+# =========================================================================
+# Per-user USER.md isolation (#27182)
+#
+# When a platform user identity is present, USER.md is partitioned at
+# memories/users/<safe_key>/USER.md so one gateway user's preferences never
+# leak into another user's conversations. MEMORY.md stays global. No
+# identity (TUI, one-shot, single-user default) keeps the global USER.md —
+# byte-for-byte the old behavior.
+# =========================================================================
+
+
+def _make_store(tmp_path, monkeypatch, **kwargs):
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+    s = MemoryStore(memory_char_limit=500, user_char_limit=300, **kwargs)
+    s.load_from_disk()
+    return s
+
+
+class TestSafeUserKey:
+    def test_safe_token_passes_through(self):
+        assert safe_user_key("U03G89W2A10") == "U03G89W2A10"
+        assert safe_user_key("123456789") == "123456789"
+
+    def test_platform_qualification(self):
+        assert safe_user_key("12345", "telegram") == "telegram-12345"
+        assert safe_user_key("12345", "discord") == "discord-12345"
+        # Same raw ID on two platforms → distinct keys (no collision).
+        assert safe_user_key("12345", "telegram") != safe_user_key("12345", "discord")
+
+    def test_traversal_and_separator_ids_are_hashed(self):
+        for hostile in ("../../etc/passwd", "..", ".", "a/b", "a\\b",
+                        "user:with:colons", "name with spaces", "e@mail.com"):
+            key = safe_user_key(hostile)
+            assert key.startswith("h-"), hostile
+            assert "/" not in key and "\\" not in key and ".." not in key
+
+    def test_unicode_id_is_hashed(self):
+        key = safe_user_key("\u7528\u6237\u540d")
+        assert key.startswith("h-")
+
+    def test_hashing_is_stable(self):
+        assert safe_user_key("a/b", "slack") == safe_user_key("a/b", "slack")
+
+    def test_hostile_platform_forces_hash_even_with_safe_id(self):
+        key = safe_user_key("U123", "../evil")
+        assert key.startswith("h-")
+
+    def test_overlong_id_is_hashed(self):
+        key = safe_user_key("x" * 65)
+        assert key.startswith("h-")
+        assert len(key) <= 64
+
+
+class TestPerUserIsolation:
+    def test_no_user_id_uses_global_paths(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch)
+        assert store._path_for("user") == tmp_path / "USER.md"
+        assert store._path_for("memory") == tmp_path / "MEMORY.md"
+
+    def test_user_id_partitions_user_md_only(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="U_ALICE", platform="slack")
+        assert store._path_for("user") == tmp_path / "users" / "slack-U_ALICE" / "USER.md"
+        # MEMORY.md stays global regardless of identity.
+        assert store._path_for("memory") == tmp_path / "MEMORY.md"
+
+    def test_empty_user_id_falls_back_to_global(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="")
+        assert store._path_for("user") == tmp_path / "USER.md"
+
+    def test_two_users_are_isolated_round_trip(self, tmp_path, monkeypatch):
+        alice = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        assert alice.add("user", "Prefers metric units.")["success"] is True
+
+        bob = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert bob.user_entries == []
+        assert bob.add("user", "Prefers imperial units.")["success"] is True
+
+        # Reload each from disk — entries stayed in their own partitions.
+        alice2 = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        assert alice2.user_entries == ["Prefers metric units."]
+        bob2 = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert bob2.user_entries == ["Prefers imperial units."]
+
+        # Global USER.md untouched by either user's writes.
+        no_id = _make_store(tmp_path, monkeypatch)
+        assert no_id.user_entries == []
+
+    def test_global_memory_shared_across_users(self, tmp_path, monkeypatch):
+        alice = _make_store(tmp_path, monkeypatch, user_id="U_ALICE")
+        alice.add("memory", "Project uses Python 3.12.")
+        bob = _make_store(tmp_path, monkeypatch, user_id="U_BOB")
+        assert "Project uses Python 3.12." in bob.memory_entries
+
+    def test_traversal_id_stays_inside_memory_dir(self, tmp_path, monkeypatch):
+        store = _make_store(tmp_path, monkeypatch, user_id="../../escape")
+        user_path = store._path_for("user").resolve()
+        assert user_path.is_relative_to(tmp_path.resolve())
+        assert user_path.parent.parent == (tmp_path / "users").resolve()
+        # Writes land inside the partition, not at the escaped location.
+        assert store.add("user", "Safe entry.")["success"] is True
+        assert user_path.exists()
+
+    def test_load_from_disk_creates_partition_dir(self, tmp_path, monkeypatch):
+        _make_store(tmp_path, monkeypatch, user_id="U_NEW")
+        assert (tmp_path / "users" / "U_NEW").is_dir()
+
+
+class TestLoadOnDiskStoreIdentity:
+    """The gateway /memory approval path must write to the same per-user
+    partition the live agent uses (review blocker on #27183)."""
+
+    def test_identity_scoped_store_matches_agent_partition(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        agent_store = MemoryStore(user_id="U_CARL", platform="slack")
+        agent_store.load_from_disk()
+        agent_store.add("user", "Wants weekly summaries.")
+
+        approval_store = load_on_disk_store(user_id="U_CARL", platform="slack")
+        assert approval_store._path_for("user") == agent_store._path_for("user")
+        assert "Wants weekly summaries." in approval_store.user_entries
+
+    def test_no_identity_store_keeps_global_behavior(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = load_on_disk_store()
+        assert store._path_for("user") == tmp_path / "USER.md"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,9 +23,11 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 from contextlib import contextmanager
@@ -120,6 +122,29 @@ def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
     }
 
 
+_SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def safe_user_key(user_id: str, platform=None) -> str:
+    """Collapse a platform-supplied user identifier into a filesystem-safe,
+    platform-qualified directory name.
+
+    Platform IDs that are already safe tokens (Slack ``U03G89W2A10``, Telegram
+    numeric IDs, Discord snowflakes) stay human-readable — qualified as
+    ``<platform>-<id>`` when the platform is known so equal raw IDs from
+    different platforms can never collide. Anything else (emails, unicode
+    display handles, hostile values like ``../../etc``) is reduced to a stable
+    ``h-<sha256[:20]>`` digest, so an attacker-controlled identifier can never
+    contribute raw path components under ``memories/users/``.
+    """
+    uid = str(user_id)
+    plat = str(platform) if platform else None
+    if _SAFE_KEY_RE.fullmatch(uid) and (plat is None or _SAFE_KEY_RE.fullmatch(plat)):
+        return f"{plat}-{uid}" if plat else uid
+    raw = f"{plat or ''}:{uid}"
+    return "h-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
+
+
 class MemoryStore:
     """
     Bounded curated memory with file persistence. One instance per AIAgent.
@@ -137,11 +162,17 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375,
+                 user_id=None, platform=None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        # Per-user USER.md partitioning key. When a platform user identity is
+        # present, USER.md lives at memories/users/<safe_key>/USER.md so each
+        # platform user gets their own preference store. None (TUI, one-shot,
+        # single-user default) keeps the global USER.md — no behavior change.
+        self._user_key = safe_user_key(user_id, platform) if user_id else None
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -195,8 +226,14 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
+        # Ensure the per-user USER.md directory exists when partitioning is
+        # active (no-op for the global fallback: parent == mem_dir, which
+        # already exists).
+        user_path = self._path_for("user")
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.memory_entries = self._read_file(self._path_for("memory"))
+        self.user_entries = self._read_file(user_path)
 
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
@@ -287,10 +324,14 @@ class MemoryStore:
                     pass
             fd.close()
 
-    @staticmethod
-    def _path_for(target: str) -> Path:
+    def _path_for(self, target: str) -> Path:
         mem_dir = get_memory_dir()
         if target == "user":
+            # Per-user partition when a platform identity is present; global
+            # USER.md for TUI / one-shot / no-identity contexts so existing
+            # single-user deployments see no change.
+            if self._user_key:
+                return mem_dir / "users" / self._user_key / "USER.md"
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
@@ -798,8 +839,13 @@ class MemoryStore:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 
-def load_on_disk_store() -> "MemoryStore":
+def load_on_disk_store(user_id=None, platform=None) -> "MemoryStore":
     """Build a fresh on-disk :class:`MemoryStore`, honoring configured char limits.
+
+    Pass the platform user identity (``user_id`` / ``platform``) when the
+    calling context has one — e.g. the gateway ``/memory`` approval handler —
+    so approved ``target="user"`` writes land in the same per-user USER.md
+    partition the live agent uses, not the global fallback.
 
     Use this from any context that has no live agent (the messaging gateway, the
     Desktop GUI, the bare CLI ``/memory`` handler) but still needs to read or
@@ -825,6 +871,8 @@ def load_on_disk_store() -> "MemoryStore":
     store = MemoryStore(
         memory_char_limit=memory_char_limit,
         user_char_limit=user_char_limit,
+        user_id=user_id,
+        platform=platform,
     )
     store.load_from_disk()
     return store

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -24,8 +24,10 @@ Design:
 """
 
 import copy
+import hashlib
 import json
 import logging
+import re
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -156,6 +158,29 @@ def _read_failed_error(path: "Path") -> Dict[str, Any]:
     }
 
 
+_SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
+def safe_user_key(user_id: str, platform=None) -> str:
+    """Collapse a platform-supplied user identifier into a filesystem-safe,
+    platform-qualified directory name.
+
+    Platform IDs that are already safe tokens (Slack ``U03G89W2A10``, Telegram
+    numeric IDs, Discord snowflakes) stay human-readable — qualified as
+    ``<platform>-<id>`` when the platform is known so equal raw IDs from
+    different platforms can never collide. Anything else (emails, unicode
+    display handles, hostile values like ``../../etc``) is reduced to a stable
+    ``h-<sha256[:20]>`` digest, so an attacker-controlled identifier can never
+    contribute raw path components under ``memories/users/``.
+    """
+    uid = str(user_id)
+    plat = str(platform) if platform else None
+    if _SAFE_KEY_RE.fullmatch(uid) and (plat is None or _SAFE_KEY_RE.fullmatch(plat)):
+        return f"{plat}-{uid}" if plat else uid
+    raw = f"{plat or ''}:{uid}"
+    return "h-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
+
+
 class MemoryStore:
     """
     Bounded curated memory with file persistence. One instance per AIAgent.
@@ -180,6 +205,8 @@ class MemoryStore:
         *,
         memory_enabled: bool = True,
         user_profile_enabled: bool = True,
+        user_id: Optional[str] = None,
+        platform: Optional[str] = None,
     ):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
@@ -187,6 +214,11 @@ class MemoryStore:
         self.user_char_limit = user_char_limit
         self.memory_enabled = memory_enabled
         self.user_profile_enabled = user_profile_enabled
+        # Per-user USER.md partitioning key. When a platform user identity is
+        # present, USER.md lives at memories/users/<safe_key>/USER.md so each
+        # platform user gets their own preference store. None (TUI, one-shot,
+        # single-user default) keeps the global USER.md — no behavior change.
+        self._user_key = safe_user_key(user_id, platform) if user_id else None
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset
@@ -244,8 +276,14 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
+        # Ensure the per-user USER.md directory exists when partitioning is
+        # active (no-op for the global fallback: parent == mem_dir, which
+        # already exists).
+        user_path = self._path_for("user")
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.memory_entries = self._read_file(self._path_for("memory"))
+        self.user_entries = self._read_file(user_path)
 
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
@@ -336,10 +374,14 @@ class MemoryStore:
                     pass
             fd.close()
 
-    @staticmethod
-    def _path_for(target: str) -> Path:
+    def _path_for(self, target: str) -> Path:
         mem_dir = get_memory_dir()
         if target == "user":
+            # Per-user partition when a platform identity is present; global
+            # USER.md for TUI / one-shot / no-identity contexts so existing
+            # single-user deployments see no change.
+            if self._user_key:
+                return mem_dir / "users" / self._user_key / "USER.md"
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
@@ -908,8 +950,13 @@ class MemoryStore:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 
-def load_on_disk_store() -> "MemoryStore":
+def load_on_disk_store(user_id=None, platform=None) -> "MemoryStore":
     """Build a fresh on-disk :class:`MemoryStore`, honoring configured char limits.
+
+    Pass the platform user identity (``user_id`` / ``platform``) when the
+    calling context has one — e.g. the gateway ``/memory`` approval handler —
+    so approved ``target="user"`` writes land in the same per-user USER.md
+    partition the live agent uses, not the global fallback.
 
     Use this from any context that has no live agent (the messaging gateway, the
     Desktop GUI, the bare CLI ``/memory`` handler) but still needs to read or
@@ -941,6 +988,8 @@ def load_on_disk_store() -> "MemoryStore":
         user_char_limit=user_char_limit,
         memory_enabled=memory_enabled,
         user_profile_enabled=user_profile_enabled,
+        user_id=user_id,
+        platform=platform,
     )
     store.load_from_disk()
     return store


### PR DESCRIPTION
Closes #27182

## Summary

Adds optional `user_id` parameter to `MemoryStore`. When set, `USER.md` is partitioned per platform user at `<HERMES_HOME>/memories/users/<user_id>/USER.md`. When unset (TUI, one-shot, current default), falls back to the global `<HERMES_HOME>/memories/USER.md` — no behavior change.

`MEMORY.md` stays global; only the personal-preferences file is partitioned.

## Implementation

- `tools/memory_tool.py`:
  - `MemoryStore.__init__` accepts `user_id: Optional[str] = None`
  - `_path_for` converted from staticmethod to instance method; routes user-scope target to `memories/users/<user_id>/USER.md` when user_id is set
  - `load_from_disk` creates the per-user directory on demand
- `run_agent.py`:
  - `AIAgent` passes `user_id=self._user_id` when constructing its MemoryStore

## Backward compatibility

Fully backward compatible. The `user_id` parameter defaults to None, preserving current behavior for every existing call site. TUI, `hermes -z`, and any one-shot invocation continue to use the global USER.md.

## Test plan

- [x] Path resolution: `user_id=None` returns global path; `user_id="X"` returns `memories/users/X/USER.md`
- [x] `load_from_disk` creates the per-user directory on demand
- [x] Existing TUI usage unaffected — uses global path
- [x] Live test with multi-user Slack ACL: user A's preferences land in user A's per-user file, user B's land in user B's per-user file, global USER.md untouched

## Production usage

Running in production since 2026-05-15 on a multi-user Slack deployment. Surviving daily `hermes update` cycles.