### PR TITLE
fix(skills): make --label and --assignee actually work in Linear skill

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -551,6 +551,14 @@ def print_rules() -> None:
 
 
 def main(argv: list[str]) -> int:
+    # Windows terminals default to cp1252, which can't encode the ✓/✗
+    # characters used in the output. Reconfigure streams to UTF-8 so the
+    # script works correctly on the very platform it is designed to help.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
+
     args = parse_args(argv)
 
     if args.list:

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -132,28 +132,50 @@ def _resolve_team_id(key_or_name: str) -> str | None:
 
 
 def _resolve_label_id(name: str, team_id: str) -> str | None:
-    """Map a label name to UUID within a team (case-insensitive)."""
-    q = """query($id: String!) {
-      team(id: $id) { labels(first: 100) { nodes { id name } } }
+    """Map a label name to UUID within a team (case-insensitive), paginating if needed."""
+    q = """query($id: String!, $after: String) {
+      team(id: $id) {
+        labels(first: 250, after: $after) {
+          nodes { id name }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
     }"""
-    nodes = gql(q, {"id": team_id}).get("team", {}).get("labels", {}).get("nodes", [])
     nl = name.lower()
-    for label in nodes:
-        if label["name"].lower() == nl:
-            return label["id"]
+    cursor = None
+    while True:
+        labels = gql(q, {"id": team_id, "after": cursor}).get("team", {}).get("labels", {})
+        for label in labels.get("nodes", []):
+            if label["name"].lower() == nl:
+                return label["id"]
+        page_info = labels.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
     return None
 
 
 def _resolve_member_id(name: str, team_id: str) -> str | None:
-    """Map a member display name or username to UUID within a team (case-insensitive)."""
-    q = """query($id: String!) {
-      team(id: $id) { members(first: 100) { nodes { id name displayName } } }
+    """Map a member display name or username to UUID within a team (case-insensitive), paginating if needed."""
+    q = """query($id: String!, $after: String) {
+      team(id: $id) {
+        members(first: 250, after: $after) {
+          nodes { id name displayName }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
     }"""
-    nodes = gql(q, {"id": team_id}).get("team", {}).get("members", {}).get("nodes", [])
     nl = name.lower()
-    for member in nodes:
-        if member["name"].lower() == nl or member["displayName"].lower() == nl:
-            return member["id"]
+    cursor = None
+    while True:
+        members = gql(q, {"id": team_id, "after": cursor}).get("team", {}).get("members", {})
+        for member in members.get("nodes", []):
+            if member["name"].lower() == nl or (member.get("displayName") or "").lower() == nl:
+                return member["id"]
+        page_info = members.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
     return None
 
 
@@ -291,7 +313,10 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
         if not issue:
             sys.stderr.write(f"Issue not found: {args.identifier}\n")
             sys.exit(1)
-        tid = issue["team"]["id"]
+        tid = (issue.get("team") or {}).get("id")
+        if not tid:
+            sys.stderr.write(f"Could not determine team for issue: {args.identifier}\n")
+            sys.exit(1)
         if args.label:
             lid = _resolve_label_id(args.label, tid)
             if lid is None:

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -131,6 +131,32 @@ def _resolve_team_id(key_or_name: str) -> str | None:
     return None
 
 
+def _resolve_label_id(name: str, team_id: str) -> str | None:
+    """Map a label name to UUID within a team (case-insensitive)."""
+    q = """query($id: String!) {
+      team(id: $id) { labels(first: 100) { nodes { id name } } }
+    }"""
+    nodes = gql(q, {"id": team_id}).get("team", {}).get("labels", {}).get("nodes", [])
+    nl = name.lower()
+    for label in nodes:
+        if label["name"].lower() == nl:
+            return label["id"]
+    return None
+
+
+def _resolve_member_id(name: str, team_id: str) -> str | None:
+    """Map a member display name or username to UUID within a team (case-insensitive)."""
+    q = """query($id: String!) {
+      team(id: $id) { members(first: 100) { nodes { id name displayName } } }
+    }"""
+    nodes = gql(q, {"id": team_id}).get("team", {}).get("members", {}).get("nodes", [])
+    nl = name.lower()
+    for member in nodes:
+        if member["name"].lower() == nl or member["displayName"].lower() == nl:
+            return member["id"]
+    return None
+
+
 def cmd_list_projects(args: argparse.Namespace) -> None:
     if args.team:
         tid = _resolve_team_id(args.team)
@@ -229,7 +255,18 @@ def cmd_create_issue(args: argparse.Namespace) -> None:
         inp["priority"] = args.priority
     if args.parent:
         inp["parentId"] = args.parent
-    # TODO: label + assignee name->id lookup (omitted for v1 brevity)
+    if args.label:
+        lid = _resolve_label_id(args.label, tid)
+        if lid is None:
+            sys.stderr.write(f"Label '{args.label}' not found in team '{args.team}'.\n")
+            sys.exit(1)
+        inp["labelIds"] = [lid]
+    if args.assignee:
+        aid = _resolve_member_id(args.assignee, tid)
+        if aid is None:
+            sys.stderr.write(f"Assignee '{args.assignee}' not found in team '{args.team}'.\n")
+            sys.exit(1)
+        inp["assigneeId"] = aid
 
     q = """mutation($input: IssueCreateInput!) {
       issueCreate(input: $input) {
@@ -247,6 +284,26 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
         inp["description"] = args.description
     if args.priority is not None:
         inp["priority"] = args.priority
+    if args.label or args.assignee:
+        # Need the team id to resolve label/member names
+        get_q = """query($id: String!) { issue(id: $id) { team { id } } }"""
+        issue = gql(get_q, {"id": args.identifier}).get("issue")
+        if not issue:
+            sys.stderr.write(f"Issue not found: {args.identifier}\n")
+            sys.exit(1)
+        tid = issue["team"]["id"]
+        if args.label:
+            lid = _resolve_label_id(args.label, tid)
+            if lid is None:
+                sys.stderr.write(f"Label '{args.label}' not found in this issue's team.\n")
+                sys.exit(1)
+            inp["labelIds"] = [lid]
+        if args.assignee:
+            aid = _resolve_member_id(args.assignee, tid)
+            if aid is None:
+                sys.stderr.write(f"Assignee '{args.assignee}' not found in this issue's team.\n")
+                sys.exit(1)
+            inp["assigneeId"] = aid
     if not inp:
         sys.stderr.write("No update fields provided.\n")
         sys.exit(1)


### PR DESCRIPTION
## What was broken

  The Linear skill's create-issue and update-issue commands listed --label
  and --assignee in the help text, but passing them did nothing. The issue
  would be created successfully with neither the label nor assignee applied
  no error, no warning, just silently dropped.

  ## Fix

  Added two lookup helpers that search the team's labels and members by
  name and return their IDs. Both create-issue and update-issue now use
  these to resolve names before sending the API request.

  If a label or assignee name doesn't exist in the team, the command exits
  with a clear error message instead of pretending it worked.

  ## Verified on

  - Windows 11, Python 3.13, live Linear workspace
  - create-issue --label Bug → label shows up on the issue ✓
  - create-issue --label doesnotexist → exits with clear error ✓
  - update-issue follows the same paths ✓