### PR TITLE
fix(security): redact xAI (Grok) API keys in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -103,6 +103,7 @@ _PREFIX_PATTERNS = [
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
+    r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -511,3 +511,29 @@ class TestFormBodyRedaction:
         text = "first=1\nsecond=2"
         # Should pass through (still subject to other redactors)
         assert "first=1" in redact_sensitive_text(text)
+
+
+class TestXaiToken:
+    KEY = "xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstu"
+
+    def test_bare_token_masked(self):
+        result = redact_sensitive_text(f"using key {self.KEY}", force=True)
+        assert self.KEY not in result
+        assert "xai-AB" in result
+
+    def test_env_assignment_masked(self):
+        result = redact_sensitive_text(f"XAI_API_KEY={self.KEY}", force=True)
+        assert self.KEY not in result
+
+    def test_too_short_not_masked(self):
+        short = "xai-tooshort"
+        result = redact_sensitive_text(f"text {short} here", force=True)
+        assert short in result
+
+    def test_company_name_not_masked(self):
+        result = redact_sensitive_text("xai is a company", force=True)
+        assert result == "xai is a company"
+
+    def test_prefix_visible_in_masked_output(self):
+        result = redact_sensitive_text(self.KEY, force=True)
+        assert result.startswith("xai-AB")


### PR DESCRIPTION
## What and why

  `agent/redact.py` masks known API key formats before they reach log files, tool output, or gateway logs. xAI
  (Grok) API keys were missing from this list.

  xAI is a first-class provider in hermes-agent with its own credential pool entry (`XAI_API_KEY` /
  `xai-oauth`). Keys follow the format `xai-<60+ alphanumeric chars>` — a distinctive prefix used by no other
  common service.

  The ENV-assignment and Bearer header patterns catch the most common cases, but a raw `xai-` token appearing in
   a stack trace, debug print, or tool result had no protection.

  ## Reproduction (before fix)

  ```python
  from agent.redact import redact_sensitive_text
  key = "xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstu"
  print(redact_sensitive_text(f"using key {key}", force=True))
  # using key xai-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstu  ← exposed

  After fix

  using key xai-AB...rstu  ← masked
  xai is a company         ← unchanged (no false positive)
  xai-tooshort             ← unchanged (below 30-char threshold)

  Changes

  One line added to _PREFIX_PATTERNS in agent/redact.py:

  r"xai-[A-Za-z0-9]{30,}",  # xAI (Grok) API key

  Five unit tests added to tests/agent/test_redact.py covering bare token masking, env assignment, short-prefix
  false positive, company name false positive, and visible prefix in masked output.
  ```