### PR TITLE
feat(cron): add `catchup` option to execute missed recurring jobs (closes #27327)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -626,6 +626,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    catchup: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -670,6 +671,15 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        catchup: When True and the gateway was down long enough for a scheduled
+                run to miss its grace window, execute the missed run immediately
+                on the next scheduler tick instead of silently fast-forwarding to
+                the next scheduled time.  Defaults to False (existing behaviour).
+                Only one catch-up run is emitted per missed period (the most
+                recent overdue run fires once, then the schedule resumes normally).
+                Useful for critical recurring jobs (backups, health-checks, daily
+                digests) where a missed run should be compensated rather than
+                silently skipped.  One-shot jobs are unaffected by this flag.
 
     Returns:
         The created job dict
@@ -704,6 +714,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_catchup = bool(catchup)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -757,6 +768,7 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "catchup": normalized_catchup,
     }
 
     with _jobs_lock():
@@ -838,6 +850,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         for i, job in enumerate(jobs):
             if job["id"] != job_id:
                 continue
+
+            # Normalize catchup flag if present in updates.
+            if "catchup" in updates:
+                updates["catchup"] = bool(updates["catchup"])
 
             # Validate / normalize workdir if present in updates.  Empty string
             # or None both mean "clear the field" (restore old behaviour).
@@ -1127,14 +1143,36 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             # For recurring jobs, check if the scheduled time is stale
-            # (gateway was down and missed the window). Fast-forward to
-            # the next future occurrence instead of firing a stale run.
+            # (gateway was down and missed the window). Default behaviour:
+            # fast-forward to the next future occurrence instead of firing
+            # a stale run.  When the job has ``catchup=True``, execute the
+            # missed run immediately once (single catch-up) and then let the
+            # schedule resume normally on the next tick.
             grace = _compute_grace_seconds(schedule)
             if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
                 new_next = compute_next_run(schedule, now.isoformat())
