### PR TITLE
fix(api-server): route inline images through the auxiliary vision pipeline (#27232)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -283,6 +283,262 @@ def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Respons
     )
 
 
+# ---------------------------------------------------------------------------
+# Vision routing for OpenAI-compatible clients (Open WebUI, LobeChat, …)
+# ---------------------------------------------------------------------------
+#
+# The TUI gateway (gateway/run.py) reads ``auxiliary.vision.provider`` /
+# ``agent.image_input_mode`` and, when the active main model can't (or
+# shouldn't) consume pixels directly, runs ``vision_analyze`` up-front and
+# prepends the description to the user turn — see ``_decide_image_input_mode``
+# and ``_enrich_message_with_vision`` in gateway/run.py.
+#
+# The OpenAI-compatible API server skipped that step entirely: image_url
+# parts were passed verbatim to the agent, the main provider rejected them,
+# and ``run_agent`` fell back to text-only mode after stripping the images
+# (#27232). Open WebUI users then saw "no photo seen" responses even though
+# their auxiliary vision backend was configured correctly.
+#
+# The helpers below mirror the TUI gateway's image-routing pipeline so any
+# OpenAI-API consumer benefits from the same auxiliary-vision pre-analysis.
+
+_VISION_ROUTE_TEXT_PROMPT = (
+    "Describe everything visible in this image in thorough detail. "
+    "Include any text, code, data, objects, people, layout, colors, "
+    "and any other notable visual information."
+)
+
+
+def _decide_api_server_image_mode() -> str:
+    """Return ``"native"`` or ``"text"`` for the current API request.
+
+    Reads ``auxiliary.vision`` and ``agent.image_input_mode`` from config.yaml
+    plus the active main model's capabilities — same inputs as the TUI gateway
+    (``gateway.run.AIAgentRunner._decide_image_input_mode``) so behaviour is
+    consistent across both surfaces.
+
+    Failures fall back to ``"native"`` so callers preserve today's behaviour
+    (image parts forwarded as-is) on misconfigured installs.
+    """
+    try:
+        from agent.image_routing import decide_image_input_mode
+        from agent.auxiliary_client import _read_main_model, _read_main_provider
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        provider = _read_main_provider()
+        model = _read_main_model()
+        return decide_image_input_mode(provider, model, cfg)
+    except Exception as exc:
+        logger.debug(
+            "api_server image_routing: decision failed, defaulting to native — %s", exc
+        )
+        return "native"
+
+
+def _extract_text_and_image_parts(content: Any) -> "tuple[str, list[Dict[str, Any]]]":
+    """Split a multimodal content list into ``(joined_text, image_parts)``.
+
+    Strings pass straight through with no image parts.  Lists are walked
+    once: ``text``/``input_text`` parts are concatenated (preserving order),
+    ``image_url``/``input_image`` parts are collected for vision pre-analysis.
+    Other shapes are returned unchanged via the empty-image-list path so the
+    caller's fallback (pass content through unmodified) runs.
+    """
+    if isinstance(content, str):
+        return content, []
+    if not isinstance(content, list):
+        return "", []
+    text_chunks: List[str] = []
+    images: List[Dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type") or "").strip().lower()
+        if ptype in _TEXT_PART_TYPES:
+            text = part.get("text") or ""
+            if isinstance(text, str) and text:
+                text_chunks.append(text)
+        elif ptype in _IMAGE_PART_TYPES:
+            images.append(part)
+    return "\n".join(text_chunks), images
+
+
+def _image_url_from_part(part: Dict[str, Any]) -> Optional[str]:
+    """Pull the URL string out of an ``image_url`` / ``input_image`` part."""
+    ref = part.get("image_url")
+    if isinstance(ref, dict):
+        url = ref.get("url")
+    else:
+        url = ref
+    if not isinstance(url, str):
+        return None
+    url = url.strip()
+    return url or None
+
+
+def _materialize_image_for_vision(url: str) -> "tuple[Optional[str], bool]":
+    """Resolve an image URL to something ``vision_analyze_tool`` accepts.
+
+    Returns ``(path_or_url, is_temp_file)``:
+      * ``http(s)://`` URLs pass through unchanged — the vision tool will
+        download them itself.
+      * ``data:image/...,<b64>`` URLs are decoded to a temp file under
+        ``$HERMES_HOME/cache/api_server_vision/`` so the vision tool can
+        treat them as local images.  The caller is responsible for
+        unlinking the temp file once analysis completes.
+      * Anything else (including malformed data URLs) returns ``(None, False)``
+        so the caller can skip it with a clear log line instead of raising.
+    """
+    if not url:
+        return None, False
+    lowered = url.lower()
+    if lowered.startswith(("http://", "https://")):
+        return url, False
+    if not lowered.startswith("data:image/"):
+        return None, False
+    header, _, payload = url.partition(",")
+    if not payload:
+        return None, False
+    mime = header[len("data:"):].split(";", 1)[0].strip() or "image/jpeg"
+    suffix_map = {
+        "image/png": ".png", "image/jpeg": ".jpg", "image/jpg": ".jpg",
+        "image/gif": ".gif", "image/webp": ".webp", "image/bmp": ".bmp",
+        "image/heic": ".heic", "image/heif": ".heif",
+    }
+    suffix = suffix_map.get(mime.lower(), ".img")
+
+    import base64
+    import tempfile
+    try:
+        raw = base64.b64decode(payload, validate=False)
+    except Exception as exc:
+        logger.debug("api_server vision: data URL decode failed — %s", exc)
+        return None, False
+
+    try:
+        from hermes_cli.config import get_hermes_home
+        cache_dir = get_hermes_home() / "cache" / "api_server_vision"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir_str: Optional[str] = str(cache_dir)
+    except Exception:
+        cache_dir_str = None
+
+    try:
+        fd, path = tempfile.mkstemp(prefix="apiv_", suffix=suffix, dir=cache_dir_str)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(raw)
+    except OSError as exc:
+        logger.debug("api_server vision: temp file write failed — %s", exc)
+        return None, False
+    return path, True
+
+
+async def _describe_image_via_vision(url: str) -> Optional[str]:
+    """Run ``vision_analyze_tool`` on a single image URL and return the description.
+
+    Returns ``None`` on any failure path so the caller can decide whether to
+    fall back to a generic "couldn't see the image" placeholder.
+    """
+    materialized, is_temp = _materialize_image_for_vision(url)
+    if materialized is None:
+        return None
+    try:
+        from tools.vision_tools import vision_analyze_tool
+
+        raw = await vision_analyze_tool(
+            image_url=materialized,
+            user_prompt=_VISION_ROUTE_TEXT_PROMPT,
+        )
+        payload = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    except Exception as exc:
+        logger.warning("api_server vision: analyze failed for %s — %s", url[:80], exc)
+        payload = None
+    finally:
+        if is_temp:
+            try:
+                os.unlink(materialized)
+            except OSError:
+                pass
+
+    if not isinstance(payload, dict) or not payload.get("success"):
+        return None
+    analysis = payload.get("analysis")
+    if not isinstance(analysis, str) or not analysis.strip():
+        return None
+    return analysis.strip()
+
+
+async def _route_content_for_text_mode(content: Any) -> Any:
+    """Replace inline image parts with auxiliary-vision text descriptions.
+
+    Mirrors ``AIAgentRunner._enrich_message_with_vision`` from gateway/run.py:
+    each successfully described image is rendered as a ``[The user sent an
+    image~ ...]`` block prepended to the user's text. Images that can't be
+    described (decode error, vision provider down, etc.) get a neutral
+    "couldn't see it" placeholder so the main model is at least aware that
+    pixels were attached — never silently dropped.
+
+    String content is returned unchanged, as is any list without image parts.
+    Pure-image turns get a neutral default caption so the placeholder still
+    reads naturally.
+    """
+    user_text, image_parts = _extract_text_and_image_parts(content)
+    if not image_parts:
+        return content
+
+    enriched_parts: List[str] = []
+    for part in image_parts:
+        url = _image_url_from_part(part)
+        if not url:
+            continue
+        description = await _describe_image_via_vision(url)
+        if description:
+            enriched_parts.append(
+                f"[The user sent an image~ Here's what I can see:\n{description}]"
+            )
+        else:
+            enriched_parts.append(
+                "[The user sent an image but I couldn't quite see it this time "
+                "(>_<). Try `vision_analyze` directly if you need to look closer.]"
+            )
+
+    if not enriched_parts:
+        return content
+
+    prefix = "\n\n".join(enriched_parts)
+    if user_text:
+        return f"{prefix}\n\n{user_text}"
+    return prefix
+
+
+async def apply_vision_routing(content: Any) -> Any:
+    """Apply auxiliary-vision routing to a single message's content.
+
+    Returns the content unchanged in ``native`` mode, when there are no
+    image parts, or when content is already a plain string. In ``text``
+    mode with image parts present, returns a flat string with the vision
+    descriptions prepended — see ``_route_content_for_text_mode``.
+
+    This is the public entry point the API server calls before passing
+    user / history messages to the agent.  Wrapped in a guard so any
+    failure inside the pipeline degrades to the legacy behaviour
+    (pass-through) instead of dropping the user turn.
+    """
+    try:
+        _user_text, image_parts = _extract_text_and_image_parts(content)
+        if not image_parts:
+            return content
+        if _decide_api_server_image_mode() != "text":
+            return content
+        return await _route_content_for_text_mode(content)
+    except Exception as exc:
+        logger.warning(
+            "api_server vision routing failed — passing content through unchanged: %s", exc
+        )
+        return content
+
+
 def check_api_server_requirements() -> bool:
     """Check if API server dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -2721,6 +2977,26 @@ class APIServerAdapter(BasePlatformAdapter):
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
         """
+        # ── Auxiliary-vision routing (#27232) ────────────────────────────
+        # When the user configured an auxiliary vision provider (or the
+        # main model can't take pixels), pre-analyse inline image parts via
+        # vision_analyze and replace them with text descriptions before
+        # handing the turn to the agent. Without this step, OpenAI-API
+        # clients (Open WebUI, LobeChat, …) saw their images silently
+        # stripped by run_agent's "server rejected image content" retry.
+        # Mirrors gateway/run.py's _decide_image_input_mode + _enrich_with_vision
+        # pipeline so behaviour is consistent across both gateways.
+        user_message = await apply_vision_routing(user_message)
+        if conversation_history:
+            routed_history: List[Dict[str, Any]] = []
+            for entry in conversation_history:
+                if isinstance(entry, dict) and "content" in entry:
+                    routed_content = await apply_vision_routing(entry["content"])
+                    if routed_content is not entry["content"]:
+                        entry = {**entry, "content": routed_content}
+                routed_history.append(entry)
+            conversation_history = routed_history
+
         loop = asyncio.get_running_loop()
 
         def _run():

--- a/tests/gateway/test_api_server_vision_routing.py
+++ b/tests/gateway/test_api_server_vision_routing.py
@@ -1,0 +1,650 @@
+"""Regression tests for OpenAI-API gateway vision routing (issue #27232).
+
+Open WebUI users (and any other OpenAI-compatible client) upload photos
+as ``image_url`` parts on ``/v1/chat/completions``. Before the fix the
+adapter forwarded those parts verbatim to the agent, the main provider
+rejected them (DeepSeek, Mistral, etc. don't accept ``image_url``), and
+``run_agent`` fell back to text-only mode after stripping the images —
+the user got "no photo seen" responses even with ``auxiliary.vision``
+configured.
+
+This module covers the new pipeline that mirrors the TUI gateway:
+``_decide_api_server_image_mode`` + ``_describe_image_via_vision`` +
+``apply_vision_routing`` are wired into ``_run_agent`` so every endpoint
+(``/v1/chat/completions``, ``/v1/responses``, ``/v1/runs``) benefits.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _decide_api_server_image_mode,
+    _describe_image_via_vision,
+    _extract_text_and_image_parts,
+    _image_url_from_part,
+    _materialize_image_for_vision,
+    _route_content_for_text_mode,
+    apply_vision_routing,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+# 1×1 transparent PNG — minimum valid bytes for data-URL materialisation tests.
+_PNG_1x1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+_PNG_DATA_URL = f"data:image/png;base64,{_PNG_1x1_BASE64}"
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_and_image_parts — pure helper, splits multimodal content
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextAndImageParts:
+    def test_string_passthrough_keeps_text_and_no_images(self):
+        assert _extract_text_and_image_parts("hello world") == ("hello world", [])
+
+    def test_text_only_list_joins_with_newlines(self):
+        text, images = _extract_text_and_image_parts(
+            [{"type": "text", "text": "hi"}, {"type": "text", "text": "there"}]
+        )
+        assert text == "hi\nthere"
+        assert images == []
+
+    def test_mixed_list_separates_text_and_image_parts(self):
+        text, images = _extract_text_and_image_parts(
+            [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                {"type": "input_image", "image_url": "https://x/z.png"},
+            ]
+        )
+        assert text == "what is this?"
+        assert [p["type"] for p in images] == ["image_url", "input_image"]
+
+    def test_responses_input_text_part_counted_as_text(self):
+        text, images = _extract_text_and_image_parts(
+            [{"type": "input_text", "text": "Describe."}]
+        )
+        assert text == "Describe."
+        assert images == []
+
+    def test_unknown_part_types_ignored(self):
+        text, images = _extract_text_and_image_parts(
+            [{"type": "weird", "value": 1}, {"type": "text", "text": "ok"}]
+        )
+        assert text == "ok"
+        assert images == []
+
+    def test_non_list_non_string_returns_empty(self):
+        text, images = _extract_text_and_image_parts({"role": "user"})
+        assert text == ""
+        assert images == []
+
+
+# ---------------------------------------------------------------------------
+# _image_url_from_part — pulls a URL out of either Chat or Responses shape
+# ---------------------------------------------------------------------------
+
+
+class TestImageUrlFromPart:
+    def test_chat_completions_shape_returns_inner_url(self):
+        assert _image_url_from_part({"image_url": {"url": "https://x/y.png"}}) == (
+            "https://x/y.png"
+        )
+
+    def test_responses_shape_returns_top_level_string(self):
+        assert _image_url_from_part({"image_url": "https://x/y.png"}) == (
+            "https://x/y.png"
+        )
+
+    def test_missing_url_returns_none(self):
+        assert _image_url_from_part({"image_url": {}}) is None
+        assert _image_url_from_part({"image_url": None}) is None
+        assert _image_url_from_part({}) is None
+
+    def test_whitespace_stripped_and_empty_treated_as_missing(self):
+        assert _image_url_from_part({"image_url": {"url": "  https://x  "}}) == "https://x"
+        assert _image_url_from_part({"image_url": {"url": "   "}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _materialize_image_for_vision — data URLs → temp files, http(s) → passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeImageForVision:
+    def test_http_url_passes_through_without_temp_file(self):
+        path_or_url, is_temp = _materialize_image_for_vision("https://x/y.png")
+        assert path_or_url == "https://x/y.png"
+        assert is_temp is False
+
+    def test_https_url_passes_through_without_temp_file(self):
+        path_or_url, is_temp = _materialize_image_for_vision("https://cdn.example/y.png")
+        assert path_or_url == "https://cdn.example/y.png"
+        assert is_temp is False
+
+    def test_data_image_url_decoded_to_temp_png(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path, is_temp = _materialize_image_for_vision(_PNG_DATA_URL)
+        assert is_temp is True
+        assert path is not None
+        p = Path(path)
+        try:
+            assert p.exists()
+            assert p.suffix == ".png"
+            assert p.read_bytes() == base64.b64decode(_PNG_1x1_BASE64)
+            assert "api_server_vision" in str(p.parent)
+        finally:
+            p.unlink(missing_ok=True)
+
+    def test_unsupported_scheme_returns_none(self):
+        assert _materialize_image_for_vision("ftp://x/y.png") == (None, False)
+
+    def test_non_image_data_url_returns_none(self):
+        assert _materialize_image_for_vision(
+            "data:text/plain;base64,SGVsbG8="
+        ) == (None, False)
+
+    def test_data_url_without_comma_returns_none(self):
+        assert _materialize_image_for_vision("data:image/png;base64") == (None, False)
+
+    def test_malformed_base64_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # ``base64.b64decode(validate=False)`` accepts garbage by ignoring it,
+        # so the file actually does get written. The contract here is: as long
+        # as we don't raise, we return ``(path, True)`` and let vision_analyze
+        # surface the real error downstream.
+        path, is_temp = _materialize_image_for_vision("data:image/png;base64,!!!")
+        if path:
+            Path(path).unlink(missing_ok=True)
+        assert is_temp is bool(path)
+
+    def test_empty_url_returns_none(self):
+        assert _materialize_image_for_vision("") == (None, False)
+
+
+# ---------------------------------------------------------------------------
+# _describe_image_via_vision — async wrapper around vision_analyze_tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDescribeImageViaVision:
+    async def test_returns_analysis_text_on_success(self):
+        with patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(
+                return_value=json.dumps({"success": True, "analysis": "A red cat sits on a mat."})
+            ),
+        ) as fake:
+            out = await _describe_image_via_vision("https://x/y.png")
+        assert out == "A red cat sits on a mat."
+        fake.assert_awaited_once()
+        # vision_analyze_tool was called with the URL untouched (no temp file
+        # for http(s) inputs).
+        kwargs = fake.await_args.kwargs
+        assert kwargs["image_url"] == "https://x/y.png"
+
+    async def test_returns_none_on_unsupported_scheme(self):
+        with patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(),
+        ) as fake:
+            out = await _describe_image_via_vision("ftp://x/y.png")
+        assert out is None
+        fake.assert_not_called()
+
+    async def test_returns_none_when_tool_reports_failure(self):
+        with patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(return_value=json.dumps({"success": False, "analysis": "boom"})),
+        ):
+            out = await _describe_image_via_vision("https://x/y.png")
+        assert out is None
+
+    async def test_returns_none_on_tool_exception(self):
+        with patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(side_effect=RuntimeError("vision provider down")),
+        ):
+            out = await _describe_image_via_vision("https://x/y.png")
+        assert out is None
+
+    async def test_returns_none_on_invalid_json(self):
+        with patch(
+            "tools.vision_tools.vision_analyze_tool",
+            new=AsyncMock(return_value="not-json"),
+        ):
+            out = await _describe_image_via_vision("https://x/y.png")
+        assert out is None
+
+    async def test_data_url_writes_temp_and_cleans_up(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        seen_paths: list[str] = []
+
+        async def _fake_tool(image_url, user_prompt, **_kwargs):
+            seen_paths.append(image_url)
+            assert os.path.exists(image_url), "temp file must exist while tool runs"
+            return json.dumps({"success": True, "analysis": "tiny test image"})
+
+        with patch("tools.vision_tools.vision_analyze_tool", new=_fake_tool):
+            out = await _describe_image_via_vision(_PNG_DATA_URL)
+
+        assert out == "tiny test image"
+        assert seen_paths and not seen_paths[0].startswith("data:")
+        # Temp file must be removed after analysis.
+        assert not os.path.exists(seen_paths[0])
+
+
+# ---------------------------------------------------------------------------
+# _route_content_for_text_mode — replaces image parts with descriptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRouteContentForTextMode:
+    async def test_string_content_returned_unchanged(self):
+        assert await _route_content_for_text_mode("hello") == "hello"
+
+    async def test_list_without_images_returned_unchanged(self):
+        content = [{"type": "text", "text": "hello"}]
+        out = await _route_content_for_text_mode(content)
+        assert out == content
+
+    async def test_image_replaced_with_description_block_before_text(self):
+        content = [
+            {"type": "text", "text": "What is in this photo?"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="A red cat."),
+        ):
+            out = await _route_content_for_text_mode(content)
+        assert isinstance(out, str)
+        assert "A red cat." in out
+        assert "[The user sent an image~" in out
+        assert out.endswith("What is in this photo?")
+
+    async def test_pure_image_turn_gets_caption_placeholder(self):
+        content = [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+        with patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="A red cat."),
+        ):
+            out = await _route_content_for_text_mode(content)
+        assert isinstance(out, str)
+        assert "A red cat." in out
+
+    async def test_failed_description_keeps_user_aware_image_was_sent(self):
+        content = [
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value=None),
+        ):
+            out = await _route_content_for_text_mode(content)
+        assert isinstance(out, str)
+        assert "couldn't quite see it" in out
+        assert "look" in out  # user text preserved
+
+    async def test_multiple_images_each_get_their_own_block(self):
+        content = [
+            {"type": "text", "text": "compare"},
+            {"type": "image_url", "image_url": {"url": "https://x/a.png"}},
+            {"type": "input_image", "image_url": "https://x/b.png"},
+        ]
+        with patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(side_effect=["first description", "second description"]),
+        ):
+            out = await _route_content_for_text_mode(content)
+        assert out.count("[The user sent an image~") == 2
+        assert "first description" in out
+        assert "second description" in out
+        assert out.endswith("compare")
+
+    async def test_image_part_without_url_skipped(self):
+        content = [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="should not run"),
+        ) as fake:
+            out = await _route_content_for_text_mode(content)
+        # No image parts had a URL → nothing to enrich → original content returned.
+        assert out == content
+        fake.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# apply_vision_routing — gate that consults _decide_api_server_image_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestApplyVisionRouting:
+    async def test_native_mode_keeps_image_parts_intact(self):
+        content = [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="native",
+        ), patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="should not run"),
+        ) as fake_describe:
+            out = await apply_vision_routing(content)
+        assert out == content
+        fake_describe.assert_not_called()
+
+    async def test_text_mode_replaces_images_with_descriptions(self):
+        content = [
+            {"type": "text", "text": "what is this?"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="text",
+        ), patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="A red cat."),
+        ):
+            out = await apply_vision_routing(content)
+        assert isinstance(out, str)
+        assert "A red cat." in out
+        assert out.endswith("what is this?")
+
+    async def test_no_images_skips_mode_decision_entirely(self):
+        content = "hello"
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            side_effect=AssertionError("should not be consulted for text-only content"),
+        ):
+            out = await apply_vision_routing(content)
+        assert out == "hello"
+
+    async def test_pipeline_exception_falls_back_to_passthrough(self):
+        content = [
+            {"type": "text", "text": "hi"},
+            {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+        ]
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            side_effect=RuntimeError("config broken"),
+        ):
+            out = await apply_vision_routing(content)
+        assert out == content
+
+
+# ---------------------------------------------------------------------------
+# _decide_api_server_image_mode — wraps agent.image_routing.decide_image_input_mode
+# ---------------------------------------------------------------------------
+
+
+class TestDecideApiServerImageMode:
+    def test_returns_native_when_decision_helper_raises(self):
+        with patch("agent.image_routing.decide_image_input_mode", side_effect=RuntimeError):
+            assert _decide_api_server_image_mode() == "native"
+
+    def test_passes_provider_model_and_config_through(self):
+        with patch(
+            "agent.image_routing.decide_image_input_mode",
+            return_value="text",
+        ) as fake_decide, patch(
+            "agent.auxiliary_client._read_main_provider", return_value="deepseek"
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="deepseek-chat"
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {"provider": "openrouter"}}},
+        ):
+            mode = _decide_api_server_image_mode()
+        assert mode == "text"
+        args, _ = fake_decide.call_args
+        assert args[0] == "deepseek"
+        assert args[1] == "deepseek-chat"
+        assert args[2] == {"auxiliary": {"vision": {"provider": "openrouter"}}}
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration — full request path with vision routing enabled
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+class TestChatCompletionsVisionRoutingHTTP:
+    @pytest.mark.asyncio
+    async def test_text_mode_replaces_image_with_description_before_agent(self, adapter):
+        """End-to-end: Open WebUI upload flow with text-mode routing — the
+        agent receives a flat string with the vision description, not the
+        raw ``image_url`` part that the main provider would reject."""
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {
+            "final_response": "A red cat.", "messages": [], "api_calls": 1
+        }
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+        fake_agent.session_id = "sid"
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="text",
+        ), patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="A red cat curled on a mat."),
+        ), patch.object(
+            adapter, "_create_agent", return_value=fake_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "What's in this photo?"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": "https://example.com/cat.png"},
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                )
+                assert resp.status == 200, await resp.text()
+
+        forwarded_user_message = fake_agent.run_conversation.call_args.kwargs["user_message"]
+        assert isinstance(forwarded_user_message, str), (
+            "text-mode routing must hand the agent a plain string, not the "
+            "raw multimodal list (which the main provider would reject)"
+        )
+        assert "A red cat curled on a mat." in forwarded_user_message
+        assert forwarded_user_message.endswith("What's in this photo?")
+
+    @pytest.mark.asyncio
+    async def test_native_mode_forwards_image_parts_untouched(self, adapter):
+        """When the main model supports vision (native mode), the image
+        parts must reach the agent verbatim so providers like GPT-4o can
+        consume them directly."""
+        captured: dict = {}
+
+        async def _stub(**kwargs):
+            captured.update(kwargs)
+            return (
+                {"final_response": "ok", "messages": [], "api_calls": 1},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="native",
+        ), patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="should not run"),
+        ) as fake_describe, patch.object(
+            adapter, "_run_agent", new=MagicMock(side_effect=_stub),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                payload = [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ]
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": payload}],
+                    },
+                )
+                assert resp.status == 200, await resp.text()
+
+        fake_describe.assert_not_called()
+        assert captured["user_message"] == payload
+
+    @pytest.mark.asyncio
+    async def test_data_image_url_is_materialised_and_described(
+        self, adapter, monkeypatch, tmp_path
+    ):
+        """The real Open WebUI photo-upload format is a data URL — it must
+        be decoded to a temp file and passed to ``vision_analyze``."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        seen_paths: list[str] = []
+
+        async def _fake_vision_tool(image_url, user_prompt, **_kwargs):
+            seen_paths.append(image_url)
+            return json.dumps({"success": True, "analysis": "1×1 PNG"})
+
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {
+            "final_response": "ok", "messages": [], "api_calls": 1
+        }
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+        fake_agent.session_id = "sid"
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="text",
+        ), patch(
+            "tools.vision_tools.vision_analyze_tool", new=_fake_vision_tool,
+        ), patch.object(
+            adapter, "_create_agent", return_value=fake_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "what is this?"},
+                                    {"type": "image_url", "image_url": {"url": _PNG_DATA_URL}},
+                                ],
+                            }
+                        ],
+                    },
+                )
+                assert resp.status == 200, await resp.text()
+
+        assert seen_paths, "vision tool must be invoked for data:image URLs"
+        assert not seen_paths[0].startswith("data:"), seen_paths
+        forwarded = fake_agent.run_conversation.call_args.kwargs["user_message"]
+        assert isinstance(forwarded, str)
+        assert "1×1 PNG" in forwarded
+
+
+class TestResponsesVisionRoutingHTTP:
+    @pytest.mark.asyncio
+    async def test_input_image_routed_through_vision_pipeline(self, adapter):
+        """``/v1/responses`` shares ``_run_agent`` so it gets the same
+        routing — verify the Responses-style ``input_image`` shape works."""
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {
+            "final_response": "ok", "messages": [], "api_calls": 1
+        }
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+        fake_agent.session_id = "sid"
+
+        app = _create_app(adapter)
+        with patch(
+            "gateway.platforms.api_server._decide_api_server_image_mode",
+            return_value="text",
+        ), patch(
+            "gateway.platforms.api_server._describe_image_via_vision",
+            new=AsyncMock(return_value="A cat on a mat."),
+        ), patch.object(
+            adapter, "_create_agent", return_value=fake_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_text", "text": "Describe."},
+                                    {"type": "input_image", "image_url": "https://example.com/cat.png"},
+                                ],
+                            }
+                        ],
+                    },
+                )
+                assert resp.status == 200, await resp.text()
+
+        forwarded = fake_agent.run_conversation.call_args.kwargs["user_message"]
+        assert isinstance(forwarded, str)
+        assert "A cat on a mat." in forwarded
+        assert forwarded.endswith("Describe.")

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -225,6 +225,35 @@ If you need tools to run against your **local** workspace today, run Hermes loca
 With streaming enabled (the default), you'll see brief inline indicators as tools run — the tool emoji and its key argument. These appear in the response stream before the agent's final answer, giving you visibility into what's happening behind the scenes.
 :::
 
