### PR TITLE
fix(dashboard): show runtime model context

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3035,9 +3035,28 @@ async def get_models_analytics(days: int = 30):
     try:
         cutoff = time.time() - (days * 86400)
 
-        cur = db._conn.execute("""
+        active_session_filter = """
+            started_at > ?
+            AND model IS NOT NULL
+            AND model != ''
+            AND NOT (
+                COALESCE(message_count, 0) = 0
+                AND COALESCE(api_call_count, 0) = 0
+                AND COALESCE(tool_call_count, 0) = 0
+                AND COALESCE(input_tokens, 0) = 0
+                AND COALESCE(output_tokens, 0) = 0
+                AND COALESCE(cache_read_tokens, 0) = 0
+                AND COALESCE(cache_write_tokens, 0) = 0
+                AND COALESCE(reasoning_tokens, 0) = 0
+                AND COALESCE(estimated_cost_usd, 0) = 0
+                AND COALESCE(actual_cost_usd, 0) = 0
+            )
+        """
+
+        cur = db._conn.execute(f"""
             SELECT model,
                    billing_provider,
+                   MAX(NULLIF(billing_base_url, '')) as billing_base_url,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
@@ -3049,7 +3068,7 @@ async def get_models_analytics(days: int = 30):
                    SUM(tool_call_count) as tool_calls,
                    MAX(started_at) as last_used_at,
                    AVG(input_tokens + output_tokens) as avg_tokens_per_session
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
+            FROM sessions WHERE {active_session_filter}
             GROUP BY model, billing_provider
             ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
         """, (cutoff,))
@@ -3058,7 +3077,20 @@ async def get_models_analytics(days: int = 30):
         models = []
         for row in rows:
             provider = row.get("billing_provider") or ""
+            base_url = row.get("billing_base_url") or ""
             model_name = row["model"]
+            runtime_context_length = 0
+            try:
+                from agent.model_metadata import get_model_context_length
+                runtime_context_length = get_model_context_length(
+                    model=model_name,
+                    provider=provider,
+                    base_url=base_url,
+                    config_context_length=None,
+                ) or 0
+            except Exception:
+                runtime_context_length = 0
+
             caps = {}
             try:
                 from agent.models_dev import get_model_capabilities
@@ -3089,10 +3121,11 @@ async def get_models_analytics(days: int = 30):
                 "tool_calls": row["tool_calls"],
                 "last_used_at": row["last_used_at"],
                 "avg_tokens_per_session": row["avg_tokens_per_session"],
+                "runtime_context_length": runtime_context_length,
                 "capabilities": caps,
             })
 
-        totals_cur = db._conn.execute("""
+        totals_cur = db._conn.execute(f"""
             SELECT COUNT(DISTINCT model) as distinct_models,
                    SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
@@ -3102,7 +3135,7 @@ async def get_models_analytics(days: int = 30):
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
                    COUNT(*) as total_sessions,
                    SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
+            FROM sessions WHERE {active_session_filter}
         """, (cutoff,))
         totals = dict(totals_cur.fetchone())
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1319,6 +1319,86 @@ class TestModelInfoEndpoint:
         assert data["auto_context_length"] == 0
 
 
+class TestModelsAnalyticsEndpoint:
+    """Tests for GET /api/analytics/models."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_models_analytics_omits_empty_ghost_sessions(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("ghost", "tui", model="gpt-5.5")
+            db.create_session("real", "cli", model="gpt-5.5")
+            db.update_token_counts(
+                "real",
+                input_tokens=100,
+                output_tokens=20,
+                model="gpt-5.5",
+                billing_provider="openai-codex",
+                api_call_count=1,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/models?days=30")
+
+        assert resp.status_code == 200
+        models = resp.json()["models"]
+        assert [(m["model"], m["provider"]) for m in models] == [
+            ("gpt-5.5", "openai-codex")
+        ]
+        assert resp.json()["totals"]["total_sessions"] == 1
+
+    def test_models_analytics_reports_runtime_context_separately_from_catalog(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("codex", "cli", model="gpt-5.5")
+            db.update_token_counts(
+                "codex",
+                input_tokens=100,
+                output_tokens=20,
+                model="gpt-5.5",
+                billing_provider="openai-codex",
+                api_call_count=1,
+            )
+        finally:
+            db.close()
+
+        mock_caps = MagicMock()
+        mock_caps.supports_tools = True
+        mock_caps.supports_vision = True
+        mock_caps.supports_reasoning = True
+        mock_caps.context_window = 1_050_000
+        mock_caps.max_output_tokens = 128_000
+        mock_caps.model_family = "gpt"
+
+        with patch("agent.models_dev.get_model_capabilities", return_value=mock_caps), \
+             patch("agent.model_metadata.get_model_context_length", return_value=272_000):
+            resp = self.client.get("/api/analytics/models?days=30")
+
+        assert resp.status_code == 200
+        entry = resp.json()["models"][0]
+        assert entry["runtime_context_length"] == 272_000
+        assert entry["capabilities"]["context_window"] == 1_050_000
+
+
 # ---------------------------------------------------------------------------
 # Gateway health probe tests
 # ---------------------------------------------------------------------------

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -525,6 +525,7 @@ export interface ModelsAnalyticsModelEntry {
   tool_calls: number;
   last_used_at: number;
   avg_tokens_per_session: number;
+  runtime_context_length?: number;
   capabilities: {
     supports_tools?: boolean;
     supports_vision?: boolean;

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -323,6 +323,9 @@ function ModelCard({
   const provider = entry.provider || modelVendor(entry.model);
   const totalTokens = entry.input_tokens + entry.output_tokens;
   const caps = entry.capabilities;
+  const runtimeContext = entry.runtime_context_length ?? 0;
+  const catalogContext = caps.context_window ?? 0;
+  const showCatalogContext = catalogContext > 0 && catalogContext !== runtimeContext;
 
   const isMain =
     !!main &&
@@ -364,9 +367,14 @@ function ModelCard({
                   {provider}
                 </Badge>
               )}
-              {caps.context_window && caps.context_window > 0 && (
+              {runtimeContext > 0 && (
                 <span className="text-[10px] text-muted-foreground">
-                  {formatTokenCount(caps.context_window)} ctx
+                  {formatTokenCount(runtimeContext)} runtime ctx
+                </span>
+              )}
+              {showCatalogContext && (
+                <span className="text-[10px] text-muted-foreground/70">
+                  {formatTokenCount(catalogContext)} catalog ctx
                 </span>
               )}
               {caps.max_output_tokens && caps.max_output_tokens > 0 && (


### PR DESCRIPTION
## Summary
- omit empty zero-activity sessions from the Models dashboard analytics so ghost TUI/session rows do not appear as separate model/provider cards
- add `runtime_context_length` to `/api/analytics/models` using the same model metadata resolver as the agent
- show runtime context separately from catalog context on model cards when the two values differ

## Why
The Models page previously displayed catalog context from models.dev as if it were the effective runtime limit. For provider-routed models such as OpenAI Codex, that can differ from the provider-enforced context length. Empty session rows could also be grouped into misleading provider-less cards.

## Tests
- `HOME=/root scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestModelsAnalyticsEndpoint -q`
- `HOME=/root scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestModelInfoEndpoint tests/hermes_cli/test_web_server.py::TestModelsAnalyticsEndpoint -q`
- `HOME=/root scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q`
- `npm run build` (web)

## Note
`npx eslint src/lib/api.ts src/pages/ModelsPage.tsx` currently fails on an existing `react-hooks/set-state-in-effect` warning at `ModelsPage.tsx:871`; this change does not touch that effect.