-                if new_next:
+                if job.get("catchup", False):
+                    # Catchup enabled: fire the missed run once, then advance
+                    # next_run_at so the scheduler doesn't re-fire on the
+                    # same stale slot on the following tick.
+                    logger.warning(
+                        "Job '%s' missed its scheduled time (%s, grace=%ds). "
+                        "Catchup enabled — executing now.",
+                        job.get("name", job["id"]),
+                        next_run,
+                        grace,
+                    )
+                    if new_next:
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["next_run_at"] = new_next
+                                needs_save = True
+                                break
+                    due.append(job)
+                    continue  # Job already appended above; skip the fallthrough append
+                elif new_next:
                     logger.info(
                         "Job '%s' missed its scheduled time (%s, grace=%ds). "
                         "Fast-forwarding to next run: %s",
@@ -1150,6 +1188,10 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
                     continue  # Skip this run
+                # If new_next is None (no computable next run for this stale
+                # recurring job), deliberately fall through to due.append(job)
+                # below so the run is surfaced to execution/mark_job_run and
+                # the recurring schedule error is not silently swallowed.
 
             due.append(job)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -219,6 +219,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        catchup=getattr(args, "catchup", False) or None,
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -233,6 +234,8 @@ def cron_create(args):
         print(f"  Script: {job_data['script']}")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    if job_data.get("catchup"):
+        print("  Catchup: enabled (missed runs fire once)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
     print(f"  Next run: {result['next_run_at']}")
@@ -281,6 +284,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        catchup=getattr(args, "catchup", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -298,6 +302,8 @@ def cron_edit(args):
         print(f"  Script: {updated['script']}")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    if updated.get("catchup"):
+        print("  Catchup: enabled (missed runs fire once)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
     return 0

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -67,6 +67,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--catchup",
+        dest="catchup",
+        action="store_true",
+        default=False,
+        help=(
+            "For recurring jobs: if a scheduled run is missed (gateway down, "
+            "scheduler busy), execute the missed run once on the next tick "
+            "instead of silently fast-forwarding to the next occurrence."
+        ),
+    )
+    cron_create.add_argument(
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -129,6 +140,24 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--catchup",
+        dest="catchup",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Enable catchup on this recurring job: a missed run fires once on "
+            "the next tick instead of being skipped."
+        ),
+    )
+    cron_edit.add_argument(
+        "--no-catchup",
+        dest="catchup",
+        action="store_const",
+        const=False,
+        help="Disable catchup on this job (missed runs fast-forward, the default).",
     )
     cron_edit.add_argument(
         "--workdir",

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -3,6 +3,7 @@
 import threading
 import pytest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from cron.jobs import (
     parse_duration,
@@ -847,6 +848,114 @@ class TestGetDueJobs:
         if recovered_dt.tzinfo is None:
             recovered_dt = recovered_dt.replace(tzinfo=timezone.utc)
         assert recovered_dt > now
+
+
+class TestCatchup:
+    """Tests for catchup=True behaviour in get_due_jobs."""
+
+    def test_catchup_false_stale_job_skipped(self, tmp_cron_dir):
+        """Default (catchup=False): a stale job outside the grace window is skipped."""
+        create_job(prompt="Stale", schedule="every 1h", catchup=False)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now(timezone.utc) - timedelta(minutes=35)).isoformat()
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        assert len(due) == 0
+
+    def test_catchup_true_stale_job_fires(self, tmp_cron_dir):
+        """catchup=True: a stale job outside the grace window executes immediately."""
+        job = create_job(prompt="Missed", schedule="every 1h", catchup=True)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now(timezone.utc) - timedelta(minutes=35)).isoformat()
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        assert len(due) == 1
+        assert due[0]["id"] == job["id"]
+
+    def test_catchup_true_advances_next_run(self, tmp_cron_dir):
+        """After a catchup fire, next_run_at is advanced to a future slot."""
+        from cron.jobs import _ensure_aware, _hermes_now
+        job = create_job(prompt="Missed", schedule="every 1h", catchup=True)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now(timezone.utc) - timedelta(minutes=35)).isoformat()
+        save_jobs(jobs)
+
+        get_due_jobs()
+
+        updated = get_job(job["id"])
+        next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
+        assert next_dt > _hermes_now()
+
+    def test_catchup_true_fires_once_not_multiple_times(self, tmp_cron_dir):
+        """Even when multiple periods were missed, only one catch-up run fires."""
+        job = create_job(prompt="Missed many", schedule="every 1h", catchup=True)
+        # Simulate 3 hours of downtime (way past a single period)
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        # Exactly one run despite 3 missed periods
+        assert len([j for j in due if j["id"] == job["id"]]) == 1
+
+    def test_catchup_within_grace_window_fires_normally(self, tmp_cron_dir):
+        """A job within its grace window fires regardless of catchup flag."""
+        job = create_job(prompt="In window", schedule="every 1h", catchup=False)
+        jobs = load_jobs()
+        # 10 min late is within 30-min grace for an hourly job
+        jobs[0]["next_run_at"] = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        assert len(due) == 1
+        assert due[0]["id"] == job["id"]
+
+    def test_catchup_stored_and_retrievable(self, tmp_cron_dir):
+        """catchup flag is persisted and readable via get_job."""
+        job = create_job(prompt="Test", schedule="every 1h", catchup=True)
+        retrieved = get_job(job["id"])
+        assert retrieved["catchup"] is True
+
+    def test_catchup_default_is_false(self, tmp_cron_dir):
+        """Jobs created without catchup= default to catchup=False."""
+        job = create_job(prompt="Default", schedule="every 1h")
+        retrieved = get_job(job["id"])
+        assert not retrieved.get("catchup", False)
+
+    def test_update_job_catchup(self, tmp_cron_dir):
+        """update_job can enable and disable catchup on an existing job."""
+        job = create_job(prompt="Updatable", schedule="every 1h", catchup=False)
+        updated = update_job(job["id"], {"catchup": True})
+        assert updated["catchup"] is True
+
+        updated2 = update_job(job["id"], {"catchup": False})
+        assert not updated2.get("catchup", True)
+
+    def test_stale_recurring_no_computable_next_still_due(self, tmp_cron_dir):
+        """Regression: a stale recurring job whose compute_next_run() returns
+        None must still be appended to ``due`` (so the recurring schedule error
+        surfaces via execution/mark_job_run) rather than being silently skipped.
+
+        Guards the upstream fallthrough that an earlier catchup change removed
+        with an ``else: continue``.
+        """
+        job = create_job(prompt="Stale no-next", schedule="every 1h", catchup=False)
+        jobs = load_jobs()
+        # Push next_run_at well outside the grace window so the stale-missed
+        # branch is taken.
+        jobs[0]["next_run_at"] = (
+            datetime.now(timezone.utc) - timedelta(hours=3)
+        ).isoformat()
+        save_jobs(jobs)
+
+        # Force compute_next_run to be uncomputable for this stale recurring job.
+        with patch("cron.jobs.compute_next_run", return_value=None):
+            due = get_due_jobs()
+
+        # The job is surfaced (not silently dropped) so the error path runs.
+        assert len([j for j in due if j["id"] == job["id"]]) == 1
 
 
 class TestEnabledToolsets:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -459,6 +459,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("catchup"):
+        result["catchup"] = True
     return result
 
 
@@ -482,6 +484,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    catchup: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -548,6 +551,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                catchup=bool(catchup) if catchup is not None else False,
             )
             return json.dumps(
                 {
@@ -695,6 +699,8 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if catchup is not None:
+                updates["catchup"] = bool(catchup)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -834,6 +840,20 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "catchup": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Default: False. When True, a recurring job that missed its scheduled run "
+                    "(because the gateway was down or the scheduler was blocked) will execute "
+                    "immediately on the next scheduler tick instead of silently fast-forwarding "
+                    "to the next future occurrence. Exactly one catch-up run fires per missed "
+                    "period — not one per skipped occurrence — then the normal schedule resumes. "
+                    "Useful for critical recurring jobs (backups, health-checks, daily digests) "
+                    "where a missed run should be compensated. Leave False (default) for jobs "
+                    "where running late makes no sense (e.g. \"send morning briefing\")."
+                ),
+            },
         },
         "required": ["action"]
     }
