### PR TITLE
fix(weixin): opt into local STT for inbound voice messages (#27300)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -930,7 +930,9 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
-def _extract_text(item_list: List[Dict[str, Any]]) -> str:
+def _extract_text(
+    item_list: List[Dict[str, Any]], *, skip_voice_text: bool = False
+) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
             text = str((item.get("text_item") or {}).get("text") or "")
@@ -951,11 +953,12 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
                 if parts:
                     return f"[引用: {' | '.join(parts)}]\n{text}".strip()
             return text
-    for item in item_list:
-        if item.get("type") == ITEM_VOICE:
-            voice_text = str((item.get("voice_item") or {}).get("text") or "")
-            if voice_text:
-                return voice_text
+    if not skip_voice_text:
+        for item in item_list:
+            if item.get("type") == ITEM_VOICE:
+                voice_text = str((item.get("voice_item") or {}).get("text") or "")
+                if voice_text:
+                    return voice_text
     return ""
 
 
@@ -1179,6 +1182,16 @@ class WeixinAdapter(BasePlatformAdapter):
             or os.getenv("WEIXIN_SPLIT_MULTILINE_MESSAGES"),
             default=False,
         )
+        # When True, ignore Tencent Cloud's pre-baked voice_item.text and route
+        # the raw audio through Hermes' own STT pipeline. Tencent STT defaults
+        # to zh/en and garbles other languages, so non-Chinese users want this
+        # on. Off by default to preserve current behavior for Chinese users.
+        self._prefer_local_voice_stt = _coerce_bool(
+            extra.get("prefer_local_voice_stt")
+            if extra.get("prefer_local_voice_stt") is not None
+            else os.getenv("WEIXIN_PREFER_LOCAL_VOICE_STT"),
+            default=False,
+        )
 
         if self._account_id and not self._token:
             persisted = load_weixin_account(hermes_home, self._account_id)
@@ -1344,7 +1357,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         # Secondary content-fingerprint dedup for text messages
         item_list = message.get("item_list") or []
-        text = _extract_text(item_list)
+        text = _extract_text(item_list, skip_voice_text=self._prefer_local_voice_stt)
         if text:
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
@@ -1488,7 +1501,7 @@ class WeixinAdapter(BasePlatformAdapter):
     async def _download_voice(self, item: Dict[str, Any]) -> Optional[str]:
         voice_item = item.get("voice_item") or {}
         media = voice_item.get("media") or {}
-        if voice_item.get("text"):
+        if voice_item.get("text") and not self._prefer_local_voice_stt:
             return None
         try:
             data = await _download_and_decrypt_media(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -882,3 +882,173 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+
+class TestWeixinPreferLocalVoiceStt:
+    """Regression tests for Issue #27300 — Tencent Cloud's voice_item.text
+    is non-Chinese-language-hostile (it transcribes Russian/Arabic/etc. as
+    garbled English/Chinese). Operators can opt into routing the raw audio
+    through Hermes' own STT pipeline instead.
+    """
+
+    @staticmethod
+    def _voice_message() -> dict:
+        return {
+            "from_user_id": "wxid_user_ru",
+            "message_id": "voice-msg-1",
+            "item_list": [
+                {
+                    "type": weixin.ITEM_VOICE,
+                    "voice_item": {
+                        "text": "garbled tencent transcription",
+                        "media": {
+                            "encrypt_query_param": "eq",
+                            "aes_key": "ZmFrZQ==",
+                            "full_url": "https://cdn.example.com/v",
+                        },
+                    },
+                }
+            ],
+        }
+
+    def test_default_extract_text_returns_tencent_voice_text(self):
+        # Baseline (no opt-in): _extract_text returns Tencent's voice text so
+        # the message reaches the agent as garbled text. This is the current
+        # international-user-hostile behavior — the test pins it so the fix's
+        # opt-in stays opt-in.
+        item_list = self._voice_message()["item_list"]
+        assert weixin._extract_text(item_list) == "garbled tencent transcription"
+
+    def test_skip_voice_text_drops_tencent_voice_text(self):
+        item_list = self._voice_message()["item_list"]
+        assert weixin._extract_text(item_list, skip_voice_text=True) == ""
+
+    def test_extract_text_still_returns_real_text_items_when_skipping_voice(self):
+        # The skip flag only suppresses voice-item fallback. A real text item
+        # adjacent to a voice item must still come through.
+        item_list = [
+            {"type": weixin.ITEM_TEXT, "text_item": {"text": "hello"}},
+            {
+                "type": weixin.ITEM_VOICE,
+                "voice_item": {"text": "ignored"},
+            },
+        ]
+        assert weixin._extract_text(item_list, skip_voice_text=True) == "hello"
+
+    def test_download_voice_skips_audio_when_feature_off_and_tencent_text_present(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        # Feature off by default — Tencent's text wins, audio not fetched.
+        assert adapter._prefer_local_voice_stt is False
+
+        with patch.object(
+            weixin, "_download_and_decrypt_media", new_callable=AsyncMock
+        ) as download_mock:
+            result = asyncio.run(
+                adapter._download_voice(self._voice_message()["item_list"][0])
+            )
+
+        assert result is None
+        download_mock.assert_not_awaited()
+
+    def test_download_voice_fetches_audio_when_feature_on_even_with_tencent_text(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "prefer_local_voice_stt": True,
+                },
+            )
+        )
+        adapter._poll_session = object()
+
+        with patch.object(
+            weixin, "_download_and_decrypt_media", new_callable=AsyncMock
+        ) as download_mock, patch.object(
+            weixin, "cache_audio_from_bytes", return_value="/tmp/voice.silk"
+        ) as cache_mock:
+            download_mock.return_value = b"silk-bytes"
+            result = asyncio.run(
+                adapter._download_voice(self._voice_message()["item_list"][0])
+            )
+
+        assert result == "/tmp/voice.silk"
+        download_mock.assert_awaited_once()
+        cache_mock.assert_called_once_with(b"silk-bytes", ".silk")
+
+    def test_env_var_enables_feature(self):
+        with patch.dict(os.environ, {"WEIXIN_PREFER_LOCAL_VOICE_STT": "1"}, clear=False):
+            adapter = WeixinAdapter(
+                PlatformConfig(
+                    enabled=True,
+                    token="test-token",
+                    extra={"account_id": "test-account"},
+                )
+            )
+        assert adapter._prefer_local_voice_stt is True
+
+    def test_extra_false_overrides_env_true(self):
+        # Explicit extra:false must win over env:true (config locality).
+        with patch.dict(os.environ, {"WEIXIN_PREFER_LOCAL_VOICE_STT": "1"}, clear=False):
+            adapter = WeixinAdapter(
+                PlatformConfig(
+                    enabled=True,
+                    token="test-token",
+                    extra={
+                        "account_id": "test-account",
+                        "prefer_local_voice_stt": False,
+                    },
+                )
+            )
+        assert adapter._prefer_local_voice_stt is False
+
+    def test_process_message_with_feature_on_routes_audio_to_media(self):
+        # End-to-end: inbound voice message with Tencent text becomes a
+        # text-empty event whose media_urls contains the decrypted audio path,
+        # so the downstream agent / media pipeline can run local STT on it.
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "prefer_local_voice_stt": True,
+                },
+            )
+        )
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        with patch.object(
+            weixin, "_download_and_decrypt_media", new_callable=AsyncMock
+        ) as download_mock, patch.object(
+            weixin, "cache_audio_from_bytes", return_value="/tmp/voice.silk"
+        ):
+            download_mock.return_value = b"silk-bytes"
+            asyncio.run(adapter._process_message(self._voice_message()))
+
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        assert event.text == ""
+        assert "/tmp/voice.silk" in event.media_urls
+        assert "audio/silk" in event.media_types
+
+    def test_process_message_with_feature_off_uses_tencent_text(self):
+        # Baseline: with feature off, the existing behavior must be preserved
+        # — Tencent's text becomes the message text and no audio is fetched.
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        with patch.object(
+            weixin, "_download_and_decrypt_media", new_callable=AsyncMock
+        ) as download_mock:
+            asyncio.run(adapter._process_message(self._voice_message()))
+
+        download_mock.assert_not_awaited()
+        assert adapter.handle_message.await_count == 1
+        event = adapter.handle_message.await_args[0][0]
+        assert event.text == "garbled tencent transcription"
+        assert event.media_urls == []


