### PR TITLE
test(gateway): accept arbitrary kwargs in _install_fake_aiohttp to absorb trust_env

### DIFF
--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2740,8 +2740,8 @@ class _FakeAiohttpSession:
 
 def _install_fake_aiohttp(monkeypatch, session):
     fake_aiohttp = types.SimpleNamespace(
-        ClientSession=lambda timeout=None: session,
-        ClientTimeout=lambda total=None: None,
+        ClientSession=lambda *args, **kwargs: session,
+        ClientTimeout=lambda *args, **kwargs: None,
     )
     monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -763,8 +763,8 @@ def _install_fake_aiohttp(monkeypatch, session):
     """Replace ``aiohttp`` in ``sys.modules`` so ``import aiohttp as _aiohttp``
     inside ``_standalone_send`` picks up our fake."""
     fake_aiohttp = types.SimpleNamespace(
-        ClientSession=lambda timeout=None: session,
-        ClientTimeout=lambda total=None: None,
+        ClientSession=lambda *args, **kwargs: session,
+        ClientTimeout=lambda *args, **kwargs: None,
     )
     monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
 


### PR DESCRIPTION
## Summary

Widen the `_install_fake_aiohttp` helper lambdas in `tests/gateway/test_google_chat.py` and `tests/gateway/test_teams.py` to accept arbitrary keyword arguments. Currently four tests in `TestGoogleChatStandaloneSend` and `TestTeamsStandaloneSend` fail on every PR's CI run with `TypeError: lambda() got an unexpected keyword argument 'trust_env'`.

## The bug

Commit [c1ae18ee8](https://github.com/NousResearch/hermes-agent/commit/c1ae18ee8) (`fix(gateway): add trust_env=True to aiohttp sessions in SMS, Slack, Teams, Google Chat adapters`, merged 2026-05-17 via [#27308](https://github.com/NousResearch/hermes-agent/pull/27308)) added a new keyword argument to the production `aiohttp.ClientSession(...)` calls in both adapters:

- `plugins/platforms/google_chat/adapter.py:3249` — `async with _aiohttp.ClientSession(timeout=..., trust_env=True)`
- `plugins/platforms/teams/adapter.py:569` — `async with _aiohttp.ClientSession(trust_env=True)`

The fake `aiohttp.ClientSession` defined inside `_install_fake_aiohttp` in each test file is `lambda timeout=None: session` — it accepts only the `timeout` kwarg. When production now also passes `trust_env=True`, the lambda raises `TypeError`. The adapters catch the error in their broad `try`/`except` and surface it as the assertion mismatch in the CI log:

```
{'error': 'Google Chat standalone send failed: '
          '_install_fake_aiohttp.<locals>.<lambda>() got an unexpected keyword '
          "argument 'trust_env'"}
```

Failing tests (all four reproduce on clean `origin/main`):
- `tests/gateway/test_google_chat.py::TestGoogleChatStandaloneSend::test_standalone_send_refreshes_token_and_posts_message`
- `tests/gateway/test_google_chat.py::TestGoogleChatStandaloneSend::test_standalone_send_propagates_api_failure`
- `tests/gateway/test_teams.py::TestTeamsStandaloneSend::test_standalone_send_acquires_token_and_posts_activity`
- `tests/gateway/test_teams.py::TestTeamsStandaloneSend::test_standalone_send_propagates_token_failure`

## The fix

Change both helper lambdas to accept and ignore arbitrary args/kwargs:

```python
ClientSession=lambda *args, **kwargs: session,
ClientTimeout=lambda *args, **kwargs: None,
```

The fake's job is just to return the scripted session/timeout regardless of how the production code invokes it. This makes the helper resilient to future kwargs added to the production call sites without further test churn.

## Test plan

- [x] Confirmed `c1ae18ee8` lands `trust_env=True` in both adapters on current `origin/main`.
- [x] Confirmed only `tests/gateway/test_google_chat.py` and `tests/gateway/test_teams.py` define a `_install_fake_aiohttp` helper of this shape (`rg "fake_aiohttp|ClientSession=lambda" tests/` finds no other call sites).
- [x] Verified all 6 call sites in both files pass exactly `(monkeypatch, session)` — no caller depends on the lambda signature shape.
- [x] CI repro on every recent PR (e.g. [#27316 run 25983241078](https://github.com/NousResearch/hermes-agent/actions/runs/25983241078)) — four `_install_fake_aiohttp.<locals>.<lambda>() got an unexpected keyword argument 'trust_env'` failures.

Local repro is partially blocked because my dev install lacks `google-cloud-pubsub` and `googleapiclient`, so the test hits `service_account is None` before reaching the lambda. The fix is verifiable by inspection: a lambda with `*args, **kwargs` accepts every shape `(timeout=...)` was previously called with, plus the new `(trust_env=...)` call.

## Related

- Production change: [c1ae18ee8](https://github.com/NousResearch/hermes-agent/commit/c1ae18ee8) (merged in [#27308](https://github.com/NousResearch/hermes-agent/pull/27308))
- SMS and Slack adapters also gained `trust_env=True` in the same commit but neither has a `_install_fake_aiohttp` helper of this shape, so no companion fix is needed for them.