### PR TITLE
fix: make xAI OAuth callback server threaded

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2101,6 +2101,7 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
         "error": None,
         "error_description": None,
     }
+    result_lock = threading.Lock()
 
     class _XAICallbackHandler(BaseHTTPRequestHandler):
         def _maybe_write_cors_headers(self) -> None:
@@ -2127,16 +2128,27 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
                 return
 
             params = parse_qs(parsed.query)
-            result["code"] = params.get("code", [None])[0]
-            result["state"] = params.get("state", [None])[0]
-            result["error"] = params.get("error", [None])[0]
-            result["error_description"] = params.get("error_description", [None])[0]
+            incoming = {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+                "error": params.get("error", [None])[0],
+                "error_description": params.get("error_description", [None])[0],
+            }
+            # ThreadingHTTPServer allows a fallback/manual callback to complete
+            # while a browser connection is stuck.  Once we have a terminal
+            # OAuth result (code or error), keep the first one so a later
+            # concurrent/invalid callback cannot overwrite state before
+            # validation in _xai_oauth_loopback_login().
+            if incoming["code"] or incoming["error"]:
+                with result_lock:
+                    if not (result["code"] or result["error"]):
+                        result.update(incoming)
 
             self.send_response(200)
             self._maybe_write_cors_headers()
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            if result["error"]:
+            if incoming["error"]:
                 body = "<html><body><h1>xAI authorization failed.</h1>You can close this tab.</body></html>"
             else:
                 body = "<html><body><h1>xAI authorization received.</h1>You can close this tab.</body></html>"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -33,7 +33,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -2155,8 +2155,9 @@ def _xai_start_callback_server(
     expected_path = XAI_OAUTH_REDIRECT_PATH
     handler_cls, result = _make_xai_callback_handler(expected_path)
 
-    class _ReuseHTTPServer(HTTPServer):
+    class _ReuseHTTPServer(ThreadingHTTPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
     ports_to_try = [preferred_port]
     if preferred_port != 0:

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -304,6 +304,28 @@ def test_xai_callback_server_accepts_fallback_code_while_browser_connection_is_s
         thread.join(timeout=1.0)
 
 
+def test_xai_callback_server_latches_first_terminal_callback_result():
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    try:
+        with urllib.request.urlopen(f"{redirect_uri}?code=first-code&state=state-1", timeout=2) as response:
+            assert response.status == 200
+        with urllib.request.urlopen(
+            f"{redirect_uri}?error=access_denied&error_description=late&state=state-2",
+            timeout=2,
+        ) as response:
+            body = response.read().decode("utf-8")
+        assert response.status == 200
+        assert "xAI authorization failed" in body
+        assert result["code"] == "first-code"
+        assert result["state"] == "state-1"
+        assert result["error"] is None
+        assert result["error_description"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Token roundtrip + reads
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -2,7 +2,9 @@
 
 import base64
 import json
+import socket
 import time
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -20,6 +22,7 @@ from hermes_cli.auth import (
     _xai_access_token_is_expiring,
     _xai_callback_cors_origin,
     _xai_oauth_build_authorize_url,
+    _xai_start_callback_server,
     _xai_validate_loopback_redirect_uri,
     get_xai_oauth_auth_status,
     refresh_xai_oauth_pure,
@@ -276,6 +279,29 @@ def test_xai_callback_cors_origin_rejects_unknown_origin():
     assert _xai_callback_cors_origin("https://attacker.example.com") == ""
     assert _xai_callback_cors_origin(None) == ""
     assert _xai_callback_cors_origin("") == ""
+
+
+def test_xai_callback_server_accepts_fallback_code_while_browser_connection_is_stuck():
+    """Regression: Chrome/xAI can leave a loopback connection open after
+    showing the Grok Build fallback code. A single-threaded callback server then
+    blocks forever and cannot accept the manual fallback callback.
+    """
+    server, thread, result, redirect_uri = _xai_start_callback_server(preferred_port=0)
+    stuck = socket.create_connection((XAI_OAUTH_REDIRECT_HOST, server.server_address[1]), timeout=2)
+    try:
+        stuck.sendall(b"GET /callback?code=stuck")
+        callback_url = f"{redirect_uri}?code=fallback-code&state=state-123"
+        with urllib.request.urlopen(callback_url, timeout=2) as response:
+            body = response.read().decode("utf-8")
+        assert response.status == 200
+        assert "xAI authorization received" in body
+        assert result["code"] == "fallback-code"
+        assert result["state"] == "state-123"
+    finally:
+        stuck.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Use `ThreadingHTTPServer` for the xAI OAuth loopback callback server.
- Allow the manual/fallback callback code path to complete even if the browser/xAI page leaves another loopback connection open.
- Add a regression test that holds one callback connection open while a second valid fallback callback succeeds.

## Why
During `hermes auth add xai-oauth`, accounts.x.ai can show the fallback "copy this code to Grok Build" flow while leaving a local browser connection established against the loopback callback port. With the previous single-threaded `HTTPServer`, that stuck connection could block the server from accepting the fallback callback, so manually sending the code to `/callback` timed out.

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_auth_xai_oauth_provider.py -q -o 'addopts='`

Result: `64 passed`
