### PR TITLE
fix(gemini): accept video_url media parts

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -191,8 +191,9 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url"}:
+            media_key = "video_url" if ptype == "video_url" else "image_url"
+            url = ((item.get(media_key) or {}).get("url") or "")
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -326,3 +326,19 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].index == 0
     assert tool_chunks[1].choices[0].delta.tool_calls[0].index == 1
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
+
+
+def test_extract_multimodal_parts_accepts_video_url_data_urls():
+    from agent.gemini_native_adapter import _extract_multimodal_parts
+
+    parts = _extract_multimodal_parts([
+        {"type": "text", "text": "describe this video"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mp4;base64,QUJD"},
+        },
+    ])
+
+    assert parts[0] == {"text": "describe this video"}
+    assert parts[1]["inlineData"]["mimeType"] == "video/mp4"
+    assert parts[1]["inlineData"]["data"] == "QUJD"


### PR DESCRIPTION
## Summary
- Treat OpenAI-format `video_url` content parts as media inputs in the Gemini native adapter.
- Preserve existing `image_url` handling while mapping video data URLs into Gemini `inlineData`.
- Add a regression test for video data URLs.

## Test Plan
- `python -m py_compile agent/gemini_native_adapter.py`
- `python -m pytest tests/agent/test_gemini_native_adapter.py -q -o addopts=`

Fixes #27311
