### PR TITLE
docs(jupyter-live-kernel): document zmq transport fallback and disable_check_xsrf pitfalls

### DIFF
--- a/skills/data-science/jupyter-live-kernel/SKILL.md
+++ b/skills/data-science/jupyter-live-kernel/SKILL.md
@@ -160,6 +160,17 @@ uv run "$SCRIPT" restart-run-all --path <notebook.ipynb> --save-outputs --compac
 8. **Occasional websocket timeouts** — some operations may timeout on first try,
    especially after a kernel restart. Retry once before escalating.
 
+9. **If websocket consistently times out on this host**, force zmq transport:
+   `uv run "$SCRIPT" execute --transport zmq ...`. Symptom: every execute returns
+   "Websocket execution may already have reached the kernel, so auto fallback was
+   skipped". The kernel actually ran fine (REST shows execution_state=idle and
+   execution_count increments) — only the websocket reply channel is broken.
+   zmq transport uses jupyter_client directly and sidesteps the issue.
+
+10. **When starting a fresh server for REST-only use**, add
+    `--ServerApp.disable_check_xsrf=True` — otherwise POST /api/sessions returns
+    `"'_xsrf' argument missing from POST"` and kernel session creation fails.
+
 ## Timeout Defaults
 
 The script has a 30-second default timeout per execution. For long-running


### PR DESCRIPTION
## What\n\nAdd two pitfalls to the `jupyter-live-kernel` skill, both encountered when running against a freshly started Jupyter server.\n\n### Pitfall #9 — Force zmq transport when websocket hangs\n\nOn some hosts the websocket reply channel hangs on every `execute` even though the kernel actually ran (REST shows `execution_state=idle` and `execution_count` increments). The symptom from the skill side is the error message:\n\n> Websocket execution may already have reached the kernel, so auto fallback was skipped\n\nThe workaround is to pass `--transport zmq` so the skill talks to the kernel through `jupyter_client` directly and sidesteps the broken websocket layer.\n\n### Pitfall #10 — `disable_check_xsrf` for REST-only flows\n\nA fresh `ServerApp` rejects `POST /api/sessions` with:\n\n> `_xsrf` argument missing from POST\n\nThe skill drives the server purely over REST, so no browser/cookie ever establishes an XSRF token. The fix is to start the server with `--ServerApp.disable_check_xsrf=True`.\n\n## Why\n\nBoth failure modes are easy to misdiagnose — pitfall #9 in particular looks like the kernel hung, when in fact only the reply path is broken. Documenting the symptom + the one-flag fix in the same place as the rest of the pitfalls section saves the next user from re-tracing the same investigation.\n\n## Scope\n\nPure docs change to `skills/data-science/jupyter-live-kernel/SKILL.md` — no code or behavior changes. +11 lines, 0 deletions, 0 lint targets.