### PR TITLE
fix(run_agent): isolate background review fork from external memory plugins

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4386,6 +4386,21 @@ class AIAgent:
                     # owns the loop and the agent-loop tools dispatch.
                     if _parent_api_mode == "codex_app_server":
                         _parent_api_mode = "codex_responses"
+                    # skip_memory=True keeps the review fork from
+                    # touching external memory plugins (honcho, mem0,
+                    # supermemory, etc.).  Without it, the fork's
+                    # __init__ rebuilds its own _memory_manager from
+                    # config, scoped to the parent's session_id, and
+                    # run_conversation() then leaks the harness prompt
+                    # into the user's real memory namespace via three
+                    # ingestion sites: on_turn_start (cadence + turn
+                    # message), prefetch_all (recall query), and
+                    # sync_all (harness prompt + review output recorded
+                    # as a (user, assistant) turn pair).  Built-in
+                    # MEMORY.md / USER.md state is re-bound from the
+                    # parent below so memory(action="add") writes from
+                    # the review still land on disk; the review just
+                    # has zero side effects on external providers.
                     review_agent = AIAgent(
                         model=self.model,
                         max_iterations=16,
@@ -4397,6 +4412,7 @@ class AIAgent:
                         api_key=_parent_runtime.get("api_key") or None,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
+                        skip_memory=True,
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -193,3 +193,51 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
     )
+
+
+def test_background_review_fork_skips_external_memory_plugins(monkeypatch):
+    """The background review fork must NOT touch external memory plugins.
+
+    Without skip_memory=True on the fork constructor, AIAgent.__init__
+    rebuilds its own _memory_manager from config, scoped to the parent's
+    session_id.  The review fork's run_conversation() then leaks the
+    harness prompt into the user's real memory namespace via three
+    ingestion sites: on_turn_start (cadence + turn message),
+    prefetch_all (recall query), and sync_all (harness prompt + review
+    output recorded as a (user, assistant) turn pair).  The fix is a
+    single kwarg on the fork constructor — this test guards it.
+    """
+    captured_kwargs: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured_kwargs.get("skip_memory") is True, (
+        "Background review fork must be constructed with skip_memory=True "
+        "so AIAgent.__init__ does not rebuild a _memory_manager wired to "
+        "external plugins (honcho, mem0, supermemory, ...).  Without this "
+        "the fork leaks harness prompts into the user's real memory "
+        "namespace via on_turn_start / prefetch_all / sync_all."
+    )


### PR DESCRIPTION
## Summary
Background memory/skill review forks no longer leak harness prompts into external memory plugin namespaces (honcho, mem0, supermemory, etc.).

Reported by @Utku — the review harness prompts (`Review the conversation above and update the skill library...`) were getting ingested by memory plugins as if they were real user conversation.

## Root cause
`_spawn_background_review()` creates a fresh `AIAgent` to do the review. That `__init__` rebuilds its own `_memory_manager` from `memory.provider` in config, scoped to the parent's `session_id`. Then `run_conversation()` triggers three ingestion sites against the user's real memory namespace:

| Site | What gets written |
|---|---|
| `on_turn_start(turn_count, prompt)` | harness prompt as the turn's user message; advances cadence |
| `prefetch_all(prompt)` | harness prompt as a recall query |
| `sync_all(prompt, review_output, session_id)` | harness prompt + review output as a `(user, assistant)` pair |

## Changes
- `run_agent.py` `_spawn_background_review()` — pass `skip_memory=True` to the fork's `AIAgent(...)` constructor
- `tests/run_agent/test_background_review.py` — regression test asserting the kwarg is set

## Why this works
`skip_memory=True` short-circuits both `_memory_store` and `_memory_manager` construction in `__init__`. The existing fork-setup block at L4310-4314 explicitly rebinds `_memory_store`, `_memory_enabled`, `_user_profile_enabled`, and the nudge intervals from the parent right after construction — so:

- Built-in `MEMORY.md` / `USER.md` writes via the `memory` tool still land on disk ✓
- Skill writes still work (skills don't go through MemoryManager at all) ✓
- All three ingestion sites short-circuit on `if self._memory_manager:` ✓
- `shutdown_memory_provider()` on the fork becomes a no-op (nothing to shut down) ✓
- Cached system prompt is still inherited verbatim from parent (prefix cache parity preserved) ✓

## Validation
| | Before | After |
|---|---|---|
| Fork `_memory_manager` (with honcho configured) | non-None, providers=['honcho'] | None |
| Fork `_memory_store` after rebinding | parent's store object | parent's store object (identity preserved) |
| Fork `_memory_enabled` after rebinding | True | True |
| `on_turn_start` / `prefetch_all` / `sync_all` gates | all evaluated | all short-circuit |
| Targeted background-review tests | 28/28 pass | 28/28 pass |

E2E verified with a stubbed honcho provider in an isolated `HERMES_HOME`: with `skip_memory=True` the fork constructs with `_memory_manager=None` even though `memory.provider=honcho` is set in config; without it, the fork builds a manager wired to the stub.

## Test plan
`scripts/run_tests.sh tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_review_prompt_class_first.py` — 28 passed.