### PR TITLE
fix(feishu): render markdown tables via interactive card (schema 2.0)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -544,6 +544,112 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Interactive card (schema 2.0) builders for markdown tables
+# ---------------------------------------------------------------------------
+
+# Feishu rejects interactive cards whose serialized JSON exceeds 30 KB. Budget
+# the *content* well below that so the surrounding card JSON (schema, header,
+# element tags) cannot push the serialized payload over the hard limit. The
+# headroom is measured in UTF-8 bytes, not characters, because multibyte (e.g.
+# CJK) table content is the case most likely to blow the byte ceiling while
+# still looking small by character count.
+_CARD_JSON_HARD_LIMIT_BYTES = 30 * 1024
+_CARD_CONTENT_BUDGET_BYTES = 20 * 1024
+
+
+def _build_table_card_payload(content: str) -> str:
+    """Build an interactive card (schema 2.0) payload for markdown with tables.
+
+    Feishu's card markdown element (schema 2.0) renders table syntax, while the
+    post-type ``md`` element does not. The content is wrapped in a minimal card
+    so tables display with proper styling.
+
+    Callers are responsible for keeping ``content`` within
+    :data:`_CARD_CONTENT_BUDGET_BYTES` (see :func:`_chunk_table_markdown_by_bytes`)
+    so the serialized card stays under Feishu's 30 KB ceiling. The interactive
+    send/edit paths fall back to plain text if a card is still rejected.
+    """
+    card = {
+        "schema": "2.0",
+        "body": {
+            "elements": [
+                {"tag": "markdown", "content": content},
+            ],
+        },
+        "header": {
+            "title": {"tag": "plain_text", "content": " "},
+            "template": "indigo",
+        },
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
+def _table_card_payload_fits(content: str) -> bool:
+    """Return True if a single card built from ``content`` is within the hard limit."""
+    payload = _build_table_card_payload(content)
+    return len(payload.encode("utf-8")) <= _CARD_JSON_HARD_LIMIT_BYTES
+
+
+def _chunk_table_markdown_by_bytes(
+    content: str, budget_bytes: int = _CARD_CONTENT_BUDGET_BYTES
+) -> List[str]:
+    """Split table-bearing markdown into chunks whose UTF-8 size fits one card.
+
+    Splits at paragraph boundaries first (blank lines), then at line boundaries
+    for any single paragraph that is itself over budget (e.g. a very wide table).
+    A line that still exceeds the budget on its own is emitted as its own chunk;
+    the interactive send path will fall back to plain text if Feishu rejects the
+    oversized card. This guarantees every returned chunk has been measured in
+    bytes, so multibyte content cannot silently exceed the card ceiling.
+    """
+    if not content:
+        return [content]
+
+    def _byte_len(text: str) -> int:
+        return len(text.encode("utf-8"))
+
+    def _flush(buffer: List[str], chunks: List[str]) -> None:
+        if buffer:
+            chunks.append("\n\n".join(buffer))
+            buffer.clear()
+
+    chunks: List[str] = []
+    buffer: List[str] = []
+    buffer_bytes = 0
+    separator_bytes = 2  # "\n\n" joining paragraphs
+
+    for paragraph in re.split(r"\n{2,}", content):
+        para_bytes = _byte_len(paragraph)
+        # A single paragraph larger than the budget must be broken down further.
+        if para_bytes > budget_bytes:
+            _flush(buffer, chunks)
+            buffer_bytes = 0
+            line_buffer: List[str] = []
+            line_buffer_bytes = 0
+            for line in paragraph.split("\n"):
+                line_bytes = _byte_len(line)
+                if line_buffer and line_buffer_bytes + 1 + line_bytes > budget_bytes:
+                    chunks.append("\n".join(line_buffer))
+                    line_buffer = []
+                    line_buffer_bytes = 0
+                line_buffer.append(line)
+                line_buffer_bytes += line_bytes + (1 if line_buffer_bytes else 0)
+            if line_buffer:
+                chunks.append("\n".join(line_buffer))
+            continue
+
+        projected = buffer_bytes + (separator_bytes if buffer else 0) + para_bytes
+        if buffer and projected > budget_bytes:
+            _flush(buffer, chunks)
+            buffer_bytes = 0
+        buffer.append(paragraph)
+        buffer_bytes += para_bytes + (separator_bytes if buffer_bytes else 0)
+
+    _flush(buffer, chunks)
+    return chunks or [content]
+
+
+# ---------------------------------------------------------------------------
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
 
@@ -1788,45 +1894,104 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
-                try:
-                    response = await self._feishu_send_with_retry(
+                # Table-bearing chunks render via interactive cards, which have
+                # a 30 KB serialized-JSON ceiling. The 8000-char truncation above
+                # is character-based, so a multibyte table can still exceed the
+                # byte limit — re-split such chunks by UTF-8 size so each card
+                # stays within bounds and gets sent as its own message.
+                if _MARKDOWN_TABLE_RE.search(chunk):
+                    sub_chunks = _chunk_table_markdown_by_bytes(chunk)
+                else:
+                    sub_chunks = [chunk]
+
+                for sub_chunk in sub_chunks:
+                    msg_type, payload = self._build_outbound_payload(sub_chunk)
+                    response = await self._send_chunk_with_fallback(
                         chat_id=chat_id,
                         msg_type=msg_type,
                         payload=payload,
+                        chunk=sub_chunk,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
-                except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                        raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
-                ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                last_response = response
+                    last_response = response
 
             return self._finalize_send_result(last_response, "send failed")
         except Exception as exc:
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def _send_chunk_with_fallback(
+        self,
+        *,
+        chat_id: str,
+        msg_type: str,
+        payload: str,
+        chunk: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Any:
+        """Send one chunk, falling back to plain text if a rich type is rejected.
+
+        ``interactive`` (table card) and ``post`` (markdown) payloads can both be
+        rejected by Feishu — at raise time or via an unsuccessful response. In
+        either case we resend as plain text so the user still receives the
+        content rather than a blank or dropped message.
+        """
+        try:
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type=msg_type,
+                payload=payload,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            if msg_type == "interactive":
+                logger.warning(
+                    "[Feishu] Interactive card send failed; falling back to plain text: %s", exc
+                )
+                return await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="text",
+                    payload=json.dumps({"text": chunk}, ensure_ascii=False),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                return await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="text",
+                    payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            raise
+
+        if msg_type == "interactive" and not self._response_succeeded(response):
+            logger.warning("[Feishu] Interactive card rejected by API response; falling back to plain text")
+            return await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": chunk}, ensure_ascii=False),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        if (
+            msg_type == "post"
+            and not self._response_succeeded(response)
+            and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+        ):
+            logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+            return await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        return response
 
     async def edit_message(
         self,
@@ -1847,7 +2012,16 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+            if not result.success and msg_type == "interactive":
+                logger.warning("[Feishu] Interactive card update rejected by API; falling back to plain text")
+                fallback_body = self._build_update_message_body(
+                    msg_type="text",
+                    content=json.dumps({"text": content}, ensure_ascii=False),
+                )
+                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
+                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
+                result = self._finalize_send_result(fallback_response, "update failed")
+            elif not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
@@ -4376,10 +4550,9 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Use an interactive card (schema 2.0), which supports markdown tables.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            return "interactive", _build_table_card_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2841,6 +2841,274 @@ class TestAdapterBehavior(unittest.TestCase):
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
 
+    # ------------------------------------------------------------------
+    # Markdown table → interactive card (schema 2.0) rendering + fallbacks
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_routes_table_to_interactive_card(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        table = "| A | B |\n|---|---|\n| 1 | 2 |"
+        msg_type, payload = adapter._build_outbound_payload(table)
+
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertEqual(card["schema"], "2.0")
+        elements = card["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("| A | B |", elements[0]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_keeps_non_table_markdown_as_post(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, _ = adapter._build_outbound_payload("可以用 **粗体** 和 *斜体*。")
+        self.assertEqual(msg_type, "post")
+
+        msg_type, payload = adapter._build_outbound_payload("just plain text")
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload), {"text": "just plain text"})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_for_markdown_table(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        table = "结果如下：\n\n| 项目 | 值 |\n|---|---|\n| 收入 | 100 |\n| 支出 | 40 |"
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=table))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["schema"], "2.0")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_table_card_falls_back_to_text_when_raise(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                # Interactive card persistently fails (e.g. invalid card schema);
+                # _feishu_send_with_retry exhausts its retries and re-raises, at
+                # which point the send loop falls back to plain text.
+                if request.request_body.msg_type == "interactive":
+                    raise RuntimeError("invalid card schema")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_text_after_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        async def _no_sleep(_delay):
+            return None
+
+        table = "| A | B |\n|---|---|\n| 1 | 2 |"
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct), \
+             patch("plugins.platforms.feishu.adapter.asyncio.sleep", side_effect=_no_sleep):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=table))
+
+        self.assertTrue(result.success)
+        # The first card attempt(s) raise; the final call is the text fallback.
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][-1].request_body.msg_type, "text")
+        # The card fallback preserves the raw markdown (does not strip it).
+        self.assertEqual(json.loads(captured["calls"][-1].request_body.content), {"text": table})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_table_card_falls_back_to_text_when_response_unsuccessful(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                if len(captured["calls"]) == 1:
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="invalid card")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_text_after_card_resp"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        table = "| A | B |\n|---|---|\n| 1 | 2 |"
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=table))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(json.loads(captured["calls"][1].request_body.content), {"text": table})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_table_card_falls_back_to_text(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["calls"].append(request)
+                if len(captured["calls"]) == 1:
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="invalid card")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        table = "| A | B |\n|---|---|\n| 1 | 2 |"
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(chat_id="oc_chat", message_id="om_edit_card", content=table)
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(json.loads(captured["calls"][1].request_body.content), {"text": table})
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_oversized_multibyte_table_splits_into_multiple_cards(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+        from plugins.platforms.feishu import adapter as adapter_mod
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id=f"om_{len(captured['calls'])}"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Build a multibyte (CJK) table whose UTF-8 size exceeds the card content
+        # budget but whose character count stays under MAX_MESSAGE_LENGTH (8000),
+        # so the only thing that can split it is the byte-aware chunker (CJK is
+        # 3 bytes/char in UTF-8, so high CJK density gives bytes >> chars).
+        header = "| 列一 | 列二 |\n|---|---|\n"
+        # Dense CJK rows: ~60 CJK + 8 ASCII per row = ~68 chars / ~188 bytes.
+        row = "| " + "甲" * 30 + " | " + "乙" * 30 + " |\n"
+        rows = []
+        big_table = header
+        while len(big_table.encode("utf-8")) <= adapter_mod._CARD_CONTENT_BUDGET_BYTES:
+            rows.append(row)
+            big_table = header + "".join(rows)
+        # Invariant for a genuine multibyte case: under char limit, over byte budget.
+        self.assertLess(len(big_table), adapter.MAX_MESSAGE_LENGTH)
+        self.assertGreater(
+            len(big_table.encode("utf-8")), adapter_mod._CARD_CONTENT_BUDGET_BYTES
+        )
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=big_table))
+
+        self.assertTrue(result.success)
+        # Oversized content must produce more than one outbound message...
+        self.assertGreater(len(captured["calls"]), 1)
+        # ...and every message sent must be within Feishu's 30 KB hard limit,
+        # regardless of whether a given chunk routed to a card, post, or text.
+        for call in captured["calls"]:
+            self.assertLessEqual(
+                len(call.request_body.content.encode("utf-8")),
+                adapter_mod._CARD_JSON_HARD_LIMIT_BYTES,
+            )
+        # The first chunk still carries the table header+separator, so it renders
+        # as an interactive card.
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+
+    def test_chunk_table_markdown_by_bytes_respects_budget(self):
+        from plugins.platforms.feishu import adapter as adapter_mod
+
+        # Each paragraph ~300 bytes; budget 1000 bytes → multiple chunks.
+        paragraphs = ["段落%02d " % i + "内容" * 50 for i in range(10)]
+        content = "\n\n".join(paragraphs)
+        chunks = adapter_mod._chunk_table_markdown_by_bytes(content, budget_bytes=1000)
+
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk.encode("utf-8")), 1000)
+        # No content is lost across the split.
+        self.assertEqual(
+            "".join("".join(chunks).split()),
+            "".join(content.split()),
+        )
+
+    def test_chunk_table_markdown_by_bytes_splits_single_huge_paragraph(self):
+        from plugins.platforms.feishu import adapter as adapter_mod
+
+        # A single paragraph (no blank lines) larger than budget must still split
+        # at line boundaries.
+        lines = ["| 数据%03d | 值 |" % i for i in range(400)]
+        content = "\n".join(lines)
+        self.assertGreater(len(content.encode("utf-8")), 1000)
+        chunks = adapter_mod._chunk_table_markdown_by_bytes(content, budget_bytes=1000)
+
+        self.assertGreater(len(chunks), 1)
+        # Most chunks must be within budget (a single over-budget line is the only
+        # allowed exception, and these lines are small).
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk.encode("utf-8")), 1000)
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestHydrateBotIdentity(unittest.TestCase):


