### PR TITLE
feat: page the TUI session picker

### DIFF
--- a/ui-tui/src/__tests__/sessionPickerPaging.test.ts
+++ b/ui-tui/src/__tests__/sessionPickerPaging.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildResumeViewport, moveResumeSelection, pageForSelection } from '../components/sessionPickerPaging.js'
+
+const makeItems = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `sid-${i + 1}`,
+    message_count: i + 1,
+    preview: `preview ${i + 1}`,
+    source: 'cli',
+    started_at: 1_700_000_000 - i * 60,
+    title: `Session ${i + 1}`
+  }))
+
+describe('resume picker paging helpers', () => {
+  it('keeps a fixed 10-row page while the selection moves within it', () => {
+    const items = makeItems(25)
+
+    expect(buildResumeViewport(items, 0, 10)).toMatchObject({
+      end: 10,
+      offset: 0,
+      page: 1,
+      totalPages: 3
+    })
+    expect(buildResumeViewport(items, 9, 10)).toMatchObject({
+      end: 10,
+      offset: 0,
+      page: 1,
+      totalPages: 3
+    })
+    expect(buildResumeViewport(items, 10, 10)).toMatchObject({
+      end: 20,
+      offset: 10,
+      page: 2,
+      totalPages: 3
+    })
+    expect(buildResumeViewport(items, 24, 10)).toMatchObject({
+      end: 25,
+      offset: 20,
+      page: 3,
+      totalPages: 3
+    })
+  })
+
+  it('supports moving by row and by whole page without leaving bounds', () => {
+    expect(moveResumeSelection(0, -1, 25)).toBe(0)
+    expect(moveResumeSelection(0, 1, 25)).toBe(1)
+    expect(moveResumeSelection(9, 1, 25)).toBe(10)
+    expect(moveResumeSelection(10, -1, 25)).toBe(9)
+    expect(moveResumeSelection(7, 10, 25)).toBe(17)
+    expect(moveResumeSelection(17, -10, 25)).toBe(7)
+    expect(moveResumeSelection(24, 10, 25)).toBe(24)
+  })
+
+  it('computes page numbers from selection indices', () => {
+    expect(pageForSelection(0, 10)).toBe(1)
+    expect(pageForSelection(9, 10)).toBe(1)
+    expect(pageForSelection(10, 10)).toBe(2)
+    expect(pageForSelection(19, 10)).toBe(2)
+    expect(pageForSelection(20, 10)).toBe(3)
+  })
+})

--- a/ui-tui/src/components/sessionPicker.tsx
+++ b/ui-tui/src/components/sessionPicker.tsx
@@ -6,9 +6,9 @@ import type { SessionDeleteResponse, SessionListItem, SessionListResponse } from
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
+import { OverlayHint, useOverlayKeys } from './overlayControls.js'
+import { RESUME_PAGE_SIZE, buildResumeViewport, moveResumeSelection } from './sessionPickerPaging.js'
 
-const VISIBLE = 15
 const MIN_WIDTH = 60
 const MAX_WIDTH = 120
 
@@ -114,12 +114,20 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
       return
     }
 
-    if (key.upArrow && sel > 0) {
-      setSel(s => s - 1)
+    if (key.upArrow) {
+      setSel(s => moveResumeSelection(s, -1, items.length))
     }
 
-    if (key.downArrow && sel < items.length - 1) {
-      setSel(s => s + 1)
+    if (key.downArrow) {
+      setSel(s => moveResumeSelection(s, 1, items.length))
+    }
+
+    if (key.pageUp) {
+      setSel(s => moveResumeSelection(s, -RESUME_PAGE_SIZE, items.length))
+    }
+
+    if (key.pageDown) {
+      setSel(s => moveResumeSelection(s, RESUME_PAGE_SIZE, items.length))
     }
 
     if (key.return && items[sel]) {
@@ -163,7 +171,8 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
     )
   }
 
-  const offset = windowOffset(items.length, sel, VISIBLE)
+  const viewport = buildResumeViewport(items, sel)
+  const { end, offset, page, totalPages } = viewport
 
   return (
     <Box flexDirection="column" width={width}>
@@ -171,9 +180,13 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         Resume Session
       </Text>
 
-      {offset > 0 && <Text color={t.color.muted}>  ↑ {offset} more</Text>}
+      <Text color={t.color.muted}>
+        Page {page}/{totalPages} · showing {offset + 1}-{end} of {items.length}
+      </Text>
 
-      {items.slice(offset, offset + VISIBLE).map((s, vi) => {
+      {offset > 0 && <Text color={t.color.muted}>  ↑ {offset} previous</Text>}
+
+      {items.slice(offset, end).map((s, vi) => {
         const i = offset + vi
         const selected = sel === i
         const pendingDelete = confirmDelete === i
@@ -208,12 +221,12 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         )
       })}
 
-      {offset + VISIBLE < items.length && <Text color={t.color.muted}>  ↓ {items.length - offset - VISIBLE} more</Text>}
+      {end < items.length && <Text color={t.color.muted}>  ↓ {items.length - end} more</Text>}
       {err && <Text color={t.color.label}>error: {err}</Text>}
       {deleting ? (
         <OverlayHint t={t}>deleting…</OverlayHint>
       ) : (
-        <OverlayHint t={t}>↑/↓ select · Enter resume · 1-9 quick · d delete · Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>↑/↓ select · PgUp/PgDn page · Enter resume · 1-9 quick · d delete · Esc/q cancel</OverlayHint>
       )}
     </Box>
   )

--- a/ui-tui/src/components/sessionPickerPaging.ts
+++ b/ui-tui/src/components/sessionPickerPaging.ts
@@ -1,0 +1,51 @@
+import type { SessionListItem } from '../gatewayTypes.js'
+
+export const RESUME_PAGE_SIZE = 10
+
+export interface ResumeViewport {
+  end: number
+  offset: number
+  page: number
+  totalPages: number
+}
+
+export const clampResumeSelection = (selected: number, count: number) => {
+  if (count <= 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(selected, count - 1))
+}
+
+export const pageForSelection = (selected: number, pageSize = RESUME_PAGE_SIZE) =>
+  Math.floor(Math.max(0, selected) / Math.max(1, pageSize)) + 1
+
+export const moveResumeSelection = (selected: number, delta: number, count: number) =>
+  clampResumeSelection(selected + delta, count)
+
+export const buildResumeViewport = (
+  items: SessionListItem[],
+  selected: number,
+  pageSize = RESUME_PAGE_SIZE
+): ResumeViewport => {
+  const safePageSize = Math.max(1, pageSize)
+
+  if (!items.length) {
+    return {
+      end: 0,
+      offset: 0,
+      page: 1,
+      totalPages: 1
+    }
+  }
+
+  const clamped = clampResumeSelection(selected, items.length)
+  const offset = Math.floor(clamped / safePageSize) * safePageSize
+
+  return {
+    end: Math.min(offset + safePageSize, items.length),
+    offset,
+    page: pageForSelection(clamped, safePageSize),
+    totalPages: Math.max(1, Math.ceil(items.length / safePageSize))
+  }
+}


### PR DESCRIPTION
## Summary
- Change the TUI session picker to show fixed 10-session pages instead of one long sliding window.
- Move selection by row with ↑/↓ and by page with PgUp/PgDn.
- Show page/count context (`Page N/M · showing A-B of C`) plus previous/more hints.
- Extract paging math into a small helper module with focused tests.

## Test Plan
- `cd ui-tui && npm test -- --run src/__tests__/sessionPickerPaging.test.ts`
- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm run build`

Refs #27244
