### PR TITLE
fix(tui): add classic input frame separator

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3078,6 +3078,46 @@ class HermesCLI:
         emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"
 
+    @staticmethod
+    def _reasoning_effort_label(reasoning_config: Any) -> str:
+        """Return the compact reasoning-effort label for status bars."""
+        if reasoning_config is None:
+            return "medium"
+        if isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                return "none"
+            return str(reasoning_config.get("effort", "") or "medium")
+        return ""
+
+    def _status_bar_model_label(self, model_short: str) -> str:
+        """Return model + reasoning + fast status for the status bar."""
+        agent = getattr(self, "agent", None)
+        reasoning_config = getattr(agent, "reasoning_config", None) if agent else None
+        if reasoning_config is None:
+            reasoning_config = getattr(self, "reasoning_config", None)
+        effort_label = self._reasoning_effort_label(reasoning_config)
+        service_tier = getattr(agent, "service_tier", None) if agent else None
+        if service_tier is None:
+            service_tier = getattr(self, "service_tier", None)
+        parts = [model_short]
+        if effort_label:
+            parts.append(effort_label)
+        if service_tier == "priority":
+            parts.append("fast")
+        return " · ".join(parts)
+
+    @staticmethod
+    def _status_bar_workspace_label() -> str:
+        """Return the compact active workspace label for status bars."""
+        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        try:
+            path = Path(cwd).expanduser()
+            if path == Path.home():
+                return "~"
+            return path.name or str(path)
+        except Exception:
+            return str(cwd).rstrip("/\\").split("/")[-1] or str(cwd)
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -3090,11 +3130,17 @@ class HermesCLI:
             model_short = model_short[:-5]
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
+        model_label = self._status_bar_model_label(model_short)
+        workspace_label = self._status_bar_workspace_label()
+        chat_status = "working" if getattr(self, "_agent_running", False) else "ready"
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
+            "chat_status": chat_status,
             "model_name": model_name,
             "model_short": model_short,
+            "model_label": model_label,
+            "workspace_label": workspace_label,
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -3352,12 +3398,13 @@ class HermesCLI:
 
             yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{snapshot['chat_status']} │ ⚕ {snapshot['model_label']} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                compact_model = self._status_bar_model_label(self._trim_status_bar_text(snapshot["model_short"], 12))
