### PR TITLE
feat(x_search): add structured output and response chaining

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -432,3 +432,188 @@ def test_x_search_bearer_requests_prefer_api_key_from_shared_resolver(monkeypatc
     assert captured.get("prefer_api_key") is True
     assert source == "xai"
 
+# ---------------------------------------------------------------------------
+# Structured output, instructions, and response chaining — salvaged behavior
+# from grok-mcp-server's x_search tool.
+# ---------------------------------------------------------------------------
+
+def _capture_post(monkeypatch, payload):
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("requests.post", _fake_post)
+    return captured
+
+
+def test_x_search_attaches_output_schema_text_format(monkeypatch):
+    """``output_schema`` expands to ``text.format.json_schema`` with strict mode."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    schema = {
+        "type": "object",
+        "properties": {"sentiment": {"type": "string"}},
+        "required": ["sentiment"],
+        "additionalProperties": False,
+    }
+    captured = _capture_post(
+        monkeypatch,
+        {"id": "resp_abc", "output_text": '{"sentiment": "positive"}'},
+    )
+
+    result = json.loads(x_search_tool(query="reactions to xai", output_schema=schema))
+
+    text_block = captured["json"]["text"]["format"]
+    assert text_block["type"] == "json_schema"
+    assert text_block["name"] == "output"
+    assert text_block["strict"] is True
+    assert text_block["schema"] == schema
+    assert result["success"] is True
+    assert result["structured_output"] == {"sentiment": "positive"}
+    assert result["answer"] == '{"sentiment": "positive"}'
+
+
+def test_x_search_includes_instructions_top_level(monkeypatch):
+    """``instructions`` lands at the top level of the request body."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(x_search_tool(query="xai news", instructions="Respond in Japanese"))
+
+    assert captured["json"]["instructions"] == "Respond in Japanese"
+
+
+def test_x_search_includes_previous_response_id_and_stores(monkeypatch):
+    """``previous_response_id`` lands top-level AND auto-enables ``store``."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "follow-up"})
+
+    json.loads(
+        x_search_tool(query="drill down on the first hit", previous_response_id="resp_seed")
+    )
+
+    assert captured["json"]["previous_response_id"] == "resp_seed"
+    assert captured["json"]["store"] is True
+
+
+def test_x_search_drops_instructions_when_previous_response_id_set(monkeypatch):
+    """When both are set, instructions is dropped (xAI API treats them as exclusive)."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "follow-up"})
+
+    json.loads(
+        x_search_tool(
+            query="continue",
+            instructions="should be ignored",
+            previous_response_id="resp_seed",
+        )
+    )
+
+    assert "instructions" not in captured["json"]
+    assert captured["json"]["previous_response_id"] == "resp_seed"
+
+
+def test_x_search_defaults_store_to_false(monkeypatch):
+    """Without ``store`` or ``previous_response_id`` the request stays unstored."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(x_search_tool(query="anything"))
+
+    assert captured["json"]["store"] is False
+
+
+def test_x_search_honors_explicit_store_true(monkeypatch):
+    """Seed call for chaining: caller sets ``store=True`` to make response_id reusable."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"id": "resp_seed", "output_text": "seed"})
+
+    result = json.loads(x_search_tool(query="seed", store=True))
+
+    assert captured["json"]["store"] is True
+    assert result["response_id"] == "resp_seed"
+
+
+def test_x_search_returns_response_id_in_success_payload(monkeypatch):
+    """``response_id`` is surfaced from ``data['id']`` on success."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"id": "resp_xyz", "output_text": "ok"})
+
+    result = json.loads(x_search_tool(query="anything"))
+
+    assert result["success"] is True
+    assert result["response_id"] == "resp_xyz"
+
+
+def test_x_search_structured_output_none_when_no_schema(monkeypatch):
+    """``structured_output`` is None when ``output_schema`` is not provided."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"output_text": "human-readable answer"})
+
+    result = json.loads(x_search_tool(query="anything"))
+
+    assert result["success"] is True
+    assert result["structured_output"] is None
+
+
+def test_x_search_structured_output_none_on_parse_failure(monkeypatch):
+    """Invalid JSON keeps ``success=True`` and ``structured_output=None``."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"output_text": "not valid json {{{"})
+
+    result = json.loads(
+        x_search_tool(
+            query="anything",
+            output_schema={"type": "object", "additionalProperties": False},
+        )
+    )
+
+    assert result["success"] is True
+    assert result["structured_output"] is None
+    assert result["answer"] == "not valid json {{{"
+
+
+def test_x_search_rejects_non_object_output_schema(monkeypatch):
+    """``output_schema`` must be a JSON object; other JSON types produce a tool error."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(x_search_tool(query="anything", output_schema=["bad"]))
+
+    assert "output_schema must be a JSON object" in result["error"]
+
+
+def test_x_search_omits_empty_instructions_and_previous_response_id(monkeypatch):
+    """Empty/whitespace strings stay out of the payload."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(
+        x_search_tool(query="anything", instructions="   ", previous_response_id="  ")
+    )
+
+    assert "instructions" not in captured["json"]
+    assert "previous_response_id" not in captured["json"]
+    assert captured["json"]["store"] is False

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -312,3 +312,189 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
 
+
+# ---------------------------------------------------------------------------
+# Structured output, instructions, and response chaining — salvaged behavior
+# from grok-mcp-server's x_search tool.
+# ---------------------------------------------------------------------------
+
+def _capture_post(monkeypatch, payload):
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("requests.post", _fake_post)
+    return captured
+
+
+def test_x_search_attaches_output_schema_text_format(monkeypatch):
+    """``output_schema`` expands to ``text.format.json_schema`` with strict mode."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    schema = {
+        "type": "object",
+        "properties": {"sentiment": {"type": "string"}},
+        "required": ["sentiment"],
+        "additionalProperties": False,
+    }
+    captured = _capture_post(
+        monkeypatch,
+        {"id": "resp_abc", "output_text": '{"sentiment": "positive"}'},
+    )
+
+    result = json.loads(x_search_tool(query="reactions to xai", output_schema=schema))
+
+    text_block = captured["json"]["text"]["format"]
+    assert text_block["type"] == "json_schema"
+    assert text_block["name"] == "output"
+    assert text_block["strict"] is True
+    assert text_block["schema"] == schema
+    assert result["success"] is True
+    assert result["structured_output"] == {"sentiment": "positive"}
+    assert result["answer"] == '{"sentiment": "positive"}'
+
+
+def test_x_search_includes_instructions_top_level(monkeypatch):
+    """``instructions`` lands at the top level of the request body."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(x_search_tool(query="xai news", instructions="Respond in Japanese"))
+
+    assert captured["json"]["instructions"] == "Respond in Japanese"
+
+
+def test_x_search_includes_previous_response_id_and_stores(monkeypatch):
+    """``previous_response_id`` lands top-level AND auto-enables ``store``."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "follow-up"})
+
+    json.loads(
+        x_search_tool(query="drill down on the first hit", previous_response_id="resp_seed")
+    )
+
+    assert captured["json"]["previous_response_id"] == "resp_seed"
+    assert captured["json"]["store"] is True
+
+
+def test_x_search_drops_instructions_when_previous_response_id_set(monkeypatch):
+    """When both are set, instructions is dropped (xAI API treats them as exclusive)."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "follow-up"})
+
+    json.loads(
+        x_search_tool(
+            query="continue",
+            instructions="should be ignored",
+            previous_response_id="resp_seed",
+        )
+    )
+
+    assert "instructions" not in captured["json"]
+    assert captured["json"]["previous_response_id"] == "resp_seed"
+
+
+def test_x_search_defaults_store_to_false(monkeypatch):
+    """Without ``store`` or ``previous_response_id`` the request stays unstored."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(x_search_tool(query="anything"))
+
+    assert captured["json"]["store"] is False
+
+
+def test_x_search_honors_explicit_store_true(monkeypatch):
+    """Seed call for chaining: caller sets ``store=True`` to make response_id reusable."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"id": "resp_seed", "output_text": "seed"})
+
+    result = json.loads(x_search_tool(query="seed", store=True))
+
+    assert captured["json"]["store"] is True
+    assert result["response_id"] == "resp_seed"
+
+
+def test_x_search_returns_response_id_in_success_payload(monkeypatch):
+    """``response_id`` is surfaced from ``data['id']`` on success."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"id": "resp_xyz", "output_text": "ok"})
+
+    result = json.loads(x_search_tool(query="anything"))
+
+    assert result["success"] is True
+    assert result["response_id"] == "resp_xyz"
+
+
+def test_x_search_structured_output_none_when_no_schema(monkeypatch):
+    """``structured_output`` is None when ``output_schema`` is not provided."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"output_text": "human-readable answer"})
+
+    result = json.loads(x_search_tool(query="anything"))
+
+    assert result["success"] is True
+    assert result["structured_output"] is None
+
+
+def test_x_search_structured_output_none_on_parse_failure(monkeypatch):
+    """Invalid JSON keeps ``success=True`` and ``structured_output=None``."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    _capture_post(monkeypatch, {"output_text": "not valid json {{{"})
+
+    result = json.loads(
+        x_search_tool(
+            query="anything",
+            output_schema={"type": "object", "additionalProperties": False},
+        )
+    )
+
+    assert result["success"] is True
+    assert result["structured_output"] is None
+    assert result["answer"] == "not valid json {{{"
+
+
+def test_x_search_rejects_non_object_output_schema(monkeypatch):
+    """``output_schema`` must be a JSON object; other JSON types produce a tool error."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(x_search_tool(query="anything", output_schema=["bad"]))
+
+    assert "output_schema must be a JSON object" in result["error"]
+
+
+def test_x_search_omits_empty_instructions_and_previous_response_id(monkeypatch):
+    """Empty/whitespace strings stay out of the payload."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    captured = _capture_post(monkeypatch, {"output_text": "ok"})
+
+    json.loads(
+        x_search_tool(query="anything", instructions="   ", previous_response_id="  ")
+    )
+
+    assert "instructions" not in captured["json"]
+    assert "previous_response_id" not in captured["json"]
+    assert captured["json"]["store"] is False

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -233,6 +233,24 @@ def _validate_date_range(from_date: str, to_date: str) -> None:
             )
 
 
+def _validate_output_schema(output_schema: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if output_schema is None:
+        return None
+    if not isinstance(output_schema, dict):
+        raise ValueError("output_schema must be a JSON object")
+    return output_schema
+
+
+def _parse_structured_output(answer: str) -> Optional[Any]:
+    if not answer or not answer.strip():
+        return None
+    try:
+        return json.loads(answer)
+    except json.JSONDecodeError:
+        logger.warning("x_search structured output parse failed", exc_info=True)
+        return None
+
+
 def _extract_response_text(payload: Dict[str, Any]) -> str:
     output_text = str(payload.get("output_text") or "").strip()
     if output_text:
@@ -307,6 +325,10 @@ def x_search_tool(
     to_date: str = "",
     enable_image_understanding: bool = False,
     enable_video_understanding: bool = False,
+    output_schema: Optional[Dict[str, Any]] = None,
+    instructions: str = "",
+    previous_response_id: str = "",
+    store: bool = False,
 ) -> str:
     if not query or not query.strip():
         return tool_error("query is required for x_search")
@@ -324,6 +346,7 @@ def x_search_tool(
 
         try:
             _validate_date_range(from_date, to_date)
+            validated_schema = _validate_output_schema(output_schema)
         except ValueError as exc:
             return tool_error(str(exc))
 
@@ -331,6 +354,17 @@ def x_search_tool(
             reasoning_effort = _get_x_search_reasoning_effort()
         except ValueError as exc:
             return tool_error(str(exc))
+
+        instructions_value = instructions.strip()
+        previous_response_id_value = previous_response_id.strip()
+        if instructions_value and previous_response_id_value:
+            logger.warning(
+                "x_search instructions dropped because previous_response_id is present "
+                "(mutually exclusive per xAI Responses API)"
+            )
+            instructions_value = ""
+
+        should_store = bool(store) or bool(previous_response_id_value)
 
         tool_def: Dict[str, Any] = {"type": "x_search"}
         if allowed:
@@ -346,7 +380,7 @@ def x_search_tool(
         if enable_video_understanding:
             tool_def["enable_video_understanding"] = True
 
-        payload = {
+        payload: Dict[str, Any] = {
             "model": _get_x_search_model(),
             "input": [
                 {
@@ -355,10 +389,23 @@ def x_search_tool(
                 }
             ],
             "tools": [tool_def],
-            "store": False,
+            "store": should_store,
         }
         if reasoning_effort:
             payload["reasoning"] = {"effort": reasoning_effort}
+        if instructions_value:
+            payload["instructions"] = instructions_value
+        if previous_response_id_value:
+            payload["previous_response_id"] = previous_response_id_value
+        if validated_schema is not None:
+            payload["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": "output",
+                    "schema": validated_schema,
+                    "strict": True,
+                }
+            }
 
         timeout_seconds = _get_x_search_timeout_seconds()
         max_retries = _get_x_search_retries()
@@ -407,6 +454,9 @@ def x_search_tool(
         answer = _extract_response_text(data)
         citations = list(data.get("citations") or [])
         inline_citations = _extract_inline_citations(data)
+        structured_output = (
+            _parse_structured_output(answer) if validated_schema is not None else None
+        )
 
         # Degraded-result detection.
         #
@@ -441,7 +491,9 @@ def x_search_tool(
                 "tool": "x_search",
                 "model": payload["model"],
                 "query": query.strip(),
+                "response_id": data.get("id"),
                 "answer": answer,
+                "structured_output": structured_output,
                 "citations": citations,
                 "inline_citations": inline_citations,
                 "degraded": degraded,
@@ -533,6 +585,41 @@ X_SEARCH_SCHEMA = {
                 "description": "Whether xAI should analyze videos attached to matching X posts.",
                 "default": False,
             },
+            "output_schema": {
+                "type": "object",
+                "description": (
+                    "Optional JSON Schema for structured output. When provided, xAI returns "
+                    "the response as JSON conforming to this schema (strict mode); the parsed "
+                    "result is exposed in the `structured_output` field while the raw JSON "
+                    "string remains in `answer`."
+                ),
+            },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "Optional system-level instructions controlling response style "
+                    "(language, tone, formatting). Separate from the search query itself. "
+                    "Ignored when previous_response_id is also set."
+                ),
+            },
+            "previous_response_id": {
+                "type": "string",
+                "description": (
+                    "Optional response ID from a previous x_search call to continue the "
+                    "conversation. The referenced response must have been created with "
+                    "store=true. If instructions is also set, instructions is ignored."
+                ),
+            },
+            "store": {
+                "type": "boolean",
+                "description": (
+                    "Whether xAI should retain this response so it can be referenced later "
+                    "via previous_response_id. Default is false for privacy. Set store=true "
+                    "on the first call if you plan to chain follow-ups using response_id. "
+                    "When previous_response_id is provided, the request is stored automatically."
+                ),
+                "default": False,
+            },
         },
         "required": ["query"],
     },
@@ -548,6 +635,10 @@ def _handle_x_search(args, **kw):
         to_date=args.get("to_date", ""),
         enable_image_understanding=bool(args.get("enable_image_understanding", False)),
         enable_video_understanding=bool(args.get("enable_video_understanding", False)),
+        output_schema=args.get("output_schema"),
+        instructions=args.get("instructions", "") or "",
+        previous_response_id=args.get("previous_response_id", "") or "",
+        store=bool(args.get("store", False)),
     )
 
 

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -222,6 +222,24 @@ def _validate_date_range(from_date: str, to_date: str) -> None:
             )
 
 
+def _validate_output_schema(output_schema: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if output_schema is None:
+        return None
+    if not isinstance(output_schema, dict):
+        raise ValueError("output_schema must be a JSON object")
+    return output_schema
+
+
+def _parse_structured_output(answer: str) -> Optional[Any]:
+    if not answer or not answer.strip():
+        return None
+    try:
+        return json.loads(answer)
+    except json.JSONDecodeError:
+        logger.warning("x_search structured output parse failed", exc_info=True)
+        return None
+
+
 def _extract_response_text(payload: Dict[str, Any]) -> str:
     output_text = str(payload.get("output_text") or "").strip()
     if output_text:
@@ -296,6 +314,10 @@ def x_search_tool(
     to_date: str = "",
     enable_image_understanding: bool = False,
     enable_video_understanding: bool = False,
+    output_schema: Optional[Dict[str, Any]] = None,
+    instructions: str = "",
+    previous_response_id: str = "",
+    store: bool = False,
 ) -> str:
     if not query or not query.strip():
         return tool_error("query is required for x_search")
@@ -313,6 +335,7 @@ def x_search_tool(
 
         try:
             _validate_date_range(from_date, to_date)
+            validated_schema = _validate_output_schema(output_schema)
         except ValueError as exc:
             return tool_error(str(exc))
 
@@ -320,6 +343,17 @@ def x_search_tool(
             reasoning_effort = _get_x_search_reasoning_effort()
         except ValueError as exc:
             return tool_error(str(exc))
+
+        instructions_value = instructions.strip()
+        previous_response_id_value = previous_response_id.strip()
+        if instructions_value and previous_response_id_value:
+            logger.warning(
+                "x_search instructions dropped because previous_response_id is present "
+                "(mutually exclusive per xAI Responses API)"
+            )
+            instructions_value = ""
+
+        should_store = bool(store) or bool(previous_response_id_value)
 
         tool_def: Dict[str, Any] = {"type": "x_search"}
         if allowed:
@@ -335,7 +369,7 @@ def x_search_tool(
         if enable_video_understanding:
             tool_def["enable_video_understanding"] = True
 
-        payload = {
+        payload: Dict[str, Any] = {
             "model": _get_x_search_model(),
             "input": [
                 {
@@ -344,10 +378,23 @@ def x_search_tool(
                 }
             ],
             "tools": [tool_def],
-            "store": False,
+            "store": should_store,
         }
         if reasoning_effort:
             payload["reasoning"] = {"effort": reasoning_effort}
+        if instructions_value:
+            payload["instructions"] = instructions_value
+        if previous_response_id_value:
+            payload["previous_response_id"] = previous_response_id_value
+        if validated_schema is not None:
+            payload["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": "output",
+                    "schema": validated_schema,
+                    "strict": True,
+                }
+            }
 
         timeout_seconds = _get_x_search_timeout_seconds()
         max_retries = _get_x_search_retries()
@@ -396,6 +443,9 @@ def x_search_tool(
         answer = _extract_response_text(data)
         citations = list(data.get("citations") or [])
         inline_citations = _extract_inline_citations(data)
+        structured_output = (
+            _parse_structured_output(answer) if validated_schema is not None else None
+        )
 
         # Degraded-result detection.
         #
@@ -430,7 +480,9 @@ def x_search_tool(
                 "tool": "x_search",
                 "model": payload["model"],
                 "query": query.strip(),
+                "response_id": data.get("id"),
                 "answer": answer,
+                "structured_output": structured_output,
                 "citations": citations,
                 "inline_citations": inline_citations,
                 "degraded": degraded,
@@ -522,6 +574,41 @@ X_SEARCH_SCHEMA = {
                 "description": "Whether xAI should analyze videos attached to matching X posts.",
                 "default": False,
             },
+            "output_schema": {
+                "type": "object",
+                "description": (
+                    "Optional JSON Schema for structured output. When provided, xAI returns "
+                    "the response as JSON conforming to this schema (strict mode); the parsed "
+                    "result is exposed in the `structured_output` field while the raw JSON "
+                    "string remains in `answer`."
+                ),
+            },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "Optional system-level instructions controlling response style "
+                    "(language, tone, formatting). Separate from the search query itself. "
+                    "Ignored when previous_response_id is also set."
+                ),
+            },
+            "previous_response_id": {
+                "type": "string",
+                "description": (
+                    "Optional response ID from a previous x_search call to continue the "
+                    "conversation. The referenced response must have been created with "
+                    "store=true. If instructions is also set, instructions is ignored."
+                ),
+            },
+            "store": {
+                "type": "boolean",
+                "description": (
+                    "Whether xAI should retain this response so it can be referenced later "
+                    "via previous_response_id. Default is false for privacy. Set store=true "
+                    "on the first call if you plan to chain follow-ups using response_id. "
+                    "When previous_response_id is provided, the request is stored automatically."
+                ),
+                "default": False,
+            },
         },
         "required": ["query"],
     },
@@ -537,6 +624,10 @@ def _handle_x_search(args, **kw):
         to_date=args.get("to_date", ""),
         enable_image_understanding=bool(args.get("enable_image_understanding", False)),
         enable_video_understanding=bool(args.get("enable_video_understanding", False)),
+        output_schema=args.get("output_schema"),
+        instructions=args.get("instructions", "") or "",
+        previous_response_id=args.get("previous_response_id", "") or "",
+        store=bool(args.get("store", False)),
     )
 
 

--- a/website/docs/user-guide/features/x-search.md
+++ b/website/docs/user-guide/features/x-search.md
@@ -96,16 +96,34 @@ The agent calls `x_search` with these arguments:
 | `to_date` | string | Optional `YYYY-MM-DD` end date. |
 | `enable_image_understanding` | boolean | Ask xAI to analyze images attached to matching posts. |
 | `enable_video_understanding` | boolean | Ask xAI to analyze videos attached to matching posts. |
+| `output_schema` | object | Optional JSON Schema for strict structured output. The parsed result is returned in `structured_output`, while `answer` keeps the raw JSON string. |
+| `instructions` | string | Optional system-level instructions for response style. Ignored when `previous_response_id` is also set. |
+| `previous_response_id` | string | Optional `response_id` from a stored response to continue. When set, the new response is stored automatically. |
+| `store` | boolean | Whether xAI should retain the response for a later chained call. Defaults to `false`. |
 
 The tool returns JSON with:
 
 - `answer` — synthesized text response from Grok
+- `response_id` — response identifier returned by xAI; pass it as `previous_response_id` to continue from a stored response
+- `structured_output` — parsed JSON matching `output_schema`, or `null` when no schema was requested or the response could not be parsed
 - `citations` — citations returned by the Responses API top-level field
 - `inline_citations` — `url_citation` annotations extracted from the message body (each with `url`, `title`, `start_index`, `end_index`)
 - `degraded` — `true` when any narrowing filter (`allowed_x_handles`, `excluded_x_handles`, `from_date`, `to_date`) was set AND both citation channels came back empty. In that case the `answer` was synthesized from the model's own knowledge rather than the X index, so treat it as unsourced. `false` otherwise (including the "no filters set" case — a broad unsourced answer is just an answer, not a filter miss)
 - `degraded_reason` — short string naming which filters were active, or `null` when `degraded` is `false`
 - `credential_source` — `"xai-oauth"` if OAuth resolved, `"xai"` if API key resolved
 - `model`, `query`, `provider`, `tool`, `success`
+
+### Structured output and response chaining
+
+To request structured output, pass a JSON Schema in `output_schema`. xAI is asked to follow it in strict mode. The raw JSON string remains available in `answer`, and the parsed value is returned in `structured_output`.
+
+Response chaining requires the first response to be stored:
+
+1. Make the initial call with `store=true`.
+2. Read its returned `response_id`.
+3. Pass that ID as `previous_response_id` on the follow-up call.
+
+Calls with `previous_response_id` are stored automatically, so their returned `response_id` can continue the chain. `instructions` and `previous_response_id` are mutually exclusive in the xAI Responses API; if both are provided, `previous_response_id` takes precedence and `instructions` is ignored.
 
 ### Date validation
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/x-search.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/x-search.md
@@ -79,16 +79,34 @@ agent 调用 `x_search` 时使用以下参数：
 | `to_date` | string | 可选，`YYYY-MM-DD` 格式的结束日期。 |
 | `enable_image_understanding` | boolean | 让 xAI 分析匹配帖子中附带的图片。 |
 | `enable_video_understanding` | boolean | 让 xAI 分析匹配帖子中附带的视频。 |
+| `output_schema` | object | 可选，用于严格结构化输出的 JSON Schema。解析后的结果返回在 `structured_output` 中，`answer` 保留原始 JSON 字符串。 |
+| `instructions` | string | 可选，控制响应样式的系统级指令。与 `previous_response_id` 同时设置时忽略此参数。 |
+| `previous_response_id` | string | 可选，用于继续已存储响应的 `response_id`。设置后，新响应会自动存储。 |
+| `store` | boolean | 是否让 xAI 保留响应，以供后续链式调用使用。默认为 `false`。 |
 
 工具返回的 JSON 包含：
 
 - `answer` — Grok 生成的综合文本回答
+- `response_id` — xAI 返回的响应标识符；可作为 `previous_response_id` 传入，以继续已存储的响应
+- `structured_output` — 与 `output_schema` 匹配的已解析 JSON；未请求 schema 或响应无法解析时为 `null`
 - `citations` — Responses API 顶层字段返回的引用
 - `inline_citations` — 从消息正文中提取的 `url_citation` 注释（每条包含 `url`、`title`、`start_index`、`end_index`）
 - `degraded` — 当设置了任意缩小范围的过滤器（`allowed_x_handles`、`excluded_x_handles`、`from_date`、`to_date`）且两个引用渠道均返回空时为 `true`。此时 `answer` 是基于模型自身知识合成的，而非来自 X 索引，应视为无来源内容。否则为 `false`（包括"未设置过滤器"的情况——宽泛的无来源回答只是一个回答，而非过滤器未命中）
 - `degraded_reason` — 列出哪些过滤器处于激活状态的简短字符串，当 `degraded` 为 `false` 时为 `null`
 - `credential_source` — OAuth 解析成功时为 `"xai-oauth"`，API 密钥解析成功时为 `"xai"`
 - `model`、`query`、`provider`、`tool`、`success`
+
+### 结构化输出与响应链
+
+如需结构化输出，请通过 `output_schema` 传入 JSON Schema。xAI 会被要求以严格模式遵循该 schema。原始 JSON 字符串仍保留在 `answer` 中，解析后的值返回在 `structured_output` 中。
+
+响应链要求先存储第一个响应：
+
+1. 首次调用时设置 `store=true`。
+2. 读取返回的 `response_id`。
+3. 后续调用时将该 ID 作为 `previous_response_id` 传入。
+
+设置 `previous_response_id` 的调用会自动存储，因此可继续使用其返回的 `response_id` 扩展响应链。xAI Responses API 中，`instructions` 与 `previous_response_id` 互斥；若同时提供，则以 `previous_response_id` 为准并忽略 `instructions`。
 
 ### 日期验证
 


### PR DESCRIPTION
## Summary

Extend the built-in `x_search` tool with four parameters that expose additional xAI Responses API capabilities:

- `output_schema` — strict JSON Schema output, expanded into `text.format.json_schema`.
- `instructions` — top-level system-style instructions controlling response style.
- `previous_response_id` — chain a follow-up call from a stored prior response.
- `store` — whether xAI stores the response so its `id` can be reused later. Defaults to `false`.

The success payload now includes:

- `response_id` — the xAI response `id`, for follow-up chaining.
- `structured_output` — parsed JSON when `output_schema` is set and parsing succeeds, otherwise `null`.

Existing fields, error shape, credential resolution, retry behavior, and citation extraction are unchanged.

## Why this matters for agent loops

`x_search` already returns an LLM-summarized answer with citations. But agent workflows often need typed fields — extracted items, classification labels, confidence annotations, or alert decisions — that downstream steps can consume without sending the prose through another LLM pass to recover the shape.

With `output_schema`, a single `x_search` call can return a strictly-shaped JSON object directly. The schema becomes an explicit tool contract rather than an implicit prompt convention, which matters most for **skills and cron jobs** that run the same query repeatedly: they can declare the expected shape once and rely on it across invocations, instead of re-coaxing it out of free-form text each time.

Combined with `previous_response_id`, follow-up calls can refine the same search while keeping the structured shape stable across turns.

This is additive: callers that do not pass `output_schema` keep the existing conversational response shape.

## Scope

This PR intentionally bundles the four new parameters together because they share the same tool schema, request payload construction, response parsing, and tests. Splitting them would create overlapping changes in `tools/x_search_tool.py` without making review materially easier.

Out of scope:

- Per-call model override.
- Adding a JSON Schema validator dependency.
- Adding a `warnings` field to tool responses.

## Behavior

- `store=false` remains the default to preserve current privacy semantics.
- Callers should set `store=true` on the initial/seed call when they plan to reuse its `response_id` with `previous_response_id`.
- When `previous_response_id` is provided, the request is stored automatically so chained follow-up responses can themselves be reused.
- `instructions` and `previous_response_id` are mutually exclusive per the xAI Responses API. If both are provided, `instructions` is ignored and a warning is logged. `previous_response_id` wins because it is required to preserve the requested response chain.
- `response_id` is only included on the success path. Failure responses keep the existing error shape.
- `structured_output` is always present on the success path:
  - `null` when `output_schema` is not provided.
  - Parsed JSON when `output_schema` is provided and parsing succeeds.
  - `null` when parsing fails, while preserving the raw `answer` and keeping the tool call successful.

## Testing

- Added tests for request payload construction:
  - `output_schema` expands into `text.format.json_schema`.
  - `instructions` is added as a top-level field.
  - `previous_response_id` is added as a top-level field.
  - `instructions` is dropped when `previous_response_id` is also provided.
  - `store` defaults to `false`.
  - `store=true` is honored.
  - `previous_response_id` automatically enables `store`.
- Added tests for response handling:
  - `data.id` is returned as `response_id` on success.
  - Valid JSON text is parsed into `structured_output`.
  - Invalid JSON text leaves `structured_output` as `null` without failing the tool call.
- Added validation coverage:
  - `output_schema` must be a JSON object.
  - Blank `instructions` and `previous_response_id` values are omitted from the request body.

```
$ pytest tests/tools/test_x_search_tool.py
............................                                             [100%]
24 passed in 1.52s
```

## Dogfood

Verified against the live xAI Responses API:

```python
import json
from tools.x_search_tool import _handle_x_search

# Seed call: structured output + store=true so we can chain a follow-up.
r1 = json.loads(_handle_x_search({
    "query": "Pick 3 recent popular posts mentioned Hermes Agent within the last 24 hours.",
    "output_schema": {
        "type": "object",
        "properties": {
            "tweets": {"type": "array", "items": {
                "type": "object",
                "properties": {
                    "handle": {"type": "string"},
                    "summary": {"type": "string"},
                    "sentiment": {
                        "type": "string",
                        "enum": ["positive", "neutral", "negative"],
                        "description": "Overall sentiment of the post",
                    },
                },
                "required": ["handle", "summary", "sentiment"],
            }},
        },
        "required": ["tweets"],
    },
    "instructions": "Respond in Japanese. Be concise.",
    "store": True,
}))
print("*** First call with structured output and store=true ***")
print("response_id      :", r1["response_id"])
print("structured type  :", type(r1["structured_output"]).__name__)
print("structured keys  :", list(r1["structured_output"].keys()))
print("inline citations :", len(r1["inline_citations"]))
for i, tweet in enumerate(r1["structured_output"]["tweets"]):
    print(f"post {i} handle  :", tweet["handle"])
    print(f"post {i} summary :", tweet["summary"][:300])
    print(f"post {i} sentiment:", tweet["sentiment"])

# Chained follow-up: reuses the prior response via previous_response_id.
# instructions is intentionally omitted (would be dropped anyway).
r2 = json.loads(_handle_x_search({
    "query": "Which of those posts likely has the highest engagement?",
    "previous_response_id": r1["response_id"],
}))
print("*** Follow-up call reusing prior response ***")
print("success :", r2["success"])
print("answer  :", r2["answer"][:300])
```

Output (handles anonymized):

```
*** First call with structured output and store=true ***
response_id      : 8723063b-b760-9dcc-b094-9b0a65226888
structured type  : dict
structured keys  : ['tweets']
inline citations : 24
post 0 handle  : @user_a
post 0 summary : Hermes Agentは手間なく自己改善し、繰り返し作業をSkills化して進化。X Premiumだけで動かせる点が良い。
post 0 sentiment: positive
post 1 handle  : @user_a
post 1 summary : Claude CodeやCodexからHermes Agentを呼び、Xリサーチ→URL抽出→Excelまとめが可能。シンプルに価値大。
post 1 sentiment: positive
post 2 handle  : @user_b
post 2 summary : Hermes AgentがOpenAI Codex CLI経由で利用可能に。ChatGPTサブスクをエージェント実行枠に変える革新的機能。
post 2 sentiment: positive
*** Follow-up call reusing prior response ***
success : True
answer  : **@user_aのXリサーチ活用投稿（Views: 4186、Likes: 31、Bookmarks: 32）** が最もエンゲージメントが高いです。ViewsとBookmarksが他を上回っています。
```

This single round-trip confirms:

- `response_id` is a non-null UUID — proves `store=True` took effect on the seed call.
- `structured_output` is a parsed `dict` matching the declared schema.
- The chained call returns `success=true` and references the prior turn's posts by handle — proves the response was actually re-used by the API, not just acknowledged.
- `inline_citations` is populated even when top-level `citations` is empty.
