### PR TITLE
feat(whatsapp): add WHATSAPP_DM_ONLY env var to skip group messages

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -51,6 +51,9 @@ const AUDIO_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'audio_cac
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const DM_ONLY = ['1', 'true', 'yes', 'on'].includes(
+  (process.env.WHATSAPP_DM_ONLY || '').toLowerCase()
+);
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -290,6 +293,22 @@ async function startSocket() {
       // Python gateway, otherwise a pairing-code reply fires in response
       // to arbitrary incoming messages (#8389).
       if (!msg.key.fromMe) {
+        // DM-only mode: silently drop group messages so the bot only
+        // responds in direct chats. Honors WHATSAPP_DM_ONLY=true.
+        if (DM_ONLY && isGroup) {
+          if (WHATSAPP_DEBUG) {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'dm_only_mode',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+          }
+          continue;
+        }
+
         if (WHATSAPP_MODE === 'self-chat') {
           try {
             console.log(JSON.stringify({
@@ -722,6 +741,9 @@ if (PAIR_ONLY) {
       console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
       console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
       console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
+    }
+    if (DM_ONLY) {
+      console.log(`📧 DM-only mode (WHATSAPP_DM_ONLY=true) — group messages will be dropped.`);
     }
     console.log();
     startSocket();


### PR DESCRIPTION
## Summary

Adds an opt-in `WHATSAPP_DM_ONLY` env var that, when set truthy (`1`/`true`/`yes`/`on`), causes the WhatsApp bridge to silently drop incoming group-chat messages from the queue before they reach the Python gateway. Direct-message handling is unchanged.

## Motivation

In deployments where a single Hermes profile owns one WhatsApp pairing and is added to shared group chats by teammates, the bot today responds to allowlisted senders **everywhere** — DMs *and* groups. There's no way to restrict to DMs without removing those senders from `WHATSAPP_ALLOWED_USERS`, which also stops their DMs.

This adds a clean, opt-in switch: when `WHATSAPP_DM_ONLY=true` the bridge keeps responding in DMs as normal but treats groups as if the bot weren't there.

## Why bridge-side (not gateway-side)

Doing the filter in `bridge.js` means group messages never enter the polling queue, so:
- No Python overhead for messages that will be discarded anyway
- Symmetric with the existing `WHATSAPP_ALLOWED_USERS` sender filter, which also lives in the bridge

## Changes

Three minimal additions to `scripts/whatsapp-bridge/bridge.js`:

1. **Read the env var at startup** (next to `ALLOWED_USERS`):
   ```js
   const DM_ONLY = ['1', 'true', 'yes', 'on'].includes(
     (process.env.WHATSAPP_DM_ONLY || '').toLowerCase()
   );
   ```

2. **Skip group messages in the `!fromMe` branch**, before the existing self-chat and allowlist checks:
   ```js
   if (DM_ONLY && isGroup) {
     if (WHATSAPP_DEBUG) {
       try { console.log(JSON.stringify({ event: 'ignored', reason: 'dm_only_mode', chatId, senderId })); } catch {}
     }
     continue;
   }
   ```

3. **One-line startup banner** so operators see the mode is active:
   ```js
   if (DM_ONLY) {
     console.log(`📧 DM-only mode (WHATSAPP_DM_ONLY=true) — group messages will be dropped.`);
   }
   ```

No behavior change when the env var is unset — totally additive, opt-in. The fromMe / status-broadcast / allowlist paths are untouched.

## Test plan

- [x] `node -c scripts/whatsapp-bridge/bridge.js` passes (syntax check)
- [x] Manual: unset → bot responds in groups as before
- [x] Manual: `WHATSAPP_DM_ONLY=true` → group messages silently dropped, DMs still flow
- [x] With `WHATSAPP_DEBUG=true` → `ignored: dm_only_mode` log line appears per skipped group message
- [x] Startup banner shows when active

(All `[x]`s above reflect manual validation against a private deployment; happy to add an automated test if the maintainers prefer — the bridge doesn't currently have a JS test harness so I didn't write one speculatively.)

## Related

We've been running this behavior in production via a stopgap plugin that monkey-patches `gateway.platforms.whatsapp.WhatsAppAdapter._build_message_event` (private repo). Moving the same logic to the bridge is the cleaner permanent fix — no Python-side hot-patching, no per-message overhead in the gateway for messages destined to be dropped, easier to extend to other platforms (Telegram/Discord) with the same `*_DM_ONLY` pattern.