### PR TITLE
Allow inspecting installed local skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -145,6 +145,40 @@ def _derive_category_from_install_path(install_path: str) -> str:
     return "" if parent == "." else parent
 
 
+def _inspect_local_skill(identifier: str) -> Optional[dict]:
+    """Return metadata and preview for an installed local skill, if present."""
+    try:
+        from tools.skills_tool import skill_view
+    except Exception:
+        return None
+
+    try:
+        raw = skill_view(identifier, preprocess=False)
+        data = json.loads(raw)
+    except Exception:
+        return None
+
+    if not data.get("success"):
+        return None
+
+    content = str(data.get("content") or "")
+    lines = content.split("\n")
+    preview = "\n".join(lines[:50])
+    if len(lines) > 50:
+        preview += f"\n\n... ({len(lines) - 50} more lines)"
+
+    return {
+        "name": data.get("name") or identifier,
+        "description": data.get("description") or "",
+        "source": "local",
+        "identifier": identifier,
+        "trust": "local",
+        "tags": [],
+        "path": data.get("path") or data.get("skill_dir"),
+        "skill_md_preview": preview,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Interactive name/category resolution for URL-installed skills
 # ---------------------------------------------------------------------------
@@ -749,6 +783,24 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
     from tools.skills_hub import GitHubAuth, create_source_router
 
     c = console or _console
+    local = _inspect_local_skill(identifier)
+    if local:
+        c.print()
+        info_lines = [
+            f"[bold]Name:[/] {local['name']}",
+            f"[bold]Description:[/] {local['description']}",
+            "[bold]Source:[/] local",
+            "[bold]Trust:[/] [dim]local[/]",
+            f"[bold]Identifier:[/] {local['identifier']}",
+        ]
+        if local.get("path"):
+            info_lines.append(f"[bold]Path:[/] {local['path']}")
+        c.print(Panel("\n".join(info_lines), title=f"Skill: {local['name']}"))
+        if local.get("skill_md_preview"):
+            c.print(Panel(local["skill_md_preview"], title="SKILL.md Preview", subtitle="installed local skill"))
+        c.print()
+        return
+
     auth = GitHubAuth()
     sources = create_source_router(auth)
 
@@ -846,6 +898,18 @@ def browse_skills(page: int = 1, page_size: int = 20, source: str = "all") -> di
 def inspect_skill(identifier: str) -> Optional[dict]:
     """Skill metadata (+ SKILL.md preview) for programmatic callers."""
     from tools.skills_hub import GitHubAuth, create_source_router
+
+    local = _inspect_local_skill(identifier)
+    if local:
+        return {
+            "name": local["name"],
+            "description": local["description"],
+            "source": "local",
+            "identifier": local["identifier"],
+            "tags": [],
+            "path": local.get("path"),
+            "skill_md_preview": local.get("skill_md_preview", ""),
+        }
 
     class _Q:
         def print(self, *a, **k):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,15 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_inspect,
+    do_install,
+    do_list,
+    do_update,
+    handle_skills_slash,
+    inspect_skill,
+)
 
 
 class _DummyLockFile:
@@ -98,6 +106,23 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
     return sink.getvalue(), installs
 
 
+def _write_local_skill(skills_dir, category: str, name: str) -> None:
+    skill_dir = skills_dir / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: local description\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    tags: [local, regression]\n"
+        "---\n"
+        f"# {name}\n\n"
+        "Local skill body from temp HERMES_HOME.\n",
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -136,6 +161,51 @@ def test_do_list_filter_local(three_source_env):
     assert "local-skill" in output
     assert "builtin-skill" not in output
     assert "hub-skill" not in output
+
+
+def test_do_inspect_prefers_categorized_local_skill_before_hub_lookup(monkeypatch, tmp_path):
+    """data-contract: local inspect uses a real temp HERMES_HOME skill first."""
+    import tools.skills_tool as skills_tool
+
+    skills_dir = tmp_path / "hermes" / "skills"
+    _write_local_skill(skills_dir, "ops", "local-skill")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        "tools.skills_hub.create_source_router",
+        lambda auth: (_ for _ in ()).throw(AssertionError("hub lookup should not run")),
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_inspect("ops/local-skill", console=console)
+    output = sink.getvalue()
+
+    assert "local-skill" in output
+    assert "local description" in output
+    assert "installed local skill" in output
+    assert "ops/local-skill/SKILL.md" in output
+
+
+def test_programmatic_inspect_returns_categorized_local_skill(monkeypatch, tmp_path):
+    """data-contract: programmatic inspect reads local SKILL.md filesystem state."""
+    import tools.skills_tool as skills_tool
+
+    skills_dir = tmp_path / "hermes" / "skills"
+    _write_local_skill(skills_dir, "ops", "local-skill")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(
+        "tools.skills_hub.create_source_router",
+        lambda auth: (_ for _ in ()).throw(AssertionError("hub lookup should not run")),
+    )
+
+    result = inspect_skill("ops/local-skill")
+
+    assert result["source"] == "local"
+    assert result["name"] == "local-skill"
+    assert result["path"] == "ops/local-skill/SKILL.md"
+    assert "Local skill body from temp HERMES_HOME." in result["skill_md_preview"]
 
 
 def test_do_list_filter_hub(three_source_env):
@@ -780,4 +850,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-


### PR DESCRIPTION
## Summary
- Narrow this PR to the installed local skill inspect bug only.
- Resolve local skills through the existing `tools.skills_tool.skill_view` path before falling back to hub sources in `hermes skills inspect`.
- Return local skill metadata for programmatic `inspect_skill` callers.

## Official Criteria Applied
- `AGENTS.md` requires resolution-chain and file-I/O changes to use real temp `HERMES_HOME` coverage rather than mocks.
- `AGENTS.md` rejects new non-secret `HERMES_*` behavioral env vars; this PR does not add any.
- The core stays narrow: no ACP, transport, auth, provider, gateway, model-switching, or runtime-loop changes are included.

## Acceptance Checklist
- [x] PR diff is limited to `hermes_cli/skills_hub.py` and `tests/hermes_cli/test_skills_hub.py`.
- [x] `hermes skills inspect` checks installed local skills before hub lookup.
- [x] Programmatic `inspect_skill` returns local skill metadata and preview.
- [x] Regression coverage creates a real local `SKILL.md` under a temp `HERMES_HOME` skills tree.
- [x] Categorized local lookup is covered with `ops/local-skill`.
- [x] Hub lookup is asserted not to run when the local match succeeds.
- [x] No new `HERMES_*` env var or unrelated runtime behavior is introduced.

## Out Of Scope / Split Out
These were intentionally removed from this PR after maintainer review flagged the previous branch as too broad:
- ACP registry/version changes.
- Codex transport changes and `HERMES_CODEX_BIN`.
- Slack channel directory changes.
- xAI auth / credential-pool changes.
- Model switching changes.
- `run_agent.py` Kimi/OpenRouter behavior changes.
- Gateway voice/thread baseline changes.
- Google Chat / Teams aiohttp fake-test changes.
- Tools config browser-provider regression changes.
- Release/package version updates.

If any of the above still matters, it should be handled as a focused follow-up PR with its own reproduction, official criteria, and tests.

## Verification
- `uv run --with pytest python -m pytest tests/hermes_cli/test_skills_hub.py -q`
- `/private/tmp/hermes-pr-27343/.venv/bin/python -m py_compile hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py`
- `git diff --check -- hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py`
