### PR TITLE
fix(skills): return None on skill load failure instead of truthy stub (salvage #27147)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -425,7 +425,7 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -466,6 +466,14 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_when_skill_load_fails(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "broken-skill")
+            scan_skill_commands()
+            with patch("agent.skill_commands._load_skill_payload", return_value=None):
+                msg = build_skill_invocation_message("/broken-skill", "do stuff")
+        assert msg is None
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []


### PR DESCRIPTION
## Summary
Salvage of #27147 — `build_skill_invocation_message()` returned a truthy stub string `[Failed to load skill: NAME]` when `_load_skill_payload()` failed, which bypassed every caller's `if msg:` failure branch and injected the stub into the conversation as the user message.

## Root cause
All three call sites (`cli.py`, `gateway/run.py`, `gateway/platforms/webhook.py`) check `if msg:` to detect failure. The truthy stub passes that check, so the agent receives `[Failed to load skill: foo]` as the user's message instead of either (a) the CLI's red error print or (b) the gateway path falling through to normal message processing.

## Changes
- `agent/skill_commands.py` — return `None` on load failure (matches the existing "skill not in cache" branch directly above).
- `tests/agent/test_skill_commands.py` — regression test mocking `_load_skill_payload` → `None`.

## Validation
- `scripts/run_tests.sh tests/agent/test_skill_commands.py -q` → 40/40 pass.

Original PR: #27147 — credit preserved via rebase-merge.