### PR TITLE
fix(homeassistant): support return_response for HA response-only services (#27256)

### DIFF
--- a/tests/tools/test_homeassistant_response_services.py
+++ b/tests/tools/test_homeassistant_response_services.py
@@ -1,0 +1,552 @@
+"""Regression tests for Home Assistant response-service support (#27256).
+
+`todo.get_items`, `calendar.get_events`, `weather.get_forecasts` and
+`conversation.process` are registered in Home Assistant with
+``SupportsResponse.ONLY``: a REST call without ``?return_response=true``
+gets rejected with HTTP 400 ("Service ... requires response data").
+
+These tests cover:
+
+* The new ``return_response`` parameter on ``_async_call_service`` and the
+  ``ha_call_service`` schema.
+* Auto-opt-in for the well-known response-only services so the model
+  doesn't have to set the flag for the most common cases.
+* Defensive auto-retry-once when HA's 400 explicitly signals the issue
+  (covers user HA versions / custom integrations that aren't in the
+  static list).
+* Backward-compat for ordinary service calls (no flag, no query string,
+  flat response shape).
+* Parsing of the new response shape that includes ``service_response``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List, Tuple
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.homeassistant_tool import (
+    _RESPONSE_ONLY_SERVICES,
+    _async_call_service,
+    _build_service_payload,
+    _handle_call_service,
+    _is_response_required_hint,
+    _parse_service_response,
+    _service_url,
+    HA_CALL_SERVICE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — a tiny aiohttp session double good enough for our call paths.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: str, content_type: str = "application/json"):
+        self.status = status
+        self._body = body
+        self.content_type = content_type
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def text(self):
+        return self._body
+
+    async def json(self):
+        return json.loads(self._body)
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            import aiohttp
+
+            raise aiohttp.ClientResponseError(
+                request_info=None,  # type: ignore[arg-type]
+                history=(),
+                status=self.status,
+                message=self._body,
+            )
+
+
+class _FakeSession:
+    """Replays scripted (status, body, content_type) tuples in order."""
+
+    def __init__(self, scripted: List[Tuple[int, str, str]]):
+        self._scripted = list(scripted)
+        self.posts: List[Dict[str, Any]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.posts.append({"url": url, "headers": headers, "json": json})
+        if not self._scripted:
+            raise AssertionError(f"Unexpected POST {url}; no more scripted responses")
+        status, body, ct = self._scripted.pop(0)
+        return _FakeResp(status, body, ct)
+
+
+def _patch_aiohttp(scripted: List[Tuple[int, str, str]]):
+    """Install a FakeSession factory that captures POSTs to HA."""
+    session = _FakeSession(scripted)
+
+    class _Factory:
+        def __call__(self):  # ClientSession()
+            return session
+
+    import aiohttp
+
+    return patch.object(aiohttp, "ClientSession", _Factory()), session
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _ha_env(monkeypatch):
+    """All tests in this module need a HASS token + a deterministic URL."""
+    monkeypatch.setenv("HASS_TOKEN", "test-token")
+    monkeypatch.setenv("HASS_URL", "http://ha.local:8123")
+    monkeypatch.setattr("tools.homeassistant_tool._HASS_TOKEN", "")
+    monkeypatch.setattr("tools.homeassistant_tool._HASS_URL", "")
+
+
+# ---------------------------------------------------------------------------
+# Service URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestServiceURL:
+    def test_no_return_response_omits_query(self):
+        url = _service_url("http://ha.local:8123", "light", "turn_on", False)
+        assert url == "http://ha.local:8123/api/services/light/turn_on"
+
+    def test_return_response_appends_query(self):
+        url = _service_url("http://ha.local:8123", "todo", "get_items", True)
+        assert url == "http://ha.local:8123/api/services/todo/get_items?return_response=true"
+
+
+# ---------------------------------------------------------------------------
+# 400-hint detector
+# ---------------------------------------------------------------------------
+
+
+class TestIsResponseRequiredHint:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"message": "Service todo.get_items requires response data"}',
+            '{"message": "Set return_response=true to receive responses"}',
+            "Service requires response data",
+            "Please call with return_response=true",
+        ],
+    )
+    def test_recognised_hints(self, body):
+        assert _is_response_required_hint(400, body) is True
+
+    @pytest.mark.parametrize(
+        "status,body",
+        [
+            (400, '{"message": "Unknown service"}'),
+            (400, '{"message": "Invalid entity_id"}'),
+            (401, "Service requires response data"),  # auth error, don't retry
+            (500, "return_response would have helped"),  # not a 400
+            (400, ""),
+            (200, "ok"),
+        ],
+    )
+    def test_negatives(self, status, body):
+        assert _is_response_required_hint(status, body) is False
+
+
+# ---------------------------------------------------------------------------
+# Static response-only allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestResponseOnlyAllowlist:
+    @pytest.mark.parametrize(
+        "domain,service",
+        [
+            ("todo", "get_items"),
+            ("calendar", "get_events"),
+            ("weather", "get_forecasts"),
+            ("conversation", "process"),
+        ],
+    )
+    def test_known_services_are_listed(self, domain, service):
+        assert (domain, service) in _RESPONSE_ONLY_SERVICES
+
+    def test_regular_services_not_listed(self):
+        assert ("light", "turn_on") not in _RESPONSE_ONLY_SERVICES
+        assert ("todo", "add_item") not in _RESPONSE_ONLY_SERVICES
+        assert ("todo", "remove_item") not in _RESPONSE_ONLY_SERVICES
+
+
+# ---------------------------------------------------------------------------
+# Response parser handles both old and new shapes
+# ---------------------------------------------------------------------------
+
+
+class TestParseServiceResponseNewShape:
+    def test_dict_with_service_response_extracts_payload(self):
+        ha_response = {
+            "changed_states": [],
+            "service_response": {
+                "todo.mylist": {
+                    "items": [
+                        {"summary": "buy milk", "status": "needs_action"},
+                        {"summary": "vacuum", "status": "completed"},
+                    ]
+                }
+            },
+        }
+        parsed = _parse_service_response("todo", "get_items", ha_response)
+        assert parsed["success"] is True
+        assert parsed["service"] == "todo.get_items"
+        assert parsed["affected_entities"] == []
+        assert parsed["service_response"] == ha_response["service_response"]
+
+    def test_dict_with_changed_states_and_response(self):
+        ha_response = {
+            "changed_states": [
+                {"entity_id": "todo.mylist", "state": "5"},
+            ],
+            "service_response": {"todo.mylist": {"items": []}},
+        }
+        parsed = _parse_service_response("todo", "get_items", ha_response)
+        assert parsed["affected_entities"] == [
+            {"entity_id": "todo.mylist", "state": "5"}
+        ]
+        assert parsed["service_response"] == ha_response["service_response"]
+
+    def test_legacy_list_response_still_works(self):
+        ha_response = [
+            {"entity_id": "light.kitchen", "state": "on"},
+            {"entity_id": "light.bedroom", "state": "on"},
+        ]
+        parsed = _parse_service_response("light", "turn_on", ha_response)
+        assert "service_response" not in parsed
+        assert len(parsed["affected_entities"]) == 2
+
+    def test_empty_dict_response(self):
+        parsed = _parse_service_response("script", "run", {})
+        assert parsed["affected_entities"] == []
+        assert "service_response" not in parsed
+
+    def test_none_response_no_crash(self):
+        parsed = _parse_service_response("automation", "trigger", None)
+        assert parsed["affected_entities"] == []
+
+    def test_malformed_changed_states_items_skipped(self):
+        ha_response = {
+            "changed_states": [None, "not-a-dict", {"entity_id": "x", "state": "y"}],
+            "service_response": {"x": 1},
+        }
+        parsed = _parse_service_response("foo", "bar", ha_response)
+        assert parsed["affected_entities"] == [{"entity_id": "x", "state": "y"}]
+        assert parsed["service_response"] == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# _async_call_service network behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCallServiceQueryString:
+    def test_regular_service_no_query(self):
+        body = json.dumps([{"entity_id": "light.x", "state": "on"}])
+        patcher, session = _patch_aiohttp([(200, body, "application/json")])
+        with patcher:
+            result = _run(
+                _async_call_service("light", "turn_on", entity_id="light.x")
+            )
+        assert "?return_response" not in session.posts[0]["url"]
+        assert result["success"] is True
+
+    def test_known_response_only_service_auto_appends_query(self):
+        body = json.dumps({
+            "changed_states": [],
+            "service_response": {"todo.mylist": {"items": []}},
+        })
+        patcher, session = _patch_aiohttp([(200, body, "application/json")])
+        with patcher:
+            result = _run(
+                _async_call_service(
+                    "todo", "get_items", entity_id="todo.mylist"
+                )
+            )
+        # No explicit flag — auto-opt-in via the allowlist.
+        assert session.posts[0]["url"].endswith("?return_response=true")
+        assert result["service_response"] == {"todo.mylist": {"items": []}}
+
+    def test_explicit_return_response_flag(self):
+        body = json.dumps({
+            "changed_states": [],
+            "service_response": {"calendar.foo": {"events": []}},
+        })
+        patcher, session = _patch_aiohttp([(200, body, "application/json")])
+        with patcher:
+            _run(
+                _async_call_service(
+                    "calendar",
+                    "get_events",
+                    entity_id="calendar.foo",
+                    return_response=True,
+                )
+            )
+        assert session.posts[0]["url"].endswith("?return_response=true")
+
+    def test_auto_retry_on_400_hint(self):
+        """HA tells us this service needs return_response → we retry once."""
+        first = (
+            400,
+            '{"message": "Service custom.fetch requires response data"}',
+            "application/json",
+        )
+        second = (
+            200,
+            json.dumps({
+                "changed_states": [],
+                "service_response": {"value": 42},
+            }),
+            "application/json",
+        )
+        patcher, session = _patch_aiohttp([first, second])
+        with patcher:
+            result = _run(_async_call_service("custom", "fetch"))
+
+        assert len(session.posts) == 2, "expected one retry, not more"
+        assert "?return_response" not in session.posts[0]["url"]
+        assert session.posts[1]["url"].endswith("?return_response=true")
+        assert result["service_response"] == {"value": 42}
+
+    def test_400_without_hint_does_not_retry(self):
+        patcher, session = _patch_aiohttp([
+            (400, '{"message": "Entity not found"}', "application/json"),
+        ])
+        with patcher:
+            with pytest.raises(Exception):
+                _run(_async_call_service("light", "turn_on", entity_id="light.x"))
+        assert len(session.posts) == 1, "must not retry on unrelated 400"
+
+    def test_known_response_service_does_not_retry_on_400(self):
+        """If we already had return_response=true and HA still 400s, surface it."""
+        patcher, session = _patch_aiohttp([
+            (
+                400,
+                '{"message": "Service todo.get_items requires response data"}',
+                "application/json",
+            ),
+        ])
+        with patcher:
+            with pytest.raises(Exception):
+                _run(
+                    _async_call_service(
+                        "todo", "get_items", entity_id="todo.mylist"
+                    )
+                )
+        # No retry — first request already used return_response=true.
+        assert len(session.posts) == 1
+        assert session.posts[0]["url"].endswith("?return_response=true")
+
+    def test_non_json_body_returned_as_text(self):
+        patcher, session = _patch_aiohttp([(200, "OK", "text/plain")])
+        with patcher:
+            result = _run(_async_call_service("script", "run"))
+        # Plain-text bodies still parse cleanly into a success envelope.
+        assert result["success"] is True
+        assert result["affected_entities"] == []
+
+    def test_empty_body_returned_as_none(self):
+        patcher, session = _patch_aiohttp([(200, "", "application/json")])
+        with patcher:
+            result = _run(_async_call_service("script", "run"))
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _handle_call_service routes return_response correctly
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerReturnResponseWiring:
+    """Confirm the handler forwards return_response (incl. string coercion)."""
+
+    def _patch_call(self):
+        """Patch _async_call_service with an AsyncMock + bypass _run_async."""
+        async_mock = AsyncMock(return_value={"success": True, "service": "x.y"})
+        return patch(
+            "tools.homeassistant_tool._async_call_service", async_mock
+        ), async_mock
+
+    @staticmethod
+    def _passthrough_run_async():
+        """Patch _run_async to actually drive the coroutine via asyncio.run."""
+        return patch(
+            "tools.homeassistant_tool._run_async",
+            side_effect=lambda coro: asyncio.run(coro),
+        )
+
+    def _last_call_kwargs(self, async_mock):
+        call = async_mock.await_args
+        # positional: (domain, service, entity_id, data, return_response)
+        return call.args, call.kwargs
+
+    def test_bool_true_flows_through(self):
+        patcher, async_mock = self._patch_call()
+        with patcher, self._passthrough_run_async():
+            _handle_call_service({
+                "domain": "todo",
+                "service": "get_items",
+                "entity_id": "todo.mylist",
+                "return_response": True,
+            })
+        args, _ = self._last_call_kwargs(async_mock)
+        assert args[-1] is True
+
+    def test_bool_false_flows_through(self):
+        patcher, async_mock = self._patch_call()
+        with patcher, self._passthrough_run_async():
+            _handle_call_service({
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": "light.x",
+                "return_response": False,
+            })
+        args, _ = self._last_call_kwargs(async_mock)
+        assert args[-1] is False
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+    ])
+    def test_string_values_coerced(self, raw, expected):
+        patcher, async_mock = self._patch_call()
+        with patcher, self._passthrough_run_async():
+            _handle_call_service({
+                "domain": "todo",
+                "service": "get_items",
+                "entity_id": "todo.mylist",
+                "return_response": raw,
+            })
+        args, _ = self._last_call_kwargs(async_mock)
+        assert args[-1] is expected
+
+    def test_default_is_false(self):
+        patcher, async_mock = self._patch_call()
+        with patcher, self._passthrough_run_async():
+            _handle_call_service({
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": "light.x",
+            })
+        args, _ = self._last_call_kwargs(async_mock)
+        assert args[-1] is False
+
+
+# ---------------------------------------------------------------------------
+# Schema advertises the new field
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaSurface:
+    def test_return_response_field_in_schema(self):
+        props = HA_CALL_SERVICE_SCHEMA["parameters"]["properties"]
+        assert "return_response" in props
+        assert props["return_response"]["type"] == "boolean"
+
+    def test_return_response_not_required(self):
+        required = HA_CALL_SERVICE_SCHEMA["parameters"]["required"]
+        assert "return_response" not in required
+
+    def test_description_mentions_response_services(self):
+        desc = HA_CALL_SERVICE_SCHEMA["description"].lower()
+        assert "todo.get_items".lower() in desc
+        assert "return_response" in desc
+
+
+# ---------------------------------------------------------------------------
+# Issue #27256 end-to-end reproduction
+# ---------------------------------------------------------------------------
+
+
+class TestIssue27256Repro:
+    """The exact failing scenario described in the bug report."""
+
+    def test_get_items_returns_items(self):
+        body = json.dumps({
+            "changed_states": [],
+            "service_response": {
+                "todo.mylist": {
+                    "items": [
+                        {"summary": "buy milk", "status": "needs_action"},
+                        {"summary": "vacuum", "status": "completed"},
+                    ]
+                }
+            },
+        })
+        patcher, session = _patch_aiohttp([(200, body, "application/json")])
+        with patcher:
+            with patch(
+                "tools.homeassistant_tool._run_async",
+                side_effect=lambda coro: _run(coro),
+            ):
+                raw = _handle_call_service({
+                    "domain": "todo",
+                    "service": "get_items",
+                    "entity_id": "todo.mylist",
+                    "data": '{"status": "needs_action"}',
+                })
+
+        result = json.loads(raw)["result"]
+        assert result["success"] is True
+        items = result["service_response"]["todo.mylist"]["items"]
+        assert {i["summary"] for i in items} == {"buy milk", "vacuum"}
+        # Confirm we used the query string the model never had to know about.
+        assert session.posts[0]["url"].endswith("?return_response=true")
+        # And the data dict round-tripped via the flat payload, like
+        # add_item/remove_item already did successfully.
+        assert session.posts[0]["json"] == {
+            "entity_id": "todo.mylist",
+            "status": "needs_action",
+        }
+
+    def test_add_item_unchanged(self):
+        """`add_item` already worked — must not regress."""
+        body = json.dumps([])
+        patcher, session = _patch_aiohttp([(200, body, "application/json")])
+        with patcher:
+            with patch(
+                "tools.homeassistant_tool._run_async",
+                side_effect=lambda coro: _run(coro),
+            ):
+                raw = _handle_call_service({
+                    "domain": "todo",
+                    "service": "add_item",
+                    "entity_id": "todo.mylist",
+                    "data": '{"item": "buy milk"}',
+                })
+
+        result = json.loads(raw)["result"]
+        assert result["success"] is True
+        # No return_response opt-in for add_item — keeps wire compat.
+        assert "?return_response" not in session.posts[0]["url"]

--- a/tests/tools/test_homeassistant_response_services.py
+++ b/tests/tools/test_homeassistant_response_services.py
@@ -464,6 +464,57 @@ class TestHandlerReturnResponseWiring:
 
 
 # ---------------------------------------------------------------------------
+# Unrelated 400s surface as a clean tool error (not an AttributeError crash)
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerUnrelated400:
+    """An unrelated 400 must come back as a tool error, not crash the handler.
+
+    Regression for the review on #27270: the error used to be raised as
+    ``aiohttp.ClientResponseError(request_info=None, ...)``. Formatting that
+    exception (``f"{e}"`` in the handler's ``except`` block) dereferences
+    ``request_info.real_url`` and raises ``AttributeError``, so the handler's
+    error path crashed instead of returning a JSON tool error.
+    """
+
+    @staticmethod
+    def _passthrough_run_async():
+        return patch(
+            "tools.homeassistant_tool._run_async",
+            side_effect=lambda coro: _run(coro),
+        )
+
+    def test_unrelated_400_returns_tool_error(self):
+        patcher, session = _patch_aiohttp([
+            (400, '{"message": "Entity not found"}', "application/json"),
+        ])
+        with patcher, self._passthrough_run_async():
+            raw = _handle_call_service({
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": "light.x",
+            })
+        # Must be a clean JSON tool error, not a raised exception.
+        payload = json.loads(raw)
+        assert "error" in payload
+        assert "light.turn_on" in payload["error"]
+        # Unrelated 400 must not trigger a retry.
+        assert len(session.posts) == 1
+
+    def test_api_error_stringifies_safely(self):
+        """The synthesized HTTP error must format without raising."""
+        from tools.homeassistant_tool import HomeAssistantAPIError
+
+        err = HomeAssistantAPIError(400, '{"message": "Entity not found"}')
+        # Any of these used to raise AttributeError under the old aiohttp path.
+        assert str(err)
+        assert f"{err}"
+        assert err.status == 400
+        assert "Entity not found" in err.message
+
+
+# ---------------------------------------------------------------------------
 # Schema advertises the new field
 # ---------------------------------------------------------------------------
 

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -59,6 +59,21 @@ _BLOCKED_DOMAINS = frozenset({
     "rest_command",     # HTTP requests from HA server (SSRF vector)
 })
 
+# Services that ALWAYS return data — i.e. registered in HA with
+# ``SupportsResponse.ONLY``.  Calling them via the REST API without
+# ``?return_response=true`` produces a 400 with a message like
+# "Service todo.get_items requires response data".  We auto-attach the
+# query string for these so the model doesn't have to know the rule.
+# Conservative list — anything not here still works via the explicit
+# ``return_response`` parameter and our 400-hint auto-retry below.
+# See: https://github.com/NousResearch/hermes-agent/issues/27256
+_RESPONSE_ONLY_SERVICES: frozenset = frozenset({
+    ("todo", "get_items"),
+    ("calendar", "get_events"),
+    ("weather", "get_forecasts"),
+    ("conversation", "process"),
+})
+
 
 def _get_headers(token: str = "") -> Dict[str, str]:
     """Return authorization headers for HA REST API."""
@@ -158,20 +173,64 @@ def _parse_service_response(
     service: str,
     result: Any,
 ) -> Dict[str, Any]:
-    """Parse HA service call response into a structured result."""
+    """Parse HA service call response into a structured result.
+
+    Two response shapes are supported:
+
+    * Legacy / non-response services: a flat list of changed state objects.
+    * Response services (called with ``?return_response=true``): a dict
+      with ``changed_states`` and ``service_response`` keys.  The latter
+      carries the actual payload the caller wants (e.g. todo items,
+      calendar events).
+    """
     affected = []
-    if isinstance(result, list):
-        for s in result:
+    service_response: Optional[Any] = None
+    changed_states: Any = result
+
+    if isinstance(result, dict) and (
+        "service_response" in result or "changed_states" in result
+    ):
+        service_response = result.get("service_response")
+        changed_states = result.get("changed_states") or []
+
+    if isinstance(changed_states, list):
+        for s in changed_states:
+            if not isinstance(s, dict):
+                continue
             affected.append({
                 "entity_id": s.get("entity_id", ""),
                 "state": s.get("state", ""),
             })
 
-    return {
+    parsed: Dict[str, Any] = {
         "success": True,
         "service": f"{domain}.{service}",
         "affected_entities": affected,
     }
+    if service_response is not None:
+        parsed["service_response"] = service_response
+    return parsed
+
+
+def _service_url(hass_url: str, domain: str, service: str, return_response: bool) -> str:
+    """Construct the /api/services URL, optionally with return_response."""
+    base = f"{hass_url}/api/services/{domain}/{service}"
+    return f"{base}?return_response=true" if return_response else base
+
+
+def _is_response_required_hint(status: int, body: str) -> bool:
+    """Detect HA's "requires response data" 400 so we can auto-retry.
+
+    HA's REST API returns 400 with a message such as
+    "Service todo.get_items requires response data" when a response-only
+    service is called without ``?return_response=true``.  Matching on
+    "return_response" / "requires response" is conservative and avoids
+    false positives — neither phrase appears in unrelated 400s in HA core.
+    """
+    if status != 400 or not body:
+        return False
+    lowered = body.lower()
+    return ("return_response" in lowered) or ("requires response" in lowered)
 
 
 async def _async_call_service(
@@ -179,23 +238,67 @@ async def _async_call_service(
     service: str,
     entity_id: Optional[str] = None,
     data: Optional[Dict[str, Any]] = None,
+    return_response: bool = False,
 ) -> Dict[str, Any]:
-    """Call a Home Assistant service."""
+    """Call a Home Assistant service.
+
+    ``return_response`` toggles HA's ``?return_response=true`` query
+    parameter, required for "response services" registered with
+    ``SupportsResponse.ONLY`` (e.g. ``todo.get_items``,
+    ``calendar.get_events``, ``weather.get_forecasts``).  Known
+    response-only services in :data:`_RESPONSE_ONLY_SERVICES` opt in
+    automatically; for everything else we auto-retry once when HA's 400
+    response explicitly says response data is required, so the model
+    never has to know the rule.  See issue #27256.
+    """
     import aiohttp
 
     hass_url, hass_token = _get_config()
-    url = f"{hass_url}/api/services/{domain}/{service}"
     payload = _build_service_payload(entity_id, data)
+    must_return_response = bool(return_response) or (
+        (domain, service) in _RESPONSE_ONLY_SERVICES
+    )
 
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
-            url,
-            headers=_get_headers(hass_token),
-            json=payload,
-            timeout=aiohttp.ClientTimeout(total=15),
-        ) as resp:
-            resp.raise_for_status()
-            result = await resp.json()
+    async def _post(use_return_response: bool):
+        url = _service_url(hass_url, domain, service, use_return_response)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                headers=_get_headers(hass_token),
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                status = resp.status
+                body_text = await resp.text()
+                return status, body_text, resp.content_type
+
+    status, body_text, content_type = await _post(must_return_response)
+
+    # Defensive auto-retry: if HA explicitly tells us this service needs
+    # ``?return_response=true`` (because the static list above didn't cover
+    # the user's HA version / custom integration), retry once with it on.
+    if (
+        not must_return_response
+        and _is_response_required_hint(status, body_text)
+    ):
+        must_return_response = True
+        status, body_text, content_type = await _post(True)
+
+    if status >= 400:
+        raise aiohttp.ClientResponseError(
+            request_info=None,  # type: ignore[arg-type]
+            history=(),
+            status=status,
+            message=body_text or f"HTTP {status}",
+        )
+
+    if content_type and "json" in content_type:
+        try:
+            result = json.loads(body_text) if body_text else None
+        except json.JSONDecodeError:
+            result = body_text
+    else:
+        result = body_text or None
 
     return _parse_service_response(domain, service, result)
 
@@ -280,8 +383,20 @@ def _handle_call_service(args: dict, **kw) -> str:
         except json.JSONDecodeError as e:
             return tool_error(f"Invalid JSON string in 'data' parameter: {e}")
 
+    # ``return_response`` may arrive as a real bool (JSON tool calling) or
+    # as a string ("true"/"false"/"1"/"0") in XML tool-calling mode.
+    raw_rr = args.get("return_response", False)
+    if isinstance(raw_rr, bool):
+        return_response = raw_rr
+    elif isinstance(raw_rr, str):
+        return_response = raw_rr.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        return_response = bool(raw_rr)
+
     try:
-        result = _run_async(_async_call_service(domain, service, entity_id, data))
+        result = _run_async(
+            _async_call_service(domain, service, entity_id, data, return_response)
+        )
         return json.dumps({"result": result})
     except Exception as e:
         logger.error("ha_call_service error: %s", e)
@@ -427,8 +542,12 @@ HA_LIST_SERVICES_SCHEMA = {
 HA_CALL_SERVICE_SCHEMA = {
     "name": "ha_call_service",
     "description": (
-        "Call a Home Assistant service to control a device. Use ha_list_services "
-        "to discover available services and their parameters for each domain."
+        "Call a Home Assistant service to control a device or read data from "
+        "a response service. Use ha_list_services to discover available "
+        "services and their parameters for each domain. For services that "
+        "return data (e.g. todo.get_items, calendar.get_events, "
+        "weather.get_forecasts), set return_response=true; well-known "
+        "response services opt in automatically."
     ),
     "parameters": {
         "type": "object",
@@ -437,7 +556,8 @@ HA_CALL_SERVICE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Service domain (e.g. 'light', 'switch', 'climate', "
-                    "'cover', 'media_player', 'fan', 'scene', 'script')."
+                    "'cover', 'media_player', 'fan', 'scene', 'script', "
+                    "'todo', 'calendar', 'weather')."
                 ),
             },
             "service": {
@@ -445,14 +565,17 @@ HA_CALL_SERVICE_SCHEMA = {
                 "description": (
                     "Service name (e.g. 'turn_on', 'turn_off', 'toggle', "
                     "'set_temperature', 'set_hvac_mode', 'open_cover', "
-                    "'close_cover', 'set_volume_level')."
+                    "'close_cover', 'set_volume_level', 'get_items', "
+                    "'add_item', 'remove_item', 'get_events', "
+                    "'get_forecasts')."
                 ),
             },
             "entity_id": {
                 "type": "string",
                 "description": (
-                    "Target entity ID (e.g. 'light.living_room'). "
-                    "Some services (like scene.turn_on) may not need this."
+                    "Target entity ID (e.g. 'light.living_room', "
+                    "'todo.mylist'). Some services (like scene.turn_on) "
+                    "may not need this."
                 ),
             },
             "data": {
@@ -461,7 +584,18 @@ HA_CALL_SERVICE_SCHEMA = {
                     "Additional service data as a JSON string. Examples: "
                     '{"brightness": 255, "color_name": "blue"} for lights, '
                     '{"temperature": 22, "hvac_mode": "heat"} for climate, '
-                    '{"volume_level": 0.5} for media players.'
+                    '{"volume_level": 0.5} for media players, '
+                    '{"status": "needs_action"} for todo.get_items.'
+                ),
+            },
+            "return_response": {
+                "type": "boolean",
+                "description": (
+                    "Set to true for response services that return data "
+                    "(todo.get_items, calendar.get_events, "
+                    "weather.get_forecasts, conversation.process). HA "
+                    "rejects these with HTTP 400 unless the request opts "
+                    "in to receiving response data. Default: false."
                 ),
             },
         },

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -35,6 +35,24 @@ def _get_config():
         _HASS_TOKEN or os.getenv("HASS_TOKEN", ""),
     )
 
+
+class HomeAssistantAPIError(Exception):
+    """Home Assistant REST API returned a non-2xx status.
+
+    Used instead of ``aiohttp.ClientResponseError(request_info=None, ...)``:
+    that exception's ``__str__`` dereferences ``request_info.real_url``, so a
+    synthesized instance with ``request_info=None`` raises ``AttributeError``
+    the moment anything formats it (``f"{e}"``, logging, ``str(e)``). The
+    handler error path does exactly that, so an unrelated 400 would crash the
+    handler instead of returning a clean tool error. This type stringifies
+    safely while still exposing ``status`` / ``message`` for callers.
+    """
+
+    def __init__(self, status: int, message: str = ""):
+        self.status = int(status)
+        self.message = message or f"HTTP {self.status}"
+        super().__init__(f"HTTP {self.status}: {self.message}")
+
 # Regex for valid HA entity_id format (e.g. "light.living_room", "sensor.temperature_1")
 _ENTITY_ID_RE = re.compile(r"^[a-z_][a-z0-9_]*\.[a-z0-9_]+$")
 
@@ -285,12 +303,7 @@ async def _async_call_service(
         status, body_text, content_type = await _post(True)
 
     if status >= 400:
-        raise aiohttp.ClientResponseError(
-            request_info=None,  # type: ignore[arg-type]
-            history=(),
-            status=status,
-            message=body_text or f"HTTP {status}",
-        )
+        raise HomeAssistantAPIError(status, body_text)
 
     if content_type and "json" in content_type:
         try:

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -94,7 +94,7 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `ha_call_service` | Call a Home Assistant service to control a device. Use ha_list_services to discover available services and their parameters for each domain. | — |
+| `ha_call_service` | Call a Home Assistant service to control a device or read data from a response service. Use ha_list_services to discover available services and their parameters for each domain. For services that return data (e.g. todo.get_items, calendar.get_events, weather.get_forecasts), set return_response=true; well-known response services opt in automatically. | — |
 | `ha_get_state` | Get the detailed state of a single Home Assistant entity, including all attributes (brightness, color, temperature setpoint, sensor readings, etc.). | — |
 | `ha_list_entities` | List Home Assistant entities. Optionally filter by domain (light, switch, climate, sensor, binary_sensor, cover, fan, etc.) or by area name (living room, kitchen, bedroom, etc.). | — |
 | `ha_list_services` | List available Home Assistant services (actions) for device control. Shows what actions can be performed on each device type and what parameters they accept. Use this to discover how to control devices found via ha_list_entities. | — |


### PR DESCRIPTION
## What does this PR do?

Fixes `homeassistant_tool.ha_call_service` silently returning HTTP 400 on Home Assistant **response services** such as `todo.get_items`, `calendar.get_events`, `weather.get_forecasts` and `conversation.process`.

HA registers these with `SupportsResponse.ONLY`, meaning a REST call without `?return_response=true` is rejected with `400 — "Service ... requires response data"`. The previous implementation never appended that query parameter, so every response service 400'd while non-response services on the same domain (e.g. `todo.add_item`, `todo.remove_item`) kept working — exactly the symptom in the bug report.

The fix is defense-in-depth so the model rarely has to think about the rule:

1. A new `return_response` parameter on `_async_call_service` / `ha_call_service` that toggles `?return_response=true`.
2. A static allowlist `_RESPONSE_ONLY_SERVICES` for the well-known response services (auto-opt-in).
3. Auto-retry-once when HA's 400 body literally mentions `return_response` / `requires response` — covers user HA versions and custom integrations not on the static list. Unrelated 400s (auth, unknown service, invalid entity_id) are *not* retried.
4. `_parse_service_response` recognises the new shape `{changed_states, service_response}` and surfaces `service_response` to the caller; the legacy list shape (all non-response services) is unchanged.

## Related Issue

Closes #27256.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/homeassistant_tool.py` — new `return_response` parameter on `_async_call_service` and the `ha_call_service` schema; new helpers `_service_url`, `_is_response_required_hint`; new constant `_RESPONSE_ONLY_SERVICES`; auto-retry-once logic in `_async_call_service`; response-shape-aware `_parse_service_response`; bool/string coercion for `return_response` in the handler; updated `HA_CALL_SERVICE_SCHEMA` description + new `return_response` field with examples.
- `tests/tools/test_homeassistant_response_services.py` — 48 new regression tests:
  - `TestServiceURL` — 2 cases pinning query-string construction.
  - `TestIsResponseRequiredHint` — 10 cases (4 positive wordings + 6 negatives for unrelated 400s / non-400s / empty body / success).
  - `TestResponseOnlyAllowlist` — 5 cases (4 known services + regular-services-not-listed).
  - `TestParseServiceResponseNewShape` — 6 cases (new shape, legacy list, empty dict, None, malformed entries skipped).
  - `TestAsyncCallServiceQueryString` — 8 cases over a scripted aiohttp double (no query for regular service, auto-opt-in for known, explicit flag, auto-retry on 400 hint, no retry on unrelated 400s, no double-retry when already opted in, non-JSON / empty bodies).
  - `TestHandlerReturnResponseWiring` — 12 cases (bool true/false, string coercion across 9 values, default false). Uses `AsyncMock` to avoid leaking unawaited coroutines.
  - `TestSchemaSurface` — 3 cases (field present, not required, description mentions response services + `todo.get_items`).
  - `TestIssue27256Repro` — 2 end-to-end cases: `todo.get_items` returns parsed items, `todo.add_item` keeps original wire format.
- `website/docs/reference/tools-reference.md` — `ha_call_service` description aligned with the new schema text.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/tools/test_homeassistant_response_services.py -v
   ```
   Expected: 48 passed.
3. Run the full Home Assistant tool suite to confirm no regression:
   ```
   scripts/run_tests.sh tests/tools/test_homeassistant_response_services.py tests/tools/test_homeassistant_tool.py
   ```
   Expected: 116 passed (68 pre-existing + 48 new).
4. Manual smoke against a real HA instance (optional, requires `HASS_TOKEN` / `HASS_URL`):
   - `ha_call_service` with `domain=todo, service=get_items, entity_id=todo.<your_list>` should now return the items in `result.service_response`.
   - `ha_call_service` with `domain=todo, service=add_item, entity_id=todo.<your_list>, data='{"item":"buy milk"}'` should keep working (no behavioural change for non-response services).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(homeassistant): ...`, `test(homeassistant): ...`, `docs(homeassistant): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_homeassistant_response_services.py tests/tools/test_homeassistant_tool.py` and all tests pass
- [x] I've added tests for my changes (48 new regression tests covering helpers, network behaviour, handler wiring, schema, and the exact issue repro)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/tools-reference.md` — `ha_call_service` description now mentions response services and `return_response`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is HTTP-layer only, no platform-specific code; tests use a fake aiohttp session (no network, no filesystem)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `HA_CALL_SERVICE_SCHEMA` description and the new `return_response` field cover the new behaviour

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_homeassistant_response_services.py -v
48 passed in 2.75s

$ scripts/run_tests.sh tests/tools/test_homeassistant_response_services.py tests/tools/test_homeassistant_tool.py -q
116 passed in 2.14s
```
