### PR TITLE
fix(cli): register `send` subcommand + add encoding on read_text (#27188 follow-up)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9611,7 +9611,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
-        "model", "pairing", "plugins", "postinstall", "profile", "proxy", "sessions", "setup",
+        "model", "pairing", "plugins", "postinstall", "profile", "proxy", "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -58,7 +58,7 @@ def _read_message_body(
         if file_path == "-":
             return sys.stdin.read()
         try:
-            return Path(file_path).read_text()
+            return Path(file_path).read_text(encoding="utf-8")
         except OSError as exc:
             print(f"hermes send: cannot read {file_path}: {exc}", file=sys.stderr)
             sys.exit(_USAGE_EXIT)


### PR DESCRIPTION
## Summary

The recently-merged `feat(cli): add hermes send` (#27188, commit `29b1bd0e2`) landed two small regressions that are blocking CI on `origin/main`:

1. `hermes_cli/main.py::_BUILTIN_SUBCOMMANDS` doesn't include `"send"`, so `tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand` fails on every PR.
2. `hermes_cli/send_cmd.py:61` calls `Path(file_path).read_text()` without an explicit `encoding=` argument, tripping `ruff PLW1514` (which is the blocking ruff job).

Both are mechanical follow-ups directly directed by the failing checks.

## The bug

### 1. Missing `"send"` in `_BUILTIN_SUBCOMMANDS`

The parity test in `test_startup_plugin_gating.py` fails with the exact message:

```
AssertionError: _BUILTIN_SUBCOMMANDS is missing these live subcommands: ['send'].
Add them to hermes_cli/main.py::_BUILTIN_SUBCOMMANDS so plugin discovery
can be skipped when the user targets them.
```

Correctness is unaffected (missing entries only force unnecessary plugin discovery for users running `hermes send …`), but the parity test guards the perf invariant and has to stay green for CI.

### 2. Missing `encoding=` on `read_text()`

The blocking `ruff enforcement` job fails with:

```
error[PLW1514]: `pathlib.Path(...).read_text` without explicit `encoding` argument
  --> hermes_cli/send_cmd.py:61:20
   |
61 |             return Path(file_path).read_text()
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
```

The `lint-diff-summary` bot already flagged this as `+1 new` on the merging PR for `hermes/hermes-db18949e`.

## The fix

* Insert `"send"` into the alphabetically-sorted `_BUILTIN_SUBCOMMANDS` frozenset between `"proxy"` and `"sessions"`.
* Pass `encoding="utf-8"` to `Path(file_path).read_text()` in `send_cmd.py:61`.

Same pattern as #24738 (lsp `_BUILTIN_SUBCOMMANDS`), which was salvage-merged via [#25011](https://github.com/NousResearch/hermes-agent/pull/25011) (`71c6dd0dc`).

## Test plan

- [x] Focused regression test: `tests/hermes_cli/test_startup_plugin_gating.py` — **37 passed** (was 1 failed on clean `origin/main`). `test_builtin_set_covers_every_registered_subcommand` and `test_builtin_set_has_no_phantom_entries` both pass.
- [x] Ruff: `ruff check hermes_cli/send_cmd.py hermes_cli/main.py` — `All checks passed!` (was `Found 1 error` on clean `origin/main`).
- [x] Regression guard: stashed the fix, re-ran the parity test → `FAILED ... _BUILTIN_SUBCOMMANDS is missing these live subcommands: ['send']`. Restored the fix → `PASSED`.

> Sibling code paths that may need the same `encoding=` widening: other `Path.read_text()` callers across `hermes_cli/` (e.g. `auth.py`, `web_server.py`, `uninstall.py`, `profiles.py`, `banner.py`, `doctor.py`). Intentionally left out of this PR's scope — ruff only flagged the new `send_cmd.py` site, and the rest are presumably grandfathered by current lint config. Happy to widen if preferred.

## Related

- Follow-up to #27188 (`feat(cli): add hermes send`)
- Precedent: #24738 → #25011 (same `_BUILTIN_SUBCOMMANDS` parity-fix pattern for `"lsp"`)