### PR TITLE
fix(tui): resolve esbuild binary path in build.mjs to avoid version m…

### DIFF
--- a/tests/hermes_cli/test_tui_esbuild_binary_path.py
+++ b/tests/hermes_cli/test_tui_esbuild_binary_path.py
@@ -1,0 +1,76 @@
+"""Subprocess regression test for ESBUILD_BINARY_PATH env-var poisoning.
+
+build.mjs must delete process.env.ESBUILD_BINARY_PATH before calling
+require("esbuild"), otherwise a stale binary path inherited from the
+environment (e.g. ~/.hermes/esbuild-built at a different version) will
+cause esbuild's generateBinPath() to return the wrong binary, triggering:
+
+    Cannot start service: Host version "X" does not match binary version "Y"
+
+See PR #27263.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ui_tui_dir() -> Path:
+    """Resolve the ui-tui/ directory relative to the repo root."""
+    # tests/hermes_cli/ → repo root
+    return Path(__file__).resolve().parent.parent.parent / "ui-tui"
+
+
+def test_build_succeeds_with_incompatible_esbuild_binary_path(
+    ui_tui_dir: Path,
+) -> None:
+    """build.mjs must tolerate an inherited ESBUILD_BINARY_PATH pointing to a
+    non-existent binary — regression for the Android/Termux version-mismatch
+    bug where a stale ~/.hermes/esbuild-built pollutes the build.
+
+    The script deletes ``process.env.ESBUILD_BINARY_PATH`` before invoking
+    ``require('esbuild')``, so esbuild falls back to its normal binary
+    resolution and finds the correct platform-specific binary from
+    node_modules.
+    """
+    env = os.environ.copy()
+    env["ESBUILD_BINARY_PATH"] = "/dev/null/esbuild-binary-stale"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import sys; print(sys.executable)"],
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [  # fmt: skip
+            "node",
+            str(ui_tui_dir / "scripts" / "build.mjs"),
+        ],
+        cwd=str(ui_tui_dir),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # The build should succeed despite the bogus ESBUILD_BINARY_PATH
+    assert result.returncode == 0, (
+        f"build.mjs failed with a stale ESBUILD_BINARY_PATH:\n"
+        f"  stderr: {result.stderr.strip()}\n"
+        f"  stdout: {result.stdout.strip()}"
+    )
+
+    # Sanity: confirm dist/entry.js was actually written
+    entry_js = ui_tui_dir / "dist" / "entry.js"
+    assert entry_js.exists(), (
+        "build.mjs claimed success but did not produce dist/entry.js"
+    )
+    assert entry_js.stat().st_size > 100_000, (
+        f"dist/entry.js is suspiciously small ({entry_js.stat().st_size} bytes)"
+    )

--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -11,27 +11,11 @@ const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const out = resolve(root, 'dist/entry.js')
 
-// esbuild binary version mismatch on Android arm64: the npm-installed
-// @esbuild/android-arm64 binary can end up with a different version than
-// the esbuild package lib/main.js expects (e.g. 0.28.0 vs 0.27.7).
-// We resolve the correct binary here and pass it via ESBUILD_BINARY_PATH
-// so the service subprocess uses the matching pair.
-const esbuildLibDir = resolve(root, 'node_modules/esbuild/lib')
-const esbuildBinPath = resolve(esbuildLibDir, '../bin/esbuild')
-
-// IMPORTANT: clear any external ESBUILD_BINARY_PATH that may point to a
-// stale version (e.g. ~/.hermes/esbuild-built on this system is 0.28.0
-// while the local node_modules/esbuild is 0.27.7).
+// Clear stale ESBUILD_BINARY_PATH that may point to a different esbuild
+// version (e.g. ~/.hermes/esbuild-built 0.28.0 vs local node_modules 0.27.7),
+// which would cause "Host version does not match binary version" on Android.
 delete process.env.ESBUILD_BINARY_PATH
-
-let esbuild
-try {
-  // Try local node_modules esbuild first (version-matched pair)
-  esbuild = require('esbuild')
-} catch {
-  // Fallback: use the explicit binary path
-  esbuild = require(resolve(esbuildLibDir, 'main.js'))
-}
+const { build } = require('esbuild')
 
 // `react-devtools-core` is only imported when DEV=true at runtime (Ink dev
 // mode). Stub it out so the bundle doesn't carry the dep.
@@ -49,7 +33,7 @@ const stubDevtools = {
   }
 }
 
-await esbuild.build({
+await build({
   entryPoints: [resolve(root, 'src/entry.tsx')],
   bundle: true,
   platform: 'node',

--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -1,14 +1,37 @@
 #!/usr/bin/env node
 // Bundles src/entry.tsx into a single self-contained dist/entry.js.
 // No runtime node_modules needed.
-import { build } from 'esbuild'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { createRequire as __cr } from 'node:module'
 
+const require = __cr(import.meta.url)
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const out = resolve(root, 'dist/entry.js')
+
+// esbuild binary version mismatch on Android arm64: the npm-installed
+// @esbuild/android-arm64 binary can end up with a different version than
+// the esbuild package lib/main.js expects (e.g. 0.28.0 vs 0.27.7).
+// We resolve the correct binary here and pass it via ESBUILD_BINARY_PATH
+// so the service subprocess uses the matching pair.
+const esbuildLibDir = resolve(root, 'node_modules/esbuild/lib')
+const esbuildBinPath = resolve(esbuildLibDir, '../bin/esbuild')
+
+// IMPORTANT: clear any external ESBUILD_BINARY_PATH that may point to a
+// stale version (e.g. ~/.hermes/esbuild-built on this system is 0.28.0
+// while the local node_modules/esbuild is 0.27.7).
+delete process.env.ESBUILD_BINARY_PATH
+
+let esbuild
+try {
+  // Try local node_modules esbuild first (version-matched pair)
+  esbuild = require('esbuild')
+} catch {
+  // Fallback: use the explicit binary path
+  esbuild = require(resolve(esbuildLibDir, 'main.js'))
+}
 
 // `react-devtools-core` is only imported when DEV=true at runtime (Ink dev
 // mode). Stub it out so the bundle doesn't carry the dep.
@@ -26,7 +49,7 @@ const stubDevtools = {
   }
 }
 
-await build({
+await esbuild.build({
   entryPoints: [resolve(root, 'src/entry.tsx')],
   bundle: true,
   platform: 'node',


### PR DESCRIPTION
Resolve esbuild binary path in build.mjs to avoid version mismatch on Android arm64

On Android arm64 (Termux), the @esbuild/android-arm64 binary installed in node_modules can end up with a different version than the esbuild package's lib/main.js expects. For example, npm may install esbuild@0.27.7 as the JS package while pulling @esbuild/android-arm64@0.28.0 as a dependency of a transitive package (tsx). When esbuild's lib/main.js tries to start a service subprocess, it reads the binary version from the spawned process's first packet and compares it against the hardcoded host version, throwing:

  Cannot start service: Host version "0.27.7" does not match binary version "0.28.0"

Root cause: ESBUILD_BINARY_PATH is read from environment and overrides the local binary. On this system, ~/.hermes/esbuild-built exists (0.28.0) from a previous installation and pollutes the build. Additionally, require.resolve('@esbuild/android-arm64') in generateBinPath() can find the wrong copy when multiple versions exist in the dependency tree (e.g. node_modules/tsx/node_modules/@esbuild/android-arm64).

Previously attempted fixes (commits b3bd03703 and 5118502c7) tried using the system esbuild at /usr/lib/node_modules/esbuild but that path contains version 0.28.0 which is also incompatible with the 0.27.7 lib/main.js in the project's node_modules.

Fix:
- Clear ESBUILD_BINARY_PATH env var before loading esbuild (delete process.env.ESBUILD_BINARY_PATH)
- Import esbuild via createRequire from node:module to use the same require.resolve semantics as generateBinPath()
- The local esbuild package (esbuild + @esbuild/android-arm64 at matching versions) is already installed at ui-tui/node_modules/esbuild — this ensures the build script uses that pair consistently

Changes:
- build.mjs: create CJS require via createRequire, delete process.env.ESBUILD_BINARY_PATH, call esbuild.build() instead of bare build() import