### PR TITLE
fix(gemini): add required role field to systemInstruction in native adapter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -323,7 +323,7 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        system_instruction = {"parts": [{"text": joined_system}]}
+        system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
     return contents, system_instruction
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -19,6 +19,29 @@ class DummyResponse:
         return self._payload
 
 
+def test_system_instruction_includes_role_field():
+    """systemInstruction must include 'role': 'system' for Gemma model compatibility.
+
+    Without the role field, Gemma models (e.g. gemma-4-31b-it) return
+    HTTP 500.  See https://github.com/NousResearch/hermes-agent/issues/27121
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    assert "systemInstruction" in request
+    si = request["systemInstruction"]
+    assert si["role"] == "system"
+    assert si["parts"][0]["text"] == "You are a helpful assistant."
+
+
 def test_build_native_request_preserves_thought_signature_on_tool_replay():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary

Fixes #27121

The Gemini native adapter constructs `systemInstruction` without the required `"role": "system"` key. This causes the Gemini API to return **HTTP 500** on any request that includes a system prompt when using **Gemma models** (e.g. `gemma-4-31b-it`).

## Root Cause

In `agent/gemini_native_adapter.py` line ~326, the system instruction was built as:

```python
system_instruction = {"parts": [{"text": joined_system}]}
```

The Gemini API requires a `role` field in the system instruction content object. Without it, Gemma models consistently return `500 Internal Server Error`. Other models (Gemini 2.5 Pro/Flash) are more lenient and tolerate the missing field, which is why this went undetected.

## Fix

One-line change — add `"role": "system"` to the `systemInstruction` dict:

```python
system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
```

## Changes

- `agent/gemini_native_adapter.py`: Added `"role": "system"` to `systemInstruction` construction
- `tests/agent/test_gemini_native_adapter.py`: Added `test_system_instruction_includes_role_field` regression test

## Verification

```bash
$ uv run --python 3.11 --extra dev python -m pytest tests/agent/test_gemini_native_adapter.py -v
# 12 passed (including new test)

$ uv run --python 3.11 --extra dev ruff check agent/gemini_native_adapter.py tests/agent/test_gemini_native_adapter.py
# All checks passed!
```

## Risk

- **Low risk**: This is a strict addition (`role` field) that the Gemini API already expects. Existing models that tolerated the missing field will continue to work with it present.
- No behavioral change for Gemini 2.5 Pro/Flash users.