### PR TITLE
fix: make streaming reasoning tag filter case-insensitive

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3848,8 +3848,8 @@ class HermesCLI:
         # suppress them during streaming too — unless show_reasoning is
         # enabled, in which case we route the inner content to the
         # reasoning display box instead of discarding it.
-        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>")
-        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>")
+        _OPEN_TAGS = ("<reasoning_scratchpad>", "<think>", "<reasoning>", "<thinking>", "<thought>")
+        _CLOSE_TAGS = ("</reasoning_scratchpad>", "</think>", "</reasoning>", "</thinking>", "</thought>")
 
         # Append to a pre-filter buffer first
         self._stream_prefilt = getattr(self, "_stream_prefilt", "") + text
@@ -3868,10 +3868,11 @@ class HermesCLI:
             self._stream_last_was_newline = True  # start of stream = boundary
 
         if not getattr(self, "_in_reasoning_block", False):
+            prefilt_lower = self._stream_prefilt.lower()
             for tag in _OPEN_TAGS:
                 search_start = 0
                 while True:
-                    idx = self._stream_prefilt.find(tag, search_start)
+                    idx = prefilt_lower.find(tag, search_start)
                     if idx == -1:
                         break
                     # Check if this is a block boundary position
@@ -3913,9 +3914,10 @@ class HermesCLI:
             if not getattr(self, "_in_reasoning_block", False):
                 # Check for partial tag match at the end
                 safe = self._stream_prefilt
+                prefilt_lower = self._stream_prefilt.lower()
                 for tag in _OPEN_TAGS:
                     for i in range(1, len(tag)):
-                        if self._stream_prefilt.endswith(tag[:i]):
+                        if prefilt_lower.endswith(tag[:i]):
                             safe = self._stream_prefilt[:-i]
                             break
                 if safe:
@@ -3928,8 +3930,9 @@ class HermesCLI:
         # Keep accumulating _stream_prefilt because close tags can arrive
         # split across multiple tokens (e.g. "</REASONING_SCRATCH" + "PAD>...").
         if getattr(self, "_in_reasoning_block", False):
+            prefilt_lower = self._stream_prefilt.lower()
             for tag in _CLOSE_TAGS:
-                idx = self._stream_prefilt.find(tag)
+                idx = prefilt_lower.find(tag)
                 if idx != -1:
                     self._in_reasoning_block = False
                     # When show_reasoning is on, route inner content to

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -97,12 +97,12 @@ class GatewayStreamConsumer:
     # Must stay in sync with cli.py _OPEN_TAGS/_CLOSE_TAGS and
     # run_agent.py _strip_think_blocks() tag variants.
     _OPEN_THINK_TAGS = (
-        "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
-        "<THINKING>", "<thinking>", "<thought>",
+        "<reasoning_scratchpad>", "<think>", "<reasoning>",
+        "<thinking>", "<thought>",
     )
     _CLOSE_THINK_TAGS = (
-        "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
-        "</THINKING>", "</thinking>", "</thought>",
+        "</reasoning_scratchpad>", "</think>", "</reasoning>",
+        "</thinking>", "</thought>",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram
@@ -272,12 +272,13 @@ class GatewayStreamConsumer:
         self._think_buffer = ""
 
         while buf:
+            lower_buf = buf.lower()
             if self._in_think_block:
                 # Look for the earliest closing tag
                 best_idx = -1
                 best_len = 0
                 for tag in self._CLOSE_THINK_TAGS:
-                    idx = buf.find(tag)
+                    idx = lower_buf.find(tag)
                     if idx != -1 and (best_idx == -1 or idx < best_idx):
                         best_idx = idx
                         best_len = len(tag)
@@ -302,7 +303,7 @@ class GatewayStreamConsumer:
                 for tag in self._OPEN_THINK_TAGS:
                     search_start = 0
                     while True:
-                        idx = buf.find(tag, search_start)
+                        idx = lower_buf.find(tag, search_start)
                         if idx == -1:
                             break
                         # Block-boundary check (mirrors cli.py logic)
@@ -339,7 +340,7 @@ class GatewayStreamConsumer:
                     held_back = 0
                     for tag in self._OPEN_THINK_TAGS:
                         for i in range(1, len(tag)):
-                            if buf.endswith(tag[:i]) and i > held_back:
+                            if lower_buf.endswith(tag[:i]) and i > held_back:
                                 held_back = i
                     if held_back:
                         self._accumulated += buf[:-held_back]

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -111,6 +111,18 @@ class TestRealReasoningBlock:
         cli._stream_delta("   <think>")
         assert cli._in_reasoning_block
 
+    @pytest.mark.parametrize(
+        "tag",
+        ["THINK", "Think", "ThInK", "THOUGHT", "REASONING", "Thinking"],
+    )
+    def test_reasoning_tags_are_case_insensitive(self, tag):
+        cli = _make_cli_stub()
+        cli._stream_delta(f"<{tag}>hidden reasoning</{tag}>Visible answer")
+        assert not cli._in_reasoning_block
+        full = "".join(cli._emitted)
+        assert full == "Visible answer"
+        assert "hidden reasoning" not in full
+
 
 class TestFlushRecovery:
     """_flush_stream should recover content from false-positive reasoning blocks."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1236,6 +1236,16 @@ class TestFilterAndAccumulate:
         c._filter_and_accumulate("<THINKING>caps</THINKING>answer")
         assert c._accumulated == "answer"
 
+    @pytest.mark.parametrize(
+        "tag",
+        ["THINK", "Think", "ThInK", "THOUGHT", "REASONING", "Thinking"],
+    )
+    def test_reasoning_tags_are_case_insensitive(self, tag):
+        c = _make_consumer()
+        c._filter_and_accumulate(f"<{tag}>hidden reasoning</{tag}>Visible answer")
+        assert c._accumulated == "Visible answer"
+        assert "hidden reasoning" not in c._accumulated
+
     def test_prose_mention_not_stripped(self):
         """<think> mentioned mid-line in prose should NOT trigger filtering."""
         c = _make_consumer()


### PR DESCRIPTION
## Summary

- Make the CLI streaming reasoning tag filter detect opening/closing tags case-insensitively.
- Make the gateway stream consumer reasoning tag filter detect opening/closing tags case-insensitively.
- Add regression tests for uppercase/title-case/mixed-case variants in both streaming paths.

Fixes #27288

## Test plan

- `/root/project/xclaw-project/hermes-agent/.venv/bin/python -m pytest -o addopts= --ignore=tests/integration --ignore=tests/e2e -m 'not integration' tests/gateway/test_stream_consumer.py tests/cli/test_stream_delta_think_tag.py -q`
