### PR TITLE
feat(weixin): tag transcribed voice messages and enforce echo on outbound

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1001,7 +1001,10 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
         if item.get("type") == ITEM_VOICE:
             voice_text = str((item.get("voice_item") or {}).get("text") or "")
             if voice_text:
-                return voice_text
+                # Prefix so the agent can distinguish auto-transcribed voice
+                # messages from typed text (Weixin's callback delivers them as
+                # indistinguishable plain strings otherwise).
+                return f"[voice:transcribed] {voice_text}"
     return ""
 
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1196,6 +1196,14 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
+        # Voice echo enforcement: cache last voice transcript per chat_id so the
+        # outbound send() can guarantee the `> 🎤 你说："…"` echo prefix even when
+        # the LLM forgets to add it. One-shot: consumed on next outbound send.
+        self._pending_voice_echo: Dict[str, str] = {}
+        _voice_echo_raw = extra.get("voice_echo_enforce")
+        if _voice_echo_raw is None:
+            _voice_echo_raw = os.getenv("WEIXIN_VOICE_ECHO_ENFORCE")
+        self._voice_echo_enforce: bool = _coerce_bool(_voice_echo_raw, default=True)
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
         self._token = str(config.token or extra.get("token") or os.getenv("WEIXIN_TOKEN", "")).strip()
@@ -1399,6 +1407,12 @@ class WeixinAdapter(BasePlatformAdapter):
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
+            # Voice echo enforcement: stash transcript keyed on the eventual
+            # outbound chat_id so send() can guarantee the echo prefix.
+            if self._voice_echo_enforce and text.startswith("[voice:transcribed] "):
+                transcript = text[len("[voice:transcribed] "):].strip()
+                if transcript:
+                    self._pending_voice_echo[sender_id] = transcript
 
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
         if chat_type == "group":
@@ -1677,6 +1691,24 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
+        # Voice echo enforcement (mechanical guarantee, not LLM-dependent):
+        # if the inbound message for this chat was a voice transcript and the
+        # outbound reply does NOT already start with the `> 🎤 你说："…"` echo,
+        # auto-prepend it. Consumed (popped) so it never bleeds into a later
+        # turn. Skips media-only sends (empty content after MEDIA: extraction
+        # would re-trigger on the same transcript next turn — popping here
+        # is one-shot regardless).
+        if self._voice_echo_enforce and content and content.strip():
+            transcript = self._pending_voice_echo.pop(chat_id, None)
+            if transcript and not content.lstrip().startswith("> 🎤 你说"):
+                # Escape any embedded double quotes in the transcript so the
+                # blockquote parses cleanly.
+                safe = transcript.replace('"', '\\"')
+                content = f'> 🎤 你说："{safe}"\n\n{content}'
+                logger.info(
+                    "[%s] voice-echo enforcer prepended prefix for %s (LLM forgot)",
+                    self.name, _safe_id(chat_id),
+                )
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
 


### PR DESCRIPTION
## Problem

Weixin's iLink callback delivers auto-transcribed voice messages as plain text, **indistinguishable** from a typed message. Two pain points fall out of that:

1. **Agents can't apply voice-specific reply conventions** (e.g. echoing the transcript so the user can verify ASR accuracy, or switching tone) because they have no signal that the inbound text was a voice transcript.
2. **Even when the agent is told to add an echo prefix**, LLMs drift on this surprisingly often — they forget on long turns, after tool calls, or when the user message is short. There's no mechanical guarantee.

## Fix

Two small, configurable changes in `gateway/platforms/weixin.py`:

### 1. Inbound: tag transcribed voice messages

`_extract_text()` now returns transcripts with a stable prefix:

```diff
 if item.get("type") == ITEM_VOICE:
     voice_text = str((item.get("voice_item") or {}).get("text") or "")
     if voice_text:
-        return voice_text
+        return f"[voice:transcribed] {voice_text}"
```