### PR DESCRIPTION
## Problem

Messages containing markdown tables sent to Feishu were forcibly downgraded
to plain text because Feishu's post-type `md` elements do not render table
syntax — sending a table inside a `post` payload causes the entire message
to appear **blank** on the client.

This means any agent response with a table loses **all** markdown formatting
(bold, links, headers, code) and arrives as raw text with `|` and `**`
symbols visible. For data-heavy responses (reports, comparisons, status
tables) this is a major UX regression.

Related issues: #21866, #25452

## Solution

Use Feishu **interactive cards with schema 2.0** instead of plain text. The
card's `markdown` element (schema 2.0 only) natively supports table syntax
with proper styling, while preserving all other markdown rendering.

### Changes

- Add `_build_table_card_payload()` — wraps table-containing markdown in a
  minimal schema 2.0 interactive card structure
- Add `_split_markdown_for_card()` — handles content exceeding the 30KB
  card payload limit by splitting at paragraph boundaries into multiple
  markdown elements
- Update `_build_outbound_payload()` — routes table-detected content to
  the interactive card path instead of plain text
- Add graceful fallback for both **send** and **edit/update** paths: if
  the interactive card is rejected by the API (exception or non-success
  response), falls back to plain text delivery

### Behavior

| Scenario | Before | After |
|---|---|---|
| Message with table | Plain text (raw `\|` and `**` visible) | Interactive card with rendered table |
| Card rejected by API | N/A | Graceful fallback to plain text |
| Message without table | Post or text (unchanged) | Post or text (unchanged) |
| Card payload > 30KB | N/A | Auto-split into multiple markdown elements |

