### PR TITLE
Retry truncated tool calls with concise-args hint

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -862,6 +862,7 @@ def run_conversation(
         has_retried_429 = False
         restart_with_compressed_messages = False
         restart_with_length_continuation = False
+        restart_with_truncated_tool_hint = False
 
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
@@ -1417,6 +1418,27 @@ def run_conversation(
                                 # just re-run the same API call from the current
                                 # message state, giving the model another chance.
                                 continue
+                            if truncated_tool_call_retries < 2:
+                                truncated_tool_call_retries += 1
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  Truncated tool call detected again — retrying with concise-args hint...",
+                                    force=True,
+                                )
+                                retry_hint = {
+                                    "role": "user",
+                                    "content": (
+                                        "[System: Your previous tool call arguments were truncated by the output "
+                                        "length limit. Retry the same tool call with complete, valid JSON "
+                                        "arguments. Keep arguments concise. If the payload is large, split it "
+                                        "into smaller tool calls or write a shorter chunk first. Return only the "
+                                        "next complete tool call.]"
+                                    ),
+                                }
+                                messages.append(retry_hint)
+                                agent._session_messages = messages
+                                agent._save_session_log(messages)
+                                restart_with_truncated_tool_hint = True
+                                break
                             agent._vprint(
                                 f"{agent.log_prefix}⚠️  Truncated tool call response detected again — refusing to execute incomplete tool arguments.",
                                 force=True,
@@ -2832,6 +2854,9 @@ def run_conversation(
             _boost_base = agent.max_tokens if agent.max_tokens else 4096
             _boost = _boost_base * (length_continue_retries + 1)
             agent._ephemeral_max_output_tokens = min(_boost, 32768)
+            continue
+
+        if restart_with_truncated_tool_hint:
             continue
 
         # Guard: if all retries exhausted without a successful response

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3399,6 +3399,116 @@ class TestRunConversation:
         assert "truncated due to output length limit" in result["error"]
         mock_handle_function_call.assert_not_called()
 
+    def test_truncated_tool_call_second_retry_adds_concise_args_hint(self, agent):
+        """A second truncated tool call should get one more retry with a concise-args hint."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+
+        bad_tc_1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        bad_tc_2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"still partial',
+            call_id="c2",
+        )
+        good_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"full content"}',
+            call_id="c3",
+        )
+
+        first_truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc_1],
+        )
+        second_truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc_2],
+        )
+        recovered_tool_call = _mock_response(
+            content="", finish_reason="stop", tool_calls=[good_tc],
+        )
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [
+                first_truncated,
+                second_truncated,
+                recovered_tool_call,
+                final_resp,
+            ]
+            result = agent.run_conversation("write the report")
+
+        mock_hfc.assert_called_once()
+        assert result["final_response"] == "Done!"
+
+        third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
+        assert third_call_messages[-1]["role"] == "user"
+        assert "tool call arguments were truncated" in third_call_messages[-1]["content"]
+        assert "Keep arguments concise" in third_call_messages[-1]["content"]
+        assert "Return only the next complete tool call" in third_call_messages[-1]["content"]
+
+    def test_truncated_tool_call_refuses_after_concise_args_retry(self, agent):
+        """The agent should still refuse after a third truncated tool-call response."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+
+        bad_tc_1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        bad_tc_2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"still partial',
+            call_id="c2",
+        )
+        bad_tc_3 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"yet again partial',
+            call_id="c3",
+        )
+
+        first_truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc_1],
+        )
+        second_truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc_2],
+        )
+        third_truncated = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc_3],
+        )
+
+        with (
+            patch("run_agent.handle_function_call") as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.client.chat.completions.create.side_effect = [
+                first_truncated,
+                second_truncated,
+                third_truncated,
+            ]
+            result = agent.run_conversation("write the report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "truncated due to output length limit" in result["error"]
+        mock_hfc.assert_not_called()
+
+        third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
+        assert third_call_messages[-1]["role"] == "user"
+        assert "Keep arguments concise" in third_call_messages[-1]["content"]
+
     def test_kanban_block_called_on_iteration_exhaustion(self, agent, monkeypatch):
         """Regression: kanban worker must call kanban_block when iteration
         budget is exhausted, otherwise the dispatcher sees a protocol


### PR DESCRIPTION
## Summary
- allow one extra retry when tool-call arguments are truncated twice
- inject a concise-args hint before the final retry so the model can shrink or split large payloads
- keep refusing incomplete tool arguments if the response is truncated again

## Testing
- python -m pytest tests/run_agent/test_run_agent.py -q -o addopts='' -k "truncated_tool"

Closes #20975