### PR TITLE
fix(cron): honor CRON_TZ schedule timezones

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -19,6 +19,11 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Union
 
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Hermes requires Python 3.9+
+    from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
+
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
@@ -44,6 +49,55 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+
+
+def _load_schedule_timezone(timezone_name: Optional[str], *, strict: bool = False) -> Optional[ZoneInfo]:
+    """Return a ZoneInfo for a schedule-level timezone.
+
+    CRON_TZ/TZ is job data, so parsing should reject invalid names while
+    runtime computation should avoid crashing the scheduler if a persisted job
+    was hand-edited incorrectly.
+    """
+    if not timezone_name:
+        return None
+    name = str(timezone_name).strip()
+    if not name:
+        return None
+    try:
+        return ZoneInfo(name)
+    except Exception as exc:
+        message = f"Invalid timezone {name!r} in cron schedule"
+        if strict:
+            raise ValueError(f"{message}: {exc}") from exc
+        logger.warning("%s; falling back to Hermes timezone", message)
+        return None
+
+
+def _split_cron_timezone_prefix(schedule: str) -> tuple[str, Optional[str]]:
+    """Split a leading CRON_TZ=/TZ= prefix from a schedule string."""
+    match = re.match(r"^(?:CRON_TZ|TZ)=([^\s]+)\s+(.+)$", schedule, flags=re.IGNORECASE)
+    if not match:
+        return schedule, None
+    timezone_name = match.group(1).strip()
+    cron_expr = match.group(2).strip()
+    _load_schedule_timezone(timezone_name, strict=True)
+    return cron_expr, timezone_name
+
+
+def _cron_base_time(schedule: Dict[str, Any], base_time: datetime) -> datetime:
+    """Return the croniter base time in the schedule's wall-clock timezone."""
+    schedule_tz = _load_schedule_timezone(schedule.get("timezone"))
+    if schedule_tz is None:
+        return base_time
+    return _ensure_aware(base_time).astimezone(schedule_tz)
+
+
+def _cron_result_time(schedule: Dict[str, Any], next_run: datetime, output_tz) -> datetime:
+    """Convert a croniter result back to Hermes scheduler timezone."""
+    schedule_tz = _load_schedule_timezone(schedule.get("timezone"))
+    if schedule_tz is None:
+        return next_run
+    return _ensure_aware(next_run).astimezone(output_tz)
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -204,10 +258,13 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     """
     schedule = schedule.strip()
     original = schedule
+    schedule, schedule_timezone = _split_cron_timezone_prefix(schedule)
     schedule_lower = schedule.lower()
     
     # "every X" pattern → recurring interval
     if schedule_lower.startswith("every "):
+        if schedule_timezone:
+            raise ValueError("CRON_TZ/TZ prefixes are only supported for cron expressions")
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
         return {
@@ -229,12 +286,17 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             croniter(schedule)
         except Exception as e:
             raise ValueError(f"Invalid cron expression '{schedule}': {e}")
-        return {
+        result = {
             "kind": "cron",
             "expr": schedule,
-            "display": schedule
+            "display": original,
         }
-    
+        if schedule_timezone:
+            result["timezone"] = schedule_timezone
+        return result
+    if schedule_timezone:
+        raise ValueError("CRON_TZ/TZ prefixes are only supported for valid cron expressions")
+
     # ISO timestamp (contains T or looks like date)
     if 'T' in schedule or re.match(r'^\d{4}-\d{2}-\d{2}', schedule):
         try:
@@ -338,7 +400,7 @@ def _compute_grace_seconds(schedule: dict) -> int:
 
     if kind == "cron" and HAS_CRONITER:
         try:
-            now = _hermes_now()
+            now = _cron_base_time(schedule, _hermes_now())
             cron = croniter(schedule["expr"], now)
             first = cron.get_next(datetime)
             second = cron.get_next(datetime)
@@ -390,9 +452,9 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         base_time = now
         if last_run_at:
             base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        cron = croniter(schedule["expr"], _cron_base_time(schedule, base_time))
         next_run = cron.get_next(datetime)
-        return next_run.isoformat()
+        return _cron_result_time(schedule, next_run, now.tzinfo).isoformat()
 
     return None
 

--- a/tests/cron/test_compute_next_run_last_run_at.py
+++ b/tests/cron/test_compute_next_run_last_run_at.py
@@ -85,3 +85,25 @@ class TestCronComputeNextRunUsesLastRunAt:
         interval_dt = datetime.fromisoformat(interval_result)
         assert cron_dt > last_run, f"Cron next {cron_dt} should be after last_run {last_run}"
         assert interval_dt > last_run, f"Interval next {interval_dt} should be after last_run {last_run}"
+
+    def test_cron_timezone_uses_last_run_in_schedule_timezone_and_returns_hermes_timezone(self, monkeypatch):
+        """CRON_TZ jobs should compute in their own wall-clock timezone.
+
+        The stored last_run_at is in Hermes/Bangkok time.  The next execution
+        must be the next 08:45 America/New_York market-time slot, returned in
+        Hermes/Bangkok time for the scheduler.
+        """
+        bangkok = ZoneInfo("Asia/Bangkok")
+        last_run = datetime(2026, 5, 15, 19, 57, 0, tzinfo=bangkok)
+        now = datetime(2026, 5, 17, 16, 0, 0, tzinfo=bangkok)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {
+            "kind": "cron",
+            "expr": "45 8 * * 1-5",
+            "timezone": "America/New_York",
+        }
+
+        result = compute_next_run(schedule, last_run_at=last_run.isoformat())
+
+        assert result == "2026-05-18T19:45:00+07:00"

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -6,6 +6,7 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from cron.jobs import (
     parse_duration,
@@ -99,6 +100,19 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    def test_cron_tz_prefix_preserves_timezone(self):
+        pytest.importorskip("croniter")
+        result = parse_schedule("CRON_TZ=America/New_York 45 8 * * 1-5")
+        assert result["kind"] == "cron"
+        assert result["expr"] == "45 8 * * 1-5"
+        assert result["timezone"] == "America/New_York"
+        assert result["display"] == "CRON_TZ=America/New_York 45 8 * * 1-5"
+
+    def test_cron_tz_prefix_rejects_invalid_timezone(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            parse_schedule("CRON_TZ=Not/AZone 0 9 * * *")
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"
@@ -171,6 +185,23 @@ class TestComputeNextRun:
         next_dt = datetime.fromisoformat(result)
         assert isinstance(next_dt, datetime)
         assert next_dt > datetime.now().astimezone()
+
+    def test_cron_with_timezone_returns_next_run_in_hermes_timezone(self, monkeypatch):
+        pytest.importorskip("croniter")
+        bangkok = ZoneInfo("Asia/Bangkok")
+        now = datetime(2026, 5, 17, 16, 0, tzinfo=bangkok)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {
+            "kind": "cron",
+            "expr": "45 8 * * 1-5",
+            "timezone": "America/New_York",
+        }
+
+        result = compute_next_run(schedule)
+
+        # Monday 08:45 in New York during EDT is Monday 19:45 in Bangkok.
+        assert result == "2026-05-18T19:45:00+07:00"
 
     def test_unknown_kind_returns_none(self):
         assert compute_next_run({"kind": "unknown"}) is None


### PR DESCRIPTION
## Summary
- Parse leading `CRON_TZ=<IANA zone>` / `TZ=<IANA zone>` prefixes for cron schedules and persist the schedule timezone separately from the cron expression.
- Compute timezone-scoped cron schedules in their own wall-clock timezone, then convert `next_run_at` back to Hermes' configured timezone for scheduler storage/comparison.
- Add regression coverage for New York market-time schedules from a Bangkok Hermes host, including `last_run_at` recomputation.

## Test plan
- `python -m pytest tests/cron/test_jobs.py::TestParseSchedule::test_cron_tz_prefix_preserves_timezone tests/cron/test_jobs.py::TestParseSchedule::test_cron_tz_prefix_rejects_invalid_timezone tests/cron/test_jobs.py::TestComputeNextRun::test_cron_with_timezone_returns_next_run_in_hermes_timezone tests/cron/test_compute_next_run_last_run_at.py::TestCronComputeNextRunUsesLastRunAt::test_cron_timezone_uses_last_run_in_schedule_timezone_and_returns_hermes_timezone -q -o 'addopts='`
- `python -m pytest tests/cron/test_jobs.py tests/cron/test_compute_next_run_last_run_at.py -q -o 'addopts='`
- `python -m pytest tests/cron -q -o 'addopts='`
- `python -m py_compile cron/jobs.py tests/cron/test_jobs.py tests/cron/test_compute_next_run_last_run_at.py`
- `git diff --check -- cron/jobs.py tests/cron/test_jobs.py tests/cron/test_compute_next_run_last_run_at.py`
