### PR TITLE
feat: gate Codex app-server runtime

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -218,6 +218,26 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
+
+    try:
+        from hermes_cli.config import load_config as _load_codex_runtime_cfg
+        _agent_cfg = _load_codex_runtime_cfg() or {}
+    except Exception:
+        _agent_cfg = {}
+    _codex_runtime_config = _agent_cfg.get("codex_runtime", {}) if isinstance(_agent_cfg, dict) else {}
+    if not isinstance(_codex_runtime_config, dict):
+        _codex_runtime_config = {}
+    agent.codex_runtime_enabled = cfg_get(_codex_runtime_config, "enabled", default=False) is True
+    _codex_runtime_mode = str(cfg_get(_codex_runtime_config, "mode", default="responses_only") or "responses_only").strip().lower()
+    agent.codex_runtime_mode = _codex_runtime_mode if _codex_runtime_mode in {"responses_only", "app_server"} else "responses_only"
+    _codex_runtime_allowlist = cfg_get(_codex_runtime_config, "allow_runtime_tools", default=[])
+    _protected_codex_tools = {"memory", "session_search", "send_message", "cronjob", "clarify", "todo", "delegate_task"}
+    agent.codex_runtime_allow_runtime_tools = [
+        tool_name.strip()
+        for tool_name in (_codex_runtime_allowlist if isinstance(_codex_runtime_allowlist, list) else [])
+        if isinstance(tool_name, str) and tool_name.strip() and tool_name.strip() not in _protected_codex_tools
+    ]
+
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
     agent.base_url = base_url or ""
     provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
