### PR TITLE
fix(tools): run _run_post_setup() in _reconfigure_provider() for parity (salvage #26642)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2549,6 +2549,9 @@ def _reconfigure_provider(provider: dict, config: dict):
         else:
             _print_info("    Kept current")
 
+    if provider.get("post_setup"):
+        _run_post_setup(provider["post_setup"])
+
     # Imagegen backends prompt for model selection on reconfig too.
     plugin_name = provider.get("image_gen_plugin_name")
     if plugin_name:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1096,6 +1096,7 @@ AUTHOR_MAP = {
     "4296245+matthewlai@users.noreply.github.com": "matthewlai",
     "109617724+0xchainer@users.noreply.github.com": "0xchainer",  # PR #27154/27138/27147 salvage
     "201800237+kronexoi@users.noreply.github.com": "kronexoi",  # PR #27167 salvage (Teams port fallback)
+    "283442588+EloquentBrush0x@users.noreply.github.com": "EloquentBrush0x",  # PR #26642 salvage (post_setup parity)
     # batch salvage (May 2026 LHF run, group 2)
     "shellybotmoyer@example.com": "shellybotmoyer",  # PR #26661 (kanban --severity >=)
     "coulson@shellybotmoyer.com": "shellybotmoyer",  # PR #25576 (credential_pool ISO rehydrate)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -989,3 +989,30 @@ def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
     provider = {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []}
     _reconfigure_provider(provider, config)
     assert config["browser"]["use_gateway"] is False
+
+
+@pytest.mark.parametrize("provider_name,post_setup_key", [
+    ("Browserbase", "agent_browser"),
+    ("Browser Use", "agent_browser"),
+    ("Firecrawl", "agent_browser"),
+    ("Camofox", "camofox"),
+])
+def test_reconfigure_provider_runs_post_setup_for_env_var_providers(
+    monkeypatch, provider_name, post_setup_key
+):
+    """_reconfigure_provider() must call _run_post_setup() for providers that have
+    both env_vars and post_setup — parity with _configure_provider() line 2286."""
+    called = []
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", lambda key: called.append(key))
+    monkeypatch.setattr("hermes_cli.tools_config.get_env_value", lambda k: None)
+    monkeypatch.setattr("hermes_cli.tools_config._prompt", lambda *a, **kw: "")
+    monkeypatch.setattr("hermes_cli.tools_config.save_env_value", lambda k, v: None)
+
+    provider = next(
+        p
+        for p in TOOL_CATEGORIES["browser"]["providers"]
+        if p["name"] == provider_name
+    )
+    _reconfigure_provider(provider, {})
+
+    assert called == [post_setup_key]


### PR DESCRIPTION
## Summary
Salvage of #26642 — `_reconfigure_provider()` skipped the `_run_post_setup()` call that `_configure_provider()` runs on first-time setup (line 2286). For providers with both env vars AND a post-setup hook (Browserbase, Browser Use, Firecrawl, Camofox), reconfiguring via `hermes tools` saved the env values but never ran `npm install` — the browser tool then failed silently at runtime.

`_run_post_setup()` handles auto-install for browser node deps, Chromium, Camoufox engine, local TTS engines, etc. — see `hermes_cli/tools_config.py:671`. Without it, reconfigure is half a setup.

## Changes
- `hermes_cli/tools_config.py` — 3-line parity fix in `_reconfigure_provider()`.
- `tests/hermes_cli/test_tools_config.py` — parametrized test asserting post_setup fires for the four affected browser providers.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -q` → 70/70 pass.
- `ruff check` clean.

Original PR: #26642 — credit preserved via rebase-merge.