### PR TITLE
fix(plugins): use path keys for bundled platform plugins

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -830,8 +830,12 @@ class PluginManager:
         )
         logger.debug("  bundled (top-level): %d manifest(s)", len(bundled))
         manifests.extend(bundled)
-        bundled_platforms = self._scan_directory(
-            repo_plugins / "platforms", source="bundled"
+        bundled_platforms = self._scan_directory_level(
+            repo_plugins / "platforms",
+            source="bundled",
+            skip_names=None,
+            prefix="platforms",
+            depth=1,
         )
         logger.debug("  bundled/platforms: %d manifest(s)", len(bundled_platforms))
         manifests.extend(bundled_platforms)

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -287,6 +287,24 @@ class TestBundledBackendAutoLoad:
         assert loaded.manifest.kind == "backend"
         assert loaded.enabled is True, f"error: {loaded.error}"
 
+    def test_bundled_platform_plugins_use_path_derived_keys(self, tmp_path, monkeypatch):
+        """Bundled platform plugins should use the same path-derived key as
+        ``hermes plugins list`` and user-installed platform plugins.
+
+        Regression: the runtime used to scan ``plugins/platforms/`` as a
+        separate root, so Teams loaded as ``teams-platform`` while the CLI
+        surfaced ``platforms/teams``. Enabling/disabling the listed key then
+        had no effect on the runtime manifest.
+        """
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "platforms/teams" in mgr._plugins
+        loaded = mgr._plugins["platforms/teams"]
+        assert loaded.manifest.name == "teams-platform"
+        assert loaded.manifest.kind == "platform"
+        assert loaded.enabled is True, f"error: {loaded.error}"
+
 
 # ── PluginContext.register_image_gen_provider ───────────────────────────────
 


### PR DESCRIPTION
## Summary
- scan bundled `plugins/platforms/*` with the same path-derived key shape used by the general plugin scanner
- make bundled platform plugins register as `platforms/<name>` instead of bare manifest names like `teams-platform`
- add a regression test covering the Teams platform plugin key

## Why
`hermes plugins list` and the docs surface sub-category plugins by path key, for example `platforms/teams`. Runtime discovery scanned the bundled `plugins/platforms` directory as a separate root, so PluginManager recorded the same plugin as `teams-platform`. That made runtime state diverge from the key users see in plugin management surfaces.

## Open PR overlap checked
- #27077 fixes Nix packaged platform discovery in `gateway/config.py`; this PR does not touch gateway config or `HERMES_BUNDLED_PLUGINS`.
- #27208 adds a plugin hook in `hermes_cli/plugins.py`; it touches `VALID_HOOKS`, not the bundled platform scanner.

## Verification
- `./scripts/run_tests.sh tests/hermes_cli/test_plugin_scanner_recursion.py::TestBundledBackendAutoLoad::test_bundled_platform_plugins_use_path_derived_keys tests/hermes_cli/test_plugin_scanner_recursion.py::TestBundledBackendAutoLoad::test_bundled_image_gen_openai_autoloads tests/gateway/test_plugin_platform_interface.py`
- `./scripts/run_tests.sh tests/hermes_cli/test_plugin_scanner_recursion.py`
- `.venv/bin/ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugin_scanner_recursion.py`
- `git diff --check`