### PR TITLE
fix(video-gen): send FAL durations with suffix

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -269,8 +269,11 @@ def _build_payload(
 
     clamped = _clamp_duration(family, duration)
     if clamped is not None and family.get("durations"):
-        # FAL exposes duration as a string in the queue API ("8" not 8).
-        payload["duration"] = str(clamped)
+        # Some FAL endpoints (notably Veo 3.1) validate duration as
+        # literal strings with an "s" suffix ("4s", "6s", "8s") rather
+        # than bare numeric strings. FAL tolerates these suffixed values for
+        # current video endpoints, so prefer the documented API shape.
+        payload["duration"] = f"{clamped}s"
 
     if family.get("audio") and audio is not None:
         payload["generate_audio"] = bool(audio)
@@ -507,7 +510,7 @@ class FALVideoGenProvider(VideoGenProvider):
             prompt=prompt,
             modality=modality_used,
             aspect_ratio=aspect_ratio if "aspect_ratio" in payload else "",
-            duration=int(payload["duration"]) if "duration" in payload else 0,
+            duration=int(str(payload.get("duration", "0")).rstrip("s") or 0) if "duration" in payload else 0,
             provider="fal",
             extra=extra,
         )

--- a/tests/plugins/test_fal_video_gen_payload.py
+++ b/tests/plugins/test_fal_video_gen_payload.py
@@ -1,0 +1,37 @@
+"""Regression tests for FAL video-generation payload construction."""
+
+from __future__ import annotations
+
+from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+
+def test_veo31_duration_uses_fal_literal_suffix():
+    payload = _build_payload(
+        FAL_FAMILIES["veo3.1"],
+        prompt="smoke test",
+        image_url=None,
+        duration=4,
+        aspect_ratio="16:9",
+        resolution="720p",
+        negative_prompt=None,
+        audio=False,
+        seed=None,
+    )
+
+    assert payload["duration"] == "4s"
+
+
+def test_veo31_duration_clamps_then_suffixes():
+    payload = _build_payload(
+        FAL_FAMILIES["veo3.1"],
+        prompt="smoke test",
+        image_url=None,
+        duration=5,
+        aspect_ratio="16:9",
+        resolution="720p",
+        negative_prompt=None,
+        audio=None,
+        seed=None,
+    )
+
+    assert payload["duration"] in {"4s", "6s"}


### PR DESCRIPTION
## Summary
- Send FAL video generation durations with an `s` suffix (for example `4s`) to match Veo 3.1 validation.
- Parse suffixed duration strings when building the tool success response.
- Add regression tests for FAL payload construction.

## Test Plan
- `python -m py_compile plugins/video_gen/fal/__init__.py`
- `python -m pytest tests/plugins/test_fal_video_gen_payload.py -q -o addopts=`

Fixes #27309