+                parts = [snapshot["chat_status"], f"⚕ {compact_model}", percent_label, snapshot["workspace_label"]]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3377,7 +3424,7 @@ class HermesCLI:
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [snapshot["chat_status"], f"⚕ {snapshot['model_label']}", context_label, percent_label, snapshot["workspace_label"]]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -3409,8 +3456,10 @@ class HermesCLI:
 
             if width < 52:
                 frags = [
-                    ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                    ("class:status-bar-strong", f" {snapshot['chat_status']}"),
+                    ("class:status-bar-dim", " │ "),
+                    ("class:status-bar", "⚕ "),
+                    ("class:status-bar-strong", snapshot["model_label"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
@@ -3422,13 +3471,18 @@ class HermesCLI:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
+                    compact_model = self._status_bar_model_label(self._trim_status_bar_text(snapshot["model_short"], 12))
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", f" {snapshot['chat_status']}"),
+                        ("class:status-bar-dim", " │ "),
+                        ("class:status-bar", "⚕ "),
+                        ("class:status-bar-strong", compact_model),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
+                        ("class:status-bar-dim", " · "),
+                        ("class:status-bar-dim", snapshot["workspace_label"]),
                     ]
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
@@ -3456,14 +3510,18 @@ class HermesCLI:
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", f" {snapshot['chat_status']}"),
+                        ("class:status-bar-dim", " │ "),
+                        ("class:status-bar", "⚕ "),
+                        ("class:status-bar-strong", snapshot["model_label"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
+                        ("class:status-bar-dim", " │ "),
+                        ("class:status-bar-dim", snapshot["workspace_label"]),
                     ]
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7690,6 +7690,41 @@ def _run_pre_update_backup(args) -> None:
     print()
 
 
+def _run_local_post_update_hooks() -> None:
+    """Run user-owned post-update hooks that live outside the source tree.
+
+    Local source edits are replaced during `hermes update`, so durable
+    customizations need a hook stored under HERMES_HOME.  This is intentionally
+    best-effort: a broken local patch should be visible but must not corrupt the
+    update flow.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        hooks = [
+            get_hermes_home() / "local-patches" / "hermes-statusbar" / "apply.sh",
+        ]
+    except Exception:
+        hooks = [Path.home() / ".hermes" / "local-patches" / "hermes-statusbar" / "apply.sh"]
+
+    existing = [hook for hook in hooks if hook.exists()]
+    if not existing:
+        return
+
+    print()
+    print("→ Running local post-update hooks...")
+    for hook in existing:
+        try:
+            result = subprocess.run([str(hook)], cwd=PROJECT_ROOT, text=True)
+        except Exception as exc:
+            print(f"  ⚠ {hook}: failed to start ({exc})")
+            continue
+        if result.returncode == 0:
+            print(f"  ✓ {hook}")
+        else:
+            print(f"  ⚠ {hook}: exited {result.returncode}")
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -8210,6 +8245,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("Skipped. Run 'hermes config migrate' later to configure.")
         else:
             print("  ✓ Configuration is up to date")
+
+        _run_local_post_update_hooks()
 
         print()
         print("✓ Update complete!")

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import os
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -73,13 +74,68 @@ class TestCLIStatusBar:
             context_length=200_000,
         )
 
-        text = cli_obj._build_status_bar_text(width=120)
+        with patch.dict(os.environ, {"TERMINAL_CWD": "/tmp/example-workspace"}):
+            text = cli_obj._build_status_bar_text(width=120)
 
-        assert "claude-sonnet-4-20250514" in text
+        assert text.startswith("ready │ ")
+        assert "claude-sonnet-4-20250514 · medium" in text
+        assert "fast" not in text
         assert "12.4K/200K" in text
-        assert "6%" in text
+        assert "6% │ example-workspace" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_build_status_bar_text_shows_reasoning_effort_and_fast_when_on(self):
+        cli_obj = _attach_agent(
+            _make_cli("openai/gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.reasoning_config = {"enabled": True, "effort": "high"}
+        cli_obj.agent.service_tier = "priority"
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.4 · high · fast" in text
+        assert "fast on" not in text
+        assert "fast off" not in text
+
+    def test_build_status_bar_text_shows_reasoning_none(self):
+        cli_obj = _attach_agent(
+            _make_cli("openai/gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.reasoning_config = {"enabled": False}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.4 · none" in text
+        assert "fast" not in text
+
+    def test_build_status_bar_text_shows_working_when_agent_running(self):
+        cli_obj = _attach_agent(
+            _make_cli("openai/gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._agent_running = True
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert text.startswith("working │ ")
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
@@ -294,9 +350,12 @@ class TestCLIStatusBar:
         )
         cli_obj._status_bar_visible = True
 
-        frags = cli_obj._get_status_bar_fragments()
+        with patch.dict(os.environ, {"TERMINAL_CWD": "/tmp/example-workspace"}):
+            with patch.object(HermesCLI, "_get_tui_terminal_width", return_value=120):
+                frags = cli_obj._get_status_bar_fragments()
         frag_texts = [text for _, text in frags]
 
+        assert "example-workspace" in frag_texts
         assert "🗜️ 7" in frag_texts
         frag_styles = {text: style for style, text in frags}
         assert frag_styles["🗜️ 7"] == "class:status-bar-warn"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3833,6 +3833,7 @@ def _(rid, params: dict) -> dict:
                 )
 
         _write_config_key("agent.service_tier", nv)
+        result = {"key": key, "value": nv}
         if agent is not None:
             agent.service_tier = "priority" if nv == "fast" else None
             current_overrides = dict(getattr(agent, "request_overrides", {}) or {})
@@ -3841,12 +3842,14 @@ def _(rid, params: dict) -> dict:
             if nv == "fast":
                 current_overrides.update(overrides)
             agent.request_overrides = current_overrides
+            info = _session_info(agent)
             _emit(
                 "session.info",
                 params.get("session_id", ""),
-                _session_info(agent),
+                info,
             )
-        return _ok(rid, {"key": key, "value": nv})
+            result["info"] = info
+        return _ok(rid, result)
 
     if key == "busy":
         raw = str(value or "").strip().lower()
@@ -3932,8 +3935,11 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 if session:
                     session["show_reasoning"] = True
-                return _ok(rid, {"key": key, "value": "show"})
-            if arg in {"hide", "off"}:
+                result = {"key": key, "value": "show"}
+                if session and session.get("agent") is not None:
+                    result["info"] = _session_info(session["agent"])
+                return _ok(rid, result)
+            if arg in ("hide", "off"):
                 cfg = _load_cfg()
                 display = (
                     cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -3950,15 +3956,22 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 if session:
                     session["show_reasoning"] = False
-                return _ok(rid, {"key": key, "value": "hide"})
+                result = {"key": key, "value": "hide"}
+                if session and session.get("agent") is not None:
+                    result["info"] = _session_info(session["agent"])
+                return _ok(rid, result)
 
             parsed = parse_reasoning_effort(arg)
             if parsed is None:
                 return _err(rid, 4002, f"unknown reasoning value: {value}")
             _write_config_key("agent.reasoning_effort", arg)
+            result = {"key": key, "value": arg}
             if session and session.get("agent") is not None:
                 session["agent"].reasoning_config = parsed
-            return _ok(rid, {"key": key, "value": arg})
+                info = _session_info(session["agent"])
+                _emit("session.info", params.get("session_id", ""), info)
+                result["info"] = info
+            return _ok(rid, result)
         except Exception as e:
             return _err(rid, 5001, str(e))
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -99,6 +99,7 @@ export const sessionCommands: SlashCommand[] = [
       if (ctx.session.guardBusySessionSwitch('switch sessions')) {
         return
       }
+
       if (!arg.trim()) {
         return patchOverlayState({ picker: true })
       }
@@ -392,6 +393,10 @@ export const sessionCommands: SlashCommand[] = [
               return
             }
 
+            if (r.info) {
+              patchUiState({ info: r.info })
+            }
+
             if (r.value === 'hide') {
               patchUiState(state => ({
                 ...state,
@@ -440,16 +445,21 @@ export const sessionCommands: SlashCommand[] = [
           ctx.guarded<ConfigSetResponse>(r => {
             const next = r.value === 'fast' ? 'fast' : 'normal'
             ctx.transcript.sys(`fast mode: ${next}`)
-            patchUiState(state => ({
-              ...state,
-              info: state.info
-                ? {
-                    ...state.info,
-                    fast: next === 'fast',
-                    service_tier: next === 'fast' ? 'priority' : ''
-                  }
-                : state.info
-            }))
+
+            if (r.info) {
+              patchUiState({ info: r.info })
+            } else {
+              patchUiState(state => ({
+                ...state,
+                info: state.info
+                  ? {
+                      ...state.info,
+                      fast: next === 'fast',
+                      service_tier: next === 'fast' ? 'priority' : ''
+                    }
+                  : state.info
+              }))
+            }
           })
         )
         .catch(ctx.guardedErr)

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -229,8 +229,10 @@ const effortLabel = (effort?: string) => {
     .trim()
     .toLowerCase()
 
-  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? value : ''
+  return value && value !== 'normal' && value !== 'default' ? value : ''
 }
+
+const fastLabel = (fast?: boolean) => (fast ? 'fast' : '')
 
 const shortModelLabel = (model: string) =>
   model
@@ -243,7 +245,7 @@ const shortModelLabel = (model: string) =>
     .trim()
 
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+  [shortModelLabel(model), effortLabel(effort), fastLabel(fast)].filter(Boolean).join(' · ')
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -261,7 +263,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
     const id = setTimeout(() => setActive(false), 650)
 
     return () => clearTimeout(id)
-  }, [t.color.accent, tick])
+  }, [t.color.accent, t.color.error, t.color.warn, tick])
 
   if (!active) {
     return null
@@ -297,18 +299,18 @@ export function StatusRule({
       : ''
 
   const bar = usage.context_max ? ctxBar(pct) : ''
-  const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
+  const leftWidth = Math.max(12, cols)
+  const chatStatus = busy ? 'working' : (status || 'ready')
 
   return (
     <Box height={1}>
       <Box flexShrink={1} width={leftWidth}>
         <Text color={t.color.border} wrap="truncate-end">
           {'─ '}
+          <Text color={statusColor}>{chatStatus}</Text>
           {busy ? (
-            <FaceTicker color={statusColor} startedAt={turnStartedAt} />
-          ) : (
-            <Text color={statusColor}>{status}</Text>
-          )}
+            <Text color={statusColor}> <FaceTicker color={statusColor} startedAt={turnStartedAt} /></Text>
+          ) : null}
           <Text color={t.color.muted}> │ {modelLabel(model, modelReasoningEffort, modelFast)}</Text>
           {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
           {bar ? (
@@ -317,6 +319,7 @@ export function StatusRule({
               <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
             </Text>
           ) : null}
+          {cwdLabel ? <Text color={t.color.label}> │ {cwdLabel}</Text> : null}
           {sessionStartedAt ? (
             <Text color={t.color.muted}>
               {' │ '}
@@ -348,9 +351,6 @@ export function StatusRule({
           ) : null}
         </Text>
       </Box>
-
-      <Text color={t.color.border}> ─ </Text>
-      <Text color={t.color.label}>{cwdLabel}</Text>
     </Box>
   )
 }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -53,7 +53,7 @@ const PromptPrefix = memo(function PromptPrefix({
   )
 })
 
-const chatTurnSeparator = (cols: number) => '─'.repeat(Math.max(12, cols - 2))
+const horizontalRule = (cols: number) => '─'.repeat(Math.max(12, cols - 2))
 
 const TranscriptPane = memo(function TranscriptPane({
   actions,
@@ -108,7 +108,7 @@ const TranscriptPane = memo(function TranscriptPane({
             <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
               {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
                 <Box marginTop={1}>
-                  <Text color={ui.theme.color.border}>{chatTurnSeparator(composer.cols)}</Text>
+                  <Text color={ui.theme.color.border}>{horizontalRule(composer.cols)}</Text>
                 </Box>
               )}
 
@@ -245,7 +245,13 @@ const ComposerPane = memo(function ComposerPane({
           {status.stickyPrompt}
         </Text>
       ) : (
-        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag} />
+        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag}>
+          {ui.statusBar === 'top' ? (
+            <Text color={ui.theme.color.border} wrap="truncate-end">
+              {horizontalRule(composer.cols)}
+            </Text>
+          ) : null}
+        </Box>
       )}
 
       <StatusRulePane at="top" composer={composer} status={status} />
@@ -351,7 +357,7 @@ const StatusRulePane = memo(function StatusRulePane({
   }
 
   return (
-    <Box marginTop={at === 'top' ? 1 : 0}>
+    <Box marginTop={0}>
       <StatusRule
         bgCount={ui.bgTasks.size}
         busy={ui.busy}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -53,6 +53,8 @@ const PromptPrefix = memo(function PromptPrefix({
   )
 })
 
+const chatTurnSeparator = (cols: number) => '─'.repeat(Math.max(12, cols - 2))
+
 const TranscriptPane = memo(function TranscriptPane({
   actions,
   composer,
@@ -77,7 +79,7 @@ const TranscriptPane = memo(function TranscriptPane({
   }, [transcript.historyItems])
 
   // Index of the first user-role message; every later user message gets a
-  // small dash above it so multi-turn transcripts visually segment by
+  // full-width rule above it so multi-turn transcripts visually segment by
   // turn. -1 when no user message has been sent yet → no separator ever
   // renders.
   const firstUserIdx = useMemo(
@@ -106,7 +108,7 @@ const TranscriptPane = memo(function TranscriptPane({
             <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
               {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
                 <Box marginTop={1}>
-                  <Text color={ui.theme.color.border}>───</Text>
+                  <Text color={ui.theme.color.border}>{chatTurnSeparator(composer.cols)}</Text>
                 </Box>
               )}
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -6,7 +6,7 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiState } from '../app/uiStore.js'
-import { INLINE_MODE, SHOW_FPS } from '../config/env.js'
+import { CLASSIC_SKIN, INLINE_MODE, SHOW_FPS } from '../config/env.js'
 import { FULL_RENDER_TAIL_ITEMS } from '../config/limits.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import {
@@ -244,14 +244,8 @@ const ComposerPane = memo(function ComposerPane({
 
           {status.stickyPrompt}
         </Text>
-      ) : (
-        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag}>
-          {ui.statusBar === 'top' ? (
-            <Text color={ui.theme.color.border} wrap="truncate-end">
-              {horizontalRule(composer.cols)}
-            </Text>
-          ) : null}
-        </Box>
+      ) : CLASSIC_SKIN && ui.statusBar === 'top' ? null : (
+        <Box height={1} onMouseDown={captureInputDrag} onMouseDrag={dragFromSpacer} onMouseUp={endInputDrag} />
       )}
 
       <StatusRulePane at="top" composer={composer} status={status} />
@@ -284,7 +278,14 @@ const ComposerPane = memo(function ComposerPane({
               </Box>
             ))}
 
+            {CLASSIC_SKIN && ui.statusBar === 'top' && (
+              <Text color={ui.theme.color.border} wrap="truncate-end">
+                {horizontalRule(composer.cols)}
+              </Text>
+            )}
+
             <Box
+              height={CLASSIC_SKIN && composer.empty ? inputHeight + 1 : undefined}
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
               onMouseUp={endInputDrag}
@@ -301,7 +302,13 @@ const ComposerPane = memo(function ComposerPane({
                 )}
               </Box>
 
-              <Box flexGrow={0} flexShrink={0} height={inputHeight} width={inputColumns}>
+              <Box
+                flexDirection="column"
+                flexGrow={0}
+                flexShrink={0}
+                height={CLASSIC_SKIN ? inputHeight + 1 : inputHeight}
+                width={inputColumns}
+              >
                 {/* Reserve the transcript scrollbar gutter too so typing never rewraps when the scrollbar column repaints. */}
                 <TextInput
                   columns={inputColumns}
@@ -309,10 +316,24 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  placeholder={
+                    CLASSIC_SKIN
+                      ? `\n${horizontalRule(inputColumns)}`
+                      : composer.empty
+                        ? PLACEHOLDER
+                        : ui.busy
+                          ? 'Ctrl+C to interrupt…'
+                          : ''
+                  }
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />
+
+                {CLASSIC_SKIN && composer.input.length > 0 && (
+                  <Text color={ui.theme.color.border} wrap="truncate-end">
+                    {horizontalRule(inputColumns)}
+                  </Text>
+                )}
               </Box>
 
               <Box position="absolute" right={0}>

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -11,6 +11,7 @@ export const NO_CONFIRM_DESTRUCTIVE = truthy(process.env.HERMES_TUI_NO_CONFIRM)
 // Experiment gate: lets us measure native scroll vs our virtualization on
 // the same pipeline.
 export const INLINE_MODE = truthy(process.env.HERMES_TUI_INLINE)
+export const CLASSIC_SKIN = truthy(process.env.HERMES_TUI_CLASSIC_SKIN)
 
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).


### PR DESCRIPTION
## Summary
- Adds env-gated classic TUI status bar/input framing via `HERMES_TUI_CLASSIC_SKIN`.
- Preserves classic statusbar customization across CLI/TUI gateway paths.
- Frames the live composer prompt line with visible separators above and below in classic mode.
- Keeps default TUI behavior unchanged unless the classic-skin env flag is enabled.

## Visual smoke evidence

Captured from tmux after running:

```bash
HERMES_TUI_CLASSIC_SKIN=1 ./venv/bin/python hermes_cli/main.py --tui
```

Typed input smoke:

```text
56  ─ ready │ gpt 5.5 · medium │ 0/272k │ [░░░░░░░░░░] 0% │ ….hermes/hermes-agent (…lassic-followup) │ 3s │ voice off
57  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
58  ❯ abc input smoke
59    ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

The separator is intentionally attached to the live composer prompt row, not just the status bar row.

## Test Plan
- [x] `cd ui-tui && npm run type-check`
- [x] `npx eslint src/config/env.ts src/components/appLayout.tsx src/components/appChrome.tsx src/app/slash/commands/session.ts --quiet`
- [x] `cd ui-tui && npm run build`
- [x] `./venv/bin/python -m pytest tests/cli/test_cli_status_bar.py -q -o 'addopts='` (`39 passed`)
- [x] tmux smoke with `HERMES_TUI_CLASSIC_SKIN=1` confirmed composer prompt separators above/below

## Notes
- Rebasing was done on current `origin/main` before opening this PR.
- This is ready for maintainer review; the visual change remains opt-in behind the classic-skin env flag.