### PR TITLE
docs: refresh README and wiki source facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ hermes-agent/
 ├── cron/                 # Scheduler — jobs.py, scheduler.py
 ├── scripts/              # run_tests.sh, release.py, auxiliary scripts
 ├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
+└── tests/                # Pytest suite (1,000+ test files; count changes frequently)
 ```
 
 **User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ hermes-agent/
 │   ├── config.py                 # Platform configuration resolution
 │   ├── session.py                # Session store, context prompts, reset policies
 │   └── platforms/                # Platform adapters
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│       ├── telegram.py, discord.py, slack.py, whatsapp.py
 │
 ├── scripts/                  # Installer and bridge scripts
 │   ├── install.sh                # Linux/macOS installer

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Run this in PowerShell:
 irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
 ```
 
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install).  Hermes uses this bundled Git Bash to run shell commands.
+The installer handles everything: uv, Python 3.11, Node.js 22, ripgrep, ffmpeg, **and a portable Git Bash** (PortableGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install).  Hermes uses this bundled Git Bash to run shell commands.
 
-If you already have Git installed, the installer detects it and uses that instead.  Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
+If you already have Git installed, the installer detects it and uses that instead. Otherwise it downloads a self-contained PortableGit build from the official Git-for-Windows release; on 32-bit Windows it falls back to MinGit, where bash-dependent terminal features are limited.
 
 > **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 **由 [Nous Research](https://nousresearch.com) 构建的自进化 AI 代理。** 它是唯一内置学习闭环的智能代理——从经验中创建技能，在使用中改进技能，主动持久化知识，搜索过往对话，并在跨会话中逐步构建对你的深度理解。可以在 $5 的 VPS 上运行，也可以在 GPU 集群上运行，或者使用几乎零成本的 Serverless 基础设施。它不绑定你的笔记本——你可以在 Telegram 上与它对话，而它在云端 VM 上工作。
 
-支持任意模型——[Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)（200+ 模型）、[NVIDIA NIM](https://build.nvidia.com)（Nemotron）、[小米 MiMo](https://platform.xiaomimimo.com)、[z.ai/GLM](https://z.ai)、[Kimi/Moonshot](https://platform.moonshot.ai)、[MiniMax](https://www.minimax.io)、[Hugging Face](https://huggingface.co)、OpenAI，或自定义端点。使用 `hermes model` 即可切换——无需改代码，无锁定。
+支持任意模型——[Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)（200+ 模型）、[NovitaAI](https://novita.ai)（Model API、Agent Sandbox 和 GPU Cloud）、[NVIDIA NIM](https://build.nvidia.com)（Nemotron）、[小米 MiMo](https://platform.xiaomimimo.com)、[z.ai/GLM](https://z.ai)、[Kimi/Moonshot](https://platform.moonshot.ai)、[MiniMax](https://www.minimax.io)、[Hugging Face](https://huggingface.co)、OpenAI，或自定义端点。使用 `hermes model` 即可切换——无需改代码，无锁定。
 
 <table>
 <tr><td><b>真正的终端界面</b></td><td>完整的 TUI，支持多行编辑、斜杠命令自动补全、对话历史、中断重定向和流式工具输出。</td></tr>
@@ -22,7 +22,7 @@
 <tr><td><b>闭环学习</b></td><td>代理管理记忆并定期自我提醒。复杂任务后自动创建技能。技能在使用中自我改进。FTS5 会话搜索配合 LLM 摘要实现跨会话回溯。<a href="https://github.com/plastic-labs/honcho">Honcho</a> 辩证式用户建模。兼容 <a href="https://agentskills.io">agentskills.io</a> 开放标准。</td></tr>
 <tr><td><b>定时自动化</b></td><td>内置 cron 调度器，支持向任何平台投递。日报、夜间备份、周审计——全部用自然语言描述，无人值守运行。</td></tr>
 <tr><td><b>委派与并行</b></td><td>生成隔离子代理处理并行工作流。编写 Python 脚本通过 RPC 调用工具，将多步管道压缩为零上下文开销的轮次。</td></tr>
-<tr><td><b>随处运行</b></td><td>六种终端后端——本地、Docker、SSH、Daytona、Singularity 和 Modal。Daytona 和 Modal 提供 Serverless 持久化——代理环境空闲时休眠、按需唤醒，空闲期间几乎零成本。$5 VPS 或 GPU 集群都能跑。</td></tr>
+<tr><td><b>随处运行</b></td><td>七种终端后端——本地、Docker、SSH、Singularity、Modal、Daytona 和 Vercel Sandbox。Daytona、Modal 和 Vercel Sandbox 可提供云端/Serverless 执行环境；代理环境可按需唤醒，空闲期间几乎零成本。$5 VPS 或 GPU 集群都能跑。</td></tr>
 <tr><td><b>研究就绪</b></td><td>批量轨迹生成、轨迹压缩——用于训练下一代工具调用模型。</td></tr>
 </table>
 
@@ -30,15 +30,25 @@
 
 ## 快速安装
 
+### Linux、macOS、WSL2、Termux
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```
 
-支持 Linux、macOS、WSL2 和 Android (Termux)。安装程序会自动处理平台特定的配置。
+### Windows（原生 PowerShell）— 早期 Beta
+
+> **提示：** 原生 Windows 支持处于**早期 Beta**。PowerShell 安装器可以安装并运行常见路径，但 Linux/macOS/WSL2 仍是最充分验证的环境。遇到问题请 [提交 issue](https://github.com/NousResearch/hermes-agent/issues)。如果你希望使用最稳定的 Windows 路径，请在 **WSL2** 中运行上面的 Linux/macOS 安装命令。
+
+在 PowerShell 中运行：
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
+
+Windows 安装器会处理 uv、Python 3.11、Node.js 22、ripgrep、ffmpeg，以及独立的 PortableGit/Git Bash（解压到 `%LOCALAPPDATA%\hermes\git`，无需管理员权限，不影响系统 Git）。Hermes 使用这个 Git Bash 执行 shell 命令；如果系统已有 Git，安装器会优先使用现有 Git。
 
 > **Android / Termux：** 已测试的手动安装路径请参考 [Termux 指南](https://hermes-agent.nousresearch.com/docs/getting-started/termux)。在 Termux 上，Hermes 会安装精选的 `.[termux]` 扩展，因为完整的 `.[all]` 扩展会拉取 Android 不兼容的语音依赖。
->
-> **Windows：** 原生 Windows 不受支持。请安装 [WSL2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 并运行上述命令。
 
 安装后：
 
@@ -155,10 +165,10 @@ cd hermes-agent
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uv venv venv --python 3.11
-source venv/bin/activate
+uv venv .venv --python 3.11
+source .venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
 ---

--- a/tests/test_readme_wiki_source_drift.py
+++ b/tests/test_readme_wiki_source_drift.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pathlib
+import re
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def _toolset_names() -> set[str]:
+    text = _read("toolsets.py")
+    match = re.search(r"TOOLSETS\s*=\s*\{(?P<body>.*?)(?:\n\}\n)", text, re.S)
+    if not match:
+        raise AssertionError("TOOLSETS mapping not found")
+    return set(re.findall(r"^[ \t]*[\"']([^\"']+)[\"']\s*:", match.group("body"), re.M))
+
+
+def _registered_tool_count() -> int:
+    total = 0
+    for path in (REPO_ROOT / "tools").glob("*.py"):
+        total += len(re.findall(r"registry\.register\s*\(", path.read_text(encoding="utf-8")))
+    return total
+
+
+def test_readmes_match_current_windows_install_and_terminal_backend_facts() -> None:
+    readme = _read("README.md")
+    readme_zh = _read("README.zh-CN.md")
+
+    assert "PortableGit" in readme
+    assert "Node.js 22" in readme
+    assert "Native Windows support is **early beta**" in readme
+
+    assert "NovitaAI" in readme_zh
+    assert "七种终端后端" in readme_zh
+    assert "Vercel Sandbox" in readme_zh
+    assert "install.ps1" in readme_zh
+    assert "原生 Windows 不受支持" not in readme_zh
+    assert "六种终端后端" not in readme_zh
+
+
+def test_contributor_docs_reference_real_gateway_platform_files_and_test_runner() -> None:
+    contributing = _read("CONTRIBUTING.md")
+    website_contributing = _read("website/docs/developer-guide/contributing.md")
+
+    assert (REPO_ROOT / "gateway/platforms/discord.py").exists()
+    assert "discord.py" in contributing
+    assert "discord_adapter.py" not in contributing
+
+    assert (REPO_ROOT / "scripts/run_tests.sh").exists()
+    assert "scripts/run_tests.sh" in contributing
+    assert "scripts/run_tests.sh" in website_contributing
+
+
+def test_architecture_docs_use_current_scale_claims_without_stale_exact_counts() -> None:
+    architecture = _read("website/docs/developer-guide/architecture.md")
+    agents = _read("AGENTS.md")
+
+    assert _registered_tool_count() >= 70
+    assert len(_toolset_names()) >= 50
+    assert "70+ statically registered tools across 50+ toolsets" in architecture
+    assert "~28 toolsets" not in architecture
+
+    assert len(list((REPO_ROOT / "tests").rglob("test_*.py"))) >= 1000
+    assert "1,000+ test files" in agents
+    assert "~17k tests" not in agents

--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -211,7 +211,7 @@ A shared runtime resolver used by CLI, gateway, cron, ACP, and auxiliary calls. 
 
 ### Tool System
 
-Central tool registry (`tools/registry.py`) with 70+ registered tools across ~28 toolsets. Each tool file self-registers at import time. The registry handles schema collection, dispatch, availability checking, and error wrapping. Terminal tools support 7 backends (local, Docker, SSH, Daytona, Modal, Singularity, Vercel Sandbox).
+Central tool registry (`tools/registry.py`) with 70+ statically registered tools across 50+ toolsets. Each tool file self-registers at import time. The registry handles schema collection, dispatch, availability checking, and error wrapping. Terminal tools support 7 user-facing backends (local, Docker, SSH, Daytona, Modal, Singularity, Vercel Sandbox), plus internal variants used by managed runtimes.
 
 → [Tools Runtime](./tools-runtime.md)
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -81,6 +81,10 @@ hermes chat -q "Hello"
 ### Run Tests
 
 ```bash
+# Preferred — matches CI parity checks and activates .venv/venv automatically
+scripts/run_tests.sh
+
+# Alternative after activating the venv
 pytest tests/ -v
 ```
 
@@ -185,7 +189,7 @@ refactor/description   # Code restructuring
 
 ### Before Submitting
 
-1. **Run tests**: `pytest tests/ -v`
+1. **Run tests**: prefer `scripts/run_tests.sh`; use `pytest tests/ -v` only after activating the dev venv
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: Consider macOS and different Linux distros
 4. **Keep PRs focused**: One logical change per PR

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -36,7 +36,7 @@ See the full **[Installation Guide](/docs/getting-started/installation)** for wh
 
 ## What is Hermes Agent?
 
-It's not a coding copilot tethered to an IDE or a chatbot wrapper around a single API. It's an **autonomous agent** that gets more capable the longer it runs. It lives wherever you put it — a $5 VPS, a GPU cluster, or serverless infrastructure (Daytona, Modal) that costs nearly nothing when idle. Talk to it from Telegram while it works on a cloud VM you never SSH into yourself. It's not tied to your laptop.
+It's not a coding copilot tethered to an IDE or a chatbot wrapper around a single API. It's an **autonomous agent** that gets more capable the longer it runs. It lives wherever you put it — a $5 VPS, a GPU cluster, or serverless infrastructure (Daytona, Modal, Vercel Sandbox) that costs nearly nothing when idle. Talk to it from Telegram while it works on a cloud VM you never SSH into yourself. It's not tied to your laptop.
 
 ## Quick Links
 
@@ -64,7 +64,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 ## Key Features
 
 - **A closed learning loop** — Agent-curated memory with periodic nudges, autonomous skill creation, skill self-improvement during use, FTS5 cross-session recall with LLM summarization, and [Honcho](https://github.com/plastic-labs/honcho) dialectic user modeling
-- **Runs anywhere, not just your laptop** — 6 terminal backends: local, Docker, SSH, Daytona, Singularity, Modal. Daytona and Modal offer serverless persistence — your environment hibernates when idle, costing nearly nothing
+- **Runs anywhere, not just your laptop** — 7 user-facing terminal backends: local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox. Cloud backends can keep agent environments available on demand while costing nearly nothing between active sessions
 - **Lives where you do** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk, Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat, and more — 20+ platforms from one gateway
 - **Built by model trainers** — Created by [Nous Research](https://nousresearch.com), the lab behind Hermes, Nomos, and Psyche. Works with [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), OpenAI, or any endpoint
 - **Scheduled automations** — Built-in cron with delivery to any platform


### PR DESCRIPTION
## Summary
- update README/Chinese README install and backend facts against current installer/runtime code
- refresh contributor and architecture docs for current gateway file names, test runner, tool/toolset scale, and test-suite scale
- add a focused drift test to catch recurring stale README/wiki source claims

## Verification
- `scripts/run_tests.sh tests/test_readme_wiki_source_drift.py -q`
- `npm run build` in `website/` (passes; Docusaurus reports pre-existing broken link/anchor warnings outside this change)
- custom stale-reference grep for old Windows/backend/toolset/test-count claims
