### PR TITLE
fix(gateway): add module-level logger to gateway.py (salvage #27154)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import logging
 import os
 import shutil
 import signal
@@ -38,6 +39,7 @@ from hermes_cli.setup import (
 )
 from hermes_cli.colors import Colors, color
 
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Process Management (for manual gateway runs)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1094,6 +1094,8 @@ AUTHOR_MAP = {
     "279959838+BROCCOLO1D@users.noreply.github.com": "BROCCOLO1D",  # PR #26796 (docs: spotify + HA)
     "m@matthewlai.ca": "matthewlai",  # PR #25293 (feat: gemma 4 reasoning allowlist)
     "4296245+matthewlai@users.noreply.github.com": "matthewlai",
+    "109617724+0xchainer@users.noreply.github.com": "0xchainer",  # PR #27154/27138/27147 salvage
+    "201800237+kronexoi@users.noreply.github.com": "kronexoi",  # PR #27167 salvage (Teams port fallback)
 }
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -559,3 +559,9 @@ class TestStopProfileGateway:
         assert calls["kill"] == 1          # one SIGTERM
         assert calls["alive_probes"] == 20 # 20 liveness polls over the 2s window
         assert calls["remove"] == 0
+
+
+def test_module_has_logger():
+    """Verify module has a logger instance (regression guard for #27154)."""
+    assert hasattr(gateway, "logger")
+    assert gateway.logger.name == "hermes_cli.gateway"


### PR DESCRIPTION
## Summary
Salvage of #27154 — adds the missing module-level `logger` in `hermes_cli/gateway.py` so `_all_platforms()`'s `except` block can `logger.debug(...)` without a `NameError` when plugin discovery fails.

## Changes
- `hermes_cli/gateway.py` — add `import logging` and `logger = logging.getLogger(__name__)` at module scope.
- `tests/hermes_cli/test_gateway.py` — regression smoke test asserting the logger exists.
- `scripts/release.py` — AUTHOR_MAP entries for @0xchainer and @kronexoi (used by upcoming salvage PRs too).

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_gateway.py -q` → 28/28 pass.

Original PR: #27154 — credit preserved via rebase-merge.