### PR TITLE
fix(hindsight): clear _session_turns after building retain content (#23724)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1444,6 +1444,8 @@ class HindsightMemoryProvider(MemoryProvider):
         logger.debug("sync_turn: retaining %d turns, total session content %d chars",
                      len(self._session_turns), sum(len(t) for t in self._session_turns))
         content = "[" + ",".join(self._session_turns) + "]"
+        num_turns = len(self._session_turns)
+        self._session_turns = []  # only send new turns next time; append preserves earlier content server-side
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1454,10 +1456,9 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(self._session_turns) * 2,
+            message_count=num_turns * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(self._session_turns)
         document_id, update_mode = self._resolve_retain_target(self._document_id)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async


### PR DESCRIPTION
## Summary

Fixes #23724.

`sync_turn()` was retaining the full accumulated session buffer on every call. On the `update_mode='append'` path (Hindsight >= 0.5.0), the server appended each payload — so retain #1 sent turns 1-N, retain #2 sent turns 1-2N, etc. Early turns were duplicated N times in the resulting document.

**Observed impact:** A 7-hour session grew to 667,098 chars / 1,155 memory units (~40x expected size). Comparable sessions were in the 15-20KB range.

## Fix

Two lines in `sync_turn()`:

1. Capture `num_turns = len(self._session_turns)` before clearing (so `message_count` metadata stays accurate)
2. `self._session_turns = []` immediately after building `content` — only the delta is sent; the server's append preserves prior retained turns

```python
content = "[" + ",".join(self._session_turns) + "]"
num_turns = len(self._session_turns)
self._session_turns = []  # only send new turns next time; append preserves earlier content server-side
```

## Relation to #20664

PR #20664 takes a different approach: switch to `update_mode='replace'` on a per-process document. That's a valid alternative — replace semantics sidestep the delta problem entirely. This PR implements the minimal delta-clear fix from the issue body, which works within the existing append architecture. Either approach resolves the duplication; the maintainers can choose which direction fits better.

## Testing

- Applied locally, deleted two bloated documents (667KB and 238KB), and the next session produced a ~250 char document for a single retain — linear growth confirmed.
- Ran `python3 -m py_compile plugins/memory/hindsight/__init__.py` — clean.