### PR TITLE
feat(auxiliary): add zhipuai alias to PROVIDER_REGISTRY and _PROVIDER_ALIASES

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -139,6 +139,7 @@ _PROVIDER_ALIASES = {
     "z-ai": "zai",
     "z.ai": "zai",
     "zhipu": "zai",
+    "zhipuai": "zai",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "kimi-cn": "kimi-coding-cn",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -250,7 +250,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="Z.AI / GLM",
         auth_type="api_key",
         inference_base_url="https://api.z.ai/api/paas/v4",
-        api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
+        api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY", "ZHIPUAI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),
     "kimi-coding": ProviderConfig(
@@ -1401,7 +1401,7 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
-        "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
+        "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai", "zhipuai": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -83,6 +83,13 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_maps_zai_glm_aliases(self):
+        assert _normalize_aux_provider("glm") == "zai"
+        assert _normalize_aux_provider("zhipu") == "zai"
+        assert _normalize_aux_provider("zhipuai") == "zai"
+        assert _normalize_aux_provider("z-ai") == "zai"
+        assert _normalize_aux_provider("z.ai") == "zai"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -53,7 +53,7 @@ class TestProviderRegistry:
 
     def test_zai_env_vars(self):
         pconfig = PROVIDER_REGISTRY["zai"]
-        assert pconfig.api_key_env_vars == ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY")
+        assert pconfig.api_key_env_vars == ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY", "ZHIPUAI_API_KEY")
         assert pconfig.base_url_env_var == "GLM_BASE_URL"
 
     def test_xai_env_vars(self):


### PR DESCRIPTION
## Summary

Add `zhipuai` as a recognized provider alias for Z.AI / GLM in both `_PROVIDER_ALIASES` (auxiliary client) and `_PROVIDER_ALIASES` (auth), and add `ZHIPUAI_API_KEY` to the zai provider's `api_key_env_vars` tuple.

Closes #26880

## Problem

Users who want to use GLM/ZhipuAI as a first-class auxiliary provider currently need complex workarounds:

```yaml
auxiliary:
  vision:
    provider: custom
    base_url: https://open.bigmodel.cn/api/paas/v4
    api_key: <key>
```

This triggers the "custom" provider branch, which strips the provider identity, breaks provider-specific logic downstream (e.g., max_tokens skip for vision), and requires manual key config.

## Solution

After this PR, users can simply write:

```yaml
auxiliary:
  vision:
    provider: zhipuai   # or: glm, zhipu, z-ai, z.ai
    model: glm-4v-flash
```

API key is auto-resolved from `GLM_API_KEY` / `ZAI_API_KEY` / `ZHIPUAI_API_KEY`; base_url auto-resolved from `PROVIDER_REGISTRY`.

The existing normalization chain (`_normalize_aux_provider` → `_PROVIDER_ALIASES` → "zai") already handles `glm` and `zhipu`. This PR adds the missing `zhipuai` alias in both alias maps and adds `ZHIPUAI_API_KEY` to the recognized env vars.

## Files Changed

| File | Change |
|------|--------|
| `agent/auxiliary_client.py` | Add `"zhipuai": "zai"` to `_PROVIDER_ALIASES` |
| `hermes_cli/auth.py` | Add `"zhipuai": "zai"` to `_PROVIDER_ALIASES`; add `ZHIPUAI_API_KEY` to zai `api_key_env_vars` |
| `tests/agent/test_auxiliary_client.py` | New test `test_maps_zai_glm_aliases` |
| `tests/hermes_cli/test_api_key_providers.py` | Update `test_zai_env_vars` expectation |

## Test Results

```
tests/agent/test_auxiliary_client.py::TestNormalizeAuxProvider::test_maps_zai_glm_aliases PASSED
tests/hermes_cli/test_api_key_providers.py -k "zai" 11 passed
```

## Design Decisions

- No new PROVIDER_REGISTRY entry was added. The `zai` provider already exists with correct config. The alias system (`_PROVIDER_ALIASES`) is the right place to add name variants since both `_normalize_aux_provider` and the auth provider resolver use it.
- `zhipuai` was chosen as the new alias because it matches the official platform name (ZhipuAI / 智谱AI).
