### PR TITLE
fix(cli): unknown skills should warn instead of crash

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -450,6 +450,12 @@ def build_skill_invocation_message(
     )
 
 
+_MISSING_SKILL_WARNING = (
+    "Unknown skill(s) requested, skipping: %s. "
+    "Available skills can be listed with `hermes skills list`."
+)
+
+
 def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,

--- a/cli.py
+++ b/cli.py
@@ -2411,6 +2411,7 @@ def _looks_like_slash_command(text: str) -> bool:
 # ============================================================================
 
 from agent.skill_commands import (
+    _MISSING_SKILL_WARNING,
     scan_skill_commands,
     get_skill_commands,
     build_skill_invocation_message,
@@ -14079,11 +14080,7 @@ def main(
         )
         if missing_skills:
             missing_display = ", ".join(missing_skills)
-            logger.warning(
-                "Unknown skill(s) requested, skipping: %s. "
-                "Available skills can be listed with `hermes skills list`.",
-                missing_display,
-            )
+            logger.warning(_MISSING_SKILL_WARNING, missing_display)
         if skills_prompt:
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part

--- a/cli.py
+++ b/cli.py
@@ -14079,7 +14079,11 @@ def main(
         )
         if missing_skills:
             missing_display = ", ".join(missing_skills)
-            raise ValueError(f"Unknown skill(s): {missing_display}")
+            logger.warning(
+                "Unknown skill(s) requested, skipping: %s. "
+                "Available skills can be listed with `hermes skills list`.",
+                missing_display,
+            )
         if skills_prompt:
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -92,7 +92,7 @@ def test_main_applies_preloaded_skills_to_system_prompt(monkeypatch):
     assert cli_obj.preloaded_skills == ["hermes-agent-dev", "github-auth"]
 
 
-def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
+def test_main_warns_for_unknown_preloaded_skill(monkeypatch, caplog):
     import cli as cli_mod
 
     monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _DummyCLI(**kwargs))
@@ -102,8 +102,10 @@ def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
         lambda skills, task_id=None: ("", [], ["missing-skill"]),
     )
 
-    with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-skill"):
+    with pytest.raises(SystemExit):
         cli_mod.main(skills="missing-skill", list_tools=True)
+
+    assert "Unknown skill(s) requested, skipping: missing-skill" in caplog.text
 
 
 def test_show_banner_does_not_print_skills():

--- a/tests/tui_gateway/test_make_agent_skills.py
+++ b/tests/tui_gateway/test_make_agent_skills.py
@@ -1,0 +1,48 @@
+"""Tests for _make_agent handling of unknown preloaded skills."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+def test_make_agent_warns_for_unknown_skill(caplog):
+    """_make_agent logs warning instead of crashing on unknown skill."""
+    caplog.set_level(logging.WARNING)
+
+    with patch("tui_gateway.server._parse_tui_skills_env", return_value=["valid-skill", "oops-typo"]), patch(
+        "tui_gateway.server._resolve_startup_runtime", return_value=("test-model", "test-provider"),
+    ), patch("tui_gateway.server._load_cfg", return_value={}), patch(
+        "agent.skill_commands.build_preloaded_skills_prompt",
+        return_value=("", ["valid-skill"], ["oops-typo"]),
+    ), patch("run_agent.AIAgent"), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}
+    ):
+        from tui_gateway.server import _make_agent
+
+        agent = _make_agent("sid", "key", "session-123")
+
+        assert agent is not None
+        assert "Unknown skill(s) requested, skipping: oops-typo" in caplog.text
+
+
+def test_make_agent_handles_all_skills_unknown(caplog):
+    """_make_agent starts properly when ALL skills are unknown (edge case)."""
+    caplog.set_level(logging.WARNING)
+
+    with patch("tui_gateway.server._parse_tui_skills_env", return_value=["typo-one", "typo-two"]), patch(
+        "tui_gateway.server._resolve_startup_runtime", return_value=("test-model", "test-provider"),
+    ), patch("tui_gateway.server._load_cfg", return_value={}), patch(
+        "agent.skill_commands.build_preloaded_skills_prompt",
+        return_value=("", [], ["typo-one", "typo-two"]),
+    ), patch("run_agent.AIAgent"), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}
+    ):
+        from tui_gateway.server import _make_agent
+
+        agent = _make_agent("sid", "key", "session-456")
+
+        assert agent is not None
+        assert "typo-one" in caplog.text
+        assert "typo-two" in caplog.text
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1874,7 +1874,11 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
             task_id=session_id or key,
         )
         if missing_skills:
-            raise ValueError(f"Unknown skill(s): {', '.join(missing_skills)}")
+            logger.warning(
+                "Unknown skill(s) requested, skipping: %s. "
+                "Available skills can be listed with `hermes skills list`.",
+                ", ".join(missing_skills),
+            )
         if skills_prompt:
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1867,18 +1867,14 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
     system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
-        from agent.skill_commands import build_preloaded_skills_prompt
+        from agent.skill_commands import _MISSING_SKILL_WARNING, build_preloaded_skills_prompt
 
         skills_prompt, _loaded_skills, missing_skills = build_preloaded_skills_prompt(
             startup_skills,
             task_id=session_id or key,
         )
         if missing_skills:
-            logger.warning(
-                "Unknown skill(s) requested, skipping: %s. "
-                "Available skills can be listed with `hermes skills list`.",
-                ", ".join(missing_skills),
-            )
+            logger.warning(_MISSING_SKILL_WARNING, ", ".join(missing_skills))
         if skills_prompt:
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part


### PR DESCRIPTION
## Summary

When a Kanban task or CLI command references a non-existent skill name, log a warning and continue with valid skills instead of crashing the worker with `ValueError`.

## Problem

Unknown skills caused a hard crash via `ValueError("Unknown skill(s): ...")` in two locations:
1. `cli.py:14073` — when `main()` receives unknown skills via CLI arguments
2. `tui_gateway/server.py:1877` — when the TUI gateway starts with unknown skills

This caused Kanban workers to exit with code 1 on task startup, triggering the dispatcher auto-block after 2 consecutive failures — making the task impossible to complete without manual intervention.

## Solution

Changed both locations to emit a `logger.warning()` and continue with whatever skills loaded successfully.

## Files Changed

| File | +/− | Change |
|------|-----|--------|
| `cli.py` | +6/−1 | `raise ValueError` → `logger.warning(...)` |
| `tui_gateway/server.py` | +6/−1 | Same change |
| `tests/cli/test_cli_preloaded_skills.py` | +4/−2 | Updated test to expect warning + SystemExit instead of ValueError |

## Test Results

```
tests/cli/test_cli_preloaded_skills.py::test_main_warns_for_unknown_preloaded_skill PASSED
tests/cli/test_cli_preloaded_skills.py::test_main_applies_preloaded_skills_to_system_prompt PASSED
```

## Design Decisions

- Uses `logger.warning()` (not `print()`) so the warning is visible in logs and follows existing patterns
- Includes suggestions (`Available skills can be listed with \`hermes skills list\``) so users can self-correct
- The `if skills_prompt:` check on the following line naturally handles the case where no skills loaded successfully — the agent just runs without preloaded skills.

Closes #27136