### PR TITLE
fix(agent): wrap _pool_may_recover_from_rate_limit with _ra() lazy import

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2251,7 +2251,7 @@ def run_conversation(
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
                     # exceptions.  Fixes #11314 and #13636.
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),


### PR DESCRIPTION
## Summary

Fixes #27370.

The eager-fallback path on rate-limit errors crashes with
`NameError: name '_pool_may_recover_from_rate_limit' is not defined`
because the refactor in `053025238` ("extract run_conversation to
agent/conversation_loop.py") missed one call site. The function lives
in `run_agent.py:239`, and every other reference to `run_agent`
helpers in `conversation_loop.py` is wrapped with the `_ra()` lazy
import. This one wasn't.

## Change

One line, `agent/conversation_loop.py:2254`:

```diff
-                    pool_may_recover = _pool_may_recover_from_rate_limit(
+                    pool_may_recover = _ra()._pool_may_recover_from_rate_limit(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),
                     )
```

## Impact

Without this fix, any user with a `fallback_providers` chain that
contains a rate-limited or quota-exhausted provider sees the whole
conversation turn crash on 429/402, instead of cleanly switching to
the next provider. The whole point of `_pool_may_recover_from_rate_limit`
(introduced in `1fc77f995`, "fall back on rate limit when pool has no
rotation room") is currently inert because the call site is unbound.

## Test plan

- [x] Manually verified the fix locally: with the patch applied, a
  configured fallback chain that hits a 429 transitions to the next
  provider without raising `NameError`.
- [ ] Existing CI / test suite — no new tests needed; this is a
  refactor regression and the fix restores the documented behaviour.

## Notes

Reported and reproduced on v0.14.0 (2026-05-16). No upstream commits
yet attempt this fix; `origin/main` is still affected at the time of
this PR.