### PR TITLE
fix(qqbot): prevent listen loop from exiting after failed reconnect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -585,6 +585,7 @@ class QQAdapter(BasePlatformAdapter):
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
                         return
+                    self._running = True  # allow loop to continue retrying
 
             except Exception as exc:
                 if not self._running:
@@ -602,6 +603,7 @@ class QQAdapter(BasePlatformAdapter):
                     quick_disconnect_count = 0
                 else:
                     backoff_idx += 1
+                    self._running = True  # allow loop to continue retrying
 
     async def _reconnect(self, backoff_idx: int) -> bool:
         """Attempt to reconnect the WebSocket. Returns True on success."""


### PR DESCRIPTION
## Summary

After `_mark_disconnected()` sets `self._running = False`, a failed `_reconnect()` call would leave it `False`, causing the `while self._running:` loop in `_listen_loop()` to exit immediately — no further retry attempts ever occur.

## Root Cause

The bug was confirmed in production: when QQ's gateway API endpoint (`https://api.sgroup.qq.com/gateway`) returned HTTP 500, the bot went permanently silent for 4+ days until the gateway process was manually restarted.

In `_listen_loop()`, both exception handlers (`QQCloseError` and `Exception`) call `_mark_disconnected()` which sets `self._running = False`. If `_reconnect()` then fails, `_mark_connected()` is never called, so `_running` stays `False` and the while loop exits.

## Fix

Set `self._running = True` after a non-fatal reconnect failure in both handlers, allowing the loop to continue retrying up to `MAX_RECONNECT_ATTEMPTS`.

## Test Plan

- [ ] Existing QQ Bot adapter tests pass
- [ ] Manual: simulate gateway API 500 by temporarily pointing to a bad URL, verify loop continues retrying instead of exiting

## Related

Discovered while debugging a production QQ Bot outage (May 12–16, 2026).