### PR TITLE
fix(schema_sanitizer): strip pattern/format from Responses-format tools for xAI compatibility

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9925,6 +9925,16 @@ class AIAgent:
             )
             is_xai_responses = self.provider in {"xai", "xai-oauth"} or self._base_url_hostname == "api.x.ai"
             _msgs_for_codex = self._prepare_messages_for_non_vision_model(api_messages)
+
+            # xAI's /responses endpoint rejects pattern and format keywords
+            # in tool schemas. Strip them before building kwargs.
+            if is_xai_responses:
+                try:
+                    from tools.schema_sanitizer import strip_pattern_and_format
+                    tools_for_api, _ = strip_pattern_and_format(tools_for_api)
+                except Exception:
+                    pass
+
             return _ct.build_kwargs(
                 model=self.model,
                 messages=_msgs_for_codex,

--- a/run_agent.py
+++ b/run_agent.py
@@ -9932,8 +9932,8 @@ class AIAgent:
                 try:
                     from tools.schema_sanitizer import strip_pattern_and_format
                     tools_for_api, _ = strip_pattern_and_format(tools_for_api)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logging.warning(f"{self.log_prefix}⚠️ Failed to sanitize tool schemas for xAI: {e}")
 
             return _ct.build_kwargs(
                 model=self.model,

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -444,3 +444,50 @@ def test_strip_responses_idempotent():
     # Pass 2 - idempotent
     _, second = strip_pattern_and_format(tools)
     assert second == 0, f"Expected 0 on second pass, got {second}"
+
+
+def test_strip_responses_mixed_formats():
+    """Mixed list of OpenAI-format and Responses-format tools should both be sanitized."""
+    from tools.schema_sanitizer import strip_pattern_and_format
+
+    tools = [
+        # OpenAI-format: {"function": {"parameters": {...}}}
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "pattern": "^[a-z]+$"}
+                    }
+                }
+            }
+        },
+        # Responses-format: {"name": "...", "parameters": {...}}
+        {
+            "name": "get_time",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tz": {"type": "string", "format": "date-time"}
+                }
+            },
+            "type": "function"
+        }
+    ]
+
+    result, stripped = strip_pattern_and_format(tools)
+    assert stripped == 2, f"Expected 2 stripped (1 pattern + 1 format), got {stripped}"
+
+    # OpenAI-format tool: pattern stripped from parameters
+    openai_params = result[0]["function"]["parameters"]["properties"]["query"]
+    assert "pattern" not in openai_params, f"pattern should be stripped: {openai_params}"
+
+    # Responses-format tool: format stripped
+    resp_params = result[1]["parameters"]["properties"]["tz"]
+    assert "format" not in resp_params, f"format should be stripped: {resp_params}"
+
+    # Verify structure preserved
+    assert result[0]["function"]["parameters"]["type"] == "object"
+    assert result[1]["parameters"]["type"] == "object"

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -304,6 +304,30 @@ def test_strip_none_returns_zero():
     assert stripped == 0
 
 
