### PR TITLE
fix(agent): reset _fallback_index at turn start even when no fallback activated

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9156,6 +9156,14 @@ class AIAgent:
         ``gateway/run.py``), so this restoration IS needed there too.
         """
         if not self._fallback_activated:
+            # Reset the chain index even when no fallback was activated this
+            # turn.  Without this, a turn where _try_activate_fallback() was
+            # called but returned False (chain exhausted or provider not
+            # configured) leaves _fallback_index >= len(_fallback_chain) while
+            # _fallback_activated stays False.  The next turn skips this block
+            # entirely, stranding the index and silently blocking all future
+            # fallback attempts for the session.  Fixes #20465.
+            self._fallback_index = 0
             return False
 
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -123,6 +123,26 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent._restore_primary_runtime() is False
 
+    def test_resets_index_when_fallback_not_activated(self):
+        """Regression for #20465: failed activation leaves _fallback_index advanced
+        with _fallback_activated=False; the next turn's restore must reset the index."""
+        fbs = [{"provider": "custom", "model": "gpt-oss:20b",
+                "base_url": "http://host.docker.internal:11434/v1", "api_key": "ollama"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        # resolve_provider_client returns None → _try_activate_fallback returns False
+        # but _fallback_index has already been incremented to 1
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+            assert agent._try_activate_fallback() is False
+
+        assert agent._fallback_activated is False
+        assert agent._fallback_index == 1  # advanced past the only entry
+
+        # _restore_primary_runtime must reset the index so the next turn can retry
+        result = agent._restore_primary_runtime()
+        assert result is False  # still no-op (primary was never left)
+        assert agent._fallback_index == 0  # chain available again
+
     def test_restores_model_and_provider(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
Salvage of #20793 onto current main. Preserves @konsisumer's authorship.

## Summary
Interactive CLI sessions now honor `fallback_providers` on Codex 429 `usage_limit_reached` (and all other failures), matching cron behavior.

Root cause: `_try_activate_fallback()` increments `_fallback_index` BEFORE resolving the provider's client. When every chain entry's resolver returns `None` (or raises), the recursive walk exhausts `_fallback_index` to `>= len(_fallback_chain)` but never sets `_fallback_activated = True`. Next turn, `_restore_primary_runtime()` early-returns because `_fallback_activated` is False, so the chain index stays exhausted forever. The eager-fallback check at the top of the retry loop sees the exhausted index and silently skips — no "trying fallback" log line, no status message, just 3 retries and "API call failed after 3 retries."

Cron jobs work because each cron run constructs a fresh `AIAgent` with `_fallback_index = 0`.

## Changes
- `run_agent.py`: add `self._fallback_index = 0` in the `not _fallback_activated` early-return branch of `_restore_primary_runtime()`.
- `tests/run_agent/test_primary_runtime_restore.py`: regression test exercising the failed-activation path.

## Validation
- `scripts/run_tests.sh tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_provider_fallback.py -q` → 54/54 passed.

Closes #20465. Original PR #20793.