### PR TITLE
[codex] Add profile runtime comparison dashboard

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -403,8 +403,18 @@ class ProfileInfo:
     path: Path
     is_default: bool
     gateway_running: bool
+    config_path: Optional[Path] = None
+    env_path: Optional[Path] = None
+    gateway_pid: Optional[int] = None
     model: Optional[str] = None
     provider: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    delegation_model: Optional[str] = None
+    delegation_provider: Optional[str] = None
+    delegation_reasoning_effort: Optional[str] = None
+    auth_kind: Optional[str] = None
+    auth_configured: bool = False
+    auth_sources: tuple = ()
     has_env: bool = False
     skill_count: int = 0
     alias_path: Optional[Path] = None
@@ -441,30 +451,222 @@ def _read_distribution_meta(profile_dir: Path) -> tuple:
 
 def _read_config_model(profile_dir: Path) -> tuple:
     """Read model/provider from a profile's config.yaml. Returns (model, provider)."""
+    summary = _read_config_runtime_summary(profile_dir)
+    return summary.get("model"), summary.get("provider")
+
+
+def _read_config_runtime_summary(profile_dir: Path) -> dict:
+    """Read non-secret runtime settings from a profile's config.yaml."""
     config_path = profile_dir / "config.yaml"
+    empty = {
+        "model": None,
+        "provider": None,
+        "reasoning_effort": None,
+        "delegation_model": None,
+        "delegation_provider": None,
+        "delegation_reasoning_effort": None,
+    }
     if not config_path.exists():
-        return None, None
+        return empty
     try:
         import yaml
         with open(config_path, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
+        if not isinstance(cfg, dict):
+            return empty
+
+        summary = dict(empty)
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):
-            return model_cfg, None
-        if isinstance(model_cfg, dict):
-            return model_cfg.get("default") or model_cfg.get("model"), model_cfg.get("provider")
-        return None, None
+            summary["model"] = model_cfg
+        elif isinstance(model_cfg, dict):
+            summary["model"] = (
+                model_cfg.get("default")
+                or model_cfg.get("name")
+                or model_cfg.get("model")
+            )
+            summary["provider"] = model_cfg.get("provider")
+
+        agent_cfg = cfg.get("agent", {})
+        if isinstance(agent_cfg, dict):
+            summary["reasoning_effort"] = agent_cfg.get("reasoning_effort")
+
+        delegation_cfg = cfg.get("delegation", {})
+        if isinstance(delegation_cfg, dict):
+            summary["delegation_model"] = delegation_cfg.get("model")
+            summary["delegation_provider"] = delegation_cfg.get("provider")
+            summary["delegation_reasoning_effort"] = delegation_cfg.get("reasoning_effort")
+
+        return summary
     except Exception:
-        return None, None
+        return empty
+
+
+def _read_gateway_pid(profile_dir: Path) -> Optional[int]:
+    """Return the running gateway PID for a profile, if present."""
+    try:
+        from gateway.status import get_running_pid
+        return get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False)
+    except Exception:
+        return None
 
 
 def _check_gateway_running(profile_dir: Path) -> bool:
     """Check if a gateway is running for a given profile directory."""
+    return _read_gateway_pid(profile_dir) is not None
+
+
+def _read_env_file(profile_dir: Path) -> dict:
+    """Read a profile .env file without exposing secret values."""
+    env_path = profile_dir / ".env"
+    if not env_path.exists():
+        return {}
+    env_vars = {}
     try:
-        from gateway.status import get_running_pid
-        return get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None
+        with open(env_path, "r", encoding="utf-8-sig", errors="replace") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                env_vars[key.strip()] = value.strip().strip('"\'')
     except Exception:
