### PR TITLE
fix(xiaomi): pass thinking param to MiMo API

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -1,9 +1,52 @@
-"""Xiaomi MiMo provider profile."""
+"""Xiaomi MiMo provider profile.
+
+MiMo supports ``thinking`` via ``extra_body`` (``{"type": "enabled"}`` /
+``{"type": "disabled"}``) in the OpenAI-compatible chat completions
+endpoint.
+
+When no ``reasoning_config`` is provided, thinking defaults to ``enabled``
+(MiMo server default).  When the user explicitly disables reasoning
+(e.g. ``reasoning_effort: none``), the ``thinking`` parameter is set to
+``disabled`` to save tokens.
+
+Refs #27325.
+"""
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xiaomi = ProviderProfile(
+
+class XiaomiProfile(ProviderProfile):
+    """Xiaomi MiMo — extra_body.thinking for token-aware thinking control."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """MiMo uses extra_body.thinking to control thinking mode.
+
+        Enabled by default (server default); emits ``disabled`` when the
+        user has explicitly turned reasoning off.
+        """
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            # No config → thinking enabled (default)
+            extra_body["thinking"] = {"type": "enabled"}
+            return extra_body, top_level
+
+        enabled = reasoning_config.get("enabled", True)
+        if enabled is False:
+            extra_body["thinking"] = {"type": "disabled"}
+            return extra_body, top_level
+
+        extra_body["thinking"] = {"type": "enabled"}
+        return extra_body, top_level
+
+
+xiaomi = XiaomiProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),


### PR DESCRIPTION
## Summary

Add a custom Xiaomi provider profile class that emits `extra_body.thinking` to control MiMo thinking mode. When the user configures `reasoning_effort: none` or otherwise disables reasoning, sends `thinking: {type: "disabled"}` to prevent unnecessary token consumption.

Closes #27325

## Problem

Xiaomi MiMo provider used a bare `ProviderProfile` with no overrides — the `thinking` parameter was never passed in API requests. MiMo defaults to thinking=enabled, consuming tokens on every request regardless of user config. Settings like `reasoning_effort: none` had no effect on the actual API call.

## Solution

Replace the bare `ProviderProfile` with a `XiaomiProfile` subclass that overrides `build_api_kwargs_extras`, following the same pattern used by `KimiProfile`:

- When `reasoning_config.enabled is False` → `extra_body.thinking = {type: "disabled"}`
- Otherwise → `extra_body.thinking = {type: "enabled"}`

Only **1 file changed** (+45/-2).

## Files Changed

| # | File | Change |
|---|------|--------|
| 1 | `plugins/model-providers/xiaomi/__init__.py` | +45/-2: add `XiaomiProfile` class with `build_api_kwargs_extras` override for `thinking` param |

## Test Results

```
94 passed (related provider profile + Xiaomi tests)
0 regressions
```

## Design Decisions

- **Follows Kimi pattern exactly** — Kimi already uses the same `extra_body.thinking` approach via `KimiProfile.build_api_kwargs_extras`. Xiaomi uses the same OpenAI-compatible API format.
- **Minimal diff** — no changes to transport, no new params, no legacy path changes. Only the provider profile needed updating.