### PR TITLE
feat(feishu): add send_slash_confirm with interactive card buttons

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1461,6 +1461,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
+        self._slash_confirm_state: Dict[str, str] = {}
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
@@ -1915,6 +1916,94 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
+
+    async def send_slash_confirm(
+        self, chat_id: str, title: str, message: str, session_key: str,
+        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive card with three slash-command confirmation buttons.
+
+        Buttons carry ``hermes_slash_confirm_action`` in their value dict so
+        that ``_handle_card_action_callback`` can route them to
+        ``_resolve_slash_confirm`` which calls
+        ``tools.slash_confirm.resolve()``.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            preview = message[:3000] + "..." if len(message) > 3000 else message
+
+            def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": btn_type,
+                    "value": {
+                        "hermes_slash_confirm_action": action_name,
+                        "confirm_id": confirm_id,
+                    },
+                }
+
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": title or "⚠️ Confirm", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": preview,
+                    },
+                    {
+                        "tag": "action",
+                        "actions": [
+                            _btn("✅ Approve Once", "sc_once", "primary"),
+                            _btn("🔒 Always Approve", "sc_always"),
+                            _btn("❌ Cancel", "sc_cancel", "danger"),
+                        ],
+                    },
+                ],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                self._slash_confirm_state[confirm_id] = session_key
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def _resolve_slash_confirm(
+        self, confirm_id: str, choice: str, user_name: str,
+    ) -> None:
+        """Pop slash-confirm state and resolve via the module-level primitive."""
+        session_key = self._slash_confirm_state.pop(confirm_id, None)
+        if not session_key:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            result_text = await _slash_confirm_mod.resolve(
+                session_key, confirm_id, choice,
+            )
+            if result_text:
+                logger.info(
+                    "Feishu slash-confirm resolved for session %s (choice=%s, user=%s): %s",
+                    session_key, choice, user_name, result_text[:100],
+                )
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu slash-confirm: %s", exc)
 
     @staticmethod
     def _build_update_prompt_card(*, prompt: str, default: str, prompt_id: int) -> Dict[str, Any]:
@@ -2513,9 +2602,15 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
+        if slash_confirm_action:
+            return self._handle_slash_confirm_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
                 event=event,
@@ -2579,6 +2674,47 @@ class FeishuAdapter(BasePlatformAdapter):
             card = CallBackCard()
             card.type = "raw"
             card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            response.card = card
