### PR TITLE
fix(whatsapp): preserve text document attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1094,8 +1094,14 @@ def _log_safe_path(path: str) -> str:
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
+    ".html": "text/html",
+    ".htm": "text/html",
     ".md": "text/markdown",
     ".txt": "text/plain",
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".ts": "text/typescript",
+    ".py": "text/x-python",
     ".csv": "text/csv",
     ".log": "text/plain",
     ".json": "application/json",
@@ -2907,6 +2913,7 @@ class BasePlatformAdapter(ABC):
         scan_content = BasePlatformAdapter._mask_protected_spans(content)
         scan_content = BasePlatformAdapter._mask_json_string_media(scan_content)
         for match in media_pattern.finditer(scan_content):
+
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
@@ -2966,6 +2973,7 @@ class BasePlatformAdapter(ABC):
             raw path strings removed).
         """
         _LOCAL_MEDIA_EXTS = MEDIA_DELIVERY_EXTS
+
         ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_MEDIA_EXTS)
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1097,6 +1097,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".html": "text/html",
     ".htm": "text/html",
     ".md": "text/markdown",
+    ".markdown": "text/markdown",
     ".txt": "text/plain",
     ".css": "text/css",
     ".js": "text/javascript",
@@ -1175,7 +1176,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".markdown", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1292,9 +1292,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Download media URLs to the local cache so agent tools
             # can access them reliably regardless of URL expiration.
             raw_urls = data.get("mediaUrls", [])
+            raw_mime_types = data.get("mediaMimeTypes", []) or []
             cached_urls = []
             media_types = []
-            for url in raw_urls:
+            for idx, url in enumerate(raw_urls):
+                bridge_mime = raw_mime_types[idx] if idx < len(raw_mime_types) else None
                 if msg_type == MessageType.PHOTO and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_image_from_url(url, ext=".jpg")
@@ -1329,7 +1331,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                    mime = bridge_mime or SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
                     media_types.append(mime)
                     print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -327,6 +327,7 @@ async function startSocket() {
       let hasMedia = false;
       let mediaType = '';
       const mediaUrls = [];
+      const mediaMimeTypes = [];
 
       if (messageContent.conversation) {
         body = messageContent.conversation;
@@ -382,7 +383,10 @@ async function startSocket() {
         body = messageContent.documentMessage.caption || '';
         hasMedia = true;
         mediaType = 'document';
-        const fileName = messageContent.documentMessage.fileName || 'document';
+        const mime = messageContent.documentMessage.mimetype || 'application/octet-stream';
+        const ext = extensionForMime(mime);
+        const rawFileName = messageContent.documentMessage.fileName || `document${ext}`;
+        const fileName = path.extname(rawFileName) ? rawFileName : `${rawFileName}${ext}`;
         try {
           const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
           mkdirSync(DOCUMENT_CACHE_DIR, { recursive: true });
@@ -390,6 +394,7 @@ async function startSocket() {
           const filePath = path.join(DOCUMENT_CACHE_DIR, `doc_${randomBytes(6).toString('hex')}_${safeFileName}`);
           writeFileSync(filePath, buf);
           mediaUrls.push(filePath);
+          mediaMimeTypes.push(mime);
         } catch (err) {
           console.error('[bridge] Failed to download document:', err.message);
         }
@@ -431,6 +436,7 @@ async function startSocket() {
         hasMedia,
         mediaType,
         mediaUrls,
+        mediaMimeTypes,
         mentionedIds,
         quotedMessageId,
         quotedParticipant,
@@ -562,11 +568,53 @@ const MIME_MAP = {
   webp: 'image/webp', gif: 'image/gif',
   mp4: 'video/mp4', mov: 'video/quicktime', avi: 'video/x-msvideo',
   mkv: 'video/x-matroska', '3gp': 'video/3gpp',
+  ogg: 'audio/ogg', opus: 'audio/ogg', mp3: 'audio/mpeg',
+  wav: 'audio/wav', m4a: 'audio/mp4', flac: 'audio/flac',
   pdf: 'application/pdf',
+  html: 'text/html', htm: 'text/html', txt: 'text/plain',
+  md: 'text/markdown', css: 'text/css', js: 'text/javascript',
+  ts: 'text/typescript', py: 'text/x-python', csv: 'text/csv',
+  json: 'application/json', xml: 'application/xml',
+  yaml: 'application/yaml', yml: 'application/yaml', log: 'text/plain',
+  zip: 'application/zip', rar: 'application/vnd.rar', '7z': 'application/x-7z-compressed',
   doc: 'application/msword',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 };
+
+const MIME_EXTENSION_MAP = {
+  'text/html': '.html',
+  'application/xhtml+xml': '.html',
+  'text/plain': '.txt',
+  'text/markdown': '.md',
+  'text/css': '.css',
+  'text/csv': '.csv',
+  'application/json': '.json',
+  'application/xml': '.xml',
+  'text/xml': '.xml',
+  'application/yaml': '.yaml',
+  'text/yaml': '.yaml',
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'application/msword': '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.ms-excel': '.xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.ms-powerpoint': '.ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+};
+
+function mimeForExtension(ext, fallback = 'application/octet-stream') {
+  return MIME_MAP[(ext || '').toLowerCase()] || fallback;
+}
+
+function extensionForMime(mime) {
+  const normalized = String(mime || '').split(';', 1)[0].trim().toLowerCase();
+  return MIME_EXTENSION_MAP[normalized] || '';
+}
 
 function inferMediaType(ext) {
   if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) return 'image';
@@ -598,10 +646,10 @@ app.post('/send-media', async (req, res) => {
 
     switch (type) {
       case 'image':
-        msgPayload = { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
+        msgPayload = { image: buffer, caption: caption || undefined, mimetype: mimeForExtension(ext, 'image/jpeg') };
         break;
       case 'video':
-        msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
+        msgPayload = { video: buffer, caption: caption || undefined, mimetype: mimeForExtension(ext, 'video/mp4') };
         break;
       case 'audio': {
         // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
@@ -637,7 +685,7 @@ app.post('/send-media', async (req, res) => {
           document: buffer,
           fileName: fileName || path.basename(filePath),
           caption: caption || undefined,
-          mimetype: MIME_MAP[ext] || 'application/octet-stream',
+          mimetype: mimeForExtension(ext),
         };
         break;
     }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -572,7 +572,7 @@ const MIME_MAP = {
   wav: 'audio/wav', m4a: 'audio/mp4', flac: 'audio/flac',
   pdf: 'application/pdf',
   html: 'text/html', htm: 'text/html', txt: 'text/plain',
-  md: 'text/markdown', css: 'text/css', js: 'text/javascript',
+  md: 'text/markdown', markdown: 'text/markdown', css: 'text/css', js: 'text/javascript',
   ts: 'text/typescript', py: 'text/x-python', csv: 'text/csv',
   json: 'application/json', xml: 'application/xml',
   yaml: 'application/yaml', yml: 'application/yaml', log: 'text/plain',

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -14,6 +14,8 @@ text-only reply, even when the path-based dedup set fails to capture it.
 import pytest
 import re
 
+from gateway.platforms.base import BasePlatformAdapter, SUPPORTED_DOCUMENT_TYPES
+
 
 def extract_media_tags_fixed(result_messages, history_len):
     """
