### PR TITLE
fix: preserve cwd for Codex handoffs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6087,8 +6087,19 @@ class HermesCLI:
         if not session_title:
             session_title = self.session_id[:8]
 
-        # Mark pending — gateway watcher will pick this up.
-        ok = self._session_db.request_handoff(self.session_id, platform_name)
+        # Mark pending — gateway watcher will pick this up. Capture the CLI
+        # working directory now because the gateway runs in a different process
+        # with its own terminal.cwd.
+        handoff_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+        try:
+            handoff_cwd = str(Path(handoff_cwd).expanduser().resolve())
+        except Exception:
+            handoff_cwd = str(handoff_cwd)
+        ok = self._session_db.request_handoff(
+            self.session_id,
+            platform_name,
+            cwd=handoff_cwd,
+        )
         if not ok:
             _cprint("  Session is already in flight for handoff. Wait for it to settle, then retry.")
             return True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3889,6 +3889,7 @@ class GatewayRunner:
 
         cli_session_id = row["id"]
         platform_name = (row.get("handoff_platform") or "").strip().lower()
+        handoff_cwd = (row.get("handoff_cwd") or "").strip()
         if not platform_name:
             raise RuntimeError("handoff_platform is empty")
 
@@ -3986,7 +3987,11 @@ class GatewayRunner:
         # ends the prior session in SQLite and reopens the CLI session under
         # the new key. The CLI's transcript becomes the active one for the
         # gateway from this moment on.
-        switched = self.session_store.switch_session(session_key, cli_session_id)
+        switched = self.session_store.switch_session(
+            session_key,
+            cli_session_id,
+            session_cwd=handoff_cwd or None,
+        )
         if switched is None:
             raise RuntimeError(
                 f"could not switch session key {session_key} → {cli_session_id}"
@@ -7710,6 +7715,7 @@ class GatewayRunner:
                 source=source,
                 session_id=session_entry.session_id,
                 session_key=session_key,
+                session_cwd=session_entry.session_cwd,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
@@ -14552,6 +14558,7 @@ class GatewayRunner:
         source: SessionSource,
         session_id: str,
         session_key: str = None,
+        session_cwd: Optional[str] = None,
         run_generation: Optional[int] = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
@@ -15327,6 +15334,9 @@ class GatewayRunner:
                         _cache[session_key] = (agent, _sig)
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
+
+            if session_cwd:
+                agent.session_cwd = session_cwd
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
@@ -16466,6 +16476,7 @@ class GatewayRunner:
                     source=next_source,
                     session_id=session_id,
                     session_key=session_key,
+                    session_cwd=session_cwd,
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -440,6 +440,7 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+    session_cwd: Optional[str] = None
     
     # Token tracking
     input_tokens: int = 0
@@ -500,6 +501,7 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "session_cwd": self.session_cwd,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -556,6 +558,7 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            session_cwd=data.get("session_cwd"),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -1154,6 +1157,7 @@ class SessionStore:
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                session_cwd=old_entry.session_cwd,
                 is_fresh_reset=True,
             )
 
@@ -1179,7 +1183,12 @@ class SessionStore:
 
         return new_entry
 
-    def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
+    def switch_session(
+        self,
+        session_key: str,
+        target_session_id: str,
+        session_cwd: Optional[str] = None,
+    ) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 
         Used by ``/resume`` to restore a previously-named session.
@@ -1201,6 +1210,10 @@ class SessionStore:
 
             # Don't switch if already on that session
             if old_entry.session_id == target_session_id:
+                if session_cwd:
+                    old_entry.session_cwd = session_cwd
+                    old_entry.updated_at = _now()
+                    self._save()
                 return old_entry
 
             db_end_session_id = old_entry.session_id
@@ -1215,6 +1228,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                session_cwd=session_cwd or old_entry.session_cwd,
             )
 
             self._entries[session_key] = new_entry

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -217,6 +217,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     api_call_count INTEGER DEFAULT 0,
     handoff_state TEXT,
     handoff_platform TEXT,
+    handoff_cwd TEXT,
     handoff_error TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
@@ -2876,7 +2877,12 @@ class SessionDB:
     # The CLI writes "pending" then poll-waits for terminal state. The gateway
     # watcher transitions pending→running→{completed,failed}.
 
