### PR TITLE
fix(markdown): preserve escaped pipes in table cells

### DIFF
--- a/agent/markdown_tables.py
+++ b/agent/markdown_tables.py
@@ -62,15 +62,34 @@ def _pad_to_width(s: str, target: int) -> str:
     return s + " " * max(0, target - _disp_width(s))
 
 
+def _is_escaped_pipe(row: str, index: int) -> bool:
+    backslashes = 0
+    cursor = index - 1
+    while cursor >= 0 and row[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 1
+
+
 def split_table_row(row: str) -> List[str]:
     """Split ``| a | b | c |`` into ``["a", "b", "c"]`` with trims."""
 
     s = row.strip()
-    if s.startswith("|"):
+    if s.startswith("|") and not _is_escaped_pipe(s, 0):
         s = s[1:]
-    if s.endswith("|"):
+    if s.endswith("|") and not _is_escaped_pipe(s, len(s) - 1):
         s = s[:-1]
-    return [c.strip() for c in s.split("|")]
+
+    cells: List[str] = []
+    current: List[str] = []
+    for index, char in enumerate(s):
+        if char == "|" and not _is_escaped_pipe(s, index):
+            cells.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    cells.append("".join(current).strip())
+    return cells
 
 
 def is_table_divider(row: str) -> bool:

--- a/tests/agent/test_markdown_tables.py
+++ b/tests/agent/test_markdown_tables.py
@@ -43,6 +43,14 @@ def test_split_strips_outer_pipes_and_trims():
     assert split_table_row("a | b | c") == ["a", "b", "c"]
 
 
+def test_split_keeps_escaped_pipes_inside_cells():
+    assert split_table_row(r"| pattern | a \| b | ok |") == [
+        "pattern",
+        r"a \| b",
+        "ok",
+    ]
+
+
 def test_is_table_divider_handles_alignment_colons():
     assert is_table_divider("|---|---|")
     assert is_table_divider("| :--- | ---: | :---: |")
@@ -132,6 +140,23 @@ def test_already_aligned_ascii_table_remains_aligned():
     out = realign_markdown_tables(src).rstrip("\n").split("\n")
     offsets = [_column_offsets(row) for row in out]
     assert all(o == offsets[0] for o in offsets)
+
+
+def test_escaped_pipes_do_not_create_extra_columns():
+    src = dedent(
+        """\
+        | Pattern | Meaning |
+        |---------|---------|
+        | `a \\| b` | literal pipe |
+        | plain | no pipe |
+        """
+    )
+
+    out = realign_markdown_tables(src)
+    body_rows = [ln for ln in out.split("\n") if ln.strip().startswith("|")]
+
+    assert r"`a \| b`" in out
+    assert all(len(split_table_row(row)) == 2 for row in body_rows)
 
 
 def test_passes_non_table_lines_through_around_a_table():


### PR DESCRIPTION
## Summary
- Keep escaped Markdown table pipes (`\|`) inside their cell while splitting rows for realignment.
- Add regression coverage for both direct row splitting and full table realignment.

## Root cause
`split_table_row()` used a plain `str.split("|")`, so escaped literal pipes inside a Markdown table cell were treated as column separators. The realigner then padded/rendered an extra column and corrupted tables that contained examples like `` `a \| b` ``.

## Validation
- `./scripts/run_tests.sh tests/agent/test_markdown_tables.py::test_split_keeps_escaped_pipes_inside_cells tests/agent/test_markdown_tables.py::test_escaped_pipes_do_not_create_extra_columns`
- `./scripts/run_tests.sh tests/agent/test_markdown_tables.py`
- `.venv/bin/ruff check agent/markdown_tables.py tests/agent/test_markdown_tables.py`
- `git diff --check`