### PR TITLE
fix(install.ps1): drop UTF-8 BOM that breaks the irm | iex one-liner (#27397)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-﻿# ============================================================================
+# ============================================================================
 # Hermes Agent Installer for Windows
 # ============================================================================
 # Installation script for Windows (PowerShell).
@@ -10,6 +10,26 @@
 # Or download and run with options:
 #   .\install.ps1 -NoVenv -SkipSetup
 #
+# ----------------------------------------------------------------------------
+# !!! FILE ENCODING REQUIREMENT !!!
+# This file MUST be saved as pure ASCII (or UTF-8 WITHOUT BOM).  A leading
+# UTF-8 BOM (EF BB BF) breaks the one-line installer:
+#
+#   irm <url> | iex
+#       -> The body bytes are decoded into a .NET string that still
+#          contains U+FEFF at position 0.  PowerShell's expression-context
+#          parser (used by Invoke-Expression / [scriptblock]::Create) does
+#          NOT strip that character the way the script-file loader does,
+#          so the `param` keyword is no longer recognised, and the param
+#          block lines are parsed as bare assignments -- producing the
+#          "The assignment expression is not valid" error from #27397.
+#
+# Direct `.\install.ps1` invocation tolerates the BOM (PowerShell's file
+# host strips it), so the failure only shows up via the canonical one-line
+# installer -- which is exactly the path the README points new users at.
+#
+# When editing this file: keep it ASCII (or UTF-8 *without* BOM).  The
+# CI test in tests/scripts/test_install_ps1_encoding.py guards this.
 # ============================================================================
 
 param(

--- a/tests/scripts/test_install_ps1_encoding.py
+++ b/tests/scripts/test_install_ps1_encoding.py
@@ -1,0 +1,168 @@
+r"""Regression tests for the Windows one-line installer's file encoding (#27397).
+
+``scripts/install.ps1`` MUST be saved as pure ASCII (or UTF-8 *without* BOM).
+When the file accidentally picks up a UTF-8 BOM (``EF BB BF`` -- easy to
+introduce by editing the file in a Windows editor that defaults to "UTF-8
+with signature"), the canonical Windows one-line installer fails::
+
+    irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+
+Why:
+
+* ``irm`` (Invoke-RestMethod) reads the response body and decodes it into a
+  .NET string.  A leading UTF-8 BOM is preserved as U+FEFF at position 0
+  of that string.
+* ``iex`` (Invoke-Expression) calls ``[scriptblock]::Create($string)`` to
+  parse.  The expression-context parser does NOT strip a leading U+FEFF
+  the way PowerShell's *script file* loader does.
+* With a stray U+FEFF in front of ``param(``, PowerShell stops recognising
+  ``param`` as a keyword.  Each line inside the ``param()`` block then
+  parses as a bare assignment, e.g. ``[string]$Branch = "main"`` becomes a
+  cast-on-LHS = literal-on-RHS expression, which is invalid -- yielding
+  the exact error reported in #27397::
+
+      The assignment expression is not valid. The input to an assignment
+      operator must be an object that is able to accept assignments, such
+      as a variable or a property.
+
+Direct ``.\install.ps1`` invocation tolerates the BOM (PowerShell's file
+host strips it), so the failure only surfaces via the canonical one-liner --
+which is exactly the path the README points new users at.
+
+These tests pin the file's on-disk byte invariants so a future editor save
+(or a script that uses ``Set-Content`` with a default encoding on Windows)
+cannot silently reintroduce the BOM.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[2] / "scripts" / "install.ps1"
+_UTF8_BOM = b"\xef\xbb\xbf"
+_UTF16_LE_BOM = b"\xff\xfe"
+_UTF16_BE_BOM = b"\xfe\xff"
+
+
+@pytest.fixture(scope="module")
+def install_ps1_bytes() -> bytes:
+    assert _INSTALL_PS1.is_file(), f"missing installer at {_INSTALL_PS1}"
+    return _INSTALL_PS1.read_bytes()
+
+
+class TestInstallPs1ByteInvariants:
+    """Catch any encoding regression at the bytes-on-disk level."""
+
+    def test_does_not_start_with_utf8_bom(self, install_ps1_bytes):
+        # The exact regression behind #27397.
+        assert not install_ps1_bytes.startswith(_UTF8_BOM), (
+            "scripts/install.ps1 has a UTF-8 BOM at byte 0. This breaks "
+            "`irm <url> | iex` because PowerShell's expression-context "
+            "parser leaves U+FEFF in the input and stops recognising "
+            "`param` as a keyword. Re-save as ASCII or UTF-8 *without* BOM."
+        )
+
+    def test_does_not_start_with_utf16_bom(self, install_ps1_bytes):
+        # PowerShell's `Set-Content` defaults to UTF-16 LE on PS 5.1.
+        # That would obviously break iex even worse than UTF-8+BOM, and is
+        # an easy footgun for an editor save / automation script.
+        assert not install_ps1_bytes.startswith(_UTF16_LE_BOM), (
+            "scripts/install.ps1 has a UTF-16 LE BOM. Re-save as ASCII."
+        )
+        assert not install_ps1_bytes.startswith(_UTF16_BE_BOM), (
+            "scripts/install.ps1 has a UTF-16 BE BOM. Re-save as ASCII."
+        )
+
+    def test_is_pure_ascii(self, install_ps1_bytes):
+        # The in-file comment claims pure ASCII for PS 5.1 parser
+        # compatibility.  Pin that contract: a stray smart quote or em
+        # dash would not break iex on its own, but it weakens the rule
+        # of "no surprises in the bytes the parser sees" that the BOM
+        # fix relies on.
+        offenders = [(i, b) for i, b in enumerate(install_ps1_bytes) if b >= 0x80]
+        assert not offenders, (
+            f"scripts/install.ps1 contains {len(offenders)} non-ASCII "
+            f"byte(s); first at offset {offenders[0][0]} (0x{offenders[0][1]:02x}). "
+            "Keep the file pure ASCII (replace em dashes with '--', smart "
+            "quotes with regular quotes, etc.)."
+        )
+
+    def test_first_line_is_a_comment_or_param(self, install_ps1_bytes):
+        # Defensive: after stripping any whitespace, the first real
+        # token must be a comment (`#`) or `param` -- never anything that
+        # would change the parser's expectation of what the script is.
+        text = install_ps1_bytes.decode("ascii")
+        first_line = text.split("\n", 1)[0].lstrip()
+        assert first_line.startswith("#") or first_line.startswith("param"), (
+            f"unexpected first line: {first_line!r}"
+        )
+
+
+class TestParamBlockStillPresent:
+    """Sanity: the param() block must remain at top level so direct invocation works."""
+
+    def test_param_block_at_top_level(self, install_ps1_bytes):
+        text = install_ps1_bytes.decode("ascii")
+        # Find the first non-comment, non-blank line.
+        first_code_line = next(
+            (
+                line.strip()
+                for line in text.splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            ),
+            None,
+        )
+        assert first_code_line is not None
+        assert first_code_line.startswith("param("), (
+            f"first executable line must be `param(`, got {first_code_line!r}"
+        )
+
+    def test_param_block_defaults_intact(self, install_ps1_bytes):
+        # Pin the documented defaults so a future refactor doesn't drop
+        # them silently and reintroduce the symptom in a different shape.
+        text = install_ps1_bytes.decode("ascii")
+        for needle in (
+            '[string]$Branch = "main"',
+            '[string]$HermesHome = "$env:LOCALAPPDATA\\hermes"',
+            '[string]$InstallDir = "$env:LOCALAPPDATA\\hermes\\hermes-agent"',
+        ):
+            assert needle in text, f"missing param default: {needle!r}"
+
+
+class TestSimulateIrmIexParsing:
+    """Smoke-test the actual byte sequence iex would receive.
+
+    We can't run PowerShell from this test suite (no PS on CI Linux runners),
+    but we can simulate the failure surface: ``iex`` parses the raw bytes
+    as a script block.  Pin that the first non-whitespace character is a
+    valid script start (``#`` for comments or ``p`` for ``param``) -- if
+    it ever becomes U+FEFF / a BOM / a stray control character, this test
+    catches it before the user hits #27397 again.
+    """
+
+    def test_first_meaningful_codepoint_is_safe(self, install_ps1_bytes):
+        text = install_ps1_bytes.decode("ascii")
+        # Strip POSIX whitespace + any stray BOM-like sentinel.
+        stripped = text.lstrip(" \t\r\n")
+        assert stripped, "file appears empty after stripping whitespace"
+        first = stripped[0]
+        assert first in {"#", "p"}, (
+            f"first meaningful character is {first!r} (U+{ord(first):04X}); "
+            "expected '#' (comment) or 'p' (start of `param`). A surprise "
+            "character here is exactly the class of bug that #27397 hit."
+        )
+
+    def test_byte_zero_is_safe_for_iex(self, install_ps1_bytes):
+        # The hard guarantee: byte 0 must be a printable ASCII character
+        # that PowerShell's expression-context parser accepts as a script
+        # start.  In practice that means the comment marker `#` (since
+        # the file currently leads with a banner).
+        assert install_ps1_bytes, "install.ps1 is empty"
+        first_byte = install_ps1_bytes[0]
+        assert first_byte == ord("#"), (
+            f"byte 0 is 0x{first_byte:02x}; expected '#' (0x23). "
+            "Any other byte at position 0 risks breaking `irm | iex`."
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes the canonical Windows one-line installer

```
irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
```

which was failing on every fresh Windows 11 box with

```
The assignment expression is not valid. The input to an assignment operator must be
an object that is able to accept assignments, such as a variable or a property.
```

at the `[string]$Branch = "main"` line inside the `param()` block, before doing any work.

### Root cause

`scripts/install.ps1` had accidentally picked up a leading **UTF-8 BOM** (`EF BB BF`) at byte 0:

```
$ file scripts/install.ps1
scripts/install.ps1: Unicode text, UTF-8 (with BOM) text
```

* PowerShell's *script-file* loader strips the BOM, so `.\install.ps1` worked fine.
* `irm | iex` decodes the body into a .NET string, the BOM survives as `U+FEFF` at position 0, and `[scriptblock]::Create()` does **not** strip it.
* With a stray `U+FEFF` in front of `param(`, PowerShell stops recognising `param` as a keyword. Each line of the block then parses as a bare assignment — `[string]$Branch = "main"` becomes type-cast-on-LHS = string-on-RHS, which is exactly the "invalid assignment expression" error in #27397.

The script's own comment even *claimed* "the file remains pure ASCII for PS 5.1 parser compatibility" — that contract was silently broken, almost certainly by an editor save defaulting to "UTF-8 with signature". The two other `.ps1` files in the repo (`acp_adapter/bootstrap/bootstrap_browser_tools.ps1`, `scripts/tests/test-install-ps1-stage-protocol.ps1`) start with a plain `# ` — only this one carried a BOM.

### The fix

1. Re-save `scripts/install.ps1` as pure ASCII (no BOM). After: `file` reports `ASCII text` and byte 0 is `0x23` (`#`).
2. Expand the in-file comment header into a loud **"FILE ENCODING REQUIREMENT"** block at the top of the file explaining the failure mode and the rule, so a future editor save doesn't quietly reintroduce the regression.
3. Add a Python CI test `tests/scripts/test_install_ps1_encoding.py` that pins the byte invariants — no UTF-8 BOM, no UTF-16 BOM, pure ASCII, byte 0 is `#`, `param(` is the first executable line, and the documented defaults (`$Branch`, `$HermesHome`, `$InstallDir`) are intact.

## Related Issue

Closes #27397.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.ps1` — file re-saved as pure ASCII (no BOM); the 13-line "FILE ENCODING REQUIREMENT" block added at the top explains why and points future editors at the regression test. **No behavioural code change** — the `param()` block, defaults, and 2138-line installer body are byte-identical to before, only the leading 3 BOM bytes were dropped and a comment block was added.
- `tests/scripts/test_install_ps1_encoding.py` — 8 new regression tests:
  - `TestInstallPs1ByteInvariants` — 4 cases: no UTF-8 BOM (the exact #27397 regression), no UTF-16 LE/BE BOM (the Set-Content default on PS 5.1, even worse for `iex`), pure ASCII (catches smart quotes / em dashes), first line is a comment or `param`.
  - `TestParamBlockStillPresent` — 2 cases: `param(` is the first executable line, and the documented defaults `$Branch = "main"`, `$HermesHome = "$env:LOCALAPPDATA\hermes"`, `$InstallDir = "$env:LOCALAPPDATA\hermes\hermes-agent"` are intact so a future refactor doesn't drop them and reintroduce the symptom in a different shape.
  - `TestSimulateIrmIexParsing` — 2 cases: byte 0 must be `#` (0x23) and the first meaningful codepoint must be `#` or `p` — the class of guarantee that `irm | iex` parsing relies on.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/scripts/test_install_ps1_encoding.py -v
   ```
   Expected: 8 passed.
3. Sensitivity check (the test must actually catch the regression):
   ```
   python -c "
   from pathlib import Path
   p = Path('scripts/install.ps1')
   orig = p.read_bytes()
   try:
       p.write_bytes(b'\xef\xbb\xbf' + orig)
       import subprocess
       r = subprocess.run(['python', '-m', 'pytest', 'tests/scripts/test_install_ps1_encoding.py', '-q'], capture_output=True, text=True)
       print(r.stdout[-400:])
   finally:
       p.write_bytes(orig)
   "
   ```
   Expected: 7 of 8 tests fail with `UTF-8 BOM` / `expected '#' (0x23)` messages.
4. Manual Windows smoke (PowerShell 5.1 or 7, requires a Windows box):
   - Pre-fix (`main` branch): `irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex` raises `The assignment expression is not valid` at the `[string]$Branch = "main"` line.
   - With this branch's `install.ps1` served at the same URL: the param block parses cleanly and the installer proceeds normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(install.ps1): ...`, `test(install.ps1): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/scripts/test_install_ps1_encoding.py` and all tests pass
- [x] I've added tests for my changes (8 new regression tests, inverted-fix sensitivity verified: 7 of 8 fail when the BOM is re-introduced)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12. The bug itself is Windows-only but the fix is byte-level and platform-independent.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`scripts/install.ps1` now carries a "FILE ENCODING REQUIREMENT" comment block at the top documenting the rule and pointing at the CI test)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the only on-wire change is "drop 3 BOM bytes". `.\install.ps1` direct invocation, `pwsh` 7+, and Windows PS 5.1 all parse the BOM-less file identically; the regression only existed for the BOM + `iex`-decoded-string path. macOS / Linux don't run this file.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ file scripts/install.ps1
scripts/install.ps1: ASCII text, with very long lines (363)

$ head -c 8 scripts/install.ps1 | xxd
00000000: 2320 3d3d 3d3d 3d3d                      # ======

$ scripts/run_tests.sh tests/scripts/test_install_ps1_encoding.py -v
8 passed in 1.49s
```

Sensitivity check (BOM re-injected, then restored):

```
$ # ... inject BOM ...
7 failed, 1 passed in 1.59s
FAILED tests/scripts/test_install_ps1_encoding.py::TestInstallPs1ByteInvariants::test_does_not_start_with_utf8_bom
FAILED tests/scripts/test_install_ps1_encoding.py::TestSimulateIrmIexParsing::test_byte_zero_is_safe_for_iex
FAILED tests/scripts/test_install_ps1_encoding.py::TestSimulateIrmIexParsing::test_first_meaningful_codepoint_is_safe
FAILED tests/scripts/test_install_ps1_encoding.py::TestInstallPs1ByteInvariants::test_is_pure_ascii
FAILED tests/scripts/test_install_ps1_encoding.py::TestInstallPs1ByteInvariants::test_first_line_is_a_comment_or_param
FAILED tests/scripts/test_install_ps1_encoding.py::TestParamBlockStillPresent::test_param_block_at_top_level
FAILED tests/scripts/test_install_ps1_encoding.py::TestParamBlockStillPresent::test_param_block_defaults_intact
```