-    def request_handoff(self, session_id: str, platform: str) -> bool:
+    def request_handoff(
+        self,
+        session_id: str,
+        platform: str,
+        cwd: Optional[str] = None,
+    ) -> bool:
         """Mark a session as pending handoff to the given platform.
 
         Returns True if the row was found and not already in flight; False if
@@ -2887,10 +2893,11 @@ class SessionDB:
                 "UPDATE sessions "
                 "SET handoff_state = 'pending', "
                 "    handoff_platform = ?, "
+                "    handoff_cwd = ?, "
                 "    handoff_error = NULL "
                 "WHERE id = ? AND (handoff_state IS NULL "
                 "                  OR handoff_state IN ('completed', 'failed'))",
-                (platform, session_id),
+                (platform, cwd, session_id),
             )
             return cur.rowcount > 0
         return self._execute_write(_do)
@@ -2898,12 +2905,12 @@ class SessionDB:
     def get_handoff_state(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Read the current handoff state for a session.
 
-        Returns ``{"state", "platform", "error"}`` or None if the session has
+        Returns ``{"state", "platform", "cwd", "error"}`` or None if the session has
         no handoff record.
         """
         try:
             cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
+                "SELECT handoff_state, handoff_platform, handoff_cwd, handoff_error "
                 "FROM sessions WHERE id = ?",
                 (session_id,),
             )
@@ -2913,6 +2920,7 @@ class SessionDB:
             return {
                 "state": row["handoff_state"],
                 "platform": row["handoff_platform"],
+                "cwd": row["handoff_cwd"],
                 "error": row["handoff_error"],
             }
         except Exception:
@@ -2963,4 +2971,3 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -469,6 +469,15 @@ def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Path | 
     return Path(os.path.abspath(str(Path.cwd() / expanded)))
 
 
+def _resolve_codex_app_server_cwd(agent: Any) -> str:
+    """Return the cwd used to spawn the Codex app-server subprocess."""
+    return str(
+        getattr(agent, "session_cwd", None)
+        or os.getenv("TERMINAL_CWD")
+        or os.getcwd()
+    )
+
+
 def _paths_overlap(left: Path, right: Path) -> bool:
     """Return True when two paths may refer to the same subtree."""
     left_parts = left.parts
@@ -16116,7 +16125,7 @@ class AIAgent:
         # Spawned on first turn, reused across turns, closed at AIAgent
         # shutdown (see _cleanup hook).
         if not hasattr(self, "_codex_session") or self._codex_session is None:
-            cwd = getattr(self, "session_cwd", None) or os.getcwd()
+            cwd = _resolve_codex_app_server_cwd(self)
             # Approval callback: defer to Hermes' standard prompt flow if a
             # CLI thread has installed one. Gateway / cron contexts get the
             # codex-side fail-closed default.

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -104,6 +104,34 @@ class TestMaybeApplyCodexAppServerRuntime:
         )
 
 
+class TestCodexAppServerCwd:
+    """Codex app-server should start in the handed-off CLI cwd when present."""
+
+    def test_prefers_session_cwd_over_terminal_env(self, monkeypatch, tmp_path) -> None:
+        from run_agent import _resolve_codex_app_server_cwd
+
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "gateway"))
+        agent = type("Agent", (), {"session_cwd": "/handoff/source"})()
+
+        assert _resolve_codex_app_server_cwd(agent) == "/handoff/source"
+
+    def test_falls_back_to_terminal_cwd(self, monkeypatch, tmp_path) -> None:
+        from run_agent import _resolve_codex_app_server_cwd
+
+        terminal_cwd = tmp_path / "terminal"
+        monkeypatch.setenv("TERMINAL_CWD", str(terminal_cwd))
+
+        assert _resolve_codex_app_server_cwd(object()) == str(terminal_cwd)
+
+    def test_falls_back_to_process_cwd(self, monkeypatch, tmp_path) -> None:
+        from run_agent import _resolve_codex_app_server_cwd
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        assert _resolve_codex_app_server_cwd(object()) == str(tmp_path)
+
+
 class TestCodexAppServerModule:
     """Module-surface tests for the JSON-RPC speaker. Don't require codex CLI."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -727,6 +727,46 @@ class TestSessionStoreSwitchSession:
         assert resumed["end_reason"] is None
         db.close()
 
+    def test_switch_session_can_override_session_cwd(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        store._db = None
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+        )
+        current_entry = store.get_or_create_session(source)
+        current_entry.session_cwd = "/old/work"
+
+        switched = store.switch_session(
+            current_entry.session_key,
+            "cli-session-1",
+            session_cwd="/handoff/work",
+        )
+
+        assert switched is not None
+        assert switched.session_id == "cli-session-1"
+        assert switched.session_cwd == "/handoff/work"
+
+    def test_session_entry_session_cwd_roundtrip(self):
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        entry = SessionEntry(
+            session_key="k",
+            session_id="s",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            session_cwd="/repo",
+        )
+
+        restored = SessionEntry.from_dict(entry.to_dict())
+        assert restored.session_cwd == "/repo"
+
 
 class TestWhatsAppSessionKeyConsistency:
     """Regression: WhatsApp session keys must collapse JID/LID aliases to a