This gives every downstream consumer (agent prompt, tools, hooks) a reliable detection signal. The prefix is plain ASCII so it survives any encoding path, and is distinctive enough to not collide with normal text.

### 2. Outbound: mechanical echo enforcement (opt-out)

When the inbound message was a voice transcript, the adapter stashes it on a per-`chat_id` map. The outbound `send()` checks that map and prepends a `> 🎤 你说："…"` blockquote echo if the LLM didn't already include one. One-shot: popped on send so it never bleeds into a later turn.

Toggleable via:
- `voice_echo_enforce` in platform config
- `WEIXIN_VOICE_ECHO_ENFORCE` env var
- defaults to **on** (the safer behaviour for human-facing voice gateways)

Operators who already enforce this in their system prompt and don't want the safety net can set `voice_echo_enforce=false`.

## Why both, and why together

These two commits are paired:
- The prefix (commit 1) makes voice messages **detectable**.
- The echo enforcement (commit 2) **uses** that detection to provide a guarantee, and is the actual user-visible benefit.

I split them as separate commits for review clarity, but they're a unit — without the prefix, the enforcer has nothing to key on; without the enforcer, the prefix is just metadata. Happy to squash on merge if maintainers prefer.

## Behaviour examples

**Voice message, agent forgets to echo:**

```
User → [voice:transcribed] 帮我看一下今天的天气
Agent draft: "今天东京晴，22-28°C..."
Adapter sends: "> 🎤 你说："帮我看一下今天的天气"\n\n今天东京晴，22-28°C..."
```

**Voice message, agent already echoed:**

```
User → [voice:transcribed] 帮我看一下今天的天气
Agent draft: "> 🎤 你说："帮我看一下今天的天气"\n\n今天东京晴..."
Adapter sends: agent draft unchanged (idempotent — startswith check)
```

**Typed message:**

```
User → 帮我看一下今天的天气
Agent draft: "今天东京晴..."
Adapter sends: agent draft unchanged (no transcript stashed)
```

## Edge cases handled

- **Quotes inside transcripts** are escaped (`safe = transcript.replace('"', '\\"')`) so the blockquote parses cleanly.
- **Empty/media-only outbound** is skipped (`if content and content.strip()`) — wouldn't render usefully.
- **Idempotent prefix detection** uses `content.lstrip().startswith("> 🎤 你说")` so manual echoes by the agent (any whitespace prefix) don't get double-stamped.
- **One-shot consumption** via `dict.pop()` — never accidentally re-stamps a later unrelated reply.

## Tests

No new tests — like the surrounding adapter code, this path isn't currently covered by the suite. Existing tests still pass. Happy to add coverage if reviewers want; the natural scaffolding would be a small async test that:
1. Feeds a synthetic voice item through `_extract_text` → asserts the prefix.
2. Drives `_handle_inbound_message` with a transcribed text → asserts `_pending_voice_echo` populated.
3. Calls `send()` with non-prefixed content → asserts the outbound payload starts with the echo and the map was popped.

## Manual verification

Running on production gateway for ~2 weeks. The enforcer log line

```
[weixin] voice-echo enforcer prepended prefix for u**** (LLM forgot)
```

fires perhaps 10–15% of voice turns when the agent gets distracted by tool use or long context. With it in place, the user-side experience is finally consistent: every voice message comes back with its own transcript echoed, every typed message comes back without one.

## Compatibility

- **No config required** — defaults preserve the new behaviour, but it can be disabled with one env var.
- **No breaking changes to existing senders** — `send()` signature and contract unchanged; prefix is only added when both (a) the feature is enabled and (b) a transcript was stashed for this `chat_id`.
- **Prefix `[voice:transcribed]`** is a new convention — happy to bikeshed the exact string (e.g. some structured tag like `<voice transcribed=1>`), but it does need to be something distinctive that downstream agents/skills can pattern-match on.
