### PR TITLE
fix(feishu): remove markdown table force-text workaround, add pipe table to post hint (#26658)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -150,12 +150,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\|.+\|)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4222,12 +4219,6 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu_outbound_payload.py
+++ b/tests/gateway/test_feishu_outbound_payload.py
@@ -1,0 +1,49 @@
+"""Tests for _build_outbound_payload after removal of markdown table force-text workaround.
+
+Issue #26658: Feishu now natively supports tables in post format, so the
+_MARKDOWN_TABLE_RE workaround that forced table content to plain text
+has been removed. Table content should now flow through the normal
+markdown post pipeline.
+"""
+
+import json
+import unittest
+from unittest.mock import patch
+
+
+class TestBuildOutboundPayload(unittest.TestCase):
+    """_build_outbound_payload routes content to correct msg_type."""
+
+    def setUp(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.config import PlatformConfig
+        self.adapter = FeishuAdapter(PlatformConfig())
+
+    def test_markdown_table_goes_to_post_not_text(self):
+        """Table content now flows through post pipeline, not forced to text."""
+        content = "| Name | Age |\n|------|-----|\n| Ada  | 30  |"
+        msg_type, payload_json = self.adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post", "Table content should be post, not text")
+        payload = json.loads(payload_json)
+        self.assertIn("zh_cn", payload)
+
+    def test_plain_text_still_goes_to_text(self):
+        """Plain text (no markdown) still goes to text mode."""
+        msg_type, _ = self.adapter._build_outbound_payload("Hello world")
+        self.assertEqual(msg_type, "text")
+
+    def test_markdown_without_table_goes_to_post(self):
+        """Non-table markdown (bold, italic) still goes to post."""
+        msg_type, _ = self.adapter._build_outbound_payload("Hello **world**")
+        self.assertEqual(msg_type, "post")
+
+    def test_empty_content_goes_to_text(self):
+        """Empty string falls through to text."""
+        msg_type, _ = self.adapter._build_outbound_payload("")
+        self.assertEqual(msg_type, "text")
+
+    def test_no_reference_to_MARKDOWN_TABLE_RE(self):
+        """Workaround constant is fully removed from the module."""
+        import gateway.platforms.feishu as feishu_mod
+        self.assertFalse(hasattr(feishu_mod, "_MARKDOWN_TABLE_RE"),
+                         "_MARKDOWN_TABLE_RE must be removed")


### PR DESCRIPTION
## Summary

Remove the `_MARKDOWN_TABLE_RE` workaround in Feishu's `_build_outbound_payload` that forced markdown table content to plain text. Feishu now natively supports tables in post format, so this workaround is no longer needed — it was making table-heavy messages (financial dashboards, data reports) lose all formatting.

## Changes

1. **Removed** `_MARKDOWN_TABLE_RE` constant and the force-text branch in `_build_outbound_payload` (gateway/platforms/feishu.py)
2. **Added** pipe table pattern `(^\|.+\|)` to `_MARKDOWN_HINT_RE` so table content flows through the normal post rendering pipeline instead of falling through to plain text

## Testing

- ✅ 5 new tests in `test_feishu_outbound_payload.py`
- ✅ 198 existing feishu tests pass with zero regression
- ✅ Table → post, plain text → text, non-table markdown → post preserved

Closes #26658