@@ -369,6 +371,35 @@ class TestStaleToolMediaLeak:
             "On the compression fallback path, path-dedup must still exclude "
             f"known-old media, got {tags}"
         )
+
+
+class TestAttachmentPathExtraction:
+    """Regression coverage for native document attachment paths."""
+
+    def test_media_tag_extracts_html_document(self):
+        media, cleaned = BasePlatformAdapter.extract_media(
+            "Done\nMEDIA:/tmp/hermes/report.html"
+        )
+
+        assert media == [("/tmp/hermes/report.html", False)]
+        assert "MEDIA:" not in cleaned
+
+    def test_bare_local_html_path_is_auto_detected(self, tmp_path):
+        html_path = tmp_path / "preview.html"
+        html_path.write_text("<html><body>ok</body></html>", encoding="utf-8")
+
+        files, cleaned = BasePlatformAdapter.extract_local_files(
+            f"I generated {html_path} for you."
+        )
+
+        assert files == [str(html_path)]
+        assert str(html_path) not in cleaned
+
+    def test_html_and_common_text_document_mimes_are_known(self):
+        assert SUPPORTED_DOCUMENT_TYPES[".html"] == "text/html"
+        assert SUPPORTED_DOCUMENT_TYPES[".htm"] == "text/html"
+        assert SUPPORTED_DOCUMENT_TYPES[".css"] == "text/css"
+        assert SUPPORTED_DOCUMENT_TYPES[".js"] == "text/javascript"
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -376,28 +376,38 @@ class TestStaleToolMediaLeak:
 class TestAttachmentPathExtraction:
     """Regression coverage for native document attachment paths."""
 
