### PR TITLE
feat: add first-class audio and video analysis routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1,8 +1,8 @@
 """Shared auxiliary client router for side tasks.
 
 Provides a single resolution chain so every consumer (context compression,
-session search, web extraction, vision analysis, browser vision) picks up
-the best available backend without duplicating fallback logic.
+session search, web extraction, vision/audio/video analysis, browser vision)
+picks up the best available backend without duplicating fallback logic.
 
 Resolution order for text tasks (auto mode):
   1. User's main provider + main model (used regardless of provider type —
@@ -30,7 +30,8 @@ openai-codex (Step 1 above) or when a caller explicitly requests it with
 a model (auxiliary.<task>.provider + auxiliary.<task>.model).
 
 Per-task overrides are configured in config.yaml under the ``auxiliary:`` section
-(e.g. ``auxiliary.vision.provider``, ``auxiliary.compression.model``).
+(e.g. ``auxiliary.vision.provider``, ``auxiliary.video.base_url``,
+``auxiliary.audio.model``, ``auxiliary.compression.model``).
 Default "auto" follows the chains above.
 
 Payment / credit exhaustion fallback:
@@ -280,6 +281,17 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()
 # can still use this dict directly. Kept in sync with _FALLBACK above.
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALLBACK
+
+# Tasks that send non-text content blocks to an LLM and therefore need the
+# multimodal/vision-capable resolution path instead of the text-only auxiliary
+# chain.  ``video`` and ``audio`` are first-class config keys, but they share
+# the same provider capabilities and transport handling as image vision.
+_MULTIMODAL_AUX_TASKS = frozenset({"vision", "video", "audio"})
+
+
+def _is_multimodal_task(task: Optional[str]) -> bool:
+    return (task or "").strip().lower() in _MULTIMODAL_AUX_TASKS
+
 
 # Vision-specific model overrides for direct providers.
 # When the user's main provider has a dedicated vision/multimodal model that
@@ -2556,13 +2568,14 @@ def _retry_same_provider_sync(
     effective_timeout: float,
     effective_extra_body: dict,
 ) -> Any:
-    if task == "vision":
+    if _is_multimodal_task(task):
         _, retry_client, retry_model = resolve_vision_provider_client(
             provider=resolved_provider,
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             async_mode=False,
+            task=task,
         )
     else:
         retry_client, retry_model = _get_cached_client(
@@ -2613,13 +2626,14 @@ async def _retry_same_provider_async(
     effective_timeout: float,
     effective_extra_body: dict,
 ) -> Any:
-    if task == "vision":
+    if _is_multimodal_task(task):
         _, retry_client, retry_model = resolve_vision_provider_client(
             provider=resolved_provider,
             model=final_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             async_mode=True,
+            task=task,
         )
     else:
         retry_client, retry_model = _get_cached_client(
@@ -3824,16 +3838,18 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
+    task: str = "vision",
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
-    """Resolve the client actually used for vision tasks.
+    """Resolve the client actually used for multimodal auxiliary tasks.
 
     Direct endpoint overrides take precedence over provider selection. Explicit
     provider overrides still use the generic provider router for non-standard
     backends, so users can intentionally force experimental providers. Auto mode
-    stays conservative and only tries vision backends known to work today.
+    stays conservative and only tries multimodal backends known to work today.
     """
+    task_key = task if _is_multimodal_task(task) else "vision"
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        "vision", provider, model, base_url, api_key
+        task_key, provider, model, base_url, api_key
     )
     requested = _normalize_vision_provider(requested)
 
@@ -4408,14 +4424,12 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url and cfg_api_key:
-            # Both base_url and api_key explicitly set → custom endpoint.
+        if cfg_base_url:
+            # Direct base_url takes precedence over provider selection for
+            # auxiliary tasks. resolve_provider_client() will fall back to
+            # OPENAI_API_KEY or no-key-required for local OpenAI-compatible
+            # servers.
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
-        if cfg_base_url and cfg_provider and cfg_provider != "auto":
-            # base_url set without api_key but with a known provider — use
-            # the provider so it can resolve credentials from env vars
-            # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
-            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
 
