### PR TITLE
fix(agent): whitelist read_file in background review agent

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4408,6 +4408,9 @@ class AIAgent:
                             quiet_mode=True,
                         )
                     }
+                    # Allow read_file so the review agent can verify
+                    # current file state before proposing skill patches
+                    review_whitelist.add("read_file")
                     set_thread_tool_whitelist(
                         review_whitelist,
                         deny_msg_fmt=(
@@ -4419,8 +4422,8 @@ class AIAgent:
                         review_agent.run_conversation(
                             user_message=(
                                 prompt
-                                + "\n\nYou can only call memory and skill "
-                                "management tools. Other tools will be denied "
+                                + "\n\nYou can call memory, skill management, "
+                                "and read_file tools. Other tools will be denied "
                                 "at runtime — do not attempt them."
                             ),
                             conversation_history=messages_snapshot,


### PR DESCRIPTION
background review agent whitelist only allows memory+skills toolsets. read_file is blocked despite being read-only. 15 sessions hit this deny since May 14.

## change
- add `read_file` to background review whitelist
- update review prompt text so agent knows read_file is available

## why
review agent tries to verify file state before proposing skill patches. without read_file, skill_manage calls fail silently when the agent cant confirm current file content. read_file is read-only — safe for background thread.

## test
before: `grep "Background review denied" ~/.hermes/logs/agent.log | wc -l` → 15 hits
after: 0