### PR TITLE
fix(gateway): skip reasoning_content replay for MiniMax models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -241,8 +241,43 @@ _ASSISTANT_REPLAY_FIELDS: tuple[str, ...] = (
     "finish_reason",
 )
 
+# Provider slugs that produce per-turn-independent reasoning content.
+# These models generate fresh thinking each turn and do NOT need
+# ``reasoning_content`` preserved in replay history (unlike DeepSeek/Kimi
+# which HTTP 400 without it).
+_REASONING_BLOAT_PROVIDERS: frozenset[str] = frozenset({
+    "minimax", "minimax-cn", "minimax-oauth",
+})
 
-def _build_replay_entry(role: str, content: Any, msg: Dict[str, Any]) -> Dict[str, Any]:
+
+def _is_reasoning_content_replay_bloat_model(
+    provider: str, model: str, base_url: str,
+) -> bool:
+    """Return True when the current model generates ``reasoning_content`` that
+    is independent per-turn and safe to omit from replay history.
+
+    Reasoning models that use a fresh thinking process each turn (MiniMax,
+    etc.) are bloat-safe — their previous thinking carries no semantic value
+    on the next turn and only inflates context.
+
+    Models that require preserved ``reasoning_content`` to avoid HTTP 400
+    (DeepSeek/Kimi thinking-mode, Anthropic extended-thinking) are NOT
+    returned as bloat.
+    """
+    _p = (provider or "").lower().strip()
+    if _p in _REASONING_BLOAT_PROVIDERS:
+        return True
+    # Host-based catch-all for custom endpoints pointing at MiniMax
+    _b = (base_url or "").lower()
+    if "api.minimax.io" in _b or "api.minimaxi.com" in _b:
+        return True
+    return False
+
+
+def _build_replay_entry(
+    role: str, content: Any, msg: Dict[str, Any],
+    *, reasoning_bloat_model: bool = False,
+) -> Dict[str, Any]:
     """Build a replay entry for a non-tool-calling message, preserving the
     assistant fields the agent's API builders rely on for multi-turn fidelity.
 
@@ -258,11 +293,23 @@ def _build_replay_entry(role: str, content: Any, msg: Dict[str, Any]) -> Dict[st
     Dropping it here would make the gateway send no ``reasoning_content`` at
     all on the next turn, which can cause HTTP 400 from strict thinking
     providers.
+
+    When ``reasoning_bloat_model`` is True, reasoning fields (``reasoning``,
+    ``reasoning_content``, ``reasoning_details``) are skipped — the model
+    generates fresh thinking each turn and does not require preserved
+    reasoning in replay (MiniMax et al.).
     """
     entry: Dict[str, Any] = {"role": role, "content": content}
     if role == "assistant":
         for _rkey in _ASSISTANT_REPLAY_FIELDS:
             if _rkey not in msg:
+                continue
+            # Skip reasoning fields for per-turn-independent reasoning models
+            # (MiniMax).  DeepSeek/Kimi/Anthropic require reasoning_content
+            # in replay and are NOT caught here.
+            if reasoning_bloat_model and _rkey in (
+                "reasoning", "reasoning_content", "reasoning_details",
+            ):
                 continue
             _rval = msg.get(_rkey)
             if _rkey == "reasoning_content":
@@ -15506,7 +15553,15 @@ class GatewayRunner:
                         # provider-specific echo requirements survive session
                         # reload.  See ``_ASSISTANT_REPLAY_FIELDS`` for the full
                         # whitelist and rationale.
-                        entry = _build_replay_entry(role, content, msg)
+                        _replay_bloat = _is_reasoning_content_replay_bloat_model(
+                            runtime_kwargs.get("provider", ""),
+                            turn_route.get("model", ""),
+                            runtime_kwargs.get("base_url", ""),
+                        )
+                        entry = _build_replay_entry(
+                            role, content, msg,
+                            reasoning_bloat_model=_replay_bloat,
+                        )
                         agent_history.append(entry)
             
             # Collect MEDIA paths already in history so we can exclude them

--- a/tests/gateway/test_replay_entry_fields.py
+++ b/tests/gateway/test_replay_entry_fields.py
@@ -1,4 +1,5 @@
-"""Tests for ``gateway.run._build_replay_entry``.
+"""
+Tests for ``gateway.run._build_replay_entry``.
 
 The gateway rebuilds ``agent_history`` from the persisted transcript on every
 turn (unlike the CLI, which keeps the live in-memory message list).  When a
@@ -18,7 +19,11 @@ from __future__ import annotations
 
 import pytest
 
-from gateway.run import _ASSISTANT_REPLAY_FIELDS, _build_replay_entry
+from gateway.run import (
+    _ASSISTANT_REPLAY_FIELDS,
+    _build_replay_entry,
+    _is_reasoning_content_replay_bloat_model,
+)
 
 
 class TestBuildReplayEntry:
@@ -252,3 +257,124 @@ class TestBuildReplayEntry:
         assert "timestamp" not in entry
         assert "internal_marker" not in entry
         assert "tool_call_id" not in entry
