### PR TITLE
wecom_callback: guard XML parsing against XML-bomb / DOCTYPE attacks

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -19,6 +19,40 @@ import time
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree as ET
 
+
+# WeCom callbacks POST XML payloads from outside the trust boundary, which
+# means the parser must defend against XML bombs (billion-laughs / quadratic
+# blow-up) and DOCTYPE-based attacks. Adding `defusedxml` is rejected by the
+# `dependencies` scope rule in pyproject.toml ("smallest possible blast
+# radius"), so we do a stdlib-only pre-check before handing the bytes to ET.
+#
+# Python 3.7.1+ already disables external entity resolution by default, but
+# DOCTYPE / inline ENTITY declarations are still parsed and counted toward
+# expansion, so we reject them outright. WeCom callbacks are well-formed
+# simple XML — no legitimate payload uses a DOCTYPE.
+_MAX_CALLBACK_XML_BYTES = 256 * 1024  # 256 KiB; WeCom callback payloads are < 8 KiB in practice
+_XML_FORBIDDEN_CONSTRUCTS = (b"<!DOCTYPE", b"<!ENTITY", b"<?xml-stylesheet")
+
+
+def _safe_parse_wecom_xml(payload: str | bytes) -> ET.Element:
+    """Parse WeCom callback XML with stdlib-only defenses against XML bombs.
+
+    Rejects payloads that exceed a hard size cap or that contain DOCTYPE /
+    ENTITY / external-stylesheet declarations. Returns the parsed root
+    element on success. Caller can treat any raised exception as a
+    malformed/hostile callback and respond with a 400.
+    """
+    raw = payload.encode("utf-8") if isinstance(payload, str) else payload
+    if len(raw) > _MAX_CALLBACK_XML_BYTES:
+        raise ET.ParseError(
+            f"callback XML payload too large ({len(raw)} > {_MAX_CALLBACK_XML_BYTES} bytes)"
+        )
+    head = raw[:2048].lstrip()  # forbidden constructs always appear in the prologue
+    for needle in _XML_FORBIDDEN_CONSTRUCTS:
+        if needle in head:
+            raise ET.ParseError(f"callback XML rejected: contains {needle!r}")
+    return ET.fromstring(raw)  # nosec B314  -- guarded by _safe_parse_wecom_xml above
+
 try:
     from aiohttp import web
 
@@ -310,13 +344,13 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self, app: Dict[str, Any], body: str,
         msg_signature: str, timestamp: str, nonce: str,
     ) -> str:
-        root = ET.fromstring(body)
+        root = _safe_parse_wecom_xml(body)
         encrypt = root.findtext("Encrypt", default="")
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
     def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
-        root = ET.fromstring(xml_text)
+        root = _safe_parse_wecom_xml(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
         if msg_type == "event":


### PR DESCRIPTION
## Summary

`gateway/platforms/wecom_callback.py` handles XML POSTed from outside the trust boundary (WeCom servers, or anyone who can spoof them before signature verify). The two `ET.fromstring(...)` sites in `_decrypt_request:313` and `_build_event:319` are **unguarded** today:

```python
def _decrypt_request(self, app, body, msg_signature, timestamp, nonce):
    root = ET.fromstring(body)       # ← external XML, no size/DOCTYPE check
    ...

def _build_event(self, app, xml_text):
    root = ET.fromstring(xml_text)   # ← external XML, no size/DOCTYPE check
    ...
```

Python 3.7.1+ disables external-entity *resolution* by default, but DOCTYPE / inline ENTITY declarations are still parsed and counted toward expansion, leaving the gateway open to **billion-laughs** and **quadratic-blowup** payloads from anyone who can hit the callback endpoint.

## What this PR does

Adds a stdlib-only `_safe_parse_wecom_xml(payload)` helper that:

1. **Caps payload size** at 256 KiB. Legitimate WeCom callback payloads are well under 8 KiB; the cap is conservative.
2. **Rejects forbidden constructs** in the prologue (first 2048 bytes after lstrip): `<!DOCTYPE`, `<!ENTITY`, `<?xml-stylesheet`. None of these appear in well-formed WeCom XML.
3. **Defers to `ET.fromstring`** with `# nosec B314` referencing the helper.

Both `ET.fromstring(...)` call sites are replaced with `_safe_parse_wecom_xml(...)`.

## Why not `defusedxml`

`defusedxml` is the obvious recommendation, but is **rejected by the dependencies-scope rule** in `pyproject.toml`:

> "Scope rule: only packages used by EVERY hermes session belong here. ... Smaller `dependencies` = smaller blast radius for the next supply-chain attack."

(Tightened 2026-05-12 after the mistralai PyPI worm.) Stdlib-only keeps the dependency surface flat.

## Real behavior proof

```
$ bandit gateway/platforms/wecom_callback.py -t B314
  Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 1
  Total issues (by severity):  (empty — was 2 medium-severity hits)
```

Trip tests with hostile callback payloads (Python inline against the new helper):

| Payload | Before | After |
|---|---|---|
| Legit WeCom encrypted callback (≈ 2 KiB) | parses ✅ | parses ✅ |
| Billion-laughs DOCTYPE with 9 nested ENTITY (≈ 1 KiB on the wire, ≈ 100 MiB expanded) | parser expands, gateway OOMs 🔴 | `ParseError: contains b'<!DOCTYPE'` ✅ |
| 1 MiB attacker payload | parses ✅ (memory blow) | `ParseError: payload too large` ✅ |
| Random non-XML 200 KiB blob | `ET.ParseError` (cheap) | `ET.ParseError` (cheap, same path) |

## Scope note

The other four `B314` sites in the repo (`watch_rss.py`, `simplify_redlines.py` ×2, `search_arxiv.py`) consume XML from **user-controlled or trusted** sources — RSS feeds the user opted into, docx files the user provided, or the arXiv API. They're a separate risk tier and intentionally out of scope; happy to follow up with a second PR for those if maintainers want them annotated with `# nosec B314 -- <reason>`.