### PR TITLE
fix(docker): chown install dirs on HERMES_UID remap (#27221)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -43,6 +43,17 @@ if [ "$(id -u)" = "0" ]; then
         # lazy_deps.py cannot install platform packages (discord.py, etc.).
         chown -R hermes:hermes "$INSTALL_DIR/.venv" 2>/dev/null || \
             echo "Warning: chown .venv failed (rootless container?) — continuing anyway"
+
+        # usermod -u only auto-updates ownership of files inside the user's
+        # home directory ($HERMES_HOME).  When HERMES_UID is remapped, the
+        # install directory retains build-time ownership (UID 10000), causing
+        # EACCES on TUI dist writes (esbuild) and gateway __pycache__ creation.
+        for _dir in "$INSTALL_DIR/ui-tui" "$INSTALL_DIR/gateway"; do
+            if [ -d "$_dir" ] && [ "$(stat -c %u "$_dir" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+                echo "Fixing ownership of $_dir to hermes ($actual_hermes_uid)"
+                chown -R hermes:hermes "$_dir" 2>/dev/null || true
+            fi
+        done
     fi
 
     # Ensure config.yaml is readable by the hermes runtime user even if it was

--- a/tests/docker/test_entrypoint_uid_remap.py
+++ b/tests/docker/test_entrypoint_uid_remap.py
@@ -1,0 +1,70 @@
+"""Tests for docker/entrypoint.sh — UID remap chown behavior (#27221).
+
+The entrypoint shell script cannot be unit-tested directly without Docker,
+so these tests parse the script to verify that the required chown logic
+is present for the install directories.
+"""
+
+import os
+import re
+
+ENTRYPOINT = os.path.join(
+    os.path.dirname(__file__), "..", "..", "docker", "entrypoint.sh",
+)
+
+
+def _read_entrypoint():
+    with open(ENTRYPOINT) as f:
+        return f.read()
+
+
+class TestEntrypointUidRemapChown:
+    """Verify that docker/entrypoint.sh chowns install dirs on UID remap."""
+
+    def test_ui_tui_chown_present(self):
+        """entrypoint.sh must chown ui-tui/ when HERMES_UID is remapped."""
+        script = _read_entrypoint()
+        assert "ui-tui" in script, "ui-tui directory not referenced in entrypoint"
+        # Verify it's in the chown block (near needs_chown)
+        block = script[script.find("needs_chown"):script.find("needs_chown") + 2000]
+        assert "ui-tui" in block, "ui-tui chown not in needs_chown block"
+
+    def test_gateway_chown_present(self):
+        """entrypoint.sh must chown gateway/ when HERMES_UID is remapped."""
+        script = _read_entrypoint()
+        assert "gateway" in script, "gateway directory not referenced in entrypoint"
+        block = script[script.find("needs_chown"):script.find("needs_chown") + 2000]
+        assert "gateway" in block, "gateway chown not in needs_chown block"
+
+    def test_chown_uses_hermes_user(self):
+        """chown must use 'hermes:hermes' as the target ownership."""
+        script = _read_entrypoint()
+        # Find the install-dir chown loop
+        for_dir_loop = re.search(
+            r'for\s+_dir\s+in\s+.*\$INSTALL_DIR/ui-tui.*\$INSTALL_DIR/gateway',
+            script,
+            re.DOTALL,
+        )
+        assert for_dir_loop is not None, (
+            "No loop chown-ing both ui-tui and gateway found"
+        )
+        # Verify the loop body uses hermes:hermes
+        loop_text = for_dir_loop.group(0)
+        # The chown call should appear after the for-in line
+        assert "hermes:hermes" in script[script.find("ui-tui"):script.find("ui-tui") + 500]
+
+    def test_chown_guarded_by_directory_check(self):
+        """chown should only run if the directory exists."""
+        script = _read_entrypoint()
+        # Look for the -d guard
+        assert '-d "$_dir"' in script or '-d "$INSTALL_DIR/ui-tui"' in script, (
+            "Directory existence guard missing"
+        )
+
+    def test_chown_guarded_by_uid_check(self):
+        """chown should only run if directory UID differs from target."""
+        script = _read_entrypoint()
+        # Look for the stat -c %u check
+        assert "stat -c %u" in script, (
+            "UID comparison guard missing"
+        )


### PR DESCRIPTION
## What broke
When `HERMES_UID` is remapped (e.g. to 99 for Unraid/Synology), `usermod -u` only auto-updates ownership inside the user's home directory (`$HERMES_HOME`). Files under `$INSTALL_DIR/ui-tui/` and `$INSTALL_DIR/gateway/` retain build-time UID 10000, causing:
- TUI dashboard esbuild fails to write to `dist/` → EACCES
- Python fails to create `__pycache__` under `gateway/` → permission errors

## Root cause
In `docker/entrypoint.sh`, the `usermod -u` chown block only covers `$HERMES_HOME` and `$INSTALL_DIR/.venv`. The install directories `ui-tui/` and `gateway/` are not included, so they keep their build-time owner after UID remap.

## Why this fix is minimal
Adds a loop to chown `ui-tui/` and `gateway/` to the remapped hermes user, following the exact same pattern as the existing `.venv` chown. Each directory is guarded by `-d` (existence check) and `stat -c %u` (UID comparison) so it only runs when needed. Non-rootless Podman users and unremapped installs are unaffected.

## What I tested
Added `tests/docker/test_entrypoint_uid_remap.py`:
- `test_ui_tui_chown_present` — ui-tui/ referenced in needs_chown block
- `test_gateway_chown_present` — gateway/ referenced in needs_chown block
- `test_chown_uses_hermes_user` — loop uses `hermes:hermes`
- `test_chown_guarded_by_directory_check` — `-d` guard present
- `test_chown_guarded_by_uid_check` — `stat -c %u` guard present

## What I intentionally did not change
- `$HERMES_HOME` chown behavior
- `.venv` chown behavior
- Any non-Docker deployment paths
- Config file permission handling