### PR TITLE
fix(kanban): don't crash dispatched workers when kanban-worker skill is absent

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3903,6 +3903,41 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """True if the bundled ``kanban-worker`` skill resolves for the home the
+    spawned worker will run under.
+
+    The dispatcher injects ``--skills kanban-worker`` into every worker. When
+    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
+    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
+    the bundled skill (it ships in the *default* root home, not every
+    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
+    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
+    worker before the agent loop runs. Gate the flag on actual resolvability;
+    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
+    omitting the flag only drops the supplementary pattern library.
+    """
+    from pathlib import Path as _Path
+
+    # An unset HERMES_HOME means the worker falls back to the default root
+    # home (``~/.hermes``), which ships the bundled skill.
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    skills_root = base / "skills"
+    if not skills_root.is_dir():
+        return False
+    # Canonical bundled location first (cheap), then a bounded scan for
+    # profiles that have it nested elsewhere.
+    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
+        return True
+    try:
+        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
+            if skill_md.is_file():
+                return True
+    except OSError:
+        pass
+    return False
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3980,16 +4015,23 @@ def _default_spawn(
     cmd = [
         *_resolve_hermes_argv(),
         "-p", profile_arg,
-        # Auto-load the kanban-worker skill so every dispatched worker
-        # has the pattern library (good summary/metadata shapes, retry
-        # diagnostics, block-reason examples) in its context, even if
-        # the profile hasn't wired it into skills config. The MANDATORY
-        # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
-        # this skill is the deeper reference. Users can point a profile
-        # at a different/additional skill via config if they want —
-        # --skills is additive to the profile's default skill set.
-        "--skills", "kanban-worker",
     ]
+    # Auto-load the kanban-worker skill so every dispatched worker
+    # has the pattern library (good summary/metadata shapes, retry
+    # diagnostics, block-reason examples) in its context, even if
+    # the profile hasn't wired it into skills config. The MANDATORY
+    # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
+    # this skill is the deeper reference. Users can point a profile
+    # at a different/additional skill via config if they want —
+    # --skills is additive to the profile's default skill set.
+    #
+    # Only add the flag when the skill actually resolves for the home
+    # the worker runs under: the bundled skill is absent from many
+    # profile-scoped skills dirs, and preloading a missing skill is
+    # fatal at CLI startup. Omitting it is safe — the lifecycle
+    # contract still ships via KANBAN_GUIDANCE.
+    if _kanban_worker_skill_available(env.get("HERMES_HOME")):
+        cmd.extend(["--skills", "kanban-worker"])
     # Per-task force-loaded skills. Each name goes in its own
     # `--skills X` pair rather than a single comma-joined arg: the CLI
     # accepts both forms (action='append' + comma-split), but


### PR DESCRIPTION
## Problem

The kanban dispatcher (`_default_spawn` in `hermes_cli/kanban_db.py`) injects `--skills kanban-worker` into **every** spawned worker. Workers run with a profile-scoped `HERMES_HOME` (set from the assignee profile), so their `SKILLS_DIR` resolves to `<profile_home>/skills`.

The bundled `kanban-worker` skill ships in the **default root home** (`~/.hermes/skills/devops/kanban-worker`). It is recorded in a profile's `.bundled_manifest` at create time, but in practice it can be **absent from the profile-scoped `skills/` tree**. Observed locally: 5 of 7 profiles had no `devops/kanban-worker/` despite the manifest listing it.

Preloading a missing skill is **fatal at CLI startup** — `build_preloaded_skills_prompt` reports it missing and `cli.py` raises `ValueError: Unknown skill(s): kanban-worker`. The worker aborts **before the agent loop runs**, so the kanban task silently fails. The per-task log contains only:

```
Error: Unknown skill(s): kanban-worker
Error: Unknown skill(s): kanban-worker
```

This is not cosmetic: any task assigned to an affected profile never executes; its `done`/comments end up written out-of-band.

## Fix

Gate the auto-injected flag on actual resolvability via a new `_kanban_worker_skill_available(hermes_home)` helper. When the skill cannot be resolved for the worker's home, the `--skills kanban-worker` pair is **omitted instead of crashing**.

This is safe by design: the **mandatory** kanban lifecycle is already delivered via `KANBAN_GUIDANCE` in the system prompt. The `kanban-worker` skill is only the *supplementary* pattern library (summary/metadata shapes, retry diagnostics, block-reason examples) — losing it degrades guidance, it never breaks the contract.

The helper:
- treats an unset `HERMES_HOME` as the default root home (which ships the skill),
- checks the canonical `skills/devops/kanban-worker/SKILL.md` first (cheap),
- falls back to a bounded `rglob` for profiles that nest it elsewhere.

Single file, +51/-9, no behavior change for profiles that *do* have the skill.

## Scope note

This PR deliberately does **not** touch profile creation. `hermes profile create` → `seed_profile_skills()` → `sync_skills()` already copies all bundled skills (incl. `devops/kanban-worker`) and records them in `.bundled_manifest`. The drift that removes the directory post-creation has an undetermined cause (curator reported `no changes`), so a creation-time hook would be redundant and wouldn't address the real failure. The spawn-guard makes the dispatcher resilient regardless of *why* the skill is missing, which is the correct layer for a defensive fix. Root-cause of the post-create drift can be a follow-up.

## Test

- `py_compile` clean.
- `_kanban_worker_skill_available()` returns `True` for profiles that have the skill and for an unset home (default root), `False` for a home whose `skills/` lacks it (→ flag omitted, worker still spawns with `KANBAN_GUIDANCE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)