+        return {}
+    return env_vars
+
+
+def _read_auth_store(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _profile_auth_entries(profile_dir: Path, provider: str) -> tuple[list, str]:
+    """Return credential pool entries using Hermes' per-provider fallback rule."""
+    profile_store = _read_auth_store(profile_dir / "auth.json")
+    profile_pool = profile_store.get("credential_pool")
+    if isinstance(profile_pool, dict):
+        entries = profile_pool.get(provider)
+        if isinstance(entries, list) and entries:
+            return entries, "profile auth.json"
+
+    global_home = Path.home() / ".hermes"
+    if profile_dir.resolve(strict=False) != global_home.resolve(strict=False):
+        global_store = _read_auth_store(global_home / "auth.json")
+        global_pool = global_store.get("credential_pool")
+        if isinstance(global_pool, dict):
+            entries = global_pool.get(provider)
+            if isinstance(entries, list) and entries:
+                return entries, "global auth.json"
+    return [], ""
+
+
+def _auth_provider_state_exists(profile_dir: Path, provider: str) -> tuple[bool, str]:
+    profile_store = _read_auth_store(profile_dir / "auth.json")
+    providers = profile_store.get("providers")
+    if isinstance(providers, dict) and isinstance(providers.get(provider), dict):
+        return True, "profile auth.json"
+
+    global_home = Path.home() / ".hermes"
+    if profile_dir.resolve(strict=False) != global_home.resolve(strict=False):
+        global_store = _read_auth_store(global_home / "auth.json")
+        providers = global_store.get("providers")
+        if isinstance(providers, dict) and isinstance(providers.get(provider), dict):
+            return True, "global auth.json"
+    return False, ""
+
+
+def _looks_like_anthropic_oauth_token(value: str) -> bool:
+    if not value:
         return False
+    if value.startswith("sk-ant-api"):
+        return False
+    return value.startswith(("sk-ant-", "eyJ", "cc-"))
+
+
+def _classify_env_auth_kind(provider: str, env_var: str, value: str) -> Optional[str]:
+    if not value:
+        return None
+    if provider == "anthropic":
+        if env_var in {"ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}:
+            return "oauth"
+        if env_var == "ANTHROPIC_API_KEY" and _looks_like_anthropic_oauth_token(value):
+            return "oauth"
+    return "api_key"
+
+
+def _read_auth_summary(profile_dir: Path, provider: Optional[str]) -> dict:
+    """Return non-secret auth method metadata for the profile's provider."""
+    provider_id = (provider or "").strip()
+    empty = {"kind": None, "configured": False, "sources": ()}
+    if not provider_id:
+        return empty
+
+    methods: set[str] = set()
+    sources: list[str] = []
+
+    entries, pool_source = _profile_auth_entries(profile_dir, provider_id)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        auth_type = str(entry.get("auth_type") or "").strip().lower()
+        if auth_type in {"oauth", "oauth_device_code", "oauth_external", "oauth_pkce"}:
+            methods.add("oauth")
+        elif auth_type in {"api_key", "key"}:
+            methods.add("api_key")
+        elif auth_type:
+            methods.add(auth_type)
+    if entries and pool_source:
+        sources.append(pool_source)
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY.get(provider_id)
+    except Exception:
+        pconfig = None
+
+    if pconfig and getattr(pconfig, "auth_type", "") == "api_key":
+        env_vars = _read_env_file(profile_dir)
+        for env_var in getattr(pconfig, "api_key_env_vars", ()) or ():
+            kind = _classify_env_auth_kind(provider_id, env_var, env_vars.get(env_var, ""))
+            if kind:
+                methods.add(kind)
+                sources.append(f".env:{env_var}")
+    elif pconfig and str(getattr(pconfig, "auth_type", "")).startswith("oauth"):
+        state_exists, state_source = _auth_provider_state_exists(profile_dir, provider_id)
+        if state_exists:
+            methods.add("oauth")
+            sources.append(state_source)
+
+    if not methods and pconfig:
+        auth_type = getattr(pconfig, "auth_type", "")
+        if auth_type == "external_process":
+            methods.add("external_process")
+        elif auth_type == "aws_sdk":
+            methods.add("aws_sdk")
+
+    if not methods:
+        return empty
+    if "oauth" in methods and "api_key" in methods:
+        kind = "mixed"
+    elif "oauth" in methods:
+        kind = "oauth"
+    elif "api_key" in methods:
+        kind = "api_key"
+    else:
+        kind = sorted(methods)[0]
+
+    deduped_sources = tuple(dict.fromkeys(sources))
+    return {
+        "kind": kind,
+        "configured": bool(deduped_sources or entries),
+        "sources": deduped_sources,
+    }
 
 
 def _count_skills(profile_dir: Path) -> int:
@@ -491,15 +693,27 @@ def list_profiles() -> List[ProfileInfo]:
     # Default profile
     default_home = _get_default_hermes_home()
     if default_home.is_dir():
-        model, provider = _read_config_model(default_home)
+        runtime = _read_config_runtime_summary(default_home)
+        auth = _read_auth_summary(default_home, runtime.get("provider"))
+        gateway_pid = _read_gateway_pid(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
         profiles.append(ProfileInfo(
             name="default",
             path=default_home,
             is_default=True,
-            gateway_running=_check_gateway_running(default_home),
-            model=model,
-            provider=provider,
+            config_path=default_home / "config.yaml",
+            env_path=default_home / ".env",
+            gateway_running=gateway_pid is not None,
+            gateway_pid=gateway_pid,
+            model=runtime.get("model"),
+            provider=runtime.get("provider"),
+            reasoning_effort=runtime.get("reasoning_effort"),
+            delegation_model=runtime.get("delegation_model"),
+            delegation_provider=runtime.get("delegation_provider"),
+            delegation_reasoning_effort=runtime.get("delegation_reasoning_effort"),
+            auth_kind=auth.get("kind"),
+            auth_configured=bool(auth.get("configured")),
+            auth_sources=auth.get("sources") or (),
             has_env=(default_home / ".env").exists(),
             skill_count=_count_skills(default_home),
             distribution_name=dist_name,
@@ -516,16 +730,28 @@ def list_profiles() -> List[ProfileInfo]:
             name = entry.name
             if not _PROFILE_ID_RE.match(name):
                 continue
-            model, provider = _read_config_model(entry)
+            runtime = _read_config_runtime_summary(entry)
+            auth = _read_auth_summary(entry, runtime.get("provider"))
+            gateway_pid = _read_gateway_pid(entry)
             alias_path = wrapper_dir / name
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
                 is_default=False,
-                gateway_running=_check_gateway_running(entry),
-                model=model,
-                provider=provider,
+                config_path=entry / "config.yaml",
+                env_path=entry / ".env",
+                gateway_running=gateway_pid is not None,
+                gateway_pid=gateway_pid,
+                model=runtime.get("model"),
+                provider=runtime.get("provider"),
+                reasoning_effort=runtime.get("reasoning_effort"),
+                delegation_model=runtime.get("delegation_model"),
+                delegation_provider=runtime.get("delegation_provider"),
+                delegation_reasoning_effort=runtime.get("delegation_reasoning_effort"),
+                auth_kind=auth.get("kind"),
+                auth_configured=bool(auth.get("configured")),
+                auth_sources=auth.get("sources") or (),
                 has_env=(entry / ".env").exists(),
                 skill_count=_count_skills(entry),
                 alias_path=alias_path if alias_path.exists() else None,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2628,12 +2628,27 @@ def _profile_attr(info, name: str, default: Any = None) -> Any:
 
 
 def _profile_to_dict(info) -> Dict[str, Any]:
+    config_path = _profile_attr(info, "config_path")
+    env_path = _profile_attr(info, "env_path")
     return {
         "name": _profile_attr(info, "name", ""),
         "path": str(_profile_attr(info, "path", "")),
         "is_default": bool(_profile_attr(info, "is_default", False)),
+        "config_path": str(config_path) if config_path else None,
+        "env_path": str(env_path) if env_path else None,
+        "gateway_running": bool(_profile_attr(info, "gateway_running", False)),
+        "gateway_pid": _profile_attr(info, "gateway_pid"),
         "model": _profile_attr(info, "model"),
         "provider": _profile_attr(info, "provider"),
+        "reasoning_effort": _profile_attr(info, "reasoning_effort"),
+        "delegation_model": _profile_attr(info, "delegation_model"),
+        "delegation_provider": _profile_attr(info, "delegation_provider"),
+        "delegation_reasoning_effort": _profile_attr(
+            info, "delegation_reasoning_effort"
+        ),
+        "auth_kind": _profile_attr(info, "auth_kind"),
+        "auth_configured": bool(_profile_attr(info, "auth_configured", False)),
+        "auth_sources": list(_profile_attr(info, "auth_sources", ()) or ()),
         "has_env": bool(_profile_attr(info, "has_env", False)),
         "skill_count": int(_profile_attr(info, "skill_count", 0) or 0),
     }
@@ -2649,13 +2664,26 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
     profiles: List[Dict[str, Any]] = []
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
-        model, provider = _safe(lambda: profiles_mod._read_config_model(default_home), (None, None))
+        runtime = _safe(lambda: profiles_mod._read_config_runtime_summary(default_home), {})
+        auth = _safe(lambda: profiles_mod._read_auth_summary(default_home, runtime.get("provider")), {})
+        gateway_pid = _safe(lambda: profiles_mod._read_gateway_pid(default_home), None)
         profiles.append({
             "name": "default",
             "path": str(default_home),
             "is_default": True,
-            "model": model,
-            "provider": provider,
+            "config_path": str(default_home / "config.yaml"),
+            "env_path": str(default_home / ".env"),
+            "gateway_running": gateway_pid is not None,
+            "gateway_pid": gateway_pid,
+            "model": runtime.get("model"),
+            "provider": runtime.get("provider"),
+            "reasoning_effort": runtime.get("reasoning_effort"),
+            "delegation_model": runtime.get("delegation_model"),
+            "delegation_provider": runtime.get("delegation_provider"),
+            "delegation_reasoning_effort": runtime.get("delegation_reasoning_effort"),
+            "auth_kind": auth.get("kind"),
+            "auth_configured": bool(auth.get("configured")),
+            "auth_sources": list(auth.get("sources") or ()),
             "has_env": (default_home / ".env").exists(),
             "skill_count": _safe(lambda: profiles_mod._count_skills(default_home), 0),
         })
@@ -2665,13 +2693,26 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
         for entry in sorted(profiles_root.iterdir()):
             if not entry.is_dir() or not profiles_mod._PROFILE_ID_RE.match(entry.name):
                 continue
-            model, provider = _safe(lambda entry=entry: profiles_mod._read_config_model(entry), (None, None))
+            runtime = _safe(lambda entry=entry: profiles_mod._read_config_runtime_summary(entry), {})
+            auth = _safe(lambda entry=entry, runtime=runtime: profiles_mod._read_auth_summary(entry, runtime.get("provider")), {})
+            gateway_pid = _safe(lambda entry=entry: profiles_mod._read_gateway_pid(entry), None)
             profiles.append({
                 "name": entry.name,
                 "path": str(entry),
                 "is_default": False,
-                "model": model,
-                "provider": provider,
+                "config_path": str(entry / "config.yaml"),
+                "env_path": str(entry / ".env"),
+                "gateway_running": gateway_pid is not None,
+                "gateway_pid": gateway_pid,
+                "model": runtime.get("model"),
+                "provider": runtime.get("provider"),
+                "reasoning_effort": runtime.get("reasoning_effort"),
+                "delegation_model": runtime.get("delegation_model"),
+                "delegation_provider": runtime.get("delegation_provider"),
+                "delegation_reasoning_effort": runtime.get("delegation_reasoning_effort"),
+                "auth_kind": auth.get("kind"),
+                "auth_configured": bool(auth.get("configured")),
+                "auth_sources": list(auth.get("sources") or ()),
                 "has_env": (entry / ".env").exists(),
                 "skill_count": _safe(lambda entry=entry: profiles_mod._count_skills(entry), 0),
             })

--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,67 @@ npm run build
 
 This outputs to `../hermes_cli/web_dist/`, which the FastAPI server serves as a static SPA. The built assets are included in the Python package via `pyproject.toml` package-data.
 
+## Profile Runtime UI Notes
+
+The Profiles page surfaces non-secret runtime metadata for each Hermes profile.
+Local Magic Moment operating policy for Shiori/Ritz/default belongs in the
+Phantom Factory SSOT, not in this UI package README.
+
+Current data flow:
+
+- Backend profile discovery lives in `hermes_cli/profiles.py`.
+- The dashboard REST payload is serialized by `hermes_cli/web_server.py`
+  through `GET /api/profiles`.
+- Frontend types live in `web/src/lib/api.ts`.
+- The UI is rendered by `web/src/pages/ProfilesPage.tsx`.
+
+`/api/profiles` currently returns non-secret runtime metadata:
+
+- profile name and `config.yaml` path
+- gateway running state and PID
+- main `model`, `provider`, and `agent.reasoning_effort`
+- subagent delegation model/provider/reasoning settings
+- auth method summary: `oauth`, `api_key`, `mixed`, `external_process`, or
+  `aws_sdk`
+- auth source labels such as `profile auth.json`, `global auth.json`, or
+  `.env:ANTHROPIC_API_KEY`
+
+Security rule: never return or render token values, key previews, refresh
+tokens, full env values, or raw `auth.json` entries from profile runtime UI.
+Only expose method and source labels. Profile credential lookup should mirror
+Hermes runtime semantics: profile `auth.json` wins for a provider, and global
+`~/.hermes/auth.json` is only a read-only fallback when the profile has no
+entries for that provider.
+
+When adding another runtime field, update all four touchpoints above and verify
+with:
+
+```bash
+python -m py_compile hermes_cli/profiles.py hermes_cli/web_server.py
+cd web && npm run build
+```
+
+If an agent sandbox cannot empty `hermes_cli/web_dist/`, build to a temporary
+directory and copy the generated `index.html` plus new assets into
+`hermes_cli/web_dist/` without deleting existing assets:
+
+```bash
+cd web
+npm run build -- --outDir /private/tmp/hermes-web-dist-check --emptyOutDir
+cp /private/tmp/hermes-web-dist-check/index.html ../hermes_cli/web_dist/index.html
+cp /private/tmp/hermes-web-dist-check/assets/* ../hermes_cli/web_dist/assets/
+```
+
+The local Mac mini dashboard is managed by the `ai.hermes.dashboard`
+LaunchAgent and serves prebuilt assets with `--skip-build`. After changing
+served assets or backend code, restart only the dashboard service:
+
+```bash
+launchctl kickstart -k gui/501/ai.hermes.dashboard
+```
+
+Do not restart Hermes profile gateways for UI-only changes.
+
 ## Structure
 
 ```

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -505,8 +505,19 @@ export interface ProfileInfo {
   name: string;
   path: string;
   is_default: boolean;
+  config_path: string | null;
+  env_path: string | null;
+  gateway_running: boolean;
+  gateway_pid: number | null;
   model: string | null;
   provider: string | null;
+  reasoning_effort: string | null;
+  delegation_model: string | null;
+  delegation_provider: string | null;
+  delegation_reasoning_effort: string | null;
+  auth_kind: string | null;
+  auth_configured: boolean;
+  auth_sources: string[];
   has_env: boolean;
   skill_count: number;
 }

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1,8 +1,22 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { ChevronDown, Pencil, Plus, Terminal, Trash2, Users, X } from "lucide-react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Pencil,
+  Plus,
+  Terminal,
+  Trash2,
+  Users,
+  X,
+  XCircle,
+} from "lucide-react";
 import { H2 } from "@/components/NouiTypography";
 import { api } from "@/lib/api";
 import type { ProfileInfo } from "@/lib/api";
+import { cn } from "@/lib/utils";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@/hooks/useToast";
 import { useConfirmDelete } from "@/hooks/useConfirmDelete";
@@ -20,13 +34,171 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 // Mirrors hermes_cli/profiles.py::_PROFILE_ID_RE so we can reject obviously
 // invalid names (uppercase, spaces, …) before round-tripping a doomed POST.
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const EXPECTED_RUNTIME = {
+  model: "gpt-5.5",
+  provider: "openai-codex",
+  reasoning: "high",
+} as const;
+
+type DriftItem = {
+  key: "model" | "provider" | "reasoning";
+  current: string;
+  expected: string;
+};
+
+const emptyValue = "-";
+
+function normalizeRuntimeValue(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function displayRuntimeValue(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed || emptyValue;
+}
+
+function hasOpusModel(profile: ProfileInfo): boolean {
+  return normalizeRuntimeValue(profile.model).includes("opus");
+}
+
+function usesAnthropicProvider(profile: ProfileInfo): boolean {
+  return normalizeRuntimeValue(profile.provider).includes("anthropic");
+}
+
+function usesGlobalAuthFallback(profile: ProfileInfo): boolean {
+  return (profile.auth_sources || []).some((source) =>
+    source.toLowerCase().includes("global auth.json"),
+  );
+}
+
+function getRuntimeDrift(profile: ProfileInfo): DriftItem[] {
+  const checks: DriftItem[] = [];
+  if (normalizeRuntimeValue(profile.model) !== EXPECTED_RUNTIME.model) {
+    checks.push({
+      key: "model",
+      current: displayRuntimeValue(profile.model),
+      expected: EXPECTED_RUNTIME.model,
+    });
+  }
+  if (normalizeRuntimeValue(profile.provider) !== EXPECTED_RUNTIME.provider) {
+    checks.push({
+      key: "provider",
+      current: displayRuntimeValue(profile.provider),
+      expected: EXPECTED_RUNTIME.provider,
+    });
+  }
+  if (normalizeRuntimeValue(profile.reasoning_effort) !== EXPECTED_RUNTIME.reasoning) {
+    checks.push({
+      key: "reasoning",
+      current: displayRuntimeValue(profile.reasoning_effort),
+      expected: EXPECTED_RUNTIME.reasoning,
+    });
+  }
+  return checks;
+}
+
+function getProfileSeverity(profile: ProfileInfo): "critical" | "warning" | "ok" {
+  if (hasOpusModel(profile) || usesAnthropicProvider(profile)) return "critical";
+  if (usesGlobalAuthFallback(profile) || getRuntimeDrift(profile).length > 0) return "warning";
+  return "ok";
+}
 
 export default function ProfilesPage() {
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const { setEnd } = usePageHeader();
+  const profileLabels =
+    locale === "ja"
+      ? {
+          actions: "操作",
+          auth: "認証",
+          authSource: "認証元",
+          authKinds: {
+            api_key: "API key",
+            aws_sdk: "AWS SDK",
+            external_process: "External process",
+            mixed: "OAuth + API key",
+            oauth: "OAuth",
+          },
+          closeDetails: "詳細を閉じる",
+          config: "設定",
+          copy: "コピー",
+          copyConfigPath: "config pathをコピー",
+          copyEnvPath: "env pathをコピー",
+          copyProfilePath: "profile pathをコピー",
+          critical: "要修正",
+          details: "詳細",
+          drift: "期待値との差分",
+          env: "Env",
+          expected: "期待値",
+          expectedRuntime: "GPT-5.5 + openai-codex + high",
+          gateway: "Gateway",
+          globalFallback: "global auth.json fallback",
+          harness: "ハーネス",
+          inherit: "継承",
+          model: "モデル",
+          noDrift: "期待値通り",
+          notConfigured: "未設定",
+          ok: "OK",
+          path: "Profile path",
+          profile: "Profile",
+          provider: "Provider",
+          reasoning: "推論",
+          running: "稼働中",
+          settings: "設定 / 参照",
+          source: "Source",
+          status: "状態",
+          stopped: "停止",
+          subagents: "Subagents",
+          warning: "注意",
+        }
+      : {
+          actions: "Actions",
+          auth: "Auth",
+          authSource: "Auth source",
+          authKinds: {
+            api_key: "API key",
+            aws_sdk: "AWS SDK",
+            external_process: "External process",
+            mixed: "OAuth + API key",
+            oauth: "OAuth",
+          },
+          closeDetails: "Close details",
+          config: "Config",
+          copy: "Copy",
+          copyConfigPath: "Copy config path",
+          copyEnvPath: "Copy env path",
+          copyProfilePath: "Copy profile path",
+          critical: "Fix",
+          details: "Details",
+          drift: "Expected drift",
+          env: "Env",
+          expected: "Expected",
+          expectedRuntime: "GPT-5.5 + openai-codex + high",
+          gateway: "Gateway",
+          globalFallback: "global auth.json fallback",
+          harness: "Harness",
+          inherit: "inherit",
+          model: "Model",
+          noDrift: "matches expected",
+          notConfigured: "not configured",
+          ok: "OK",
+          path: "Profile path",
+          profile: "Profile",
+          provider: "Provider",
+          reasoning: "Reasoning",
+          running: "running",
+          settings: "Settings / reference",
+          source: "Source",
+          status: "Status",
+          stopped: "stopped",
+          subagents: "Subagents",
+          warning: "Warning",
+        };
+  const formatAuthKind = (kind: string | null | undefined) =>
+    kind ? profileLabels.authKinds[kind as keyof typeof profileLabels.authKinds] || kind : profileLabels.notConfigured;
 
   // Create modal
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -42,6 +214,7 @@ export default function ProfilesPage() {
   // Inline rename state
   const [renamingFrom, setRenamingFrom] = useState<string | null>(null);
   const [renameTo, setRenameTo] = useState("");
+  const [expandedProfile, setExpandedProfile] = useState<string | null>(null);
 
   // Inline SOUL editor state
   const [editingSoulFor, setEditingSoulFor] = useState<string | null>(null);
@@ -117,6 +290,7 @@ export default function ProfilesPage() {
         setEditingSoulFor(null);
         return;
       }
+      setExpandedProfile(name);
       setEditingSoulFor(name);
       setSoulText("");
       activeSoulRequest.current = name;
@@ -132,6 +306,19 @@ export default function ProfilesPage() {
       }
     },
     [editingSoulFor, showToast, t.status.error],
+  );
+
+  const copyText = useCallback(
+    async (label: string, value: string | null | undefined) => {
+      if (!value) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        showToast(`${label}: ${value}`, "success");
+      } catch {
+        showToast(`${t.profiles.copyFailed}: ${value}`, "error");
+      }
+    },
+    [showToast, t.profiles.copyFailed],
   );
 
   const handleSaveSoul = async (name: string) => {
@@ -313,182 +500,419 @@ export default function ProfilesPage() {
           </Card>
         )}
 
-        {profiles.map((p) => {
-          const isRenaming = renamingFrom === p.name;
-          const isEditingSoul = editingSoulFor === p.name;
-          return (
-            <Card key={p.name}>
-              <CardContent className="flex items-center gap-4 py-4">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1 flex-wrap">
-                    {isRenaming ? (
-                      <Input
-                        autoFocus
-                        value={renameTo}
-                        onChange={(e) => setRenameTo(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") handleRenameSubmit();
-                          if (e.key === "Escape") setRenamingFrom(null);
-                        }}
-                        aria-invalid={
-                          renameTo.trim() !== "" &&
-                          renameTo.trim() !== p.name &&
-                          !PROFILE_NAME_RE.test(renameTo.trim())
-                        }
-                        className="max-w-xs"
-                      />
-                    ) : (
-                      <span className="font-medium text-sm truncate">
-                        {p.name}
-                      </span>
-                    )}
-                    {p.is_default && (
-                      <Badge tone="secondary">{t.profiles.defaultBadge}</Badge>
-                    )}
-                    {p.has_env && (
-                      <Badge tone="outline">{t.profiles.hasEnv}</Badge>
-                    )}
-                  </div>
-                  {isRenaming &&
-                    (() => {
-                      const trimmed = renameTo.trim();
-                      const invalid =
-                        trimmed !== "" &&
-                        trimmed !== p.name &&
-                        !PROFILE_NAME_RE.test(trimmed);
-                      return (
-                        <p
-                          className={
-                            "text-xs mb-1 " +
-                            (invalid
-                              ? "text-destructive"
-                              : "text-muted-foreground")
-                          }
-                        >
-                          {invalid
-                            ? `${t.profiles.invalidName}: ${t.profiles.nameRule}`
-                            : t.profiles.nameRule}
-                        </p>
-                      );
-                    })()}
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">
-                    {p.model && (
-                      <span>
-                        {t.profiles.model}: {p.model}
-                        {p.provider ? ` (${p.provider})` : ""}
-                      </span>
-                    )}
-                    <span>
-                      {t.profiles.skills}: {p.skill_count}
-                    </span>
-                    <span className="font-mono truncate max-w-[28rem]">
-                      {p.path}
-                    </span>
-                  </div>
-                </div>
+        {profiles.length > 0 && (
+          <div className="overflow-x-auto border border-border bg-card/80">
+            <table className="w-full min-w-[1120px] text-left text-sm">
+              <thead className="border-b border-border bg-muted/20 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 font-medium">{profileLabels.profile}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.model}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.provider}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.auth}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.reasoning}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.gateway}</th>
+                  <th className="px-4 py-3 font-medium">{profileLabels.drift}</th>
+                  <th className="px-4 py-3 text-right font-medium">{profileLabels.actions}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {profiles.map((p) => {
+                  const isRenaming = renamingFrom === p.name;
+                  const isEditingSoul = editingSoulFor === p.name;
+                  const isExpanded = expandedProfile === p.name;
+                  const drift = getRuntimeDrift(p);
+                  const severity = getProfileSeverity(p);
+                  const isCritical = severity === "critical";
+                  const isWarning = severity === "warning";
+                  const globalFallback = usesGlobalAuthFallback(p);
+                  const authLabel = p.auth_configured
+                    ? formatAuthKind(p.auth_kind)
+                    : profileLabels.notConfigured;
+                  const authSources = p.auth_sources?.length
+                    ? p.auth_sources.join(", ")
+                    : profileLabels.notConfigured;
+                  const subagentReasoning =
+                    p.delegation_reasoning_effort ||
+                    (p.reasoning_effort
+                      ? `${profileLabels.inherit} (${p.reasoning_effort})`
+                      : profileLabels.inherit);
+                  const subagentModel = [p.delegation_provider, p.delegation_model]
+                    .filter(Boolean)
+                    .join(":");
+                  const soulPath = `${p.path}/SOUL.md`;
 
-                <div className="flex items-center gap-1 shrink-0">
-                  {isRenaming ? (
-                    <>
-                      <Button
-                        size="sm"
-                        onClick={handleRenameSubmit}
-                      >
-                        {t.common.save}
-                      </Button>
-                      <Button
-                        size="sm"
-                        ghost
-                        onClick={() => setRenamingFrom(null)}
-                      >
-                        {t.common.cancel}
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <Button
-                        ghost
-                        size="icon"
-                        title={t.profiles.editSoul}
-                        aria-label={t.profiles.editSoul}
-                        onClick={() => openSoulEditor(p.name)}
-                      >
-                        {isEditingSoul ? (
-                          <ChevronDown className="h-4 w-4" />
-                        ) : (
-                          <span aria-hidden className="text-xs font-bold">
-                            S
-                          </span>
+                  return (
+                    <Fragment key={p.name}>
+                      <tr
+                        className={cn(
+                          "border-b border-border align-top transition-colors",
+                          isExpanded && "bg-muted/10",
+                          isCritical && "bg-destructive/10",
+                          isWarning && "bg-yellow-500/10",
                         )}
-                      </Button>
-                      <Button
-                        ghost
-                        size="icon"
-                        title={t.profiles.openInTerminal}
-                        aria-label={t.profiles.openInTerminal}
-                        onClick={() => handleCopyTerminalCommand(p.name)}
                       >
-                        <Terminal className="h-4 w-4" />
-                      </Button>
-                      {!p.is_default && (
-                        <Button
-                          ghost
-                          size="icon"
-                          title={t.profiles.rename}
-                          aria-label={t.profiles.rename}
-                          onClick={() => {
-                            setRenamingFrom(p.name);
-                            setRenameTo(p.name);
-                          }}
+                        <td className="px-4 py-3">
+                          <div className="flex items-start gap-2">
+                            <Button
+                              ghost
+                              size="icon"
+                              className="h-7 w-7 shrink-0"
+                              title={isExpanded ? profileLabels.closeDetails : profileLabels.details}
+                              aria-label={isExpanded ? profileLabels.closeDetails : profileLabels.details}
+                              onClick={() => setExpandedProfile(isExpanded ? null : p.name)}
+                            >
+                              {isExpanded ? (
+                                <ChevronDown className="h-4 w-4" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <div className="min-w-0">
+                              {isRenaming ? (
+                                <Input
+                                  autoFocus
+                                  value={renameTo}
+                                  onChange={(e) => setRenameTo(e.target.value)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter") handleRenameSubmit();
+                                    if (e.key === "Escape") setRenamingFrom(null);
+                                  }}
+                                  aria-invalid={
+                                    renameTo.trim() !== "" &&
+                                    renameTo.trim() !== p.name &&
+                                    !PROFILE_NAME_RE.test(renameTo.trim())
+                                  }
+                                  className="h-8 max-w-[13rem]"
+                                />
+                              ) : (
+                                <div className="flex items-center gap-2">
+                                  <span className="truncate font-medium">{p.name}</span>
+                                  {severity === "ok" && (
+                                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-600" />
+                                  )}
+                                  {severity === "warning" && (
+                                    <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-yellow-600" />
+                                  )}
+                                  {severity === "critical" && (
+                                    <XCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+                                  )}
+                                </div>
+                              )}
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {p.is_default && (
+                                  <Badge tone="secondary">{t.profiles.defaultBadge}</Badge>
+                                )}
+                                {p.has_env && <Badge tone="outline">{t.profiles.hasEnv}</Badge>}
+                                <Badge tone="outline">{t.profiles.skills}: {p.skill_count}</Badge>
+                              </div>
+                              {isRenaming &&
+                                (() => {
+                                  const trimmed = renameTo.trim();
+                                  const invalid =
+                                    trimmed !== "" &&
+                                    trimmed !== p.name &&
+                                    !PROFILE_NAME_RE.test(trimmed);
+                                  return (
+                                    <p
+                                      className={cn(
+                                        "mt-1 text-xs",
+                                        invalid ? "text-destructive" : "text-muted-foreground",
+                                      )}
+                                    >
+                                      {invalid
+                                        ? `${t.profiles.invalidName}: ${t.profiles.nameRule}`
+                                        : t.profiles.nameRule}
+                                    </p>
+                                  );
+                                })()}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs">
+                          {displayRuntimeValue(p.model)}
+                        </td>
+                        <td
+                          className={cn(
+                            "px-4 py-3 font-mono text-xs",
+                            usesAnthropicProvider(p) && "font-semibold text-destructive",
+                          )}
                         >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                      )}
-                      {!p.is_default && (
-                        <Button
-                          ghost
-                          size="icon"
-                          title={t.common.delete}
-                          aria-label={t.common.delete}
-                          onClick={() => profileDelete.requestDelete(p.name)}
-                        >
-                          <Trash2 className="h-4 w-4 text-destructive" />
-                        </Button>
-                      )}
-                    </>
-                  )}
-                </div>
-              </CardContent>
+                          {displayRuntimeValue(p.provider)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-col gap-1">
+                            <span className="text-xs">{authLabel}</span>
+                            {globalFallback && (
+                              <span className="inline-flex w-fit items-center gap-1 text-xs font-medium text-yellow-700 dark:text-yellow-400">
+                                <AlertTriangle className="h-3 w-3" />
+                                {profileLabels.globalFallback}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs">
+                          {displayRuntimeValue(p.reasoning_effort)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div
+                            className={cn(
+                              "inline-flex items-center gap-1 text-xs font-medium",
+                              p.gateway_running ? "text-emerald-600" : "text-muted-foreground",
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                "h-2 w-2 rounded-full",
+                                p.gateway_running ? "bg-emerald-500" : "bg-muted-foreground/40",
+                              )}
+                            />
+                            {p.gateway_running ? profileLabels.running : profileLabels.stopped}
+                            {p.gateway_pid ? ` / PID ${p.gateway_pid}` : ""}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex max-w-[22rem] flex-col gap-1 text-xs">
+                            {hasOpusModel(p) && (
+                              <span className="inline-flex items-center gap-1 font-semibold text-destructive">
+                                <XCircle className="h-3 w-3" />
+                                Opus model
+                              </span>
+                            )}
+                            {usesAnthropicProvider(p) && (
+                              <span className="inline-flex items-center gap-1 font-semibold text-destructive">
+                                <XCircle className="h-3 w-3" />
+                                Anthropic provider
+                              </span>
+                            )}
+                            {globalFallback && (
+                              <span className="inline-flex items-center gap-1 font-medium text-yellow-700 dark:text-yellow-400">
+                                <AlertTriangle className="h-3 w-3" />
+                                {profileLabels.globalFallback}
+                              </span>
+                            )}
+                            {drift.length === 0 ? (
+                              <span className="inline-flex items-center gap-1 text-emerald-600">
+                                <CheckCircle2 className="h-3 w-3" />
+                                {profileLabels.noDrift}
+                              </span>
+                            ) : (
+                              drift.map((item) => (
+                                <span key={item.key} className="text-muted-foreground">
+                                  <span className="font-medium text-foreground">
+                                    {profileLabels[item.key]}:
+                                  </span>{" "}
+                                  <span className="font-mono">{item.current}</span>
+                                  {" -> "}
+                                  <span className="font-mono text-foreground">
+                                    {item.expected}
+                                  </span>
+                                </span>
+                              ))
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center justify-end gap-1">
+                            {isRenaming ? (
+                              <>
+                                <Button size="sm" onClick={handleRenameSubmit}>
+                                  {t.common.save}
+                                </Button>
+                                <Button size="sm" ghost onClick={() => setRenamingFrom(null)}>
+                                  {t.common.cancel}
+                                </Button>
+                              </>
+                            ) : (
+                              <>
+                                <Button
+                                  ghost
+                                  size="icon"
+                                  title={t.profiles.editSoul}
+                                  aria-label={t.profiles.editSoul}
+                                  onClick={() => openSoulEditor(p.name)}
+                                >
+                                  {isEditingSoul ? (
+                                    <ChevronDown className="h-4 w-4" />
+                                  ) : (
+                                    <Pencil className="h-4 w-4" />
+                                  )}
+                                </Button>
+                                <Button
+                                  ghost
+                                  size="icon"
+                                  title={t.profiles.openInTerminal}
+                                  aria-label={t.profiles.openInTerminal}
+                                  onClick={() => handleCopyTerminalCommand(p.name)}
+                                >
+                                  <Terminal className="h-4 w-4" />
+                                </Button>
+                                {!p.is_default && (
+                                  <Button
+                                    ghost
+                                    size="icon"
+                                    title={t.profiles.rename}
+                                    aria-label={t.profiles.rename}
+                                    onClick={() => {
+                                      setRenamingFrom(p.name);
+                                      setRenameTo(p.name);
+                                    }}
+                                  >
+                                    <Pencil className="h-4 w-4" />
+                                  </Button>
+                                )}
+                                {!p.is_default && (
+                                  <Button
+                                    ghost
+                                    size="icon"
+                                    title={t.common.delete}
+                                    aria-label={t.common.delete}
+                                    onClick={() => profileDelete.requestDelete(p.name)}
+                                  >
+                                    <Trash2 className="h-4 w-4 text-destructive" />
+                                  </Button>
+                                )}
+                              </>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
 
-              {isEditingSoul && (
-                <div className="border-t border-border px-4 pb-4 pt-3 flex flex-col gap-2">
-                  <Label
-                    htmlFor={`soul-editor-${p.name}`}
-                    className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground"
-                  >
-                    {t.profiles.soulSection}
-                  </Label>
-                  <textarea
-                    id={`soul-editor-${p.name}`}
-                    className="flex min-h-[180px] w-full border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    placeholder={t.profiles.soulPlaceholder}
-                    value={soulText}
-                    onChange={(e) => setSoulText(e.target.value)}
-                  />
-                  <div>
-                    <Button
-                      size="sm"
-                      onClick={() => handleSaveSoul(p.name)}
-                      disabled={soulSaving}
-                    >
-                      {soulSaving ? t.common.saving : t.profiles.saveSoul}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </Card>
-          );
-        })}
+                      {isExpanded && (
+                        <tr className="border-b border-border bg-muted/10">
+                          <td colSpan={8} className="px-4 py-4">
+                            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+                              <div className="grid gap-3">
+                                <div className="text-xs font-medium uppercase text-muted-foreground">
+                                  {profileLabels.settings}
+                                </div>
+                                <dl className="grid gap-2 text-xs">
+                                  {[
+                                    {
+                                      label: profileLabels.config,
+                                      value: p.config_path,
+                                      action: profileLabels.copyConfigPath,
+                                    },
+                                    {
+                                      label: profileLabels.env,
+                                      value: p.env_path,
+                                      action: profileLabels.copyEnvPath,
+                                    },
+                                    {
+                                      label: profileLabels.path,
+                                      value: p.path,
+                                      action: profileLabels.copyProfilePath,
+                                    },
+                                    {
+                                      label: "SOUL.md",
+                                      value: soulPath,
+                                      action: `${profileLabels.copy} SOUL.md`,
+                                    },
+                                  ].map((row) => (
+                                    <div
+                                      key={row.label}
+                                      className="grid grid-cols-[7rem_minmax(0,1fr)_2rem] items-center gap-2"
+                                    >
+                                      <dt className="text-muted-foreground">{row.label}</dt>
+                                      <dd className="min-w-0 truncate font-mono">
+                                        {displayRuntimeValue(row.value)}
+                                      </dd>
+                                      <Button
+                                        ghost
+                                        size="icon"
+                                        className="h-7 w-7"
+                                        title={row.action}
+                                        aria-label={row.action}
+                                        disabled={!row.value}
+                                        onClick={() => copyText(row.action, row.value)}
+                                      >
+                                        <Copy className="h-3.5 w-3.5" />
+                                      </Button>
+                                    </div>
+                                  ))}
+                                  <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
+                                    <dt className="text-muted-foreground">
+                                      {profileLabels.authSource}
+                                    </dt>
+                                    <dd className="min-w-0 break-words font-mono">
+                                      {authSources}
+                                    </dd>
+                                  </div>
+                                  <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
+                                    <dt className="text-muted-foreground">
+                                      {profileLabels.subagents}
+                                    </dt>
+                                    <dd className="min-w-0 break-words font-mono">
+                                      {subagentReasoning}
+                                      {subagentModel ? ` / ${subagentModel}` : ""}
+                                    </dd>
+                                  </div>
+                                  <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
+                                    <dt className="text-muted-foreground">
+                                      {profileLabels.expected}
+                                    </dt>
+                                    <dd className="font-mono">{profileLabels.expectedRuntime}</dd>
+                                  </div>
+                                </dl>
+                              </div>
+
+                              <div className="grid gap-3">
+                                <div className="flex items-center justify-between gap-2">
+                                  <div className="text-xs font-medium uppercase text-muted-foreground">
+                                    {profileLabels.harness}
+                                  </div>
+                                  {!isEditingSoul && (
+                                    <Button size="sm" ghost onClick={() => openSoulEditor(p.name)}>
+                                      <Pencil className="h-3.5 w-3.5" />
+                                      {t.profiles.editSoul}
+                                    </Button>
+                                  )}
+                                </div>
+
+                                {isEditingSoul ? (
+                                  <div className="flex flex-col gap-2">
+                                    <Label
+                                      htmlFor={`soul-editor-${p.name}`}
+                                      className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground"
+                                    >
+                                      {t.profiles.soulSection}
+                                    </Label>
+                                    <textarea
+                                      id={`soul-editor-${p.name}`}
+                                      className="flex min-h-[220px] w-full border border-input bg-background/40 px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                                      placeholder={t.profiles.soulPlaceholder}
+                                      value={soulText}
+                                      onChange={(e) => setSoulText(e.target.value)}
+                                    />
+                                    <div className="flex justify-end">
+                                      <Button
+                                        size="sm"
+                                        onClick={() => handleSaveSoul(p.name)}
+                                        disabled={soulSaving}
+                                      >
+                                        {soulSaving ? t.common.saving : t.profiles.saveSoul}
+                                      </Button>
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <div className="border border-border bg-background/30 p-3 text-xs text-muted-foreground">
+                                    <div className="font-mono text-foreground">{soulPath}</div>
+                                    <div className="mt-2">
+                                      {profileLabels.harness}: SOUL.md / {profileLabels.config}: config.yaml
+                                    </div>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds non-secret runtime metadata to profile discovery and `/api/profiles`.
- Converts the Profiles page from profile cards to a comparison table.
- Flags Anthropic/Opus drift, reasoning/model/provider drift, gateway state, and global `auth.json` fallback.
- Adds per-profile details for config path, env path, auth source, delegation summary, and SOUL.md editing.

## Validation

- `python -m py_compile hermes_cli/profiles.py hermes_cli/web_server.py`
- `git diff --check`
- `npm --cache /tmp/codex-npm-cache ci --ignore-scripts`
- `npm run build -- --outDir /private/tmp/hermes-web-dist-pr-check --emptyOutDir`

## Notes

The UI only exposes auth method/source labels and file paths. It does not render token values, API key previews, refresh tokens, raw `.env`, or raw `auth.json`.
