### PR TITLE
feat(gateway): fire agent_loop_stopped plugin hook on interrupt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23935,6 +23935,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _process_baseline = None
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             request_hard_interrupt(running_agent, interrupt_reason)
+
+            # Notify plugins so they can drop in-flight per-turn resources
+            # (e.g. external services blocked on a tool result that the
+            # agent loop will never consume). Fires for /stop and the /new
+            # fast-path taken from the running-agent guard in
+            # _dispatch_message; on the slow /new path on_session_finalize
+            # fires later in _handle_reset_command. Gated on a real running
+            # agent: the pending-sentinel /stop path has no in-flight work
+            # to cancel, so emitting the hook there would just be noise.
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+                _invoke_hook(
+                    "agent_loop_stopped",
+                    session_key=session_key,
+                    platform=source.platform.value if source.platform else "",
+                    reason=interrupt_reason,
+                    invalidation_reason=invalidation_reason,
+                )
+            except Exception:
+                logger.debug("agent_loop_stopped hook dispatch failed", exc_info=True)
+
             _process_task_id = getattr(
                 running_agent, "_gateway_turn_process_task_id", ""
             )

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -393,6 +393,28 @@ class GatewayAgentCacheMixin:
         _process_task_id, _process_baseline = "", None
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             request_hard_interrupt(running_agent, interrupt_reason)
+
+            # Notify plugins so they can drop in-flight per-turn resources
+            # (e.g. external services blocked on a tool result that the
+            # agent loop will never consume). Fires for /stop and the /new
+            # fast-path taken from the running-agent guard in
+            # _dispatch_message; on the slow /new path on_session_finalize
+            # fires later in _handle_reset_command. Gated on a real running
+            # agent: the pending-sentinel /stop path has no in-flight work
+            # to cancel, so emitting the hook there would just be noise.
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+                _invoke_hook(
+                    "agent_loop_stopped",
+                    session_key=session_key,
+                    platform=source.platform.value if source.platform else "",
+                    reason=interrupt_reason,
+                    invalidation_reason=invalidation_reason,
+                )
+            except Exception:
+                logger.debug("agent_loop_stopped hook dispatch failed", exc_info=True)
+
             _process_task_id = getattr(running_agent, "_gateway_turn_process_task_id", "")
             _process_baseline = getattr(running_agent, "_gateway_turn_process_baseline", None)
         # Bump the generation BEFORE scheduling the reap thread and capture the post-bump value:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -167,6 +167,13 @@ VALID_HOOKS: Set[str] = {
     "on_skill_lifecycle",
     "subagent_start",
     "subagent_stop",
