### PR TITLE
docs(readme): remove hermes-eval and Hermes MemPalace from Community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,6 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
-- 🛠️ [hermes-eval](https://github.com/Saurav0989/hermes-eval) — Skill regression testing and trajectory quality scoring. Catch skill drift before it propagates. Exports quality-filtered trajectories in Atropos RL format. GitHub Actions CI template included.
-- 🧠 [Hermes MemPalace](https://github.com/kjames2001/hermes-mempalace) — Native MemPalace memory provider plugin: semantic search, knowledge graph, and diary journaling via ChromaDB.
 
 ---
 


### PR DESCRIPTION
Reverting the two README community links added in PR #27247. Both were brand-new single-commit personal repos with zero stars/forks and no track record. README links from us implicitly endorse community projects; the Community section needs a minimum activity bar before we link, not just "the contributor opened a PR."

MemPalace in particular wraps an in-process memory provider, so a README endorsement carries more risk than a typical docs link.

The other 8 PRs salvaged in #27247 stand (docs/api_mode/cron/YOLO/spotify/dashboard + the fallback context-length fix + gemma-4 reasoning allowlist).