@@ -889,6 +909,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        catchup=args.get("catchup"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Adds a per-job `catchup` boolean to recurring cron jobs (default `false` for full backward compatibility).

When `catchup: true`, a recurring job that misses its scheduled run because the gateway was down (machine reboot, Docker restart, crash) or the scheduler was blocked executes immediately on the next tick instead of silently fast-forwarding to the next future occurrence.

This is analogous to systemd timer `Persistent=true` or AWS CloudWatch's catch-up behaviour.

Closes #27327

## Behaviour

| `catchup` | Gateway was down, job missed | Scheduler was busy, job missed |
|---|---|---|
| `false` (default) | Fast-forward to next run (current behaviour) | Fast-forward to next run (current behaviour) |
| `true` | **Execute immediately on next tick**, then resume normal schedule | **Execute immediately on next tick**, then resume normal schedule |

**Single catch-up only:** Exactly one catch-up run fires per missed period — not one per skipped occurrence. `next_run_at` is advanced to a future slot atomically with the due-job detection so the stale slot cannot re-fire on the next tick.

## Changes

### `cron/jobs.py`
- `create_job()` accepts a new `catchup: bool = False` parameter and stores it on the job dict.
- `update_job()` normalises `catchup` to `bool` when present in the updates dict.
- `_get_due_jobs_locked()` — before the existing fast-forward path, check `job.get("catchup")`: if `True`, append to `due` and advance `next_run_at`; if `False` (default), fast-forward as before.

### `tools/cronjob_tools.py`
- `cronjob()` function signature gains `catchup: Optional[bool] = None`.
- `create` action passes `catchup` through to `create_job()`.
- `update` action sets `updates["catchup"]` when provided.
- Job summary helper emits `catchup: True` when set.
- JSON schema updated with description for the new parameter.

## Tests

8 new tests in `tests/cron/test_jobs.py::TestCatchup`:

| Test | What it verifies |
|---|---|
| `test_catchup_false_stale_job_skipped` | Default (False): stale job outside grace window is skipped |
| `test_catchup_true_stale_job_fires` | True: stale job outside grace window executes immediately |
| `test_catchup_true_advances_next_run` | After catch-up fire, next_run_at is advanced to a future slot |
| `test_catchup_true_fires_once_not_multiple_times` | 3 missed periods → exactly 1 catch-up run |
| `test_catchup_within_grace_window_fires_normally` | Jobs within grace window fire regardless of catchup flag |
| `test_catchup_stored_and_retrievable` | Flag is persisted and readable |
| `test_catchup_default_is_false` | Jobs without catchup= default to False |
| `test_update_job_catchup` | update_job can toggle catchup on/off |

**Full test run:** `135 passed` in `tests/cron/test_jobs.py` and `tests/tools/test_cronjob_tools.py`.