### PR TITLE
fix(doctor): show xAI OAuth login state in hermes doctor Auth Providers section

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -164,6 +164,7 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
         from hermes_cli.auth import (
             get_gemini_oauth_auth_status,
             get_minimax_oauth_auth_status,
+            get_xai_oauth_auth_status,
         )
     except Exception:
         return False
@@ -173,6 +174,8 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
         return bool((get_gemini_oauth_auth_status() or {}).get("logged_in"))
     if normalized == "minimax":
         return bool((get_minimax_oauth_auth_status() or {}).get("logged_in"))
+    if normalized == "xai":
+        return bool((get_xai_oauth_auth_status() or {}).get("logged_in"))
     return False
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -823,6 +823,20 @@ def run_doctor(args):
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
+    # xAI OAuth — separate try/except so an import failure here cannot
+    # disrupt the already-printed Nous/Codex/Gemini/MiniMax rows above.
+    try:
+        from hermes_cli.auth import get_xai_oauth_auth_status
+        xai_oauth_status = get_xai_oauth_auth_status() or {}
+        if xai_oauth_status.get("logged_in"):
+            check_ok("xAI OAuth", "(logged in)")
+        else:
+            check_warn("xAI OAuth", "(not logged in)")
+            if xai_oauth_status.get("error"):
+                check_info(xai_oauth_status["error"])
+    except Exception:
+        pass
+
     if _safe_which("codex"):
         check_ok("codex CLI")
     else:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -160,22 +160,25 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
     still show a failed API-key connectivity row, but it should not promote
     that direct-key problem into the final blocking summary.
     """
-    try:
-        from hermes_cli.auth import (
-            get_gemini_oauth_auth_status,
-            get_minimax_oauth_auth_status,
-            get_xai_oauth_auth_status,
-        )
-    except Exception:
-        return False
-
     normalized = (provider_label or "").strip().lower()
     if normalized in {"google / gemini", "gemini"}:
-        return bool((get_gemini_oauth_auth_status() or {}).get("logged_in"))
+        try:
+            from hermes_cli.auth import get_gemini_oauth_auth_status
+            return bool((get_gemini_oauth_auth_status() or {}).get("logged_in"))
+        except Exception:
+            return False
     if normalized == "minimax":
-        return bool((get_minimax_oauth_auth_status() or {}).get("logged_in"))
+        try:
+            from hermes_cli.auth import get_minimax_oauth_auth_status
+            return bool((get_minimax_oauth_auth_status() or {}).get("logged_in"))
+        except Exception:
+            return False
     if normalized == "xai":
-        return bool((get_xai_oauth_auth_status() or {}).get("logged_in"))
+        try:
+            from hermes_cli.auth import get_xai_oauth_auth_status
+            return bool((get_xai_oauth_auth_status() or {}).get("logged_in"))
+        except Exception:
+            return False
     return False
 
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -259,6 +259,27 @@ def show_status(args):
     if minimax_status.get("error") and not minimax_logged_in:
         print(f"    Error:      {minimax_status.get('error')}")
 
+    # xAI OAuth — separate try/except so an import failure here cannot
+    # disrupt the already-printed Nous/Codex/Qwen/MiniMax rows above.
+    try:
+        from hermes_cli.auth import get_xai_oauth_auth_status
+        xai_oauth_status = get_xai_oauth_auth_status() or {}
+    except Exception:
+        xai_oauth_status = {}
+
+    xai_oauth_logged_in = bool(xai_oauth_status.get("logged_in"))
+    print(
+        f"  {'xAI OAuth':<12}  {check_mark(xai_oauth_logged_in)} "
+        f"{'logged in' if xai_oauth_logged_in else 'not logged in (run: hermes auth add xai-oauth)'}"
+    )
+    xai_auth_file = xai_oauth_status.get("auth_store")
+    if xai_auth_file:
+        print(f"    Auth file:  {xai_auth_file}")
+    if xai_oauth_status.get("last_refresh"):
+        print(f"    Refreshed:  {_format_iso_timestamp(xai_oauth_status.get('last_refresh'))}")
+    if xai_oauth_status.get("error") and not xai_oauth_logged_in:
+        print(f"    Error:      {xai_oauth_status.get('error')}")
+
     # =========================================================================
     # Nous Subscription Features
     # =========================================================================

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -320,6 +320,7 @@ class TestDoctorMemoryProviderSection:
             from hermes_cli import auth as _auth_mod
             monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
             monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
         except Exception:
             pass
 
@@ -426,6 +427,7 @@ def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, t
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -463,6 +465,7 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -510,6 +513,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -556,6 +560,7 @@ def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_auth_status", lambda provider: {"logged_in": True})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -594,6 +599,7 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -633,6 +639,7 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except Exception:
         pass
 
@@ -681,6 +688,7 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except ImportError:
         pass
 
@@ -739,6 +747,7 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
         from hermes_cli import auth as _auth_mod
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
     except ImportError:
         pass
 
@@ -1004,3 +1013,171 @@ class TestHasHealthyOauthFallbackForXai:
         monkeypatch.delitem(sys.modules, "hermes_cli.doctor", raising=False)
         from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
         assert _has_healthy_oauth_fallback_for_apikey_provider("gemini") is True
+
+
+# ---------------------------------------------------------------------------
+# ◆ Auth Providers — xAI OAuth display in run_doctor()
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorXaiOAuthStatus:
+    """The ◆ Auth Providers section must show xAI OAuth login state.
+
+    xAI OAuth is checked in a *separate* try/except block so that an import
+    failure (or runtime exception) cannot silence the Nous / Codex / Gemini /
+    MiniMax rows that were already printed above it.
+    """
+
+    def _run(self, monkeypatch, tmp_path, *, xai_auth_fn) -> str:
+        """Run doctor with a controlled xAI auth callable; return stdout."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", xai_auth_fn)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_logged_in_shows_ok(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch, tmp_path,
+            xai_auth_fn=lambda: {"logged_in": True},
+        )
+        assert "xAI OAuth" in out
+        assert "(logged in)" in out
+
+    def test_not_logged_in_shows_warn(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch, tmp_path,
+            xai_auth_fn=lambda: {"logged_in": False},
+        )
+        assert "xAI OAuth" in out
+        assert "(not logged in)" in out
+
+    def test_error_shown_when_not_logged_in_and_error_present(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch, tmp_path,
+            xai_auth_fn=lambda: {"logged_in": False, "error": "refresh token expired"},
+        )
+        assert "xAI OAuth" in out
+        assert "refresh token expired" in out
+
+    def test_no_error_line_when_error_key_absent(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch, tmp_path,
+            xai_auth_fn=lambda: {"logged_in": False},
+        )
+        assert "xAI OAuth" in out
+        # The check_info line is only emitted when the "error" key is present.
+        # Pick a token that would appear in no ordinary doctor output.
+        assert "refresh token expired" not in out
+
+    def test_logged_in_does_not_emit_not_logged_in_on_xai_line(self, monkeypatch, tmp_path):
+        out = self._run(
+            monkeypatch, tmp_path,
+            xai_auth_fn=lambda: {"logged_in": True},
+        )
+        assert "xAI OAuth" in out
+        # The xAI OAuth line itself must say "(logged in)", not "(not logged in)".
+        xai_line = next(l for l in out.splitlines() if "xAI OAuth" in l)
+        assert "(logged in)" in xai_line
+        assert "(not logged in)" not in xai_line
+
+    def test_import_failure_does_not_crash_doctor(self, monkeypatch, tmp_path):
+        """Doctor must not crash when get_xai_oauth_auth_status cannot be imported."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        out = buf.getvalue()
+        # The ◆ Auth Providers header must still appear — other providers unaffected.
+        assert "Auth Providers" in out
+
+    def test_import_failure_does_not_affect_other_providers(self, monkeypatch, tmp_path):
+        """Nous / Codex / Gemini / MiniMax rows must survive an xAI import failure."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": True})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {"logged_in": False})
+        monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        out = buf.getvalue()
+        assert "Nous Portal auth" in out
+        assert "logged in" in out
+
+    def test_function_raises_does_not_crash_doctor(self, monkeypatch, tmp_path):
+        """A runtime exception from get_xai_oauth_auth_status must be swallowed."""
+        def _raise():
+            raise RuntimeError("simulated xAI status failure")
+
+        out = self._run(monkeypatch, tmp_path, xai_auth_fn=_raise)
+        assert "Auth Providers" in out
+
+    def test_function_returns_none_does_not_crash_doctor(self, monkeypatch, tmp_path):
+        """None return is normalised to {} via `or {}` — must not AttributeError."""
+        out = self._run(monkeypatch, tmp_path, xai_auth_fn=lambda: None)
+        # None → {} → logged_in falsy → shows not-logged-in warn
+        assert "xAI OAuth" in out
+        assert "(not logged in)" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -944,3 +944,21 @@ def test_run_doctor_ignores_invalid_direct_keys_when_oauth_fallback_is_healthy(
 
     assert "invalid API key" in out
     assert unexpected_issue not in out
+
+
+class TestHasHealthyOauthFallbackForXai:
+    def test_returns_true_when_xai_oauth_healthy(self, monkeypatch):
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": True})
+        from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+        assert _has_healthy_oauth_fallback_for_apikey_provider("xai") is True
+
+    def test_returns_false_when_xai_oauth_not_logged_in(self, monkeypatch):
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {"logged_in": False})
+        from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+        assert _has_healthy_oauth_fallback_for_apikey_provider("xai") is False
+
+    def test_returns_false_for_unknown_provider(self):
+        from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+        assert _has_healthy_oauth_fallback_for_apikey_provider("unknown-provider") is False

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -850,6 +850,7 @@ def _run_doctor_with_healthy_oauth_fallback(
     failing_host: str,
     gemini_oauth_status: dict,
     minimax_oauth_status: dict,
+    xai_oauth_status: dict | None = None,
 ) -> str:
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)
@@ -886,6 +887,8 @@ def _run_doctor_with_healthy_oauth_fallback(
     monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
     monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: gemini_oauth_status)
     monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: minimax_oauth_status)
