### PR TITLE
fix(gateway): normalize quoted reset-policy values and null home channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -56,6 +56,22 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+def _coerce_str_tuple(
+    value: Any,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Coerce a list-like config value to a tuple of non-empty strings."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        stripped = value.strip()
+        return (stripped,) if stripped else default
+    if isinstance(value, (list, tuple, set)):
+        items = tuple(str(item).strip() for item in value if str(item).strip())
+        return items or default
+    return default
+
+
 def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> str:
     """Normalize unauthorized DM behavior to a supported value."""
     if isinstance(value, str):
@@ -270,10 +286,12 @@ class SessionResetPolicy:
         exclude = data.get("notify_exclude_platforms")
         return cls(
             mode=mode if mode is not None else "both",
-            at_hour=at_hour if at_hour is not None else 4,
-            idle_minutes=idle_minutes if idle_minutes is not None else 1440,
+            at_hour=_coerce_int(at_hour, 4),
+            idle_minutes=_coerce_int(idle_minutes, 1440),
             notify=_coerce_bool(notify, True),
-            notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
+            notify_exclude_platforms=_coerce_str_tuple(
+                exclude, ("api_server", "webhook")
+            ),
         )
 
 
@@ -319,7 +337,12 @@ class PlatformConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
-        if "home_channel" in data:
+        home_data = data.get("home_channel")
+        if (
+            isinstance(home_data, dict)
+            and "platform" in home_data
+            and "chat_id" in home_data
+        ):
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
         return cls(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,16 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_from_dict_ignores_null_home_channel(self):
+        restored = PlatformConfig.from_dict({"enabled": True, "home_channel": None})
+        assert restored.enabled is True
+        assert restored.home_channel is None
+
+    def test_from_dict_ignores_malformed_home_channel_mapping(self):
+        restored = PlatformConfig.from_dict({"enabled": True, "home_channel": {}})
+        assert restored.enabled is True
+        assert restored.home_channel is None
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -161,6 +171,19 @@ class TestSessionResetPolicy:
     def test_from_dict_coerces_quoted_false_notify(self):
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
+
+    def test_from_dict_coerces_quoted_numeric_values(self):
+        restored = SessionResetPolicy.from_dict(
+            {"at_hour": "6", "idle_minutes": "120"}
+        )
+        assert restored.at_hour == 6
+        assert restored.idle_minutes == 120
+
+    def test_from_dict_normalizes_scalar_notify_excludes(self):
+        restored = SessionResetPolicy.from_dict(
+            {"notify_exclude_platforms": "api_server"}
+        )
+        assert restored.notify_exclude_platforms == ("api_server",)
 
 
 class TestStreamingConfig:

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -184,6 +184,19 @@ class TestResetPolicyNotify:
         policy = SessionResetPolicy.from_dict({"notify": False})
         assert policy.notify is False
 
+    def test_from_dict_quoted_numeric_values_work_in_reset_checks(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy.from_dict({"mode": "idle", "idle_minutes": "1"}),
+            tmp_path,
+        )
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now() - timedelta(minutes=10),
+            updated_at=datetime.now() - timedelta(minutes=5),
+        )
+        assert store._is_session_expired(entry) is True
+
     def test_from_dict_with_custom_excludes(self):
         policy = SessionResetPolicy.from_dict({
             "notify_exclude_platforms": ["api_server", "webhook", "homeassistant"],


### PR DESCRIPTION
## What does this PR do?

Hardens gateway config parsing for nested reset-policy and home-channel values.

This fixes three small but real failure modes in `gateway/config.py`:

- quoted numeric `session_reset` values like `"1"` / `"4"` were preserved as strings and could later raise `TypeError` in session expiry checks
- scalar `notify_exclude_platforms` values like `"api_server"` were converted into a character tuple instead of a single platform entry
- `platforms.<name>.home_channel: null` or malformed home-channel mappings could crash config hydration

The fix keeps the change narrow by normalizing these values at parse time instead of changing downstream session logic.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `_coerce_str_tuple()` in `gateway/config.py` for list-like string tuple parsing
- Normalized `SessionResetPolicy.from_dict()` numeric fields with `_coerce_int()`
- Normalized scalar `notify_exclude_platforms` inputs into a single-item tuple
- Guarded `PlatformConfig.from_dict()` so `home_channel` is only hydrated from valid mappings with required keys
- Added regression coverage in `tests/gateway/test_config.py`
- Added expiry-path coverage for quoted numeric reset values in `tests/gateway/test_session_reset_notify.py`

## How to Test

1. Run `pytest tests/gateway/test_config.py tests/gateway/test_session_reset_notify.py -v`
2. Confirm all tests pass
3. Verify quoted reset-policy values and null/malformed `home_channel` inputs no longer break config/session handling

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= 67 passed in 5.77s ==============================
Exit code: 0