### PR TITLE
fix(gateway): add missing source code extensions to SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -830,8 +830,19 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     ".ts": "text/plain",
+    ".tsx": "text/plain",
+    ".js": "text/plain",
+    ".jsx": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".go": "text/plain",
+    ".rs": "text/plain",
+    ".rb": "text/plain",
+    ".java": "text/plain",
+    ".cs": "text/plain",
+    ".cpp": "text/plain",
+    ".c": "text/plain",
+    ".h": "text/plain",
 }
 
 

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -155,3 +155,11 @@ class TestSupportedDocumentTypes:
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES
+
+    @pytest.mark.parametrize(
+        "ext",
+        [".ts", ".tsx", ".js", ".jsx", ".py", ".sh", ".go", ".rs", ".rb", ".java", ".cs", ".cpp", ".c", ".h"],
+    )
+    def test_source_code_extensions_present(self, ext):
+        assert ext in SUPPORTED_DOCUMENT_TYPES
+        assert SUPPORTED_DOCUMENT_TYPES[ext] == "text/plain"


### PR DESCRIPTION
## Problem

Commit `508b022ac` added `.ts`, `.py`, `.sh` to `SUPPORTED_DOCUMENT_TYPES` in `gateway/platforms/base.py` but omitted 11 other common source-code extensions: `.tsx`, `.js`, `.jsx`, `.go`, `.rs`, `.rb`, `.java`, `.cs`, `.cpp`, `.c`, `.h`.

All three platform document handlers (Telegram, Discord, Slack) gate on this dict:

```python
# gateway/platforms/telegram.py
if doc_ext not in SUPPORTED_DOCUMENT_TYPES:
    return tool_error(f"Unsupported document type: {doc_ext}")

# gateway/platforms/discord.py
if doc_ext in SUPPORTED_DOCUMENT_TYPES or _allow_any:
    ...
```

Any file with a missing extension is either silently dropped or surfaces an "Unsupported document type" error to the user, even though the content is perfectly valid `text/plain`.

## Fix

Add the 11 missing extensions to `SUPPORTED_DOCUMENT_TYPES`, each mapped to `"text/plain"`:

| Extension | Language |
|-----------|----------|
| `.tsx` | TypeScript/React |
| `.js` | JavaScript |
| `.jsx` | JavaScript/React |
| `.go` | Go |
| `.rs` | Rust |
| `.rb` | Ruby |
| `.java` | Java |
| `.cs` | C# |
| `.cpp` | C++ |
| `.c` | C |
| `.h` | C/C++ header |

## Tests

Extended the parametrized test in `tests/gateway/test_document_cache.py` to cover all 14 source-code extensions and assert each maps to `text/plain`.

## Checklist

- [x] Root cause identified (parity gap from `508b022ac`)
- [x] All 3 platform handlers benefit from this fix
- [x] No new dependencies
- [x] Test added/extended