@@ -256,6 +276,13 @@ def init_agent(
         agent.api_mode = "bedrock_converse"
     else:
         agent.api_mode = "chat_completions"
+
+    if agent.api_mode == "codex_app_server" and not (
+        agent.codex_runtime_enabled is True and agent.codex_runtime_mode == "app_server"
+    ):
+        # Legacy/explicit codex_app_server must not bypass the authoritative
+        # codex_runtime gate. Fall back to the normal OpenAI/Codex runtime.
+        agent.api_mode = "codex_responses" if agent.provider in {"openai", "openai-codex"} else "chat_completions"
 
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -60,12 +60,13 @@ logger = logging.getLogger(__name__)
 #   - terminal / shell / read_file / write_file / patch / search_files /
 #     process — codex's built-ins cover these and approval routes through
 #     codex's own UI.
-#   - delegate_task / memory / session_search / todo — these are
-#     `_AGENT_LOOP_TOOLS` in Hermes (model_tools.py:493). They require
-#     the running AIAgent context to dispatch (mid-loop state), so a
-#     stateless MCP callback can't drive them. Hermes' default runtime
-#     keeps these working; the codex_app_server runtime cannot.
-EXPOSED_TOOLS: tuple[str, ...] = (
+#   - delegate_task / memory / session_search / send_message / cronjob /
+#     clarify / todo — these are Hermes agent-loop or delivery/state tools.
+#     A stateless MCP callback must not own them.
+#
+# The default callback exposes no tools. The configured allowlist arrives via
+# HERMES_CODEX_RUNTIME_TOOLS and is intersected with AVAILABLE_CALLBACK_TOOLS.
+AVAILABLE_CALLBACK_TOOLS: tuple[str, ...] = (
     "web_search",
     "web_extract",
     "browser_navigate",
@@ -122,14 +123,26 @@ def _build_server() -> Any:
         handle_function_call,
     )
 
+    allowed_tools = {
+        name.strip()
+        for name in os.environ.get("HERMES_CODEX_RUNTIME_TOOLS", "").split(",")
+        if name.strip()
+    }
+    protected_tools = {
+        "memory", "session_search", "send_message", "cronjob",
+        "clarify", "todo", "delegate_task",
+    }
+    exposed_tools = tuple(
+        name for name in AVAILABLE_CALLBACK_TOOLS
+        if name in allowed_tools and name not in protected_tools
+    )
+
     mcp = FastMCP(
         "hermes-tools",
         instructions=(
-            "Hermes Agent's tool surface, exposed for use inside a Codex "
-            "session. Use these for capabilities Codex's built-in toolset "
-            "doesn't cover: web search/extract, browser automation, "
-            "subagent delegation, vision, image generation, persistent "
-            "memory, skills, and cross-session search."
+            "Hermes Agent's explicitly allowlisted tool surface, exposed for "
+            "use inside a Codex session. Protected Hermes state/delivery "
+            "tools are never exposed through this callback."
         ),
     )
 
@@ -143,7 +156,7 @@ def _build_server() -> Any:
 
     exposed_count = 0
 
-    for name in EXPOSED_TOOLS:
+    for name in exposed_tools:
         spec = all_defs.get(name)
         if spec is None:
             logger.debug(
@@ -189,7 +202,7 @@ def _build_server() -> Any:
     logger.info(
         "hermes-tools MCP server registered %d/%d tools",
         exposed_count,
-        len(EXPOSED_TOOLS),
+        len(exposed_tools),
     )
     return mcp
 

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -554,10 +554,10 @@ def _looks_like_test_tempdir(path: str) -> bool:
     return any(needle in normalized for needle in needles)
 
 
-def _build_hermes_tools_mcp_entry() -> dict:
+def _build_hermes_tools_mcp_entry(allowed_tools: Optional[list[str]] = None) -> dict:
     """Build the codex stdio-transport entry that launches Hermes' own
     tool surface as an MCP server. Codex's subprocess will call back into
-    this for browser/web/delegate_task/vision/memory/skills tools.
+    this only for names listed in codex_runtime.allow_runtime_tools.
 
     The command runs the worktree's Python via the current sys.executable
     so a hermes installed under /opt/, /usr/local/, or a venv all work.
@@ -592,6 +592,18 @@ def _build_hermes_tools_mcp_entry() -> dict:
     # Quiet mode + redaction defaults so the MCP wire stays clean.
     env["HERMES_QUIET"] = "1"
     env["HERMES_REDACT_SECRETS"] = env.get("HERMES_REDACT_SECRETS", "true")
+    protected_tools = {
+        "memory", "session_search", "send_message", "cronjob",
+        "clarify", "todo", "delegate_task",
+    }
+    sanitized_allowed = []
+    for tool_name in allowed_tools or []:
+        if not isinstance(tool_name, str):
+            continue
+        normalized = tool_name.strip()
+        if normalized and normalized not in protected_tools and normalized not in sanitized_allowed:
+            sanitized_allowed.append(normalized)
+    env["HERMES_CODEX_RUNTIME_TOOLS"] = ",".join(sanitized_allowed)
 
     out: dict[str, Any] = {
         "command": sys.executable,
@@ -694,7 +706,9 @@ def migrate(
     # The server itself is agent/transports/hermes_tools_mcp_server.py
     # and is launched on demand by codex (stdio MCP).
     if expose_hermes_tools:
-        translated["hermes-tools"] = _build_hermes_tools_mcp_entry()
+        runtime_cfg = (hermes_config or {}).get("codex_runtime") or {}
+        allowed_tools = runtime_cfg.get("allow_runtime_tools") if isinstance(runtime_cfg, dict) else []
+        translated["hermes-tools"] = _build_hermes_tools_mcp_entry(allowed_tools)
         if "hermes-tools" not in report.migrated:
             report.migrated.append("hermes-tools")
 

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -1,14 +1,11 @@
 """Shared logic for the /codex-runtime slash command.
 
-Toggles `model.openai_runtime` between "auto" (= chat_completions, Hermes'
-default) and "codex_app_server" (= hand turns to a codex subprocess).
+Authoritative runtime state lives under ``codex_runtime.*``.
+``model.openai_runtime`` is legacy compatibility only and is neutralized by
+rollback so old values do not continue to enable Codex app-server.
 
 Both CLI (cli.py) and gateway (gateway/run.py) call into this module so the
 behavior stays identical across surfaces.
-
-The actual runtime resolution happens in hermes_cli.runtime_provider's
-_maybe_apply_codex_app_server_runtime() helper, which reads the persisted
-config value. This module just persists the value and reports the change.
 """
 
 from __future__ import annotations
@@ -19,8 +16,13 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-
 VALID_RUNTIMES = ("auto", "codex_app_server")
+DEFAULT_CODEX_RUNTIME = {"enabled": False, "mode": "responses_only", "allow_runtime_tools": []}
+DEFAULT_RUNTIME_TOOLS: list[str] = []
+PROTECTED_RUNTIME_TOOLS = {
+    "memory", "session_search", "send_message", "cronjob",
+    "clarify", "todo", "delegate_task",
+}
 
 
 @dataclass
@@ -47,10 +49,9 @@ def parse_args(arg_string: str) -> tuple[Optional[str], list[str]]:
     raw = (arg_string or "").strip().lower()
     if not raw:
         return None, []
-    # Accept human-friendly synonyms
     if raw in {"on", "codex", "enable"}:
         return "codex_app_server", []
-    if raw in {"off", "default", "disable", "hermes"}:
+    if raw in {"off", "default", "disable", "hermes", "rollback"}:
         return "auto", []
     if raw in VALID_RUNTIMES:
         return raw, []
@@ -59,31 +60,75 @@ def parse_args(arg_string: str) -> tuple[Optional[str], list[str]]:
     ]
 
 
+def _sanitize_allowlist(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        name = item.strip()
+        if name and name not in PROTECTED_RUNTIME_TOOLS and name not in out:
+            out.append(name)
+    return out
+
+
+def _get_codex_runtime(config: dict) -> dict:
+    runtime = config.get("codex_runtime") if isinstance(config, dict) else None
+    if not isinstance(runtime, dict):
+        return dict(DEFAULT_CODEX_RUNTIME)
+    enabled = runtime.get("enabled") is True
+    mode = str(runtime.get("mode") or "responses_only").strip().lower()
+    if mode not in {"responses_only", "app_server"}:
+        mode = "responses_only"
+    return {
+        "enabled": enabled,
+        "mode": mode,
+        "allow_runtime_tools": _sanitize_allowlist(runtime.get("allow_runtime_tools")),
+    }
+
+
 def get_current_runtime(config: dict) -> str:
-    """Read the current `model.openai_runtime` value from a config dict.
-    Returns 'auto' for unset / empty / unrecognized values."""
-    if not isinstance(config, dict):
-        return "auto"
-    model_cfg = config.get("model") or {}
-    if not isinstance(model_cfg, dict):
-        return "auto"
-    value = str(model_cfg.get("openai_runtime") or "").strip().lower()
-    if value in VALID_RUNTIMES:
-        return value
+    """Return active runtime from the authoritative codex_runtime gate.
+
+    Legacy ``model.openai_runtime`` is intentionally not authoritative.
+    """
+    runtime = _get_codex_runtime(config)
+    if runtime.get("enabled") is True and runtime.get("mode") == "app_server":
+        return "codex_app_server"
     return "auto"
 
 
+def _disable_codex_runtime(config: dict) -> None:
+    config["codex_runtime"] = dict(DEFAULT_CODEX_RUNTIME)
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        model_cfg.pop("openai_runtime", None)
+
+
+def _enable_codex_runtime(config: dict) -> None:
+    config["codex_runtime"] = {
+        "enabled": True,
+        "mode": "app_server",
+        "allow_runtime_tools": list(DEFAULT_RUNTIME_TOOLS),
+    }
+    if not isinstance(config.get("model"), dict):
+        config["model"] = {}
+    # Compatibility marker only. Runtime resolution still requires codex_runtime.*.
+    config["model"]["openai_runtime"] = "codex_app_server"
+
+
 def set_runtime(config: dict, new_value: str) -> str:
-    """Mutate the config dict in place to persist the new runtime value.
-    Returns the previous value for callers that want to report a delta."""
+    """Mutate the config dict in place. Returns the previous active value."""
     if new_value not in VALID_RUNTIMES:
         raise ValueError(
             f"invalid runtime {new_value!r}; must be one of {VALID_RUNTIMES}"
         )
     old = get_current_runtime(config)
-    if not isinstance(config.get("model"), dict):
-        config["model"] = {}
-    config["model"]["openai_runtime"] = new_value
+    if new_value == "codex_app_server":
+        _enable_codex_runtime(config)
+    else:
+        _disable_codex_runtime(config)
     return old
 
 
@@ -98,28 +143,32 @@ def check_codex_binary_ok() -> tuple[bool, Optional[str]]:
         return False, f"codex check failed: {exc}"
 
 
+def _runtime_status_lines(config: dict) -> list[str]:
+    runtime = _get_codex_runtime(config)
+    model_cfg = config.get("model") if isinstance(config.get("model"), dict) else {}
+    provider = str(model_cfg.get("provider") or "unknown").strip() or "unknown"
+    model = str(model_cfg.get("default") or model_cfg.get("model") or "unknown").strip() or "unknown"
+    allowed = runtime.get("allow_runtime_tools") or []
+    gate_open = runtime.get("enabled") is True and runtime.get("mode") == "app_server"
+    active_mode = "codex_app_server" if gate_open else "normal_tool_loop"
+    legacy = model_cfg.get("openai_runtime") if isinstance(model_cfg, dict) else None
+    return [
+        f"provider/model: {provider} / {model}",
+        f"active execution mode: {active_mode}",
+        f"gate state: codex_runtime.enabled={runtime.get('enabled') is True} mode={runtime.get('mode')}",
+        f"allowed runtime tools: {', '.join(allowed) if allowed else '(none)'}",
+        f"legacy openai_runtime: {legacy!r}",
+    ]
+
+
 def apply(
     config: dict,
     new_value: Optional[str],
     *,
     persist_callback=None,
 ) -> CodexRuntimeStatus:
-    """Top-level entry point used by both CLI and gateway handlers.
-
-    Args:
-        config: in-memory config dict (will be mutated when new_value is set)
-        new_value: desired runtime; None means "show current state only"
-        persist_callback: optional callable taking the mutated config dict
-            and persisting it to disk. Skipped when None (used by tests).
-
-    Returns: CodexRuntimeStatus describing the outcome.
-    """
+    """Top-level entry point used by both CLI and gateway handlers."""
     current = get_current_runtime(config)
-
-    # Cache the codex binary check for this apply() call. Subprocess spawn
-    # is cheap (~50ms for `codex --version`), but we'd otherwise call it up
-    # to 3 times in the enable path (read-only/state, gate, success message).
-    # None = not yet checked; (bool, str) = result.
     _binary_check: Optional[tuple[bool, Optional[str]]] = None
 
     def _check_binary_cached() -> tuple[bool, Optional[str]]:
@@ -128,12 +177,13 @@ def apply(
             _binary_check = check_codex_binary_ok()
         return _binary_check
 
-    # Read-only call: just report state
     if new_value is None:
         ok, ver = _check_binary_cached()
-        msg = (
-            f"openai_runtime: {current}\n"
-            f"codex CLI: {'OK ' + ver if ok else 'not available — ' + (ver or 'install with `npm i -g @openai/codex`')}"
+        msg = "\n".join(
+            [
+                *_runtime_status_lines(config),
+                f"codex CLI: {'OK ' + ver if ok else 'not available — ' + (ver or 'install with `npm i -g @openai/codex`')}",
+            ]
         )
         return CodexRuntimeStatus(
             success=True,
@@ -144,18 +194,14 @@ def apply(
             codex_version=ver if ok else None,
         )
 
-    # No change requested
     if new_value == current:
         return CodexRuntimeStatus(
             success=True,
             new_value=current,
             old_value=current,
-            message=f"openai_runtime already set to {current}",
+            message=f"codex_runtime already set to {current}",
         )
 
-    # If switching ON, verify codex CLI is installed before persisting —
-    # an opt-in toggle that silently fails on the first turn is the
-    # worst possible UX. Block here with a clear install hint.
     if new_value == "codex_app_server":
         ok, ver_or_msg = _check_binary_cached()
         if not ok:
@@ -163,11 +209,11 @@ def apply(
                 success=False,
                 new_value=None,
                 old_value=current,
-                message=(
-                    "Cannot enable codex_app_server runtime: "
-                    f"{ver_or_msg or 'codex CLI not available'}\n"
-                    "Install with: npm i -g @openai/codex"
-                ),
+                message="\n".join([
+                    "Cannot enable codex_app_server runtime:",
+                    f"{ver_or_msg or 'codex CLI not available'}",
+                    "Install with: npm i -g @openai/codex",
+                ]),
                 codex_binary_ok=False,
                 codex_version=None,
             )
@@ -177,7 +223,7 @@ def apply(
         try:
             persist_callback(config)
         except Exception as exc:
-            logger.exception("failed to persist openai_runtime change")
+            logger.exception("failed to persist codex_runtime change")
             return CodexRuntimeStatus(
                 success=False,
                 new_value=new_value,
@@ -185,60 +231,41 @@ def apply(
                 message=f"updated config in memory but persist failed: {exc}",
             )
 
-    msg_lines = [
-        f"openai_runtime: {current} → {new_value}",
-    ]
+    msg_lines = [f"openai_runtime: {current} → {new_value}", *_runtime_status_lines(config)]
     if new_value == "codex_app_server":
         ok, ver = _check_binary_cached()
         if ok:
             msg_lines.append(f"codex CLI: {ver}")
-        # Auto-migrate Hermes' MCP servers + Codex's installed curated
-        # plugins into ~/.codex/config.toml so the spawned codex subprocess
-        # sees the same tool surface AND can call back into Hermes for
-        # browser/web/delegate_task/vision/memory tools (#7 fix).
-        # Failures are non-fatal — the runtime change still proceeds.
         try:
             from hermes_cli.codex_runtime_plugin_migration import migrate
+            runtime_cfg = _get_codex_runtime(config)
             mig_report = migrate(config)
-            # Tools/MCP servers (excluding the hermes-tools callback,
-            # which is internal plumbing — surface separately).
-            user_servers = [
-                s for s in mig_report.migrated if s != "hermes-tools"
-            ]
+            user_servers = [s for s in mig_report.migrated if s != "hermes-tools"]
             if user_servers:
                 msg_lines.append(
-                    f"Migrated {len(user_servers)} MCP server(s): "
-                    f"{', '.join(user_servers)}"
+                    f"Migrated {len(user_servers)} MCP server(s): {', '.join(user_servers)}"
                 )
-            # Native Codex plugin migration (Linear, GitHub, etc.)
             if mig_report.migrated_plugins:
                 msg_lines.append(
-                    f"Migrated {len(mig_report.migrated_plugins)} native "
-                    f"Codex plugin(s): {', '.join(mig_report.migrated_plugins)}"
+                    f"Migrated {len(mig_report.migrated_plugins)} native Codex plugin(s): "
+                    f"{', '.join(mig_report.migrated_plugins)}"
                 )
             elif mig_report.plugin_query_error:
-                msg_lines.append(
-                    f"Codex plugin discovery skipped: "
-                    f"{mig_report.plugin_query_error}"
-                )
-            # Permissions + Hermes tool callback are always-on production
-            # bits the user benefits from knowing about.
+                msg_lines.append(f"Codex plugin discovery skipped: {mig_report.plugin_query_error}")
             if mig_report.wrote_permissions_default:
                 msg_lines.append(
-                    f"Default sandbox: {mig_report.wrote_permissions_default} "
-                    f"(no approval prompt on every write)"
+                    f"Default sandbox: {mig_report.wrote_permissions_default} (no approval prompt on every write)"
                 )
             if "hermes-tools" in mig_report.migrated:
+                allowed = runtime_cfg.get("allow_runtime_tools") or []
+                if allowed:
+                    msg_lines.append(
+                        "Hermes tool callback registered for allowed tools: " + ", ".join(allowed)
+                    )
+                else:
+                    msg_lines.append("Hermes tool callback registered with no Hermes tools exposed by default.")
                 msg_lines.append(
-                    "Hermes tool callback registered: codex can now use "
-                    "web_search, web_extract, browser_*, vision_analyze, "
-                    "image_generate, skill_view, skills_list, text_to_speech, "
-                    "kanban_* (worker + orchestrator) via MCP."
-                )
-                msg_lines.append(
-                    "  (delegate_task, memory, session_search, todo run "
-                    "only on the default Hermes runtime — they need the "
-                    "agent loop context.)"
+                    "  (delegate_task, memory, session_search, send_message, cronjob, clarify, and todo stay on the default Hermes runtime.)"
                 )
             msg_lines.append(f"  (config: {mig_report.target_path})")
             for err in mig_report.errors:
@@ -246,21 +273,21 @@ def apply(
         except Exception as exc:
             msg_lines.append(f"⚠ MCP migration skipped: {exc}")
         msg_lines.append(
-            "OpenAI/Codex turns now run through `codex app-server` "
-            "(terminal/file ops/patching inside Codex; "
-            "Hermes tools available via MCP callback)."
+            "Codex app-server is enabled only for codex_runtime.enabled=True and codex_runtime.mode=app_server."
         )
         msg_lines.append(
-            "Effective on next session — current cached agent keeps "
-            "the prior runtime to preserve prompt cache."
+            "Effective on next session — current cached agent keeps the prior runtime to preserve prompt cache."
         )
     else:
         msg_lines.append("OpenAI/Codex turns will use the default Hermes runtime.")
         msg_lines.append("Effective on next session.")
+
     return CodexRuntimeStatus(
         success=True,
         new_value=new_value,
         old_value=current,
         message="\n".join(msg_lines),
         requires_new_session=True,
+        codex_binary_ok=True,
+        codex_version=_binary_check[1] if _binary_check and _binary_check[0] else None,
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -473,6 +473,11 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "codex_runtime": {
+        "enabled": False,
+        "mode": "responses_only",
+        "allow_runtime_tools": [],
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -127,6 +127,9 @@ def _get_model_config() -> Dict[str, Any]:
             detected = _auto_detect_local_model(base_url)
             if detected:
                 cfg["default"] = detected
+        codex_runtime_cfg = config.get("codex_runtime")
+        if isinstance(codex_runtime_cfg, dict):
+            cfg["codex_runtime"] = dict(codex_runtime_cfg)
         return cfg
     if isinstance(model_cfg, str) and model_cfg.strip():
         return {"default": model_cfg.strip()}
@@ -175,9 +178,9 @@ _VALID_API_MODES = {
     "bedrock_converse",
     # Optional opt-in: hand the entire turn to a `codex app-server` subprocess
     # so terminal/file-ops/patching/sandboxing run inside Codex's own runtime
-    # instead of Hermes' tool dispatch. Gated behind config key
-    # `model.openai_runtime == "codex_app_server"` AND provider in
-    # {"openai", "openai-codex"}. Default is unchanged.
+    # instead of Hermes' tool dispatch. Gated behind `codex_runtime.enabled`
+    # AND `codex_runtime.mode == "app_server"`. Legacy model.openai_runtime
+    # is compatibility-only and cannot activate the runtime by itself.
     "codex_app_server",
 }
 
@@ -197,22 +200,19 @@ def _maybe_apply_codex_app_server_runtime(
     api_mode: str,
     model_cfg: Optional[Dict[str, Any]],
 ) -> str:
-    """Optional opt-in: rewrite api_mode → "codex_app_server" for OpenAI/Codex
-    providers when the user has explicitly enabled that runtime via
-    `model.openai_runtime: codex_app_server` in config.yaml.
+    """Rewrite api_mode to codex_app_server only when the authoritative gate is open.
 
-    Default behavior is preserved: when the key is unset, "auto", or empty,
-    this function is a no-op. Only providers in {"openai", "openai-codex"}
-    are eligible — other providers (anthropic, openrouter, etc.) cannot be
-    rerouted through codex.
-
-    Returns the (possibly-rewritten) api_mode."""
+    `model.openai_runtime` is legacy compatibility only. Stale values there must
+    not activate app-server execution after rollback or config migration.
+    """
     if not model_cfg:
         return api_mode
     if provider not in {"openai", "openai-codex"}:
         return api_mode
-    runtime = str(model_cfg.get("openai_runtime") or "").strip().lower()
-    if runtime == "codex_app_server":
+    codex_cfg = model_cfg.get("codex_runtime")
+    if not isinstance(codex_cfg, dict):
+        return api_mode
+    if codex_cfg.get("enabled") is True and str(codex_cfg.get("mode") or "").strip().lower() == "app_server":
         return "codex_app_server"
     return api_mode
 
@@ -859,9 +859,14 @@ def _resolve_explicit_runtime(
             last_refresh = creds.get("last_refresh")
             if not explicit_base_url:
                 base_url = creds.get("base_url", "").rstrip("/") or base_url
+        api_mode = _maybe_apply_codex_app_server_runtime(
+            provider="openai-codex",
+            api_mode="codex_responses",
+            model_cfg=model_cfg,
+        )
         return {
             "provider": "openai-codex",
-            "api_mode": "codex_responses",
+            "api_mode": api_mode,
             "base_url": base_url,
             "api_key": api_key,
             "source": "explicit",

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -54,11 +54,20 @@ class TestMaybeApplyCodexAppServerRuntime:
         )
         assert got == "chat_completions"
 
+
+    def test_legacy_openai_runtime_is_ignored_when_gate_disabled(self) -> None:
+        got = _maybe_apply_codex_app_server_runtime(
+            provider="openai",
+            api_mode="chat_completions",
+            model_cfg={"codex_runtime": {"enabled": False, "mode": "responses_only"}, "openai_runtime": "codex_app_server"},
+        )
+        assert got == "chat_completions"
+
     def test_opt_in_rewrites_openai(self) -> None:
         got = _maybe_apply_codex_app_server_runtime(
             provider="openai",
             api_mode="chat_completions",
-            model_cfg={"openai_runtime": "codex_app_server"},
+            model_cfg={"codex_runtime": {"enabled": True, "mode": "app_server"}, "openai_runtime": "codex_app_server"},
         )
         assert got == "codex_app_server"
 
@@ -66,7 +75,7 @@ class TestMaybeApplyCodexAppServerRuntime:
         got = _maybe_apply_codex_app_server_runtime(
             provider="openai-codex",
             api_mode="codex_responses",
-            model_cfg={"openai_runtime": "codex_app_server"},
+            model_cfg={"codex_runtime": {"enabled": True, "mode": "app_server"}, "openai_runtime": "codex_app_server"},
         )
         assert got == "codex_app_server"
 
@@ -74,7 +83,7 @@ class TestMaybeApplyCodexAppServerRuntime:
         got = _maybe_apply_codex_app_server_runtime(
             provider="openai",
             api_mode="chat_completions",
-            model_cfg={"openai_runtime": "Codex_App_Server"},
+            model_cfg={"codex_runtime": {"enabled": True, "mode": "APP_SERVER"}, "openai_runtime": "Codex_App_Server"},
         )
         assert got == "codex_app_server"
 
@@ -97,7 +106,7 @@ class TestMaybeApplyCodexAppServerRuntime:
         got = _maybe_apply_codex_app_server_runtime(
             provider=provider,
             api_mode="anthropic_messages",
-            model_cfg={"openai_runtime": "codex_app_server"},
+            model_cfg={"codex_runtime": {"enabled": True, "mode": "app_server"}, "openai_runtime": "codex_app_server"},
         )
         assert got == "anthropic_messages", (
             f"provider={provider!r} should not be rerouted to codex_app_server"

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -49,10 +49,16 @@ class TestGetCurrentRuntime:
             {"model": {"openai_runtime": "garbage"}}
         ) == "auto"
 
-    def test_explicit_codex(self):
+    def test_legacy_openai_runtime_is_not_authoritative(self):
         assert crs.get_current_runtime(
             {"model": {"openai_runtime": "codex_app_server"}}
-        ) == "codex_app_server"
+        ) == "auto"
+
+    def test_prefers_codex_runtime_flag_over_legacy_key(self):
+        assert crs.get_current_runtime({
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
+        }) == "codex_app_server"
 
     def test_handles_non_dict_config(self):
         assert crs.get_current_runtime(None) == "auto"  # type: ignore[arg-type]
@@ -68,10 +74,15 @@ class TestSetRuntime:
         assert cfg["model"]["openai_runtime"] == "codex_app_server"
 
     def test_returns_previous_value(self):
-        cfg = {"model": {"openai_runtime": "codex_app_server"}}
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
+        }
         old = crs.set_runtime(cfg, "auto")
         assert old == "codex_app_server"
-        assert cfg["model"]["openai_runtime"] == "auto"
+        assert cfg["model"].get("openai_runtime") in (None, "")
+        assert cfg["codex_runtime"]["enabled"] is False
+        assert cfg["codex_runtime"]["mode"] == "responses_only"
 
     def test_invalid_value_raises(self):
         with pytest.raises(ValueError):
@@ -80,7 +91,10 @@ class TestSetRuntime:
 
 class TestApply:
     def test_read_only_call_reports_state(self):
-        cfg = {"model": {"openai_runtime": "codex_app_server"}}
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
+        }
         with patch.object(crs, "check_codex_binary_ok",
                           return_value=(True, "0.130.0")):
             r = crs.apply(cfg, None)
@@ -94,7 +108,7 @@ class TestApply:
         cfg = {"model": {"openai_runtime": "auto"}}
         r = crs.apply(cfg, "auto")
         assert r.success
-        assert r.message == "openai_runtime already set to auto"
+        assert r.message == "codex_runtime already set to auto"
 
     def test_enable_blocked_when_codex_missing(self):
         cfg = {}
@@ -128,12 +142,16 @@ class TestApply:
         assert r.new_value == "codex_app_server"
         assert r.old_value == "auto"
         assert r.requires_new_session is True
-        assert "via MCP" in r.message  # hermes-tools callback message
+        assert cfg["codex_runtime"]["enabled"] is True
+        assert cfg["codex_runtime"]["mode"] == "app_server"
         assert cfg["model"]["openai_runtime"] == "codex_app_server"
-        assert persisted["model"]["openai_runtime"] == "codex_app_server"
+        assert persisted["codex_runtime"]["enabled"] is True
 
     def test_disable_does_not_check_binary(self):
-        cfg = {"model": {"openai_runtime": "codex_app_server"}}
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
+        }
         with patch.object(crs, "check_codex_binary_ok") as bin_check:
             r = crs.apply(cfg, "auto")
         assert r.success
@@ -182,12 +200,13 @@ class TestApply:
         # Permissions default surfaces
         assert "Default sandbox: :workspace" in r.message
         # Hermes tool callback announcement
-        assert "via MCP" in r.message
+        assert "Hermes tool callback registered" in r.message
 
     def test_disable_does_not_trigger_migration(self):
         """Switching back to auto must not write to ~/.codex/."""
         cfg = {
             "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
             "mcp_servers": {"x": {"command": "y"}},
         }
         with patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
@@ -231,7 +250,10 @@ class TestApply:
     def test_binary_check_cached_on_read_only_call(self):
         """Read-only call (new_value=None) calls the binary check exactly
         once and reuses the result for the message."""
-        cfg = {"model": {"openai_runtime": "codex_app_server"}}
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_runtime": {"enabled": True, "mode": "app_server"},
+        }
         with patch.object(crs, "check_codex_binary_ok",
                           return_value=(True, "0.130.0")) as bin_check:
             crs.apply(cfg, None)

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -53,15 +53,19 @@ def _make_codex_agent():
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
-    return run_agent.AIAgent(
-        api_key="stub",
-        base_url="https://stub.invalid",
-        provider="openai",
-        api_mode="codex_app_server",
-        quiet_mode=True,
-        skip_context_files=True,
-        skip_memory=True,
-    )
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"codex_runtime": {"enabled": True, "mode": "app_server", "allow_runtime_tools": []}},
+    ):
+        return run_agent.AIAgent(
+            api_key="stub",
+            base_url="https://stub.invalid",
+            provider="openai",
+            api_mode="codex_app_server",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
 
 
 class TestApiModeAccepted:


### PR DESCRIPTION
## Summary
- Add authoritative codex_runtime controls for Codex app-server execution
- Preserve legacy model.openai_runtime as compatibility-only
- Add status and rollback behavior for the command surface
- Keep Hermes-owned tools blocked by default unless explicitly allowlisted

## Test Plan
- python -m pytest tests/hermes_cli/test_codex_runtime_switch.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_run_agent.py tests/agent/transports/test_codex_app_server_runtime.py tests/hermes_cli/test_codex_runtime_plugin_migration.py tests/hermes_cli/test_config.py
- git diff --check

Telegram test thread validation also passed for status, on, rollback, and final status restoration.