-    def test_media_tag_extracts_html_document(self):
-        media, cleaned = BasePlatformAdapter.extract_media(
-            "Done\nMEDIA:/tmp/hermes/report.html"
-        )
+    @pytest.mark.parametrize(
+        ("extension", "path"),
+        [
+            ("html", "/tmp/hermes/report.html"),
+            ("md", "/tmp/hermes/article.md"),
+            ("markdown", "/tmp/hermes/article.markdown"),
+        ],
+    )
+    def test_media_tag_extracts_text_documents(self, extension, path):
+        media, cleaned = BasePlatformAdapter.extract_media(f"Done\nMEDIA:{path}")
 
-        assert media == [("/tmp/hermes/report.html", False)]
+        assert media == [(path, False)]
         assert "MEDIA:" not in cleaned
+        assert extension in path
 
-    def test_bare_local_html_path_is_auto_detected(self, tmp_path):
-        html_path = tmp_path / "preview.html"
-        html_path.write_text("<html><body>ok</body></html>", encoding="utf-8")
+    @pytest.mark.parametrize("filename", ["preview.html", "article.md", "article.markdown"])
+    def test_bare_local_text_document_path_is_auto_detected(self, tmp_path, filename):
+        doc_path = tmp_path / filename
+        doc_path.write_text("ok", encoding="utf-8")
 
         files, cleaned = BasePlatformAdapter.extract_local_files(
-            f"I generated {html_path} for you."
+            f"I generated {doc_path} for you."
         )
 
-        assert files == [str(html_path)]
-        assert str(html_path) not in cleaned
+        assert files == [str(doc_path)]
+        assert str(doc_path) not in cleaned
 
     def test_html_and_common_text_document_mimes_are_known(self):
         assert SUPPORTED_DOCUMENT_TYPES[".html"] == "text/html"
         assert SUPPORTED_DOCUMENT_TYPES[".htm"] == "text/html"
+        assert SUPPORTED_DOCUMENT_TYPES[".md"] == "text/markdown"
+        assert SUPPORTED_DOCUMENT_TYPES[".markdown"] == "text/markdown"
         assert SUPPORTED_DOCUMENT_TYPES[".css"] == "text/css"
         assert SUPPORTED_DOCUMENT_TYPES[".js"] == "text/javascript"
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -149,6 +149,38 @@ class TestCloseBridgeLog:
 # data variable initialization
 # ---------------------------------------------------------------------------
 
