### PR TITLE
feat(agent): dynamic reasoning_content echo-back detection

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -541,6 +541,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             raw_reasoning_content = model_extra["reasoning_content"]
     if raw_reasoning_content is not None:
         msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
+        # Dynamic echo-back detection: if the API included reasoning_content,
+        # this provider enforces the thinking-mode echo protocol.  Set a
+        # session-level flag so _needs_thinking_reasoning_pad() returns True
+        # for the rest of the conversation — even for providers not covered
+        # by the static name-based checks (Qwen-TP, GLM, MiniMax, custom
+        # gateways, etc.).  Refs #27297.
+        if not getattr(agent, "_requires_reasoning_echo", False):
+            agent._requires_reasoning_echo = True
+            logger.debug("Auto-detected thinking-mode echo-back protocol from API response")
     elif assistant_tool_calls and agent._needs_thinking_reasoning_pad():
         # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
         # both require reasoning_content on every assistant tool-call

--- a/run_agent.py
+++ b/run_agent.py
@@ -3592,10 +3592,25 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400). Xiaomi MiMo thinking mode has the same requirement.
+        Detection is two-tier:
+
+        1. **Dynamic (primary):** If the API response included
+           ``reasoning_content``, the session flag
+           ``_requires_reasoning_echo`` is set at message-build time
+           (see ``agent.chat_completion_helpers.build_assistant_message``).
+           This works for *any* thinking-mode provider — including custom
+           gateways, new providers, and providers behind reverse proxies —
+           without requiring a code change.
+
+        2. **Static (fallback):** Hardcoded provider-name / domain checks
+           for DeepSeek, Kimi/Moonshot, and Xiaomi MiMo.  These cover edge
+           cases where the dynamic flag isn't set yet (e.g. history replay
+           on a fresh session that hasn't seen a thinking response).
+
+        Refs #15250, #17400, #17341.
         """
+        if getattr(self, "_requires_reasoning_echo", False):
+            return True
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()

--- a/tests/run_agent/test_dynamic_reasoning_echo.py
+++ b/tests/run_agent/test_dynamic_reasoning_echo.py
@@ -1,0 +1,157 @@
+"""Tests for dynamic reasoning_content echo-back detection.
+
+When the API response includes ``reasoning_content`` (either as a top-level
+SDK attribute or in ``model_extra``), the session flag
+``_requires_reasoning_echo`` is set.  This makes ``_needs_thinking_reasoning_pad()``
+return True for *any* thinking-mode provider — including those not covered by
+the static provider-name checks.
+
+Refs #27297.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _sdk_tool_call(call_id: str = "c1", name: str = "terminal", arguments: str = "{}"):
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+        extra_content=None,
+    )
+
+
+def _build_sdk_message(reasoning_content=None, **extra):
+    kwargs = {"content": "", **extra}
+    if reasoning_content is not None:
+        kwargs["reasoning_content"] = reasoning_content
+    return SimpleNamespace(**kwargs)
+
+
+_ATTR_ABSENT = object()
+
+
+class TestDynamicEchoDetection:
+    """_requires_reasoning_echo is auto-set when API returns reasoning_content."""
+
+    def test_flag_set_on_sdk_reasoning_content(self) -> None:
+        """When SDK exposes reasoning_content, flag is set on agent."""
+        agent = _make_agent(provider="unknown-custom", model="my-model")
+        assert not getattr(agent, "_requires_reasoning_echo", False)
+
+        msg_obj = _build_sdk_message(
+            reasoning_content="Let me think about this...",
+            tool_calls=[_sdk_tool_call()],
+        )
+        result = agent._build_assistant_message(msg_obj, finish_reason="tool_calls")
+
+        assert agent._requires_reasoning_echo is True
+        assert "reasoning_content" in result
+
+    def test_flag_set_on_model_extra_reasoning_content(self) -> None:
+        """When reasoning_content comes via model_extra, flag is set."""
+        agent = _make_agent(provider="qwen-tp", model="qwen3.6-plus")
+        msg_obj = SimpleNamespace(
+            content="",
+            tool_calls=[_sdk_tool_call()],
+            model_extra={"reasoning_content": "Step 1: analyze..."},
+        )
+        result = agent._build_assistant_message(msg_obj, finish_reason="tool_calls")
+
+        assert agent._requires_reasoning_echo is True
+        assert "reasoning_content" in result
+
+    def test_flag_not_set_without_reasoning_content(self) -> None:
+        """Normal (non-thinking) response does not set the flag."""
+        agent = _make_agent(provider="openrouter", model="gpt-4o")
+        msg_obj = _build_sdk_message(content="Hello!")
+        agent._build_assistant_message(msg_obj, finish_reason="stop")
+
+        assert not getattr(agent, "_requires_reasoning_echo", False)
+
+    def test_flag_idempotent(self) -> None:
+        """Setting the flag multiple times is safe (no error)."""
+        agent = _make_agent(provider="custom")
+        for _ in range(3):
+            msg_obj = _build_sdk_message(
+                reasoning_content="thinking...",
+                tool_calls=[_sdk_tool_call()],
+            )
+            agent._build_assistant_message(msg_obj, finish_reason="tool_calls")
+
+        assert agent._requires_reasoning_echo is True
+
+
+class TestNeedsThinkingPadWithDynamicFlag:
+    """_needs_thinking_reasoning_pad uses dynamic flag as primary check."""
+
+    def test_dynamic_flag_overrides_unknown_provider(self) -> None:
+        """Unknown provider returns True once dynamic flag is set."""
+        agent = _make_agent(provider="qwen-tp", model="qwen3.6-plus")
+        # Static checks should be False for unknown provider
+        assert agent._needs_deepseek_tool_reasoning() is False
+        assert agent._needs_kimi_tool_reasoning() is False
+        assert agent._needs_mimo_tool_reasoning() is False
+
+        # Before dynamic flag
+        assert agent._needs_thinking_reasoning_pad() is False
+
+        # Set dynamic flag
+        agent._requires_reasoning_echo = True
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_static_fallback_still_works(self) -> None:
+        """Static checks work when dynamic flag is not set."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        # No dynamic flag set
+        assert not getattr(agent, "_requires_reasoning_echo", False)
+        # Static check should still detect DeepSeek
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_dynamic_flag_wins_over_static(self) -> None:
+        """Even with wrong provider, dynamic flag makes pad return True."""
+        agent = _make_agent(provider="custom-gateway", model="my-model")
+        agent._requires_reasoning_echo = True
+        assert agent._needs_thinking_reasoning_pad() is True
+
+
+class TestEndToEndDynamicDetection:
+    """Full flow: API response → flag set → pad returns True → echo applied."""
+
+    def test_unknown_provider_tool_call_gets_reasoning_content(self) -> None:
+        """Unknown provider with thinking mode gets reasoning_content on tool calls."""
+        agent = _make_agent(provider="aliyun-qwen", model="qwen3.6-plus")
+        # First response has reasoning_content → sets flag
+        msg1 = _build_sdk_message(
+            reasoning_content="I need to use a tool...",
+            tool_calls=[_sdk_tool_call()],
+        )
+        agent._build_assistant_message(msg1, finish_reason="tool_calls")
+        assert agent._requires_reasoning_echo is True
+
+        # Second tool-call message WITHOUT reasoning_content should still get padded
+        msg2 = _build_sdk_message(
+            tool_calls=[_sdk_tool_call()],
+        )
+        result = agent._build_assistant_message(msg2, finish_reason="tool_calls")
+        assert "reasoning_content" in result
+        assert result["reasoning_content"]  # non-empty


### PR DESCRIPTION
## Summary

Replace the current provider-name-based `reasoning_content` echo-back detection with a **dynamic, response-pattern-based detection** that works for any provider automatically. When the first assistant API response in a session includes `reasoning_content`, a session-level flag `_requires_reasoning_echo` is set — making `_needs_thinking_reasoning_pad()` return `True` for all subsequent tool-call turns, regardless of provider name, model name, or base URL.

Closes #27297

## Problem

Currently, `_needs_thinking_reasoning_pad()` relies on three hardcoded provider-name/domain checks (`_needs_deepseek_tool_reasoning`, `_needs_kimi_tool_reasoning`, `_needs_mimo_tool_reasoning`). This means:

1. **Every new thinking-mode provider requires a code change** (Qwen-TP, GLM, MiniMax, future providers)
2. **Fails for users behind custom API gateways / proxies** — the code matches by provider name or known domain, not by actual API behavior

## Solution

A minimal **+27/-3** change across two files:

1. **`agent/chat_completion_helpers.py`** — when `build_assistant_message` detects `reasoning_content` in the API response (either via SDK attribute or `model_extra`), set `agent._requires_reasoning_echo = True` and log the auto-detection.

2. **`run_agent.py`** — `_needs_thinking_reasoning_pad()` now checks the dynamic flag first (`getattr(self, "_requires_reasoning_echo", False)`), then falls back to the existing static checks.

## Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `agent/chat_completion_helpers.py` | +9: set `_requires_reasoning_echo` flag when `reasoning_content` is detected in API response |
| 2 | `run_agent.py` | +18/-3: update `_needs_thinking_reasoning_pad` to check dynamic flag first, then static fallback |
| 3 | `tests/run_agent/test_dynamic_reasoning_echo.py` | +157: 8 new tests covering flag setting, idempotency, dynamic override, static fallback, and end-to-end flow |

## Test Results

```
8 passed (new tests)
35 passed (related existing reasoning echo tests, 1 pre-existing failure excluded)
0 regressions
```

## Design Decisions

- **Keep static checks as fallback** — covers edge cases where history replays on a fresh session that hasn't seen a thinking response yet
- **Session-level flag** (not global/per-provider) — the detection is per-agent-instance, scoped to a single conversation, matching the existing pattern of reasoning_content handling
- **Minimal diff** — no refactoring of the three existing `_needs_*` methods, no architectural changes beyond the two-tier detection