### PR TITLE
fix(copilot): honor target_model when resolving api_mode override

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -150,13 +150,16 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str, target_model: Optional[str] = None) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Prefer the explicitly requested target model over model_cfg.default so
+    # that e.g. `--provider copilot --model claude-opus-4.7` from a profile
+    # whose default is GPT-5.x does not inherit codex_responses (Copilot 400).
+    model_name = (target_model or "").strip() or str(model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -271,7 +274,7 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""), target_model=effective_model)
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config

--- a/tests/hermes_cli/test_runtime_provider.py
+++ b/tests/hermes_cli/test_runtime_provider.py
@@ -1,0 +1,90 @@
+"""Regression tests for hermes_cli.runtime_provider helpers."""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+
+
+def test_copilot_api_mode_honors_explicit_target_model_over_stale_config_default(monkeypatch):
+    """Regression: when a user runs e.g.
+
+        hermes --profile X -m claude-opus-4.7 --provider copilot ...
+
+    from a profile whose ``model.default`` is ``gpt-5.x`` (a Responses-API
+    model), ``_copilot_runtime_api_mode`` must compute api_mode from the
+    *override* model — not silently fall back to ``model_cfg["default"]``
+    and pick ``codex_responses`` for a Claude model that only serves
+    ``/chat/completions``.
+
+    Before the fix this surfaced as Copilot returning::
+
+        HTTP 400: model claude-opus-4.7 does not support Responses API
+
+    which was swallowed by oneshot's stderr redirect (exit 0, empty stdout).
+    """
+    # Profile config that mirrors the real-world repro: provider mismatch
+    # disables the persisted api_mode shortcut, so the function falls through
+    # to model-name based detection — which is the path under test.
+    model_cfg = {
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "default": "gpt-5.5",
+        "base_url": "https://example.invalid/codex",
+    }
+
+    # Stub out the catalog/normalization path so the test is fully offline.
+    # _should_use_copilot_responses_api is pattern-based (offline) for the
+    # exact IDs we pass, but normalize_copilot_model_id may try to hit the
+    # catalog — short-circuit it to identity.
+    monkeypatch.setattr(
+        "hermes_cli.models.normalize_copilot_model_id",
+        lambda model_id, catalog=None, api_key=None: model_id,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_github_model_catalog",
+        lambda api_key=None: [],
+    )
+
+    # Override → Claude. Must NOT pick up gpt-5.5's codex_responses.
+    assert (
+        rp._copilot_runtime_api_mode(model_cfg, api_key="x", target_model="claude-opus-4.7")
+        == "chat_completions"
+    )
+
+    # No override → falls back to model_cfg.default (gpt-5.5) → codex_responses.
+    # Preserves the previous behaviour for callers that don't pass target_model.
+    assert (
+        rp._copilot_runtime_api_mode(model_cfg, api_key="x")
+        == "codex_responses"
+    )
+
+    # Override → GPT-5 sibling: should resolve to codex_responses via target_model.
+    assert (
+        rp._copilot_runtime_api_mode(model_cfg, api_key="x", target_model="gpt-5.4")
+        == "codex_responses"
+    )
+
+
+def test_copilot_api_mode_still_honors_matching_config(monkeypatch):
+    """When the configured provider matches (``copilot``) and a persisted
+    api_mode is set, the explicit-config path still wins regardless of
+    target_model. This guards the existing happy path."""
+    model_cfg = {
+        "provider": "copilot",
+        "api_mode": "codex_responses",
+        "default": "gpt-5.5",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.models.normalize_copilot_model_id",
+        lambda model_id, catalog=None, api_key=None: model_id,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_github_model_catalog",
+        lambda api_key=None: [],
+    )
+    # Even with a Claude target_model, the explicit matching-provider config wins.
+    assert (
+        rp._copilot_runtime_api_mode(model_cfg, api_key="x", target_model="claude-opus-4.7")
+        == "codex_responses"
+    )


### PR DESCRIPTION
## Summary

`_copilot_runtime_api_mode` was computing `api_mode` from `model_cfg["default"]`
when the persisted `api_mode` couldn't be honored (provider mismatch). For a
profile whose default model is GPT-5.x with `api_mode=codex_responses`,
overriding the model on the CLI with e.g.
`hermes -p X -m claude-opus-4.7 --provider copilot ...` then resolved to
`codex_responses` for the *Claude* override, and Copilot answered:

```
HTTP 400: model claude-opus-4.7 does not support Responses API
```

The exception was swallowed by `oneshot.run_oneshot`'s `redirect_stderr(devnull)`,
surfacing as **exit 0 with empty stdout** — indistinguishable from "the agent
returned nothing".

## Fix

Thread the explicit `target_model` into `_copilot_runtime_api_mode` so the
override model — not the stale config default — drives `api_mode` selection.
The persisted-config shortcut (matching provider + valid api_mode) is
unchanged, and callers that don't pass `target_model` still get the old
`model_cfg["default"]` fallback.

## Repro

With bug present:
```bash
hermes -p some_profile_with_codex_default -m claude-opus-4.7 --provider copilot -z "reply OK"
# exit 0, no output
```

After fix:
```
OK
```

## Tests

`tests/hermes_cli/test_runtime_provider.py` — three cases:

1. Claude override from `openai-codex`/`codex_responses` profile → `chat_completions` ✅
2. No override → still falls back to `model_cfg.default` → `codex_responses` (backward-compatible) ✅
3. Matching-provider explicit config still wins regardless of `target_model` ✅

All offline (monkeypatches catalog fetch / id normalization).
