### PR TITLE
WAT-1371: add Pinecone memory client and document models

### DIFF
--- a/agent/memory_documents.py
+++ b/agent/memory_documents.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Literal, Sequence
+
+MemoryType = Literal[
+    "profile",
+    "project_context",
+    "session_summary",
+    "artifact_summary",
+    "ephemeral",
+]
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip())
+
+
+def _slugify_header(header: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", header.lower()).strip("-")
+    return slug or "root"
+
+
+def _iso8601(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, str):
+        return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+@dataclass(frozen=True)
+class MemorySourceRef:
+    source_kind: str
+    source_id: str
+    source_path: str = ""
+
+
+@dataclass(frozen=True)
+class MemoryChunk:
+    id: str
+    document_id: str
+    chunk_index: int
+    text: str
+    header_path: tuple[str, ...]
+    memory_type: MemoryType
+    scope: str
+    source_kind: str
+    source_id: str
+    source_path: str
+    created_at: str
+    updated_at: str
+    freshness_hint: str
+    confidence: float
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("MemoryChunk.text must be non-empty")
+        if not self.source_kind:
+            raise ValueError("MemoryChunk.source_kind is required")
+        if not self.source_id:
+            raise ValueError("MemoryChunk.source_id is required")
+        if not self.scope:
+            raise ValueError("MemoryChunk.scope is required")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("MemoryChunk.confidence must be between 0 and 1")
+
+    @property
+    def metadata(self) -> dict[str, object]:
+        return {
+            "memory_type": self.memory_type,
+            "scope": self.scope,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "source_path": self.source_path,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "freshness_hint": self.freshness_hint,
+            "confidence": self.confidence,
+            "tags": list(self.tags),
+            "canonical": self.canonical,
+            "header_path": list(self.header_path),
+            "chunk_index": self.chunk_index,
+            "document_id": self.document_id,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryDocument:
+    memory_type: MemoryType
+    scope: str
+    source: MemorySourceRef
+    text: str
+    created_at: str | datetime | None = None
+    updated_at: str | datetime | None = None
+    freshness_hint: str = "durable"
+    confidence: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+    title: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.scope:
+            raise ValueError("MemoryDocument.scope is required")
+        if not self.text.strip():
+            raise ValueError("MemoryDocument.text must be non-empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("MemoryDocument.confidence must be between 0 and 1")
+        object.__setattr__(self, "created_at", _iso8601(self.created_at))
+        object.__setattr__(self, "updated_at", _iso8601(self.updated_at or self.created_at))
+        object.__setattr__(self, "text", self.text.strip())
+
+    @property
+    def document_id(self) -> str:
+        payload = "|".join(
+            [
+                self.memory_type,
+                self.scope,
+                self.source.source_kind,
+                self.source.source_id,
+                self.source.source_path,
+                self.title,
+            ]
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+    def chunk(self, *, target_chars: int = 900, max_chars: int = 1200) -> list[MemoryChunk]:
+        if target_chars <= 0 or max_chars <= 0 or target_chars > max_chars:
+            raise ValueError("target_chars and max_chars must be positive and target_chars <= max_chars")
+        sections = _split_sections(self.text)
+        chunks: list[MemoryChunk] = []
+        for header_path, section_text in sections:
+            parts = _chunk_section_text(section_text, target_chars=target_chars, max_chars=max_chars)
+            for part in parts:
+                chunk_index = len(chunks)
+                stable_id = _stable_chunk_id(
+                    document_id=self.document_id,
+                    chunk_index=chunk_index,
+                    header_path=header_path,
+                    text=part,
+                )
+                chunks.append(
+                    MemoryChunk(
+                        id=stable_id,
+                        document_id=self.document_id,
+                        chunk_index=chunk_index,
+                        text=part,
+                        header_path=header_path,
+                        memory_type=self.memory_type,
+                        scope=self.scope,
+                        source_kind=self.source.source_kind,
+                        source_id=self.source.source_id,
+                        source_path=self.source.source_path,
+                        created_at=self.created_at,
+                        updated_at=self.updated_at,
+                        freshness_hint=self.freshness_hint,
+                        confidence=self.confidence,
+                        tags=tuple(self.tags),
+                        canonical=self.canonical,
+                    )
+                )
+        return chunks
+
+
+def _split_sections(text: str) -> list[tuple[tuple[str, ...], str]]:
+    sections: list[tuple[tuple[str, ...], str]] = []
+    header_stack: list[str] = []
+    buffer: list[str] = []
+
+    def flush() -> None:
+        body = "\n".join(buffer).strip()
+        if body:
+            sections.append((tuple(header_stack), body))
+        buffer.clear()
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        match = re.match(r"^(#{1,6})\s+(.*\S)\s*$", line)
+        if match:
+            flush()
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            header_stack[:] = header_stack[: level - 1]
+            header_stack.append(title)
+            continue
+        buffer.append(line)
+    flush()
+    if not sections:
+        sections.append((tuple(), text.strip()))
+    return sections
+
+
+def _chunk_section_text(text: str, *, target_chars: int, max_chars: int) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        return []
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            if len(current) >= target_chars:
+                chunks.append(current)
+                current = ""
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        chunks.extend(_split_long_paragraph(paragraph, max_chars=max_chars))
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_long_paragraph(paragraph: str, *, max_chars: int) -> list[str]:
+    sentences = re.split(r"(?<=[.!?])\s+", paragraph.strip())
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        candidate = sentence if not current else f"{current} {sentence}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        while len(sentence) > max_chars:
+            split_at = sentence.rfind(" ", 0, max_chars)
+            if split_at <= 0:
+                split_at = max_chars
+            chunks.append(sentence[:split_at].strip())
+            sentence = sentence[split_at:].strip()
+        current = sentence
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _stable_chunk_id(*, document_id: str, chunk_index: int, header_path: Sequence[str], text: str) -> str:
+    fingerprint = "|".join(
+        [document_id, str(chunk_index), "/".join(_slugify_header(h) for h in header_path), _normalize_text(text)]
+    )
+    return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()[:24]
+
+
+__all__ = [
+    "MemoryChunk",
+    "MemoryDocument",
+    "MemorySourceRef",
+]

--- a/agent/pinecone_memory.py
+++ b/agent/pinecone_memory.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class PineconeMemoryClient:
+    """Fail-open wrapper around the Pinecone index client."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        index_name: str | None = None,
+        namespace: str | None = None,
+        top_k: int = 5,
+        fail_open: bool = True,
+        sdk_client: Any | None = None,
+        index: Any | None = None,
+    ) -> None:
+        self.api_key = api_key or os.getenv("PINECONE_API_KEY", "")
+        self.index_name = index_name or os.getenv("PINECONE_INDEX", "")
+        self.namespace = namespace or os.getenv("PINECONE_NAMESPACE", "hermes")
+        self.top_k = top_k
+        self.fail_open = fail_open
+        self._sdk_client = sdk_client
+        self._index = index
+
+    def is_configured(self) -> bool:
+        return bool(self.api_key and self.index_name)
+
+    def upsert_records(self, records: Iterable[dict[str, Any]]) -> int:
+        normalized = [self._normalize_record(record) for record in records]
+        if not normalized:
+            return 0
+        if not self.is_configured():
+            logger.warning("Pinecone upsert skipped: missing configuration")
+            return 0
+        try:
+            index = self._get_index()
+            response = index.upsert(vectors=normalized, namespace=self.namespace)
+            if isinstance(response, dict):
+                return int(response.get("upserted_count", len(normalized)))
+            return int(getattr(response, "upserted_count", len(normalized)))
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone upsert failed; continuing fail-open: %s", exc)
+                return 0
+            raise
+
+    def query(self, vector: Sequence[float], *, top_k: int | None = None, filter: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        if not self.is_configured():
+            logger.warning("Pinecone query skipped: missing configuration")
+            return []
+        try:
+            index = self._get_index()
+            response = index.query(
+                vector=list(vector),
+                top_k=top_k or self.top_k,
+                namespace=self.namespace,
+                include_metadata=True,
+                filter=filter,
+            )
+            matches = response.get("matches", []) if isinstance(response, dict) else getattr(response, "matches", [])
+            return [self._normalize_match(match) for match in matches]
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone query failed; continuing fail-open: %s", exc)
+                return []
+            raise
+
+    def delete_by_source(self, *, source_kind: str, source_id: str) -> int:
+        if not self.is_configured():
+            logger.warning("Pinecone delete skipped: missing configuration")
+            return 0
+        try:
+            index = self._get_index()
+            index.delete(
+                namespace=self.namespace,
+                filter={"source_kind": {"$eq": source_kind}, "source_id": {"$eq": source_id}},
+            )
+            return 1
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone delete failed; continuing fail-open: %s", exc)
+                return 0
+            raise
+
+    def _get_index(self) -> Any:
+        if self._index is not None:
+            return self._index
+        if self._sdk_client is None:
+            self._sdk_client = self._build_sdk_client()
+        index_factory = getattr(self._sdk_client, "Index")
+        self._index = index_factory(self.index_name)
+        return self._index
+
+    def _build_sdk_client(self) -> Any:
+        from pinecone import Pinecone  # type: ignore
+
+        return Pinecone(api_key=self.api_key)
+
+    @staticmethod
+    def _normalize_record(record: dict[str, Any]) -> dict[str, Any]:
+        if "id" not in record or "values" not in record or "metadata" not in record:
+            raise ValueError("Pinecone record must include id, values, and metadata")
+        return {
+            "id": str(record["id"]),
+            "values": [float(value) for value in record["values"]],
+            "metadata": dict(record["metadata"]),
+        }
+
+    @staticmethod
+    def _normalize_match(match: Any) -> dict[str, Any]:
+        if isinstance(match, dict):
+            return {
+                "id": match.get("id", ""),
+                "score": match.get("score"),
+                "metadata": dict(match.get("metadata") or {}),
+            }
+        return {
+            "id": getattr(match, "id", ""),
+            "score": getattr(match, "score", None),
+            "metadata": dict(getattr(match, "metadata", {}) or {}),
+        }
+
+
+__all__ = ["PineconeMemoryClient"]

--- a/tests/agent/test_memory_documents.py
+++ b/tests/agent/test_memory_documents.py
@@ -1,0 +1,65 @@
+from agent.memory_documents import MemoryDocument, MemorySourceRef
+
+
+def _make_document(text: str) -> MemoryDocument:
+    return MemoryDocument(
+        memory_type="project_context",
+        scope="repo:hermes-agent",
+        source=MemorySourceRef(source_kind="file", source_id="docs/test.md", source_path="docs/test.md"),
+        text=text,
+        created_at="2026-05-07T00:00:00+00:00",
+        updated_at="2026-05-07T01:00:00+00:00",
+        freshness_hint="weekly",
+        confidence=0.8,
+        tags=("pinecone", "memory"),
+        canonical=True,
+        title="Test doc",
+    )
+
+
+def test_chunk_size_bounds_and_header_awareness():
+    text = """# Overview
+This is the overview paragraph. It explains the system.
+
+## Details
+""" + ("Sentence. " * 140) + """
+
+## Notes
+A short closing note.
+"""
+    doc = _make_document(text)
+    chunks = doc.chunk(target_chars=220, max_chars=320)
+
+    assert len(chunks) >= 3
+    assert all(1 <= len(chunk.text) <= 320 for chunk in chunks)
+    assert chunks[0].header_path == ("Overview",)
+    assert any(chunk.header_path == ("Overview", "Details") for chunk in chunks)
+    assert chunks[-1].header_path == ("Overview", "Notes")
+
+
+def test_metadata_preservation_and_required_fields():
+    doc = _make_document("# Title\nUseful memory content for retrieval.")
+    chunk = doc.chunk(target_chars=200, max_chars=300)[0]
+
+    assert chunk.memory_type == "project_context"
+    assert chunk.scope == "repo:hermes-agent"
+    assert chunk.source_kind == "file"
+    assert chunk.source_id == "docs/test.md"
+    assert chunk.source_path == "docs/test.md"
+    assert chunk.created_at == "2026-05-07T00:00:00+00:00"
+    assert chunk.updated_at == "2026-05-07T01:00:00+00:00"
+    assert chunk.freshness_hint == "weekly"
+    assert chunk.confidence == 0.8
+    assert chunk.tags == ("pinecone", "memory")
+    assert chunk.canonical is True
+    assert chunk.metadata["source_kind"] == "file"
+    assert chunk.metadata["tags"] == ["pinecone", "memory"]
+
+
+def test_chunk_ids_are_stable_for_same_input():
+    text = "# Same\n" + ("Repeatable text. " * 40)
+    first = _make_document(text).chunk(target_chars=180, max_chars=240)
+    second = _make_document(text).chunk(target_chars=180, max_chars=240)
+
+    assert [chunk.id for chunk in first] == [chunk.id for chunk in second]
+    assert [chunk.document_id for chunk in first] == [chunk.document_id for chunk in second]

--- a/tests/agent/test_pinecone_memory.py
+++ b/tests/agent/test_pinecone_memory.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.pinecone_memory import PineconeMemoryClient
+
+
+class FakeIndex:
+    def __init__(self):
+        self.upsert_calls = []
+        self.query_calls = []
+        self.delete_calls = []
+
+    def upsert(self, *, vectors, namespace):
+        self.upsert_calls.append({"vectors": vectors, "namespace": namespace})
+        return {"upserted_count": len(vectors)}
+
+    def query(self, **kwargs):
+        self.query_calls.append(kwargs)
+        return {
+            "matches": [
+                {"id": "chunk-1", "score": 0.99, "metadata": {"source_id": "doc-1"}},
+            ]
+        }
+
+    def delete(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        return {"ok": True}
+
+
+class RaisingIndex:
+    def upsert(self, **kwargs):
+        raise RuntimeError("boom")
+
+    def query(self, **kwargs):
+        raise RuntimeError("boom")
+
+    def delete(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_missing_config_returns_empty_results_and_logs_warning(caplog):
+    client = PineconeMemoryClient(api_key="", index_name="", fail_open=True)
+
+    with caplog.at_level("WARNING"):
+        assert client.upsert_records([{"id": "1", "values": [1, 2], "metadata": {}}]) == 0
+        assert client.query([0.1, 0.2]) == []
+        assert client.delete_by_source(source_kind="file", source_id="abc") == 0
+
+    assert "missing configuration" in caplog.text
+
+
+def test_successful_upsert_query_and_delete():
+    index = FakeIndex()
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        namespace="ns1",
+        fail_open=True,
+        index=index,
+    )
+
+    count = client.upsert_records([
+        {"id": "chunk-1", "values": [1, 2, 3], "metadata": {"source_id": "doc-1"}},
+    ])
+    matches = client.query([0.1, 0.2, 0.3], top_k=3, filter={"scope": {"$eq": "repo"}})
+    deleted = client.delete_by_source(source_kind="file", source_id="doc-1")
+
+    assert count == 1
+    assert matches == [{"id": "chunk-1", "score": 0.99, "metadata": {"source_id": "doc-1"}}]
+    assert deleted == 1
+    assert index.upsert_calls[0]["namespace"] == "ns1"
+    assert index.query_calls[0]["top_k"] == 3
+    assert index.query_calls[0]["filter"] == {"scope": {"$eq": "repo"}}
+    assert index.delete_calls[0]["filter"] == {
+        "source_kind": {"$eq": "file"},
+        "source_id": {"$eq": "doc-1"},
+    }
+
+
+def test_sdk_exception_is_fail_open_when_enabled(caplog):
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        fail_open=True,
+        index=RaisingIndex(),
+    )
+
+    with caplog.at_level("WARNING"):
+        assert client.upsert_records([{"id": "1", "values": [1], "metadata": {}}]) == 0
+        assert client.query([0.1]) == []
+        assert client.delete_by_source(source_kind="file", source_id="abc") == 0
+
+    assert "continuing fail-open" in caplog.text
+
+
+def test_sdk_exception_raises_when_fail_open_disabled():
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        fail_open=False,
+        index=RaisingIndex(),
+    )
+
+    with pytest.raises(RuntimeError):
+        client.query([0.1])


### PR DESCRIPTION
## Summary
- add fail-open `PineconeMemoryClient` wrapper with upsert/query/delete helpers
- add canonical memory document/chunk dataclasses with stable IDs and header-aware chunking
- cover missing-config, success, exception, metadata, and stability cases with targeted tests

## Testing
- pytest tests/agent/test_pinecone_memory.py tests/agent/test_memory_documents.py -q