+
+def test_strip_responses_format_strips_format_keyword():
+    """Responses-format:  keyword should be stripped."""
+    from tools.schema_sanitizer import strip_pattern_and_format
+
+    tools = [
+        {
+            "name": "get_event",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ts": {"type": "string", "format": "date-time"},
+                }
+            },
+            "type": "function"
+        }
+    ]
+
+    result, stripped = strip_pattern_and_format(tools)
+    assert stripped == 1, f"Expected 1 format stripped, got {stripped}"
+    assert "format" not in result[0]["parameters"]["properties"]["ts"], "format should be stripped"
+    assert result[0]["parameters"]["properties"]["ts"]["type"] == "string", "type should be preserved"
+
+
 def test_top_level_allof_stripped_for_codex_backend_compat():
     """OpenAI Codex backend rejects top-level allOf/oneOf/anyOf/enum/not."""
     tools = [_tool("memory", {

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -360,3 +360,63 @@ def test_nested_allof_preserved():
     nested = out[0]["function"]["parameters"]["properties"]["config"]
     assert "allOf" in nested
     assert nested["allOf"] == [{"required": ["mode"]}]
+
+
+def test_strip_responses_format_tools():
+    """strip_pattern_and_format should handle Responses-format tools (no function wrapper)."""
+    from tools.schema_sanitizer import strip_pattern_and_format
+
+    # Responses-format: {"name": "...", "parameters": {...}, "type": "function"}
+    tools = [
+        {
+            "name": "mcp_firecrawl_search",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "includeDomains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "pattern": "^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+                        }
+                    }
+                }
+            },
+            "type": "function"
+        }
+    ]
+
+    result, stripped = strip_pattern_and_format(tools)
+    assert stripped == 1, f"Expected 1 pattern stripped, got {stripped}"
+    
+    # Verify pattern keyword was removed from includeDomains
+    domains = result[0]["parameters"]["properties"]["includeDomains"]["items"]
+    assert "pattern" not in domains, f"pattern should be stripped: {domains}"
+    assert domains["type"] == "string", "type should be preserved"
+
+
+def test_strip_responses_idempotent():
+    """Second call on already-stripped Responses-format tools should return 0."""
+    from tools.schema_sanitizer import strip_pattern_and_format
+
+    tools = [
+        {
+            "name": "search_files",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"}  # This is a property named pattern, NOT schema keyword
+                }
+            }
+        }
+    ]
+
+    # Pass 1 - property named 'pattern' should NOT be stripped
+    result, first = strip_pattern_and_format(tools)
+    assert first == 0, f"Expected 0 stripped (property pattern preserved), got {first}"
+    assert "pattern" in result[0]["parameters"]["properties"], "property named pattern should survive"
+    
+    # Pass 2 - idempotent
+    _, second = strip_pattern_and_format(tools)
+    assert second == 0, f"Expected 0 on second pass, got {second}"

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -355,11 +355,23 @@ def strip_pattern_and_format(tools: list[dict]) -> tuple[list[dict], int]:
                 _walk(item)
 
     for tool in tools:
-        fn = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(tool, dict):
+            continue
+        
+        # OpenAI-format: {"function": {"parameters": {...}}}
+        fn = tool.get("function")
         if isinstance(fn, dict):
             params = fn.get("parameters")
             if isinstance(params, dict):
                 _walk(params)
+                continue
+        
+        # Responses-format: {"name": "...", "parameters": {...}}
+        # (used by codex_responses API mode — xAI, OpenAI Codex, etc.)
+        params = tool.get("parameters")
+        if isinstance(params, dict):
+            _walk(params)
+            continue
 
     if stripped:
         logger.info(


### PR DESCRIPTION
# Summary

strip_pattern_and_format() now handles Responses-format tool schemas ({\name\: ..., \parameters\: ...}) used by codex_responses API mode, plus auto-strips before xAI /responses calls.

Closes #27197

## Problem

xAI's /responses endpoint rejects pattern and format keywords in tool schemas with HTTP 400. The existing strip_pattern_and_format() only walked OpenAI-format tools ({\function\: {\parameters\: ...}}), missing Responses-format shapes.

## Solution

1. tools/schema_sanitizer.py: Extended strip_pattern_and_format() to handle both OpenAI-format ({\function\: {\parameters\: ...}}) and Responses-format ({\name\: ..., \parameters\: ...}) tools
2. run_agent.py: Auto-strip pattern/format from tool schemas before building codex_responses kwargs for xAI providers (xai, xai-oauth)

## Files Changed

| File | +/- | Description |
|------|-----|-------------|
| tools/schema_sanitizer.py | +14/-1 | Responses-format tool walk path |
| run_agent.py | +10/-0 | xAI auto-strip in _build_api_kwargs |
| tests/tools/test_schema_sanitizer.py | +60/-0 | 2 new tests |

## Test Results

tests/tools/test_schema_sanitizer.py ✓ 29 passed in 3.61s