### PR TITLE
fix(agent): trigger preflight compression on token threshold for few huge messages (#27405)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -502,11 +502,39 @@ def run_conversation(
     # while having a large existing session — compress proactively rather
     # than waiting for an API error (which might be caught as a non-retryable
     # 4xx and abort the request entirely).
-    if (
-        agent.compression_enabled
-        and len(messages) > agent.context_compressor.protect_first_n
-                            + agent.context_compressor.protect_last_n + 1
-    ):
+    if agent.compression_enabled:
+        _msg_count_gate = (
+            len(messages)
+            > agent.context_compressor.protect_first_n
+            + agent.context_compressor.protect_last_n
+            + 1
+        )
+        # Fallback gate: even with few messages, a single huge message
+        # (e.g. failed prior compression output, large file read) can blow
+        # the token threshold.  Use a cheap char-based approximation to
+        # decide whether to run the (more expensive) full rough estimator.
+        # See issue #27405.
+        if not _msg_count_gate:
+            _approx_chars = 0
+            for _m in messages:
+                _c = _m.get("content") if isinstance(_m, dict) else None
+                if isinstance(_c, str):
+                    _approx_chars += len(_c)
+                elif isinstance(_c, list):
+                    for _part in _c:
+                        if isinstance(_part, dict):
+                            _t = _part.get("text")
+                            if isinstance(_t, str):
+                                _approx_chars += len(_t)
+            _approx_tokens = _approx_chars // 4
+            _token_gate = _approx_tokens >= agent.context_compressor.threshold_tokens
+        else:
+            _token_gate = True
+    else:
+        _msg_count_gate = False
+        _token_gate = False
+
+    if agent.compression_enabled and (_msg_count_gate or _token_gate):
         # Include tool schema tokens — with many tools these can add
         # 20-30K+ tokens that the old sys+msg estimate missed entirely.
         _preflight_tokens = estimate_request_tokens_rough(

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -577,6 +577,50 @@ class TestPreflightCompression:
         mock_compress.assert_not_called()
         assert result["completed"] is True
 
+    def test_preflight_triggers_on_few_huge_messages(self, agent):
+        """Issue #27405: few messages but huge content must still trigger preflight.
+
+        Previously the gate was message-count only — a 5-message session
+        with one giant message (e.g. prior failed compression output)
+        slipped past and caused silent context overflow.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 1000
+        # Defaults: protect_first_n=3, protect_last_n=20 → count-gate needs >24.
+        # 5 messages is well under that.
+        huge_content = "x" * (4 * 5000)  # ~5000 tokens, well above 1000 threshold
+        small_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": huge_content},
+            {"role": "user", "content": "ok"},
+            {"role": "assistant", "content": "sure"},
+        ]
+
+        ok_resp = _mock_response(content="After preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [
+                    {"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious"},
+                    {"role": "user", "content": "hello"},
+                ],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=small_history)
+
+        assert mock_compress.call_count >= 1, (
+            "Preflight must trigger via token-gate fallback when message "
+            "count is low but content is huge"
+        )
+        assert result["completed"] is True
+
 
 class TestToolResultPreflightCompression:
     """Compression should trigger when tool results push context past the threshold."""


### PR DESCRIPTION
## Summary

Fixes #27405 — preflight compression silently skipped on sessions with few messages but enormous content per message.

## Root Cause

`agent/conversation_loop.py:run_conversation()` gated the entire preflight compression block on message **count**:

```python
if (agent.compression_enabled
    and len(messages) > agent.context_compressor.protect_first_n
                        + agent.context_compressor.protect_last_n + 1):  # 24
    _preflight_tokens = estimate_request_tokens_rough(...)
    if _preflight_tokens >= agent.context_compressor.threshold_tokens:
        # compress
```

When a session has e.g. 8 messages but one carries a 1.3M-token failed-compression summary or a big file read, `len(messages) > 24` is False and the token-threshold check is never reached. The agent then hits the model's hard context limit on the next API call with no automatic recovery — only manual `/compress` or `/new` saves the session.

Reporter's evidence from #27405: latest request_dump had 8 messages totaling ~1.34M tokens (well above the 500K threshold), and `agent.log` contains zero `Preflight compression` / `context compression started` entries.

## Fix

Add a **token-based fallback gate**: if the message-count gate doesn't trip, sum approximate chars across message `content` (handling both string and list-of-parts shapes) and divide by 4 to cheaply estimate tokens. If that estimate already exceeds `context_compressor.threshold_tokens`, fall through to the existing rough-estimator + 3-pass compression loop unchanged.

This preserves existing behaviour when the count gate trips (no path changes when there are >24 messages), and only adds the new path for the few-but-huge case.

## Files

- `agent/conversation_loop.py` — gate logic only; existing inner compression body untouched
- `tests/run_agent/test_413_compression.py` — new test `test_preflight_triggers_on_few_huge_messages` in `TestPreflightCompression`

## Tests

```
$ pytest tests/run_agent/test_413_compression.py -x -q
................                                                         [100%]
16 passed in 11.90s
```

(4 pre-existing preflight tests + new one + the rest of the file's compression-related suite.)

## Out of Scope

The issue also lists two secondary observations:

- `ContextCompressor.update_from_response()` storing `prompt_tokens` but `should_compress()` never being called from the main loop
- `_CHARS_PER_TOKEN=4` underestimating CJK / code / base64

These are real but separate; this PR keeps scope tight on the gate fix that closes the silent-overflow bug. Happy to follow up.

---

🤖 AI-assisted (Claude Code authored the patch + tests under direction; reviewed by hand)