+class TestHtmlDocumentAttachments:
+    """Regression tests for HTML document attachment metadata."""
+
+    @pytest.mark.asyncio
+    async def test_bridge_cached_html_document_uses_bridge_mime(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._should_process_message = MagicMock(return_value=True)
+        html_path = tmp_path / "doc_abc_preview.html"
+        html_path.write_text("<html><body>Hello</body></html>", encoding="utf-8")
+
+        event = await adapter._build_message_event(
+            {
+                "chatId": "61400000000@c.us",
+                "senderId": "61400000000@c.us",
+                "body": "",
+                "hasMedia": True,
+                "mediaType": "document",
+                "mediaUrls": [str(html_path)],
+                "mediaMimeTypes": ["text/html"],
+                "isGroup": False,
+                "messageId": "msg-html",
+            }
+        )
+
+        assert event is not None
+        assert event.media_urls == [str(html_path)]
+        assert event.media_types == ["text/html"]
+        assert event.message_type.name == "DOCUMENT"
+        assert "[Content of preview.html]:" in event.text
+        assert "<html><body>Hello</body></html>" in event.text
+
+
 class TestDataInitialized:
     """Verify ``data = {}`` prevents NameError when resp.json() fails."""
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -150,7 +150,15 @@ class TestCloseBridgeLog:
 # ---------------------------------------------------------------------------
 
 class TestHtmlDocumentAttachments:
-    """Regression tests for HTML document attachment metadata."""
+    """Regression tests for text document attachment metadata."""
+
+    def test_bridge_mime_map_covers_markdown_documents(self):
+        bridge_js = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge" / "bridge.js"
+        source = bridge_js.read_text(encoding="utf-8")
+
+        assert "md: 'text/markdown'" in source
+        assert "markdown: 'text/markdown'" in source
+        assert "'text/markdown': '.md'" in source
 
     @pytest.mark.asyncio
     async def test_bridge_cached_html_document_uses_bridge_mime(self, tmp_path):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -821,6 +821,33 @@ class TestSendToPlatformWhatsapp:
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
 
+    def test_whatsapp_routes_media_via_local_bridge_sender(self, tmp_path):
+        chat_id = "test-user@lid"
+        report = tmp_path / "article.md"
+        report.write_text("# Report\n", encoding="utf-8")
+        media_files = [(str(report), False)]
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "doc123"})
+
+        with patch("tools.send_message_tool._send_whatsapp", async_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    "attached",
+                    media_files=media_files,
+                )
+            )
+
+        assert result["success"] is True
+        async_mock.assert_awaited_once_with(
+            {"bridge_port": 3000},
+            chat_id,
+            "attached",
+            media_files=media_files,
+            force_document=False,
+        )
+
 
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -717,6 +717,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- WhatsApp: native media support via the local bridge /send-media endpoint ---
+    if platform == Platform.WHATSAPP and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_whatsapp(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Yuanbao: native media attachment support via running gateway adapter ---
     if platform == Platform.YUANBAO and media_files:
         last_result = None
@@ -753,7 +770,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -761,7 +778,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu"
         )
 
     last_result = None
@@ -1072,15 +1089,72 @@ async def _send_slack(token, chat_id, message):
         return _error(f"Slack send failed: {e}")
 
 
-async def _send_whatsapp(extra, chat_id, message):
-    """Send via the local WhatsApp bridge HTTP API."""
+async def _send_whatsapp(extra, chat_id, message, media_files=None, force_document=False):
+    """Send via the local WhatsApp bridge HTTP API.
+
+    Text-only messages use /send. Attachments use /send-media so send_message
+    can deliver the same MEDIA: document/image/audio files as inbound gateway
+    replies. When text is supplied with attachments, the first attachment carries
+    it as a WhatsApp caption instead of sending a separate duplicate text bubble.
+    """
     try:
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    def _media_type_for_path(media_path: str, is_voice: bool) -> str:
+        if force_document:
+            return "document"
+        ext = os.path.splitext(media_path)[1].lower()
+        if ext in _IMAGE_EXTS:
+            return "image"
+        if ext in _VIDEO_EXTS:
+            return "video"
+        if ext in _AUDIO_EXTS or is_voice:
+            return "audio"
+        return "document"
+
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        valid_media = []
+        for media_path, is_voice in (media_files or []):
+            if os.path.exists(media_path):
+                valid_media.append((media_path, is_voice))
+            else:
+                logger.warning("WhatsApp media file not found, skipping: %s", media_path)
+
         async with aiohttp.ClientSession() as session:
