### PR TITLE
fix(security): redact Airtable Personal Access Token in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -103,6 +103,8 @@ _PREFIX_PATTERNS = [
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
+    r"lin_api_[A-Za-z0-9_-]{10,}",      # Linear API key (lin_api_...)
+    r"pat[A-Za-z0-9]{14}\.[A-Za-z0-9]{40,}",  # Airtable Personal Access Token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -103,8 +103,7 @@ _PREFIX_PATTERNS = [
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
-    r"lin_api_[A-Za-z0-9_-]{10,}",      # Linear API key (lin_api_...)
-    r"pat[A-Za-z0-9]{14}\.[A-Za-z0-9]{40,}",  # Airtable Personal Access Token
+    r"pat[A-Za-z0-9]{14}\.[A-Za-z0-9_-]{40,}",  # Airtable Personal Access Token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -511,3 +511,47 @@ class TestFormBodyRedaction:
         text = "first=1\nsecond=2"
         # Should pass through (still subject to other redactors)
         assert "first=1" in redact_sensitive_text(text)
+
+
+class TestAirtableToken:
+    """Airtable Personal Access Token redaction (pat<14chars>.<64chars>)."""
+
+    PAT = "patABCDEFGHIJKLMN.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"
+    PAT_WITH_DASHES = "patABCDEFGHIJKLMN.abcdefghijklmnopqrstuvwxyz-ABCDEFGHIJKLMNOP_01234"
+
+    def test_bare_token_is_masked(self):
+        result = redact_sensitive_text(f"token: {self.PAT}", force=True)
+        assert "ABCDEFGHIJKLMN" not in result
+        assert "abcdefghijklmnop" not in result
+        assert "..." in result
+
+    def test_token_with_dashes_and_underscores_is_masked(self):
+        result = redact_sensitive_text(f"key: {self.PAT_WITH_DASHES}", force=True)
+        assert "ABCDEFGHIJKLMN" not in result
+
+    def test_in_env_assignment_is_masked(self):
+        result = redact_sensitive_text(f"AIRTABLE_API_KEY={self.PAT}", force=True)
+        assert "AIRTABLE_API_KEY=" in result
+        assert "ABCDEFGHIJKLMN" not in result
+
+    def test_word_patch_unchanged(self):
+        assert redact_sensitive_text("patch this file", force=True) == "patch this file"
+
+    def test_word_path_unchanged(self):
+        assert redact_sensitive_text("path=/some/path", force=True) == "path=/some/path"
+
+    def test_word_pattern_unchanged(self):
+        assert redact_sensitive_text("pattern=abc", force=True) == "pattern=abc"
+
+    def test_word_patched_unchanged(self):
+        assert redact_sensitive_text("patched the bug", force=True) == "patched the bug"
+
+    def test_short_pat_prefix_no_dot_unchanged(self):
+        # Too short and no dot separator — must not match
+        result = redact_sensitive_text("patABCDEFGHIJKLMN", force=True)
+        assert result == "patABCDEFGHIJKLMN"
+
+    def test_token_preserved_prefix_visible(self):
+        # First 6 chars of the full token should be visible in masked output
+        result = redact_sensitive_text(self.PAT, force=True)
+        assert result.startswith("patABC")


### PR DESCRIPTION
## What and why

  `agent/redact.py` masks known API key formats before they reach log files,
  tool output, or gateway logs. Airtable Personal Access Tokens were missing
  from this list.

  Airtable PATs follow the format `pat<14 chars>.<64 chars>` — a distinctive
  dot-separated shape used by no other common token format. Users running the
  bundled Airtable skill (`skills/productivity/airtable/`) with verbose or
  debug logging enabled would have their credentials written to log files in
  plain text.

  ## Reproduction (before fix)

  ```python
  from agent.redact import redact_sensitive_text
  key = "patABCDEFGHIJKLMN.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"
  print(redact_sensitive_text(f"token: {key}", force=True))
  # token: patABCDEFGHIJKLMN.abcde...  ← exposed

  After fix

  token: patABC...4567        ← masked
  patch this file patched     ← unchanged (no false positives)
  pattern=abc path=/some/path ← unchanged (no false positives)

  Changes

  One line added to _PREFIX_PATTERNS in agent/redact.py:

  r"pat[A-Za-z0-9]{14}\.[A-Za-z0-9_-]{40,}",  # Airtable Personal Access Token

  The dot separator is the key distinguishing feature — common English words
  starting with pat (patch, path, pattern, patched) do not contain it and
  are unaffected.

  Nine unit tests added to tests/agent/test_redact.py covering valid token
  masking, base64url characters, env assignment redaction, false positive
  checks, and boundary cases.
  ```