### PR TITLE
fix(update): auto-recover from stale remote-tracking refs in hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5092,6 +5092,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _ensure_acp_launcher,
     _ensure_fhs_path_guard,
     _ensure_uv_for_termux,
+    _fetch_with_stale_ref_recovery,
     _finish_dashboard_update_cleanup,
     _for_each_systemd_gateway_unit,
     _format_concurrent_instances_message,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5076,6 +5076,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_ensure_acp_launcher",
         "_ensure_fhs_path_guard",
         "_ensure_uv_for_termux",
+        "_fetch_with_stale_ref_recovery",
         "_finish_dashboard_update_cleanup",
         "_fleet_probe_expected_runtimes",
         "_filter_non_gateway_concurrent_instances",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2198,6 +2198,70 @@ def _run_logged_subprocess(cmd, *, cwd=None, env=None):
     _log_only_write(result.stdout or "")
     return result
 
+def _fetch_with_stale_ref_recovery(
+    git_cmd, remote: str, branch: str, cwd, depth_args: list[str] | None = None
+):
+    """Run ``git fetch <remote> <branch>`` with one-shot stale-ref recovery.
+
+    When a remote branch is force-pushed upstream or a dependabot/PR ref is
+    rewritten, ``$cwd/.git/refs/remotes/<remote>/...`` can be left pointing
+    at an object that no longer exists. The next fetch then aborts with:
+
+        fatal: bad object refs/remotes/<remote>/dependabot/...
+
+    ``git remote prune <remote>`` purges every dangling tracking ref in a
+    single call, so attempt it once and retry the same scoped fetch.
+
+    Critical invariant: the retry must stay branch-scoped. A bare
+    ``git fetch <remote>`` pulls every ref in the repo, which on a
+    non-single-branch checkout can stall for minutes. Both the original and
+    retried fetch keep the explicit ``<branch>`` argument. ``depth_args`` lets
+    callers preserve shallow-fetch flags such as ``--depth 1`` across both
+    attempts.
+    """
+    depth_args = depth_args or []
+    fetch_result = subprocess.run(
+        git_cmd + ["fetch"] + depth_args + [remote, branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if fetch_result.returncode == 0:
+        return fetch_result
+
+    stderr = fetch_result.stderr or ""
+    if f"bad object refs/remotes/{remote}/" not in stderr:
+        return fetch_result
+
+    print(
+        f"  ⚠ Detected stale remote-tracking ref in '{remote}'; "
+        f"running 'git remote prune {remote}' and retrying..."
+    )
+    prune_result = subprocess.run(
+        git_cmd + ["remote", "prune", remote],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if prune_result.returncode != 0:
+        return fetch_result
+
+    retried = subprocess.run(
+        git_cmd + ["fetch"] + depth_args + [remote, branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if retried.returncode == 0:
+        print("  ✓ Stale refs cleaned up; fetch succeeded.")
+    return retried
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -2284,22 +2348,16 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         else:
             # No upstream remote, or the upstream fetch failed — use origin.
             print("→ Fetching from origin...")
-            fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["origin", branch],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
+            fetch_result = _fetch_with_stale_ref_recovery(
+                git_cmd, "origin", branch, _m().PROJECT_ROOT, depth_args
             )
             upstream_exists = False
             compare_branch = f"origin/{branch}"
     else:
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch"] + depth_args + ["origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+        fetch_result = _fetch_with_stale_ref_recovery(
+            git_cmd, "origin", branch, _m().PROJECT_ROOT, depth_args
         )
         upstream_exists = False
         compare_branch = f"origin/{branch}"
@@ -2310,6 +2368,14 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             print("✗ Network error — cannot reach the remote repository.")
         elif "Authentication failed" in stderr or "could not read Username" in stderr:
             print("✗ Authentication failed — check your git credentials or SSH key.")
+        elif f"bad object refs/remotes/origin/" in stderr:
+            print("✗ Failed to fetch (stale remote refs).")
+            if stderr:
+                print(f"  {stderr.splitlines()[0]}")
+            print(
+                f"  Try manually: cd {_m().PROJECT_ROOT} && "
+                f"git remote prune origin && git fetch origin {branch}"
+            )
         else:
             print("✗ Failed to fetch.")
             if stderr:
@@ -3980,11 +4046,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         branch = _m()._resolve_update_branch(args)
 
         print("→ Fetching updates...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+        fetch_result = _fetch_with_stale_ref_recovery(
+            git_cmd, "origin", branch, _m().PROJECT_ROOT
         )
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
@@ -3996,6 +4059,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
             ):
                 print(
                     "✗ Authentication failed — check your git credentials or SSH key."
+                )
+            elif f"bad object refs/remotes/origin/" in stderr:
+                print("✗ Failed to fetch updates from origin (stale remote refs).")
+                if stderr:
+                    print(f"  {stderr.splitlines()[0]}")
+                print(
+                    f"  Try manually: cd {_m().PROJECT_ROOT} && "
+                    f"git remote prune origin && git fetch origin {branch}"
                 )
             else:
                 print("✗ Failed to fetch updates from origin.")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3297,6 +3297,8 @@ def _classify_fetch_failure(stderr: str) -> str:
         return "✗ Network error — cannot reach the remote repository."
     if "Authentication failed" in stderr or "could not read Username" in stderr:
         return "✗ Authentication failed — check your git credentials or SSH key."
+    if "bad object refs/remotes/" in stderr:
+        return "✗ Failed to fetch updates from origin (stale remote refs)."
     return "✗ Failed to fetch updates from origin."
 
 
@@ -3307,6 +3309,70 @@ def _print_fetch_failure(stderr: str) -> None:
     if stderr:
         print(f"  {stderr.splitlines()[0]}")
 
+
+def _fetch_with_stale_ref_recovery(
+    git_cmd, remote: str, branch: str, cwd, depth_args: list[str] | None = None
+):
+    """Run ``git fetch <remote> <branch>`` with one-shot stale-ref recovery.
+
+    When a remote branch is force-pushed upstream or a dependabot/PR ref is
+    rewritten, ``$cwd/.git/refs/remotes/<remote>/...`` can be left pointing
+    at an object that no longer exists. The next fetch then aborts with:
+
+        fatal: bad object refs/remotes/<remote>/dependabot/...
+
+    ``git remote prune <remote>`` purges every dangling tracking ref in a
+    single call, so attempt it once and retry the same scoped fetch.
+
+    Critical invariant: the retry must stay branch-scoped. A bare
+    ``git fetch <remote>`` pulls every ref in the repo, which on a
+    non-single-branch checkout can stall for minutes. Both the original and
+    retried fetch keep the explicit ``<branch>`` argument. ``depth_args`` lets
+    callers preserve shallow-fetch flags such as ``--depth 1`` across both
+    attempts.
+    """
+    depth_args = depth_args or []
+    fetch_result = subprocess.run(
+        git_cmd + ["fetch"] + depth_args + [remote, branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if fetch_result.returncode == 0:
+        return fetch_result
+
+    stderr = fetch_result.stderr or ""
+    if f"bad object refs/remotes/{remote}/" not in stderr:
+        return fetch_result
+
+    print(
+        f"  ⚠ Detected stale remote-tracking ref in '{remote}'; "
+        f"running 'git remote prune {remote}' and retrying..."
+    )
+    prune_result = subprocess.run(
+        git_cmd + ["remote", "prune", remote],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if prune_result.returncode != 0:
+        return fetch_result
+
+    retried = subprocess.run(
+        git_cmd + ["fetch"] + depth_args + [remote, branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if retried.returncode == 0:
+        print("  ✓ Stale refs cleaned up; fetch succeeded.")
+    return retried
 
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
@@ -3408,28 +3474,28 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         else:
             # No upstream remote, or the upstream fetch failed — use origin.
             print("→ Fetching from origin...")
-            fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["origin", branch],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
+            fetch_result = _fetch_with_stale_ref_recovery(
+                git_cmd, "origin", branch, _m().PROJECT_ROOT, depth_args
             )
             upstream_exists = False
             compare_branch = f"origin/{branch}"
     else:
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch"] + depth_args + ["origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+        fetch_result = _fetch_with_stale_ref_recovery(
+            git_cmd, "origin", branch, _m().PROJECT_ROOT, depth_args
         )
         upstream_exists = False
         compare_branch = f"origin/{branch}"
 
     if fetch_result.returncode != 0:
         _print_fetch_failure(fetch_result.stderr)
+        stderr = fetch_result.stderr or ""
+        if "bad object refs/remotes/origin/" in stderr:
+            print(
+                f"  Try manually: cd {_m().PROJECT_ROOT} && "
+                f"git remote prune origin && git fetch origin {branch}"
+            )
         sys.exit(1)
 
     # Verify the compare ref actually exists before asking rev-list about it.
@@ -6200,14 +6266,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  (removed stale git lock(s): %s)" % ", ".join(cleared))
 
         print("→ Fetching updates...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
+        fetch_result = _fetch_with_stale_ref_recovery(
+            git_cmd, "origin", branch, _m().PROJECT_ROOT
         )
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
+            stderr = fetch_result.stderr or ""
+            if "bad object refs/remotes/origin/" in stderr:
+                print(
+                    f"  Try manually: cd {_m().PROJECT_ROOT} && "
+                    f"git remote prune origin && git fetch origin {branch}"
+                )
             sys.exit(1)
 
         # Get current branch (returns literal "HEAD" when detached)
@@ -7018,7 +7087,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # shows ON while macOS re-prompts on every capture, and the modern prompt
         # has no Allow button, so users loop. One line of guidance after update
         # tells affected users how to complete the one-time re-grant.
-        if sys.platform == "darwin" and had_desktop_app_before_update:
+        has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)
+        if sys.platform == "darwin" and has_desktop_app:
             print()
             print(
                 "  ℹ macOS: if Hermes re-prompts for permissions you already "

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -776,6 +776,79 @@ class TestCmdUpdateCheckBranchFlag:
 
         return side_effect
 
+    def _check_stale_ref_side_effect(
+        self,
+        target_branch: str,
+        *,
+        upstream_fetch_ok: bool = True,
+    ):
+        """Mock a shallow ``update --check`` stale-ref recovery flow.
+
+        The invariant under review is that both origin fetch attempts preserve
+        ``--depth 1`` and the explicit branch argument.
+        """
+        state = {
+            "upstream_fetch_calls": [],
+            "origin_fetch_calls": [],
+            "prune_calls": 0,
+        }
+        stale_err = (
+            "error: refs/remotes/origin/dependabot/github_actions/"
+            "actions/setup-python-6.2.0 does not point to a valid object!\n"
+            "fatal: bad object refs/remotes/origin/dependabot/"
+            "github_actions/actions/setup-python-6.2.0\n"
+        )
+
+        def side_effect(cmd, **kwargs):
+            if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="true\n", stderr="")
+
+            if cmd[:2] == ["git", "fetch"] and "upstream" in cmd:
+                state["upstream_fetch_calls"].append(list(cmd))
+                if upstream_fetch_ok:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    128,
+                    stdout="",
+                    stderr="fatal: 'upstream' does not appear to be a git repository\n",
+                )
+
+            if cmd[:2] == ["git", "fetch"] and "origin" in cmd:
+                state["origin_fetch_calls"].append(list(cmd))
+                if len(state["origin_fetch_calls"]) == 1:
+                    return subprocess.CompletedProcess(
+                        cmd, 128, stdout="", stderr=stale_err
+                    )
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd == ["git", "remote", "prune", "origin"]:
+                state["prune_calls"] += 1
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd[:4] == ["git", "rev-parse", "--verify", "--quiet"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd == ["git", "rev-parse", "HEAD"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="local-sha\n", stderr="")
+
+            if cmd == ["git", "rev-parse", f"origin/{target_branch}"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="remote-sha\n", stderr=""
+                )
+
+            if cmd == ["git", "rev-parse", f"upstream/{target_branch}"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="remote-sha\n", stderr=""
+                )
+
+            if cmd[:2] == ["git", "rev-list"]:
+                raise AssertionError("shallow check path must not call rev-list")
+
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        return side_effect, state
+
     @patch("hermes_cli.config.detect_install_method", return_value="git")
     @patch("subprocess.run")
     def test_check_branch_compares_against_named_origin_branch(
@@ -849,6 +922,55 @@ class TestCmdUpdateCheckBranchFlag:
         # Compare ref is upstream/main (upstream fetch succeeded).
         rev_list_cmds = [c for c in commands if "rev-list" in c]
         assert any("upstream/main" in c for c in rev_list_cmds), rev_list_cmds
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_check_branch_stale_ref_retry_keeps_shallow_scoped_origin_fetch(
+        self, mock_run, _mock_method, capsys
+    ):
+        """Non-main ``--check`` origin retries preserve ``--depth 1`` and branch."""
+        mock_run.side_effect, state = self._check_stale_ref_side_effect("bb/gui")
+        args = SimpleNamespace(check=True, branch="bb/gui")
+
+        cmd_update(args)
+
+        out = capsys.readouterr().out
+        assert "stale remote-tracking ref" in out
+        assert state["prune_calls"] == 1
+        assert state["upstream_fetch_calls"] == []
+        assert state["origin_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "origin", "bb/gui"],
+            ["git", "fetch", "--depth", "1", "origin", "bb/gui"],
+        ]
+        assert ["git", "fetch", "origin", "bb/gui"] not in state["origin_fetch_calls"]
+        assert ["git", "fetch", "origin"] not in state["origin_fetch_calls"]
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_check_main_upstream_fallback_stale_ref_retry_keeps_shallow_origin_fetch(
+        self, mock_run, _mock_method, capsys
+    ):
+        """Main upstream fallback preserves ``--depth 1`` on both origin retries."""
+        mock_run.side_effect, state = self._check_stale_ref_side_effect(
+            "main", upstream_fetch_ok=False
+        )
+        args = SimpleNamespace(check=True, branch=None)
+
+        cmd_update(args)
+
+        out = capsys.readouterr().out
+        assert "Fetching from upstream" in out
+        assert "Fetching from origin" in out
+        assert state["prune_calls"] == 1
+        assert state["upstream_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "upstream", "main"]
+        ]
+        assert state["origin_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "origin", "main"],
+            ["git", "fetch", "--depth", "1", "origin", "main"],
+        ]
+        assert ["git", "fetch", "origin", "main"] not in state["origin_fetch_calls"]
+        assert ["git", "fetch", "origin"] not in state["origin_fetch_calls"]
 
 
 class TestCmdUpdateZipBranchRefusal:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -556,6 +556,79 @@ class TestCmdUpdateCheckBranchFlag:
 
         return side_effect
 
+    def _check_stale_ref_side_effect(
+        self,
+        target_branch: str,
+        *,
+        upstream_fetch_ok: bool = True,
+    ):
+        """Mock a shallow ``update --check`` stale-ref recovery flow.
+
+        The invariant under review is that both origin fetch attempts preserve
+        ``--depth 1`` and the explicit branch argument.
+        """
+        state = {
+            "upstream_fetch_calls": [],
+            "origin_fetch_calls": [],
+            "prune_calls": 0,
+        }
+        stale_err = (
+            "error: refs/remotes/origin/dependabot/github_actions/"
+            "actions/setup-python-6.2.0 does not point to a valid object!\n"
+            "fatal: bad object refs/remotes/origin/dependabot/"
+            "github_actions/actions/setup-python-6.2.0\n"
+        )
+
+        def side_effect(cmd, **kwargs):
+            if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="true\n", stderr="")
+
+            if cmd[:2] == ["git", "fetch"] and "upstream" in cmd:
+                state["upstream_fetch_calls"].append(list(cmd))
+                if upstream_fetch_ok:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    128,
+                    stdout="",
+                    stderr="fatal: 'upstream' does not appear to be a git repository\n",
+                )
+
+            if cmd[:2] == ["git", "fetch"] and "origin" in cmd:
+                state["origin_fetch_calls"].append(list(cmd))
+                if len(state["origin_fetch_calls"]) == 1:
+                    return subprocess.CompletedProcess(
+                        cmd, 128, stdout="", stderr=stale_err
+                    )
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd == ["git", "remote", "prune", "origin"]:
+                state["prune_calls"] += 1
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd[:4] == ["git", "rev-parse", "--verify", "--quiet"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            if cmd == ["git", "rev-parse", "HEAD"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="local-sha\n", stderr="")
+
+            if cmd == ["git", "rev-parse", f"origin/{target_branch}"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="remote-sha\n", stderr=""
+                )
+
+            if cmd == ["git", "rev-parse", f"upstream/{target_branch}"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="remote-sha\n", stderr=""
+                )
+
+            if cmd[:2] == ["git", "rev-list"]:
+                raise AssertionError("shallow check path must not call rev-list")
+
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        return side_effect, state
+
     @patch("hermes_cli.config.detect_install_method", return_value="git")
     @patch("subprocess.run")
     def test_check_branch_compares_against_named_origin_branch(
@@ -629,6 +702,55 @@ class TestCmdUpdateCheckBranchFlag:
         # Compare ref is upstream/main (upstream fetch succeeded).
         rev_list_cmds = [c for c in commands if "rev-list" in c]
         assert any("upstream/main" in c for c in rev_list_cmds), rev_list_cmds
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_check_branch_stale_ref_retry_keeps_shallow_scoped_origin_fetch(
+        self, mock_run, _mock_method, capsys
+    ):
+        """Non-main ``--check`` origin retries preserve ``--depth 1`` and branch."""
+        mock_run.side_effect, state = self._check_stale_ref_side_effect("bb/gui")
+        args = SimpleNamespace(check=True, branch="bb/gui")
+
+        cmd_update(args)
+
+        out = capsys.readouterr().out
+        assert "stale remote-tracking ref" in out
+        assert state["prune_calls"] == 1
+        assert state["upstream_fetch_calls"] == []
+        assert state["origin_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "origin", "bb/gui"],
+            ["git", "fetch", "--depth", "1", "origin", "bb/gui"],
+        ]
+        assert ["git", "fetch", "origin", "bb/gui"] not in state["origin_fetch_calls"]
+        assert ["git", "fetch", "origin"] not in state["origin_fetch_calls"]
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_check_main_upstream_fallback_stale_ref_retry_keeps_shallow_origin_fetch(
+        self, mock_run, _mock_method, capsys
+    ):
+        """Main upstream fallback preserves ``--depth 1`` on both origin retries."""
+        mock_run.side_effect, state = self._check_stale_ref_side_effect(
+            "main", upstream_fetch_ok=False
+        )
+        args = SimpleNamespace(check=True, branch=None)
+
+        cmd_update(args)
+
+        out = capsys.readouterr().out
+        assert "Fetching from upstream" in out
+        assert "Fetching from origin" in out
+        assert state["prune_calls"] == 1
+        assert state["upstream_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "upstream", "main"]
+        ]
+        assert state["origin_fetch_calls"] == [
+            ["git", "fetch", "--depth", "1", "origin", "main"],
+            ["git", "fetch", "--depth", "1", "origin", "main"],
+        ]
+        assert ["git", "fetch", "origin", "main"] not in state["origin_fetch_calls"]
+        assert ["git", "fetch", "origin"] not in state["origin_fetch_calls"]
 
 
 class TestCmdUpdateZipBranchRefusal:

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -157,6 +157,177 @@ def _make_update_side_effect(
 # ---------------------------------------------------------------------------
 
 
+def _make_stale_ref_side_effect(
+    retry_succeeds=True,
+    remote="origin",
+    branch="main",
+):
+    """Build a subprocess.run side_effect for stale-ref recovery flows."""
+    normal = _make_update_side_effect()[0]
+    state = {"fetch_calls": [], "prune_calls": 0}
+    stale_err = (
+        f"error: refs/remotes/{remote}/dependabot/github_actions/"
+        "actions/setup-python-6.2.0 does not point to a valid object!\n"
+        f"fatal: bad object refs/remotes/{remote}/dependabot/"
+        "github_actions/actions/setup-python-6.2.0\n"
+    )
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        is_fetch = (
+            "fetch" in joined and remote in joined and "rev-parse" not in joined
+        )
+        if is_fetch:
+            state["fetch_calls"].append(list(cmd))
+            if len(state["fetch_calls"]) == 1:
+                return SimpleNamespace(stdout="", stderr=stale_err, returncode=128)
+            if retry_succeeds:
+                return SimpleNamespace(stdout="", stderr="", returncode=0)
+            return SimpleNamespace(stdout="", stderr=stale_err, returncode=128)
+        if "remote" in joined and "prune" in joined and remote in joined:
+            state["prune_calls"] += 1
+            return SimpleNamespace(
+                stdout="* [pruned] origin/dependabot/...\n",
+                stderr="",
+                returncode=0,
+            )
+        return normal(cmd, **kwargs)
+
+    return side_effect, state
+
+
+def test_cmd_update_auto_prunes_and_retries_on_stale_remote_ref(
+    monkeypatch, tmp_path, capsys
+):
+    """A stale-ref fetch failure triggers ``git remote prune`` + retry."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+
+    side_effect, state = _make_stale_ref_side_effect(retry_succeeds=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "stale remote-tracking ref" in out
+    assert "git remote prune origin" in out
+    assert "Stale refs cleaned up" in out
+    assert "Failed to fetch updates from origin" not in out
+    assert state["prune_calls"] == 1
+    assert len(state["fetch_calls"]) == 2
+
+
+def test_cmd_update_stale_ref_retry_stays_branch_scoped(monkeypatch, tmp_path):
+    """Both fetches must stay ``git fetch origin <branch>``."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+
+    side_effect, state = _make_stale_ref_side_effect(retry_succeeds=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    for call in state["fetch_calls"]:
+        assert call == ["git", "fetch", "origin", "main"], (
+            f"stale-ref recovery dropped branch scope: {call!r}"
+        )
+
+
+def test_cmd_update_falls_through_to_manual_message_when_prune_does_not_help(
+    monkeypatch, tmp_path, capsys
+):
+    """If prune cannot resolve the breakage, show the manual recovery command."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None
+    )
+
+    side_effect, state = _make_stale_ref_side_effect(retry_succeeds=False)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(SimpleNamespace())
+    assert exc_info.value.code == 1
+
+    out = capsys.readouterr().out
+    assert state["prune_calls"] == 1
+    assert len(state["fetch_calls"]) == 2
+    assert "stale remote refs" in out
+    assert "git remote prune origin && git fetch origin" in out
+
+
+def test_cmd_update_network_error_does_not_trigger_prune(
+    monkeypatch, tmp_path, capsys
+):
+    """Network / auth failures must not trigger the prune branch."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    prune_calls = {"n": 0}
+    side_effect, _ = _make_update_side_effect(
+        fetch_fails=True,
+        fetch_stderr=(
+            "fatal: unable to access 'https://github.com/...': "
+            "Could not resolve host: github.com\n"
+        ),
+    )
+
+    def tracking(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "remote" in joined and "prune" in joined:
+            prune_calls["n"] += 1
+        return side_effect(cmd, **kwargs)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", tracking)
+
+    with pytest.raises(SystemExit):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert prune_calls["n"] == 0
+    assert "Network error" in out
+
+
+def test_fetch_with_stale_ref_recovery_helper_branch_scoping(monkeypatch):
+    """The helper must preserve the caller's branch argument across retry."""
+    calls = []
+    stale_err = (
+        "fatal: bad object refs/remotes/origin/dependabot/github_actions/"
+        "actions/setup-python-6.2.0\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        joined = " ".join(str(c) for c in cmd)
+        if "fetch" in joined and "rev-parse" not in joined:
+            fetch_count = len(
+                [c for c in calls if "fetch" in " ".join(str(x) for x in c)]
+            )
+            if fetch_count == 1:
+                return SimpleNamespace(stdout="", stderr=stale_err, returncode=128)
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "prune" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    result = hermes_main._fetch_with_stale_ref_recovery(
+        ["git"], "origin", "feature/x", "/some/cwd"
+    )
+
+    assert result.returncode == 0
+    fetch_calls = [c for c in calls if "fetch" in " ".join(str(x) for x in c)]
+    assert len(fetch_calls) == 2
+    for call in fetch_calls:
+        assert call == ["git", "fetch", "origin", "feature/x"], (
+            f"helper dropped branch scope on retry: {call!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Fetch failure — friendly error messages
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Fixes a recurring support-thread issue.** Recent example: [support-threads / can_t_update_hermes](https://discord.com/channels/1053877538025386074/1505262545370349638) where `progged` needed 10+ messages of manual `git update-ref -d` surgery before `hermes update` would run again.

## Problem

When a remote branch is force-pushed upstream or a dependabot/PR ref is rewritten, `~/.hermes/hermes-agent/.git/refs/remotes/origin/...` can be left pointing at an object that no longer exists. The next `hermes update` then aborts in the initial `git fetch origin` with:

## Problem

When a remote branch is force-pushed upstream or a dependabot/PR ref is rewritten, `~/.hermes/hermes-agent/.git/refs/remotes/origin/...` can be left pointing at an object that no longer exists. The next `hermes update` then aborts in the initial `git fetch origin` with:

fatal: bad object refs/remotes/origin/dependabot/github_actions/actions/setup-python-6.2.0
✗ Failed to fetch updates from origin.

Previously the user had to run `git update-ref -d` by hand for each broken ref. The thread above found three broken refs in one go — none of which the user had created themselves.

## Fix

`git remote prune origin` purges every dangling remote-tracking ref in a single call, so the update flow now:

1. Detects `bad object refs/remotes/origin/` in the fetch stderr.
2. Runs `git remote prune origin` once.
3. Retries the fetch.
4. If recovery succeeds, prints `✓ Stale refs cleaned up; fetch succeeded.` and the rest of the update proceeds normally. Users see the original error only if the second fetch still fails.
5. If the retry also fails with the same bad-object error, prints the explicit manual recovery command (`cd ~/.hermes/hermes-agent && git remote prune origin && git fetch origin`) instead of the bare generic `Failed to fetch` message.

Network and authentication failures keep their existing dedicated error paths and never trigger the prune retry.

## Test plan

Added `TestCmdUpdateStaleRefRecovery` in `tests/hermes_cli/test_cmd_update.py` with three regression tests:

- `test_update_auto_prunes_and_retries_on_bad_object` — simulates a stale ref, verifies exactly one prune + retried fetch + recovery banner; the generic "Failed to fetch" path is not taken.
- `test_update_falls_through_to_manual_message_when_prune_does_not_help` — if prune cannot resolve the breakage, the user gets the explicit manual recovery command, not a bare error.
- `test_update_does_not_prune_on_unrelated_fetch_failure` — network / auth fetch failures must not trigger the prune branch.

**The first two tests fail on current main and pass with this patch.**

`tests/hermes_cli/test_cmd_update.py`: 13 passed.
Neighboring update tests (`autostash`, `yes_flag`, `hangup_protection`, `config_clears_custom_fields`): 46 passed.