--- a/tests/hermes_cli/test_session_handoff.py
+++ b/tests/hermes_cli/test_session_handoff.py
@@ -41,7 +41,7 @@ class TestHandoffStateDB:
 
     def test_columns_exist(self, db):
         db._conn.execute(
-            "SELECT handoff_state, handoff_platform, handoff_error "
+            "SELECT handoff_state, handoff_platform, handoff_cwd, handoff_error "
             "FROM sessions LIMIT 0"
         )
 
@@ -49,12 +49,13 @@ class TestHandoffStateDB:
         sid = "sess-1"
         self._make_session(db, sid)
 
-        assert db.request_handoff(sid, "telegram") is True
+        assert db.request_handoff(sid, "telegram", cwd="/work/source") is True
 
         state = db.get_handoff_state(sid)
         assert state == {
             "state": "pending",
             "platform": "telegram",
+            "cwd": "/work/source",
             "error": None,
         }
 
@@ -73,15 +74,16 @@ class TestHandoffStateDB:
     def test_request_handoff_after_terminal_state_resets_error(self, db):
         sid = "sess-3"
         self._make_session(db, sid)
-        db.request_handoff(sid, "telegram")
+        db.request_handoff(sid, "telegram", cwd="/old/work")
         db.claim_handoff(sid)
         db.fail_handoff(sid, "earlier failure")
 
         # User retries — should be allowed and clear the prior error.
-        assert db.request_handoff(sid, "discord") is True
+        assert db.request_handoff(sid, "discord", cwd="/new/work") is True
         state = db.get_handoff_state(sid)
         assert state["state"] == "pending"
         assert state["platform"] == "discord"
+        assert state["cwd"] == "/new/work"
         assert state["error"] is None
 
     def test_list_pending_handoffs_excludes_running_and_terminal(self, db):
@@ -89,7 +91,7 @@ class TestHandoffStateDB:
         for sid in (a, b, c, d):
             self._make_session(db, sid)
 
-        db.request_handoff(a, "telegram")
+        db.request_handoff(a, "telegram", cwd="/work/a")
         db.request_handoff(b, "discord")
         db.request_handoff(c, "telegram")
         db.claim_handoff(c)  # c is now running, not pending
@@ -100,6 +102,7 @@ class TestHandoffStateDB:
         pending = db.list_pending_handoffs()
         ids = [r["id"] for r in pending]
         assert set(ids) == {a, b}
+        assert {r["id"]: r["handoff_cwd"] for r in pending}[a] == "/work/a"
 
     def test_claim_handoff_is_atomic(self, db):
         sid = "sess-claim"


### PR DESCRIPTION
## What does this PR do?

Preserves the CLI working directory when `/handoff <platform>` moves a session into the gateway, so Codex app-server starts in the original project instead of the gateway install directory.

The change keeps the scope narrow:
- capture the CLI cwd when `/handoff` marks the session pending
- persist it on the handoff row and destination gateway session entry
- pass it to the cached `AIAgent` for that gateway session
- use it only when spawning the Codex app-server subprocess

## Why?

Without this, a handoff from a project directory can continue from Slack while Codex app-server starts from the Hermes install cwd, so Codex loads the wrong local context and answers from the wrong workspace.

Related: #21427 covers broader resume cwd restoration. This PR is narrower and handoff-specific.

## How has this been tested?

- `scripts/run_tests.sh tests/hermes_cli/test_session_handoff.py tests/gateway/test_session.py tests/agent/transports/test_codex_app_server_runtime.py -q`
- `git diff --check`

Platform tested: macOS.