### PR TITLE
fix(security): add missing credential paths to write denylist

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -36,6 +36,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
             os.path.join(home, ".pypirc"),
+            os.path.join(home, ".git-credentials"),
             "/etc/sudoers",
             "/etc/passwd",
             "/etc/shadow",
@@ -57,6 +58,7 @@ def build_write_denied_prefixes(home: str) -> list[str]:
             os.path.join(home, ".docker"),
             os.path.join(home, ".azure"),
             os.path.join(home, ".config", "gh"),
+            os.path.join(home, ".config", "gcloud"),
         ]
     ]
 


### PR DESCRIPTION
## What was missing

  The write denylist protects SSH keys, AWS, GPG, npm, PyPI, Docker,
  Azure, and GitHub CLI credentials from being written to by the agent.
  Two common credential stores were not included:

  **`~/.git-credentials`** — stores plaintext git tokens in the format
  `https://username:token@github.com` when using `git credential-store`.
  Directly analogous to `~/.netrc` which was already protected.

  **`~/.config/gcloud/`** — contains Google Cloud OAuth tokens and service
  account credentials. Directly analogous to `~/.aws/` which was already
  protected.

  ## Why it matters

  Under prompt injection, an agent could be instructed to overwrite these
  files destroying credentials or planting malicious ones that get picked
  up silently by git or the gcloud SDK on the next operation.

  ## Verified

  Ran `is_write_denied()` against both paths before and after:

  Before: `NOT PROTECTED ~/.git-credentials` / `NOT PROTECTED ~/.config/gcloud/`
  After:  `DENIED ~/.git-credentials` / `DENIED ~/.config/gcloud/credentials.db`