### PR TITLE
fix(gateway): coerce port on invalid config in msgraph_webhook and wecom_callback

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -41,6 +41,13 @@ def check_msgraph_webhook_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
+def _coerce_port(value: Any, *, default: int = DEFAULT_PORT) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class MSGraphWebhookAdapter(BasePlatformAdapter):
     """Receive Microsoft Graph change notifications and surface them internally."""
 
@@ -48,7 +55,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.MSGRAPH_WEBHOOK)
         extra = config.extra or {}
         self._host: str = str(extra.get("host", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", DEFAULT_PORT))
+        self._port: int = _coerce_port(extra.get("port", DEFAULT_PORT))
         self._webhook_path: str = self._normalize_path(
             extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
         )

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -52,12 +52,19 @@ def check_wecom_callback_requirements() -> bool:
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
 
 
+def _coerce_port(value: Any, *, default: int = DEFAULT_PORT) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class WecomCallbackAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM_CALLBACK)
         extra = config.extra or {}
         self._host = str(extra.get("host") or DEFAULT_HOST)
-        self._port = int(extra.get("port") or DEFAULT_PORT)
+        self._port = _coerce_port(extra.get("port") or DEFAULT_PORT)
         self._path = str(extra.get("path") or DEFAULT_PATH)
         self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)
         self._runner: Optional[web.AppRunner] = None

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -68,6 +68,14 @@ class TestMSGraphWebhookConfig:
             "chats/getAllMessages",
         ]
 
+    def test_invalid_port_falls_back_to_default(self):
+        adapter = _make_adapter(port="not-a-port")
+        assert adapter._port == 8646
+
+    def test_none_port_falls_back_to_default(self):
+        adapter = _make_adapter(port=None)
+        assert adapter._port == 8646
+
 
 class TestMSGraphValidationHandshake:
     @pytest.mark.anyio

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -54,6 +54,24 @@ class TestWecomCrypto:
             crypt.decrypt("bad-sig", "1", "n", root.findtext("Encrypt", default=""))
 
 
+class TestWecomCallbackConfig:
+    def test_invalid_port_falls_back_to_default(self):
+        config = PlatformConfig(
+            enabled=True,
+            extra={"mode": "callback", "port": "not-a-port", "apps": [_app()]},
+        )
+        adapter = WecomCallbackAdapter(config)
+        assert adapter._port == 8645
+
+    def test_none_port_falls_back_to_default(self):
+        config = PlatformConfig(
+            enabled=True,
+            extra={"mode": "callback", "apps": [_app()]},
+        )
+        adapter = WecomCallbackAdapter(config)
+        assert adapter._port == 8645
+
+
 class TestWecomCallbackEventConstruction:
     def test_build_event_extracts_text_message(self):
         adapter = WecomCallbackAdapter(_config())


### PR DESCRIPTION
## What does this PR do?

Root cause: `MSGraphWebhookAdapter.__init__()` and `WecomCallbackAdapter.__init__()` both call `int()` directly on the port value read from `extra` config. A non-integer string — e.g. `port: "abc"` in `config.yaml` or `None` from an explicit YAML null — raises `ValueError`/`TypeError` and crashes the adapter at gateway startup, before any connection attempt is made.

Fix: add a module-level `_coerce_port()` helper to each file (matching the pattern introduced for `TeamsAdapter` in #27291, merged today) that falls back to `DEFAULT_PORT` on `TypeError`/`ValueError`. No behavior change for valid integer or integer-string port values.

```
# msgraph_webhook.py  — before
self._port: int = int(extra.get("port", DEFAULT_PORT))

# after
self._port: int = _coerce_port(extra.get("port", DEFAULT_PORT))
```

```
# wecom_callback.py  — before
self._port = int(extra.get("port") or DEFAULT_PORT)

# after
self._port = _coerce_port(extra.get("port") or DEFAULT_PORT)
```

Symmetric across both adapters. Default unchanged means no behavior change for correctly configured deployments.

## Related Issue

Parity fix with #27291 (TeamsAdapter, merged today).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/msgraph_webhook.py`: add `_coerce_port()`, replace `int()` call (+7 lines)
- `gateway/platforms/wecom_callback.py`: add `_coerce_port()`, replace `int()` call (+7 lines)
- `tests/gateway/test_msgraph_webhook.py`: two regression tests in `TestMSGraphWebhookConfig` (+8 lines)
- `tests/gateway/test_wecom_callback.py`: new `TestWecomCallbackConfig` class with two regression tests (+16 lines)

## How to Test

```
pytest tests/gateway/test_msgraph_webhook.py tests/gateway/test_wecom_callback.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical fix | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A