### PR TITLE
WAT-1374: add Pinecone memory indexer for topic files and session summaries

### DIFF
--- a/agent/memory_documents.py
+++ b/agent/memory_documents.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Literal, Sequence
+
+MemoryType = Literal[
+    "profile",
+    "project_context",
+    "session_summary",
+    "artifact_summary",
+    "ephemeral",
+]
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip())
+
+
+def _slugify_header(header: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", header.lower()).strip("-")
+    return slug or "root"
+
+
+def _iso8601(value: datetime | str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if isinstance(value, str):
+        return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+@dataclass(frozen=True)
+class MemorySourceRef:
+    source_kind: str
+    source_id: str
+    source_path: str = ""
+
+
+@dataclass(frozen=True)
+class MemoryChunk:
+    id: str
+    document_id: str
+    chunk_index: int
+    text: str
+    header_path: tuple[str, ...]
+    memory_type: MemoryType
+    scope: str
+    source_kind: str
+    source_id: str
+    source_path: str
+    created_at: str
+    updated_at: str
+    freshness_hint: str
+    confidence: float
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("MemoryChunk.text must be non-empty")
+        if not self.source_kind:
+            raise ValueError("MemoryChunk.source_kind is required")
+        if not self.source_id:
+            raise ValueError("MemoryChunk.source_id is required")
+        if not self.scope:
+            raise ValueError("MemoryChunk.scope is required")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("MemoryChunk.confidence must be between 0 and 1")
+
+    @property
+    def metadata(self) -> dict[str, object]:
+        return {
+            "memory_type": self.memory_type,
+            "scope": self.scope,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "source_path": self.source_path,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "freshness_hint": self.freshness_hint,
+            "confidence": self.confidence,
+            "tags": list(self.tags),
+            "canonical": self.canonical,
+            "header_path": list(self.header_path),
+            "chunk_index": self.chunk_index,
+            "document_id": self.document_id,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryDocument:
+    memory_type: MemoryType
+    scope: str
+    source: MemorySourceRef
+    text: str
+    created_at: str | datetime | None = None
+    updated_at: str | datetime | None = None
+    freshness_hint: str = "durable"
+    confidence: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+    title: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.scope:
+            raise ValueError("MemoryDocument.scope is required")
+        if not self.text.strip():
+            raise ValueError("MemoryDocument.text must be non-empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("MemoryDocument.confidence must be between 0 and 1")
+        object.__setattr__(self, "created_at", _iso8601(self.created_at))
+        object.__setattr__(self, "updated_at", _iso8601(self.updated_at or self.created_at))
+        object.__setattr__(self, "text", self.text.strip())
+
+    @property
+    def document_id(self) -> str:
+        payload = "|".join(
+            [
+                self.memory_type,
+                self.scope,
+                self.source.source_kind,
+                self.source.source_id,
+                self.source.source_path,
+                self.title,
+            ]
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+    def chunk(self, *, target_chars: int = 900, max_chars: int = 1200) -> list[MemoryChunk]:
+        if target_chars <= 0 or max_chars <= 0 or target_chars > max_chars:
+            raise ValueError("target_chars and max_chars must be positive and target_chars <= max_chars")
+        sections = _split_sections(self.text)
+        chunks: list[MemoryChunk] = []
+        for header_path, section_text in sections:
+            parts = _chunk_section_text(section_text, target_chars=target_chars, max_chars=max_chars)
+            for part in parts:
+                chunk_index = len(chunks)
+                stable_id = _stable_chunk_id(
+                    document_id=self.document_id,
+                    chunk_index=chunk_index,
+                    header_path=header_path,
+                    text=part,
+                )
+                chunks.append(
+                    MemoryChunk(
+                        id=stable_id,
+                        document_id=self.document_id,
+                        chunk_index=chunk_index,
+                        text=part,
+                        header_path=header_path,
+                        memory_type=self.memory_type,
+                        scope=self.scope,
+                        source_kind=self.source.source_kind,
+                        source_id=self.source.source_id,
+                        source_path=self.source.source_path,
+                        created_at=self.created_at,
+                        updated_at=self.updated_at,
+                        freshness_hint=self.freshness_hint,
+                        confidence=self.confidence,
+                        tags=tuple(self.tags),
+                        canonical=self.canonical,
+                    )
+                )
+        return chunks
+
+
+def _split_sections(text: str) -> list[tuple[tuple[str, ...], str]]:
+    sections: list[tuple[tuple[str, ...], str]] = []
+    header_stack: list[str] = []
+    buffer: list[str] = []
+
+    def flush() -> None:
+        body = "\n".join(buffer).strip()
+        if body:
+            sections.append((tuple(header_stack), body))
+        buffer.clear()
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        match = re.match(r"^(#{1,6})\s+(.*\S)\s*$", line)
+        if match:
+            flush()
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            header_stack[:] = header_stack[: level - 1]
+            header_stack.append(title)
+            continue
+        buffer.append(line)
+    flush()
+    if not sections:
+        sections.append((tuple(), text.strip()))
+    return sections
+
+
+def _chunk_section_text(text: str, *, target_chars: int, max_chars: int) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        return []
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            if len(current) >= target_chars:
+                chunks.append(current)
+                current = ""
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        chunks.extend(_split_long_paragraph(paragraph, max_chars=max_chars))
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_long_paragraph(paragraph: str, *, max_chars: int) -> list[str]:
+    sentences = re.split(r"(?<=[.!?])\s+", paragraph.strip())
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        candidate = sentence if not current else f"{current} {sentence}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        while len(sentence) > max_chars:
+            split_at = sentence.rfind(" ", 0, max_chars)
+            if split_at <= 0:
+                split_at = max_chars
+            chunks.append(sentence[:split_at].strip())
+            sentence = sentence[split_at:].strip()
+        current = sentence
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _stable_chunk_id(*, document_id: str, chunk_index: int, header_path: Sequence[str], text: str) -> str:
+    fingerprint = "|".join(
+        [document_id, str(chunk_index), "/".join(_slugify_header(h) for h in header_path), _normalize_text(text)]
+    )
+    return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()[:24]
+
+
+__all__ = [
+    "MemoryChunk",
+    "MemoryDocument",
+    "MemorySourceRef",
+]

--- a/agent/memory_embeddings.py
+++ b/agent/memory_embeddings.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any, Optional
+
+from agent.auxiliary_client import resolve_provider_client
+from hermes_cli.config import load_config
+
+_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+_DEFAULT_EMBEDDING_PROVIDER = "openrouter"
+_CHUNK_ID_PREFIX = "memory-chunk"
+
+
+class MemoryEmbedder:
+    """Thin embedding wrapper for memory ingestion and retrieval.
+
+    Provider/model resolution comes from explicit constructor overrides first,
+    then ``config.yaml`` ``memory.embedding_*`` keys when present, and finally
+    the ``MEMORY_EMBEDDING_*`` environment variables.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        client: Any = None,
+        config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self._config = config if config is not None else load_config()
+        memory_cfg = self._config.get("memory", {}) if isinstance(self._config, dict) else {}
+        self.provider = (
+            provider
+            or (memory_cfg.get("embedding_provider") if isinstance(memory_cfg, dict) else None)
+            or os.getenv("MEMORY_EMBEDDING_PROVIDER")
+            or _DEFAULT_EMBEDDING_PROVIDER
+        )
+        requested_model = (
+            model
+            or (memory_cfg.get("embedding_model") if isinstance(memory_cfg, dict) else None)
+            or os.getenv("MEMORY_EMBEDDING_MODEL")
+            or _DEFAULT_EMBEDDING_MODEL
+        )
+        self.client, resolved_model = (client, requested_model)
+        if self.client is None:
+            self.client, resolved_model = resolve_provider_client(self.provider, requested_model)
+        if self.client is None:
+            raise RuntimeError(
+                f"Unable to initialize memory embedding client for provider {self.provider!r}"
+            )
+        self.model = resolved_model or requested_model
+
+    @staticmethod
+    def content_hash(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def chunk_id_for_text(cls, text: str, *, prefix: str = _CHUNK_ID_PREFIX) -> str:
+        return f"{prefix}:{cls.content_hash(text)}"
+
+    def chunk_ids_for_texts(self, texts: list[str], *, prefix: str = _CHUNK_ID_PREFIX) -> list[str]:
+        return [self.chunk_id_for_text(text, prefix=prefix) for text in texts]
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        response = self.client.embeddings.create(model=self.model, input=texts)
+        return [list(item.embedding) for item in response.data]
+
+    def embed_query(self, text: str) -> list[float]:
+        response = self.client.embeddings.create(model=self.model, input=text)
+        if not response.data:
+            raise RuntimeError("Embedding provider returned no vectors for query")
+        return list(response.data[0].embedding)

--- a/agent/memory_indexer.py
+++ b/agent/memory_indexer.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from agent.memory_documents import MemoryDocument, MemorySourceRef
+from agent.memory_embeddings import MemoryEmbedder
+from agent.pinecone_memory import PineconeMemoryClient
+from hermes_cli.config import load_config
+from hermes_state import SessionDB
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOPIC_FILES = (
+    "platform-state.md",
+    "linear-labels.md",
+    "projects.md",
+    "decisions.md",
+)
+
+_LINK_RE = re.compile(r"https?://\S+|\b[A-Z]{2,10}-\d+\b")
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_./:-]{2,}")
+
+
+@dataclass(frozen=True)
+class IndexResult:
+    scanned: int = 0
+    indexed: int = 0
+    skipped: int = 0
+    upserted: int = 0
+
+
+class MemoryIndexer:
+    """Indexes curated topic files and distilled session summaries into Pinecone."""
+
+    def __init__(
+        self,
+        *,
+        pinecone: PineconeMemoryClient,
+        embedder: MemoryEmbedder,
+        session_db: SessionDB,
+        config: dict[str, Any] | None = None,
+        topic_files: Sequence[str | Path] | None = None,
+    ) -> None:
+        self.pinecone = pinecone
+        self.embedder = embedder
+        self.session_db = session_db
+        self.config = config if config is not None else load_config()
+        self.memory_config = self.config.get("memory", {}) if isinstance(self.config, dict) else {}
+        self.topic_files = tuple(Path(p) for p in topic_files) if topic_files is not None else self._discover_topic_files()
+
+    def index_topic_files(self, paths: Sequence[str | Path] | None = None) -> IndexResult:
+        if not self.memory_config.get("pinecone_ingest_topic_files", True):
+            return IndexResult()
+        selected = [Path(p) for p in (paths if paths is not None else self.topic_files)]
+        result = IndexResult()
+        for path in selected:
+            result = self._accumulate(result, self._index_topic_file(path))
+        return result
+
+    def index_session_summaries(self, *, limit: int = 100, session_ids: Sequence[str] | None = None) -> IndexResult:
+        if not self.memory_config.get("pinecone_ingest_session_summaries", True):
+            return IndexResult()
+        summaries = self.session_db.export_session_summaries(limit=limit)
+        if session_ids is not None:
+            allowed = set(session_ids)
+            summaries = [item for item in summaries if item.get("session_id") in allowed]
+        result = IndexResult(scanned=len(summaries))
+        for summary in summaries:
+            if not summary.get("text"):
+                result = self._accumulate(result, IndexResult(scanned=0, skipped=1))
+                continue
+            source_id = str(summary["session_id"])
+            source_key = self._source_key("session_summary", source_id)
+            content_hash = self._content_hash(str(summary["text"]))
+            if self._get_stored_hash(source_key) == content_hash:
+                result = self._accumulate(result, IndexResult(scanned=0, skipped=1))
+                continue
+            document = MemoryDocument(
+                memory_type="session_summary",
+                scope=str(summary.get("scope") or "global"),
+                source=MemorySourceRef(
+                    source_kind="session_summary",
+                    source_id=source_id,
+                    source_path=str(summary.get("source_path") or source_id),
+                ),
+                title=str(summary.get("title") or source_id),
+                text=str(summary["text"]),
+                created_at=summary.get("created_at"),
+                updated_at=summary.get("updated_at"),
+                freshness_hint="weekly",
+                confidence=0.62,
+                canonical=False,
+                tags=tuple(summary.get("tags") or ("session_search",)),
+            )
+            upserted = self._upsert_document(document)
+            self._set_stored_hash(source_key, content_hash)
+            result = self._accumulate(result, IndexResult(indexed=1, upserted=upserted))
+        return result
+
+    def reindex_all(self, *, limit: int = 100) -> dict[str, IndexResult]:
+        return {
+            "topic_files": self.index_topic_files(),
+            "session_summaries": self.index_session_summaries(limit=limit),
+        }
+
+    def _index_topic_file(self, path: Path) -> IndexResult:
+        if not path.exists() or not path.is_file():
+            return IndexResult(scanned=1, skipped=1)
+        text = path.read_text(encoding="utf-8")
+        source_key = self._source_key("file", str(path.resolve()))
+        content_hash = self._content_hash(text)
+        if self._get_stored_hash(source_key) == content_hash:
+            return IndexResult(scanned=1, skipped=1)
+        stat = path.stat()
+        document = MemoryDocument(
+            memory_type="project_context",
+            scope="global",
+            source=MemorySourceRef(
+                source_kind="file",
+                source_id=str(path.resolve()),
+                source_path=str(path.resolve()),
+            ),
+            title=path.name,
+            text=text,
+            created_at=self._iso_from_timestamp(stat.st_ctime),
+            updated_at=self._iso_from_timestamp(stat.st_mtime),
+            freshness_hint="monthly",
+            confidence=0.96,
+            canonical=True,
+            tags=self._file_tags(path),
+        )
+        upserted = self._upsert_document(document)
+        self._set_stored_hash(source_key, content_hash)
+        return IndexResult(scanned=1, indexed=1, upserted=upserted)
+
+    def _upsert_document(self, document: MemoryDocument) -> int:
+        chunks = document.chunk()
+        if not chunks:
+            return 0
+        vectors = self.embedder.embed_texts([chunk.text for chunk in chunks])
+        records = []
+        for chunk, vector in zip(chunks, vectors, strict=True):
+            metadata = dict(chunk.metadata)
+            metadata["text"] = chunk.text
+            metadata["title"] = document.title
+            metadata["content_hash"] = self._content_hash(chunk.text)
+            records.append({"id": chunk.id, "values": vector, "metadata": metadata})
+        return self.pinecone.upsert_records(records)
+
+    def _discover_topic_files(self) -> tuple[Path, ...]:
+        discovered: list[Path] = []
+        roots = [Path.cwd(), Path.home() / ".hermes"]
+        seen: set[Path] = set()
+        for root in roots:
+            if not root.exists():
+                continue
+            for name in _DEFAULT_TOPIC_FILES:
+                for candidate in root.rglob(name):
+                    if ".plans" in candidate.parts:
+                        continue
+                    resolved = candidate.resolve()
+                    if resolved not in seen:
+                        seen.add(resolved)
+                        discovered.append(resolved)
+        return tuple(discovered)
+
+    def _source_key(self, source_kind: str, source_id: str) -> str:
+        return f"pinecone_index_hash:{source_kind}:{source_id}"
+
+    def _get_stored_hash(self, source_key: str) -> str | None:
+        return self.session_db.get_meta(source_key)
+
+    def _set_stored_hash(self, source_key: str, value: str) -> None:
+        self.session_db.set_meta(source_key, value)
+
+    @staticmethod
+    def _content_hash(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _iso_from_timestamp(value: float) -> str:
+        from datetime import datetime, timezone
+
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+
+    @staticmethod
+    def _file_tags(path: Path) -> tuple[str, ...]:
+        tags = {"topic-file", path.stem.lower()}
+        if any(part.startswith(".") for part in path.parts):
+            tags.add("hidden")
+        return tuple(sorted(tags))
+
+    @staticmethod
+    def _accumulate(left: IndexResult, right: IndexResult) -> IndexResult:
+        return IndexResult(
+            scanned=left.scanned + right.scanned,
+            indexed=left.indexed + right.indexed,
+            skipped=left.skipped + right.skipped,
+            upserted=left.upserted + right.upserted,
+        )
+
+
+def build_session_summary_text(*, title: str, tools: Iterable[str], links_and_ids: Iterable[str], end_reason: str | None) -> str:
+    tool_list = sorted({tool.strip() for tool in tools if tool and tool.strip()})
+    linked = sorted({item.strip() for item in links_and_ids if item and item.strip()})
+    topics = _extract_topics_from_title(title)
+    lines = [f"Session title: {title.strip() or 'Untitled session'}"]
+    if topics:
+        lines.append(f"Key topics: {', '.join(topics)}")
+    if linked:
+        lines.append(f"Linked IDs/URLs: {', '.join(linked[:8])}")
+    if tool_list:
+        lines.append(f"Tools used: {', '.join(tool_list[:8])}")
+    if end_reason:
+        lines.append(f"Final resolution: session ended with reason `{end_reason}`")
+    lines.append("Transcript body intentionally omitted; this summary only stores distilled metadata.")
+    return "\n".join(lines)
+
+
+def extract_links_and_ids(text: str) -> list[str]:
+    return sorted({match.group(0).rstrip(').,') for match in _LINK_RE.finditer(text or "")})
+
+
+def _extract_topics_from_title(title: str) -> list[str]:
+    raw_tokens = [token.lower() for token in _TOKEN_RE.findall(title or "")]
+    stopwords = {"the", "and", "for", "with", "from", "into", "this", "that", "ticket", "issue", "auto"}
+    topics: list[str] = []
+    seen: set[str] = set()
+    for token in raw_tokens:
+        if token in stopwords or token.isdigit() or len(token) < 3:
+            continue
+        if token not in seen:
+            seen.add(token)
+            topics.append(token)
+        if len(topics) >= 8:
+            break
+    return topics
+
+
+__all__ = [
+    "IndexResult",
+    "MemoryIndexer",
+    "build_session_summary_text",
+    "extract_links_and_ids",
+]

--- a/agent/pinecone_memory.py
+++ b/agent/pinecone_memory.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class PineconeMemoryClient:
+    """Fail-open wrapper around the Pinecone index client."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        index_name: str | None = None,
+        namespace: str | None = None,
+        top_k: int = 5,
+        fail_open: bool = True,
+        sdk_client: Any | None = None,
+        index: Any | None = None,
+    ) -> None:
+        self.api_key = api_key or os.getenv("PINECONE_API_KEY", "")
+        self.index_name = index_name or os.getenv("PINECONE_INDEX", "")
+        self.namespace = namespace or os.getenv("PINECONE_NAMESPACE", "hermes")
+        self.top_k = top_k
+        self.fail_open = fail_open
+        self._sdk_client = sdk_client
+        self._index = index
+
+    def is_configured(self) -> bool:
+        return bool(self.api_key and self.index_name)
+
+    def upsert_records(self, records: Iterable[dict[str, Any]]) -> int:
+        normalized = [self._normalize_record(record) for record in records]
+        if not normalized:
+            return 0
+        if not self.is_configured():
+            logger.warning("Pinecone upsert skipped: missing configuration")
+            return 0
+        try:
+            index = self._get_index()
+            response = index.upsert(vectors=normalized, namespace=self.namespace)
+            if isinstance(response, dict):
+                return int(response.get("upserted_count", len(normalized)))
+            return int(getattr(response, "upserted_count", len(normalized)))
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone upsert failed; continuing fail-open: %s", exc)
+                return 0
+            raise
+
+    def query(self, vector: Sequence[float], *, top_k: int | None = None, filter: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        if not self.is_configured():
+            logger.warning("Pinecone query skipped: missing configuration")
+            return []
+        try:
+            index = self._get_index()
+            response = index.query(
+                vector=list(vector),
+                top_k=top_k or self.top_k,
+                namespace=self.namespace,
+                include_metadata=True,
+                filter=filter,
+            )
+            matches = response.get("matches", []) if isinstance(response, dict) else getattr(response, "matches", [])
+            return [self._normalize_match(match) for match in matches]
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone query failed; continuing fail-open: %s", exc)
+                return []
+            raise
+
+    def delete_by_source(self, *, source_kind: str, source_id: str) -> int:
+        if not self.is_configured():
+            logger.warning("Pinecone delete skipped: missing configuration")
+            return 0
+        try:
+            index = self._get_index()
+            index.delete(
+                namespace=self.namespace,
+                filter={"source_kind": {"$eq": source_kind}, "source_id": {"$eq": source_id}},
+            )
+            return 1
+        except Exception as exc:
+            if self.fail_open:
+                logger.warning("Pinecone delete failed; continuing fail-open: %s", exc)
+                return 0
+            raise
+
+    def _get_index(self) -> Any:
+        if self._index is not None:
+            return self._index
+        if self._sdk_client is None:
+            self._sdk_client = self._build_sdk_client()
+        index_factory = getattr(self._sdk_client, "Index")
+        self._index = index_factory(self.index_name)
+        return self._index
+
+    def _build_sdk_client(self) -> Any:
+        from pinecone import Pinecone  # type: ignore
+
+        return Pinecone(api_key=self.api_key)
+
+    @staticmethod
+    def _normalize_record(record: dict[str, Any]) -> dict[str, Any]:
+        if "id" not in record or "values" not in record or "metadata" not in record:
+            raise ValueError("Pinecone record must include id, values, and metadata")
+        return {
+            "id": str(record["id"]),
+            "values": [float(value) for value in record["values"]],
+            "metadata": dict(record["metadata"]),
+        }
+
+    @staticmethod
+    def _normalize_match(match: Any) -> dict[str, Any]:
+        if isinstance(match, dict):
+            return {
+                "id": match.get("id", ""),
+                "score": match.get("score"),
+                "metadata": dict(match.get("metadata") or {}),
+            }
+        return {
+            "id": getattr(match, "id", ""),
+            "score": getattr(match, "score", None),
+            "metadata": dict(getattr(match, "metadata", {}) or {}),
+        }
+
+
+__all__ = ["PineconeMemoryClient"]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -960,6 +960,16 @@ DEFAULT_CONFIG = {
         "user_profile_enabled": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "pinecone_enabled": False,
+        "pinecone_namespace": "",
+        "pinecone_top_k": 8,
+        "pinecone_min_score": 0.0,
+        "pinecone_max_context_items": 8,
+        "pinecone_retrieval_enabled_platforms": [],
+        "pinecone_ingest_session_summaries": True,
+        "pinecone_ingest_topic_files": True,
+        "pinecone_ingest_skills": True,
+        "pinecone_fail_open": True,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
@@ -1336,7 +1346,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================
@@ -1352,6 +1362,10 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    24: [
+        "PINECONE_API_KEY", "PINECONE_INDEX_HOST", "PINECONE_INDEX_NAME",
+        "PINECONE_NAMESPACE", "MEMORY_EMBEDDING_MODEL", "MEMORY_EMBEDDING_PROVIDER",
+    ],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1993,6 +2007,52 @@ OPTIONAL_ENV_VARS = {
         "description": "Base URL for self-hosted Honcho instances (no API key needed)",
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
+    },
+
+    # ── Pinecone memory retrieval ──
+    "PINECONE_API_KEY": {
+        "description": "Pinecone API key for vector memory retrieval",
+        "prompt": "Pinecone API key",
+        "url": "https://app.pinecone.io/",
+        "password": True,
+        "category": "tool",
+    },
+    "PINECONE_INDEX_HOST": {
+        "description": "Pinecone index host URL",
+        "prompt": "Pinecone index host",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "PINECONE_INDEX_NAME": {
+        "description": "Pinecone index name",
+        "prompt": "Pinecone index name",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "PINECONE_NAMESPACE": {
+        "description": "Default Pinecone namespace for Hermes memory",
+        "prompt": "Pinecone namespace",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "MEMORY_EMBEDDING_MODEL": {
+        "description": "Embedding model used for Hermes memory vectors",
+        "prompt": "Memory embedding model",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "MEMORY_EMBEDDING_PROVIDER": {
+        "description": "Provider used for Hermes memory embeddings",
+        "prompt": "Memory embedding provider",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
     },
 
     # ── Langfuse observability ──

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -22,6 +22,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from datetime import datetime, timezone
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
@@ -877,6 +878,81 @@ class SessionDB:
             )
             row = cursor.fetchone()
         return row["title"] if row else None
+
+    def export_session_summaries(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Return distilled session summaries safe for semantic indexing."""
+        sessions = self.search_sessions(limit=limit)
+        summaries: list[dict[str, Any]] = []
+        token_re = re.compile(r"[A-Za-z0-9][A-Za-z0-9_./:-]{2,}")
+        link_re = re.compile(r"https?://\S+|\b[A-Z]{2,10}-\d+\b")
+        stopwords = {"the", "and", "for", "with", "from", "into", "this", "that", "ticket", "issue", "auto"}
+
+        for session in sessions:
+            session_id = session["id"]
+            title = (session.get("title") or session_id or "").strip()
+            with self._lock:
+                cursor = self._conn.execute(
+                    "SELECT content, tool_name FROM messages WHERE session_id = ? ORDER BY timestamp ASC, id ASC",
+                    (session_id,),
+                )
+                rows = cursor.fetchall()
+
+            links_and_ids: set[str] = set()
+            tools: set[str] = set()
+            for row in rows:
+                content = row["content"] or ""
+                for match in link_re.finditer(content):
+                    links_and_ids.add(match.group(0).rstrip(").,"))
+                tool_name = (row["tool_name"] or "").strip()
+                if tool_name:
+                    tools.add(tool_name)
+
+            topics: list[str] = []
+            seen_topics: set[str] = set()
+            for token in [tok.lower() for tok in token_re.findall(title)]:
+                if token in stopwords or token.isdigit() or len(token) < 3:
+                    continue
+                if token not in seen_topics:
+                    seen_topics.add(token)
+                    topics.append(token)
+                if len(topics) >= 8:
+                    break
+
+            lines = [f"Session title: {title or 'Untitled session'}"]
+            if topics:
+                lines.append(f"Key topics: {', '.join(topics)}")
+            if links_and_ids:
+                lines.append(f"Linked IDs/URLs: {', '.join(sorted(links_and_ids)[:8])}")
+            if tools:
+                lines.append(f"Tools used: {', '.join(sorted(tools)[:8])}")
+            end_reason = (session.get("end_reason") or "").strip()
+            if end_reason:
+                lines.append(f"Final resolution: session ended with reason `{end_reason}`")
+            lines.append("Transcript body intentionally omitted; this summary only stores distilled metadata.")
+
+            started_at = session.get("started_at")
+            updated_at = session.get("last_active") or started_at
+            created_iso = (
+                datetime.fromtimestamp(float(started_at), tz=timezone.utc).isoformat()
+                if started_at is not None else None
+            )
+            updated_iso = (
+                datetime.fromtimestamp(float(updated_at), tz=timezone.utc).isoformat()
+                if updated_at is not None else created_iso
+            )
+            summaries.append(
+                {
+                    "session_id": session_id,
+                    "title": title or session_id,
+                    "text": "\n".join(lines),
+                    "created_at": created_iso,
+                    "updated_at": updated_iso,
+                    "source_path": f"session://{session_id}",
+                    "scope": "global",
+                    "tags": tuple(sorted({"session_search", session.get("source") or "session"})),
+                }
+            )
+        return summaries
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""

--- a/tests/agent/test_memory_documents.py
+++ b/tests/agent/test_memory_documents.py
@@ -1,0 +1,65 @@
+from agent.memory_documents import MemoryDocument, MemorySourceRef
+
+
+def _make_document(text: str) -> MemoryDocument:
+    return MemoryDocument(
+        memory_type="project_context",
+        scope="repo:hermes-agent",
+        source=MemorySourceRef(source_kind="file", source_id="docs/test.md", source_path="docs/test.md"),
+        text=text,
+        created_at="2026-05-07T00:00:00+00:00",
+        updated_at="2026-05-07T01:00:00+00:00",
+        freshness_hint="weekly",
+        confidence=0.8,
+        tags=("pinecone", "memory"),
+        canonical=True,
+        title="Test doc",
+    )
+
+
+def test_chunk_size_bounds_and_header_awareness():
+    text = """# Overview
+This is the overview paragraph. It explains the system.
+
+## Details
+""" + ("Sentence. " * 140) + """
+
+## Notes
+A short closing note.
+"""
+    doc = _make_document(text)
+    chunks = doc.chunk(target_chars=220, max_chars=320)
+
+    assert len(chunks) >= 3
+    assert all(1 <= len(chunk.text) <= 320 for chunk in chunks)
+    assert chunks[0].header_path == ("Overview",)
+    assert any(chunk.header_path == ("Overview", "Details") for chunk in chunks)
+    assert chunks[-1].header_path == ("Overview", "Notes")
+
+
+def test_metadata_preservation_and_required_fields():
+    doc = _make_document("# Title\nUseful memory content for retrieval.")
+    chunk = doc.chunk(target_chars=200, max_chars=300)[0]
+
+    assert chunk.memory_type == "project_context"
+    assert chunk.scope == "repo:hermes-agent"
+    assert chunk.source_kind == "file"
+    assert chunk.source_id == "docs/test.md"
+    assert chunk.source_path == "docs/test.md"
+    assert chunk.created_at == "2026-05-07T00:00:00+00:00"
+    assert chunk.updated_at == "2026-05-07T01:00:00+00:00"
+    assert chunk.freshness_hint == "weekly"
+    assert chunk.confidence == 0.8
+    assert chunk.tags == ("pinecone", "memory")
+    assert chunk.canonical is True
+    assert chunk.metadata["source_kind"] == "file"
+    assert chunk.metadata["tags"] == ["pinecone", "memory"]
+
+
+def test_chunk_ids_are_stable_for_same_input():
+    text = "# Same\n" + ("Repeatable text. " * 40)
+    first = _make_document(text).chunk(target_chars=180, max_chars=240)
+    second = _make_document(text).chunk(target_chars=180, max_chars=240)
+
+    assert [chunk.id for chunk in first] == [chunk.id for chunk in second]
+    assert [chunk.document_id for chunk in first] == [chunk.document_id for chunk in second]

--- a/tests/agent/test_memory_embeddings.py
+++ b/tests/agent/test_memory_embeddings.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from agent.memory_embeddings import MemoryEmbedder
+
+
+class _FakeEmbeddingsAPI:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, *, model, input):
+        self.calls.append({"model": model, "input": input})
+        if isinstance(input, list):
+            data = [SimpleNamespace(embedding=[float(i), float(i) + 0.5]) for i, _ in enumerate(input)]
+        else:
+            data = [SimpleNamespace(embedding=[1.0, 2.0, 3.0])]
+        return SimpleNamespace(data=data)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddingsAPI()
+
+
+def test_embed_texts_batches_inputs(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+    vectors = embedder.embed_texts(["alpha", "beta"])
+
+    assert vectors == [[0.0, 0.5], [1.0, 1.5]]
+    assert fake_client.embeddings.calls == [
+        {"model": "text-embedding-test", "input": ["alpha", "beta"]}
+    ]
+
+
+def test_embed_query_uses_single_string_input(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+    vector = embedder.embed_query("find this")
+
+    assert vector == [1.0, 2.0, 3.0]
+    assert fake_client.embeddings.calls == [
+        {"model": "text-embedding-test", "input": "find this"}
+    ]
+
+
+def test_chunk_id_generation_is_stable_and_content_based(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+
+    text = "same input text"
+    same_id = embedder.chunk_id_for_text(text)
+
+    assert same_id == embedder.chunk_id_for_text(text)
+    assert same_id == "memory-chunk:df5a302847fc7c0cdba82e0c6c263841bff5dc3d80eb693889b66d4d6f650f8d"
+    assert same_id != embedder.chunk_id_for_text("different text")
+    assert embedder.chunk_ids_for_texts([text, "different text"]) == [
+        same_id,
+        embedder.chunk_id_for_text("different text"),
+    ]

--- a/tests/agent/test_memory_indexer.py
+++ b/tests/agent/test_memory_indexer.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.memory_embeddings import MemoryEmbedder
+from agent.memory_indexer import MemoryIndexer, build_session_summary_text, extract_links_and_ids
+from agent.pinecone_memory import PineconeMemoryClient
+from hermes_state import SessionDB
+
+
+class _FakeEmbeddingsAPI:
+    def create(self, *, model, input):
+        if isinstance(input, list):
+            data = [type("Emb", (), {"embedding": [float(i), float(i) + 0.25]})() for i, _ in enumerate(input)]
+        else:
+            data = [type("Emb", (), {"embedding": [1.0, 2.0]})()]
+        return type("Resp", (), {"data": data})()
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddingsAPI()
+
+
+class _FakeIndex:
+    def __init__(self):
+        self.upserts = []
+
+    def upsert(self, *, vectors, namespace):
+        self.upserts.append({"vectors": vectors, "namespace": namespace})
+        return {"upserted_count": len(vectors)}
+
+
+def _make_embedder(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+    return MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+
+
+def _make_db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def test_topic_file_reindex_skips_unchanged_content(monkeypatch, tmp_path):
+    db = _make_db(tmp_path)
+    embedder = _make_embedder(monkeypatch)
+    index = _FakeIndex()
+    pinecone = PineconeMemoryClient(api_key="key", index_name="idx", index=index)
+    topic_file = tmp_path / "platform-state.md"
+    topic_file.write_text("# Platform\n\nCurrent rollout state.")
+
+    indexer = MemoryIndexer(
+        pinecone=pinecone,
+        embedder=embedder,
+        session_db=db,
+        topic_files=[topic_file],
+        config={"memory": {"pinecone_ingest_topic_files": True}},
+    )
+
+    first = indexer.index_topic_files()
+    second = indexer.index_topic_files()
+
+    assert first.indexed == 1
+    assert first.upserted >= 1
+    assert second.indexed == 0
+    assert second.skipped == 1
+    assert len(index.upserts) == 1
+
+
+def test_session_summary_index_replaces_on_update(monkeypatch, tmp_path):
+    db = _make_db(tmp_path)
+    db.create_session(session_id="sess-1", source="cron")
+    db.set_session_title("sess-1", "WAT-1374 ingest summaries")
+    db.append_message(session_id="sess-1", role="user", content="Investigate WAT-1374 and https://linear.app/watsiai/issue/WAT-1374")
+    db.append_message(session_id="sess-1", role="tool", content="done", tool_name="terminal")
+    db.end_session("sess-1", end_reason="completed")
+
+    embedder = _make_embedder(monkeypatch)
+    index = _FakeIndex()
+    pinecone = PineconeMemoryClient(api_key="key", index_name="idx", index=index)
+    indexer = MemoryIndexer(
+        pinecone=pinecone,
+        embedder=embedder,
+        session_db=db,
+        config={"memory": {"pinecone_ingest_session_summaries": True}},
+    )
+
+    first = indexer.index_session_summaries()
+    second = indexer.index_session_summaries()
+    db.set_session_title("sess-1", "WAT-1374 ingest summaries updated")
+    third = indexer.index_session_summaries()
+
+    assert first.indexed == 1
+    assert second.skipped == 1
+    assert third.indexed == 1
+    assert len(index.upserts) == 2
+    assert all("Transcript body intentionally omitted" in vec["metadata"]["text"] for call in index.upserts for vec in call["vectors"])
+
+
+def test_session_summary_ingest_is_noop_when_unconfigured(monkeypatch, tmp_path):
+    db = _make_db(tmp_path)
+    db.create_session(session_id="sess-2", source="cli")
+    db.set_session_title("sess-2", "Ignored summary")
+    embedder = _make_embedder(monkeypatch)
+    index = _FakeIndex()
+    pinecone = PineconeMemoryClient(api_key="key", index_name="idx", index=index)
+    indexer = MemoryIndexer(
+        pinecone=pinecone,
+        embedder=embedder,
+        session_db=db,
+        config={"memory": {"pinecone_ingest_session_summaries": False}},
+    )
+
+    result = indexer.index_session_summaries()
+
+    assert result == result.__class__()
+    assert index.upserts == []
+
+
+def test_extract_links_and_ids_dedupes_and_strips_trailing_punctuation():
+    text = "See WAT-1374, WAT-1374, and https://example.com/demo)."
+    assert extract_links_and_ids(text) == ["WAT-1374", "https://example.com/demo"]
+
+
+def test_build_session_summary_text_omits_raw_transcript_body():
+    summary = build_session_summary_text(
+        title="WAT-1374 ingest summaries",
+        tools=["terminal", "terminal", "pytest"],
+        links_and_ids=["WAT-1374", "https://linear.app/watsiai/issue/WAT-1374"],
+        end_reason="completed",
+    )
+    assert "WAT-1374 ingest summaries" in summary
+    assert "Tools used: pytest, terminal" in summary
+    assert "Transcript body intentionally omitted" in summary

--- a/tests/agent/test_pinecone_memory.py
+++ b/tests/agent/test_pinecone_memory.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.pinecone_memory import PineconeMemoryClient
+
+
+class FakeIndex:
+    def __init__(self):
+        self.upsert_calls = []
+        self.query_calls = []
+        self.delete_calls = []
+
+    def upsert(self, *, vectors, namespace):
+        self.upsert_calls.append({"vectors": vectors, "namespace": namespace})
+        return {"upserted_count": len(vectors)}
+
+    def query(self, **kwargs):
+        self.query_calls.append(kwargs)
+        return {
+            "matches": [
+                {"id": "chunk-1", "score": 0.99, "metadata": {"source_id": "doc-1"}},
+            ]
+        }
+
+    def delete(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        return {"ok": True}
+
+
+class RaisingIndex:
+    def upsert(self, **kwargs):
+        raise RuntimeError("boom")
+
+    def query(self, **kwargs):
+        raise RuntimeError("boom")
+
+    def delete(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_missing_config_returns_empty_results_and_logs_warning(caplog):
+    client = PineconeMemoryClient(api_key="", index_name="", fail_open=True)
+
+    with caplog.at_level("WARNING"):
+        assert client.upsert_records([{"id": "1", "values": [1, 2], "metadata": {}}]) == 0
+        assert client.query([0.1, 0.2]) == []
+        assert client.delete_by_source(source_kind="file", source_id="abc") == 0
+
+    assert "missing configuration" in caplog.text
+
+
+def test_successful_upsert_query_and_delete():
+    index = FakeIndex()
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        namespace="ns1",
+        fail_open=True,
+        index=index,
+    )
+
+    count = client.upsert_records([
+        {"id": "chunk-1", "values": [1, 2, 3], "metadata": {"source_id": "doc-1"}},
+    ])
+    matches = client.query([0.1, 0.2, 0.3], top_k=3, filter={"scope": {"$eq": "repo"}})
+    deleted = client.delete_by_source(source_kind="file", source_id="doc-1")
+
+    assert count == 1
+    assert matches == [{"id": "chunk-1", "score": 0.99, "metadata": {"source_id": "doc-1"}}]
+    assert deleted == 1
+    assert index.upsert_calls[0]["namespace"] == "ns1"
+    assert index.query_calls[0]["top_k"] == 3
+    assert index.query_calls[0]["filter"] == {"scope": {"$eq": "repo"}}
+    assert index.delete_calls[0]["filter"] == {
+        "source_kind": {"$eq": "file"},
+        "source_id": {"$eq": "doc-1"},
+    }
+
+
+def test_sdk_exception_is_fail_open_when_enabled(caplog):
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        fail_open=True,
+        index=RaisingIndex(),
+    )
+
+    with caplog.at_level("WARNING"):
+        assert client.upsert_records([{"id": "1", "values": [1], "metadata": {}}]) == 0
+        assert client.query([0.1]) == []
+        assert client.delete_by_source(source_kind="file", source_id="abc") == 0
+
+    assert "continuing fail-open" in caplog.text
+
+
+def test_sdk_exception_raises_when_fail_open_disabled():
+    client = PineconeMemoryClient(
+        api_key="key",
+        index_name="memory-index",
+        fail_open=False,
+        index=RaisingIndex(),
+    )
+
+    with pytest.raises(RuntimeError):
+        client.query([0.1])

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -379,6 +379,53 @@ class TestSanitizeEnvLines:
             assert fixes == 0
 
 
+class TestMemoryPineconeConfig:
+    def test_memory_defaults_include_pinecone_settings(self):
+        memory_cfg = DEFAULT_CONFIG["memory"]
+        assert memory_cfg["pinecone_enabled"] is False
+        assert memory_cfg["pinecone_namespace"] == ""
+        assert memory_cfg["pinecone_top_k"] == 8
+        assert memory_cfg["pinecone_min_score"] == 0.0
+        assert memory_cfg["pinecone_max_context_items"] == 8
+        assert memory_cfg["pinecone_retrieval_enabled_platforms"] == []
+        assert memory_cfg["pinecone_ingest_session_summaries"] is True
+        assert memory_cfg["pinecone_ingest_topic_files"] is True
+        assert memory_cfg["pinecone_ingest_skills"] is True
+        assert memory_cfg["pinecone_fail_open"] is True
+
+    def test_migrate_config_adds_pinecone_defaults_without_overwriting_existing_values(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 23,
+                    "memory": {
+                        "provider": "builtin",
+                        "pinecone_enabled": True,
+                        "pinecone_top_k": 42,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["memory"]["pinecone_enabled"] is True
+        assert raw["memory"]["pinecone_top_k"] == 42
+        assert raw["memory"]["pinecone_namespace"] == ""
+        assert raw["memory"]["pinecone_min_score"] == 0.0
+        assert raw["memory"]["pinecone_max_context_items"] == 8
+        assert raw["memory"]["pinecone_retrieval_enabled_platforms"] == []
+        assert raw["memory"]["pinecone_ingest_session_summaries"] is True
+        assert raw["memory"]["pinecone_ingest_topic_files"] is True
+        assert raw["memory"]["pinecone_ingest_skills"] is True
+        assert raw["memory"]["pinecone_fail_open"] is True
+
+
 class TestOptionalEnvVarsRegistry:
     """Verify that key env vars are registered in OPTIONAL_ENV_VARS."""
 
@@ -386,6 +433,16 @@ class TestOptionalEnvVarsRegistry:
         """TAVILY_API_KEY is listed in OPTIONAL_ENV_VARS."""
         from hermes_cli.config import OPTIONAL_ENV_VARS
         assert "TAVILY_API_KEY" in OPTIONAL_ENV_VARS
+
+    def test_pinecone_and_memory_embedding_env_vars_registered(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        assert OPTIONAL_ENV_VARS["PINECONE_API_KEY"]["password"] is True
+        assert OPTIONAL_ENV_VARS["PINECONE_INDEX_HOST"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["PINECONE_INDEX_NAME"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["PINECONE_NAMESPACE"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["MEMORY_EMBEDDING_MODEL"]["advanced"] is True
+        assert OPTIONAL_ENV_VARS["MEMORY_EMBEDDING_PROVIDER"]["advanced"] is True
 
     def test_tavily_api_key_is_tool_category(self):
         """TAVILY_API_KEY is in the 'tool' category."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2542,6 +2542,51 @@ class TestConcurrentWriteSafety:
 
 
 # =========================================================================
+# Session summary export
+# =========================================================================
+
+class TestSessionSummaryExport:
+    def test_export_session_summaries_distills_metadata_without_raw_transcript(self, db):
+        db.create_session(session_id="sess-summary", source="cron")
+        db.set_session_title("sess-summary", "WAT-1374 ingest summaries")
+        db.append_message(
+            session_id="sess-summary",
+            role="user",
+            content="Please investigate WAT-1374 and https://linear.app/watsiai/issue/WAT-1374.",
+        )
+        db.append_message(
+            session_id="sess-summary",
+            role="tool",
+            content="done",
+            tool_name="terminal",
+        )
+        db.end_session("sess-summary", end_reason="completed")
+
+        summaries = db.export_session_summaries(limit=10)
+
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert summary["session_id"] == "sess-summary"
+        assert "WAT-1374" in summary["text"]
+        assert "https://linear.app/watsiai/issue/WAT-1374" in summary["text"]
+        assert "terminal" in summary["text"]
+        assert "Transcript body intentionally omitted" in summary["text"]
+        assert "Please investigate" not in summary["text"]
+
+    def test_export_session_summaries_updates_when_title_changes(self, db):
+        db.create_session(session_id="sess-update", source="cli")
+        db.set_session_title("sess-update", "Initial title")
+
+        first = db.export_session_summaries(limit=10)[0]
+        db.set_session_title("sess-update", "Updated title")
+        second = db.export_session_summaries(limit=10)[0]
+
+        assert "Initial title" in first["text"]
+        assert "Updated title" in second["text"]
+        assert first["text"] != second["text"]
+
+
+# =========================================================================
 # Auto-maintenance: state_meta + vacuum + maybe_auto_prune_and_vacuum
 # =========================================================================
 


### PR DESCRIPTION
## Summary
- add a `MemoryIndexer` that ingests curated memory topic files and distilled session summaries into Pinecone
- export session summaries from `SessionDB` as metadata-only records with links, IDs, tools, and an explicit omission of transcript bodies
- keep Pinecone indexing fail-open and cover the new indexing/export paths with targeted tests

## Testing
- pytest tests/agent/test_memory_embeddings.py tests/agent/test_memory_documents.py tests/agent/test_pinecone_memory.py tests/agent/test_memory_indexer.py tests/test_hermes_state.py tests/tools/test_session_search.py -q

## Notes
- This branch is stacked on the WAT-1370 foundation commit and the WAT-1371 memory document/client work because those blockers are not upstream yet.
- No raw transcript body content is exported or indexed; summaries are distilled metadata only.