### PR TITLE
docs(README): link community fix for xAI OAuth callback failure on WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ If you already have Git installed, the installer detects it and uses that instea
 > **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
 >
 > **Windows:** Native Windows is supported as an **early beta** — the PowerShell one-liner above installs everything, but expect rough edges and please file issues when you hit them. If you'd rather use WSL2 (our most battle-tested Windows path), the Linux command works there too. Native Windows install lives under `%LOCALAPPDATA%\hermes`; WSL2 installs under `~/.hermes` as on Linux.  The only Hermes feature that currently needs WSL2 specifically is the browser-based dashboard chat pane (it uses a POSIX PTY — classic CLI and gateway both run natively).
+>
+> **WSL2 + xAI SuperGrok OAuth — known issue:** On WSL2 with mirrored networking (Microsoft's current default), `hermes auth add xai-oauth --type oauth` opens a loopback listener that the Windows Hyper-V Firewall blocks by default (`DefaultInboundAction = Block` on the WSL VM). The browser lands on xAI's "Could not establish connection" fallback page with the auth code as text, and Hermes has no `--code` flag to paste it back. Community-maintained fix (wrapper script + one-shot `New-NetFirewallHyperVRule` for the permanent fix): [jettoptx/hermes-xai-oauth-wsl](https://github.com/jettoptx/hermes-xai-oauth-wsl).
 
 After installation:
 


### PR DESCRIPTION
## Summary

Adds a one-paragraph callout in the `## Quick Install` section's Windows/WSL2 blockquote pointing at a community-maintained fix repo for the `hermes auth add xai-oauth --type oauth` callback failure on WSL2: [jettoptx/hermes-xai-oauth-wsl](https://github.com/jettoptx/hermes-xai-oauth-wsl).

Single insertion, two lines, no other changes.

## Why

After xAI shipped native SuperGrok OAuth (~2026-05-15), every WSL2 user trying to log in via Hermes hits this:

1. `hermes auth add xai-oauth --type oauth` opens an HTTP listener on `127.0.0.1:<ephemeral-port>/callback` inside WSL.
2. The Windows browser completes consent at `accounts.x.ai`.
3. xAI's `302 Found` redirect to the loopback URL is silently dropped by the **Hyper-V Firewall**'s default policy on the WSL VM (`DefaultInboundAction = Block`), which ships *enabled* with mirrored networking — Microsoft's current default.
4. xAI's "Could not establish connection" fallback page renders, showing the auth code as plain text.
5. Hermes (`v0.14.0`) has **no `--code` flag** on `hermes auth add`. The code is orphaned. The listener times out.

Verify the firewall block on any affected machine:

```powershell
Get-NetFirewallHyperVVMSetting -PolicyStore ActiveStore |
  Format-List Name, DefaultInboundAction, LoopbackEnabled
# DefaultInboundAction : Block   <-- root cause
```

The same flow breaks xAI's own [Grok Build CLI](https://x.ai/news/grok-build-cli), since Hermes impersonates the Grok-CLI `client_id` (`b1a00492-073a-47ea-816f-4c329264a828`) and both share the loopback redirect path.

## What the linked repo provides

- `scripts/hermes-xai-oauth-wsl.sh` — wrapper that starts the Hermes listener, prints the URL, prompts for the code from xAI's fallback page, and `curl`s the callback URL **from inside WSL** (same kernel as the listener, so the firewall is irrelevant). No admin required.
- `docs/permanent-fix.ps1` — elevated PowerShell that punches a one-time `New-NetFirewallHyperVRule` for the ephemeral TCP range, after which plain `hermes auth add xai-oauth --type oauth` works directly.
- Root cause writeup with the verify-the-block command and the NAT-vs-mirrored explanation.
- MIT license, signed commits, issue template.

## Why a docs link rather than a code PR

A real fix would add a `--code` flag to `hermes_cli/auth.py` (`_xai_oauth_loopback_login` around line 5315) so the wrapper becomes unnecessary. **I'm happy to follow up with that PR** if you want it — wanted to land the unblock for users today first, since the docs link is zero-risk and the code change touches an auth path that probably warrants its own review cycle.

If you'd prefer to vendor the script or write your own callout instead of linking out, also happy to defer — the point is that something in the README acknowledges this trap for WSL2 users.

## Test plan

- [x] README renders cleanly (verified with local markdown preview)
- [x] Existing WSL2 / Windows callouts unchanged
- [x] Diff is +2 lines, no formatting churn

Falls under priority 2 (cross-platform compatibility — WSL2) in [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#contribution-priorities).