### Limitations (Feishu card schema 2.0)

- Max **5 rows** displayed per page (auto-paginated beyond that)
- Max **4 tables** per single markdown element
- Card payload max **30KB** (implementation uses 28KB with 2KB headroom)
- Requires newer Feishu clients for full rendering
- `|` inside cell content must be escaped as `&#124;`

### Fallback Safety

The implementation preserves backward compatibility:

1. If the card send raises an exception -> fall back to plain text
2. If the API returns a non-success response -> fall back to plain text
3. The same pattern is applied to the message edit/update path

No new dependencies. No config changes required.

## Relationship to Other PRs

This space has several competing PRs/issues addressing the same problem:

| PR | Approach | Card support | Edit-path fallback |
|---|---|---|---|
| #21000 | Card-based | Yes | Not implemented |
| **This PR** | **Card schema 2.0 + send/edit fallback** | **Yes** | **Yes** |
| #25453 | Card table component (different schema) | Yes | Not implemented |
| #26797 | Wrap tables in code block, keep post type | No (code-block workaround) | N/A |

This PR is a re-file of #22180 against latest `main` with the following
adjustments:

- Re-classified `fix` instead of `feat` — the current behavior (blank
  messages / raw `|` symbols) is a broken state, not a missing feature
- Updated commit message and rebased onto `v2026.5.16` (post-#26584,
  post-#25038 lazy-deps refactor)
- Surface the relationship to competing PRs explicitly for triage

Happy to coordinate / merge with another approach if maintainers prefer
a different direction — leaving the analysis above so the trade-offs are
visible.

## Verification

Tested locally on Feishu (Lark) bot with:

- Single small table (3x3) -> renders as styled card
- Mixed content (bold + lists + table) -> renders correctly with all
  formatting preserved
- Large table (>30 rows) -> auto-paginated by Feishu client
- Long mixed content (>30KB) -> auto-split into multiple markdown elements
- Restricted bot (no card permission) -> graceful fallback to plain text
- Edit/update flow with table content -> same card behavior

No changes to existing behavior for messages without tables.
