### PR TITLE
feat(cli): support self-hosted mem0 setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,13 @@
 # Also requires ~/.honcho/config.json with enabled=true (see README).
 # HONCHO_API_KEY=
 
+# Mem0 - Cross-session memory provider (optional)
+# For Mem0 Platform, leave MEM0_HOST unset and set MEM0_API_KEY.
+# For self-hosted Mem0, set MEM0_HOST to the base URL and MEM0_API_KEY
+# to an API key or ADMIN_API_KEY.
+# MEM0_HOST=
+# MEM0_API_KEY=
+
 # =============================================================================
 # HYPERLIQUID OPTIONAL SKILL
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2284,6 +2284,20 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
     },
+    "MEM0_API_KEY": {
+        "description": "Mem0 API key for persistent memory",
+        "prompt": "Mem0 API key",
+        "url": "https://app.mem0.ai",
+        "password": True,
+        "category": "tool",
+    },
+    "MEM0_HOST": {
+        "description": "Mem0 URL (blank for Mem0 Platform)",
+        "prompt": "Mem0 URL",
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
 
     # ── Langfuse observability ──
     "HERMES_LANGFUSE_PUBLIC_KEY": {

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1759,7 +1759,10 @@ def run_doctor(args):
             mem0_key = mem0_cfg.get("api_key", "")
             if mem0_key:
                 check_ok("Mem0 API key configured")
-                check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+                mem0_info = f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}"
+                if mem0_cfg.get("host"):
+                    mem0_info += f"  host={mem0_cfg.get('host')}"
+                check_info(mem0_info)
             else:
                 check_fail("Mem0 API key not set", "(set MEM0_API_KEY in .env or run hermes memory setup)")
                 issues.append("Mem0 is set as memory provider but API key is missing")

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -324,12 +324,19 @@ def cmd_setup(args) -> None:
                 # Regular text prompt
                 current = provider_config.get(key)
                 effective_default = current or default
-                val = _prompt(desc, default=str(effective_default) if effective_default else None)
+                prompt_default = None if field.get("clear_on_blank") else effective_default
+                val = _prompt(desc, default=str(prompt_default) if prompt_default else None)
                 if val:
-                    provider_config[key] = val
+                    if not field.get("env_only"):
+                        provider_config[key] = val
                     # Also write to .env if this field has an env_var
                     if env_var and env_var not in env_writes:
                         env_writes[env_var] = val
+                elif field.get("clear_on_blank"):
+                    if not field.get("env_only"):
+                        provider_config[key] = ""
+                    if env_var and env_var not in env_writes:
+                        env_writes[env_var] = None
 
     # Write activation key to config.yaml
     config["memory"]["provider"] = name
@@ -357,8 +364,15 @@ def cmd_setup(args) -> None:
 
 
 def _write_env_vars(env_path: Path, env_writes: dict) -> None:
-    """Append or update env vars in .env file."""
+    """Append, update, or remove env vars in .env file.
+
+    Values set to ``None`` remove the key.
+    """
     env_path.parent.mkdir(parents=True, exist_ok=True)
+    if not env_path.exists():
+        template_path = Path(__file__).resolve().parents[1] / ".env.example"
+        if template_path.exists():
+            env_path.write_text(template_path.read_text(encoding="utf-8"), encoding="utf-8")
 
     existing_lines = []
     if env_path.exists():
@@ -367,15 +381,21 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
     updated_keys = set()
     new_lines = []
     for line in existing_lines:
-        key_match = line.split("=", 1)[0].strip() if "=" in line else ""
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            candidate = stripped[1:].lstrip()
+        else:
+            candidate = stripped
+        key_match = candidate.split("=", 1)[0].strip() if "=" in candidate else ""
         if key_match in env_writes:
-            new_lines.append(f"{key_match}={env_writes[key_match]}")
+            if env_writes[key_match] is not None:
+                new_lines.append(f"{key_match}={env_writes[key_match]}")
             updated_keys.add(key_match)
         else:
             new_lines.append(line)
 
     for key, val in env_writes.items():
-        if key not in updated_keys:
+        if key not in updated_keys and val is not None:
             new_lines.append(f"{key}={val}")
 
     env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -5,7 +5,7 @@ Server-side LLM fact extraction with semantic search, reranking, and automatic d
 ## Requirements
 
 - `pip install mem0ai`
-- Mem0 API key from [app.mem0.ai](https://app.mem0.ai)
+- Mem0 API key from [app.mem0.ai](https://app.mem0.ai) or the admin API key for your self-hosted instance
 
 ## Setup
 
@@ -17,6 +17,8 @@ Or manually:
 ```bash
 hermes config set memory.provider mem0
 echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
+# Optional, for self-hosted Mem0:
+echo "MEM0_HOST=https://your-app.up.railway.app" >> ~/.hermes/.env
 ```
 
 ## Config
@@ -25,6 +27,8 @@ Config file: `$HERMES_HOME/mem0.json`
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `api_key` | | Mem0 Cloud API key or self-hosted API key |
+| `host` | | Mem0 URL; leave blank for Mem0 Platform |
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `true` | Enable reranking for recall |

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -6,7 +6,8 @@ automatic deduplication via the Mem0 Platform API.
 Original PR #2933 by kartik-mem0, adapted to MemoryProvider ABC.
 
 Config via environment variables:
-  MEM0_API_KEY       — Mem0 Platform API key (required)
+  MEM0_HOST          — Mem0 URL (blank for Mem0 Platform)
+  MEM0_API_KEY       — Mem0 API key (required)
   MEM0_USER_ID       — User identifier (default: hermes-user)
   MEM0_AGENT_ID      — Agent identifier (default: hermes)
 
@@ -21,6 +22,7 @@ import os
 import threading
 import time
 from typing import Any, Dict, List
+from urllib.parse import urljoin
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
@@ -48,6 +50,7 @@ def _load_config() -> dict:
 
     config = {
         "api_key": os.environ.get("MEM0_API_KEY", ""),
+        "host": os.environ.get("MEM0_HOST", ""),
         "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
@@ -116,6 +119,60 @@ CONCLUDE_SCHEMA = {
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
 
+class _SelfHostedMem0Client:
+    """Small REST client for Mem0 OSS servers, which do not use /v1 paths."""
+
+    def __init__(self, *, api_key: str, host: str):
+        import requests
+
+        self._requests = requests
+        self._base_url = host.rstrip("/") + "/"
+        self._headers = {
+            "Content-Type": "application/json",
+            "X-API-Key": api_key,
+        }
+
+    def _url(self, path: str) -> str:
+        return urljoin(self._base_url, path.lstrip("/"))
+
+    def _request(self, method: str, path: str, **kwargs) -> Any:
+        response = self._requests.request(
+            method,
+            self._url(path),
+            headers=self._headers,
+            timeout=30,
+            **kwargs,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return {}
+        return response.json()
+
+    def get_all(self, **kwargs) -> Any:
+        filters = kwargs.get("filters") or {}
+        params = {k: v for k, v in filters.items() if v is not None and v != ""}
+        return self._request("GET", "/memories", params=params)
+
+    def search(self, **kwargs) -> Any:
+        filters = kwargs.get("filters") or {}
+        payload = {
+            "query": kwargs.get("query", ""),
+            "filters": {k: v for k, v in filters.items() if v is not None and v != ""},
+        }
+        if kwargs.get("top_k") is not None:
+            payload["top_k"] = kwargs["top_k"]
+        if kwargs.get("rerank") is not None:
+            payload["rerank"] = kwargs["rerank"]
+        return self._request("POST", "/search", json=payload)
+
+    def add(self, messages, **kwargs) -> Any:
+        payload = {
+            "messages": messages,
+            **{k: v for k, v in kwargs.items() if v is not None and v != ""},
+        }
+        return self._request("POST", "/memories", json=payload)
+
+
 class Mem0MemoryProvider(MemoryProvider):
     """Mem0 Platform memory with server-side extraction and semantic search."""
 
@@ -124,6 +181,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._client = None
         self._client_lock = threading.Lock()
         self._api_key = ""
+        self._host = ""
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
@@ -148,6 +206,7 @@ class Mem0MemoryProvider(MemoryProvider):
         import json
         from pathlib import Path
         config_path = Path(hermes_home) / "mem0.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
         existing = {}
         if config_path.exists():
             try:
@@ -155,11 +214,13 @@ class Mem0MemoryProvider(MemoryProvider):
             except Exception:
                 pass
         existing.update(values)
+        existing = {k: v for k, v in existing.items() if v is not None and v != ""}
         config_path.write_text(json.dumps(existing, indent=2))
 
     def get_config_schema(self):
         return [
-            {"key": "api_key", "description": "Mem0 Platform API key", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "host", "description": "Mem0 URL (blank for Mem0 Platform)", "required": False, "env_var": "MEM0_HOST", "clear_on_blank": True, "env_only": True},
+            {"key": "api_key", "description": "Mem0 API key", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai or your self-hosted dashboard"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
@@ -171,8 +232,13 @@ class Mem0MemoryProvider(MemoryProvider):
             if self._client is not None:
                 return self._client
             try:
+                if self._host:
+                    self._client = _SelfHostedMem0Client(api_key=self._api_key, host=self._host)
+                    return self._client
+
                 from mem0 import MemoryClient
-                self._client = MemoryClient(api_key=self._api_key)
+                client_kwargs = {"api_key": self._api_key}
+                self._client = MemoryClient(**client_kwargs)
                 return self._client
             except ImportError:
                 raise RuntimeError("mem0 package not installed. Run: pip install mem0ai")
@@ -203,6 +269,7 @@ class Mem0MemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()
         self._api_key = self._config.get("api_key", "")
+        self._host = self._config.get("host", "")
         # Prefer gateway-provided user_id for per-user memory scoping;
         # fall back to config/env default for CLI (single-user) sessions.
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
@@ -221,7 +288,10 @@ class Mem0MemoryProvider(MemoryProvider):
     def _unwrap_results(response: Any) -> list:
         """Normalize Mem0 API response — v2 wraps results in {"results": [...]}."""
         if isinstance(response, dict):
-            return response.get("results", [])
+            for key in ("results", "memories"):
+                if isinstance(response.get(key), list):
+                    return response[key]
+            return []
         if isinstance(response, list):
             return response
         return []

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,78 @@
+import json
+
+from hermes_cli.memory_setup import _write_env_vars
+
+
+def test_write_env_vars_removes_none_values(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "MEM0_HOST=https://mem0.example.com\nMEM0_API_KEY=keep\n",
+        encoding="utf-8",
+    )
+
+    _write_env_vars(env_path, {"MEM0_HOST": None})
+
+    assert env_path.read_text(encoding="utf-8") == "MEM0_API_KEY=keep\n"
+
+
+def test_write_env_vars_seeds_env_example_when_missing(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _write_env_vars(env_path, {"MEM0_API_KEY": "test-key"})
+
+    text = env_path.read_text(encoding="utf-8")
+    assert "# Hermes Agent Environment Configuration" in text
+    assert "MEM0_API_KEY=test-key" in text
+    assert "# MEM0_HOST=" in text
+
+
+def test_write_env_vars_uncomments_matching_placeholders(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# MEM0_API_KEY=\n# MEM0_HOST=\n# OTHER_KEY=\n",
+        encoding="utf-8",
+    )
+
+    _write_env_vars(env_path, {
+        "MEM0_HOST": "https://mem0.example.com",
+        "MEM0_API_KEY": "test-key",
+    })
+
+    assert env_path.read_text(encoding="utf-8") == (
+        "MEM0_API_KEY=test-key\n"
+        "MEM0_HOST=https://mem0.example.com\n"
+        "# OTHER_KEY=\n"
+    )
+
+
+def test_mem0_host_setup_is_env_only(tmp_path, monkeypatch):
+    from hermes_cli import memory_setup
+    from plugins.memory.mem0 import Mem0MemoryProvider
+
+    hermes_home = tmp_path / "hermes-home"
+    prompts = iter([
+        "https://mem0.example.com",
+        "mem0-key",
+        "tommy",
+        "hermes",
+    ])
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(memory_setup, "_get_available_providers", lambda: [
+        ("mem0", "API key / local", Mem0MemoryProvider())
+    ])
+    monkeypatch.setattr(memory_setup, "_curses_select", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(memory_setup, "_install_dependencies", lambda name: None)
+    monkeypatch.setattr(memory_setup, "_prompt", lambda *args, **kwargs: next(prompts))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    memory_setup.cmd_setup(None)
+
+    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+    assert "MEM0_HOST=https://mem0.example.com\n" in env_text
+    assert "MEM0_API_KEY=mem0-key\n" in env_text
+
+    provider_cfg = json.loads((hermes_home / "mem0.json").read_text(encoding="utf-8"))
+    assert "host" not in provider_cfg
+    assert provider_cfg["user_id"] == "tommy"
+    assert provider_cfg["agent_id"] == "hermes"

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -4,9 +4,11 @@ Salvaged from PRs #5301 (qaqcvc) and #5117 (vvvanguards).
 """
 
 import json
+import sys
+import types
 import pytest
 
-from plugins.memory.mem0 import Mem0MemoryProvider
+from plugins.memory.mem0 import Mem0MemoryProvider, _SelfHostedMem0Client, _load_config
 
 
 class FakeClientV2:
@@ -225,3 +227,141 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+    def test_mem0_host_env_loaded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_HOST", "https://mem0.example.com")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = _load_config()
+
+        assert cfg["host"] == "https://mem0.example.com"
+
+    def test_mem0_json_host_overrides_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        monkeypatch.setenv("MEM0_HOST", "https://env.example.com")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(
+            json.dumps({"host": "https://file.example.com"}),
+            encoding="utf-8",
+        )
+
+        cfg = _load_config()
+
+        assert cfg["host"] == "https://file.example.com"
+
+    def test_save_config_removes_blank_host(self, tmp_path):
+        config_path = tmp_path / "mem0.json"
+        config_path.write_text(
+            json.dumps({
+                "host": "https://mem0.example.com",
+                "user_id": "hermes-user",
+            }),
+            encoding="utf-8",
+        )
+        provider = Mem0MemoryProvider()
+
+        provider.save_config({"host": ""}, tmp_path)
+
+        cfg = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "host" not in cfg
+        assert cfg["user_id"] == "hermes-user"
+
+    def test_memory_client_omits_empty_host(self, monkeypatch):
+        captured_kwargs = {}
+
+        class FakeMemoryClient:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        fake_mem0 = types.SimpleNamespace(MemoryClient=FakeMemoryClient)
+        monkeypatch.setitem(sys.modules, "mem0", fake_mem0)
+
+        provider = Mem0MemoryProvider()
+        provider._api_key = "test-key"
+        provider._host = ""
+
+        provider._get_client()
+
+        assert captured_kwargs == {"api_key": "test-key"}
+
+    def test_memory_client_uses_configured_host(self, monkeypatch):
+        provider = Mem0MemoryProvider()
+        provider._api_key = "test-key"
+        provider._host = "https://mem0.example.com"
+
+        client = provider._get_client()
+
+        assert isinstance(client, _SelfHostedMem0Client)
+
+    def test_self_hosted_client_uses_oss_routes(self, monkeypatch):
+        captured_calls = []
+
+        class FakeResponse:
+            content = b"{}"
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"results": []}
+
+        def fake_request(method, url, **kwargs):
+            captured_calls.append({"method": method, "url": url, **kwargs})
+            return FakeResponse()
+
+        fake_requests = types.SimpleNamespace(request=fake_request)
+        monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+        client = _SelfHostedMem0Client(
+            api_key="test-key",
+            host="https://mem0.example.com",
+        )
+        client.add([{"role": "user", "content": "hello"}], user_id="u123", agent_id="hermes")
+        client.search(query="hello", filters={"user_id": "u123"}, top_k=3, rerank=False)
+        client.get_all(filters={"user_id": "u123"})
+
+        assert captured_calls[0]["method"] == "POST"
+        assert captured_calls[0]["url"] == "https://mem0.example.com/memories"
+        assert captured_calls[0]["headers"]["X-API-Key"] == "test-key"
+        assert captured_calls[0]["json"]["user_id"] == "u123"
+        assert captured_calls[0]["json"]["agent_id"] == "hermes"
+
+        assert captured_calls[1]["method"] == "POST"
+        assert captured_calls[1]["url"] == "https://mem0.example.com/search"
+        assert captured_calls[1]["json"] == {
+            "query": "hello",
+            "filters": {"user_id": "u123"},
+            "top_k": 3,
+            "rerank": False,
+        }
+
+        assert captured_calls[2]["method"] == "GET"
+        assert captured_calls[2]["url"] == "https://mem0.example.com/memories"
+        assert captured_calls[2]["params"] == {"user_id": "u123"}
+
+    def test_self_hosted_api_key_uses_only_x_api_key(self, monkeypatch):
+        captured_calls = []
+
+        class FakeResponse:
+            content = b"{}"
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        def fake_request(method, url, **kwargs):
+            captured_calls.append({"method": method, "url": url, **kwargs})
+            return FakeResponse()
+
+        fake_requests = types.SimpleNamespace(request=fake_request)
+        monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+        client = _SelfHostedMem0Client(api_key="mem0-test-key", host="https://mem0.example.com")
+        client.get_all(filters={"user_id": "u123"})
+
+        headers = captured_calls[0]["headers"]
+        assert headers["X-API-Key"] == "mem0-test-key"
+        assert "Authorization" not in headers


### PR DESCRIPTION
Support self-hosted Mem0 instances and improve environment variable handling. Adds `MEM0_HOST` and `MEM0_API_KEY` entries (`.env.example` and config), updates doctor output to show configured host, and extends `memory_setup` to seed `.env` from `.env.example`, uncomment placeholder env lines, remove keys when set to `None`, and respect `clear_on_blank`/`env_only` fields. Introduces a small `_SelfHostedMem0Client` for OSS routes and selects it when `MEM0_HOST` is set; normal Mem0 client usage unchanged otherwise. Also normalizes Mem0 responses (handles "memories"), updates README, and adds tests covering env writes and self-hosted client behavior.

## What does this PR do?

Adds support for self-hosted Mem0 instances via `MEM0_HOST` while preserving the existing Mem0 Platform path when `MEM0_HOST` is unset.

Self-hosted Mem0 uses REST endpoints and accepts programmatic API keys or the legacy `ADMIN_API_KEY` through `X-API-Key`, so the provider now selects a small REST client when a host is configured. The setup flow also keeps Mem0 secrets and host configuration in `.env`, avoids stale `mem0.json` host values for new setup runs, and handles blank/cleared values consistently.

## Related Issue

N/A

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [x] 📝 Documentation update
* [x] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* **`plugins/memory/mem0/__init__.py`**: Add `_SelfHostedMem0Client`, select it when `MEM0_HOST` is set, use `X-API-Key`, and normalize self-hosted response shapes.
* **`hermes_cli/memory_setup.py`**: Support `env_only` and `clear_on_blank`, seed missing `.env` from `.env.example`, uncomment placeholder env lines, and remove env keys when passed `None`.
* **`.env.example`**: Add documented `MEM0_HOST` and `MEM0_API_KEY` placeholders.
* **`hermes_cli/config.py`**: Register `MEM0_HOST` and `MEM0_API_KEY`.
* **`hermes_cli/doctor.py`**: Include configured Mem0 host in doctor output.
* **`plugins/memory/mem0/README.md`**: Document Mem0 Platform vs self-hosted setup.
* **`tests/plugins/memory/test_mem0_v2.py`** and **`tests/hermes_cli/test_memory_setup.py`**: Add coverage for self-hosted client behavior and env writing.

## How to Test

1. **Run focused tests:**
```bash
scripts/run_tests.sh tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_mem0_v2.py tests/hermes_cli/test_config.py tests/hermes_cli/test_doctor.py

```


2. **Run lint on touched Python files:**

```bash
ruff check plugins/memory/mem0/__init__.py hermes_cli/memory_setup.py hermes_cli/config.py hermes_cli/doctor.py tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_mem0_v2.py

```

3. **Configure Mem0:**

```bash
hermes memory setup

```

* For **Mem0 Platform**, leave `MEM0_HOST` blank and provide `MEM0_API_KEY`.
* For **self-hosted Mem0**, set `MEM0_HOST` to the deployed base URL and `MEM0_API_KEY` to either a key from `/api-keys` or the legacy `ADMIN_API_KEY`.

4. **Verify:**

```bash
hermes doctor

```

---

## Checklist

### Code

* [x] I've read the Contributing Guide
* [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
* [ ] I searched for existing PRs to make sure this isn't a duplicate
* [x] My PR contains only changes related to this fix/feature (no unrelated commits)
* [ ] I've run `pytest tests/ -q` and all tests pass
* [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
* [x] I've tested on my platform: macOS

### Documentation & Housekeeping

* [x] I've updated relevant documentation (`README`, `docs/`, docstrings) — *or N/A*
* [x] I've updated `cli-config.yaml.example` if I added/changed config keys — *or N/A*
* [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — *or N/A*
* [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — *or N/A*
* [x] I've updated tool descriptions/schemas if I changed tool behavior — *or N/A*

---

## Screenshots / Logs

**Focused validation passed:**

```bash
scripts/run_tests.sh tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_mem0_v2.py tests/hermes_cli/test_config.py tests/hermes_cli/test_doctor.py
# 121 passed

```

**Full suite was run:**

```bash
scripts/run_tests.sh tests/ -v
# 58 failed, 23054 passed, 175 skipped, 13 errors

```

> [!NOTE]
> The full-suite failures/errors were outside Mem0-related tests.