### PR DESCRIPTION
## Summary

- Adds a `prefer_local_voice_stt` opt-in to the Weixin gateway so non-Chinese users can bypass Tencent Cloud's garbled voice transcription and route the raw audio through Hermes' own STT pipeline.
- Default off — preserves existing behavior for Chinese-speaking users who already get correct Tencent transcriptions.

## The bug

When Hermes receives a WeChat voice message, two paths in `gateway/platforms/weixin.py` short-circuit on Tencent Cloud's pre-baked `voice_item.text`:

1. `_extract_text` (~ line 1001) returns `voice_item.text` directly as the message body.
2. `_download_voice` (~ line 1529) aborts the SILK audio download whenever any `text` is present on the voice item.

Tencent's STT defaults to `zh`/`en` and produces garbled phonetic transcriptions for Russian, Arabic, and other non-CJK audio. The result is that the agent receives nonsense text and responds to it — effectively breaking voice messaging for international users.

## The fix

New opt-in `platforms.weixin.extra.prefer_local_voice_stt: true` (or env `WEIXIN_PREFER_LOCAL_VOICE_STT=1`):

- `_extract_text(item_list, *, skip_voice_text=False)` gains a keyword-only flag. The adapter passes `self._prefer_local_voice_stt`. When True, the voice-item text fallback is suppressed.
- `_download_voice` only honors the Tencent-text early-return when the opt-in is False, so the SILK audio is always fetched in opt-in mode.
- The existing `_collect_media` path then attaches the SILK file to `event.media_urls` / `event.media_types` and the downstream media + STT pipeline (mlx-whisper / whisper.cpp / etc.) handles it.

Default is False so this is a no-op upgrade for current installs.

## Test plan

- [x] Focused regression test: `tests/gateway/test_weixin.py::TestWeixinPreferLocalVoiceStt` — 9 tests covering `_extract_text`, `_download_voice`, env-var/extra precedence, and an end-to-end `_process_message` round-trip.
- [x] Adjacent suite: `tests/gateway/test_weixin.py` — all 62 prior tests still pass. (One unrelated baseline failure exists in `TestWeixinQrLogin::test_qr_login_timeout_uses_monotonic_clock` on clean `origin/main`; reproduces under `git stash` of this change, so not caused by this PR.)
- [x] Regression guard:
  - With feature OFF: `_extract_text` still returns Tencent text, `_download_voice` still returns None, `_process_message` produces the same garbled-text event.
  - With feature ON: `_extract_text` returns "", `_download_voice` fetches the audio, `_process_message` produces a text-empty event whose `media_urls` contains the audio path.

## Contract protected

- Invariant: existing Chinese-speaking deployments see no behavior change unless they explicitly opt in.
- Known-bad input: voice message with non-empty `voice_item.text` (Tencent transcribed) — opt-in routes through local STT instead of using the garbled text.
- Negative case: opt-in does not affect the text-only message path or content-dedup; real text items adjacent to a voice item still propagate normally.

## Related

- Fixes #27300