+    # Fired by the gateway when an agent turn is interrupted mid-run --
+    # either by /stop or by the running-agent fast-path of /new (see
+    # gateway/run.py::_interrupt_and_clear_session). Lets plugins fail
+    # any per-turn external resources they are holding (e.g. remote tool
+    # calls awaiting a result). Kwargs: session_key, platform, reason,
+    # invalidation_reason. Return values are ignored.
+    "agent_loop_stopped",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -126,6 +126,13 @@ VALID_HOOKS: Set[str] = {
     "on_session_finalize", "on_session_reset",
     # on_skill_lifecycle: successful skill lifecycle facts (local skill name visible to plugins).
     "on_skill_lifecycle", "subagent_start", "subagent_stop",
+    # Fired by the gateway when an agent turn is interrupted mid-run --
+    # either by /stop or by the running-agent fast-path of /new (see
+    # gateway/run_agent_cache.py::_interrupt_and_clear_session). Lets plugins fail
+    # any per-turn external resources they are holding (e.g. remote tool
+    # calls awaiting a result). Kwargs: session_key, platform, reason,
+    # invalidation_reason. Return values are ignored.
+    "agent_loop_stopped",
     # pre_gateway_dispatch: once per incoming MessageEvent, after the internal-event guard, BEFORE
     # auth/pairing and dispatch. Kwargs: event, gateway, session_store. Return {"action": "skip",
     # "reason"} -> drop; {"action": "rewrite", "text"} -> replace event.text; "allow"/None -> normal.

--- a/tests/gateway/test_agent_loop_stopped_hook.py
+++ b/tests/gateway/test_agent_loop_stopped_hook.py
@@ -1,0 +1,165 @@
+"""Tests that the ``agent_loop_stopped`` plugin hook fires when the gateway
+interrupts a running agent turn — both via ``/stop`` and via the running-agent
+fast-path inside ``/new``.
+
+Mirrors ``test_session_boundary_hooks.py``: we bypass ``GatewayRunner.__init__``
+and stub just enough attributes to drive ``_interrupt_and_clear_session``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource, build_session_key
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    # SimpleNamespace, not MagicMock — _interrupt_and_clear_session calls
+    # adapter.interrupt_session_activity() only when hasattr(...) is true,
+    # and MagicMock fakes every attribute, which would push us into an
+    # await on a non-awaitable.
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+
+    # _invalidate_session_run_generation + _release_running_agent_state are
+    # called downstream; stub to no-op so we exercise the hook emit only.
+    runner._invalidate_session_run_generation = lambda *a, **kw: None
+    runner._release_running_agent_state = lambda *a, **kw: None
+    return runner
+
+
+def test_agent_loop_stopped_in_valid_hooks():
+    """Plugins must be able to subscribe to the new hook without warnings."""
+    assert "agent_loop_stopped" in VALID_HOOKS
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_interrupt_fires_agent_loop_stopped_hook(mock_invoke_hook):
+    """Calling ``_interrupt_and_clear_session`` with a real running agent
+    must interrupt it AND dispatch the hook with the session, platform,
+    and reasons attached."""
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    await runner._interrupt_and_clear_session(
+        session_key,
+        source,
+        interrupt_reason="user_stop",
+        invalidation_reason="stop_command",
+    )
+
+    running_agent.interrupt.assert_called_once_with("user_stop")
+    mock_invoke_hook.assert_any_call(
+        "agent_loop_stopped",
+        session_key=session_key,
+        platform="telegram",
+        reason="user_stop",
+        invalidation_reason="stop_command",
+    )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_hook_not_fired_for_pending_sentinel_stop(mock_invoke_hook):
+    """The pending-sentinel /stop path (slash_commands.py) has no in-flight
+    work to cancel — the agent loop never started. The hook is gated on a
+    real running agent and must not fire in this case."""
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+
+    await runner._interrupt_and_clear_session(
+        session_key,
+        source,
+        interrupt_reason="user_stop",
+        invalidation_reason="stop_command_pending",
+    )
+
+    agent_loop_stopped_calls = [
+        call for call in mock_invoke_hook.call_args_list
+        if call.args and call.args[0] == "agent_loop_stopped"
+    ]
+    assert agent_loop_stopped_calls == [], (
+        f"agent_loop_stopped must not fire on the pending-sentinel path "
+        f"(saw {len(agent_loop_stopped_calls)} call(s))"
+    )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_hook_not_fired_when_no_running_agent(mock_invoke_hook):
+    """If there is no agent at all for the session key (already cleared),
+    there is nothing to interrupt and the hook must not fire."""
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+
+    # _running_agents stays empty — no entry for this session_key.
+    await runner._interrupt_and_clear_session(
+        session_key,
+        source,
+        interrupt_reason="user_stop",
+        invalidation_reason="stop_command_no_agent",
+    )
+
+    agent_loop_stopped_calls = [
+        call for call in mock_invoke_hook.call_args_list
+        if call.args and call.args[0] == "agent_loop_stopped"
+    ]
+    assert agent_loop_stopped_calls == []
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_hook_dispatch_failure_does_not_break_interrupt(mock_invoke_hook):
+    """A misbehaving plugin must not prevent the interrupt from completing."""
+    mock_invoke_hook.side_effect = RuntimeError("plugin exploded")
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    # Should not raise — the hook block has try/except for exactly this.
+    await runner._interrupt_and_clear_session(
+        session_key,
+        source,
+        interrupt_reason="user_stop",
+        invalidation_reason="stop_command",
+    )
+
+    # The interrupt itself still happened despite the hook blowing up.
+    running_agent.interrupt.assert_called_once_with("user_stop")

--- a/tests/gateway/test_agent_loop_stopped_hook.py
+++ b/tests/gateway/test_agent_loop_stopped_hook.py
@@ -1,0 +1,119 @@
+"""Real plugin discovery and interrupt delivery, including idle and failure controls."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource, build_session_key
+
+
+@pytest.fixture
+def interrupt_plugin(tmp_path, monkeypatch):
+    from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    plugin_dir = tmp_path / "plugins" / "interrupt-observer"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: interrupt-observer\n", encoding="utf-8")
+    (plugin_dir / "__init__.py").write_text(
+        "events = []\n"
+        "fail = False\n"
+        "def observe(*, session_key, platform, reason, invalidation_reason):\n"
+        "    events.append(dict(session_key=session_key, platform=platform,\n"
+        "                       reason=reason, invalidation_reason=invalidation_reason))\n"
+        "    if fail:\n"
+        "        raise RuntimeError('plugin exploded')\n"
+        "def register(ctx):\n"
+        "    ctx.register_hook('agent_loop_stopped', observe)\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "config.yaml").write_text(
+        "plugins:\n  enabled: [interrupt-observer]\n", encoding="utf-8"
+    )
+    discover_plugins()
+    return get_plugin_manager()._plugins["interrupt-observer"].module
+
+
+class InterruptAdapter:
+    def __init__(self):
+        self.interrupted = []
+
+    async def interrupt_session_activity(self, session_key, chat_id, *, metadata=None):
+        self.interrupted.append((session_key, chat_id))
+
+
+def _make_turn(agent_kind):
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM, user_id="u1", chat_id="c1", chat_type="dm"
+    )
+    session_key = build_session_key(source)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    )
+    adapter = InterruptAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    # Keep gateway-status persistence outside this plugin/turn boundary test.
+    runner._persist_active_agents = Mock()
+    state = runner._session_state(session_key)
+    state.persistent.pending_command_text = "queued command"
+    state.conversation.ephemeral_pin = "cached prompt context"
+    agent = SimpleNamespace(hard_interrupt=Mock())
+    state.turn.agent = {
+        "running": agent, "pending": _AGENT_PENDING_SENTINEL, "missing": None
+    }[agent_kind]
+    generation = runner._begin_session_run_generation(session_key)
+    return runner, source, session_key, agent, adapter, state, generation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("agent_kind", ["running", "pending", "missing"])
+@pytest.mark.parametrize("reason,invalidation_reason", [
+    ("user_stop", "stop_command"), ("session_reset", "new_command")
+])
+async def test_registered_plugin_observes_only_running_turns(
+    interrupt_plugin, agent_kind, reason, invalidation_reason
+):
+    runner, source, key, agent, adapter, state, generation = _make_turn(agent_kind)
+
+    await runner._interrupt_and_clear_session(
+        key, source, interrupt_reason=reason, invalidation_reason=invalidation_reason
+    )
+
+    expected = [{"session_key": key, "platform": source.platform.value,
+                 "reason": reason, "invalidation_reason": invalidation_reason}]
+    assert interrupt_plugin.events == (expected if agent_kind == "running" else [])
+    if agent_kind == "running":
+        agent.hard_interrupt.assert_called_once_with(reason)
+    else:
+        agent.hard_interrupt.assert_not_called()
+    assert adapter.interrupted == [(key, source.chat_id)]
+    assert not runner._is_session_run_current(key, generation)
+    assert state.turn.agent is None
+    assert state.persistent.pending_command_text is None
+    assert state.conversation.ephemeral_pin is None
+
+
+@pytest.mark.asyncio
+async def test_failing_plugin_cannot_prevent_interrupt_cleanup(interrupt_plugin):
+    interrupt_plugin.fail = True
+    runner, source, key, agent, adapter, state, generation = _make_turn("running")
+
+    await runner._interrupt_and_clear_session(
+        key, source, interrupt_reason="user_stop", invalidation_reason="stop_command"
+    )
+
+    assert interrupt_plugin.events == [{
+        "session_key": key, "platform": source.platform.value,
+        "reason": "user_stop", "invalidation_reason": "stop_command"
+    }]
+    agent.hard_interrupt.assert_called_once_with("user_stop")
+    assert adapter.interrupted == [(key, source.chat_id)]
+    assert not runner._is_session_run_current(key, generation)
+    assert state.turn.agent is None
+    assert state.persistent.pending_command_text is None
+    assert state.conversation.ephemeral_pin is None

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -408,6 +408,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown or expiry may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
+| `agent_loop_stopped` | Observer | Immediately after a real gateway agent is interrupted in `_interrupt_and_clear_session`; return ignored. | `session_key`, `platform`, `reason`, `invalidation_reason` | Session/routing identifiers and interruption reasons; no message body. |
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
@@ -901,6 +902,33 @@ def my_callback(session_id: str, platform: str, **kwargs):
 ---
 
 See the **[Build a Plugin guide](/developer-guide/plugins)** for the full walkthrough including tool schemas, handlers, and advanced hook patterns.