@@ -4704,8 +4718,9 @@ def call_llm(
     handles auth, request formatting, and model-specific arg adjustments.
 
     Args:
-        task: Auxiliary task name ("compression", "vision", "web_extract",
-              "session_search", "skills_hub", "mcp", "title_generation").
+        task: Auxiliary task name ("compression", "vision", "video", "audio",
+              "web_extract", "session_search", "skills_hub", "mcp",
+              "title_generation").
               Reads provider:model from config/env. Ignored if provider is set.
         provider: Explicit provider override.
         model: Explicit model override.
@@ -4727,23 +4742,28 @@ def call_llm(
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
-    if task == "vision":
+    is_multimodal_task = _is_multimodal_task(task)
+
+    if is_multimodal_task:
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=False,
+            task=task,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
+                "Multimodal provider %s unavailable for task %s, falling back to auto multimodal backends",
                 resolved_provider,
+                task,
             )
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
                 async_mode=False,
+                task=task,
             )
         if client is None:
             raise RuntimeError(
@@ -4883,7 +4903,7 @@ def call_llm(
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
                 main_runtime=main_runtime,
-                is_vision=(task == "vision"),
+                is_vision=_is_multimodal_task(task),
             )
             if refreshed_client is not None:
                 logger.info("Auxiliary %s: refreshed Nous runtime credentials after 401, retrying",
@@ -5129,23 +5149,26 @@ async def async_call_llm(
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
-    if task == "vision":
+    if _is_multimodal_task(task):
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
             model=resolved_model or model,
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=True,
+            task=task,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
-                "Vision provider %s unavailable, falling back to auto vision backends",
+                "Multimodal provider %s unavailable for task %s, falling back to auto multimodal backends",
                 resolved_provider,
+                task,
             )
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
                 model=resolved_model,
                 async_mode=True,
+                task=task,
             )
         if client is None:
             raise RuntimeError(
@@ -5263,7 +5286,7 @@ async def async_call_llm(
                 base_url=resolved_base_url,
                 api_key=resolved_api_key,
                 api_mode=resolved_api_mode,
-                is_vision=(task == "vision"),
+                is_vision=_is_multimodal_task(task),
             )
             if refreshed_client is not None:
                 logger.info("Auxiliary %s (async): refreshed Nous runtime credentials after 401, retrying",
@@ -5380,7 +5403,7 @@ async def async_call_llm(
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
                 # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(
-                    fb_client, fb_model or "", is_vision=(task == "vision")
+                    fb_client, fb_model or "", is_vision=_is_multimodal_task(task)
                 )
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model

--- a/cli.py
+++ b/cli.py
@@ -443,6 +443,18 @@ def load_cli_config() -> Dict[str, Any]:
                 "base_url": "",
                 "api_key": "",
             },
+            "video": {
+                "provider": "auto",
+                "model": "",
+                "base_url": "",
+                "api_key": "",
+            },
+            "audio": {
+                "provider": "auto",
+                "model": "",
+                "base_url": "",
+                "api_key": "",
+            },
             "web_extract": {
                 "provider": "auto",
                 "model": "",
@@ -627,6 +639,18 @@ def load_cli_config() -> Dict[str, Any]:
             "model": "AUXILIARY_VISION_MODEL",
             "base_url": "AUXILIARY_VISION_BASE_URL",
             "api_key": "AUXILIARY_VISION_API_KEY",
+        },
+        "video": {
+            "provider": "AUXILIARY_VIDEO_PROVIDER",
+            "model": "AUXILIARY_VIDEO_MODEL",
+            "base_url": "AUXILIARY_VIDEO_BASE_URL",
+            "api_key": "AUXILIARY_VIDEO_API_KEY",
+        },
+        "audio": {
+            "provider": "AUXILIARY_AUDIO_PROVIDER",
+            "model": "AUXILIARY_AUDIO_MODEL",
+            "base_url": "AUXILIARY_AUDIO_BASE_URL",
+            "api_key": "AUXILIARY_AUDIO_API_KEY",
         },
         "web_extract": {
             "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -853,19 +853,19 @@ if _config_path.exists():
                         os.environ[_env_var] = str(_val)
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
-        # Auxiliary model/direct-endpoint overrides (vision, web_extract,
-        # approval, plus any plugin-registered auxiliary tasks).
+        # Auxiliary model/direct-endpoint overrides (vision, video, audio,
+        # web_extract, approval, plus any plugin-registered auxiliary tasks).
         # Each task has provider/model/base_url/api_key; bridge non-default
         # values to env vars named AUXILIARY_<KEY_UPPER>_*. The legacy
-        # hard-coded list (vision/web_extract/approval) is replaced by a
-        # dynamic loop so plugin-registered tasks benefit from the same
-        # config→env bridging without core knowing about each one.
+        # hard-coded list is replaced by a dynamic loop so plugin-registered
+        # tasks benefit from the same config→env bridging without core knowing
+        # about each one.
         _auxiliary_cfg = _cfg.get("auxiliary", {})
         if _auxiliary_cfg and isinstance(_auxiliary_cfg, dict):
             # Built-in tasks that previously had explicit env-var bridging.
             # Kept here as the canonical bridged set; plugin tasks are added
             # below via the plugin auxiliary registry.
-            _aux_bridged_keys = {"vision", "web_extract", "approval"}
+            _aux_bridged_keys = {"vision", "video", "audio", "web_extract", "approval"}
             try:
                 from hermes_cli.plugins import get_plugin_auxiliary_tasks
                 for _entry in get_plugin_auxiliary_tasks():

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -899,6 +899,24 @@ DEFAULT_CONFIG = {
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
+        "video": {
+            "provider": "auto",    # auto | openrouter | nous | codex | custom
+            "model": "",           # video-capable model, e.g. Gemini/Nemotron Omni
+            "base_url": "",        # direct OpenAI-compatible endpoint for video_url content
+            "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY/no-key-required)
+            "timeout": 300,        # seconds — video payloads and local omni models can be slow
+            "extra_body": {},
+            "download_timeout": 60,
+        },
+        "audio": {
+            "provider": "auto",    # auto | openrouter | nous | codex | custom
+            "model": "",           # audio-capable model, e.g. Gemini/Nemotron Omni
+            "base_url": "",        # direct OpenAI-compatible endpoint for audio_url content
+            "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY/no-key-required)
+            "timeout": 300,        # seconds — audio payloads and local omni models can be slow
+            "extra_body": {},
+            "download_timeout": 60,
+        },
         "web_extract": {
             "provider": "auto",
             "model": "",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2492,6 +2492,8 @@ def _clear_stale_openai_base_url():
 # (task_key, display_name, short_description)
 _AUX_TASKS: list[tuple[str, str, str]] = [
     ("vision", "Vision", "image/screenshot analysis"),
+    ("video", "Video", "video understanding"),
+    ("audio", "Audio", "audio/sound understanding"),
     ("compression", "Compression", "context summarization"),
     ("web_extract", "Web extract", "web page summarization"),
     ("approval", "Approval", "smart command approval"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -59,6 +59,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
+    ("audio",           "🎧 Audio Analysis",            "audio_analyze (requires audio-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text-to-video + image-to-video)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
@@ -94,7 +95,7 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "audio", "video_gen", "x_search"}
 
 
 def _xai_credentials_present() -> bool:

--- a/model_tools.py
+++ b/model_tools.py
@@ -221,6 +221,8 @@ _LEGACY_TOOLSET_MAP = {
     "web_tools": ["web_search", "web_extract"],
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
+    "video_tools": ["video_analyze"],
+    "audio_tools": ["audio_analyze"],
     "moa_tools": ["mixture_of_agents"],
     "image_tools": ["image_generate"],
     "skills_tools": ["skills_list", "skill_view", "skill_manage"],

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -27,6 +27,7 @@ from agent.auxiliary_client import (
     _try_payment_fallback,
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
+    _resolve_task_provider_model,
     _CodexCompletionsAdapter,
 )
 
@@ -709,6 +710,42 @@ class TestGetTextAuxiliaryClient:
 
 class TestVisionClientFallback:
     """Vision client auto mode resolves known-good multimodal backends."""
+
+    @pytest.mark.parametrize("task", ["video", "audio"])
+    def test_resolve_vision_provider_client_honors_media_task_config(self, task):
+        client = MagicMock()
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("custom", "omni-model", "http://omni.local/v1", "local", None),
+            ) as mock_resolve,
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(client, "omni-model"),
+            ) as mock_provider,
+        ):
+            provider, resolved_client, model = resolve_vision_provider_client(task=task)
+
+        assert mock_resolve.call_args[0][0] == task
+        assert provider == "custom"
+        assert resolved_client is client
+        assert model == "omni-model"
+        assert mock_provider.call_args.kwargs["explicit_base_url"] == "http://omni.local/v1"
+
+    @pytest.mark.parametrize("provider", ["auto", "openrouter"])
+    def test_base_url_media_config_resolves_to_custom(self, provider):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={
+                "provider": provider,
+                "model": "omni-model",
+                "base_url": "http://omni.local/v1",
+                "api_key": "",
+            },
+        ):
+            resolved = _resolve_task_provider_model("audio")
+
+        assert resolved == ("custom", "omni-model", "http://omni.local/v1", None, None)
 
     def test_vision_auto_includes_active_provider_when_configured(self, monkeypatch):
         """Active provider appears in available backends when credentials exist."""

--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -26,6 +26,10 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
     for key in (
         "AUXILIARY_VISION_PROVIDER", "AUXILIARY_VISION_MODEL",
         "AUXILIARY_VISION_BASE_URL", "AUXILIARY_VISION_API_KEY",
+        "AUXILIARY_VIDEO_PROVIDER", "AUXILIARY_VIDEO_MODEL",
+        "AUXILIARY_VIDEO_BASE_URL", "AUXILIARY_VIDEO_API_KEY",
+        "AUXILIARY_AUDIO_PROVIDER", "AUXILIARY_AUDIO_MODEL",
+        "AUXILIARY_AUDIO_BASE_URL", "AUXILIARY_AUDIO_API_KEY",
         "AUXILIARY_WEB_EXTRACT_PROVIDER", "AUXILIARY_WEB_EXTRACT_MODEL",
         "AUXILIARY_WEB_EXTRACT_BASE_URL", "AUXILIARY_WEB_EXTRACT_API_KEY",
     ):
@@ -42,6 +46,18 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
                 "model": "AUXILIARY_VISION_MODEL",
                 "base_url": "AUXILIARY_VISION_BASE_URL",
                 "api_key": "AUXILIARY_VISION_API_KEY",
+            },
+            "video": {
+                "provider": "AUXILIARY_VIDEO_PROVIDER",
+                "model": "AUXILIARY_VIDEO_MODEL",
+                "base_url": "AUXILIARY_VIDEO_BASE_URL",
+                "api_key": "AUXILIARY_VIDEO_API_KEY",
+            },
+            "audio": {
+                "provider": "AUXILIARY_AUDIO_PROVIDER",
+                "model": "AUXILIARY_AUDIO_MODEL",
+                "base_url": "AUXILIARY_AUDIO_BASE_URL",
+                "api_key": "AUXILIARY_AUDIO_API_KEY",
             },
             "web_extract": {
                 "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
@@ -161,6 +177,33 @@ class TestAuxiliaryConfigBridge:
         assert os.environ.get("AUXILIARY_WEB_EXTRACT_PROVIDER") is None
         assert os.environ.get("AUXILIARY_WEB_EXTRACT_MODEL") == "custom-llm"
 
+    def test_video_and_audio_bridged(self, monkeypatch):
+        config = {
+            "auxiliary": {
+                "video": {
+                    "provider": "custom",
+                    "model": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+                    "base_url": "http://192.168.247.207:18093/v1",
+                    "api_key": "local",
+                },
+                "audio": {
+                    "provider": "custom",
+                    "model": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+                    "base_url": "http://192.168.247.207:18093/v1",
+                    "api_key": "local",
+                },
+            }
+        }
+        _run_auxiliary_bridge(config, monkeypatch)
+        assert os.environ.get("AUXILIARY_VIDEO_PROVIDER") == "custom"
+        assert os.environ.get("AUXILIARY_VIDEO_MODEL") == "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
+        assert os.environ.get("AUXILIARY_VIDEO_BASE_URL") == "http://192.168.247.207:18093/v1"
+        assert os.environ.get("AUXILIARY_VIDEO_API_KEY") == "local"
+        assert os.environ.get("AUXILIARY_AUDIO_PROVIDER") == "custom"
+        assert os.environ.get("AUXILIARY_AUDIO_MODEL") == "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
+        assert os.environ.get("AUXILIARY_AUDIO_BASE_URL") == "http://192.168.247.207:18093/v1"
+        assert os.environ.get("AUXILIARY_AUDIO_API_KEY") == "local"
+
     def test_all_tasks_with_overrides(self, monkeypatch):
         config = {
             "auxiliary": {
@@ -217,9 +260,11 @@ class TestGatewayBridgeCodeParity:
         assert 'f"AUXILIARY_{_upper}_MODEL"' in content
         assert 'f"AUXILIARY_{_upper}_BASE_URL"' in content
         assert 'f"AUXILIARY_{_upper}_API_KEY"' in content
-        # Built-in bridged keys present
+        # Built-in bridged keys present, including first-class media tasks.
         assert "_aux_bridged_keys" in content
         assert '"vision"' in content
+        assert '"video"' in content
+        assert '"audio"' in content
         assert '"web_extract"' in content
         assert '"approval"' in content
         # Plugin-aux-task discovery hooked into bridging
@@ -281,6 +326,21 @@ class TestDefaultConfigShape:
         assert vision["provider"] == "auto"
         assert vision["model"] == ""
 
+    @pytest.mark.parametrize("task", ["video", "audio"])
+    def test_media_task_structure(self, task):
+        from hermes_cli.config import DEFAULT_CONFIG
+        media = DEFAULT_CONFIG["auxiliary"][task]
+        assert "provider" in media
+        assert "model" in media
+        assert "base_url" in media
+        assert "api_key" in media
+        assert "timeout" in media
+        assert "extra_body" in media
+        assert "download_timeout" in media
+        assert media["provider"] == "auto"
+        assert media["model"] == ""
+        assert media["timeout"] == 300
+
     def test_web_extract_task_structure(self):
         from hermes_cli.config import DEFAULT_CONFIG
         web = DEFAULT_CONFIG["auxiliary"]["web_extract"]
@@ -294,16 +354,10 @@ class TestDefaultConfigShape:
 
 
 class TestCLIDefaultsHaveAuxiliaryKeys:
-    """Verify cli.py load_cli_config() defaults dict does NOT include auxiliary
-    (it comes from config.yaml deep merge, not hardcoded defaults)."""
+    """Verify cli.py bridges auxiliary config values to compatibility env vars."""
 
     def test_cli_defaults_can_merge_auxiliary(self):
-        """The load_cli_config deep merge logic handles keys not in defaults.
-        Verify auxiliary would be picked up from config.yaml."""
-        # This is a structural assertion: cli.py's second-pass loop
-        # carries over keys from file_config that aren't in defaults.
-        # So auxiliary config from config.yaml gets merged even though
-        # cli.py's defaults dict doesn't define it.
+        """The load_cli_config deep merge logic handles auxiliary keys."""
         import cli as _cli_mod
         # See note in test_gateway_has_auxiliary_bridge — pin UTF-8 so the
         # test runs on Windows where the default locale is cp1252.
@@ -311,3 +365,7 @@ class TestCLIDefaultsHaveAuxiliaryKeys:
         assert "auxiliary_config = defaults.get(\"auxiliary\"" in source
         assert "AUXILIARY_VISION_PROVIDER" in source
         assert "AUXILIARY_VISION_MODEL" in source
+        assert "AUXILIARY_VIDEO_PROVIDER" in source
+        assert "AUXILIARY_VIDEO_MODEL" in source
+        assert "AUXILIARY_AUDIO_PROVIDER" in source
+        assert "AUXILIARY_AUDIO_MODEL" in source

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -158,7 +158,7 @@ class TestHandleVideoAnalyze:
             args = mock_tool.call_args[0]
             assert args[2] == "google/gemini-2.5-flash"
 
-    def test_falls_back_to_vision_model_env(self, tmp_path, monkeypatch):
+    def test_does_not_fall_back_to_vision_model_env(self, tmp_path, monkeypatch):
         monkeypatch.setenv("AUXILIARY_VIDEO_MODEL", "")
         monkeypatch.setenv("AUXILIARY_VISION_MODEL", "google/gemini-flash")
 
@@ -168,7 +168,7 @@ class TestHandleVideoAnalyze:
                 _handle_video_analyze({"video_url": "/tmp/test.mp4", "question": "test"})
             )
             args = mock_tool.call_args[0]
-            assert args[2] == "google/gemini-flash"
+            assert args[2] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -13,14 +13,24 @@ import pytest
 from tools.vision_tools import (
     _validate_image_url,
     _handle_vision_analyze,
+    _handle_video_analyze,
+    _handle_audio_analyze,
     _determine_mime_type,
+    _detect_audio_mime_type,
+    _download_audio,
+    _download_video,
+    _audio_to_base64_data_url,
     _image_to_base64_data_url,
     _resize_image_for_vision,
     _is_image_size_error,
     _MAX_BASE64_BYTES,
     _RESIZE_TARGET_BYTES,
     vision_analyze_tool,
+    video_analyze_tool,
+    audio_analyze_tool,
     check_vision_requirements,
+    check_video_requirements,
+    check_audio_requirements,
 )
 
 
@@ -426,6 +436,226 @@ class TestVisionConfig:
         assert mock_llm.await_args.kwargs["timeout"] == 120.0
 
 
+class TestMediaAuxiliaryConfig:
+    @pytest.mark.asyncio
+    async def test_video_analyze_uses_video_task_config(self, tmp_path):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"fake mp4 bytes")
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Configured video analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={
+                "auxiliary": {"video": {"temperature": 0.2, "timeout": 333}}
+            }),
+            patch(
+                "tools.vision_tools._video_to_base64_data_url",
+                return_value="data:video/mp4;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(await video_analyze_tool(str(video), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["task"] == "video"
+        assert mock_llm.await_args.kwargs["temperature"] == 0.2
+        assert mock_llm.await_args.kwargs["timeout"] == 333.0
+        content = mock_llm.await_args.kwargs["messages"][0]["content"]
+        assert content[1]["type"] == "video_url"
+
+    @pytest.mark.asyncio
+    async def test_oversized_local_video_rejected_before_encoding(self, tmp_path):
+        video = tmp_path / "huge.mp4"
+        video.write_bytes(b"x" * 32)
+
+        with (
+            patch("tools.vision_tools._MAX_VIDEO_BASE64_BYTES", 10),
+            patch("tools.vision_tools._video_to_base64_data_url") as mock_b64,
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm,
+        ):
+            result = json.loads(await video_analyze_tool(str(video), "describe"))
+
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+        mock_b64.assert_not_called()
+        mock_llm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_video_download_stream_enforces_size_limit(self, tmp_path):
+        class FakeResponse:
+            headers = {}
+            url = "https://example.com/video.mp4"
+            is_redirect = False
+            next_request = None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                yield b"123456"
+                yield b"789012"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def stream(self, *args, **kwargs):
+                return FakeStream()
+
+        dest = tmp_path / "download.mp4"
+        with (
+            patch("tools.vision_tools._MAX_VIDEO_BASE64_BYTES", 10),
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient", return_value=FakeClient()),
+            pytest.raises(ValueError, match="Video too large"),
+        ):
+            await _download_video("https://example.com/video.mp4", dest, max_retries=1)
+
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_audio_analyze_uses_audio_task_config(self, tmp_path):
+        audio = tmp_path / "tone.wav"
+        audio.write_bytes(b"RIFF" + b"\x00" * 32)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Configured audio analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={
+                "auxiliary": {"audio": {"temperature": 0.3, "timeout": 444}}
+            }),
+            patch(
+                "tools.vision_tools._audio_to_base64_data_url",
+                return_value="data:audio/wav;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(await audio_analyze_tool(str(audio), "what is this", "test/model"))
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["task"] == "audio"
+        assert mock_llm.await_args.kwargs["temperature"] == 0.3
+        assert mock_llm.await_args.kwargs["timeout"] == 444.0
+        content = mock_llm.await_args.kwargs["messages"][0]["content"]
+        assert content[1]["type"] == "audio_url"
+
+    def test_audio_mime_and_data_url(self, tmp_path):
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"abc")
+        assert _detect_audio_mime_type(audio) == "audio/mpeg"
+        assert _audio_to_base64_data_url(audio).startswith("data:audio/mpeg;base64,")
+
+    @pytest.mark.asyncio
+    async def test_oversized_local_audio_rejected_before_encoding(self, tmp_path):
+        audio = tmp_path / "huge.mp3"
+        audio.write_bytes(b"x" * 32)
+
+        with (
+            patch("tools.vision_tools._MAX_AUDIO_BASE64_BYTES", 10),
+            patch("tools.vision_tools._audio_to_base64_data_url") as mock_b64,
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm,
+        ):
+            result = json.loads(await audio_analyze_tool(str(audio), "describe"))
+
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+        mock_b64.assert_not_called()
+        mock_llm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_audio_download_stream_enforces_size_limit(self, tmp_path):
+        class FakeResponse:
+            headers = {}
+            url = "https://example.com/audio.mp3"
+            is_redirect = False
+            next_request = None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self):
+                yield b"123456"
+                yield b"789012"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def stream(self, *args, **kwargs):
+                return FakeStream()
+
+        dest = tmp_path / "download.mp3"
+        with (
+            patch("tools.vision_tools._MAX_AUDIO_BASE64_BYTES", 10),
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient", return_value=FakeClient()),
+            pytest.raises(ValueError, match="Audio too large"),
+        ):
+            await _download_audio("https://example.com/audio.mp3", dest, max_retries=1)
+
+        assert not dest.exists()
+
+    def test_video_handler_uses_video_model_env(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_VIDEO_MODEL", "video/model")
+        monkeypatch.setenv("AUXILIARY_VISION_MODEL", "vision/model")
+        with patch("tools.vision_tools.video_analyze_tool", new_callable=AsyncMock) as mock_tool:
+            mock_tool.return_value = json.dumps({"success": True})
+            coro = _handle_video_analyze({"video_url": "https://example.com/v.mp4", "question": "test"})
+            coro.close()
+        assert mock_tool.call_args[0][2] == "video/model"
+
+    def test_video_handler_does_not_fall_back_to_vision_model_env(self, monkeypatch):
+        monkeypatch.delenv("AUXILIARY_VIDEO_MODEL", raising=False)
+        monkeypatch.setenv("AUXILIARY_VISION_MODEL", "vision/model")
+        with patch("tools.vision_tools.video_analyze_tool", new_callable=AsyncMock) as mock_tool:
+            mock_tool.return_value = json.dumps({"success": True})
+            coro = _handle_video_analyze({"video_url": "https://example.com/v.mp4", "question": "test"})
+            coro.close()
+        assert mock_tool.call_args[0][2] is None
+
+    def test_audio_handler_uses_audio_model_env(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_AUDIO_MODEL", "audio/model")
+        with patch("tools.vision_tools.audio_analyze_tool", new_callable=AsyncMock) as mock_tool:
+            mock_tool.return_value = json.dumps({"success": True})
+            coro = _handle_audio_analyze({"audio_url": "https://example.com/a.wav", "question": "test"})
+            coro.close()
+        assert mock_tool.call_args[0][2] == "audio/model"
+
+
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio
     async def test_local_non_image_file_rejected_before_llm_call(self, tmp_path):
@@ -508,6 +738,22 @@ class TestVisionRequirements:
     def test_check_requirements_returns_bool(self):
         result = check_vision_requirements()
         assert isinstance(result, bool)
+
+    @pytest.mark.parametrize(
+        ("checker", "task"),
+        [
+            (check_vision_requirements, "vision"),
+            (check_video_requirements, "video"),
+            (check_audio_requirements, "audio"),
+        ],
+    )
+    def test_multimodal_requirement_checks_use_task_specific_routing(self, checker, task):
+        with patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("custom", object(), "omni"),
+        ) as mock_resolve:
+            assert checker() is True
+        assert mock_resolve.call_args.kwargs["task"] == task
 
     def test_check_requirements_accepts_codex_auth(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -723,6 +969,18 @@ class TestVisionRegistration:
         entry = registry._tools.get("vision_analyze")
         assert entry is not None
         assert entry.toolset == "vision"
+        assert entry.is_async is True
+
+    @pytest.mark.parametrize(
+        ("tool_name", "toolset"),
+        [("video_analyze", "video"), ("audio_analyze", "audio")],
+    )
+    def test_media_tools_registered(self, tool_name, toolset):
+        from tools.registry import registry
+
+        entry = registry._tools.get(tool_name)
+        assert entry is not None
+        assert entry.toolset == toolset
         assert entry.is_async is True
 
     def test_schema_has_required_fields(self):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -913,30 +913,44 @@ async def vision_analyze_tool(
                 )
 
 
-def check_vision_requirements() -> bool:
-    """Check if the configured runtime vision path can resolve a client.
+def _check_multimodal_requirements(task: str = "vision") -> bool:
+    """Check if a configured multimodal auxiliary task can resolve a client.
 
-    Mirrors the fallback chain that ``call_llm(task="vision")`` actually uses
-    at runtime: first the explicit ``auxiliary.vision.provider`` (if any),
-    and if that fails, the auto chain (main provider → openrouter → nous).
-    Without the auto-fallback step the tool would disappear from the model's
-    tool list whenever the explicit provider name was unresolvable, even
-    when the auto chain would have served the request (issue #31179).
+    Mirrors the fallback chain that ``call_llm(task=...)`` uses at runtime:
+    first the task's explicit auxiliary provider (if any), then the auto chain
+    when that provider is unavailable. Without the auto-fallback step the media
+    tools can disappear from the model's tool list even though a fallback
+    multimodal backend would serve the request.
     """
     try:
         from agent.auxiliary_client import resolve_vision_provider_client
     except ImportError:
         return False
     try:
-        _provider, client, _model = resolve_vision_provider_client()
+        _provider, client, _model = resolve_vision_provider_client(task=task)
         if client is not None:
             return True
-        # Same fallback to "auto" that call_llm performs when the configured
-        # provider can't be resolved.
-        _provider, client, _model = resolve_vision_provider_client(provider="auto")
+        _provider, client, _model = resolve_vision_provider_client(
+            provider="auto", task=task
+        )
         return client is not None
     except Exception:
         return False
+
+
+def check_vision_requirements() -> bool:
+    """Check if the configured runtime vision path can resolve a client."""
+    return _check_multimodal_requirements("vision")
+
+
+def check_video_requirements() -> bool:
+    """Check if the configured runtime video path can resolve a client."""
+    return _check_multimodal_requirements("video")
+
+
+def check_audio_requirements() -> bool:
+    """Check if the configured runtime audio path can resolve a client."""
+    return _check_multimodal_requirements("audio")
 
 
 
@@ -1091,6 +1105,48 @@ _VIDEO_MIME_TYPES = {
 _MAX_VIDEO_BASE64_BYTES = 50 * 1024 * 1024  # 50 MB hard cap
 _VIDEO_SIZE_WARN_BYTES = 20 * 1024 * 1024
 
+_AUDIO_MIME_TYPES = {
+    ".mp3": "audio/mpeg",
+    ".mpeg": "audio/mpeg",
+    ".mpga": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".mp4": "audio/mp4",
+    ".aac": "audio/aac",
+    ".ogg": "audio/ogg",
+    ".opus": "audio/ogg",
+    ".flac": "audio/flac",
+    ".webm": "audio/webm",
+}
+
+_MAX_AUDIO_BASE64_BYTES = 50 * 1024 * 1024  # 50 MB hard cap
+_AUDIO_SIZE_WARN_BYTES = 20 * 1024 * 1024
+
+
+def _resolve_aux_task_float(task: str, key: str, default: float) -> float:
+    """Read a numeric auxiliary.<task> setting, returning default on errors."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        _cfg = load_config()
+        _task_cfg = cfg_get(_cfg, "auxiliary", task, default={})
+        if isinstance(_task_cfg, dict) and _task_cfg.get(key) is not None:
+            return float(_task_cfg[key])
+    except Exception:
+        pass
+    return default
+
+
+def _resolve_media_timeout(task: str, default: float = 300.0, minimum: float = 180.0) -> float:
+    return max(_resolve_aux_task_float(task, "timeout", default), minimum)
+
+
+def _resolve_media_temperature(task: str, default: float = 0.1) -> float:
+    return _resolve_aux_task_float(task, "temperature", default)
+
+
+def _resolve_media_download_timeout(task: str, default: float = 60.0) -> float:
+    return _resolve_aux_task_float(task, "download_timeout", default)
+
 
 def _detect_video_mime_type(video_path: Path) -> Optional[str]:
     """Return a video MIME type based on file extension, or None if unsupported."""
@@ -1104,6 +1160,99 @@ def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None)
     encoded = base64.b64encode(data).decode("ascii")
     mime = mime_type or _VIDEO_MIME_TYPES.get(video_path.suffix.lower(), "video/mp4")
     return f"data:{mime};base64,{encoded}"
+
+
+def _detect_audio_mime_type(audio_path: Path) -> Optional[str]:
+    """Return an audio MIME type based on file extension, or None if unsupported."""
+    ext = audio_path.suffix.lower()
+    return _AUDIO_MIME_TYPES.get(ext)
+
+
+def _audio_to_base64_data_url(audio_path: Path, mime_type: Optional[str] = None) -> str:
+    """Convert an audio file to a base64-encoded data URL."""
+    data = audio_path.read_bytes()
+    encoded = base64.b64encode(data).decode("ascii")
+    mime = mime_type or _AUDIO_MIME_TYPES.get(audio_path.suffix.lower(), "audio/mpeg")
+    return f"data:{mime};base64,{encoded}"
+
+
+async def _download_audio(audio_url: str, destination: Path, max_retries: int = 3) -> Path:
+    """Download audio from URL with SSRF protection and retry."""
+    import asyncio
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _ssrf_redirect_guard(response):
+        if response.is_redirect and response.next_request:
+            redirect_url = str(response.next_request.url)
+            from tools.url_safety import is_safe_url
+            if not is_safe_url(redirect_url):
+                raise ValueError(
+                    f"Blocked redirect to private/internal address: {redirect_url}"
+                )
+
+    last_error = None
+    for attempt in range(max_retries):
+        try:
+            blocked = check_website_access(audio_url)
+            if blocked:
+                raise PermissionError(blocked["message"])
+
+            async with httpx.AsyncClient(
+                timeout=_resolve_media_download_timeout("audio", 60.0),
+                follow_redirects=True,
+                event_hooks={"response": [_ssrf_redirect_guard]},
+            ) as client:
+                async with client.stream(
+                    "GET",
+                    audio_url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                        "Accept": "audio/*,*/*;q=0.8",
+                    },
+                ) as response:
+                    response.raise_for_status()
+
+                    cl = response.headers.get("content-length")
+                    if cl and int(cl) > _MAX_AUDIO_BASE64_BYTES:
+                        raise ValueError(
+                            f"Audio too large ({int(cl)} bytes, max {_MAX_AUDIO_BASE64_BYTES})"
+                        )
+
+                    final_url = str(response.url)
+                    blocked = check_website_access(final_url)
+                    if blocked:
+                        raise PermissionError(blocked["message"])
+
+                    chunks = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_AUDIO_BASE64_BYTES:
+                            raise ValueError(
+                                f"Audio too large ({total} bytes, max {_MAX_AUDIO_BASE64_BYTES})"
+                            )
+                        chunks.append(chunk)
+                    destination.write_bytes(b"".join(chunks))
+
+            return destination
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries - 1:
+                wait_time = 2 ** (attempt + 1)
+                logger.warning("Audio download failed (attempt %s/%s): %s", attempt + 1, max_retries, str(e)[:50])
+                await asyncio.sleep(wait_time)
+            else:
+                logger.error(
+                    "Audio download failed after %s attempts: %s",
+                    max_retries, str(e)[:100], exc_info=True,
+                )
+
+    if last_error is None:
+        raise RuntimeError(
+            f"_download_audio exited retry loop without attempting (max_retries={max_retries})"
+        )
+    raise last_error
 
 
 async def _download_video(video_url: str, destination: Path, max_retries: int = 3) -> Path:
@@ -1129,39 +1278,48 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
                 raise PermissionError(blocked["message"])
 
             async with httpx.AsyncClient(
-                timeout=60.0,
+                timeout=_resolve_media_download_timeout("video", 60.0),
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
             ) as client:
-                response = await client.get(
+                async with client.stream(
+                    "GET",
                     video_url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                         "Accept": "video/*,*/*;q=0.8",
                     },
-                )
-                response.raise_for_status()
+                ) as response:
+                    response.raise_for_status()
 
-                cl = response.headers.get("content-length")
-                if cl and int(cl) > _MAX_VIDEO_BASE64_BYTES:
-                    raise ValueError(
-                        f"Video too large ({int(cl)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
-                    )
+                    cl = response.headers.get("content-length")
+                    if cl and int(cl) > _MAX_VIDEO_BASE64_BYTES:
+                        raise ValueError(
+                            f"Video too large ({int(cl)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
+                        )
 
-                final_url = str(response.url)
-                blocked = check_website_access(final_url)
-                if blocked:
-                    raise PermissionError(blocked["message"])
+                    final_url = str(response.url)
+                    blocked = check_website_access(final_url)
+                    if blocked:
+                        raise PermissionError(blocked["message"])
 
-                body = response.content
-                if len(body) > _MAX_VIDEO_BASE64_BYTES:
-                    raise ValueError(
-                        f"Video too large ({len(body)} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
-                    )
-                destination.write_bytes(body)
+                    total = 0
+                    with destination.open("wb") as f:
+                        async for chunk in response.aiter_bytes():
+                            total += len(chunk)
+                            if total > _MAX_VIDEO_BASE64_BYTES:
+                                raise ValueError(
+                                    f"Video too large ({total} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
+                                )
+                            f.write(chunk)
 
             return destination
         except Exception as e:
+            if destination.exists():
+                try:
+                    destination.unlink()
+                except Exception:
+                    pass
             last_error = e
             if attempt < max_retries - 1:
                 wait_time = 2 ** (attempt + 1)
@@ -1236,6 +1394,10 @@ async def video_analyze_tool(
             )
 
         video_size_bytes = temp_video_path.stat().st_size
+        if video_size_bytes > _MAX_VIDEO_BASE64_BYTES:
+            raise ValueError(
+                f"Video too large ({video_size_bytes} bytes, max {_MAX_VIDEO_BASE64_BYTES})"
+            )
         video_size_mb = video_size_bytes / (1024 * 1024)
         logger.info("Video ready (%.1f MB)", video_size_mb)
 
@@ -1279,27 +1441,15 @@ async def video_analyze_tool(
             }
         ]
 
-        vision_timeout = 180.0
-        vision_temperature = 0.1
-        try:
-            from hermes_cli.config import cfg_get, load_config
-            _cfg = load_config()
-            _vision_cfg = cfg_get(_cfg, "auxiliary", "vision", default={})
-            _vt = _vision_cfg.get("timeout")
-            if _vt is not None:
-                vision_timeout = max(float(_vt), 180.0)
-            _vtemp = _vision_cfg.get("temperature")
-            if _vtemp is not None:
-                vision_temperature = float(_vtemp)
-        except Exception:
-            pass
+        media_timeout = _resolve_media_timeout("video", default=300.0, minimum=180.0)
+        media_temperature = _resolve_media_temperature("video", default=0.1)
 
         call_kwargs = {
-            "task": "vision",
+            "task": "video",
             "messages": messages,
-            "temperature": vision_temperature,
+            "temperature": media_temperature,
             "max_tokens": 4000,
-            "timeout": vision_timeout,
+            "timeout": media_timeout,
         }
         if model:
             call_kwargs["model"] = model
@@ -1421,7 +1571,7 @@ def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "including visual content, motion, audio cues, text overlays, and scene "
         f"transitions. Then answer the following question:\n\n{question}"
     )
