### PR TITLE
weixin: annotate AES-128-ECB cipher with protocol context + # nosec B305

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -177,13 +177,19 @@ def _pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
 
 
 def _aes128_ecb_encrypt(plaintext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    # WeChat's customer-service / message-encrypt protocols mandate AES-128-ECB
+    # with PKCS#7 padding (see official Java/PHP SDK reference). The format is
+    # interoperable — switching to a streaming or CBC mode would break the
+    # signature handshake with WeChat servers, even though ECB is generically
+    # vulnerable to block-substitution attacks.
+    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())  # nosec B305  -- WeChat protocol requires AES-128-ECB
     encryptor = cipher.encryptor()
     return encryptor.update(_pkcs7_pad(plaintext)) + encryptor.finalize()
 
 
 def _aes128_ecb_decrypt(ciphertext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    # Inverse of _aes128_ecb_encrypt — same WeChat protocol constraint.
+    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())  # nosec B305  -- WeChat protocol requires AES-128-ECB
     decryptor = cipher.decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     if not padded:


### PR DESCRIPTION
## Summary

`gateway/platforms/weixin.py:180,186` use `modes.ECB()` directly, which bandit flags as **medium-severity B305** ("insecure cipher mode"). Both call sites live inside `_aes128_ecb_encrypt` and the matching `_aes128_ecb_decrypt`, which exist specifically to interoperate with WeChat's customer-service / message-encrypt protocols. Those protocols **mandate AES-128-ECB with PKCS#7 padding** (see the official Java/PHP SDK reference); switching to a streaming or CBC mode would break the signature handshake with WeChat servers.

Adds a short comment block on each helper explaining the protocol constraint, and annotates the `modes.ECB()` call with `# nosec B305  -- WeChat protocol requires AES-128-ECB` so:

1. The next contributor doesn't open a "convert to GCM/CBC" PR and silently break WeChat integration.
2. Static-analysis CI stays green without hiding genuine ECB misuse elsewhere in the codebase.

No runtime change — pure annotation + comment.

## Real behavior proof

```
$ bandit gateway/platforms/weixin.py -t B305
  Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 2
  Total issues (by severity): (empty — was 2 medium-severity hits)
```

## Style

Follows the same pattern used in this repo for protocol-required `# nosec B324` annotations on `hashlib.md5(...)` / `hashlib.sha1(...)` calls in the WeChat / WeCom / QQ / Tencent Cloud platform modules — keep the lock-in concern visible to readers while letting CI scanners pass.