+        return response
+
+    _SLASH_CONFIRM_CHOICE_MAP: Dict[str, str] = {
+        "sc_once": "once",
+        "sc_always": "always",
+        "sc_cancel": "cancel",
+    }
+
+    def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule slash-confirm resolution and build the synchronous callback response."""
+        confirm_id = action_value.get("confirm_id")
+        if confirm_id is None:
+            logger.debug("[Feishu] Card action missing confirm_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        choice = self._SLASH_CONFIRM_CHOICE_MAP.get(
+            action_value.get("hermes_slash_confirm_action"), "cancel",
+        )
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        user_name = self._get_cached_sender_name(open_id) or open_id
+
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning("[Feishu] Unauthorized slash-confirm click from %s", open_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if not self._submit_on_loop(loop, self._resolve_slash_confirm(confirm_id, choice, user_name)):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            label_map = {"once": "✅ Approved once", "always": "🔒 Always approved", "cancel": "❌ Cancelled"}
+            label = label_map.get(choice, "Resolved")
+            card.data = {"config": {"wide_screen_mode": True}, "elements": [
+                {"tag": "markdown", "content": f"**{label}** by {user_name}"},
+            ]}
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_slash_confirm.py
+++ b/tests/gateway/test_feishu_slash_confirm.py
@@ -1,0 +1,276 @@
+"""Tests for Feishu send_slash_confirm interactive card buttons."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Feishu mock so FeishuAdapter can be imported without lark-oapi
+# ---------------------------------------------------------------------------
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.feishu import FeishuAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> FeishuAdapter:
+    """Create a FeishuAdapter with mocked internals."""
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_abc",
+) -> SimpleNamespace:
+    """Create a mock Feishu card action callback data object."""
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=action_value,
+            ),
+        ),
+    )
+
+
+# ===========================================================================
+# send_slash_confirm — interactive card with buttons
+# ===========================================================================
+
+class TestFeishuSlashConfirmSend:
+    """Test send_slash_confirm sends an interactive card with three buttons."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm /reload-mcp",
+                message="This will invalidate the provider prompt cache.",
+                session_key="agent:main:feishu:group:oc_12345",
+                confirm_id="42",
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc001"
+
+        mock_send.assert_called_once()
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+
+        # Verify card payload
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "blue"
+        assert "invalidate the provider prompt cache" in card["elements"][0]["content"]
+
+        # Check buttons
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 3
+        action_keys = [a["value"]["hermes_slash_confirm_action"] for a in actions]
+        assert action_keys == ["sc_once", "sc_always", "sc_cancel"]
+        # All buttons carry the same confirm_id
+        confirm_ids = [a["value"]["confirm_id"] for a in actions]
+        assert all(cid == "42" for cid in confirm_ids)
+
+    @pytest.mark.asyncio
+    async def test_stores_slash_confirm_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_999",
+                title="Confirm",
+                message="Please confirm.",
+                session_key="my-session-key",
+                confirm_id="99",
+            )
+
+        assert adapter._slash_confirm_state.get("99") == "my-session-key"
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = await adapter.send_slash_confirm(
+            chat_id="oc_12345",
+            title="Confirm",
+            message="msg",
+            session_key="sk",
+            confirm_id="1",
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_send_failure_returns_error(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            side_effect=RuntimeError("send failed"),
+        ):
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="T",
+                message="m",
+                session_key="sk",
+                confirm_id="1",
+            )
+        assert result.success is False
+        assert "send failed" in (result.error or "")
+
+
+# ===========================================================================
+# Card action callback routing for slash-confirm
+# ===========================================================================
+
+class TestFeishuSlashConfirmCardAction:
+    """Test card action callback routing for slash-confirm buttons."""
+
+    def test_routes_slash_confirm_action(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["42"] = "agent:main:feishu:group:oc_12345"
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+
+        data = _make_card_action_data({
+            "hermes_slash_confirm_action": "sc_once",
+            "confirm_id": "42",
+        })
+
+        submitted = []
+
+        def _fake_submit(loop, coro):
+            submitted.append(coro)
+            return SimpleNamespace(add_done_callback=lambda *a, **kw: None)
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=_fake_submit):
+            with patch.object(adapter, "_is_interactive_operator_authorized", return_value=True):
+                response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert len(submitted) == 1
+
+    def test_unauthorized_user_rejected(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["42"] = "sk"
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+
+        data = _make_card_action_data({
+            "hermes_slash_confirm_action": "sc_once",
+            "confirm_id": "42",
+        })
+
+        with patch.object(adapter, "_submit_on_loop") as mock_submit:
+            with patch.object(adapter, "_is_interactive_operator_authorized", return_value=False):
+                response = adapter._on_card_action_trigger(data)
+
+        # Should NOT have scheduled resolution
+        mock_submit.assert_not_called()
+        assert response is not None
+
+
+# ===========================================================================
+# _resolve_slash_confirm
+# ===========================================================================
+
+class TestFeishuSlashConfirmResolve:
+    """Test _resolve_slash_confirm pops state and calls tools.slash_confirm.resolve."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_via_slash_confirm_module(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["42"] = "agent:main:feishu:group:oc_12345"
+
+        with patch(
+            "tools.slash_confirm.resolve", new_callable=AsyncMock, return_value="Done",
+        ) as mock_resolve:
+            await adapter._resolve_slash_confirm("42", "once", "TestUser")
+
+        mock_resolve.assert_called_once_with(
+            "agent:main:feishu:group:oc_12345", "42", "once",
+        )
+        # State should be popped
+        assert "42" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_ignores_unknown_confirm_id(self):
+        adapter = _make_adapter()
+
+        with patch(
+            "tools.slash_confirm.resolve", new_callable=AsyncMock,
+        ) as mock_resolve:
+            await adapter._resolve_slash_confirm("nonexistent", "once", "User")
+
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_resolve_exception(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["42"] = "sk"
+
+        with patch(
+            "tools.slash_confirm.resolve", new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            # Should not raise
+            await adapter._resolve_slash_confirm("42", "always", "User")
+
+        # State still popped even on error
+        assert "42" not in adapter._slash_confirm_state


### PR DESCRIPTION
## Summary

Override `send_slash_confirm` on the Feishu adapter to render three interactive card buttons (Approve Once / Always Approve / Cancel) for slash-command confirmation prompts (`/new`, `/reset`, `/undo`, `/reload-mcp`), matching the UX already available on Telegram, Discord, and Slack.

Closes #27322

## Problem

Feishu did not override `send_slash_confirm`, so the gateway fell back to plain text prompts for `/reload-mcp` and destructive-slash-confirm (`/new`, `/reset`, `/undo`). Users had to manually type `/approve`, `/always`, or `/cancel` — inconsistent with the button-based UX on other platforms.

## Solution

1. **`send_slash_confirm` override** — builds a Feishu Interactive Card (blue header, markdown body, 3 action buttons) using the same `_feishu_send_with_retry` path as `send_exec_approval`.

2. **Card action routing** — buttons carry `hermes_slash_confirm_action` (distinct from `hermes_action` used by exec approval) so `_on_card_action_trigger` routes them to the new `_handle_slash_confirm_card_action` handler.

3. **Resolution** — `_resolve_slash_confirm` pops state and calls `tools.slash_confirm.resolve(session_key, confirm_id, choice)`, the same module-level primitive used by Telegram/Discord/Slack.

4. **Authorization** — reuses `_is_interactive_operator_authorized` (admin/allowed-group-user check) consistent with existing approval buttons.

## Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `gateway/platforms/feishu.py` | +136: add `_slash_confirm_state`, `send_slash_confirm`, `_resolve_slash_confirm`, `_handle_slash_confirm_card_action`, update `_on_card_action_trigger` routing |
| 2 | `tests/gateway/test_feishu_slash_confirm.py` | +276: 9 new tests covering send, callback routing, authorization, and resolution |

## Test Results

```
9 passed (new tests)
53 passed (related existing tests: approval_buttons, destructive_slash_confirm, slash_confirm)
0 failures, 0 regressions
```

## Design Decisions

- **Separate `hermes_slash_confirm_action` key** (not reusing `hermes_action`) — keeps the card action routing table clean and avoids ambiguity between exec-approval and slash-confirm flows which resolve through different modules.
- **Blue header template** (vs orange for exec approval) — visually distinguishes "confirm" from "dangerous command approval".
- **Class-level `_SLASH_CONFIRM_CHOICE_MAP`** — mirrors `_APPROVAL_CHOICE_MAP` pattern for consistency.