+
+---
+
+### `agent_loop_stopped`
+
+Fires when the gateway **interrupts a running agent turn** — the user ran `/stop` while the loop was working, or the running-agent fast-path inside `/new` cleared the in-flight run before swapping the session. Unlike `on_session_finalize`, this fires earlier, while a turn is mid-flight, so plugins can drop per-turn external resources the agent loop will never consume (e.g. an outbound RPC that was waiting for a tool result).
+
+**Gateway only.** Does not fire in the CLI; there is no equivalent interruption surface there.
+
+**Callback signature:**
+
+```python
+def my_callback(session_key: str, platform: str, reason: str, invalidation_reason: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_key` | `str` | The session whose run was interrupted. |
+| `platform` | `str` | The messaging platform name (`"telegram"`, `"discord"`, etc.); empty string if unknown. |
+| `reason` | `str` | Why the agent was interrupted (e.g. `"user_stop"`, the reset/new reason). |
+| `invalidation_reason` | `str` | Why queued session state was invalidated (e.g. `"stop_command"`, `"stop_command_thread_sibling"`, `"reset_command"`). |
+
+**Fires:** In `gateway/run.py::_interrupt_and_clear_session`, immediately after `request_hard_interrupt()` interrupts the running agent. Only when a real agent was running — the pending-sentinel `/stop` path (no agent loop yet started) does **not** fire this hook, since there is no in-flight work to drop. On the slow `/new` reset path, `on_session_finalize` fires later in `_handle_reset_command` instead.
+
+**Return value:** Ignored.
+
+**Use cases:** Cancel external requests blocked on a tool result the loop will never consume, notify a connected voice/realtime client that a tool call was abandoned, release per-turn credentials or locks held only for the duration of an active turn.
 
 ---
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -459,6 +459,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
+| `agent_loop_stopped` | Observer | Immediately after a real gateway agent is interrupted in `_interrupt_and_clear_session`; return ignored. | `session_key`, `platform`, `reason`, `invalidation_reason` | Session/routing identifiers and interruption reasons; no message body. |
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
@@ -1042,6 +1043,33 @@ def my_callback(session_id: str, platform: str, **kwargs):
 ---
 
 See the **[Build a Plugin guide](/developer-guide/plugins)** for the full walkthrough including tool schemas, handlers, and advanced hook patterns.