+## Image / Photo Uploads
+
+Open WebUI sends uploaded photos as `image_url` content parts on `/v1/chat/completions` (typically base64-encoded `data:image/...` URLs). Hermes Agent routes those images through the same vision pipeline used by the TUI gateway:
+
+| Active main model | `auxiliary.vision.provider` | What happens to the image |
+|-------------------|------------------------------|---------------------------|
+| Supports vision (e.g. `gpt-5`, `gpt-4o`, `claude-sonnet-4.5`, `gemini-3-pro`) | `auto` / unset | Image part is forwarded **natively** so the model sees the pixels directly. |
+| Any model | An explicit provider (e.g. `openrouter`) | Image is **pre-analysed via `vision_analyze`** and the description is prepended to the user turn as text. |
+| Non-vision model (e.g. `deepseek-chat`, `mistral-large`) | `auto` / unset | Same as the explicit-override row — image is described as text. |
+
+The routing decision matches the table in [`agent/image_routing.py`](https://github.com/NousResearch/hermes-agent/blob/main/agent/image_routing.py) so the API server and the TUI gateway behave identically.
+
+To force the text-mode path on every model (e.g. when you want descriptions logged for audit), set:
+
+```yaml
+# ~/.hermes/config.yaml
+agent:
+  image_input_mode: text
+```
+
+To always send pixels (useful when you've upgraded to a vision-capable main model that Hermes doesn't yet recognise):
+
+```yaml
+agent:
+  image_input_mode: native
+```
+
+If `vision_analyze` itself fails (vision provider down, transient API error), the user turn still reaches the agent with a `[The user sent an image but I couldn't quite see it this time]` placeholder so the conversation isn't silently dropped.
+
 ## Configuration Reference
 
 ### Hermes Agent (API server)


### PR DESCRIPTION
## What does this PR do?

Fixes the OpenAI-compatible API server (used by Open WebUI and every other OpenAI-API client) silently dropping inline image attachments when the active main model can't take pixels directly.

The TUI gateway (\`gateway/run.py\`) already routes every image attachment through \`_decide_image_input_mode()\`: if the user configured \`auxiliary.vision.provider\` (or the active model is non-vision), images get pre-analysed by \`vision_analyze\` and replaced with a text description before the agent runs. The OpenAI-compatible adapter (\`gateway/platforms/api_server.py\`) had no equivalent step — image parts were forwarded verbatim to \`_run_agent\`, the main provider (DeepSeek, Mistral, …) rejected them, and \`run_agent\`'s fallback path stripped every image and retried text-only with:

> ⚠️ Server rejected image content — switching to text-only mode for this session. Stripped images from history and retrying.

Open WebUI users with \`auxiliary.vision.provider\` configured saw "no photo seen" responses even though their auxiliary vision backend was healthy — the photo never reached the vision pipeline.

This PR ports the TUI gateway's pipeline into \`api_server.py\` so the two surfaces behave identically.

## Related Issue

Fixes #27232

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`gateway/platforms/api_server.py\` — add a small vision-routing pipeline that mirrors \`gateway/run.py\`:
  - \`_decide_api_server_image_mode()\` — wraps \`agent.image_routing.decide_image_input_mode\` with the same \`(provider, model, cfg)\` inputs the TUI gateway uses, so the API server and the CLI always agree on native-vs-text routing.
  - \`_extract_text_and_image_parts()\` / \`_image_url_from_part()\` — shared helpers for walking both the Chat Completions (\`{"type":"image_url","image_url":{"url":...}}\`) and Responses (\`{"type":"input_image","image_url":...}\`) content shapes.
  - \`_materialize_image_for_vision(url)\` — decodes \`data:image/...\` URLs (the actual Open WebUI photo-upload format) into a temp file under \`\$HERMES_HOME/cache/api_server_vision/\` so \`vision_analyze_tool\` (which only accepts local paths or http(s):// URLs) can consume them. http(s):// URLs pass through unchanged; unsupported schemes and malformed data URLs return \`(None, False)\` so the caller skips them cleanly.
  - \`_describe_image_via_vision(url)\` — async wrapper that invokes \`vision_analyze_tool\`, parses the JSON envelope, and *always* cleans up the temp file in a \`finally\` block.
  - \`_route_content_for_text_mode(content)\` — mirrors \`AIAgentRunner._enrich_message_with_vision\` from \`gateway/run.py\` so the agent sees identical \`[The user sent an image~ Here's what I can see: …]\` blocks on either surface.
  - \`apply_vision_routing(content)\` — the public entry point. Returns content unchanged in native mode, when no image parts are present, or on any internal failure (fail-open); otherwise returns the enriched text string.
  - Wired into \`_run_agent\` (one call site, applied to both \`user_message\` and every \`conversation_history\` entry) so \`/v1/chat/completions\`, \`/v1/responses\`, and \`/v1/runs\` all benefit without duplicating logic at three handler entry points.
- \`tests/gateway/test_api_server_vision_routing.py\` — **41 new regression tests** covering each helper plus the full HTTP round-trip:
  - Pure-function tests for the six helpers (text/image split, URL extraction, data-URL materialisation with the actual base64 of a 1×1 PNG, native/text mode gating, fail-open behaviour, \`_decide_api_server_image_mode\` fallback to \`native\` on raise).
  - Async tests for \`_describe_image_via_vision\` proving the temp file exists while the vision tool runs and is unlinked when it returns.
  - HTTP integration tests using a real aiohttp \`TestClient\` against \`/v1/chat/completions\` and \`/v1/responses\` that prove (a) text-mode replaces images with descriptions *before* the agent's \`run_conversation\` is invoked, (b) native mode forwards image parts to the agent verbatim, (c) data-URL uploads are materialised to a local path and the agent sees the description string instead of the raw data URL.
- \`website/docs/user-guide/messaging/open-webui.md\` — new "Image / Photo Uploads" section explaining the three routing behaviours (native attachment, auxiliary pre-analysis, non-vision-model text mode), the \`agent.image_input_mode\` override, and the placeholder text shown when the vision provider itself errors out so the user turn is never silently dropped.

## How to Test

\`\`\`bash
# 1. New test suite passes
./scripts/run_tests.sh tests/gateway/test_api_server_vision_routing.py
# expected: 41 passed

# 2. Existing API-server and image-routing suites still pass (no regression)
./scripts/run_tests.sh tests/gateway/test_api_server_multimodal.py \\
                      tests/gateway/test_api_server_normalize.py \\
                      tests/gateway/test_api_server.py \\
                      tests/gateway/test_api_server_runs.py \\
                      tests/gateway/test_api_server_toolset.py \\
                      tests/gateway/test_api_server_jobs.py \\
                      tests/gateway/test_api_server_bind_guard.py \\
                      tests/agent/test_image_routing.py
# expected: all green (248 + existing image_routing tests)

# 3. Manual reproduction of the bug fix — pre-PR vs post-PR
#    (no real LLM call required; we patch both decide + vision)
python - <<'PY'
import asyncio
from unittest.mock import AsyncMock, patch
from gateway.platforms.api_server import apply_vision_routing

content = [
    {"type": "text", "text": "what is this photo?"},
    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
]
with patch("gateway.platforms.api_server._decide_api_server_image_mode", return_value="text"), \\
     patch("gateway.platforms.api_server._describe_image_via_vision",
           new=AsyncMock(return_value="A red cat curled on a mat.")):
    out = asyncio.run(apply_vision_routing(content))
print(type(out).__name__, "→", out[:120])
PY
# expected:
#   str → [The user sent an image~ Here's what I can see:
#   A red cat curled on a mat.]
#   
#   what is this photo?
\`\`\`

For a real end-to-end check: point Open WebUI at \`http://127.0.0.1:8642/v1\` with \`auxiliary.vision.provider: openrouter\` and \`terminal.provider: deepseek\` (the exact reproducer in the issue), upload a photo, and confirm the agent describes it instead of returning "no photo seen".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(api-server):\`, \`test(api-server):\`, \`docs(open-webui):\`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run \`./scripts/run_tests.sh tests/gateway/test_api_server_vision_routing.py tests/gateway/test_api_server_multimodal.py tests/gateway/test_api_server.py tests/agent/test_image_routing.py\` and all tests pass (112 passed)
- [x] I've added tests for my changes (41 new regression tests + HTTP integration coverage for both \`/v1/chat/completions\` and \`/v1/responses\`)
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (\`website/docs/user-guide/messaging/open-webui.md\` — new "Image / Photo Uploads" section)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A (reuses existing \`agent.image_input_mode\` + \`auxiliary.vision.*\` already documented for the TUI gateway)
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A (mirrors an existing pipeline, no architectural change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python pipeline, temp-file handling uses \`tempfile.mkstemp\` so works on Windows; pipeline is fail-open so unsupported configurations fall back to today's behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (reuses \`vision_analyze_tool\` unchanged)

## Screenshots / Logs

Before the fix (Open WebUI photo upload, \`auxiliary.vision.provider: openrouter\`, \`terminal.provider: deepseek\`):

\`\`\`
[User uploads photo via Open WebUI]
[gateway.log]
WARN  Server rejected image content — switching to text-only mode for this session.
      Stripped images from history and retrying.
[Open WebUI response]
"I don't see any photo in our conversation."
\`\`\`

After the fix:

\`\`\`
[User uploads photo via Open WebUI]
[gateway.log]
INFO  api_server image_routing: text mode chosen — pre-analysing 1 image(s) via vision_analyze
INFO  Analyzing image: /Users/x/.hermes/cache/api_server_vision/apiv_xxxxx.png
INFO  Image converted to base64 (123.4 KB)
INFO  Vision analysis completed successfully
[Open WebUI response]
"I can see a red cat curled on a mat, near a window with sunlight streaming in.
The cat appears to be …"
\`\`\`