### PR TITLE
fix(telegram): handle blog review callbacks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2897,6 +2897,76 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- Blog review callbacks (br:approve|reject:review_id) ---
+        if data.startswith("br:"):
+            parts = data.split(":", 2)
+            if len(parts) != 3 or parts[1] not in {"approve", "reject"}:
+                await query.answer(text="Invalid blog review action.")
+                return
+            action = parts[1]
+            review_id = parts[2]
+            bridge_dir = _Path("/home/hermes/didik-bridge")
+            bridge_env = bridge_dir / ".env"
+            allowed_user = os.getenv("ADMIN_USER_ID", "5978641389")
+            allowed_chat = os.getenv("GROUP_CHAT_ID", "-1003959197523")
+            if bridge_env.is_file():
+                try:
+                    for line in bridge_env.read_text().splitlines():
+                        line = line.strip()
+                        if not line or line.startswith("#") or "=" not in line:
+                            continue
+                        k, v = line.split("=", 1)
+                        v = v.strip().strip('"').strip("'")
+                        if k.strip() == "ADMIN_USER_ID":
+                            allowed_user = v
+                        elif k.strip() == "GROUP_CHAT_ID":
+                            allowed_chat = v
+                except Exception:
+                    pass
+            caller_id = str(getattr(query.from_user, "id", ""))
+            chat_id_str = str(query_chat_id) if query_chat_id is not None else ""
+            if caller_id != str(allowed_user):
+                await query.answer(text="⛔ Hanya Yoventius yang bisa approve/reject blog.")
+                return
+            if allowed_chat and chat_id_str != str(allowed_chat):
+                await query.answer(text="⛔ Tombol ini hanya aktif di approval group.")
+                return
+
+            await query.answer(text="Diproses…")
+            cmd = [sys.executable, str(bridge_dir / "bridge_cli.py"), action, review_id]
+            if action == "reject":
+                cmd.append("skipped via Telegram button")
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    cwd=str(bridge_dir),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=180)
+                ok = proc.returncode == 0
+                label = "✅ Approved" if action == "approve" else "⏭ Rejected / skipped"
+                if not ok:
+                    err = (stderr or stdout).decode("utf-8", "replace")[:300]
+                    label = f"⚠ Blog action failed: {err}"
+                user_display = getattr(query.from_user, "first_name", "User")
+                try:
+                    await query.edit_message_caption(
+                        caption=f"{label} by {user_display} · {review_id[:8]}",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    try:
+                        await query.edit_message_reply_markup(reply_markup=None)
+                    except Exception:
+                        pass
+                return
+            except Exception as exc:
+                logger.error("[%s] blog-review callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text=f"⚠ Gagal: {str(exc)[:120]}")
+                return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -378,6 +378,79 @@ class TestTelegramClarifyCallback:
 
 
 # ===========================================================================
+# Blog review callback dispatch — br:approve|reject:<review_id>
+# ===========================================================================
+
+class TestTelegramBlogReviewCallback:
+    """Verify Unitree blog approval buttons are admin- and group-gated."""
+
+    @staticmethod
+    def _query(data="br:approve:review-1234567890", *, user_id="5978641389", chat_id=-1003959197523):
+        query = AsyncMock()
+        query.data = data
+        query.message = MagicMock()
+        query.message.chat_id = chat_id
+        query.message.chat.type = "supergroup"
+        query.from_user = MagicMock()
+        query.from_user.id = user_id
+        query.from_user.first_name = "Yoventius"
+        query.answer = AsyncMock()
+        query.edit_message_caption = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+        return query
+
+    @pytest.mark.asyncio
+    async def test_authorized_approve_runs_bridge_cli_and_edits_caption(self):
+        adapter = _make_adapter()
+        query = self._query()
+        update = MagicMock()
+        update.callback_query = query
+
+        proc = SimpleNamespace(
+            returncode=0,
+            communicate=AsyncMock(return_value=(b"ok", b"")),
+        )
+
+        with patch.dict(
+            os.environ,
+            {"ADMIN_USER_ID": "5978641389", "GROUP_CHAT_ID": "-1003959197523"},
+            clear=False,
+        ), patch(
+            "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ) as create_proc:
+            await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_any_call(text="Diproses…")
+        create_proc.assert_called_once()
+        args = create_proc.call_args[0]
+        assert args[-2:] == ("approve", "review-1234567890")
+        query.edit_message_caption.assert_called_once()
+        assert "Approved" in query.edit_message_caption.call_args[1]["caption"]
+
+    @pytest.mark.asyncio
+    async def test_reject_denies_non_admin_without_running_bridge(self):
+        adapter = _make_adapter()
+        query = self._query(data="br:reject:review-1", user_id="111")
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(
+            os.environ,
+            {"ADMIN_USER_ID": "5978641389", "GROUP_CHAT_ID": "-1003959197523"},
+            clear=False,
+        ), patch(
+            "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+            AsyncMock(),
+        ) as create_proc:
+            await adapter._handle_callback_query(update, MagicMock())
+
+        create_proc.assert_not_called()
+        query.answer.assert_called_once()
+        assert "Hanya Yoventius" in query.answer.call_args[1]["text"]
+
+
+# ===========================================================================
 # Base adapter fallback render — text numbered list
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- add Telegram br:approve/br:reject callback handling for Unitree blog approval buttons
- gate actions to configured admin/group before invoking didik-bridge bridge_cli.py
- add tests for authorized approve and unauthorized reject paths

## Tests
- python -m pytest tests/gateway/test_telegram_clarify_buttons.py -q -o 'addopts='
- python -m pytest tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_approval_buttons.py -q -o 'addopts='
- python -m py_compile gateway/platforms/telegram.py