### PR TITLE
fix(plugins): hide bundled model providers from plugin list

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -741,7 +741,7 @@ def _discover_all_plugins() -> list:
             if (
                 depth == 0
                 and source == "bundled"
-                and d.name in {"memory", "context_engine"}
+                and d.name in {"memory", "context_engine", "model-providers"}
             ):
                 continue
             manifest_file = d / "plugin.yaml"

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -496,6 +496,25 @@ class TestDiscoverAllPlugins:
         assert "context_engine/compressor" not in entries
         assert "observability/langfuse" in entries
 
+    def test_bundled_model_providers_skipped(self, tmp_path, monkeypatch):
+        """``plugins/model-providers/`` has its own provider registry loader.
+
+        Bundled providers should not appear in ``hermes plugins list`` as
+        general opt-in plugins, or users get a misleading enable/disable
+        surface for providers selected via ``model.provider`` / ``--provider``.
+        """
+        bundled, _, discover = self._entries_by_key(tmp_path, monkeypatch)
+        self._write_plugin(
+            bundled,
+            ["model-providers", "openrouter"],
+            manifest_name="openrouter-provider",
+        )
+        self._write_plugin(bundled, ["observability", "langfuse"])
+
+        entries = discover()
+        assert "model-providers/openrouter" not in entries
+        assert "observability/langfuse" in entries
+
     def test_user_memory_subdir_is_still_scanned(self, tmp_path, monkeypatch):
         """The memory/context_engine skip only applies to *bundled* — a user
         plugin at ``~/.hermes/plugins/memory/<x>/`` should still be discovered


### PR DESCRIPTION
## Summary
- skip bundled `plugins/model-providers/` in the generic `hermes plugins list` discovery path
- keep the existing standalone/category plugin scan behavior unchanged
- add a regression test covering the model-provider skip next to the existing memory/context-engine skip test

## Why
Model provider plugins use the dedicated provider registry loader, not the general PluginManager opt-in surface. Listing bundled providers such as `model-providers/openrouter` as ordinary plugins gives users a misleading enable/disable surface for providers selected through `--provider` or model config.

## Open PR overlap checked
- #27258 handles the separate `hermes send` startup follow-up; this PR does not touch `hermes_cli/main.py` or `send_cmd.py`.
- #27240 handles runtime keys for bundled platform plugins; this PR only touches the CLI plugin-list scanner for model-provider entries.

## Verification
- `./scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py::TestDiscoverAllPlugins::test_bundled_model_providers_skipped tests/hermes_cli/test_plugins_cmd.py::TestDiscoverAllPlugins::test_bundled_memory_and_context_engine_skipped tests/hermes_cli/test_plugins_cmd.py::TestDiscoverAllPlugins::test_category_namespaced_plugin_uses_path_derived_key`
- `./scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py`
- `.venv/bin/ruff check hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins_cmd.py`
- `git diff --check`