+
+
+class TestReasoningBloatModel:
+    """Tests for the MiniMax-specific reasoning content bloat mitigation."""
+
+    def test_bloat_model_minimax_provider(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "minimax-cn", "MiniMax-M2.7-highspeed", "https://api.minimaxi.com/v1",
+        ) is True
+
+    def test_bloat_model_minimax_global(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "minimax", "MiniMax-M2.7", "https://api.minimax.io/v1",
+        ) is True
+
+    def test_bloat_model_minimax_oauth(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "minimax-oauth", "MiniMax-M2.7", "https://api.minimax.io/v1",
+        ) is True
+
+    def test_bloat_model_host_detection_minimaxio(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "custom", "MiniMax-M2.7", "https://api.minimax.io/anthropic",
+        ) is True
+
+    def test_bloat_model_host_detection_minimaxicom(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "custom", "miniMax-M2.7-highspeed", "https://api.minimaxi.com/v1",
+        ) is True
+
+    def test_bloat_model_deepseek_not_bloat(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "deepseek", "deepseek-r1", "https://api.deepseek.com/v1",
+        ) is False
+
+    def test_bloat_model_kimi_not_bloat(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "kimi-coding-cn", "kimi-thinking", "https://api.moonshot.ai/v1",
+        ) is False
+
+    def test_bloat_model_anthropic_not_bloat(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "anthropic", "claude-sonnet-4", "https://api.anthropic.com/v1",
+        ) is False
+
+    def test_bloat_model_empty_not_bloat(self):
+        assert _is_reasoning_content_replay_bloat_model(
+            "", "", "",
+        ) is False
+
+
+class TestBuildReplayEntryWithBloatModel:
+    """Tests that ``reasoning_bloat_model=True`` correctly suppresses
+    reasoning fields while preserving Codex and finish_reason fields."""
+
+    def test_reasoning_content_skipped_when_bloat(self):
+        msg = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "I think...",
+            "reasoning": "I think...",
+            "finish_reason": "stop",
+        }
+        entry = _build_replay_entry(
+            "assistant", "answer", msg,
+            reasoning_bloat_model=True,
+        )
+        assert "reasoning_content" not in entry
+        assert "reasoning" not in entry
+        assert entry["finish_reason"] == "stop"
+
+    def test_reasoning_details_skipped_when_bloat(self):
+        details = [{"type": "reasoning.summary", "summary": "thought hard"}]
+        msg = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "thinking",
+            "reasoning_content": "structured",
+            "reasoning_details": details,
+            "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "b"}],
+            "codex_message_items": [
+                {"type": "message", "role": "assistant", "phase": "final_answer",
+                 "content": [{"type": "output_text", "text": "Done"}]}
+            ],
+            "finish_reason": "stop",
+        }
+        entry = _build_replay_entry(
+            "assistant", "Done", msg,
+            reasoning_bloat_model=True,
+        )
+        # Reasoning fields dropped
+        assert "reasoning" not in entry
+        assert "reasoning_content" not in entry
+        assert "reasoning_details" not in entry
+        # Non-reasoning fields still preserved
+        assert "codex_reasoning_items" in entry
+        assert "codex_message_items" in entry
+        assert entry["finish_reason"] == "stop"
+
+    def test_bloat_false_preserves_reasoning(self):
+        """When reasoning_bloat_model=False (default), all fields preserved."""
+        msg = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "I think...",
+        }
+        entry = _build_replay_entry("assistant", "answer", msg)
+        assert entry["reasoning_content"] == "I think..."
+
+    def test_bloat_still_drops_none_reasoning_content(self):
+        """None reasoning_content still dropped even when bloat=True."""
+        msg = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": None,
+        }
+        entry = _build_replay_entry(
+            "assistant", "answer", msg,
+            reasoning_bloat_model=True,
+        )
+        assert "reasoning_content" not in entry


### PR DESCRIPTION
## Problem

MiniMax models generate per-turn-independent `reasoning_content`. Unlike DeepSeek/Kimi which require it preserved in replay to avoid HTTP 400, MiniMax's reasoning is fresh each turn and adds only context bloat when replayed.

## Fix

- `_REASONING_BLOAT_PROVIDERS`: minimax, minimax-cn, minimax-oauth
- Host-based detection for custom endpoints at api.minimax.io / api.minimaxi.com
- `_is_reasoning_content_replay_bloat_model()` — returns True for affected models
- `_build_replay_entry()` gets `reasoning_bloat_model=True` kwarg — skips reasoning/reasoning_content/reasoning_details when True
- DeepSeek/Kimi/Anthropic are explicitly NOT affected

## Tests

- `TestReasoningBloatModel`: 10 cases (provider slugs, host detection, negative cases)
- `TestBuildReplayEntryWithBloatModel`: 4 cases (field suppression, non-reasoning field preservation)

## Files

- `gateway/run.py` (+57/-2)
- `tests/gateway/test_replay_entry_fields.py` (+128/-2)