### PR TITLE
fix(cli): replace misleading "Starting fresh" message on empty-session resume (#27168)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4442,7 +4442,8 @@ class HermesCLI:
                 )
             else:
                 ChatConsole().print(
-                    f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
+                    f"[bold {_accent_hex()}]Session {_escape(self.session_id)} has no prior messages — resuming as an empty session.[/] "
+                    f"[dim](To remove it instead, run `hermes sessions delete {_escape(self.session_id)}`.)[/]"
                 )
             # Re-open the session (clear ended_at so it's active again)
             try:
@@ -4708,8 +4709,10 @@ class HermesCLI:
         else:
             accent_color = _accent_hex()
             self._console_print(
-                f"[{accent_color}]Session {self.session_id} found but has no "
-                f"messages. Starting fresh.[/]"
+                f"[{accent_color}]Session {self.session_id} has no prior "
+                f"messages — resuming as an empty session. "
+                f"[dim](To remove it instead, run "
+                f"`hermes sessions delete {self.session_id}`.)[/][/]"
             )
             return False
 

--- a/cli.py
+++ b/cli.py
@@ -4708,11 +4708,12 @@ class HermesCLI:
             )
         else:
             accent_color = _accent_hex()
+            safe_session_id = _escape(self.session_id)
             self._console_print(
-                f"[{accent_color}]Session {self.session_id} has no prior "
+                f"[{accent_color}]Session {safe_session_id} has no prior "
                 f"messages — resuming as an empty session. "
                 f"[dim](To remove it instead, run "
-                f"`hermes sessions delete {self.session_id}`.)[/][/]"
+                f"`hermes sessions delete {safe_session_id}`.)[/][/]"
             )
             return False
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -643,6 +643,47 @@ class TestInitAgentSkipsPreloaded:
         # get_messages_as_conversation should NOT have been called
         mock_db.get_messages_as_conversation.assert_not_called()
 
+    def test_init_agent_empty_session_shows_new_wording(self):
+        """When _preload_resumed_session is bypassed and _init_agent itself
+        hits an empty-but-existing session, the same #27168 wording (no
+        misleading "Starting fresh") must surface so both copies stay in sync.
+        """
+        cli = _make_cli(resume="empty_session_init")
+        # conversation_history left empty to exercise the in-_init_agent branch
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "empty_session_init", "title": None}
+        mock_db.resolve_resume_session_id.return_value = "empty_session_init"
+        mock_db.get_messages_as_conversation.return_value = []
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+
+        # _init_agent prints through ChatConsole(), which routes to _cprint
+        # instead of cli.console — patch _cprint to capture the rendered output.
+        # Credentials must succeed so we actually reach the resume branch; the
+        # rest of _init_agent (AIAgent construction, etc.) is allowed to raise
+        # because the message is already printed by that point.
+        captured = []
+
+        def _capture(text):
+            captured.append(text)
+
+        with (
+            patch.object(cli_mod, "_cprint", side_effect=_capture),
+            patch.object(cli, "_ensure_runtime_credentials", return_value=True),
+        ):
+            try:
+                cli._init_agent()
+            except Exception:
+                pass
+
+        output = "\n".join(captured)
+        # Same regression guard as _preload_resumed_session — keep both paths
+        # aligned so the user sees the same message regardless of entry point.
+        assert "no prior messages" in output
+        assert "empty session" in output
+        assert "Starting fresh" not in output
+        assert "hermes sessions delete empty_session_init" in output
+
 
 # ── Config default tests ─────────────────────────────────────────────
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -539,6 +539,8 @@ class TestPreloadResumedSession:
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "empty_session", "title": None}
         mock_db.get_messages_as_conversation.return_value = []
+        # No compression chain — resume_session_id resolves to itself.
+        mock_db.resolve_resume_session_id.return_value = "empty_session"
         cli._session_db = mock_db
 
         buf = StringIO()
@@ -547,7 +549,14 @@ class TestPreloadResumedSession:
 
         assert result is False
         output = buf.getvalue()
-        assert "no messages" in output
+        # Regression for #27168: the old "Starting fresh." wording was misleading
+        # because the empty session is reused, not replaced. The new wording must
+        # describe the actual behavior and surface the `sessions delete`
+        # remediation the user actually wants in this case.
+        assert "no prior messages" in output
+        assert "empty session" in output
+        assert "Starting fresh" not in output
+        assert "hermes sessions delete empty_session" in output
 
     def test_loads_session_successfully(self):
         cli = _make_cli(resume="good_session")


### PR DESCRIPTION
## Summary

Rewords both `--resume` paths in `cli.py` so the message printed when a
session exists in `sessions` but has zero rows in `messages` matches
what the code actually does (reuse the empty session) and surfaces the
remediation the reporter wanted (`hermes sessions delete <id>`).
Behavior is unchanged — only the user-facing message.

Fixes the user-visible piece of #27168 (Bug 1). Bug 2 (the ~5 s
startup hang in `_check_compression_model_feasibility`) is out of
scope here — the reporter notes they could not localize it, and
chasing it would be speculative without a clean repro.

## The bug

Both `_init_agent` (cli.py:4445) and `_preload_resumed_session`
(cli.py:4711) printed:

> Session `<id>` found but has no messages. Starting fresh.

The "Starting fresh" claim is inaccurate — the empty session is
reused: its `ended_at` is cleared and the user's next message
becomes the first one for that session ID. No new session is created.
Users reading the message reasonably expected a brand-new session,
then saw the same orphan ID stick around.

## The fix

One-line wording change at each call site. Both now print:

> Session `<id>` has no prior messages — resuming as an empty session. (To remove it instead, run `hermes sessions delete <id>`.)

- Accurate ("resuming as an empty session" matches the `ended_at = NULL` reopen that follows).
- Actionable (mentions the `sessions delete` command the reporter wanted as a remediation).
- No behavior change — same return values, same DB writes, same flow.

## Test plan

- [x] Focused regression test: `tests/cli/test_resume_display.py::TestPreloadResumedSession::test_returns_false_when_session_has_no_messages` updated to assert the new wording (`no prior messages`, `empty session`, `hermes sessions delete empty_session`) and that the old `Starting fresh` text is gone. Also fixes a pre-existing gap in the test where `resolve_resume_session_id` was not mocked, so the mock returned a `MagicMock` that the production code then mistook for a redirected session ID.
- [x] Adjacent suite: `tests/cli/test_resume_display.py` — all 37 tests pass under `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest`.
- [x] Regression guard: the new assertions (`"no prior messages" in output`, `"Starting fresh" not in output`, `"hermes sessions delete empty_session" in output`) all fail against the old wording and pass against the new wording.

> Sibling code paths that may need the same fix: both `_init_agent` and `_preload_resumed_session` were updated in this PR. No other call site prints this string. If a future maintainer wants stronger behavior (auto-delete the orphan, or refuse the resume entirely rather than reopen the empty session), happy to follow up — those are behavior changes I intentionally left out of this message-only fix.

## Related

- Fixes the user-facing piece of #27168
- Adjacent context: #7001 (already fixed one origin of empty-session-on-disk by clearing `conversation_history` after mid-loop compression). This PR addresses what users see when they encounter such a session (or any other empty session) on resume.