### PR TITLE
fix(hindsight): drop probe for non-existent 'hindsight' package in local runtime check

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -92,7 +92,6 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     a broken local memory backend.
     """
     try:
-        importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
         return True, None
     except Exception as exc:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1440,6 +1440,33 @@ class TestAvailability:
         p = HindsightMemoryProvider()
         assert not p.is_available()
 
+    def test_check_local_runtime_does_not_import_nonexistent_hindsight_pkg(self, monkeypatch):
+        """Regression for #27386: _check_local_runtime must not require the
+        legacy top-level ``hindsight`` package - only ``hindsight_embed`` is
+        installed in supported deployments, and probing for the missing
+        ``hindsight`` module caused ``hermes memory status`` to falsely
+        report the provider as "not available" in local_embedded mode."""
+        from plugins.memory import hindsight as hs_mod
+
+        imported = []
+
+        def _record(name):
+            imported.append(name)
+            if name == "hindsight":
+                raise ModuleNotFoundError("No module named 'hindsight'")
+            return object()
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module", _record
+        )
+        ok, err = hs_mod._check_local_runtime()
+        assert ok is True, f"_check_local_runtime should succeed when hindsight_embed is importable; got err={err!r}"
+        assert err is None
+        assert "hindsight" not in imported, (
+            f"_check_local_runtime must not probe legacy 'hindsight' package; imported={imported!r}"
+        )
+        assert "hindsight_embed.daemon_embed_manager" in imported
+
     def test_initialize_disables_local_mode_when_runtime_import_fails(self, tmp_path, monkeypatch):
         config = {"mode": "local_embedded"}
         config_path = tmp_path / "hindsight" / "config.json"


### PR DESCRIPTION
## Summary

Fixes #27386 — `hermes memory status` falsely reports hindsight as **"not available"** in `local_embedded` mode even when the embedded daemon is healthy and memory operations work correctly.

## Root cause

`_check_local_runtime()` in `plugins/memory/hindsight/__init__.py` probed a top-level module called `hindsight` *before* probing `hindsight_embed.daemon_embed_manager`:

```python
try:
    importlib.import_module("hindsight")                           # ❌ always fails
    importlib.import_module("hindsight_embed.daemon_embed_manager") # ✅ real probe
    return True, None
except Exception as exc:
    return False, str(exc)
```

No package named `hindsight` is installed in any supported deployment — the installed packages are `hindsight_embed` and `hindsight_client`. So the very first line always raised `ModuleNotFoundError: No module named 'hindsight'`, `is_available()` returned `False`, and `cmd_status()` rendered a misleading `not available ✗` plus a fake missing `HINDSIGHT_API_KEY` row (which embedded mode does not need).

## Fix

Drop the dead `importlib.import_module("hindsight")` line (Option A from the issue). The remaining probe of `hindsight_embed.daemon_embed_manager` still covers the NumPy / x86_64-v2 runtime-failure case the docstring describes.

## Test plan

- Added a regression test `test_check_local_runtime_does_not_import_nonexistent_hindsight_pkg` that monkeypatches `importlib.import_module` to raise `ModuleNotFoundError` for the name `hindsight` and succeed for everything else, then asserts `_check_local_runtime()` returns `(True, None)` and that the name `hindsight` was never probed.
- Ran the hindsight provider tests:

```
$ scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py \
    -k "local_runtime or local_mode or check_local_runtime or available" -x -q
.......                                                                  [100%]
7 passed in 3.87s
```

## Risk

Very low. The dropped line was unreachable-success / always-failing; nothing in the codebase relies on a top-level `hindsight` module being importable.

## Checklist

- [x] Tests added for the regression
- [x] Existing hindsight tests still pass
- [x] No behavior change for cloud / disabled / runtime-import-fails paths (covered by existing tests)

Fixes #27386
