### PR TITLE
fix(security): honor shell hook blocks even when message/reason is absent

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -83,6 +83,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT_SECONDS = 60
 MAX_TIMEOUT_SECONDS = 300
 ALLOWLIST_FILENAME = "shell-hooks-allowlist.json"
+_DEFAULT_BLOCK_MESSAGE = "Blocked by shell hook."
 
 # (event, matcher, command) triples that have been wired to the plugin
 # manager in the current process.  Matcher is part of the key because
@@ -515,10 +516,12 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
 
     if event == "pre_tool_call":
         if data.get("action") == "block":
-            message = data.get("message") or data.get("reason") or "Blocked by shell hook."
+            raw = data.get("message") or data.get("reason")
+            message = raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
             return {"action": "block", "message": message}
         if data.get("decision") == "block":
-            message = data.get("reason") or data.get("message") or "Blocked by shell hook."
+            raw = data.get("reason") or data.get("message")
+            message = raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
             return {"action": "block", "message": message}
         return None
 

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -515,13 +515,11 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
 
     if event == "pre_tool_call":
         if data.get("action") == "block":
-            message = data.get("message") or data.get("reason") or ""
-            if isinstance(message, str) and message:
-                return {"action": "block", "message": message}
+            message = data.get("message") or data.get("reason") or "Blocked by shell hook."
+            return {"action": "block", "message": message}
         if data.get("decision") == "block":
-            message = data.get("reason") or data.get("message") or ""
-            if isinstance(message, str) and message:
-                return {"action": "block", "message": message}
+            message = data.get("reason") or data.get("message") or "Blocked by shell hook."
+            return {"action": "block", "message": message}
         return None
 
     context = data.get("context")

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -482,6 +482,17 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, default=str)
 
 
+def _block_message(primary: Any, secondary: Any) -> str:
+    """Return a validated string block message, falling back to the default.
+
+    Accepts two candidate fields (primary wins over secondary) so callers
+    can express field-priority differences between the two hook wire formats
+    without duplicating the type-check logic.
+    """
+    raw = primary or secondary
+    return raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
+
+
 def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     """Translate stdout JSON into a Hermes wire-shape dict.
 
@@ -516,13 +527,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
 
     if event == "pre_tool_call":
         if data.get("action") == "block":
-            raw = data.get("message") or data.get("reason")
-            message = raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
-            return {"action": "block", "message": message}
+            return {"action": "block", "message": _block_message(data.get("message"), data.get("reason"))}
         if data.get("decision") == "block":
-            raw = data.get("reason") or data.get("message")
-            message = raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
-            return {"action": "block", "message": message}
+            return {"action": "block", "message": _block_message(data.get("reason"), data.get("message"))}
         return None
 
     context = data.get("context")

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -100,6 +100,30 @@ class TestParseResponse:
         )
         assert r is None
 
+    def test_block_action_without_message_uses_default(self):
+        """Block is honored even when message/reason is absent."""
+        r = shell_hooks._parse_response("pre_tool_call", '{"action": "block"}')
+        assert r == {"action": "block", "message": shell_hooks._DEFAULT_BLOCK_MESSAGE}
+
+    def test_block_decision_without_reason_uses_default(self):
+        """Block is honored even when reason/message is absent."""
+        r = shell_hooks._parse_response("pre_tool_call", '{"decision": "block"}')
+        assert r == {"action": "block", "message": shell_hooks._DEFAULT_BLOCK_MESSAGE}
+
+    def test_block_action_empty_message_uses_default(self):
+        """Empty string message falls back to default, not empty string."""
+        r = shell_hooks._parse_response(
+            "pre_tool_call", '{"action": "block", "message": ""}',
+        )
+        assert r == {"action": "block", "message": shell_hooks._DEFAULT_BLOCK_MESSAGE}
+
+    def test_block_action_non_string_message_uses_default(self):
+        """Non-string message (e.g. integer) falls back to default."""
+        r = shell_hooks._parse_response(
+            "pre_tool_call", '{"action": "block", "message": 42}',
+        )
+        assert r == {"action": "block", "message": shell_hooks._DEFAULT_BLOCK_MESSAGE}
+
 
 # ── _serialize_payload ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Bug

  `_parse_response` in `agent/shell_hooks.py` only forwarded a
  `pre_tool_call` block directive if the hook also provided a non-empty
  `message` or `reason`. When either field was missing the function
  returned `None`, causing Hermes to treat the block as a no-op and
  execute the tool unconditionally.

  A hook that outputs `{"action": "block"}` or `{"decision": "block"}`
  without a reason string is silently ignored. The security boundary
  fails open — tools the user intended to gate are executed anyway.

  ## Reproduction

  ```python
  from agent.shell_hooks import _parse_response

  print(_parse_response("pre_tool_call", '{"action": "block"}'))
  # None  ← tool executes, block ignored

  print(_parse_response("pre_tool_call", '{"action": "block", "message": "x"}'))
  # {'action': 'block', 'message': 'x'}  ← works

  Fix

  Remove the message-presence guard. Honor the block unconditionally and
  fall back to "Blocked by shell hook." when no message is provided.
  Existing hooks that already include a message or reason are unaffected.

  After fix

  {"action": "block"}            → {'action': 'block', 'message': 'Blocked by shell hook.'}
  {"decision": "block"}          → {'action': 'block', 'message': 'Blocked by shell hook.'}
  {"action": "block", "message": "Forbidden"} → {'action': 'block', 'message': 'Forbidden'}
  {"decision": "block", "reason": "Forbidden"} → {'action': 'block', 'message': 'Forbidden'}