+            if valid_media:
+                message_ids = []
+                last_data = {}
+                for i, (media_path, is_voice) in enumerate(valid_media):
+                    payload = {
+                        "chatId": chat_id,
+                        "filePath": media_path,
+                        "mediaType": _media_type_for_path(media_path, is_voice),
+                        "fileName": os.path.basename(media_path),
+                    }
+                    if i == 0 and message.strip():
+                        payload["caption"] = message
+                    async with session.post(
+                        f"http://localhost:{bridge_port}/send-media",
+                        json=payload,
+                        timeout=aiohttp.ClientTimeout(total=120),
+                    ) as resp:
+                        if resp.status != 200:
+                            body = await resp.text()
+                            return _error(f"WhatsApp bridge media error ({resp.status}): {body}")
+                        last_data = await resp.json()
+                        if last_data.get("messageId"):
+                            message_ids.append(last_data["messageId"])
+                return {
+                    "success": True,
+                    "platform": "whatsapp",
+                    "chat_id": chat_id,
+                    "message_id": last_data.get("messageId"),
+                    "message_ids": message_ids,
+                }
+
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
                 json={"chatId": chat_id, "message": message},


### PR DESCRIPTION
## Summary

Fixes WhatsApp text-document attachment handling end-to-end so generated or received `.html`, `.md`, and `.markdown` files are delivered and processed as native documents instead of falling through to generic/octet-stream, plain text, or omitted-media paths.

## What changed

- Adds `text/html` / `.html` / `.htm` and markdown document coverage (`.md`, `.markdown`) to the shared document MIME/extraction paths.
- Expands `MEDIA:` extraction and bare local path detection so paths like `MEDIA:/tmp/article.md`, `/tmp/article.markdown`, and `/tmp/report.html` are recognized and routed as native attachments.
- Updates the WhatsApp bridge MIME table used by `/send-media` so outbound markdown documents are sent with `mimetype: text/markdown`.
- Wires `send_message` WhatsApp media delivery through the local bridge `/send-media` endpoint, including document captions and multiple attachments, instead of silently omitting `MEDIA:` files.
- Preserves inbound document MIME metadata from the bridge (`mediaMimeTypes`) so Python sees HTML documents as `text/html` even when fallback extension inference would be lossy.
- Ensures inbound documents without a filename get an extension inferred from their MIME type, so `text/html` still caches as `.html` and can be text-injected for the agent.
- Adds regression coverage for HTML/markdown `MEDIA:` tags, bare local HTML/markdown attachment paths, shared MIME mappings, WhatsApp bridge markdown MIME entries, WhatsApp inbound HTML documents, and `send_message` WhatsApp media routing.

## Validation

- `node --check scripts/whatsapp-bridge/bridge.js`
- `git diff --check`
- `scripts/run_tests.sh tests/gateway/test_media_extraction.py tests/gateway/test_whatsapp_connect.py::TestHtmlDocumentAttachments tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp` — wrapper only selected `test_media_extraction.py` for this nodeid-shaped command; 11 passed, 0 failed
- `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/tools/test_send_message_tool.py` — 151 passed, 0 failed

No gateway or WhatsApp bridge restart was performed in Sebastian's live environment; the code is updated in the PR branch only and will take effect after an explicit later restart/deploy.

<!-- hermes-refresh-status -->
## Refresh status
- Updated the existing PR branch with the markdown/send_message follow-up requested from live WhatsApp debugging.
- Current head: `f3abeafbb`.
- Mergeability/check status should be read from the latest GitHub API response because editing this body can temporarily reset GitHub's mergeability calculation.
- Notes: PR now covers both the original HTML attachment fix and the discovered `.md` / `.markdown` WhatsApp attachment path, including the active `MEDIA:` extractor and `send_message` tool path.
- Test plan:
  - `node --check scripts/whatsapp-bridge/bridge.js`
  - `git diff --check`
  - `scripts/run_tests.sh tests/gateway/test_media_extraction.py tests/gateway/test_whatsapp_connect.py::TestHtmlDocumentAttachments tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp` — 11 passed, 0 failed for selected file
  - `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py tests/tools/test_send_message_tool.py` — 151 passed, 0 failed
