### PR TITLE
feat(feishu): table rendering in post messages + card plugin hooks

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -490,6 +490,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    # HERMES_FEISHU_CARD_CRON_PATCH_BEGIN
+    try:
+        from hermes_feishu_card.hook_runtime import emit_cron_delivery as _hfc_emit_cron
+        _hfc_cron_metadata = {"delivery_kind": "cron"}
+        # event_name="message.completed"
+        if _hfc_emit_cron(locals()):
+            return None
+    except Exception:
+        pass
+    # HERMES_FEISHU_CARD_CRON_PATCH_END
     targets = _resolve_delivery_targets(job)
     if not targets:
         if job.get("deliver", "local") != "local":

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -162,6 +162,13 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+# Match a full markdown table block: header row + separator row + zero or more
+# data rows, bounded by a blank line or end-of-string. Feishu post 'md' elements
+# do not support table rendering; splitting the full block lets us emit table
+# rows as plain-text elements instead.
+_TABLE_BLOCK_RE = re.compile(
+    r"(?:^|\n\n)(\|.+\|\n\|[-|: ]+\|\n(?:\|.+\|\n?)*)", re.MULTILINE
+)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -559,32 +566,103 @@ def _build_markdown_post_payload(content: str) -> str:
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
-    """Build Feishu post rows while isolating fenced code blocks.
+    """Build Feishu post rows, isolating fenced code blocks and tables.
 
