### PR TITLE
fix(dashboard): block serving plugin backend python files

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4300,6 +4300,8 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         raise HTTPException(status_code=403, detail="Path traversal blocked")
     if not target.exists() or not target.is_file():
         raise HTTPException(status_code=404, detail="File not found")
+    if target.suffix.lower() in {".py", ".pyc", ".pyo"}:
+        raise HTTPException(status_code=404, detail="File not found")
 
     # Guess content type
     suffix = target.suffix.lower()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2050,6 +2050,27 @@ class TestDashboardPluginManifestExtensions:
             "chat:top",
         ]
 
+    @pytest.mark.asyncio
+    async def test_plugin_asset_route_does_not_serve_backend_python(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "python-backend", {
+            "name": "python-backend",
+            "label": "Python Backend",
+            "tab": {"path": "/python-backend"},
+            "entry": "dist/index.js",
+            "api": "plugin_api.py",
+        })
+        plugin_file = tmp_path / "plugins" / "python-backend" / "dashboard" / "plugin_api.py"
+        plugin_file.write_text("SECRET = 'should-not-be-static'\n")
+
+        from fastapi import HTTPException
+        from hermes_cli import web_server
+
+        web_server._dashboard_plugins_cache = None
+        with pytest.raises(HTTPException) as exc:
+            await web_server.serve_plugin_asset("python-backend", "plugin_api.py")
+        assert exc.value.status_code == 404
+
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.


### PR DESCRIPTION

## What does this PR do?

Prevents the dashboard plugin static asset route from serving backend Python files from a plugin's `dashboard/` directory.

Dashboard plugins can declare a backend API file such as `plugin_api.py`, which is mounted under `/api/plugins/<name>/`. The static asset route `/dashboard-plugins/{plugin_name}/{file_path}` is meant for frontend assets, but it currently serves any file under the plugin dashboard directory. This change keeps normal assets working while returning 404 for `.py`, `.pyc`, and `.pyo` files.

This is a narrow hardening change: backend API files remain importable by the plugin API mounting path, but are no longer exposed as static assets.

## Related Issue

N/A. I did not create a public issue because this is security-adjacent hardening and the project security policy asks contributors not to open public issues for security vulnerabilities.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Make `serve_plugin_asset()` return 404 for `.py`, `.pyc`, and `.pyo` files.
  - Leave existing path traversal protection and static asset content-type handling intact.

- `tests/hermes_cli/test_web_server.py`
  - Add a regression test proving `plugin_api.py` is not served through the dashboard static asset route.

## How to Test

1. Run the focused regression test:

```bash
/private/tmp/hermes-agent-test-venv/bin/python -m pytest -o addopts='' \
  tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions::test_plugin_asset_route_does_not_serve_backend_python \
  -q
```

2. Confirm the result:

```text
1 passed in 1.16s
```

3. Confirm whitespace/diff hygiene:

```bash
git diff --check HEAD~1..HEAD
```

No output means the check passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Python 3.13.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib`/suffix check, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ /private/tmp/hermes-agent-test-venv/bin/python -m pytest -o addopts='' \
  tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions::test_plugin_asset_route_does_not_serve_backend_python \
  -q

.                                                                        [100%]
1 passed in 1.16s
```