### PR TITLE
fix(logs): expand filtered tail search

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -261,16 +261,22 @@ def _read_tail(
     When filters are active, we read more raw lines to find enough matches.
     """
     if has_filters:
-        # Read more lines to ensure we get enough after filtering.
-        # For large files, read last 10K lines and filter down.
-        raw_lines = _read_last_n_lines(path, max(num_lines * 20, 2000))
-        filtered = [
-            l for l in raw_lines
-            if _matches_filters(l, min_level=min_level,
-                                session_filter=session_filter, since=since,
-                                component_prefixes=component_prefixes)
-        ]
-        return filtered[-num_lines:]
+        raw_count = max(num_lines * 20, 2000)
+        previous_raw_count = -1
+        while True:
+            raw_lines = _read_last_n_lines(path, raw_count)
+            filtered = [
+                l for l in raw_lines
+                if _matches_filters(l, min_level=min_level,
+                                    session_filter=session_filter, since=since,
+                                    component_prefixes=component_prefixes)
+            ]
+            if len(filtered) >= num_lines or len(raw_lines) < raw_count:
+                return filtered[-num_lines:]
+            if len(raw_lines) == previous_raw_count:
+                return filtered[-num_lines:]
+            previous_raw_count = len(raw_lines)
+            raw_count *= 2
     else:
         return _read_last_n_lines(path, num_lines)
 

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -237,6 +237,31 @@ class TestReadTail:
         assert "gw msg" in result[0]
         assert "session msg" in result[1]
 
+    def test_filtered_tail_expands_past_recent_non_matches(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        lines = [
+            "2026-01-01 00:00:00 INFO gateway.run: gw msg 1\n",
+            "2026-01-01 00:00:01 INFO gateway.session: gw msg 2\n",
+            "2026-01-01 00:00:02 INFO gateway.run: gw msg 3\n",
+        ]
+        lines.extend(
+            f"2026-01-01 00:{i // 60:02d}:{i % 60:02d} INFO tools.file: noise {i}\n"
+            for i in range(2100)
+        )
+        log_file.write_text("".join(lines), encoding="utf-8")
+
+        result = _read_tail(
+            log_file,
+            3,
+            has_filters=True,
+            component_prefixes=("gateway",),
+        )
+
+        assert len(result) == 3
+        assert "gw msg 1" in result[0]
+        assert "gw msg 2" in result[1]
+        assert "gw msg 3" in result[2]
+
     def test_empty_file(self, tmp_path):
         log_file = tmp_path / "empty.log"
         log_file.write_text("")


### PR DESCRIPTION
## Summary
- Expand `hermes logs` filtered tail reads until enough matching lines are found or the file is exhausted.
- Add a regression test where older gateway log entries are followed by more than the previous 2000-line scan window of non-matching tool logs.

## Root cause
Filtered log views used a fixed raw tail window (`max(num_lines * 20, 2000)`) before applying `--component`, `--level`, `--session`, or `--since` filters. Sparse matching entries outside that window were silently omitted even though callers asked for the last N matching lines.

## Validation
- `./scripts/run_tests.sh tests/hermes_cli/test_logs.py::TestReadTail::test_filtered_tail_expands_past_recent_non_matches`
- `./scripts/run_tests.sh tests/hermes_cli/test_logs.py`
- `.venv/bin/ruff check hermes_cli/logs.py tests/hermes_cli/test_logs.py`
- `git diff --check`