+
+---
+
+### `agent_loop_stopped`
+
+Fires when the gateway **interrupts a running agent turn** — the user ran `/stop` while the loop was working, or the running-agent fast-path inside `/new` cleared the in-flight run before swapping the session. Unlike `on_session_finalize`, this fires earlier, while a turn is mid-flight, so plugins can drop per-turn external resources the agent loop will never consume (e.g. an outbound RPC that was waiting for a tool result).
+
+**Gateway only.** Does not fire in the CLI; there is no equivalent interruption surface there.
+
+**Callback signature:**
+
+```python
+def my_callback(session_key: str, platform: str, reason: str, invalidation_reason: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_key` | `str` | The session whose run was interrupted. |
+| `platform` | `str` | The messaging platform name (`"telegram"`, `"discord"`, etc.); empty string if unknown. |
+| `reason` | `str` | Why the agent was interrupted (e.g. `"user_stop"`, the reset/new reason). |
+| `invalidation_reason` | `str` | Why queued session state was invalidated (e.g. `"stop_command"`, `"stop_command_thread_sibling"`, `"reset_command"`). |
+
+**Fires:** In `gateway/run_agent_cache.py::_interrupt_and_clear_session`, immediately after `request_hard_interrupt()` interrupts the running agent. Only when a real agent was running — the pending-sentinel `/stop` path (no agent loop yet started) does **not** fire this hook, since there is no in-flight work to drop. On the slow `/new` reset path, `on_session_finalize` fires later in `_handle_reset_command` instead.
+
+**Return value:** Ignored.
+
+**Use cases:** Cancel external requests blocked on a tool result the loop will never consume, notify a connected voice/realtime client that a tool call was abandoned, release per-turn credentials or locks held only for the duration of an active turn.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -188,13 +188,13 @@ When you upgrade to a version of Hermes that has opt-in plugins (config schema v
 
 ## Available hooks
 
-Plugins can register the 24 lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
+Plugins can register the 25 lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
 
 | Descriptive category | Shipped hooks |
 |---|---|
 | **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
 | **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output` |
-| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
+| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `agent_loop_stopped`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
 
 These categories describe current behavior rather than defining future naming rules. Plugin middleware remains a separate registry/surface.
 ## Plugin types

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -268,13 +268,13 @@ When you upgrade to a version of Hermes that has opt-in plugins (config schema v
 
 ## Available hooks
 
-Plugins can register the 26 lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
+Plugins can register the lifecycle events currently accepted by `hermes_cli.plugins.VALID_HOOKS`. The **[Event Hooks catalog](/user-guide/features/hooks#shipped-plugin-hook-catalog)** is canonical for exact timing, return handling, payload fields, and privacy notes.
 
 | Descriptive category | Shipped hooks |
 |---|---|
 | **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
 | **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription` |
-| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
+| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `agent_loop_stopped`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
 
 These categories describe current behavior rather than defining future naming rules. Plugin middleware remains a separate registry/surface.
 ## Plugin types


### PR DESCRIPTION
## What does this PR do?

When `/stop` or the running-agent fast path of `/new` interrupts a gateway turn, plugins need a prompt signal to release external work waiting for a tool result. This adds the observer hook `agent_loop_stopped` immediately after `request_hard_interrupt()` in `gateway/run_agent_cache.py::_interrupt_and_clear_session`.

Fixes #27206. The motivating consumer is [hermes-livekit](https://github.com/kortexa-ai/hermes-livekit), which uses interruption signals to cancel remote tool requests and notify its client.

## Behavior

- Fires only for a real running agent; pending and missing-agent paths still perform normal cleanup without emitting the hook.
- Supplies `session_key`, `platform`, `reason` and `invalidation_reason`; callback return values are ignored.
- A failing plugin cannot prevent adapter cleanup, generation invalidation or session-state release.
- Documents the gateway-only hook and its relationship to the later `on_session_finalize` event.

The rebase onto upstream `3a7bf7455f` moves dispatch into the current gateway sibling and preserves the existing hard-interrupt, process-reaping and session-state paths.

## Validation

Two behavior tests cover seven cases through real temporary-plugin discovery, real hook dispatch and real session state: running/pending/missing turns for stop/new, plus a raising plugin. The three positive-observation cases fail against upstream source at `520e63661c`; all seven pass with this change. The subsequent upstream commit changes desktop files only.

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 4 \
  tests/gateway/test_agent_loop_stopped_hook.py \
  tests/gateway/test_session_state_cleanup.py \
  tests/hermes_cli/test_plugins.py
```

**87 passed, 1 existing environment-dependent failure**, macOS / Python 3.11. The failure is `test_failed_discovery_is_not_cached`: installed third-party plugin entry points make its isolated count assertion fail. The identical failure was reproduced with unchanged upstream source. The hook and session-cleanup files pass completely.

Changed-file Ruff, compatibility-pointer checks, contributor attribution and `git diff --check` pass. The full repository suite was not run for this rebase.

## Related proposal

#99930 contains this gateway patch with its original authorship and adds TUI/desktop coverage. It is a broader successor that remains open; this PR retains the narrower gateway scope for review.

## Checklist

- [x] Contribution guidance and existing review feedback addressed.
- [x] Real-path invariant tests verified against upstream and the fix.
- [x] User-facing hook documentation updated.
- [x] No new configuration, dependency or model-tool schema.