-    model = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip() or os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    model = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip() or None
     return video_analyze_tool(video_url, full_prompt, model)
 
 
@@ -1430,7 +1580,260 @@ registry.register(
     toolset="video",
     schema=VIDEO_ANALYZE_SCHEMA,
     handler=_handle_video_analyze,
-    check_fn=check_vision_requirements,
+    check_fn=check_video_requirements,
     is_async=True,
     emoji="🎬",
+)
+
+
+# ---------------------------------------------------------------------------
+# Audio Analysis Tool
+# ---------------------------------------------------------------------------
+
+
+async def audio_analyze_tool(
+    audio_url: str,
+    user_prompt: str,
+    model: str = None,
+) -> str:
+    """Analyze an audio file via multimodal LLM. Returns JSON {success, analysis}."""
+    if not isinstance(user_prompt, str):
+        user_prompt = str(user_prompt) if user_prompt is not None else ""
+    debug_call_data = {
+        "parameters": {
+            "audio_url": audio_url,
+            "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
+            "model": model,
+        },
+        "error": None,
+        "success": False,
+        "analysis_length": 0,
+        "model_used": model,
+        "audio_size_bytes": 0,
+    }
+
+    temp_audio_path = None
+    should_cleanup = True
+
+    try:
+        from tools.interrupt import is_interrupted
+        if is_interrupted():
+            return tool_error("Interrupted", success=False)
+
+        logger.info("Analyzing audio: %s", audio_url[:60])
+        logger.info("User prompt: %s", user_prompt[:100])
+
+        resolved_url = audio_url
+        if resolved_url.startswith("file://"):
+            resolved_url = resolved_url[len("file://"):]
+        local_path = Path(os.path.expanduser(resolved_url))
+
+        if local_path.is_file():
+            logger.info("Using local audio file: %s", audio_url)
+            temp_audio_path = local_path
+            should_cleanup = False
+        elif _validate_image_url(audio_url):
+            blocked = check_website_access(audio_url)
+            if blocked:
+                raise PermissionError(blocked["message"])
+            temp_dir = get_hermes_dir("cache/audio", "temp_audio_files")
+            ext = Path(urlparse(audio_url).path).suffix.lower()
+            if ext not in _AUDIO_MIME_TYPES:
+                ext = ".mp3"
+            temp_audio_path = temp_dir / f"temp_audio_{uuid.uuid4()}{ext}"
+            await _download_audio(audio_url, temp_audio_path)
+            should_cleanup = True
+        else:
+            raise ValueError(
+                "Invalid audio source. Provide an HTTP/HTTPS URL or a valid local file path."
+            )
+
+        audio_size_bytes = temp_audio_path.stat().st_size
+        if audio_size_bytes > _MAX_AUDIO_BASE64_BYTES:
+            raise ValueError(
+                f"Audio too large ({audio_size_bytes} bytes, max {_MAX_AUDIO_BASE64_BYTES})"
+            )
+        audio_size_mb = audio_size_bytes / (1024 * 1024)
+        logger.info("Audio ready (%.1f MB)", audio_size_mb)
+
+        detected_mime = _detect_audio_mime_type(temp_audio_path)
+        if not detected_mime:
+            raise ValueError(
+                f"Unsupported audio format: '{temp_audio_path.suffix}'. "
+                f"Supported: {', '.join(sorted(_AUDIO_MIME_TYPES.keys()))}"
+            )
+
+        if audio_size_bytes > _AUDIO_SIZE_WARN_BYTES:
+            logger.warning("Audio is %.1f MB — may be slow or rejected", audio_size_mb)
+
+        audio_data_url = _audio_to_base64_data_url(temp_audio_path, mime_type=detected_mime)
+        data_size_mb = len(audio_data_url) / (1024 * 1024)
+
+        if len(audio_data_url) > _MAX_AUDIO_BASE64_BYTES:
+            raise ValueError(
+                f"Audio too large for API: base64 payload is {data_size_mb:.1f} MB "
+                f"(limit {_MAX_AUDIO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
+                f"Compress or trim the audio and retry."
+            )
+
+        debug_call_data["audio_size_bytes"] = audio_size_bytes
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": user_prompt,
+                    },
+                    {
+                        "type": "audio_url",
+                        "audio_url": {
+                            "url": audio_data_url,
+                        },
+                    },
+                ],
+            }
+        ]
+
+        media_timeout = _resolve_media_timeout("audio", default=300.0, minimum=180.0)
+        media_temperature = _resolve_media_temperature("audio", default=0.1)
+
+        call_kwargs = {
+            "task": "audio",
+            "messages": messages,
+            "temperature": media_temperature,
+            "max_tokens": 4000,
+            "timeout": media_timeout,
+        }
+        if model:
+            call_kwargs["model"] = model
+
+        response = await async_call_llm(**call_kwargs)
+        analysis = extract_content_or_reasoning(response)
+
+        if not analysis:
+            logger.warning("Empty audio response, retrying once")
+            response = await async_call_llm(**call_kwargs)
+            analysis = extract_content_or_reasoning(response)
+
+        analysis_length = len(analysis) if analysis else 0
+        logger.info("Audio analysis completed (%s characters)", analysis_length)
+
+        result = {
+            "success": True,
+            "analysis": analysis or "There was a problem with the request and the audio could not be analyzed.",
+        }
+
+        debug_call_data["success"] = True
+        debug_call_data["analysis_length"] = analysis_length
+        _debug.log_call("audio_analyze_tool", debug_call_data)
+        _debug.save()
+
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    except Exception as e:
+        error_msg = f"Error analyzing audio: {str(e)}"
+        logger.error("%s", error_msg, exc_info=True)
+
+        err_str = str(e).lower()
+        if any(hint in err_str for hint in (
+            "402", "insufficient", "payment required", "credits", "billing",
+        )):
+            analysis = (
+                "Insufficient credits or payment required. Please top up your "
+                f"API provider account and try again. Error: {e}"
+            )
+        elif any(hint in err_str for hint in (
+            "does not support", "not support audio", "audio input",
+            "content_policy", "multimodal", "unrecognized request argument",
+            "audio_url", "input_audio",
+        )):
+            analysis = (
+                "The model does not support audio analysis or the request was "
+                "rejected. Ensure you're using an audio-capable model "
+                f"(for example a Nemotron/Gemini omni model). Error: {e}"
+            )
+        elif any(hint in err_str for hint in (
+            "too large", "payload", "413", "content_too_large",
+            "request_too_large", "exceeds", "size limit",
+        )):
+            analysis = (
+                "The audio is too large for the API. Try compressing or trimming "
+                f"the audio (max ~50 MB). Error: {e}"
+            )
+        else:
+            analysis = (
+                "There was a problem with the request and the audio could not "
+                f"be analyzed. Error: {e}"
+            )
+
+        result = {
+            "success": False,
+            "error": error_msg,
+            "analysis": analysis,
+        }
+
+        debug_call_data["error"] = error_msg
+        _debug.log_call("audio_analyze_tool", debug_call_data)
+        _debug.save()
+
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    finally:
+        if should_cleanup and temp_audio_path and temp_audio_path.exists():
+            try:
+                temp_audio_path.unlink()
+                logger.debug("Cleaned up temporary audio file")
+            except Exception as cleanup_error:
+                logger.warning(
+                    "Could not delete temporary file: %s", cleanup_error, exc_info=True
+                )
+
+
+AUDIO_ANALYZE_SCHEMA = {
+    "name": "audio_analyze",
+    "description": (
+        "Analyze an audio file from a URL or local file path using a multimodal AI model. "
+        "Use this for sound/music/speech understanding when transcription alone is not enough. "
+        "Supports mp3, wav, m4a, aac, ogg/opus, flac, webm formats. "
+        "Note: large audio files (>20 MB) may be slow; max ~50 MB."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "audio_url": {
+                "type": "string",
+                "description": "Audio URL (http/https) or local file path to analyze.",
+            },
+            "question": {
+                "type": "string",
+                "description": "Your specific question about the audio. The AI will describe what it hears and answer your question.",
+            },
+        },
+        "required": ["audio_url", "question"],
+    },
+}
+
+
+def _handle_audio_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
+    audio_url = args.get("audio_url", "")
+    question = args.get("question", "")
+    full_prompt = (
+        "Fully describe and explain everything audible in this audio, including "
+        "speech, music, sound effects, background noise, timing, and any notable "
+        f"audio cues. Then answer the following question:\n\n{question}"
+    )
+    model = os.getenv("AUXILIARY_AUDIO_MODEL", "").strip() or None
+    return audio_analyze_tool(audio_url, full_prompt, model)
+
+
+registry.register(
+    name="audio_analyze",
+    toolset="audio",
+    schema=AUDIO_ANALYZE_SCHEMA,
+    handler=_handle_audio_analyze,
+    check_fn=check_audio_requirements,
+    is_async=True,
+    emoji="🎧",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -121,6 +121,12 @@ TOOLSETS = {
         "tools": ["video_analyze"],
         "includes": []
     },
+
+    "audio": {
+        "description": "Audio and sound analysis tools (opt-in, not in default toolset)",
+        "tools": ["audio_analyze"],
+        "includes": []
+    },
     
     "image_gen": {
         "description": "Creative generation tools (images)",


### PR DESCRIPTION
## Summary
- Adds first-class `auxiliary.video` and `auxiliary.audio` routing entries.
- Routes `video_analyze` through `task="video"` instead of piggybacking on `auxiliary.vision`.
- Adds an `audio_analyze` tool using OpenAI-style `audio_url` data URL blocks for multimodal/omni endpoints.
- Adds download/local-size guards and tests for media routing/tool schemas.
- Keeps blank `AUXILIARY_VIDEO_MODEL` from falling back to the vision env override, so video/audio routing stays independent.

## Smoke verification
- Verified `check_video_requirements()` and `check_audio_requirements()` against a private OpenAI-compatible multimodal endpoint.
- Verified `audio_analyze` with a generated WAV tone.
- Verified `video_analyze` with a generated tiny MP4.

## Test plan
- `python -m pytest -q -n 0 tests/tools/test_video_analyze.py::TestHandleVideoAnalyze::test_does_not_fall_back_to_vision_model_env -o 'addopts='` → 1 passed
- `python -m pytest -q -n 0 tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_config_bridge.py tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py -o 'addopts='` → 299 passed
- `python -m pytest -q -n 0 tests/hermes_cli/test_tools_config.py -k 'audio or video or media or default_off' -o 'addopts='` → 4 passed, 70 deselected
- `python -m py_compile agent/auxiliary_client.py cli.py gateway/run.py hermes_cli/config.py hermes_cli/main.py hermes_cli/tools_config.py model_tools.py tools/vision_tools.py toolsets.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_config_bridge.py tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py`
- `git diff --check origin/main..HEAD`

Note: the full `tests/hermes_cli/test_tools_config.py` currently has 3 browser-provider failures on `origin/main` in this checkout; the media-specific subset above passes.
