### PR TITLE
Add user story: From smart home to intelligent home

### DIFF
--- a/website/src/data/userStories.json
+++ b/website/src/data/userStories.json
@@ -2605,5 +2605,16 @@
     "headline": "One agent, many roles: nutritionist, developer, finance advisor",
     "quote": "Users treat their AI agent as a unified personal assistant across life domains: health tracking, software dev, financial planning, language learning. Multi-role auto-routing with named roles.",
     "size": "sm"
+  },
+  {
+  "id": "telegram-samimk-intelligent-home",
+  "source": "telegram",
+  "author": "@samimk",
+  "url": "https://github.com/samimk",
+  "date": "2026-05",
+  "category": "integrations",
+  "headline": "From smart home to intelligent home — my agent watches, thinks, and acts",
+  "quote": "I have a fairly extensive smart home system built on OpenHAB — door and motion sensors in every room, IP cameras with object detection, presence detection, LoRaWAN gateway monitoring, night presence simulation, and more. After a few weeks of 'raising' my Hermes agent, I no longer reach for the OpenHAB interface or Alexa — I just tell it what I need or ask what happened, and it handles everything. It filters out noise and only surfaces events that actually matter, takes contextual actions based on circumstances — scanning cameras when doors open while nobody is home, sending annotated snapshots via Telegram, monitoring infrastructure health, and giving me comprehensive nightly reports. It even knows that movement on the stairs at 3am isn't an intruder — it's just the cat going for a snack. The system went from me checking dashboards to the system proactively telling me what matters. That's the difference between a smart home and an intelligent home powered by Hermes Agent.",
+  "size": "lg"
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Adds a user story about using Hermes Agent as the intelligent layer on top of an OpenHAB-based smart home system — transforming a traditional "smart home" (dashboards, manual checks, Alexa commands) into an "intelligent home" where the agent autonomously filters noise, takes contextual security actions, monitors infrastructure, and proactively reports what matters.

## Related Issue
N/A

## Fixes #
N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- website/src/data/userStories.json: Added one new user story entry (telegram-samimk-intelligent-home) to the end of the array

## How to Test

1. Open the website locally (npm run dev in website/)
2. Navigate to the user stories section
3. Verify the new story appears with correct headline, quote, author ([@samimk](https://t.me/samimk)), and size (lg)
4. Verify JSON is valid: node -e "JSON.parse(require('fs').readFileSync('website/src/data/userStories.json'))" (no errors)

## Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate user story submissions found
- [x] My PR contains only changes related to this feature
- [x] No pytest needed — this is a data file, not code
- [x] N/A — no code tests needed for a JSON data change
- [x] N/A — platform-independent change

Documentation & Housekeeping

- [x] N/A — no documentation changes needed beyond the user story itself
- [x] N/A — no config keys changed
- [x] N/A — no architecture changes
- [x] N/A — cross-platform irrelevant for JSON data
- [x] N/A — no tool behavior changes

## For New Skills

N/A — not a skill submission

## Screenshots / Logs

N/A — single JSON entry addition