### PR TITLE
fix(dashboard): require auth for plugin rescan

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -118,7 +118,6 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/model/info",
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
-    "/api/dashboard/plugins/rescan",
 })
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -327,6 +327,12 @@ class TestWebServerEndpoints:
         # Public endpoints should still work
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
+        resp = unauth_client.get("/api/dashboard/plugins")
+        assert resp.status_code == 200
+        resp = unauth_client.get("/api/dashboard/plugins/rescan")
+        assert resp.status_code == 401
+        resp = self.client.get("/api/dashboard/plugins/rescan")
+        assert resp.status_code == 200
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""


### PR DESCRIPTION
## What does this PR do?

Requires the dashboard session token for `/api/dashboard/plugins/rescan`.

`/api/dashboard/plugins` remains public because it is a read-only metadata endpoint. `rescan` is different: it forces dashboard plugin discovery to refresh process-local cache, so it should not be in `_PUBLIC_API_PATHS`, whose comment says only non-sensitive read-only endpoints belong there.

The dashboard frontend already attaches the session token to all `/api/*` requests via `fetchJSON()`, so normal UI use continues to work.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Remove `/api/dashboard/plugins/rescan` from `_PUBLIC_API_PATHS`.

- `tests/hermes_cli/test_web_server.py`
  - Assert unauthenticated callers can still read `/api/dashboard/plugins`.
  - Assert unauthenticated callers cannot trigger `/api/dashboard/plugins/rescan`.
  - Assert authenticated dashboard callers can still trigger rescan.

## How to Test

1. Run the focused regression test:

```bash
/private/tmp/hermes-agent-test-venv/bin/python -m pytest -o addopts='' \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_unauthenticated_api_blocked \
  -q
```

2. Confirm the result:

```text
1 passed in 1.16s
```

3. Confirm whitespace/diff hygiene:

```bash
git diff --check HEAD~1..HEAD
```

No output means the check passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Python 3.13.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure allowlist change, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ /private/tmp/hermes-agent-test-venv/bin/python -m pytest -o addopts='' \
  tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_unauthenticated_api_blocked \
  -q

.                                                                        [100%]
1 passed in 1.16s
```