### PR TITLE
fix(prompt_builder): clarify WhatsApp markdown guidance for image URLs

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -411,13 +411,13 @@ DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
-        "Please do not use markdown as it does not render. "
+        "Please do not use markdown for normal text formatting as it does not render. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. The file "
         "will be sent as a native WhatsApp attachment — images (.jpg, .png, "
         ".webp) appear as photos, videos (.mp4, .mov) play inline, and other "
-        "files arrive as downloadable documents. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as photos."
+        "files arrive as downloadable documents. The one exception is image "
+        "URLs in markdown format ![alt](url), which will be sent as photos."
     ),
     "telegram": (
         "You are on a text messaging communication platform, Telegram. "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -834,6 +834,12 @@ class TestPromptBuilderConstants:
         assert "Markdown" in hint
         assert "absolute" in hint
 
+    def test_platform_hints_whatsapp_clarifies_image_markdown_exception(self):
+        hint = PLATFORM_HINTS["whatsapp"]
+        assert "normal text formatting" in hint
+        assert "The one exception is image" in hint
+        assert "![alt](url)" in hint
+
 
 # =========================================================================
 # Environment hints


### PR DESCRIPTION
## Summary

Clarifies the WhatsApp platform hint so the agent receives a consistent instruction about markdown usage.

The previous wording told the agent not to use markdown on WhatsApp because it does not render, but then immediately recommended markdown image syntax (`![alt](url)`) for image delivery. That made the guidance internally inconsistent and increased the chance of confused formatting decisions in WhatsApp sessions.

This change keeps the existing behavior but makes the rule explicit:

- do not use markdown for normal text formatting on WhatsApp
- `![alt](url)` remains the single exception for image URLs

## Problem

The WhatsApp platform hint in `agent/prompt_builder.py` mixed a broad prohibition with a specific exception without clearly separating the two.

Before:
- "Please do not use markdown as it does not render."
- "You can also include image URLs in markdown format `![alt](url)`..."

For the model, that creates an avoidable ambiguity:
- is markdown always disallowed?
- or is only some markdown disallowed?
- if image markdown is allowed, are other markdown constructs also acceptable?

For a prompt-driven system, that kind of contradiction is worth fixing even when the runtime behavior is unchanged.

## What Changed

### Prompt clarification
Updated the WhatsApp hint to explicitly scope the markdown restriction to normal text formatting and to call out image markdown as the one allowed exception.

### Regression coverage
Added a focused test in `tests/agent/test_prompt_builder.py` to verify that the WhatsApp hint now:
- mentions normal text formatting specifically
- preserves the `![alt](url)` image syntax
- presents the image syntax as an explicit exception rather than a contradiction

## Why This Approach

This patch intentionally stays narrow.

It does not:
- change WhatsApp delivery behavior
- alter formatting code paths
- introduce new platform-specific logic
- refactor prompt construction

It only removes ambiguity from an existing platform instruction and locks the wording in with a targeted test.

## Testing

Ran:

```bash
uv run pytest tests/agent/test_prompt_builder.py -q

122 passed, 1 skipped in 5.79s