### PR TITLE
fix(weixin): preserve zero-valued chunk settings and fallback on bad numeric config

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -976,6 +976,35 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _coerce_numeric_config(
+    extra: Dict[str, Any],
+    *,
+    key: str,
+    env_var: str,
+    default: Any,
+    cast: Any,
+) -> Any:
+    """Coerce numeric config from ``extra``/env while preserving explicit zeroes."""
+    raw = extra.get(key)
+    source = f"config.extra.{key}"
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        raw = os.getenv(env_var)
+        source = env_var
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return default
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "weixin: invalid %s value %r from %s; using default %r",
+            key,
+            raw,
+            source,
+            default,
+        )
+        return default
+
+
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
@@ -1200,15 +1229,26 @@ class WeixinAdapter(BasePlatformAdapter):
         self._cdn_base_url = str(
             extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
-        self._send_chunk_delay_seconds = float(
-            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")
+        self._send_chunk_delay_seconds = _coerce_numeric_config(
+            extra,
+            key="send_chunk_delay_seconds",
+            env_var="WEIXIN_SEND_CHUNK_DELAY_SECONDS",
+            default=1.5,
+            cast=float,
         )
-        self._send_chunk_retries = int(
-            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "4")
+        self._send_chunk_retries = _coerce_numeric_config(
+            extra,
+            key="send_chunk_retries",
+            env_var="WEIXIN_SEND_CHUNK_RETRIES",
+            default=4,
+            cast=int,
         )
-        self._send_chunk_retry_delay_seconds = float(
-            extra.get("send_chunk_retry_delay_seconds")
-            or os.getenv("WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS", "1.0")
+        self._send_chunk_retry_delay_seconds = _coerce_numeric_config(
+            extra,
+            key="send_chunk_retry_delay_seconds",
+            env_var="WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS",
+            default=1.0,
+            cast=float,
         )
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "open")).strip().lower()
         self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -238,6 +238,74 @@ class TestWeixinConfig:
 
         assert config.get_connected_platforms() == []
 
+    def test_adapter_ignores_invalid_chunk_env_values_and_uses_defaults(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WEIXIN_SEND_CHUNK_DELAY_SECONDS": "abc",
+                "WEIXIN_SEND_CHUNK_RETRIES": "xyz",
+                "WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS": "NaNnope",
+            },
+            clear=False,
+        ), patch.object(weixin.logger, "warning") as warning_mock:
+            adapter = WeixinAdapter(
+                PlatformConfig(
+                    enabled=True,
+                    token="test-token",
+                    extra={"account_id": "test-account"},
+                )
+            )
+
+        assert adapter._send_chunk_delay_seconds == 1.5
+        assert adapter._send_chunk_retries == 4
+        assert adapter._send_chunk_retry_delay_seconds == 1.0
+        assert warning_mock.call_count == 3
+
+    def test_adapter_preserves_explicit_zero_chunk_settings(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "send_chunk_delay_seconds": 0,
+                    "send_chunk_retries": 0,
+                    "send_chunk_retry_delay_seconds": 0,
+                },
+            )
+        )
+
+        assert adapter._send_chunk_delay_seconds == 0.0
+        assert adapter._send_chunk_retries == 0
+        assert adapter._send_chunk_retry_delay_seconds == 0.0
+
+    def test_adapter_explicit_zero_chunk_settings_override_env_values(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WEIXIN_SEND_CHUNK_DELAY_SECONDS": "9.5",
+                "WEIXIN_SEND_CHUNK_RETRIES": "7",
+                "WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS": "2.5",
+            },
+            clear=False,
+        ):
+            adapter = WeixinAdapter(
+                PlatformConfig(
+                    enabled=True,
+                    token="test-token",
+                    extra={
+                        "account_id": "test-account",
+                        "send_chunk_delay_seconds": 0,
+                        "send_chunk_retries": 0,
+                        "send_chunk_retry_delay_seconds": 0,
+                    },
+                )
+            )
+
+        assert adapter._send_chunk_delay_seconds == 0.0
+        assert adapter._send_chunk_retries == 0
+        assert adapter._send_chunk_retry_delay_seconds == 0.0
+
 
 class TestWeixinStatePersistence:
     def test_save_weixin_account_preserves_existing_file_on_replace_failure(self, tmp_path, monkeypatch):


### PR DESCRIPTION


### Summary

This PR hardens Weixin chunk-send config parsing in `WeixinAdapter` and fixes an override bug where explicit zero-valued settings were ignored.

### Problem

The adapter currently reads these settings with `extra.get(...) or os.getenv(...)`:

- `send_chunk_delay_seconds`
- `send_chunk_retries`
- `send_chunk_retry_delay_seconds`

That causes two issues:

1. Invalid env/config values such as `WEIXIN_SEND_CHUNK_DELAY_SECONDS=abc` raise `ValueError` during adapter initialization and can break gateway startup.
2. Explicit `0` / `0.0` values from config are treated as falsy and incorrectly fall back to env/default values, so users cannot disable chunk delay or retries intentionally.

### Fix

This change introduces a small local numeric-coercion helper for these three fields only.

Behavior after this change:

- preserves explicit zero-valued config overrides
- falls back to env only when the config value is `None` or blank
- falls back to the built-in default on invalid numeric input
- logs a warning instead of crashing on malformed values

This is intentionally scoped to the three Weixin chunk-send numeric settings and does not refactor broader config handling.

### Why this is safe

- The behavior change is limited to malformed numeric input and explicit-zero overrides.
- Valid nonzero values continue to behave the same.
- No platform-wide config logic was changed.
- No message send path or retry loop logic was modified beyond initialization of these fields.

### Tests

Added targeted regression coverage for:

- invalid env values fall back to defaults without crashing
- explicit zero values from config are preserved
- explicit zero config values take precedence over nonzero env values

Validated locally with:

```powershell
uv run pytest tests/gateway/test_weixin.py -n 0 -k "invalid_chunk_env_values or explicit_zero_chunk_settings" -v

3 passed