-    Feishu's `md` renderer can swallow trailing content when a fenced code block
-    appears inside one large markdown element. Split the reply at real fence
-    lines so prose before/after the code block remains visible while code stays
-    in a dedicated row.
+    Feishu's ``md`` element cannot render markdown tables — a table rendered
+    in an ``md`` element appears blank on the client.  Split the reply so that:
+
+    * Prose with markdown formatting uses ``{"tag": "md"}`` elements.
+    * Tables are emitted as ``{"tag": "text"}`` elements (readable but no
+      formatting rendering issues).
+    * Fenced code blocks inside prose segments are isolated into their own rows
+      to prevent the ``md`` renderer from swallowing trailing content.
     """
     if not content:
         return [[{"tag": "md", "text": ""}]]
-    if "```" not in content:
+
+    has_code = "```" in content
+    has_table = _TABLE_BLOCK_RE.search(content)
+
+    if not has_code and not has_table:
         return [[{"tag": "md", "text": content}]]
+
+    # ------------------------------------------------------------------
+    # Phase 1 — split into table / non-table segments
+    # ------------------------------------------------------------------
+    segments: list[tuple[str, bool]]  # (text, is_table)
+    if has_table:
+        segments = _split_by_table_blocks(content)
+    else:
+        segments = [(content, False)]
+
+    # ------------------------------------------------------------------
+    # Phase 2 — render each segment, isolating code fences in prose
+    # ------------------------------------------------------------------
+    rows: List[List[Dict[str, str]]] = []
+    for segment_text, is_table in segments:
+        if is_table:
+            segment = segment_text.strip()
+            if segment:
+                rows.append([{"tag": "text", "text": segment}])
+            continue
+
+        # Prose segment — apply the fence-isolation logic
+        segment_rows = _build_prose_rows(segment_text)
+        rows.extend(segment_rows)
+
+    return rows if rows else [[{"tag": "md", "text": content}]]
+
+
+def _split_by_table_blocks(content: str) -> list:
+    """Split *content* into (text, is_table) segments.
+
+    Each table block (header + separator + data rows) gets ``is_table=True``;
+    everything else between them gets ``is_table=False``.
+    """
+    segments: list = []
+    last_end = 0
+    for match in _TABLE_BLOCK_RE.finditer(content):
+        start = match.start()
+        # Allow a leading newline on the table block (the pattern captures it
+        # with (?:^|\n\n)).  Push the boundary back so we don't swallow the
+        # blank line that belongs to the preceding paragraph.
+        text_before = content[last_end:start]
+        if match.group(0).startswith("\n\n"):
+            # The pattern anchored on ^ or \n\n — keep the final blank line
+            # out of the prose segment so the message doesn't get extra spacing.
+            pass
+        if text_before.strip():
+            segments.append((text_before, False))
+        segments.append((match.group(0).lstrip("\n"), True))
+        last_end = match.end()
+
+    remainder = content[last_end:]
+    if remainder.strip():
+        segments.append((remainder, False))
+
+    return segments
+
+
+def _build_prose_rows(text: str) -> List[List[Dict[str, str]]]:
+    """Build post rows for a prose segment (no tables), isolating fenced code."""
+    if "```" not in text:
+        stripped = text.strip()
+        return [[{"tag": "md", "text": stripped}]] if stripped else []
 
     rows: List[List[Dict[str, str]]] = []
     current: List[str] = []
     in_code_block = False
 
-    def _flush_current() -> None:
+    def _flush() -> None:
         nonlocal current
         if not current:
             return
-        segment = "\n".join(current)
-        if segment.strip():
+        segment = "\n".join(current).strip()
+        if segment:
             rows.append([{"tag": "md", "text": segment}])
-        current = []
+        current.clear()
 
-    for raw_line in content.splitlines():
+    for raw_line in text.splitlines():
         stripped_line = raw_line.strip()
         is_fence = bool(
             _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line)
@@ -594,17 +672,17 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 
         if is_fence:
             if not in_code_block:
-                _flush_current()
+                _flush()
             current.append(raw_line)
             in_code_block = not in_code_block
             if not in_code_block:
-                _flush_current()
+                _flush()
             continue
 
         current.append(raw_line)
 
-    _flush_current()
-    return rows or [[{"tag": "md", "text": content}]]
+    _flush()
+    return rows if rows else [[{"tag": "md", "text": text.strip()}]]
 
 
 def parse_feishu_post_payload(
@@ -4232,13 +4310,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Feishu post-type 'md' elements do not render markdown tables; the
+        # _build_markdown_post_rows function handles this by emitting table rows
+        # as plain-text elements inside the post payload (so the table stays
+        # readable while other formatting is preserved).
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7017,6 +7017,13 @@ class GatewayRunner:
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        # HERMES_FEISHU_CARD_PATCH_BEGIN
+        try:
+            from hermes_feishu_card.hook_runtime import emit_from_hermes_locals as _hfc_emit
+            _hfc_emit(locals())
+        except Exception:
+            pass
+        # HERMES_FEISHU_CARD_PATCH_END
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")
@@ -7958,6 +7965,36 @@ class GatewayRunner:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            # HERMES_FEISHU_CARD_COMPLETE_PATCH_BEGIN
+            try:
+                from hermes_feishu_card.hook_runtime import build_event as _hfc_build_event
+                from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_async as _hfc_emit_async
+                from hermes_feishu_card.hook_runtime import should_suppress_native_response as _hfc_should_suppress
+                _hfc_completed_locals = {
+                    **locals(),
+                    "answer": response,
+                    "duration": _response_time,
+                    "model": agent_result.get("model", ""),
+                    "tokens": {
+                        "input_tokens": agent_result.get("input_tokens", 0),
+                        "output_tokens": agent_result.get("output_tokens", 0),
+                    },
+                    "context": {
+                        "used_tokens": agent_result.get("last_prompt_tokens", 0),
+                        "max_tokens": agent_result.get("context_length", 0),
+                    },
+                }
+                _hfc_completed_event = _hfc_build_event("message.completed", _hfc_completed_locals, preview=True)
+                _hfc_attachments = []
+                if _hfc_completed_event is not None:
+                    _hfc_attachments = _hfc_completed_event.get("data", {}).get("attachments", [])
+                _hfc_card_delivered = await _hfc_emit_async(_hfc_completed_locals, event_name="message.completed")
+                _hfc_platform = getattr(source.platform, "value", source.platform)
+                if _hfc_should_suppress(_hfc_platform, _hfc_card_delivered, _hfc_attachments):
+                    return None
+            except Exception:
+                pass
+            # HERMES_FEISHU_CARD_COMPLETE_PATCH_END
             return response
             
         except Exception as e:
@@ -14425,6 +14462,24 @@ class GatewayRunner:
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # HERMES_FEISHU_CARD_TOOL_PATCH_BEGIN
+            try:
+                from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                if event_type in ("tool.started", "tool.completed") and _run_still_current():
+                    if _hfc_emit_threadsafe({
+                        **locals(),
+                        "source": source,
+                        "message_id": event_message_id,
+                        "_hfc_loop": _loop_for_step,
+                        "tool_id": tool_name or "tool",
+                        "name": tool_name or "tool",
+                        "status": "completed" if event_type == "tool.completed" else "running",
+                        "detail": preview or "",
+                    }, event_name="tool.updated"):
+                        return
+            except Exception:
+                pass
+            # HERMES_FEISHU_CARD_TOOL_PATCH_END
             if not progress_queue or not _run_still_current():
                 return
 
@@ -14973,6 +15028,21 @@ class GatewayRunner:
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:
+                                # HERMES_FEISHU_CARD_ANSWER_DELTA_PATCH_BEGIN
+                                try:
+                                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                                    if text and _run_still_current():
+                                        if _hfc_emit_threadsafe({
+                                            **locals(),
+                                            "source": source,
+                                            "message_id": event_message_id,
+                                            "_hfc_loop": _loop_for_step,
+                                            "text": text,
+                                        }, event_name="answer.delta"):
+                                            return
+                                except Exception:
+                                    pass
+                                # HERMES_FEISHU_CARD_ANSWER_DELTA_PATCH_END
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
                         stream_consumer_holder[0] = _stream_consumer
@@ -14980,6 +15050,21 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+                # HERMES_FEISHU_CARD_THINKING_DELTA_PATCH_BEGIN
+                try:
+                    from hermes_feishu_card.hook_runtime import emit_from_hermes_locals_threadsafe as _hfc_emit_threadsafe
+                    if text and not already_streamed and _run_still_current():
+                        if _hfc_emit_threadsafe({
+                            **locals(),
+                            "source": source,
+                            "message_id": event_message_id,
+                            "_hfc_loop": _loop_for_step,
+                            "text": text,
+                        }, event_name="thinking.delta"):
+                            return
+                except Exception:
+                    pass
+                # HERMES_FEISHU_CARD_THINKING_DELTA_PATCH_END
                 if not _run_still_current():
                     return
                 if _stream_consumer is not None:


### PR DESCRIPTION
## Summary

Two related improvements for the Feishu platform adapter:

### 1. Table rendering in post messages (`gateway/platforms/feishu.py`)

Previously, any message containing a markdown table was forced to plain text — losing all formatting (bold, code, links) for the entire message. This PR introduces proper table handling within the post content type:

- Tables are detected and split into separate `text` elements inside the post payload
- Prose segments between/before/after tables keep their `md` element with full formatting
- Fenced code blocks inside prose segments are still isolated correctly

**Result:** Tables render as readable plain text while surrounding content keeps all markdown formatting.

### 2. Plugin hook points for `hermes_feishu_card` (`gateway/run.py` + `cron/scheduler.py`)

Non-invasive integration points for a Feishu interactive card plugin:

- **Message start** — hook before agent processing begins
- **Answer delta** — each streamed text chunk  
- **Thinking delta** — each streamed thinking chunk
- **Tool lifecycle** — tool started/completed events
- **Message completed** — final response with tokens/model/duration, plus card delivery and native response suppression logic
- **Cron delivery** — hook in `cron/scheduler.py` for scheduled job output

All hooks are wrapped in `try/except` — zero impact when the plugin is not installed.

## Testing

- [x] Table-heavy messages render correctly in Feishu post format
- [x] Messages without tables are unaffected (no regression)
- [x] Fenced code blocks still isolated correctly
- [x] Hook points are no-ops when hermes_feishu_card is not installed