+    _xai_status = xai_oauth_status if xai_oauth_status is not None else {}
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: _xai_status)
 
     def fake_get(url, headers=None, timeout=None):
         status = 401 if failing_host in url else 200
@@ -902,7 +905,7 @@ def _run_doctor_with_healthy_oauth_fallback(
 
 
 @pytest.mark.parametrize(
-    ("env_key", "bad_key", "failing_host", "gemini_oauth_status", "minimax_oauth_status", "unexpected_issue"),
+    ("env_key", "bad_key", "failing_host", "gemini_oauth_status", "minimax_oauth_status", "xai_oauth_status", "unexpected_issue"),
     [
         (
             "GOOGLE_API_KEY",
@@ -910,6 +913,7 @@ def _run_doctor_with_healthy_oauth_fallback(
             "googleapis.com",
             {"logged_in": True, "email": "user@example.com"},
             {},
+            None,
             "Check GOOGLE_API_KEY in .env",
         ),
         (
@@ -918,7 +922,17 @@ def _run_doctor_with_healthy_oauth_fallback(
             "minimax.io",
             {},
             {"logged_in": True, "region": "global"},
+            None,
             "Check MINIMAX_API_KEY in .env",
+        ),
+        (
+            "XAI_API_KEY",
+            "bad-xai-key",
+            "api.x.ai",
+            {},
+            {},
+            {"logged_in": True, "auth_mode": "oauth_pkce"},
+            "Check XAI_API_KEY in .env",
         ),
     ],
 )
@@ -930,6 +944,7 @@ def test_run_doctor_ignores_invalid_direct_keys_when_oauth_fallback_is_healthy(
     failing_host,
     gemini_oauth_status,
     minimax_oauth_status,
+    xai_oauth_status,
     unexpected_issue,
 ):
     out = _run_doctor_with_healthy_oauth_fallback(
@@ -940,10 +955,16 @@ def test_run_doctor_ignores_invalid_direct_keys_when_oauth_fallback_is_healthy(
         failing_host=failing_host,
         gemini_oauth_status=gemini_oauth_status,
         minimax_oauth_status=minimax_oauth_status,
+        xai_oauth_status=xai_oauth_status,
     )
 
     assert "invalid API key" in out
     assert unexpected_issue not in out
+
+
+def test_has_healthy_oauth_fallback_returns_false_for_unknown_provider():
+    from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+    assert _has_healthy_oauth_fallback_for_apikey_provider("unknown-provider") is False
 
 
 class TestHasHealthyOauthFallbackForXai:
@@ -959,6 +980,27 @@ class TestHasHealthyOauthFallbackForXai:
         from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
         assert _has_healthy_oauth_fallback_for_apikey_provider("xai") is False
 
-    def test_returns_false_for_unknown_provider(self):
+    def test_returns_false_when_xai_oauth_returns_none(self, monkeypatch):
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: None)
         from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
-        assert _has_healthy_oauth_fallback_for_apikey_provider("unknown-provider") is False
+        assert _has_healthy_oauth_fallback_for_apikey_provider("xai") is False
+
+    def test_returns_false_when_xai_import_unavailable(self, monkeypatch):
+        import sys
+        # Simulate get_xai_oauth_auth_status missing from auth module
+        monkeypatch.delattr("hermes_cli.auth.get_xai_oauth_auth_status", raising=False)
+        # Force doctor module to re-import the function
+        monkeypatch.delitem(sys.modules, "hermes_cli.doctor", raising=False)
+        from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+        assert _has_healthy_oauth_fallback_for_apikey_provider("xai") is False
+
+    def test_xai_import_failure_does_not_affect_gemini(self, monkeypatch):
+        import sys
+        from hermes_cli import auth as _auth_mod
+        # xAI function missing, but Gemini is healthy
+        monkeypatch.delattr(_auth_mod, "get_xai_oauth_auth_status", raising=False)
+        monkeypatch.setattr(_auth_mod, "get_gemini_oauth_auth_status", lambda: {"logged_in": True})
+        monkeypatch.delitem(sys.modules, "hermes_cli.doctor", raising=False)
+        from hermes_cli.doctor import _has_healthy_oauth_fallback_for_apikey_provider
+        assert _has_healthy_oauth_fallback_for_apikey_provider("gemini") is True

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -29,6 +29,7 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
     monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
 
     def _unexpected_systemctl(*args, **kwargs):
@@ -70,6 +71,7 @@ def test_show_status_reports_nous_auth_error(monkeypatch, capsys, tmp_path):
     )
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
 
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
@@ -96,6 +98,7 @@ def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_pa
     monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
 
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
@@ -109,3 +112,223 @@ def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_pa
     assert "oidc-token" not in output
     assert "snapshot filesystem" in output
     assert "live processes do not survive" in output
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by xAI OAuth status tests
+# ---------------------------------------------------------------------------
+
+def _base_xai_mocks(monkeypatch, tmp_path):
+    """Set up the minimal environment for show_status, returning status_mod."""
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    return status_mod
+
+
+class TestShowStatusXaiOAuth:
+    """xAI OAuth row in hermes status."""
+
+    # ------------------------------------------------------------------
+    # Logged-in branch
+    # ------------------------------------------------------------------
+
+    def test_logged_in_shows_check_mark_and_label(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": True, "auth_store": "/a/auth.json"},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "xAI OAuth" in out
+        # The logged-in label must appear; the "not logged in" label must not
+        assert "✓" in out or "logged in" in out
+        assert "not logged in" not in out.split("xAI OAuth", 1)[1].split("\n")[0]
+
+    def test_logged_in_shows_auth_store(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": True, "auth_store": "/home/u/.hermes/auth.json"},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "Auth file:  /home/u/.hermes/auth.json" in out
+
+    def test_logged_in_shows_last_refresh(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {
+                                "logged_in": True,
+                                "auth_store": "/a/auth.json",
+                                "last_refresh": "2026-05-17T10:00:00+00:00",
+                            },
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "Refreshed:" in out
+
+    def test_logged_in_does_not_show_error_line(self, monkeypatch, capsys, tmp_path):
+        """Error field must be suppressed when logged_in is True."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {
+                                "logged_in": True,
+                                "auth_store": "/a/auth.json",
+                                "error": "stale-error-must-not-appear",
+                            },
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        xai_section = out.split("xAI OAuth", 1)[1]
+        assert "stale-error-must-not-appear" not in xai_section
+
+    def test_no_auth_store_line_when_field_absent(self, monkeypatch, capsys, tmp_path):
+        """Auth file line must not appear when auth_store is missing."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": True},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        xai_section = out.split("xAI OAuth", 1)[1].split("◆", 1)[0]
+        assert "Auth file:" not in xai_section
+
+    def test_no_refreshed_line_when_last_refresh_absent(self, monkeypatch, capsys, tmp_path):
+        """Refreshed line must not appear when last_refresh is not present."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": True, "auth_store": "/a/auth.json"},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        xai_section = out.split("xAI OAuth", 1)[1].split("◆", 1)[0]
+        assert "Refreshed:" not in xai_section
+
+    # ------------------------------------------------------------------
+    # Not-logged-in branch
+    # ------------------------------------------------------------------
+
+    def test_not_logged_in_shows_login_command(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": False, "error": "no credentials"},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "not logged in (run: hermes auth add xai-oauth)" in out
+
+    def test_not_logged_in_shows_error(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": False, "error": "Token has expired"},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "Error:      Token has expired" in out
+
+    def test_not_logged_in_omits_error_line_when_error_absent(self, monkeypatch, capsys, tmp_path):
+        """No Error: line when not logged in but error key is missing."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: {"logged_in": False},
+                            raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        xai_section = out.split("xAI OAuth", 1)[1].split("◆", 1)[0]
+        assert "Error:" not in xai_section
+
+    # ------------------------------------------------------------------
+    # Resilience: import failure and runtime exception
+    # ------------------------------------------------------------------
+
+    def test_import_failure_does_not_crash_show_status(self, monkeypatch, capsys, tmp_path):
+        """show_status must complete even when get_xai_oauth_auth_status cannot be imported."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.delattr(auth_mod, "get_xai_oauth_auth_status", raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "◆ Auth Providers" in out
+
+    def test_import_failure_does_not_break_other_oauth_providers(self, monkeypatch, capsys, tmp_path):
+        """Nous/Codex/MiniMax rows must still appear when xAI import fails."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_nous_auth_status",
+                            lambda: {"logged_in": True}, raising=False)
+        monkeypatch.delattr(auth_mod, "get_xai_oauth_auth_status", raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "Nous Portal" in out
+        assert "MiniMax OAuth" in out
+
+    def test_status_function_exception_does_not_crash(self, monkeypatch, capsys, tmp_path):
+        """show_status must not propagate an exception raised by get_xai_oauth_auth_status."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+
+        def _raises():
+            raise RuntimeError("backend unreachable")
+
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", _raises, raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "◆ Auth Providers" in out
+
+    def test_status_function_returns_none_does_not_crash(self, monkeypatch, capsys, tmp_path):
+        """get_xai_oauth_auth_status returning None must be handled gracefully."""
+        import hermes_cli.auth as auth_mod
+        status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+        monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status",
+                            lambda: None, raising=False)
+
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        out = capsys.readouterr().out
+
+        assert "xAI OAuth" in out
+        assert "not logged in (run: hermes auth add xai-oauth)" in out


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` prints an **◆ Auth Providers** section that checks login state for Nous, Codex, Gemini, and MiniMax OAuth — but silently omits xAI OAuth, even though `get_xai_oauth_auth_status()` exists in `hermes_cli/auth.py` and the same information is already surfaced in `hermes status` (PR #27202).

A user who runs `hermes auth add xai-oauth` has no way to confirm their session is recognised by `hermes doctor`.

## Changes Made

**`hermes_cli/doctor.py`**
- Added xAI OAuth status check in `run_doctor()` immediately after the shared Nous/Codex/Gemini/MiniMax try/except block.
- Isolated in its own `try/except` so an import failure cannot disrupt the provider rows already printed above — consistent with the per-provider isolation introduced in PR #27196.
- Shows `check_ok` when logged in, `check_warn` when not, and `check_info` with the error message when one is present.
- Guards the return value with `or {}` so a `None` return (defensive) normalises safely.

**`tests/hermes_cli/test_doctor.py`**
- New `TestDoctorXaiOAuthStatus` class — 9 tests:
  - `test_logged_in_shows_ok`
  - `test_not_logged_in_shows_warn`
  - `test_error_shown_when_not_logged_in_and_error_present`
  - `test_no_error_line_when_error_key_absent`
  - `test_logged_in_does_not_emit_not_logged_in_on_xai_line`
  - `test_import_failure_does_not_crash_doctor`
  - `test_import_failure_does_not_affect_other_providers`
  - `test_function_raises_does_not_crash_doctor`
  - `test_function_returns_none_does_not_crash_doctor`
- 9 existing `run_doctor` helpers updated to stub `get_xai_oauth_auth_status` for deterministic output.

## Related Issue

Parity gap introduced when xAI OAuth was added — `hermes status` received display support but `hermes doctor` was not updated.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Test Results

56/56 passing (`tests/hermes_cli/test_doctor.py`)