### PR TITLE
fix(web): open language menu above footer button

### DIFF
--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -69,7 +69,7 @@ export function LanguageSwitcher() {
         <div
           role="listbox"
           aria-label={t.language.switchTo}
-          className="absolute right-0 top-full mt-1 z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto"
+          className="absolute right-0 bottom-full mb-1 z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto"
         >
           {allLocales.map(([code, meta]) => {
             const selected = code === locale;


### PR DESCRIPTION
## Summary
- Open the dashboard language picker upward from the footer button instead of downward.
- Prevent the locale dropdown from being clipped/off-screen when the switcher sits near the bottom edge.

## Test Plan
- `cd web && npm run build`
- `git diff --check`
