### PR TITLE
fix(scripts): fix UnicodeEncodeError in footgun checker on Windows

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -551,6 +551,14 @@ def print_rules() -> None:
 
 
 def main(argv: list[str]) -> int:
+    # Windows terminals default to cp1252, which can't encode the ✓/✗
+    # characters used in the output. Reconfigure streams to UTF-8 so the
+    # script works correctly on the very platform it is designed to help.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
+
     args = parse_args(argv)
 
     if args.list:


### PR DESCRIPTION
 ## What

  `scripts/check-windows-footguns.py` uses ✓ and ✗ characters in its output. Windows terminals default to cp1252, which
  cannot encode these characters — running the script on Windows threw a `UnicodeEncodeError` before printing any
  results.

  ## Why it matters

  This made the tool completely unusable on the exact platform it exists to help. A developer on Windows trying to check
   their code for Windows-safety issues would get a crash instead of results.

  ## Fix

  Reconfigure `stdout` and `stderr` to UTF-8 at the start of `main()`, before any output is produced.

  ## Verified on

  - Windows 11 Home, Python 3.13, terminal defaulting to cp1252
  - Before: `UnicodeEncodeError: 'charmap' codec can't encode character '\u2713'`
  - After: `✓ No Windows footguns found (462 file(s) scanned).