### PR TITLE
fix(docker): align process HOME with active profile home

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -70,6 +70,11 @@ source "${INSTALL_DIR}/.venv/bin/activate"
 # ephemeral and shared across profiles.  See issue #4426.
 mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home}
 
+# Tell the Python CLI entrypoint that this is the official container path.
+# The CLI applies sticky profile selection before aligning process HOME, so
+# named profiles get HOME=<profile>/home rather than the default profile home.
+export HERMES_DOCKER_ALIGN_HOME=1
+
 # .env
 if [ ! -f "$HERMES_HOME/.env" ]; then
     cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -202,7 +202,30 @@ def _apply_profile_override() -> None:
                     break
 
 
+def _align_process_home_for_docker_profile() -> None:
+    """Use the active profile's home/ as process HOME in the official image.
+
+    The Docker entrypoint creates ``{HERMES_HOME}/home`` for per-profile tool
+    configs. Aligning the main Python process after profile selection keeps
+    ``~`` consistent between Hermes itself and the subprocesses it spawns,
+    while leaving non-container installs on the existing subprocess-only model.
+    """
+    if os.environ.get("HERMES_DOCKER_ALIGN_HOME") != "1":
+        return
+
+    try:
+        from hermes_constants import get_subprocess_home
+
+        profile_home = get_subprocess_home()
+    except Exception:
+        return
+
+    if profile_home:
+        os.environ["HOME"] = profile_home
+
+
 _apply_profile_override()
+_align_process_home_for_docker_profile()
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -111,6 +111,74 @@ class TestApplyProfileOverrideHermesHomeGuard:
             "HERMES_HOME must remain unchanged when already pointing to a profile dir"
         )
 
+    def test_docker_home_alignment_uses_default_profile_home(
+        self, tmp_path, monkeypatch
+    ):
+        """Official Docker mode should align process HOME to the default profile home."""
+        hermes_root = tmp_path / "opt" / "data"
+        profile_home = hermes_root / "home"
+        profile_home.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HOME", str(hermes_root))
+        monkeypatch.setenv("HERMES_DOCKER_ALIGN_HOME", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import (
+            _align_process_home_for_docker_profile,
+            _apply_profile_override,
+        )
+
+        _apply_profile_override()
+        _align_process_home_for_docker_profile()
+
+        assert os.environ["HERMES_HOME"] == str(hermes_root)
+        assert os.environ["HOME"] == str(profile_home)
+
+    def test_docker_home_alignment_runs_after_named_profile_selection(
+        self, tmp_path, monkeypatch
+    ):
+        """Named Docker profiles should align HOME to that profile's home/ dir."""
+        hermes_root = tmp_path / "opt" / "data"
+        profile_dir = hermes_root / "profiles" / "coder"
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("coder")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HOME", str(hermes_root))
+        monkeypatch.setenv("HERMES_DOCKER_ALIGN_HOME", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import (
+            _align_process_home_for_docker_profile,
+            _apply_profile_override,
+        )
+
+        _apply_profile_override()
+        _align_process_home_for_docker_profile()
+
+        assert os.environ["HERMES_HOME"] == str(profile_dir)
+        assert os.environ["HOME"] == str(profile_home)
+
+    def test_home_alignment_is_opt_in(self, tmp_path, monkeypatch):
+        """Non-Docker installs keep the subprocess-only HOME isolation model."""
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "home").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_DOCKER_ALIGN_HOME", raising=False)
+
+        from hermes_cli.main import _align_process_home_for_docker_profile
+
+        _align_process_home_for_docker_profile()
+
+        assert os.environ["HOME"] == str(tmp_path)
+
     def test_hermes_home_unset_reads_active_profile(self, tmp_path, monkeypatch):
         """Classic case: HERMES_HOME unset + active_profile=coder must set
         HERMES_HOME to the profile directory (existing behaviour must not regress).


### PR DESCRIPTION
## Summary

- align the official Docker process `HOME` with the active profile's `home/` directory
- run the alignment after sticky/explicit profile selection so named profiles use their own `home/`
- keep non-Docker installs on the existing subprocess-only HOME isolation model

Fixes #27250

## Testing

- `bash -n docker/entrypoint.sh`
- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_apply_profile_override.py`
- `python3 -m pytest tests/hermes_cli/test_apply_profile_override.py -q`
- `python3 -m pytest tests/test_subprocess_home_isolation.py -q`
- `python3 -m pytest tests/hermes_cli/test_profiles.py -q`
