### PR TITLE
chore: drop unused signal import in tts_tool, hoist webhook constant (salvage #27138)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -54,6 +54,13 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+_BUILTIN_DELIVER_PLATFORMS = {
+    "telegram", "discord", "slack", "signal", "sms", "whatsapp",
+    "matrix", "mattermost", "homeassistant", "email", "dingtalk",
+    "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
+    "qqbot", "yuanbao",
+}
+
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
@@ -238,12 +245,6 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
-        _BUILTIN_DELIVER_PLATFORMS = {
-            "telegram", "discord", "slack", "signal", "sms", "whatsapp",
-            "matrix", "mattermost", "homeassistant", "email", "dingtalk",
-            "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
-            "qqbot", "yuanbao",
-        }
         _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
         if not _is_known_platform:
             try:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -44,7 +44,6 @@ import queue
 import re
 import shlex
 import shutil
-import signal
 import subprocess
 import tempfile
 import threading


### PR DESCRIPTION
## Summary
Salvage of #27138 — two unrelated micro-fixes packaged together by the contributor.

## Changes
- `tools/tts_tool.py` — drop unused `import signal` (no `signal.` usage anywhere in the module).
- `gateway/platforms/webhook.py` — hoist `_BUILTIN_DELIVER_PLATFORMS` set from `send()` method body to module scope, so it's not reconstructed on every call.

## Validation
- `ruff check tools/tts_tool.py gateway/platforms/webhook.py` → clean.
- Imports OK.

Original PR: #27138 — credit preserved via rebase-merge.